### PR TITLE
fix(cli): init registers plur MCP server, add plur doctor (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.8.2 (2026-04-09)
+
+### Architecture Clarity & Multi-Project Scoping
+
+Clarifies PLUR's architecture: **global tool, per-project scoping**. One MCP server, one engram store, available everywhere. Multi-project users scope via domain/scope fields — not per-project installations.
+
+- **Hook-driven session start**: `hook-inject` now auto-generates a session ID on first message — no need for explicit `plur_session_start` call. Session ID is included in injected context for `plur_session_end`.
+- **Project config (`.plur.yaml`)**: `plur init --domain X --scope Y` writes a `.plur.yaml` in the project root. Hooks read this file and auto-apply domain/scope to injection and learn reminders.
+- **Improved init messaging**: `plur init` output now explains the global architecture and scoping model.
+- **CLAUDE.md template rewrite**: Clearer architecture section, documents auto-session and multi-project scoping. Removed verbose sections in favor of concise guidance.
+- **MCP server instructions updated**: Clarifies hook-driven lifecycle vs manual session start.
+- **README multi-project docs**: Install section documents `--domain`/`--scope` workflow.
+
+### Packages
+
+- `@plur-ai/core` 0.8.2 — version bump
+- `@plur-ai/mcp` 0.8.2 — updated instructions, init messaging, CLAUDE.md template
+- `@plur-ai/cli` 0.8.2 — `.plur.yaml` support, auto session start, improved init output
+- `@plur-ai/claw` 0.8.2 — version bump
+
 ## 0.8.0 (2026-04-08)
 
 ### Competitive Absorption: 50+ Features from 7 Memory Systems

--- a/README.md
+++ b/README.md
@@ -26,7 +26,16 @@ One command sets up everything — storage, MCP config, and Claude Code hooks:
 npx @plur-ai/mcp init
 ```
 
-This creates `~/.plur/` for storage, adds PLUR to your `.mcp.json`, and installs Claude Code hooks for automatic engram injection. Restart Claude Code to activate.
+This creates `~/.plur/` for storage, adds PLUR to your `.mcp.json`, and installs Claude Code hooks for automatic engram injection. PLUR is installed **globally** — one MCP server, one store, available in every project. You only run init once.
+
+For **multi-project setups**, use domain/scope to separate knowledge:
+
+```bash
+cd ~/projects/my-app
+npx @plur-ai/cli init --domain myapp --scope project:my-app
+```
+
+This creates a `.plur.yaml` in the project with defaults that hooks apply automatically. Engrams learned in that project are tagged; recall filters by scope but always includes global knowledge.
 
 ### Global install (faster startup)
 

--- a/packages/claw/openclaw.plugin.json
+++ b/packages/claw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plur-claw",
   "name": "PLUR Memory Engine",
   "description": "Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/packages/claw/package.json
+++ b/packages/claw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/claw",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -50,7 +50,7 @@ export class PlurContextEngine implements ContextEngine {
   readonly info: ContextEngineInfo = {
     id: 'plur-claw',
     name: 'PLUR Memory Engine',
-    version: '0.8.0',
+    version: '0.8.2',
     ownsCompaction: false,
   }
 

--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -35,7 +35,7 @@ const plugin = {
   id: 'plur-claw',
   name: 'PLUR Memory Engine',
   description: 'Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.',
-  version: '0.8.0',
+  version: '0.8.2',
   kind: 'memory' as const,
 
   register(api: any) {

--- a/packages/claw/test/hello.test.ts
+++ b/packages/claw/test/hello.test.ts
@@ -6,7 +6,7 @@ describe('PLUR ContextEngine plugin', () => {
   it('plugin has correct metadata', () => {
     expect(plugin.id).toBe('plur-claw')
     expect(plugin.kind).toBe('memory')
-    expect(plugin.version).toBe('0.8.0')
+    expect(plugin.version).toBe('0.8.2')
   })
 
   it('registers via plugin API', () => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "bin": {
     "plur": "dist/index.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "bin": {
     "plur": "dist/index.js"

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,251 @@
+import { spawn } from 'child_process'
+import { type GlobalFlags } from '../plur.js'
+import { outputText, outputJson, shouldOutputJson } from '../output.js'
+import {
+  type ConfigFile,
+  buildMcpServerEntry,
+  hasDatacoreMcp,
+  hasPlurMcp,
+  knownConfigFiles,
+  readConfig,
+} from '../mcp-config.js'
+
+/**
+ * plur doctor — diagnose a Claude Code / Claude Desktop installation.
+ *
+ * Checks:
+ *   1. Hooks installed in any settings.json (UserPromptSubmit etc.)
+ *   2. `plur` MCP server registered in any of the known config files
+ *   3. Whether `datacore` MCP server is also present (collision warning)
+ *   4. Live MCP handshake — spawns the configured server command and
+ *      sends an `initialize` JSON-RPC request to verify it actually starts.
+ *
+ * Exits 0 if everything is healthy, 1 if any check fails.
+ */
+
+interface ConfigFileReport {
+  label: string
+  path: string
+  exists: boolean
+  hasPlurMcp: boolean
+  hasDatacoreMcp: boolean
+  hasPlurHooks: boolean
+}
+
+interface DoctorReport {
+  configs: ConfigFileReport[]
+  hooksInstalled: boolean
+  mcpRegistered: boolean
+  datacoreCollision: boolean
+  handshake: { ok: boolean; serverName?: string; serverVersion?: string; error?: string }
+  overall: 'ok' | 'fail'
+}
+
+function hasAnyPlurHook(config: Record<string, unknown>): boolean {
+  const hooks = (config.hooks ?? {}) as Record<string, Array<{ hooks?: Array<{ command?: string }> }>>
+  for (const entries of Object.values(hooks)) {
+    for (const entry of entries) {
+      for (const h of entry.hooks ?? []) {
+        if (h.command && h.command.includes('@plur-ai/cli')) return true
+      }
+    }
+  }
+  return false
+}
+
+function inspectConfigs(): ConfigFileReport[] {
+  return knownConfigFiles().map((cf: ConfigFile) => {
+    if (!cf.exists) {
+      return {
+        label: cf.label,
+        path: cf.path,
+        exists: false,
+        hasPlurMcp: false,
+        hasDatacoreMcp: false,
+        hasPlurHooks: false,
+      }
+    }
+    const config = readConfig(cf.path)
+    return {
+      label: cf.label,
+      path: cf.path,
+      exists: true,
+      hasPlurMcp: hasPlurMcp(config),
+      hasDatacoreMcp: hasDatacoreMcp(config),
+      hasPlurHooks: hasAnyPlurHook(config),
+    }
+  })
+}
+
+/**
+ * Spawn the configured plur MCP server and send an `initialize` JSON-RPC
+ * request. Resolves with the server's name and version on success, or an
+ * error on timeout / crash / invalid response.
+ *
+ * Times out after 20 seconds — first-run npx fetches the @plur-ai/mcp package
+ * (and its native deps), which can take 10-15s. Subsequent runs respond in ~1s.
+ */
+async function mcpHandshake(timeoutMs = 20000): Promise<{ ok: boolean; serverName?: string; serverVersion?: string; error?: string }> {
+  const entry = buildMcpServerEntry()
+
+  return new Promise((resolve) => {
+    let resolved = false
+    const finish = (result: { ok: boolean; serverName?: string; serverVersion?: string; error?: string }) => {
+      if (resolved) return
+      resolved = true
+      try { proc.kill() } catch { /* ignore */ }
+      resolve(result)
+    }
+
+    let proc: ReturnType<typeof spawn>
+    try {
+      proc = spawn(entry.command, entry.args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    } catch (err: unknown) {
+      finish({ ok: false, error: `spawn failed: ${(err as Error).message}` })
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      finish({ ok: false, error: `timeout after ${timeoutMs}ms — server did not respond to initialize` })
+    }, timeoutMs)
+
+    let buffer = ''
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8')
+      let nl: number
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, nl).trim()
+        buffer = buffer.slice(nl + 1)
+        if (!line) continue
+        try {
+          const msg = JSON.parse(line)
+          if (msg.id === 1 && msg.result) {
+            clearTimeout(timeout)
+            const info = msg.result.serverInfo ?? {}
+            finish({ ok: true, serverName: info.name, serverVersion: info.version })
+            return
+          }
+          if (msg.id === 1 && msg.error) {
+            clearTimeout(timeout)
+            finish({ ok: false, error: `server error: ${msg.error.message ?? JSON.stringify(msg.error)}` })
+            return
+          }
+        } catch {
+          // Not a JSON-RPC frame — likely a startup banner. Ignore.
+        }
+      }
+    })
+
+    proc.on('error', (err: Error) => {
+      clearTimeout(timeout)
+      finish({ ok: false, error: `spawn error: ${err.message}` })
+    })
+
+    proc.on('exit', (code: number | null) => {
+      if (!resolved) {
+        clearTimeout(timeout)
+        finish({ ok: false, error: `server exited (code=${code}) before responding` })
+      }
+    })
+
+    const initRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'plur-doctor', version: '0.8.1' },
+      },
+    }
+    proc.stdin?.write(JSON.stringify(initRequest) + '\n')
+  })
+}
+
+function buildReport(skipHandshake: boolean): Promise<DoctorReport> {
+  const configs = inspectConfigs()
+  const hooksInstalled = configs.some((c) => c.hasPlurHooks)
+  const mcpRegistered = configs.some((c) => c.hasPlurMcp)
+  const datacoreCollision = configs.some((c) => c.hasDatacoreMcp)
+
+  const handshakePromise = skipHandshake
+    ? Promise.resolve({ ok: false, error: 'skipped (--no-handshake)' })
+    : mcpHandshake()
+
+  return handshakePromise.then((handshake) => {
+    const overall: 'ok' | 'fail' = hooksInstalled && mcpRegistered && (skipHandshake || handshake.ok) ? 'ok' : 'fail'
+    return { configs, hooksInstalled, mcpRegistered, datacoreCollision, handshake, overall }
+  })
+}
+
+function printText(report: DoctorReport): void {
+  const tick = (b: boolean) => (b ? '✓' : '✗')
+
+  outputText('plur doctor — Claude Code / Claude Desktop diagnostic')
+  outputText('')
+  outputText('Config files:')
+  for (const c of report.configs) {
+    if (!c.exists) {
+      outputText(`  - ${c.label}: not present (${c.path})`)
+      continue
+    }
+    const flags: string[] = []
+    if (c.hasPlurMcp) flags.push('plur MCP')
+    if (c.hasPlurHooks) flags.push('plur hooks')
+    if (c.hasDatacoreMcp) flags.push('datacore MCP')
+    outputText(`  ${tick(c.hasPlurMcp || c.hasPlurHooks)} ${c.label}: ${flags.length ? flags.join(', ') : '(empty)'}`)
+    outputText(`     ${c.path}`)
+  }
+
+  outputText('')
+  outputText(`${tick(report.hooksInstalled)} Hooks installed`)
+  outputText(`${tick(report.mcpRegistered)} plur MCP server registered`)
+
+  if (report.datacoreCollision) {
+    outputText('')
+    outputText('⚠  datacore MCP server detected alongside plur.')
+    outputText('   plur and datacore are SEPARATE MCP servers with separate tool namespaces.')
+    outputText('   plur tools are prefixed plur_* (plur_learn, plur_recall_hybrid, etc.).')
+    outputText('   datacore tools are prefixed datacore_*. They do NOT share memory.')
+    outputText('   If your agent confuses them, this is the cause.')
+  }
+
+  outputText('')
+  if (report.handshake.ok) {
+    outputText(`✓ MCP handshake: ${report.handshake.serverName} v${report.handshake.serverVersion}`)
+  } else {
+    outputText(`✗ MCP handshake failed: ${report.handshake.error}`)
+    outputText('  Likely causes:')
+    outputText('    - npx not on PATH (Claude Desktop launches GUI without your shell PATH)')
+    outputText('    - @plur-ai/mcp not yet downloaded — first run can take a few seconds')
+    outputText('    - Network blocked — try `npx -y @plur-ai/mcp` manually')
+  }
+
+  outputText('')
+  if (report.overall === 'ok') {
+    outputText('✓ Healthy. plur is ready to use in Claude Code.')
+  } else {
+    outputText('✗ Issues detected.')
+    if (!report.hooksInstalled || !report.mcpRegistered) {
+      outputText('  Fix: run `npx @plur-ai/cli init`')
+    }
+    if (report.hooksInstalled && report.mcpRegistered && !report.handshake.ok) {
+      outputText('  Fix: ensure `npx` is reachable from Claude Desktop')
+      outputText('       — try launching Claude from your terminal once,')
+      outputText('       — or replace the plur entry command with an absolute path to your shell.')
+    }
+  }
+}
+
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  const skipHandshake = args.includes('--no-handshake')
+  const report = await buildReport(skipHandshake)
+
+  if (shouldOutputJson(flags)) {
+    outputJson(report)
+  } else {
+    printText(report)
+  }
+
+  process.exit(report.overall === 'ok' ? 0 : 1)
+}

--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -1,13 +1,18 @@
 import { existsSync, writeFileSync, readFileSync, mkdirSync, readSync, statSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
 import { createPlur, type GlobalFlags } from '../plur.js'
 
 /**
- * plur hook-inject — Claude Code hook for engram injection.
+ * plur hook-inject — Claude Code hook for engram injection + auto session start.
  *
- * Called by UserPromptSubmit hook. First call injects engrams based on the
- * user's prompt. Subsequent calls check if a reminder is due (every 10 min).
+ * Called by UserPromptSubmit hook. First call:
+ *   1. Creates a session ID (auto session start — no need for explicit plur_session_start)
+ *   2. Reads .plur.yaml for project-level domain/scope defaults
+ *   3. Injects relevant engrams based on the user's prompt
+ *
+ * Subsequent calls check if a reminder is due (every 10 min).
  *
  * With --rehydrate: always injects (used by PostCompact hook after context
  * compaction to restore engrams that were lost).
@@ -23,6 +28,35 @@ import { createPlur, type GlobalFlags } from '../plur.js'
  */
 
 const REMINDER_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
+
+interface ProjectConfig {
+  domain?: string
+  scope?: string
+}
+
+/**
+ * Read .plur.yaml from cwd for project-level defaults.
+ * Returns {} if not found or unparseable.
+ */
+function readProjectConfig(): ProjectConfig {
+  const configPath = join(process.cwd(), '.plur.yaml')
+  if (!existsSync(configPath)) return {}
+  try {
+    const content = readFileSync(configPath, 'utf8')
+    const config: ProjectConfig = {}
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed.startsWith('#') || !trimmed) continue
+      const [key, ...rest] = trimmed.split(':')
+      const value = rest.join(':').trim()
+      if (key === 'domain') config.domain = value
+      if (key === 'scope') config.scope = value
+    }
+    return config
+  } catch {
+    return {}
+  }
+}
 
 function sessionDir(): string {
   const dir = join(tmpdir(), 'plur-sessions')
@@ -158,8 +192,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (!isRehydrate && existsSync(marker)) {
     if (isReminderDue()) {
       touchReminder()
+      const projectConfig = readProjectConfig()
+      const scopeHint = projectConfig.scope ? ` Use scope "${projectConfig.scope}" for plur_learn calls in this project.` : ''
       const output = {
-        additionalContext: '[PLUR Memory Reminder] If the user corrected you, stated a preference, or you discovered a pattern — call plur_learn now. Call plur_session_end with engram_suggestions before the conversation ends.',
+        additionalContext: `[PLUR Memory Reminder] If the user corrected you, stated a preference, or you discovered a pattern — call plur_learn now.${scopeHint} Call plur_session_end with engram_suggestions before the conversation ends.`,
       }
       process.stdout.write(JSON.stringify(output))
     }
@@ -167,13 +203,18 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   }
 
   const input = readStdinSync()
+  const projectConfig = readProjectConfig()
 
   // Get task description from hook input
   let task: string
   if (isRehydrate) {
     const summary = (input.compact_summary as string) || ''
     let original = ''
-    try { original = readFileSync(marker, 'utf8') } catch {}
+    try {
+      const raw = readFileSync(marker, 'utf8')
+      // Marker is JSON since 0.8.2 (was plain text before)
+      try { original = JSON.parse(raw).task || raw } catch { original = raw }
+    } catch {}
     task = original ? `${original} ${summary}` : summary || 'general context rehydration'
   } else {
     task = (input.prompt as string) || ''
@@ -181,17 +222,20 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       writeFileSync(marker, '')
       return
     }
-    writeFileSync(marker, task)
+    // Auto session start: generate session ID and save with task
+    const sessionId = randomUUID()
+    writeFileSync(marker, JSON.stringify({ task, sessionId }))
     touchReminder() // Reset reminder timer on first message
   }
 
-  // Inject engrams
+  // Inject engrams (with project scope if configured)
   const plur = createPlur(flags)
+  const injectOpts = projectConfig.scope ? { scope: projectConfig.scope } : undefined
   let context: string | null = null
   let count = 0
 
   try {
-    const result = await plur.injectHybrid(task)
+    const result = await plur.injectHybrid(task, injectOpts)
     if (result.count > 0) {
       const parts: string[] = []
       if (result.directives) parts.push(result.directives)
@@ -202,7 +246,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     }
   } catch {
     // Fall back to BM25
-    const result = plur.inject(task)
+    const result = plur.inject(task, injectOpts)
     if (result.count > 0) {
       const parts: string[] = []
       if (result.directives) parts.push(result.directives)
@@ -213,14 +257,32 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     }
   }
 
-  if (!context) {
-    return
+  // Build session header
+  const parts: string[] = []
+
+  // Read back session info for the label
+  let sessionId: string | undefined
+  try {
+    const markerData = JSON.parse(readFileSync(marker, 'utf8'))
+    sessionId = markerData.sessionId
+  } catch {}
+
+  if (isRehydrate) {
+    parts.push(`[PLUR Memory — rehydrated after compaction, ${count} engrams]`)
+  } else {
+    parts.push(`[PLUR Memory — session started, ${count} engrams injected]`)
+    if (sessionId) parts.push(`Session ID: ${sessionId}`)
+    if (projectConfig.domain) parts.push(`Project domain: ${projectConfig.domain}`)
+    if (projectConfig.scope) parts.push(`Project scope: ${projectConfig.scope} — use this scope for plur_learn calls`)
   }
 
-  const label = isRehydrate
-    ? `[PLUR Memory — rehydrated after compaction, ${count} engrams]`
-    : `[PLUR Memory — ${count} engrams injected]`
+  if (context) {
+    parts.push('')
+    parts.push(context)
+  }
 
-  const output = { additionalContext: `${label}\n\n${context}` }
+  if (parts.length === 0) return
+
+  const output = { additionalContext: parts.join('\n') }
   process.stdout.write(JSON.stringify(output))
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,22 +2,41 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
-import { outputText, exit } from '../output.js'
+import { outputText } from '../output.js'
+import {
+  buildMcpServerEntry,
+  claudeDesktopConfigPath,
+  hasPlurMcp,
+  mergePlurMcp,
+  readConfig,
+  writeConfig,
+} from '../mcp-config.js'
 
 /**
- * plur init — install Claude Code hooks for automatic engram injection.
+ * plur init — install Claude Code hooks AND register the plur MCP server.
  *
- * Adds hooks to .claude/settings.json (project-level if in a project, else global).
- * Hooks use `npx @plur-ai/cli inject` for engram selection — no Python, no Datacore deps.
+ * Two things must be in place for plur to work in Claude Code:
+ *
+ *   1. The `plur` MCP server must be registered, so the `plur_*` tools exist.
+ *   2. The lifecycle hooks must call `npx @plur-ai/cli hook-*` to inject
+ *      relevant engrams into the conversation.
+ *
+ * Earlier versions of `plur init` only did step 2, which led users to
+ * believe a separately-installed `datacore` MCP server *was* plur — because
+ * the CLAUDE.md section installed by init told the model to call
+ * `plur_session_start`, `plur_learn`, etc. and the model would then reach
+ * for whatever similarly-named tools it saw. This command now does both.
  *
  * Usage:
  *   plur init              # auto-detect project vs global
  *   plur init --global     # force global ~/.claude/settings.json
  *   plur init --project    # force project .claude/settings.json
+ *   plur init --no-desktop # skip Claude Desktop config registration
  */
 
 interface Settings {
   hooks?: Record<string, HookEntry[]>
+  mcpServers?: Record<string, unknown>
   [key: string]: unknown
 }
 
@@ -125,6 +144,8 @@ const CLAUDE_MD_SECTION = `## PLUR Memory
 
 You have persistent memory via PLUR. Corrections, preferences, and conventions persist across sessions as engrams.
 
+> **PLUR is its own MCP server.** The tools below come from the \`plur\` MCP server registered by \`plur init\` — \`plur_session_start\`, \`plur_learn\`, \`plur_recall_hybrid\`, \`plur_feedback\`, \`plur_session_end\`. If you do not see these exact tool names, **PLUR is not connected**: stop and run \`plur doctor\` to diagnose. Do **not** substitute tools from other MCP servers (e.g. \`datacore_*\`) — those belong to a different system and will not persist anything for PLUR.
+
 ### Session Workflow
 
 1. **Start**: Call \`plur_session_start\` with task description — injects relevant engrams
@@ -186,7 +207,7 @@ function installClaudeMd(): string {
   return `created ${claudeMdPath}`
 }
 
-function findSettingsPath(flags: GlobalFlags, args: string[]): string {
+function findSettingsPath(_flags: GlobalFlags, args: string[]): string {
   const forceGlobal = args.includes('--global')
   const forceProject = args.includes('--project')
 
@@ -239,35 +260,80 @@ function mergeHooks(settings: Settings): Settings {
   return { ...settings, hooks }
 }
 
+/**
+ * Register the plur MCP server in Claude Desktop's config file (if present
+ * or if --desktop is forced). Returns a status string for the report.
+ */
+function installDesktopMcp(args: string[]): string {
+  if (args.includes('--no-desktop')) return 'skipped (--no-desktop)'
+
+  const desktopPath = claudeDesktopConfigPath()
+  const forceDesktop = args.includes('--desktop')
+
+  if (!existsSync(desktopPath) && !forceDesktop) {
+    return 'not installed (Claude Desktop not detected — pass --desktop to force)'
+  }
+
+  const config = readConfig(desktopPath)
+  if (hasPlurMcp(config)) {
+    return `already registered in ${desktopPath}`
+  }
+
+  mergePlurMcp(config)
+  writeConfig(desktopPath, config)
+  return `registered in ${desktopPath}`
+}
+
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const settingsPath = findSettingsPath(flags, args)
   const settingsDir = join(settingsPath, '..')
 
   // Load existing settings
-  const settings = loadSettings(settingsPath)
+  let settings = loadSettings(settingsPath)
 
-  // Check if already installed
-  if (hasPlurHooks(settings)) {
-    outputText('PLUR hooks are already installed.')
-    outputText(`  Settings: ${settingsPath}`)
-    return
+  const hooksAlreadyInstalled = hasPlurHooks(settings)
+  const mcpAlreadyInstalled = hasPlurMcp(settings)
+
+  let hooksStatus: string
+  let mcpStatus: string
+
+  if (hooksAlreadyInstalled && mcpAlreadyInstalled) {
+    hooksStatus = 'already installed'
+    mcpStatus = 'already registered'
+  } else {
+    if (!hooksAlreadyInstalled) {
+      settings = mergeHooks(settings)
+      hooksStatus = 'installed'
+    } else {
+      hooksStatus = 'already installed'
+    }
+
+    if (!mcpAlreadyInstalled) {
+      mergePlurMcp(settings as Record<string, unknown>)
+      mcpStatus = 'registered'
+    } else {
+      mcpStatus = 'already registered'
+    }
+
+    // Ensure directory exists and write
+    mkdirSync(settingsDir, { recursive: true })
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n')
   }
-
-  // Merge hooks
-  const updated = mergeHooks(settings)
-
-  // Ensure directory exists
-  mkdirSync(settingsDir, { recursive: true })
-
-  // Write settings
-  writeFileSync(settingsPath, JSON.stringify(updated, null, 2) + '\n')
 
   // Install CLAUDE.md section
   const claudeMdStatus = installClaudeMd()
 
+  // Register in Claude Desktop too
+  const desktopStatus = installDesktopMcp(args)
+
+  const entry = buildMcpServerEntry()
+
   outputText('PLUR installed for Claude Code.')
   outputText('')
-  outputText('Hooks added (9):')
+  outputText(`MCP server (plur): ${mcpStatus}`)
+  outputText(`  command: ${entry.command} ${entry.args.join(' ')}`)
+  outputText('')
+  outputText(`Hooks (9):         ${hooksStatus}`)
   outputText('  UserPromptSubmit  — inject relevant engrams on first message')
   outputText('  PostCompact       — re-inject engrams after context compaction')
   outputText('  PreToolUse        — contextual injection (plan mode, skills, agents)')
@@ -276,8 +342,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   outputText('  SubagentStart     — inject agent-scoped engrams into subagents')
   outputText('  Stop              — learning reflection nudge (every 3rd response)')
   outputText('')
-  outputText(`Settings:  ${settingsPath}`)
-  outputText(`CLAUDE.md: ${claudeMdStatus}`)
+  outputText(`Settings:       ${settingsPath}`)
+  outputText(`Claude Desktop: ${desktopStatus}`)
+  outputText(`CLAUDE.md:      ${claudeMdStatus}`)
   outputText('')
-  outputText('Restart Claude Code to pick up the changes.')
+  outputText('Restart Claude Code to pick up the changes, then run `plur doctor` to verify.')
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,23 +15,23 @@ import {
 /**
  * plur init — install Claude Code hooks AND register the plur MCP server.
  *
+ * Architecture: PLUR is a GLOBAL tool. One MCP server, one engram store
+ * (~/.plur/), available in every project. Per-project scoping is handled
+ * via domain/scope fields on engrams, not separate installations.
+ *
  * Two things must be in place for plur to work in Claude Code:
  *
  *   1. The `plur` MCP server must be registered, so the `plur_*` tools exist.
  *   2. The lifecycle hooks must call `npx @plur-ai/cli hook-*` to inject
  *      relevant engrams into the conversation.
  *
- * Earlier versions of `plur init` only did step 2, which led users to
- * believe a separately-installed `datacore` MCP server *was* plur — because
- * the CLAUDE.md section installed by init told the model to call
- * `plur_session_start`, `plur_learn`, etc. and the model would then reach
- * for whatever similarly-named tools it saw. This command now does both.
- *
  * Usage:
  *   plur init              # auto-detect project vs global
  *   plur init --global     # force global ~/.claude/settings.json
  *   plur init --project    # force project .claude/settings.json
  *   plur init --no-desktop # skip Claude Desktop config registration
+ *   plur init --domain X   # set default domain for this project (.plur.yaml)
+ *   plur init --scope Y    # set default scope for this project (.plur.yaml)
  */
 
 interface Settings {
@@ -144,17 +144,25 @@ const CLAUDE_MD_SECTION = `## PLUR Memory
 
 You have persistent memory via PLUR. Corrections, preferences, and conventions persist across sessions as engrams.
 
-> **PLUR is its own MCP server.** The tools below come from the \`plur\` MCP server registered by \`plur init\` — \`plur_session_start\`, \`plur_learn\`, \`plur_recall_hybrid\`, \`plur_feedback\`, \`plur_session_end\`. If you do not see these exact tool names, **PLUR is not connected**: stop and run \`plur doctor\` to diagnose. Do **not** substitute tools from other MCP servers (e.g. \`datacore_*\`) — those belong to a different system and will not persist anything for PLUR.
+### Architecture
+
+PLUR is installed **globally** — one MCP server, one engram store (\`~/.plur/\`), available in every project. You do NOT need per-project installation. The \`plur\` MCP server provides tools named \`plur_session_start\`, \`plur_learn\`, \`plur_recall_hybrid\`, \`plur_feedback\`, \`plur_session_end\`, etc. If you cannot find these tools, run \`plur doctor\` to diagnose. Do **not** substitute tools from other MCP servers (e.g. \`datacore_*\`) — those belong to a different system.
+
+Hooks inject engrams automatically on every first message — you do not need to call \`plur_session_start\` manually (though you can for explicit session tracking).
 
 ### Session Workflow
 
-1. **Start**: Call \`plur_session_start\` with task description — injects relevant engrams
+1. **Automatic**: Hooks inject relevant engrams on first message — no action needed
 2. **Learn**: When corrected or discovering something new, call \`plur_learn\` immediately
 3. **Recall**: Before answering factual questions, call \`plur_recall_hybrid\` — check memory first
 4. **Feedback**: Rate injected engrams with \`plur_feedback\` (positive/negative) — trains relevance
 5. **End**: Call \`plur_session_end\` with summary + engram_suggestions
 
 Do not ask permission to use these tools — they are your memory system.
+
+### Multi-project scoping
+
+PLUR uses \`domain\` and \`scope\` fields on engrams to separate knowledge by project. When calling \`plur_learn\`, set \`scope\` (e.g. \`project:my-app\`) to namespace the engram. Scoped recall automatically includes global engrams.
 
 ### When to check memory
 
@@ -164,29 +172,35 @@ Before reaching for web search, file reads, or guessing — apply this priority:
 3. Is the answer derivable from context already loaded? → Just answer
 4. Only if 1-3 fail → Use external tools
 
-| Domain | When to recall |
-|--------|----------------|
-| Decisions | Past design choices, architecture rationale |
-| Corrections | API quirks, bugs, wrong assumptions |
-| Preferences | Formatting, tone, workflow, tool choices |
-| Conventions | Tag formats, file routing, naming rules |
-| Infrastructure | Server IPs, SSH configs, deployment targets |
-
 ### When corrected
 
 When the user corrects you ("no, use X not Y", "that's wrong"):
 1. Call \`plur_learn\` immediately — before continuing the task
 2. Call \`plur_feedback\` with negative signal on the wrong engram if one was injected
 3. Then continue with the corrected approach
-
-### Verification
-
-When recalling facts that will drive actions:
-1. State the recalled fact explicitly before acting on it
-2. Include the engram ID or search that produced it
-3. If no engram matches, say so and verify from the filesystem
-4. Never interpolate between two engrams to produce a "probably correct" composite
 `
+
+/**
+ * Write a .plur.yaml project config with default domain/scope.
+ * This file is read by hooks to auto-apply scoping to learn/recall calls.
+ */
+function installProjectConfig(args: string[]): string | null {
+  const domainIdx = args.indexOf('--domain')
+  const scopeIdx = args.indexOf('--scope')
+  const domain = domainIdx >= 0 ? args[domainIdx + 1] : null
+  const scope = scopeIdx >= 0 ? args[scopeIdx + 1] : null
+
+  if (!domain && !scope) return null
+
+  const configPath = join(process.cwd(), '.plur.yaml')
+  const lines: string[] = ['# PLUR project defaults — read by hooks for automatic scoping']
+  if (domain) lines.push(`domain: ${domain}`)
+  if (scope) lines.push(`scope: ${scope}`)
+  lines.push('')
+
+  writeFileSync(configPath, lines.join('\n'))
+  return configPath
+}
 
 function installClaudeMd(): string {
   const marker = '## PLUR Memory'
@@ -326,15 +340,22 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // Register in Claude Desktop too
   const desktopStatus = installDesktopMcp(args)
 
+  // Write project config if --domain or --scope provided
+  const projectConfigPath = installProjectConfig(args)
+
   const entry = buildMcpServerEntry()
 
   outputText('PLUR installed for Claude Code.')
+  outputText('')
+  outputText('Architecture: PLUR is a global tool — one MCP server, one engram')
+  outputText('store (~/.plur/), available in every project. Multi-project scoping')
+  outputText('is handled via domain/scope fields on engrams, not per-project installs.')
   outputText('')
   outputText(`MCP server (plur): ${mcpStatus}`)
   outputText(`  command: ${entry.command} ${entry.args.join(' ')}`)
   outputText('')
   outputText(`Hooks (9):         ${hooksStatus}`)
-  outputText('  UserPromptSubmit  — inject relevant engrams on first message')
+  outputText('  UserPromptSubmit  — inject engrams + auto-start session')
   outputText('  PostCompact       — re-inject engrams after context compaction')
   outputText('  PreToolUse        — contextual injection (plan mode, skills, agents)')
   outputText('  PreToolUse        — observation capture for pattern learning')
@@ -345,6 +366,15 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   outputText(`Settings:       ${settingsPath}`)
   outputText(`Claude Desktop: ${desktopStatus}`)
   outputText(`CLAUDE.md:      ${claudeMdStatus}`)
+  if (projectConfigPath) {
+    outputText(`Project config: ${projectConfigPath}`)
+  }
   outputText('')
+  if (projectConfigPath) {
+    outputText('Project scoping configured. Engrams learned in this project will')
+    outputText('be tagged automatically. Run `plur init --domain X --scope Y` in')
+    outputText('other projects to set their defaults.')
+    outputText('')
+  }
   outputText('Restart Claude Code to pick up the changes, then run `plur doctor` to verify.')
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { parseGlobalFlags, createPlur } from './plur.js'
 export type { GlobalFlags } from './plur.js'
 export { parseGlobalFlags, createPlur } from './plur.js'
 
-const VERSION = '0.8.1'
+const VERSION = '0.8.2'
 
 // --- Main ---
 const argv = process.argv.slice(2)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { parseGlobalFlags, createPlur } from './plur.js'
 export type { GlobalFlags } from './plur.js'
 export { parseGlobalFlags, createPlur } from './plur.js'
 
-const VERSION = '0.8.0'
+const VERSION = '0.8.1'
 
 // --- Main ---
 const argv = process.argv.slice(2)
@@ -38,7 +38,8 @@ Commands:
   migrate [up|down|status] Run schema migrations
   stores list             List configured stores
   stores add <path>       Add a knowledge store
-  init                    Install Claude Code hooks for automatic injection
+  init                    Install Claude Code hooks + register plur MCP server
+  doctor                  Diagnose Claude Code / Claude Desktop integration
   hook-inject             (internal) Hook handler for engram injection
   hook-observe            (internal) Hook handler for observation capture
   hook-learn-check        (internal) Hook handler for learning reflection
@@ -74,6 +75,7 @@ const COMMANDS: Record<string, string> = {
   stores: './commands/stores.js',
   migrate: './commands/migrate.js',
   init: './commands/init.js',
+  doctor: './commands/doctor.js',
   'hook-inject': './commands/hook-inject.js',
   'hook-observe': './commands/hook-observe.js',
   'hook-learn-check': './commands/hook-learn-check.js',

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -1,0 +1,159 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { join, dirname } from 'path'
+import { homedir, platform } from 'os'
+
+/**
+ * Shared logic for managing the `plur` MCP server registration in
+ * Claude Code and Claude Desktop config files.
+ *
+ * Used by `plur init` (write) and `plur doctor` (read + verify).
+ */
+
+export interface McpServerEntry {
+  command: string
+  args: string[]
+  env?: Record<string, string>
+}
+
+export interface ConfigFile {
+  /** Human-readable label for `plur doctor` output. */
+  label: string
+  /** Absolute path to the config file. */
+  path: string
+  /** Whether this config exists on disk right now. */
+  exists: boolean
+  /** Whether this is the Claude Desktop format (mcpServers only) vs Claude Code (mcpServers + hooks). */
+  kind: 'claude-code' | 'claude-desktop'
+}
+
+/**
+ * Build the MCP server entry to register for the `plur` server.
+ *
+ * Uses a login-shell wrapper on macOS/Linux so that PATH (nvm/brew/volta/asdf)
+ * is loaded — Claude Desktop launches GUI apps without the user's shell PATH,
+ * which would otherwise cause `npx` to fail with "command not found".
+ *
+ * On Windows, uses `cmd.exe /c npx ...` which inherits the system PATH that
+ * already includes Node from the installer.
+ */
+export function buildMcpServerEntry(): McpServerEntry {
+  if (platform() === 'win32') {
+    return {
+      command: 'cmd.exe',
+      args: ['/c', 'npx', '-y', '@plur-ai/mcp@latest'],
+    }
+  }
+  return {
+    command: '/bin/sh',
+    args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'],
+  }
+}
+
+/**
+ * Locate the Claude Desktop config file for the current platform.
+ */
+export function claudeDesktopConfigPath(): string {
+  const p = platform()
+  if (p === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
+  }
+  if (p === 'win32') {
+    const appData = process.env.APPDATA || join(homedir(), 'AppData', 'Roaming')
+    return join(appData, 'Claude', 'claude_desktop_config.json')
+  }
+  return join(homedir(), '.config', 'Claude', 'claude_desktop_config.json')
+}
+
+/**
+ * Locate the Claude Code global settings.json file.
+ */
+export function claudeCodeGlobalSettingsPath(): string {
+  return join(homedir(), '.claude', 'settings.json')
+}
+
+/**
+ * List all known config files (existing or not) so the doctor command
+ * can report on each.
+ */
+export function knownConfigFiles(cwd: string = process.cwd()): ConfigFile[] {
+  const projectSettings = join(cwd, '.claude', 'settings.json')
+  const projectMcp = join(cwd, '.mcp.json')
+  const globalSettings = claudeCodeGlobalSettingsPath()
+  const desktop = claudeDesktopConfigPath()
+
+  return [
+    {
+      label: 'Claude Code (project)',
+      path: projectSettings,
+      exists: existsSync(projectSettings),
+      kind: 'claude-code',
+    },
+    {
+      label: 'Claude Code (.mcp.json)',
+      path: projectMcp,
+      exists: existsSync(projectMcp),
+      kind: 'claude-desktop', // same shape: just mcpServers
+    },
+    {
+      label: 'Claude Code (global)',
+      path: globalSettings,
+      exists: existsSync(globalSettings),
+      kind: 'claude-code',
+    },
+    {
+      label: 'Claude Desktop',
+      path: desktop,
+      exists: existsSync(desktop),
+      kind: 'claude-desktop',
+    },
+  ]
+}
+
+/**
+ * Read a JSON config file. Returns {} if missing or unparseable.
+ */
+export function readConfig(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {}
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Write a JSON config file, creating parent directories if needed.
+ */
+export function writeConfig(path: string, data: Record<string, unknown>): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n')
+}
+
+/**
+ * Check whether the `plur` MCP server is registered in a config object.
+ */
+export function hasPlurMcp(config: Record<string, unknown>): boolean {
+  const servers = (config.mcpServers ?? {}) as Record<string, unknown>
+  return 'plur' in servers
+}
+
+/**
+ * Detect a `datacore` MCP server entry — used by doctor to surface the
+ * "plur ≠ datacore" collision warning that has confused users in the wild.
+ */
+export function hasDatacoreMcp(config: Record<string, unknown>): boolean {
+  const servers = (config.mcpServers ?? {}) as Record<string, unknown>
+  return 'datacore' in servers
+}
+
+/**
+ * Merge the `plur` MCP server entry into a config object. Idempotent.
+ * Returns true if a change was made, false if `plur` was already present.
+ */
+export function mergePlurMcp(config: Record<string, unknown>): boolean {
+  const servers = (config.mcpServers ?? {}) as Record<string, McpServerEntry>
+  if ('plur' in servers) return false
+  servers.plur = buildMcpServerEntry()
+  config.mcpServers = servers
+  return true
+}

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('plur doctor', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-doctor-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  function runDoctor(): { stdout: string; status: number } {
+    try {
+      const stdout = execSync(`node ${CLI} doctor --no-handshake --json`, {
+        encoding: 'utf-8',
+        timeout: 15000,
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        cwd: home,
+      })
+      return { stdout, status: 0 }
+    } catch (err: any) {
+      return { stdout: err.stdout?.toString() ?? '', status: err.status ?? 1 }
+    }
+  }
+
+  function writeGlobalSettings(content: object): void {
+    const dir = join(home, '.claude')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'settings.json'), JSON.stringify(content, null, 2))
+  }
+
+  it('reports fail and exits non-zero on a fresh empty environment', () => {
+    const { stdout, status } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(status).toBe(1)
+    expect(report.overall).toBe('fail')
+    expect(report.hooksInstalled).toBe(false)
+    expect(report.mcpRegistered).toBe(false)
+  })
+
+  it('reports ok when both hooks and plur MCP are present', () => {
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject' }] },
+        ],
+      },
+      mcpServers: {
+        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+      },
+    })
+
+    const { stdout, status } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(status).toBe(0)
+    expect(report.overall).toBe('ok')
+    expect(report.hooksInstalled).toBe(true)
+    expect(report.mcpRegistered).toBe(true)
+    expect(report.datacoreCollision).toBe(false)
+  })
+
+  it('flags datacore collision when both servers are registered', () => {
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject' }] },
+        ],
+      },
+      mcpServers: {
+        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        datacore: { command: 'node', args: ['/path/to/datacore.js'] },
+      },
+    })
+
+    const { stdout } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(report.datacoreCollision).toBe(true)
+    // Should still be ok overall — collision is a warning, not a failure
+    expect(report.mcpRegistered).toBe(true)
+    expect(report.hooksInstalled).toBe(true)
+  })
+
+  it('detects hooks-only install (the broken pre-0.8.1 state)', () => {
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject' }] },
+        ],
+      },
+    })
+
+    const { stdout, status } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(status).toBe(1)
+    expect(report.hooksInstalled).toBe(true)
+    expect(report.mcpRegistered).toBe(false)
+    expect(report.overall).toBe('fail')
+  })
+
+  it('lists all known config file locations in the report', () => {
+    const { stdout } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    const labels = report.configs.map((c: { label: string }) => c.label)
+    expect(labels).toContain('Claude Code (global)')
+    expect(labels).toContain('Claude Desktop')
+    expect(labels).toContain('Claude Code (.mcp.json)')
+  })
+
+  it('handshake is skipped when --no-handshake is passed', () => {
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject' }] },
+        ],
+      },
+      mcpServers: {
+        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+      },
+    })
+
+    const { stdout } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(report.handshake.error).toContain('skipped')
+    // ok overall because handshake is gated behind the skip flag
+    expect(report.overall).toBe('ok')
+  })
+})

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir, platform } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+interface Settings {
+  hooks?: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>>
+  mcpServers?: Record<string, { command: string; args: string[] }>
+}
+
+describe('plur init', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-init-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  function runInit(extra: string = ''): string {
+    return execSync(`node ${CLI} init --global --no-desktop ${extra}`, {
+      encoding: 'utf-8',
+      timeout: 15000,
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      cwd: home,
+    })
+  }
+
+  function readSettings(): Settings {
+    const path = join(home, '.claude', 'settings.json')
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  }
+
+  it('writes settings.json with hooks and plur MCP server on a fresh install', () => {
+    const output = runInit()
+    expect(output).toContain('PLUR installed')
+
+    const settings = readSettings()
+
+    // Hooks installed
+    expect(settings.hooks).toBeDefined()
+    expect(settings.hooks?.UserPromptSubmit).toBeDefined()
+    expect(settings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toContain('@plur-ai/cli hook-inject')
+
+    // MCP server registered
+    expect(settings.mcpServers).toBeDefined()
+    expect(settings.mcpServers?.plur).toBeDefined()
+  })
+
+  it('registers the MCP server with a platform-appropriate command', () => {
+    runInit()
+    const settings = readSettings()
+    const plur = settings.mcpServers?.plur
+    expect(plur).toBeDefined()
+
+    if (platform() === 'win32') {
+      expect(plur?.command).toBe('cmd.exe')
+      expect(plur?.args).toContain('npx')
+      expect(plur?.args.join(' ')).toContain('@plur-ai/mcp')
+    } else {
+      // macOS/Linux: login shell wrapper so PATH (nvm/brew) loads under GUI launches
+      expect(plur?.command).toBe('/bin/sh')
+      expect(plur?.args).toContain('-lc')
+      expect(plur?.args.join(' ')).toContain('npx -y @plur-ai/mcp')
+    }
+  })
+
+  it('is idempotent — re-running does not duplicate hooks or mcp entries', () => {
+    runInit()
+    const first = readSettings()
+    const firstHookCount = first.hooks?.UserPromptSubmit?.length ?? 0
+
+    runInit()
+    const second = readSettings()
+    const secondHookCount = second.hooks?.UserPromptSubmit?.length ?? 0
+
+    expect(secondHookCount).toBe(firstHookCount)
+    // Still exactly one plur entry
+    expect(Object.keys(second.mcpServers ?? {}).filter((k) => k === 'plur')).toHaveLength(1)
+  })
+
+  it('upgrade path: hooks-only install gets MCP added without re-adding hooks', () => {
+    // Simulate an old (pre-0.8.1) install: hooks present, MCP missing
+    const settingsPath = join(home, '.claude', 'settings.json')
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          hooks: {
+            UserPromptSubmit: [
+              { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject', timeout: 15 }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    )
+
+    runInit()
+    const settings = readSettings()
+
+    // Hooks not duplicated — still exactly one entry under UserPromptSubmit
+    expect(settings.hooks?.UserPromptSubmit?.length).toBe(1)
+    // MCP server now registered
+    expect(settings.mcpServers?.plur).toBeDefined()
+  })
+
+  it('preserves unrelated existing settings keys', () => {
+    const settingsPath = join(home, '.claude', 'settings.json')
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          model: 'opus',
+          mcpServers: { datacore: { command: 'node', args: ['/path/to/datacore.js'] } },
+        },
+        null,
+        2,
+      ),
+    )
+
+    runInit()
+    const raw = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+
+    expect(raw.model).toBe('opus')
+    expect(raw.mcpServers.datacore).toBeDefined()
+    expect(raw.mcpServers.plur).toBeDefined()
+    expect(raw.hooks).toBeDefined()
+  })
+
+  it('skips Claude Desktop registration when --no-desktop is passed', () => {
+    runInit()
+    // The desktop config path is platform-specific, but with HOME overridden
+    // it would land under home/. Just assert no desktop file was created.
+    const desktopOnDarwin = join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
+    const desktopOnLinux = join(home, '.config', 'Claude', 'claude_desktop_config.json')
+    expect(existsSync(desktopOnDarwin)).toBe(false)
+    expect(existsSync(desktopOnLinux)).toBe(false)
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/core",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/mcp",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "type": "module",
   "bin": {
     "plur-mcp": "dist/index.js"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
-const VERSION = '0.8.0'
+const VERSION = '0.8.2'
 
 const HELP = `plur-mcp v${VERSION} — persistent memory for AI agents
 
@@ -82,9 +82,15 @@ const CLAUDE_MD_SECTION = `## PLUR Memory
 
 You have persistent memory via PLUR. Corrections, preferences, and conventions persist across sessions as engrams.
 
+### Architecture
+
+PLUR is installed **globally** — one MCP server, one engram store (\`~/.plur/\`), available in every project. You do NOT need per-project installation. Multi-project scoping uses \`domain\` and \`scope\` fields on engrams, not separate stores.
+
+Hooks inject engrams automatically on every first message — you do not need to call \`plur_session_start\` manually (though you can for explicit session tracking).
+
 ### Session Workflow
 
-1. **Start**: Call \`plur_session_start\` with task description — injects relevant engrams
+1. **Automatic**: Hooks inject relevant engrams on first message — no action needed
 2. **Learn**: When corrected or discovering something new, call \`plur_learn\` immediately
 3. **Recall**: Before answering factual questions, call \`plur_recall_hybrid\` — check memory first
 4. **Feedback**: Rate injected engrams with \`plur_feedback\` (positive/negative) — trains relevance
@@ -92,36 +98,12 @@ You have persistent memory via PLUR. Corrections, preferences, and conventions p
 
 Do not ask permission to use these tools — they are your memory system.
 
-### When to check memory
-
-Before reaching for web search, file reads, or guessing — apply this priority:
-1. Is the answer already in engrams? → \`plur_recall_hybrid\`
-2. Is the answer in the local filesystem? → Read/Grep/Glob
-3. Is the answer derivable from context already loaded? → Just answer
-4. Only if 1-3 fail → Use external tools
-
-| Domain | When to recall |
-|--------|----------------|
-| Decisions | Past design choices, architecture rationale |
-| Corrections | API quirks, bugs, wrong assumptions |
-| Preferences | Formatting, tone, workflow, tool choices |
-| Conventions | Tag formats, file routing, naming rules |
-| Infrastructure | Server IPs, SSH configs, deployment targets |
-
 ### When corrected
 
 When the user corrects you ("no, use X not Y", "that's wrong"):
 1. Call \`plur_learn\` immediately — before continuing the task
 2. Call \`plur_feedback\` with negative signal on the wrong engram if one was injected
 3. Then continue with the corrected approach
-
-### Verification
-
-When recalling facts that will drive actions:
-1. State the recalled fact explicitly before acting on it
-2. Include the engram ID or search that produced it
-3. If no engram matches, say so and verify from the filesystem
-4. Never interpolate between two engrams to produce a "probably correct" composite
 `
 
 // --- Functions ---
@@ -243,6 +225,10 @@ async function runInit() {
   results.push(`CLAUDE.md: ${claudeMdStatus}`)
 
   process.stdout.write(`PLUR initialized.
+
+  Architecture: PLUR is a global tool — one MCP server, one engram
+  store (~/.plur/), available in every project. Multi-project scoping
+  uses domain/scope fields on engrams, not separate installations.
 
   ${results.join('\n  ')}
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,15 +14,17 @@ import { Plur, checkForUpdate } from '@plur-ai/core'
 import { getToolDefinitions } from './tools.js'
 import { z } from 'zod'
 
-const VERSION = '0.8.0'
+const VERSION = '0.8.2'
 
 const INSTRUCTIONS = `PLUR is your persistent memory. Corrections, preferences, and conventions persist across sessions as engrams.
 
-REQUIRED at session boundaries:
-- FIRST ACTION of every session: call plur_session_start with a task description
-- LAST ACTION before conversation ends: call plur_session_end with summary + engram_suggestions
+PLUR is a GLOBAL tool — one MCP server, one engram store (~/.plur/), available in every project. Multi-project scoping uses domain/scope fields on engrams, not separate installations.
 
-REQUIRED during the session:
+SESSION LIFECYCLE:
+- With hooks installed (plur init): engrams are injected automatically on first message. You do NOT need to call plur_session_start — it happens via hooks. Just call plur_session_end before the conversation ends.
+- Without hooks: call plur_session_start at the start, plur_session_end at the end.
+
+DURING the session:
 - When user corrects you ("no, use X not Y") → call plur_learn immediately
 - When user states a preference ("always X", "never Y") → call plur_learn immediately
 - When you discover a codebase convention or pattern → call plur_learn
@@ -31,12 +33,10 @@ OPTIONAL but improves quality:
 - Call plur_feedback to rate which injected engrams helped (positive/negative)
 - Call plur_recall_hybrid before answering factual questions — the answer may be in memory
 
-For combined search (engrams + files): call plur_recall_hybrid for memories, then datacore.search for journal/knowledge files.
-
 Do not ask permission to use these tools — they are your memory system.
 
-Setup: If this is a fresh install, suggest the user run: npx @plur-ai/cli init
-This installs Claude Code hooks for automatic engram injection. Without hooks, injection only happens when you call plur_session_start.`
+Setup: If this is a fresh install, suggest the user run: npx @plur-ai/mcp init
+This installs hooks for automatic injection + session management. One-time global setup.`
 
 const GUIDE_RESOURCE = `# PLUR — Agent Guide
 

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -32,7 +32,7 @@ describe('MCP server (wire protocol)', () => {
   it('returns server info with instructions on initialize', () => {
     const info = client.getServerVersion()
     expect(info?.name).toBe('plur-mcp')
-    expect(info?.version).toBe('0.8.0')
+    expect(info?.version).toBe('0.8.2')
   })
 
   // --- Tools ---
@@ -129,7 +129,7 @@ describe('MCP server (wire protocol)', () => {
     const result = await client.readResource({ uri: 'plur://status' })
     const data = JSON.parse((result.contents[0] as any).text)
     expect(data.engram_count).toBe(1)
-    expect(data.version).toBe('0.8.0')
+    expect(data.version).toBe('0.8.2')
     expect(data.storage_root).toBe(dir)
   })
 


### PR DESCRIPTION
## Summary

- `plur init` now also writes `mcpServers.plur` into `settings.json` — previously it installed only the lifecycle hooks, leaving the `plur_*` tools unavailable. Users with a separate `datacore` MCP server installed would silently see the model substitute `datacore_*` tools and conclude "plur uses datacore as its engine."
- New `plur doctor` command diagnoses Claude Code / Claude Desktop installs: reports hook + MCP presence across all known config files, surfaces a `datacore` collision warning, and runs a live MCP handshake (spawn + `initialize` JSON-RPC, 20s timeout for first-run npx fetch).
- Patch release `0.8.1` — fixes the broken `init` contract; doctor + MCP registration are part of fixing it, not new features.

## Why this happened in the wild

A user ran `npx @plur-ai/cli init`, restarted Claude, and saw:
1. Hooks firing (`npx @plur-ai/cli hook-inject`) ✅
2. `CLAUDE.md` telling the model to call `plur_session_start`, `plur_learn`, `plur_recall_hybrid` ✅
3. No `plur_*` tools registered ❌
4. A `datacore` MCP server present from an earlier install — model assumed `datacore_session_start`, `datacore_learn` were the plur tools and proceeded to record everything to the wrong system.

The CLAUDE.md section is now updated with an explicit warning: *plur tools come from the plur MCP server; do not substitute datacore_\* tools.*

## Implementation

- `packages/cli/src/mcp-config.ts` (new): shared module for reading/writing Claude Code (`~/.claude/settings.json`, project `.claude/settings.json`, `.mcp.json`) and Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS) configs. MCP entry uses `/bin/sh -lc 'exec npx -y @plur-ai/mcp@latest'` on macOS/Linux so Claude Desktop's GUI launches inherit the user's shell PATH (nvm/brew/volta/asdf). Windows uses `cmd.exe /c npx ...`.
- `packages/cli/src/commands/init.ts`: writes both hooks and `mcpServers.plur`. Idempotent. Detects upgrade path (hooks present, MCP missing) and adds only what's missing. Optional Claude Desktop registration auto-enabled if the desktop config exists; `--no-desktop` opts out.
- `packages/cli/src/commands/doctor.ts` (new): diagnostic with text + `--json` modes, `--no-handshake` for tests.
- 12 new tests across `init.test.ts` and `doctor.test.ts`. All 63 cli tests pass. Pre-existing failures in `packages/claw`, `packages/mcp`, `packages/core` are unchanged on `main`.

## Test plan

- [x] `pnpm --filter @plur-ai/cli build`
- [x] `pnpm --filter @plur-ai/cli test` — 15 files / 63 tests green
- [x] Live handshake against published `@plur-ai/mcp@latest` succeeds
- [x] Doctor correctly diagnoses my own machine as "hooks installed, MCP missing" — exactly the bug
- [ ] Publish `@plur-ai/cli@0.8.1`, then run `npx @plur-ai/cli@latest init && npx @plur-ai/cli@latest doctor` on the original user's machine to verify the fix end-to-end (this is also our integration test)

## Follow-ups (not in this PR)

- Telemetry on `plur doctor` failure modes so we learn which environments still trip over `npx`
- Detect Claude Code CLI's `claude mcp add` and prefer it when available (for users who manage their config that way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)