### PR TITLE
chore(claw): bump to 0.9.10

### DIFF
--- a/packages/claw/openclaw.plugin.json
+++ b/packages/claw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plur-claw",
   "name": "PLUR Memory Engine",
   "description": "Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "kind": "memory",
   "enabledByDefault": true,
   "configSchema": {

--- a/packages/claw/package.json
+++ b/packages/claw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/claw",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -50,7 +50,7 @@ export class PlurContextEngine implements ContextEngine {
   readonly info: ContextEngineInfo = {
     id: 'plur-claw',
     name: 'PLUR Memory Engine',
-    version: '0.9.9',
+    version: '0.9.10',
     ownsCompaction: false,
   }
 

--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -35,7 +35,7 @@ const plugin = {
   id: 'plur-claw',
   name: 'PLUR Memory Engine',
   description: 'Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.',
-  version: '0.9.9',
+  version: '0.9.10',
   kind: 'memory' as const,
 
   register(api: any) {

--- a/packages/claw/test/hello.test.ts
+++ b/packages/claw/test/hello.test.ts
@@ -6,7 +6,7 @@ describe('PLUR ContextEngine plugin', () => {
   it('plugin has correct metadata', () => {
     expect(plugin.id).toBe('plur-claw')
     expect(plugin.kind).toBe('memory')
-    expect(plugin.version).toBe('0.9.9')
+    expect(plugin.version).toBe('0.9.10')
   })
 
   it('registers via plugin API', () => {


### PR DESCRIPTION
## Summary

Cuts `@plur-ai/claw` v0.9.10 to ship the four slices of #51 that merged to `main` yesterday (2026-04-23) but have not yet reached npm.

npm currently serves `0.9.9` as `latest`; `main` already has everything below on top of that tag:

| PR | Commit | Contents |
|---|---|---|
| #52 (slice A) | `301d332` | auto-append `plur-claw` to `plugins.allow` when the allowlist is active |
| #53 (slice B) | `8c719ac` | step taxonomy split (`plugin_discovered` / `plugin_enabled` / `slot_selected` / `runtime_registered`) |
| #54 (slice C) | `58d598d` | `npx @plur-ai/claw doctor` read-only activation probe |
| #55 (slice E) | `390ccbc` | `npx @plur-ai/claw setup --repair` targeted fix |
| #56 | `b5c6604` | README refresh to cover the new setup CLI surface |

## Why now

The 2026-04-23T22:54Z comment on #51 closes with an explicit ask: the reporter (`@data-on-claw`) should run `npx @plur-ai/claw doctor` on a clean OpenClaw install and share the output. That command landed in slice C (PR #54) on main but does not exist in the published 0.9.9 tarball — so the reporter currently can't run what they've been asked to run. Publishing 0.9.10 closes that validation gap.

## Changes

Version string synced across all five locations:

- `packages/claw/package.json` → `0.9.10`
- `packages/claw/openclaw.plugin.json` → `0.9.10`
- `packages/claw/src/index.ts` (plugin manifest) → `0.9.10`
- `packages/claw/src/context-engine.ts` (\`ContextEngineInfo.version\`) → `0.9.10`
- `packages/claw/test/hello.test.ts` (metadata assertion) → `0.9.10`

No runtime behavior change; release artifact only.

## Test plan

- [ ] CI green (test 20 + test 22) — the test suite asserts `plugin.version === '0.9.10'`, so a stale version anywhere would fail.
- [ ] After merge: `npm publish` the `@plur-ai/claw@0.9.10` release from `packages/claw/`.
- [ ] Post-publish: `npm view @plur-ai/claw version` returns `0.9.10`; `npx @plur-ai/claw@latest doctor --help` resolves.
- [ ] Update #51 with the release tag so `@data-on-claw` has a live version to run `doctor` against.