### PR TITLE
docs(claw): README reflects shipped setup CLI (setup/doctor/setup --repair)

### DIFF
--- a/packages/claw/README.md
+++ b/packages/claw/README.md
@@ -8,23 +8,36 @@ Part of [PLUR](https://plur.ai) — where **Haiku with memory outperforms Opus w
 
 ```bash
 openclaw plugins install @plur-ai/claw
+npx @plur-ai/claw setup
 ```
 
-Then enable the plugin in `~/.openclaw/openclaw.json`:
+`setup` enables the plugin in `~/.openclaw/openclaw.json`, assigns it to the memory slot, and (if you've opted into a community allowlist) adds `plur-claw` to it. Restart the OpenClaw gateway and every agent session now has persistent memory.
+
+If you'd rather configure by hand, the equivalent edit to `~/.openclaw/openclaw.json` is:
 
 ```json
 {
   "plugins": {
     "entries": {
       "plur-claw": { "enabled": true }
+    },
+    "slots": {
+      "memory": "plur-claw"
     }
   }
 }
 ```
 
-Restart the OpenClaw gateway so the new config is picked up. Every agent session now has persistent memory.
+### Troubleshooting activation
 
-> Until v0.9.4 ships `npx @plur-ai/claw setup` (tracked in [#39](https://github.com/plur-ai/plur/issues/39)), the `plugins.entries` block must be added manually — `openclaw plugins install` writes the package to disk but does not enable it in your config.
+If `setup` ran but PLUR still isn't active, two read/fix tools ship with the package:
+
+```bash
+npx @plur-ai/claw doctor          # read-only: reports which step is failing
+npx @plur-ai/claw setup --repair  # re-runs only the failing steps, preserves the rest
+```
+
+`doctor` walks the full activation chain — `package_present` → `plugin_discovered` → `plugin_enabled` → `slot_selected` → `reload_required` → `runtime_registered` — and names the specific step that's off, along with whether the fix is on `setup`, on upstream `openclaw`, or a human judgment call (slot owned by another plugin). `setup --repair` then fixes only the steps `doctor` flagged, leaving healthy config fields byte-identical.
 
 ## What happens automatically
 


### PR DESCRIPTION
## Summary

- README's setup section still told users `npx @plur-ai/claw setup` was unshipped (tracked in the now-closed #39) and walked them through a manual `plugins.entries` edit
- Claw is on v0.9.9 and the full CLI — `setup`, `doctor`, `setup --repair` — is live in main via #51 slices A/B/C/E
- Updates README to lead with the two-command install, keeps the manual JSON path as a fallback, and adds a troubleshooting subsection pointing users at `doctor` + `setup --repair`

## Rationale

Users landing on the npm package README are getting obsolete guidance three versions after the setup CLI shipped. The stale note actively misdirects — especially for Hermes-channel installs (1.5k+ per month per H004/E1) where the README is effectively the onboarding path. Doctor and setup --repair are the tools that resolve the fragility class issue #51 reported; if users don't know they exist, they can't use them.

## Test plan

- [x] `git diff` on README.md reviewed — 16 insertions, 3 deletions, no code changes
- [x] Commands documented match what `cli.ts` actually dispatches (`setup`, `setup --repair`, `doctor`)
- [x] Manual JSON fallback block kept for users who don't want to run the CLI
- [ ] CI green on docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)