### PR TITLE
fix: pack recall + OpenClaw compat (issues #13, #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ plur-mcp init
 
 ```bash
 openclaw plugins install @plur-ai/claw
-openclaw config set plur.enabled true
 ```
+
+Requires OpenClaw >= 2026.3. The plugin auto-registers on install — no additional config needed.
 
 That's it. PLUR works in the background from here. No workflow changes needed — just use your tools as usual. Corrections accumulate automatically.
 

--- a/packages/claw/openclaw.plugin.json
+++ b/packages/claw/openclaw.plugin.json
@@ -4,6 +4,7 @@
   "description": "Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.",
   "version": "0.7.6",
   "kind": "memory",
+  "pluginApi": ">=2026.3",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,7 +101,6 @@ export class Plur {
   private _loadAllEngrams(): Engram[] {
     const primary = this._loadCached(this.paths.engrams)
     const stores = this.config.stores ?? []
-    if (stores.length === 0) return primary
 
     const all: Engram[] = [...primary]
     for (const store of stores) {

--- a/packages/core/test/packs.test.ts
+++ b/packages/core/test/packs.test.ts
@@ -78,18 +78,13 @@ describe('pack management', () => {
 `)
     plur.installPack(packSource)
 
-    // Debug: check list and status
-    const allEngrams = plur.list()
-    console.log('All engrams via list():', allEngrams.length, allEngrams.map(e => e.id))
-    const status = plur.status()
-    console.log('Status engram_count:', status.engram_count, 'pack_count:', status.pack_count)
-
     // Recall should find the pack engram
     const results = plur.recall('stoicism philosophy communication')
     expect(results.length).toBeGreaterThan(0)
     expect(results[0].statement).toContain('Stoic communication')
 
     // Status should count the pack engram
+    const status = plur.status()
     expect(status.engram_count).toBeGreaterThanOrEqual(1)
     expect(status.pack_count).toBe(1)
 


### PR DESCRIPTION
## Summary

- **#13 (bug)**: Pack engrams are now searchable via `plur_recall`. The root cause was an early return in `_loadAllEngrams()` that skipped pack loading when no additional stores were configured (the default case). One-line fix.
- **#9 (bug)**: OpenClaw plugin manifest now declares `pluginApi: ">=2026.3"` so OpenClaw doesn't fall back to legacy API version 1. README updated to remove the incorrect `openclaw config set plur.enabled true` instruction.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/index.ts` | Remove early return in `_loadAllEngrams()` that bypassed pack loading |
| `packages/core/test/packs.test.ts` | Clean up test — remove debug logs, add missing variable declaration |
| `packages/claw/openclaw.plugin.json` | Add `pluginApi: ">=2026.3"` field |
| `README.md` | Fix OpenClaw install instructions |

## Test plan

- [x] New test: installed pack engrams findable via `recall()` 
- [x] `status().engram_count` includes pack engrams
- [x] All 377 tests pass (pre-existing openclaw-integration.test.mjs env failure unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)