### PR TITLE
docs(benchmarks): verify Letta temporal / encryption / MCP cells (#8)

### DIFF
--- a/docs/benchmarks/feature-comparison.md
+++ b/docs/benchmarks/feature-comparison.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft, Phase 1 (feature matrix). Performance benchmarks tracked separately — see [Issue #8 Phase 2](https://github.com/plur-ai/plur/issues/8).
 
-**Last updated:** 2026-04-22 (Zep/Graphiti row split + verified)
+**Last updated:** 2026-04-22 (Letta row — temporal / encryption / MCP cells verified)
 
 ## Scope
 
@@ -49,7 +49,7 @@ The local-first memory space went from "a few projects" to "a credible category"
 | System | Local-first | Team-shareable | Sync mechanism | Storage | Search | Feedback loop | Temporal | Encryption | Cross-tool (MCP) | Pack format | License |
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | **Claude Code built-in memory** | Yes | No | — | Markdown in `~/.claude/` | Keyword | No | File mtime | No | **No (Claude Code only)** | No | Proprietary |
-| **Letta / MemGPT** | Hybrid | Shared memory blocks (multi-agent, not multi-user) | Cloud | Postgres + custom | Self-managing recall | Yes (sleep-time compute) | ? | ? | SDK (not MCP-native) | No | Apache-2.0 |
+| **Letta / MemGPT** ([source](https://github.com/letta-ai/letta)) | Hybrid | [Shared memory blocks](https://docs.letta.com/guides/agents/memory) (multi-agent, not multi-user) | Cloud | Postgres + pgvector | Self-managing recall | Yes (sleep-time compute) | No (editable [memory blocks](https://docs.letta.com/guides/agents/memory); no validity windows / "what was true when") | Not first-party ([deploy-layer only, e.g. Postgres/Aurora encryption](https://aws.amazon.com/blogs/database/how-letta-builds-production-ready-ai-agents-with-amazon-aurora-postgresql/)) | [MCP client only](https://docs.letta.com/guides/mcp/overview) (consumes external MCP tools; memory exposed via SDK, not MCP) | No | Apache-2.0 |
 | **Graphiti** ([source](https://github.com/getzep/graphiti)) | Yes (self-hosted OSS) | No (single-instance OSS) | — | Neo4j / FalkorDB / Kuzu / Neptune (pluggable) | [Hybrid (semantic + BM25 + graph traversal)](https://github.com/getzep/graphiti#why-graphiti) | [Auto-invalidation of contradicting facts](https://github.com/getzep/graphiti#why-graphiti) (temporal; old facts invalidated, not deleted) | **Yes (bi-temporal validity windows)** | Not in OSS (backend-dependent) | **Yes ([first-party MCP server](https://github.com/getzep/graphiti/tree/main/mcp_server))** | No | Apache-2.0 |
 | **Zep** ([source](https://www.getzep.com/)) | Hybrid (managed cloud; self-host via Graphiti OSS) | **Yes (managed users/threads)** | Cloud | Managed (Graphiti-backed) | Hybrid (semantic + BM25 + graph) | [Auto-invalidation](https://blog.getzep.com/state-of-the-art-agent-memory/) (inherited from Graphiti) | **Yes (bi-temporal)** | [Enterprise security](https://docs.getzep.com/deployment/security/) (cloud tier) | Yes (via [Graphiti MCP server](https://help.getzep.com/graphiti/getting-started/mcp-server)) | No | Apache-2.0 (Graphiti core) / Proprietary (Zep platform) |
 | **LangMem** (LangChain) | Hybrid | No | — | Pluggable | Background manager | Yes | ? | ? | SDK only | No | MIT |


### PR DESCRIPTION
## Summary

Resolves the three `?` cells on the **Letta / MemGPT** row of `docs/benchmarks/feature-comparison.md`, all cited against Letta's own docs or a Letta co-authored source.

| Cell | Before | After (this PR) | Source |
|---|---|---|---|
| Temporal | `?` | **No** (editable memory blocks; no validity windows / "what was true when") | [docs.letta.com/guides/agents/memory](https://docs.letta.com/guides/agents/memory) |
| Encryption | `?` | **Not first-party** (deploy-layer only, e.g. Aurora/Postgres encryption) | [AWS blog co-authored with Letta](https://aws.amazon.com/blogs/database/how-letta-builds-production-ready-ai-agents-with-amazon-aurora-postgresql/) |
| Cross-tool (MCP) | `SDK (not MCP-native)` | **MCP client only** (consumes external MCP tools; memory exposed via SDK, not MCP) | [docs.letta.com/guides/mcp/overview](https://docs.letta.com/guides/mcp/overview) |

Also corrected `Postgres + custom` → `Postgres + pgvector` (Letta's upstream architecture uses pgvector for `archival_passages` / `source_passages` embedding storage), and added a repo citation link to the row header.

### Why this matters

The MCP cell is the most load-bearing for PLUR's positioning thesis: Letta is frequently cited as a "memory MCP" by third parties, but Letta's own docs are explicit that it only acts as an MCP *client*. That means an MCP-native client like Claude Code / Cursor / Windsurf can **not** attach to Letta memory over MCP — it has to use Letta's SDK. That's a real competitive gap we should be able to claim with a citation, not with hand-waving.

### Phase 1 progress (Issue #8)

- [x] Mem0 — verified (PR #29)
- [x] Zep / Graphiti split — verified (PR #32)
- [x] **Letta — verified (this PR)**
- [ ] Cognee — pending
- [ ] MemOS — pending (all `?`)
- [ ] Basic Memory / Engram (Go) / Engram (E2EE) / Hindsight / Claude Code — residual gaps
- [ ] LangMem / Google Always-On Memory Agent — adjacent row gaps

## Test plan

- [x] Only one file changed (`docs/benchmarks/feature-comparison.md`)
- [x] Every new claim carries an inline citation
- [x] No markdown table structure changes beyond the Letta row + the "Last updated" line
- [ ] CI green on docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)