### PR TITLE
feat(claw): auto-add plur-claw to plugins.allow when allowlist is active (#51 slice A)

### DIFF
--- a/packages/claw/src/setup.ts
+++ b/packages/claw/src/setup.ts
@@ -74,6 +74,15 @@ function mergeEnable(cfg: OpenclawConfig): { cfg: OpenclawConfig; changed: boole
   }
   ;(plugins as any).slots = slots
 
+  // Append to plugins.allow only when the user is already gating via a non-empty
+  // allowlist — matching OpenClaw's buildPluginsAllowPatch semantics. Creating an
+  // allowlist where none existed would silently gate other plugins the user had.
+  const allowCurrent = (plugins as any).allow
+  if (Array.isArray(allowCurrent) && allowCurrent.length > 0 && !allowCurrent.includes(PLUGIN_ID)) {
+    ;(plugins as any).allow = [...allowCurrent, PLUGIN_ID]
+    changed = true
+  }
+
   cfg.plugins = plugins
 
   // Configure MCP server for agent-callable tools

--- a/packages/claw/test/setup.test.ts
+++ b/packages/claw/test/setup.test.ts
@@ -85,6 +85,37 @@ describe('claw setup command', () => {
     expect(r.steps.find((s) => s.step === 'runtime_confirmed')!.status).toBe('pending')
   })
 
+  it('appends plur-claw to a non-empty plugins.allow allowlist', () => {
+    const prior = { plugins: { allow: ['other-plugin'] } }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.allow).toEqual(['other-plugin', 'plur-claw'])
+  })
+
+  it('does not create plugins.allow when it is absent (avoid gating other plugins)', () => {
+    writeFileSync(cfgPath, '{}', 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.allow).toBeUndefined()
+  })
+
+  it('does not create plugins.allow when it is present but empty', () => {
+    const prior = { plugins: { allow: [] } }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.allow).toEqual([])
+  })
+
+  it('leaves plugins.allow alone when plur-claw is already allowlisted', () => {
+    const prior = { plugins: { allow: ['other-plugin', 'plur-claw'] } }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.allow).toEqual(['other-plugin', 'plur-claw'])
+  })
+
   it('creates valid JSON output on write', () => {
     writeFileSync(cfgPath, '{}', 'utf8')
     runSetup({ configPath: cfgPath })


### PR DESCRIPTION
## Summary

Closes **slice A** of the #51 triage plan: `npx @plur-ai/claw setup` now adds `plur-claw` to `plugins.allow` automatically when the user already gates community plugins via a non-empty allowlist. Prior to this PR, this was the one manual step still required to reach a green `openclaw doctor` output.

Semantics match OpenClaw's own `buildPluginsAllowPatch` (bundled in `dist/shared-*.js`):

| Prior `plugins.allow` | Setup behavior |
|---|---|
| absent | **leave alone** — creating one would silently gate other plugins the user already had |
| `[]` | **leave alone** — same reason |
| `["other"]` | **append** → `["other", "plur-claw"]` |
| `["other", "plur-claw"]` | no-op |

Verified against `openclaw@2026.4.22` by inspecting the allow-patch helper in the shipped dist.

## Scope

Setup-side only. Slices B (discovered/registered steps), C (runtime verification), D (error-classification chain) tracked separately on #51. Slices E/F require upstream OpenClaw coordination.

## Test plan

- [x] 4 new unit tests in `packages/claw/test/setup.test.ts` (append / absent / empty / already-present)
- [x] All 11 setup tests pass locally (`vitest run packages/claw/test/setup.test.ts`)
- [x] No changes to behavior when `plugins.allow` is absent — idempotent test still passes

Ref: plur-ai/plur#51