### PR TITLE
docs: retire 86.7% benchmark-as-headline from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You rate the result     →  engram strengthens or decays  →  quality improves
 Unused engrams          →  activation decays  →  naturally fade from injection
 ```
 
-Search is fully local: BM25 (with IDF weighting, TF saturation, length normalization) + BGE embeddings + Reciprocal Rank Fusion. Zero API calls. 86.7% on LongMemEval — on par with cloud-based solutions that charge per query.
+Search is fully local: BM25 (with IDF weighting, TF saturation, length normalization) + BGE embeddings + Reciprocal Rank Fusion. Zero API calls, zero per-query cost. [Benchmark methodology →](https://plur.ai/benchmark.html)
 
 Plugins (OpenClaw, Hermes) automatically capture learnings from agent conversations — no manual saving needed. The agent's corrections become engrams without you doing anything.
 


### PR DESCRIPTION
## Summary

Retire the `86.7% on LongMemEval — on par with cloud-based solutions that charge per query` claim from the README, per the monthly positioning review on 2026-04-22.

## Why

Peer set has shifted. At the time the claim was written, cloud-only competitors (Mem0/Letta/Zep) were the relevant comparison. Since then:

- OMEGA: 95.4%, fully local, no cloud
- Mastra Observational Memory: 94.87%, passive capture
- Hindsight (Vectorize): 91.4%, open-source, Docker/Ollama local
- agentmemory: 96.2%

The "on par with cloud-based solutions that charge per query" framing no longer describes reality — the relevant comparison is now local-first open-source peers scoring above 86.7%. Claiming leadership under the old framing would misrepresent PLUR's position today. The positioning review's decision: keep benchmarks as a credibility signal, retire them as a competitive headline.

Additionally, the specific 86.7% figure is being re-measured under a new reproducible harness in #46's Phase 2 methodology — re-citing the old number in the README during that process is premature.

## Change

```diff
- Search is fully local: BM25 (...) + BGE embeddings + Reciprocal Rank Fusion. Zero API calls. 86.7% on LongMemEval — on par with cloud-based solutions that charge per query.
+ Search is fully local: BM25 (...) + BGE embeddings + Reciprocal Rank Fusion. Zero API calls, zero per-query cost. [Benchmark methodology →](https://plur.ai/benchmark.html)
```

What's preserved:
- Architecture claim (BM25 + BGE + RRF, fully local) — the actual differentiator, unchanged
- Credibility signal — reader can still follow the link to the methodology page
- Other non-comparative claims (2.6x Haiku-vs-Opus, 89% house-rules win rate) — those are PLUR-vs-no-memory benefit claims, not competitive positioning against other memory systems

## Scope note

This PR only touches the monorepo `README.md`. The `plur-ai/website` repo still carries the same line and needs a parallel change; that's a separate PR against a separate repo.

## Test plan

- [x] Diff is README-only, one line
- [x] Markdown rendering: link syntax `[Benchmark methodology →](https://plur.ai/benchmark.html)` matches the same target already linked in the README masthead (line 5)
- [x] No other `86.7` / `on par with cloud` occurrences in the README after the change