### PR TITLE
feat(claw): postinstall guidance for plur-claw activation (#39)

### DIFF
--- a/packages/claw/package.json
+++ b/packages/claw/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "dist",
+    "scripts",
     "openclaw.plugin.json"
   ],
   "openclaw": {
@@ -24,7 +25,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "dependencies": {
     "@plur-ai/core": "workspace:*"

--- a/packages/claw/scripts/postinstall.mjs
+++ b/packages/claw/scripts/postinstall.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+// Postinstall runner. Must never fail an install, ever.
+// Imports the built module when present; no-ops silently otherwise
+// (monorepo dev before `pnpm build`, CI, --ignore-scripts, etc.).
+try {
+  const mod = await import('../dist/postinstall.js')
+  const rc = mod.runPostinstallCli()
+  process.exit(typeof rc === 'number' ? rc : 0)
+} catch {
+  process.exit(0)
+}

--- a/packages/claw/src/postinstall-bin.ts
+++ b/packages/claw/src/postinstall-bin.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { runPostinstallCli } from './postinstall.js'
+process.exit(runPostinstallCli())

--- a/packages/claw/src/postinstall.ts
+++ b/packages/claw/src/postinstall.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export type PostinstallEnv = {
+  cwd: string
+  initCwd?: string
+  openclawHome?: string
+  ci?: boolean
+  skip?: boolean
+  isTTY: boolean
+  home: string
+}
+
+export type PostinstallDecision =
+  | { kind: 'skip'; reason: string }
+  | { kind: 'already-enabled'; configPath: string; message: string }
+  | { kind: 'prompt-setup'; configPath: string | null; message: string }
+
+const PLUGIN_ID = 'plur-claw'
+
+function isSelfInstall(env: PostinstallEnv): boolean {
+  if (!env.initCwd) return false
+  return env.initCwd === env.cwd
+}
+
+function resolveConfigPath(env: PostinstallEnv): string {
+  const envHome = env.openclawHome
+  const root = envHome && envHome.trim().length > 0 ? envHome : join(env.home, '.openclaw')
+  return join(root, 'openclaw.json')
+}
+
+function isAlreadyEnabled(path: string): boolean {
+  try {
+    const raw = readFileSync(path, 'utf8')
+    if (raw.trim().length === 0) return false
+    const parsed = JSON.parse(raw)
+    const entry = parsed?.plugins?.entries?.[PLUGIN_ID]
+    return !!(entry && entry.enabled === true)
+  } catch {
+    return false
+  }
+}
+
+export function decide(env: PostinstallEnv): PostinstallDecision {
+  if (env.skip) return { kind: 'skip', reason: 'PLUR_SKIP_POSTINSTALL set' }
+  if (env.ci) return { kind: 'skip', reason: 'CI environment detected' }
+  if (isSelfInstall(env)) return { kind: 'skip', reason: 'self-install in package dir' }
+
+  const configPath = resolveConfigPath(env)
+  if (existsSync(configPath) && isAlreadyEnabled(configPath)) {
+    return {
+      kind: 'already-enabled',
+      configPath,
+      message: `PLUR: plur-claw already enabled in ${configPath}`,
+    }
+  }
+
+  const msg = [
+    'PLUR installed. One more step to enable it in OpenClaw:',
+    '  Run: npx @plur-ai/claw setup',
+    existsSync(configPath)
+      ? `  (will update ${configPath})`
+      : `  (will create ${configPath} when OpenClaw is set up)`,
+    '  Then restart the OpenClaw gateway so the plugin loader picks it up.',
+  ].join('\n')
+
+  return { kind: 'prompt-setup', configPath: existsSync(configPath) ? configPath : null, message: msg }
+}
+
+export function readEnv(): PostinstallEnv {
+  return {
+    cwd: process.cwd(),
+    initCwd: process.env.INIT_CWD,
+    openclawHome: process.env.OPENCLAW_HOME,
+    ci: process.env.CI === 'true' || process.env.CI === '1',
+    skip: process.env.PLUR_SKIP_POSTINSTALL === '1' || process.env.PLUR_SKIP_POSTINSTALL === 'true',
+    isTTY: !!process.stdout.isTTY,
+    home: process.env.HOME ?? homedir(),
+  }
+}
+
+export function runPostinstallCli(): number {
+  try {
+    const decision = decide(readEnv())
+    if (decision.kind === 'skip') return 0
+    process.stdout.write(decision.message + '\n')
+    return 0
+  } catch {
+    return 0
+  }
+}

--- a/packages/claw/test/postinstall.test.ts
+++ b/packages/claw/test/postinstall.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { decide, type PostinstallEnv } from '../src/postinstall.js'
+
+function newHome(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-postinstall-home-'))
+}
+
+function baseEnv(home: string, overrides: Partial<PostinstallEnv> = {}): PostinstallEnv {
+  return {
+    cwd: '/some/consumer/project/node_modules/@plur-ai/claw',
+    initCwd: '/some/consumer/project',
+    openclawHome: join(home, '.openclaw'),
+    ci: false,
+    skip: false,
+    isTTY: true,
+    home,
+    ...overrides,
+  }
+}
+
+describe('claw postinstall decide()', () => {
+  let home: string
+  beforeEach(() => {
+    home = newHome()
+  })
+
+  it('skips when CI is set', () => {
+    expect(decide(baseEnv(home, { ci: true })).kind).toBe('skip')
+  })
+
+  it('skips when PLUR_SKIP_POSTINSTALL is set', () => {
+    expect(decide(baseEnv(home, { skip: true })).kind).toBe('skip')
+  })
+
+  it('skips when INIT_CWD equals cwd (self-install in package dir)', () => {
+    expect(decide(baseEnv(home, { cwd: '/pkg', initCwd: '/pkg' })).kind).toBe('skip')
+  })
+
+  it('prints prompt-setup message when config file does not yet exist', () => {
+    const d = decide(baseEnv(home))
+    expect(d.kind).toBe('prompt-setup')
+    if (d.kind !== 'prompt-setup') return
+    expect(d.message).toContain('npx @plur-ai/claw setup')
+    expect(d.configPath).toBeNull()
+  })
+
+  it('prints prompt-setup message when config exists but plugin not enabled', () => {
+    const cfgDir = join(home, '.openclaw')
+    mkdirSync(cfgDir, { recursive: true })
+    writeFileSync(join(cfgDir, 'openclaw.json'), JSON.stringify({ plugins: { entries: {} } }), 'utf8')
+    const d = decide(baseEnv(home))
+    expect(d.kind).toBe('prompt-setup')
+    if (d.kind !== 'prompt-setup') return
+    expect(d.message).toContain('Run: npx @plur-ai/claw setup')
+  })
+
+  it('reports already-enabled when plugin is enabled in config', () => {
+    const cfgDir = join(home, '.openclaw')
+    mkdirSync(cfgDir, { recursive: true })
+    writeFileSync(
+      join(cfgDir, 'openclaw.json'),
+      JSON.stringify({ plugins: { entries: { 'plur-claw': { enabled: true } } } }),
+      'utf8',
+    )
+    const d = decide(baseEnv(home))
+    expect(d.kind).toBe('already-enabled')
+    if (d.kind !== 'already-enabled') return
+    expect(d.message).toContain('already enabled')
+  })
+
+  it('honors OPENCLAW_HOME override', () => {
+    const custom = join(home, 'custom-openclaw')
+    mkdirSync(custom, { recursive: true })
+    writeFileSync(
+      join(custom, 'openclaw.json'),
+      JSON.stringify({ plugins: { entries: { 'plur-claw': { enabled: true } } } }),
+      'utf8',
+    )
+    const d = decide(baseEnv(home, { openclawHome: custom }))
+    expect(d.kind).toBe('already-enabled')
+    if (d.kind !== 'already-enabled') return
+    expect(d.configPath).toBe(join(custom, 'openclaw.json'))
+  })
+
+  it('treats malformed JSON as not-enabled (prompts setup without throwing)', () => {
+    const cfgDir = join(home, '.openclaw')
+    mkdirSync(cfgDir, { recursive: true })
+    writeFileSync(join(cfgDir, 'openclaw.json'), '{not json', 'utf8')
+    expect(decide(baseEnv(home)).kind).toBe('prompt-setup')
+  })
+})

--- a/packages/claw/tsup.config.ts
+++ b/packages/claw/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
-  entry: ['src/index.ts', 'src/setup.ts', 'src/cli.ts'],
+  entry: ['src/index.ts', 'src/setup.ts', 'src/cli.ts', 'src/postinstall.ts', 'src/postinstall-bin.ts'],
   format: ['esm'],
   target: 'node22',
   dts: true,


### PR DESCRIPTION
## Summary

Slice 2 of the v0.9.4 fix plan for #39. Installing `@plur-ai/claw` no longer leaves users silently stuck with a disabled plugin — the postinstall hook now prints a one-line prompt pointing them at `npx @plur-ai/claw setup`.

Deliberately does **not** mutate user config during `npm install` (breaks global installs, CI). Guidance first, user-initiated action second.

- `scripts/postinstall.mjs` — runner wired as the `postinstall` npm script; imports built module, never throws (monorepo dev before build, `--ignore-scripts`, missing dist all no-op cleanly)
- `src/postinstall.ts` — `decide()` returns one of `skip` / `already-enabled` / `prompt-setup` based on env + config state
- Honors `CI`, `PLUR_SKIP_POSTINSTALL=1`, `INIT_CWD === cwd` (self-install), `$OPENCLAW_HOME`
- Treats malformed openclaw.json as not-enabled (never throws from postinstall)
- Exposes `npx @plur-ai/claw postinstall` as a manual/debug bin
- Adds `scripts/` to published `files` allowlist so the runner ships

## Test plan

- [x] `npx vitest run test/postinstall.test.ts` — 8 / 8 passing
- [x] Smoke: `HOME=/tmp/fake OPENCLAW_HOME=/tmp/nonexistent node scripts/postinstall.mjs` prints prompt
- [x] Smoke: `PLUR_SKIP_POSTINSTALL=1 node scripts/postinstall.mjs` → silent
- [x] Smoke: `CI=true node scripts/postinstall.mjs` → silent
- [x] ESM build succeeds (`postinstall.js`, `postinstall-bin.js` both emitted)
- [ ] CI green on the branch
- [ ] Manual end-to-end after merge: fresh `npm install @plur-ai/claw` in clean dir prints the prompt

Remaining for v0.9.4: slice 3 (gateway reload detection), slice 4 (post-setup runtime verification).