### PR TITLE
feat(claw): setup --repair mode (#51 slice E)

### DIFF
--- a/packages/claw/src/cli.ts
+++ b/packages/claw/src/cli.ts
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
-import { runDoctorCli, runSetupCli } from './setup.js'
+import { runDoctorCli, runRepairCli, runSetupCli } from './setup.js'
 
 function help(): string {
   return [
     'Usage: npx @plur-ai/claw <command>',
     '',
     'Commands:',
-    '  setup    Enable plur-claw in ~/.openclaw/openclaw.json',
-    '  doctor   Inspect current activation state without modifying config',
-    '  help     Show this help',
+    '  setup            Enable plur-claw in ~/.openclaw/openclaw.json',
+    '  setup --repair   Fix only the steps that `doctor` reports as failed',
+    '  doctor           Inspect current activation state without modifying config',
+    '  help             Show this help',
     '',
     'Env:',
     '  OPENCLAW_HOME   Override the OpenClaw config directory (default: ~/.openclaw)',
@@ -21,7 +22,10 @@ function main(argv: string[]): number {
     process.stdout.write(help() + '\n')
     return cmd ? 0 : 1
   }
-  if (cmd === 'setup') return runSetupCli()
+  if (cmd === 'setup') {
+    if (argv[3] === '--repair') return runRepairCli()
+    return runSetupCli()
+  }
   if (cmd === 'doctor') return runDoctorCli()
   process.stderr.write(`Unknown command: ${cmd}\n\n${help()}\n`)
   return 1

--- a/packages/claw/src/setup.ts
+++ b/packages/claw/src/setup.ts
@@ -354,6 +354,76 @@ export function runDoctorCli(): number {
   return failed ? 1 : 0
 }
 
+export function runRepair(opts: { configPath?: string } = {}): SetupReport {
+  const path = opts.configPath ?? resolveConfigPath()
+
+  // Diagnose first — repair only acts on steps doctor reports as failing.
+  const pre = runDoctor({ configPath: path })
+  const enableFailed = pre.steps.find((s) => s.step === 'plugin_enabled')!.status === 'fail'
+  const slotFailed = pre.steps.find((s) => s.step === 'slot_selected')!.status === 'fail'
+  if (!enableFailed && !slotFailed) return pre
+
+  // Slot conflicts (memory slot taken by a different plugin) are preserved — repair
+  // does not overturn a human judgment call on which plugin owns the memory slot.
+  let cfg: OpenclawConfig = {}
+  if (existsSync(path)) {
+    const readRes = readConfig(path)
+    if (!readRes.ok) return pre
+    cfg = readRes.data
+  }
+
+  const plugins = (cfg.plugins && typeof cfg.plugins === 'object' && !Array.isArray(cfg.plugins)
+    ? cfg.plugins
+    : {}) as NonNullable<OpenclawConfig['plugins']>
+  const entries =
+    plugins.entries && typeof plugins.entries === 'object' && !Array.isArray(plugins.entries)
+      ? plugins.entries
+      : {}
+  let changed = false
+
+  if (enableFailed) {
+    const existing = entries[PLUGIN_ID]
+    if (!existing) {
+      entries[PLUGIN_ID] = {
+        enabled: true,
+        config: { auto_learn: true, auto_capture: true, injection_budget: 2000 },
+      }
+      changed = true
+    } else if (existing.enabled !== true) {
+      entries[PLUGIN_ID] = { ...existing, enabled: true }
+      changed = true
+    }
+    plugins.entries = entries
+  }
+
+  const slots =
+    (plugins as any).slots && typeof (plugins as any).slots === 'object'
+      ? (plugins as any).slots
+      : {}
+  if (slotFailed && !slots.memory) {
+    slots.memory = PLUGIN_ID
+    ;(plugins as any).slots = slots
+    changed = true
+  }
+
+  cfg.plugins = plugins
+
+  if (changed) {
+    const w = writeConfig(path, cfg)
+    if (!w.ok) return pre
+  }
+
+  return runDoctor({ configPath: path })
+}
+
+export function runRepairCli(): number {
+  const report = runRepair()
+  const rendered = formatReport(report).replace(/^PLUR setup →/, 'PLUR repair →')
+  process.stdout.write(rendered + '\n')
+  const failed = report.steps.some((s) => s.status === 'fail')
+  return failed ? 1 : 0
+}
+
 // Auto-run when executed directly (postinstall)
 const isMain = typeof process !== 'undefined' && process.argv[1]?.endsWith('setup.js')
 if (isMain) {

--- a/packages/claw/test/setup.test.ts
+++ b/packages/claw/test/setup.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 import { mkdtempSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { runDoctor, runSetup } from '../src/setup.js'
+import { runDoctor, runRepair, runSetup } from '../src/setup.js'
 
 function newDir(): string {
   return mkdtempSync(join(tmpdir(), 'plur-setup-'))
@@ -277,5 +277,142 @@ describe('claw doctor command', () => {
     const r = runDoctor({ configPath: cfgPath })
     expect(r.steps.find((s) => s.step === 'reload_required')!.status).toBe('pending')
     expect(r.steps.find((s) => s.step === 'runtime_registered')!.status).toBe('pending')
+  })
+})
+
+describe('claw setup --repair mode', () => {
+  let dir: string
+  let cfgPath: string
+  beforeEach(() => {
+    dir = newDir()
+    cfgPath = join(dir, 'openclaw.json')
+  })
+
+  it('no-ops when doctor reports enable + slot healthy', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: true, config: { injection_budget: 4000 } } },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    const raw = JSON.stringify(prior)
+    writeFileSync(cfgPath, raw, 'utf8')
+    const r = runRepair({ configPath: cfgPath })
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('ok')
+    expect(r.steps.find((s) => s.step === 'slot_selected')!.status).toBe('ok')
+    // Byte-identical: repair didn't write.
+    expect(readFileSync(cfgPath, 'utf8')).toBe(raw)
+  })
+
+  it('flips enabled=false to true without rewriting config.injection_budget', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: false, config: { injection_budget: 4000 } } },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    const r = runRepair({ configPath: cfgPath })
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('ok')
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
+    expect(written.plugins.entries['plur-claw'].config.injection_budget).toBe(4000)
+  })
+
+  it('adds missing plur-claw entry with default config when only entry is missing', () => {
+    const prior = {
+      plugins: {
+        entries: { 'other-plugin': { enabled: true } },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    const r = runRepair({ configPath: cfgPath })
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('ok')
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
+    expect(written.plugins.entries['plur-claw'].config).toEqual({
+      auto_learn: true,
+      auto_capture: true,
+      injection_budget: 2000,
+    })
+    expect(written.plugins.entries['other-plugin']).toEqual({ enabled: true })
+  })
+
+  it('sets memory slot when it is unset, without adding MCP config', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: true, config: { injection_budget: 2000 } } },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    const r = runRepair({ configPath: cfgPath })
+    expect(r.steps.find((s) => s.step === 'slot_selected')!.status).toBe('ok')
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.slots.memory).toBe('plur-claw')
+    // MCP is not a doctor step; repair doesn't add it.
+    expect(written.mcp).toBeUndefined()
+  })
+
+  it('does NOT overwrite a memory slot pointing to a different plugin', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: true } },
+        slots: { memory: 'other-memory' },
+      },
+    }
+    const raw = JSON.stringify(prior)
+    writeFileSync(cfgPath, raw, 'utf8')
+    const r = runRepair({ configPath: cfgPath })
+    const slotStep = r.steps.find((s) => s.step === 'slot_selected')!
+    expect(slotStep.status).toBe('fail')
+    expect(slotStep.detail).toContain('other-memory')
+    // Slot conflict preserved; file untouched.
+    expect(readFileSync(cfgPath, 'utf8')).toBe(raw)
+  })
+
+  it('creates a minimal config when file is missing', () => {
+    const r = runRepair({ configPath: cfgPath })
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('ok')
+    expect(r.steps.find((s) => s.step === 'slot_selected')!.status).toBe('ok')
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
+    expect(written.plugins.slots.memory).toBe('plur-claw')
+    expect(written.mcp).toBeUndefined()
+  })
+
+  it('does not overwrite a malformed config file', () => {
+    const raw = '{not json'
+    writeFileSync(cfgPath, raw, 'utf8')
+    const r = runRepair({ configPath: cfgPath })
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('fail')
+    expect(readFileSync(cfgPath, 'utf8')).toBe(raw)
+  })
+
+  it('fixes both enable and slot in a single pass when both failed', () => {
+    writeFileSync(cfgPath, '{}', 'utf8')
+    const r = runRepair({ configPath: cfgPath })
+    expect(r.steps.find((s) => s.step === 'plugin_enabled')!.status).toBe('ok')
+    expect(r.steps.find((s) => s.step === 'slot_selected')!.status).toBe('ok')
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
+    expect(written.plugins.slots.memory).toBe('plur-claw')
+  })
+
+  it('preserves unrelated plugin entries when flipping enabled', () => {
+    const prior = {
+      plugins: {
+        entries: {
+          'plur-claw': { enabled: false, config: { injection_budget: 1500 } },
+          'other-plugin': { enabled: true, config: { foo: 'bar' } },
+        },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runRepair({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['other-plugin']).toEqual({ enabled: true, config: { foo: 'bar' } })
+    expect(written.plugins.entries['plur-claw'].config.injection_budget).toBe(1500)
   })
 })


### PR DESCRIPTION
## Summary

Adds `npx @plur-ai/claw setup --repair` — a targeted repair mode that re-runs **only** the activation-chain steps that `doctor` reports as failing. Reuses Slice B's step taxonomy and Slice C's `runDoctor()` output, so every mutation is justified by a specific failing probe.

Part of issue #51 (OpenClaw activation fragility). Slices A/B/C already shipped; this is Slice E.

## Behavior

| Doctor reports | Repair action |
|---|---|
| `plugin_enabled fail` + no entry for `plur-claw` | add entry with default config |
| `plugin_enabled fail` + entry exists, `enabled != true` | flip `enabled: true`, preserve `config.injection_budget` and other fields |
| `slot_selected fail` + `plugins.slots.memory` unset | set memory slot to `plur-claw` |
| `slot_selected fail` + `plugins.slots.memory` owned by another plugin | **preserved** (human judgment call) |
| all steps healthy | byte-identical no-op (no file write) |
| malformed config | no write, fails fast |

Distinct from full `setup`: repair does not touch MCP config, does not write unchanged sections, and explicitly refuses to reassign a memory slot owned by another plugin.

## Why this shape

Slice C's `doctor` surfaces the *what* (which step failed). Slice E's `repair` closes the loop with the *how* (fix only that step, leave the rest alone). Together they replace the current "re-run setup and pray it didn't overwrite your config" workflow.

## Test plan

- [x] 9 new tests in `packages/claw/test/setup.test.ts` covering each branch of the table above
- [x] 31 total tests pass locally (`npx vitest run test/setup.test.ts`)
- [ ] CI green on node 20 + node 22

## Next on #51

- **D** (telemetry counters) — unblocks `2026-04-29` when PR #23 comment window closes
- **F** (upstream `plugins.slots.<slot>.owner` proposal) — opens after E lands; concrete repair logic informs the upstream shape