### PR TITLE
feat(claw): distinguish discovered/enabled/slotted/registered steps (#51 slice B)

### DIFF
--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -56,8 +56,9 @@ const plugin = {
     // 2. Run setup if config is incomplete (idempotent, skips if already configured)
     import('./setup.js').then(({ runSetup }) => {
       const report = runSetup()
-      const configStep = report.steps.find((s: any) => s.step === 'config_enabled')
-      if (configStep?.status === 'ok') {
+      const enabled = report.steps.find((s: any) => s.step === 'plugin_enabled')
+      const slotted = report.steps.find((s: any) => s.step === 'slot_selected')
+      if (enabled?.status === 'ok' || slotted?.status === 'ok') {
         api.logger.info('PLUR: auto-configured openclaw.json (memory slot + MCP server)')
       }
     }).catch((err: any) => {

--- a/packages/claw/src/setup.ts
+++ b/packages/claw/src/setup.ts
@@ -12,10 +12,17 @@ type OpenclawConfig = {
 
 const PLUGIN_ID = 'plur-claw'
 
-function resolveConfigPath(): string {
+function resolveOpenclawHome(): string {
   const envHome = process.env.OPENCLAW_HOME
-  const root = envHome && envHome.trim().length > 0 ? envHome : join(homedir(), '.openclaw')
-  return join(root, 'openclaw.json')
+  return envHome && envHome.trim().length > 0 ? envHome : join(homedir(), '.openclaw')
+}
+
+function resolveConfigPath(): string {
+  return join(resolveOpenclawHome(), 'openclaw.json')
+}
+
+function resolveExtensionPath(): string {
+  return join(resolveOpenclawHome(), 'extensions', PLUGIN_ID)
 }
 
 function canonicalBlock(): string {
@@ -25,6 +32,7 @@ function canonicalBlock(): string {
         entries: {
           [PLUGIN_ID]: { enabled: true },
         },
+        slots: { memory: PLUGIN_ID },
       },
     },
     null,
@@ -46,7 +54,16 @@ function readConfig(path: string): { ok: true; data: OpenclawConfig } | { ok: fa
   }
 }
 
-function mergeEnable(cfg: OpenclawConfig): { cfg: OpenclawConfig; changed: boolean; alreadyEnabled: boolean } {
+type MergeResult = {
+  cfg: OpenclawConfig
+  anyChanged: boolean
+  enableChanged: boolean
+  enableAlready: boolean
+  slotChanged: boolean
+  slotAlready: boolean
+}
+
+function mergeEnable(cfg: OpenclawConfig): MergeResult {
   const plugins = (cfg.plugins && typeof cfg.plugins === 'object' && !Array.isArray(cfg.plugins)
     ? cfg.plugins
     : {}) as NonNullable<OpenclawConfig['plugins']>
@@ -55,22 +72,23 @@ function mergeEnable(cfg: OpenclawConfig): { cfg: OpenclawConfig; changed: boole
       ? plugins.entries
       : {}
   const existing = entries[PLUGIN_ID]
-  const alreadyEnabled = !!(existing && existing.enabled === true)
+  const enableAlready = !!(existing && existing.enabled === true)
   const nextEntry = {
     ...(existing ?? {}),
     enabled: true,
     config: (existing as any)?.config ?? { auto_learn: true, auto_capture: true, injection_budget: 2000 },
   }
-  let changed = !existing || existing.enabled !== true
+  const enableChanged = !existing || existing.enabled !== true
   entries[PLUGIN_ID] = nextEntry
   plugins.entries = entries
 
   // Set memory slot
   const slots = (plugins as any).slots && typeof (plugins as any).slots === 'object'
     ? (plugins as any).slots : {}
-  if (slots.memory !== PLUGIN_ID) {
+  const slotAlready = slots.memory === PLUGIN_ID
+  const slotChanged = !slotAlready
+  if (slotChanged) {
     slots.memory = PLUGIN_ID
-    changed = true
   }
   ;(plugins as any).slots = slots
 
@@ -78,9 +96,10 @@ function mergeEnable(cfg: OpenclawConfig): { cfg: OpenclawConfig; changed: boole
   // allowlist — matching OpenClaw's buildPluginsAllowPatch semantics. Creating an
   // allowlist where none existed would silently gate other plugins the user had.
   const allowCurrent = (plugins as any).allow
+  let allowChanged = false
   if (Array.isArray(allowCurrent) && allowCurrent.length > 0 && !allowCurrent.includes(PLUGIN_ID)) {
     ;(plugins as any).allow = [...allowCurrent, PLUGIN_ID]
-    changed = true
+    allowChanged = true
   }
 
   cfg.plugins = plugins
@@ -88,15 +107,23 @@ function mergeEnable(cfg: OpenclawConfig): { cfg: OpenclawConfig; changed: boole
   // Configure MCP server for agent-callable tools
   const mcp = (cfg as any).mcp && typeof (cfg as any).mcp === 'object' ? (cfg as any).mcp : {}
   const servers = mcp.servers && typeof mcp.servers === 'object' ? mcp.servers : {}
+  let mcpChanged = false
   if (!servers.plur) {
     const plurPath = process.env.PLUR_PATH || join(homedir(), '.plur')
     servers.plur = { command: 'npx', args: ['-y', '@plur-ai/mcp'], env: { PLUR_PATH: plurPath } }
-    changed = true
+    mcpChanged = true
   }
   mcp.servers = servers
   ;(cfg as any).mcp = mcp
 
-  return { cfg, changed, alreadyEnabled }
+  return {
+    cfg,
+    anyChanged: enableChanged || slotChanged || allowChanged || mcpChanged,
+    enableChanged,
+    enableAlready,
+    slotChanged,
+    slotAlready,
+  }
 }
 
 function writeConfig(path: string, cfg: OpenclawConfig): { ok: true } | { ok: false; reason: string } {
@@ -109,7 +136,13 @@ function writeConfig(path: string, cfg: OpenclawConfig): { ok: true } | { ok: fa
   }
 }
 
-export type SetupStep = 'package_present' | 'config_enabled' | 'reload_required' | 'runtime_confirmed'
+export type SetupStep =
+  | 'package_present'
+  | 'plugin_discovered'
+  | 'plugin_enabled'
+  | 'slot_selected'
+  | 'reload_required'
+  | 'runtime_registered'
 export type SetupStatus = 'ok' | 'skip' | 'fail' | 'pending'
 export type SetupReport = {
   path: string
@@ -117,56 +150,91 @@ export type SetupReport = {
   fallbackBlock?: string
 }
 
+function discoveryStep(): { step: SetupStep; status: SetupStatus; detail?: string } {
+  const extPath = resolveExtensionPath()
+  if (existsSync(extPath)) {
+    return { step: 'plugin_discovered', status: 'ok', detail: extPath }
+  }
+  return {
+    step: 'plugin_discovered',
+    status: 'fail',
+    detail: `extensions dir missing: ${extPath} — run \`openclaw plugins install @plur-ai/claw\``,
+  }
+}
+
 export function runSetup(opts: { configPath?: string } = {}): SetupReport {
   const path = opts.configPath ?? resolveConfigPath()
-  const report: SetupReport = { path, steps: [{ step: 'package_present', status: 'ok' }] }
+  const report: SetupReport = {
+    path,
+    steps: [{ step: 'package_present', status: 'ok' }, discoveryStep()],
+  }
+
+  const tailPending = () => {
+    report.steps.push({
+      step: 'reload_required',
+      status: 'pending',
+      detail: 'restart the OpenClaw gateway so the plugin loader re-reads config',
+    })
+    report.steps.push({
+      step: 'runtime_registered',
+      status: 'pending',
+      detail: 'automatic verification not yet implemented (tracked in #39)',
+    })
+  }
 
   if (!existsSync(path)) {
-    report.steps.push({
-      step: 'config_enabled',
-      status: 'fail',
-      detail: `config file not found: ${path}`,
-    })
+    report.steps.push({ step: 'plugin_enabled', status: 'fail', detail: `config file not found: ${path}` })
+    report.steps.push({ step: 'slot_selected', status: 'fail', detail: 'config file missing' })
     report.fallbackBlock = canonicalBlock()
-    report.steps.push({ step: 'reload_required', status: 'pending', detail: 'restart OpenClaw gateway after editing config' })
-    report.steps.push({ step: 'runtime_confirmed', status: 'pending' })
+    tailPending()
     return report
   }
 
   const readRes = readConfig(path)
   if (!readRes.ok) {
-    report.steps.push({ step: 'config_enabled', status: 'fail', detail: readRes.reason })
+    report.steps.push({ step: 'plugin_enabled', status: 'fail', detail: readRes.reason })
+    report.steps.push({ step: 'slot_selected', status: 'fail', detail: 'config unreadable' })
     report.fallbackBlock = canonicalBlock()
-    report.steps.push({ step: 'reload_required', status: 'pending' })
-    report.steps.push({ step: 'runtime_confirmed', status: 'pending' })
+    tailPending()
     return report
   }
 
   const merged = mergeEnable(readRes.data)
-  if (merged.alreadyEnabled && !merged.changed) {
-    report.steps.push({ step: 'config_enabled', status: 'skip', detail: 'already enabled' })
-  } else {
-    const w = writeConfig(path, merged.cfg)
-    if (!w.ok) {
-      report.steps.push({ step: 'config_enabled', status: 'fail', detail: w.reason })
-      report.fallbackBlock = canonicalBlock()
-      report.steps.push({ step: 'reload_required', status: 'pending' })
-      report.steps.push({ step: 'runtime_confirmed', status: 'pending' })
-      return report
-    }
-    report.steps.push({ step: 'config_enabled', status: 'ok' })
+  if (!merged.anyChanged) {
+    report.steps.push({
+      step: 'plugin_enabled',
+      status: merged.enableAlready ? 'skip' : 'ok',
+      detail: merged.enableAlready ? 'already enabled' : undefined,
+    })
+    report.steps.push({
+      step: 'slot_selected',
+      status: merged.slotAlready ? 'skip' : 'ok',
+      detail: merged.slotAlready ? `already set to ${PLUGIN_ID}` : undefined,
+    })
+    tailPending()
+    return report
+  }
+
+  const w = writeConfig(path, merged.cfg)
+  if (!w.ok) {
+    report.steps.push({ step: 'plugin_enabled', status: 'fail', detail: w.reason })
+    report.steps.push({ step: 'slot_selected', status: 'fail', detail: 'write failed' })
+    report.fallbackBlock = canonicalBlock()
+    tailPending()
+    return report
   }
 
   report.steps.push({
-    step: 'reload_required',
-    status: 'pending',
-    detail: 'restart the OpenClaw gateway so the plugin loader re-reads config',
+    step: 'plugin_enabled',
+    status: merged.enableChanged ? 'ok' : 'skip',
+    detail: merged.enableChanged ? undefined : 'already enabled',
   })
   report.steps.push({
-    step: 'runtime_confirmed',
-    status: 'pending',
-    detail: 'automatic verification not yet implemented (tracked in #39)',
+    step: 'slot_selected',
+    status: merged.slotChanged ? 'ok' : 'skip',
+    detail: merged.slotChanged ? undefined : `already set to ${PLUGIN_ID}`,
   })
+  tailPending()
   return report
 }
 

--- a/packages/claw/test/setup.test.ts
+++ b/packages/claw/test/setup.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runSetup } from '../src/setup.js'
@@ -16,20 +16,20 @@ describe('claw setup command', () => {
     cfgPath = join(dir, 'openclaw.json')
   })
 
-  it('reports fail + fallback when config file is missing', () => {
+  it('reports fail on enable + slot when config file is missing', () => {
     const r = runSetup({ configPath: cfgPath })
     expect(r.path).toBe(cfgPath)
-    const cfgStep = r.steps.find((s) => s.step === 'config_enabled')!
-    expect(cfgStep.status).toBe('fail')
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('fail')
+    expect(r.steps.find((s) => s.step === 'slot_selected')!.status).toBe('fail')
     expect(r.fallbackBlock).toContain('plur-claw')
     expect(r.fallbackBlock).toContain('"enabled": true')
   })
 
-  it('enables plugin in empty object config', () => {
+  it('enables plugin + selects slot in empty object config', () => {
     writeFileSync(cfgPath, '{}', 'utf8')
     const r = runSetup({ configPath: cfgPath })
-    const cfgStep = r.steps.find((s) => s.step === 'config_enabled')!
-    expect(cfgStep.status).toBe('ok')
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('ok')
+    expect(r.steps.find((s) => s.step === 'slot_selected')!.status).toBe('ok')
     const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
     expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
     expect(written.plugins.entries['plur-claw'].config).toEqual({ auto_learn: true, auto_capture: true, injection_budget: 2000 })
@@ -49,14 +49,14 @@ describe('claw setup command', () => {
     }
     writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
     const r = runSetup({ configPath: cfgPath })
-    expect(r.steps.find((s) => s.step === 'config_enabled')!.status).toBe('ok')
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('ok')
     const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
     expect(written.plugins.entries['plur-claw'].config.injection_budget).toBe(4000)
     expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
     expect(written.plugins.entries['other-plugin']).toEqual({ enabled: true })
   })
 
-  it('is idempotent when fully configured (reports skip)', () => {
+  it('is idempotent when fully configured (reports skip on enable + slot)', () => {
     const prior = {
       plugins: {
         entries: { 'plur-claw': { enabled: true, config: { auto_learn: true, auto_capture: true, injection_budget: 2000 } } },
@@ -66,23 +66,27 @@ describe('claw setup command', () => {
     }
     writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
     const r = runSetup({ configPath: cfgPath })
-    const cfgStep = r.steps.find((s) => s.step === 'config_enabled')!
-    expect(cfgStep.status).toBe('skip')
-    expect(cfgStep.detail).toBe('already enabled')
+    const enableStep = r.steps.find((s) => s.step === 'plugin_enabled')!
+    const slotStep = r.steps.find((s) => s.step === 'slot_selected')!
+    expect(enableStep.status).toBe('skip')
+    expect(enableStep.detail).toBe('already enabled')
+    expect(slotStep.status).toBe('skip')
+    expect(slotStep.detail).toBe('already set to plur-claw')
   })
 
   it('reports fail + fallback on malformed JSON', () => {
     writeFileSync(cfgPath, '{not json', 'utf8')
     const r = runSetup({ configPath: cfgPath })
-    expect(r.steps.find((s) => s.step === 'config_enabled')!.status).toBe('fail')
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('fail')
+    expect(r.steps.find((s) => s.step === 'slot_selected')!.status).toBe('fail')
     expect(r.fallbackBlock).toBeDefined()
   })
 
-  it('always marks reload_required and runtime_confirmed as pending', () => {
+  it('always marks reload_required and runtime_registered as pending', () => {
     writeFileSync(cfgPath, '{}', 'utf8')
     const r = runSetup({ configPath: cfgPath })
     expect(r.steps.find((s) => s.step === 'reload_required')!.status).toBe('pending')
-    expect(r.steps.find((s) => s.step === 'runtime_confirmed')!.status).toBe('pending')
+    expect(r.steps.find((s) => s.step === 'runtime_registered')!.status).toBe('pending')
   })
 
   it('appends plur-claw to a non-empty plugins.allow allowlist', () => {
@@ -122,5 +126,47 @@ describe('claw setup command', () => {
     expect(existsSync(cfgPath)).toBe(true)
     const parsed = JSON.parse(readFileSync(cfgPath, 'utf8'))
     expect(parsed).toBeTypeOf('object')
+  })
+
+  describe('plugin_discovered step', () => {
+    const origHome = process.env.OPENCLAW_HOME
+    beforeEach(() => {
+      process.env.OPENCLAW_HOME = dir
+    })
+    afterAll(() => {
+      if (origHome === undefined) delete process.env.OPENCLAW_HOME
+      else process.env.OPENCLAW_HOME = origHome
+    })
+
+    it('reports fail with guidance when extensions dir is missing', () => {
+      writeFileSync(cfgPath, '{}', 'utf8')
+      const r = runSetup({ configPath: cfgPath })
+      const step = r.steps.find((s) => s.step === 'plugin_discovered')!
+      expect(step.status).toBe('fail')
+      expect(step.detail).toContain('openclaw plugins install @plur-ai/claw')
+    })
+
+    it('reports ok when plur-claw is present under OPENCLAW_HOME/extensions', () => {
+      mkdirSync(join(dir, 'extensions', 'plur-claw'), { recursive: true })
+      writeFileSync(cfgPath, '{}', 'utf8')
+      const r = runSetup({ configPath: cfgPath })
+      const step = r.steps.find((s) => s.step === 'plugin_discovered')!
+      expect(step.status).toBe('ok')
+      expect(step.detail).toContain('plur-claw')
+    })
+  })
+
+  it('emits steps in install → activation order', () => {
+    writeFileSync(cfgPath, '{}', 'utf8')
+    const r = runSetup({ configPath: cfgPath })
+    const stepNames = r.steps.map((s) => s.step)
+    expect(stepNames).toEqual([
+      'package_present',
+      'plugin_discovered',
+      'plugin_enabled',
+      'slot_selected',
+      'reload_required',
+      'runtime_registered',
+    ])
   })
 })


### PR DESCRIPTION
## Summary

- Splits the single `config_enabled` step into three distinct installation-chain signals: `plugin_discovered`, `plugin_enabled`, `slot_selected`. Renames `runtime_confirmed` → `runtime_registered` for consistency with the activation vocabulary from the #51 triage.
- New `plugin_discovered` step checks that `$OPENCLAW_HOME/extensions/plur-claw` exists — surfaces the "installed but not discovered" gap called out in #51 problem 4.
- `plugin_enabled` and `slot_selected` now report independently, so a user can see *which* of the two the installer changed vs. skipped vs. failed. The canonical fallback block also now includes `plugins.slots.memory` matching what we actually write.

Final step order:

    package_present → plugin_discovered → plugin_enabled → slot_selected
                    → reload_required → runtime_registered

## Context

Slice B of #51 (OpenClaw activation fragility). Unblocks:
- Slice C (runtime verification) — replaces the `pending` placeholder on the `runtime_registered` step
- Slice D (guided error classification) — both depend on the per-step granularity landed here

Follows PR #52 (Slice A — plugins.allow).

## Test plan

- [x] 14/14 setup tests passing locally
- [x] Added coverage for `plugin_discovered` ok (extension dir present) and fail (extension dir missing, with install-guidance detail) cases under a scoped `OPENCLAW_HOME` override
- [x] Added a step-order assertion locking in the install → activation sequence so future reorderings are caught
- [x] `register()` in `src/index.ts` updated to read the split step names when deciding whether to log auto-configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)