### PR TITLE
fix(core): robust BM25 fallback for tiny/uniform corpora (#30)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -111,9 +111,21 @@ export function searchEngrams(engrams: Engram[], query: string, limit = 20): Eng
     ? engrams.reduce((sum, e) => sum + ftsTokenize(engramSearchText(e)).length, 0) / engrams.length
     : 0
 
-  return engrams
+  let scored = engrams
     .map(e => ({ engram: e, score: ftsScore(e, queryTokens, idfWeights, avgDocLength) }))
     .filter(r => r.score > 0)
+
+  // Fallback: on tiny/uniform corpora, every query token can be either
+  // corpus-universal (IDF skipped to 0) or corpus-absent (tf=0), collapsing
+  // all scores to 0. Re-score with uniform weights so we still surface
+  // lexically-similar docs.
+  if (scored.length === 0) {
+    scored = engrams
+      .map(e => ({ engram: e, score: ftsScore(e, queryTokens, undefined, avgDocLength) }))
+      .filter(r => r.score > 0)
+  }
+
+  return scored
     .sort((a, b) => b.score - a.score)
     .slice(0, limit)
     .map(r => r.engram)

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -187,6 +187,11 @@ export async function learnAsync(
   } catch {
     candidates = deps.recall(statement, { limit: 5 })
   }
+  // Fallback to BM25 when hybrid returns empty (e.g. embedding model warmup on
+  // cold CI runners makes embeddings return []; BM25 usually still matches).
+  if (candidates.length === 0) {
+    candidates = deps.recall(statement, { limit: 5 })
+  }
   candidates = candidates.filter(c => c.status === 'active')
 
   if (candidates.length === 0) {


### PR DESCRIPTION
## Summary

Fixes **Signature A** of #30: `learnAsync circuit breaker trips after 3 failures` flake that is now causing **deterministic CI failures** on main (last 5+ runs red).

## Root cause

Two-layer collapse in BM25 scoring on tiny corpora (typical in tests):

1. When every query token is either **corpus-universal** (IDF skipped to 0) or **corpus-absent** (tf=0), BM25 collapses every document score to 0 and returns `[]`.
2. The circuit-breaker test depends on `recallHybrid` finding the seeded engram so LLM dedup actually runs and increments the failure counter. When BM25 hides candidates and embeddings are cold/unavailable on CI runners, `learnAsync` early-returns at `learn-async.ts:192` (`candidates.length === 0`), the LLM is never called, and the breaker never trips.

## Fix

1. **`fts.ts`** — when BM25 with IDF weights scores every doc at 0, re-score with uniform weights (no IDF) so lexically-similar docs still surface.
2. **`learn-async.ts`** — when `recallHybrid` returns `[]` (embedding warmup on cold CI runners), fall back to BM25 `deps.recall()` in addition to the existing throw-catch fallback.

## Validation

- `sp1-memory-intelligence.test.ts` circuit-breaker test: 5/5 locally (was ~1/5 in CI).
- All existing core tests still pass.

## Scope

Signature B (multi-store `recallHybrid` / `similaritySearch`) is tracked separately in #30 and not addressed here — that's a distinct issue (store fanout / cross-store index refresh).

Closes Signature A of #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)