### PR TITLE
docs(benchmarks): point Phase 2 refs to issue #46 (Phase 1 → Phase 2 handoff)

### DIFF
--- a/docs/benchmarks/feature-comparison.md
+++ b/docs/benchmarks/feature-comparison.md
@@ -1,8 +1,8 @@
 # Local-first AI memory: feature comparison
 
-**Status:** Draft, Phase 1 (feature matrix). Performance benchmarks tracked separately — see [Issue #8 Phase 2](https://github.com/plur-ai/plur/issues/8).
+**Status:** Phase 1 sealed 2026-04-23 (12 of 12 rows cell-verified). Performance benchmarks are Phase 2 — scoped and tracked in [issue #46](https://github.com/plur-ai/plur/issues/46); methodology scaffold at [docs/benchmarks/phase2-methodology.md](./phase2-methodology.md).
 
-**Last updated:** 2026-04-23 (Engram (Go) row verified — 4 of 4 `?` cells resolved via upstream README: Feedback loop → No, Temporal → `mem_timeline` + session lifecycle (no bi-temporal windows), Encryption → not documented, Cross-tool MCP → Yes with 8 named clients)
+**Last updated:** 2026-04-23 (Finding 3 tightened to surface the Polyform NC 1.0.0 license implication on Engram (E2EE) — the category has zero Apache/MIT-licensed systems with first-party at-rest encryption)
 
 ## Scope
 
@@ -72,6 +72,6 @@ If you maintain one of the systems above, or know one of the `?` cells cold, PRs
 
 ## Out of scope for Phase 1
 
-- Performance numbers (LongMemEval, retrieval latency, RAM/disk footprint) — see [Issue #8 Phase 2](https://github.com/plur-ai/plur/issues/8). Requires a reproducible harness that doesn't yet exist.
+- Performance numbers (LongMemEval, retrieval latency, RAM/disk footprint) — tracked in [issue #46](https://github.com/plur-ai/plur/issues/46); methodology scaffold at [docs/benchmarks/phase2-methodology.md](./phase2-methodology.md). Requires a reproducible harness that doesn't yet exist.
 - Subjective UX comparison — deliberately excluded to keep the matrix verifiable.
 - Pricing / commercial tier comparison — tracked separately under the enterprise positioning doc.


### PR DESCRIPTION
## Summary

Pure docs hygiene — completes the Phase 1 → Phase 2 handoff that landed across PRs #44 (Engram E2EE row), #45 (Finding 3 tightening), and #47 (Phase 2 methodology scaffold), plus issue #46 (Phase 2 scope).

`docs/benchmarks/feature-comparison.md` still referenced \"Issue #8 Phase 2\" in two places (status line at the top and the out-of-scope section at the bottom). Phase 2 now has its own tracking issue (#46) with a dedicated methodology scaffold (`docs/benchmarks/phase2-methodology.md`). This PR repoints both references at #46 and updates the header's \"Last updated\" line, which was still dated to the Engram (Go) row verification even though #44 and #45 have shipped since.

### Changes

- **Status line (L3):** \"Draft, Phase 1\" → \"Phase 1 sealed 2026-04-23 (12/12 rows cell-verified)\". Phase 2 link repointed from #8 → #46, with a forward pointer to the methodology scaffold.
- **Last-updated line (L5):** Refreshed to reflect the Finding 3 tightening that landed in #45 (the Polyform NC license implication on Engram (E2EE)).
- **Out-of-scope section (L75):** \"Issue #8 Phase 2\" → \"issue #46\", same forward pointer to the methodology doc.

**No matrix cells touched. No findings rewritten. No URL additions beyond the two local forward-pointers to the methodology doc.**

## Test plan

- [x] `git diff` reviewed — exactly 3 lines changed, all in the header + out-of-scope sections, no matrix mutations.
- [ ] CI green (markdown lint / link check if configured).
- [ ] After merge: comment on #8 marking close-out action 2's passive-invitation variant complete (Contributing section already invites maintainer PRs; see L69–71), and re-surface whether to close #8 now that Phase 2 has its own tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)