### PR TITLE
docs: retire 86.7% benchmark-as-headline from package READMEs

### DIFF
--- a/packages/claw/README.md
+++ b/packages/claw/README.md
@@ -65,7 +65,7 @@ Next session starts      →  relevant ones injected →  agent remembers
 Agent rates the result   →  engram strengthens    →  quality improves
 ```
 
-**86.7% on LongMemEval** — on par with cloud memory services that charge per query.
+Search is independently benchmarked. [Methodology →](https://plur.ai/benchmark.html)
 
 ## Adding explicit memory tools
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -56,7 +56,7 @@ Next session starts     →  relevant ones injected →  agent remembers
 You rate the result     →  engram strengthens    →  quality improves
 ```
 
-Search is fully local: BM25 over enriched text + BGE-small-en-v1.5 embeddings + Reciprocal Rank Fusion. **86.7% on LongMemEval** — on par with cloud solutions that charge per query.
+Search is fully local: BM25 over enriched text + BGE-small-en-v1.5 embeddings + Reciprocal Rank Fusion. Zero API calls, zero per-query cost. [Benchmark methodology →](https://plur.ai/benchmark.html)
 
 ## Search modes
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -42,7 +42,7 @@ Next session starts     →  relevant ones injected →  agent remembers
 You rate the result     →  engram strengthens    →  quality improves
 ```
 
-Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant. Search is fully local (BM25 + embeddings), so memory recall costs nothing and works offline. **86.7% on LongMemEval** — on par with cloud memory services.
+Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant. Search is fully local (BM25 + embeddings), so memory recall costs nothing and works offline. [Benchmark methodology →](https://plur.ai/benchmark.html)
 
 ## Tools
 


### PR DESCRIPTION
## Summary

Continues [#57](https://github.com/plur-ai/plur/pull/57) — which retired the `86.7% on LongMemEval — on par with cloud-based solutions that charge per query` claim from the root README — across the three package READMEs (`packages/core`, `packages/mcp`, `packages/claw`).

## Why

The 2026-04-22 positioning review (§5) decided: **benchmarks as credibility signal, not competitive headline.** Peer set has shifted — OMEGA 95.4%, Mastra 94.87%, Hindsight 91.4%, agentmemory 96.2% are all local-first or open-source competitors scoring at or above 86.7%. The "on par with cloud" framing no longer describes reality.

PR #57 already executed this retirement in the root README. [plur-ai/website#1](https://github.com/plur-ai/website/pull/1) executed it on the landing page, llms.txt, and benchmark.html. This PR completes the user-facing-surface sweep.

## Change (three files, one-line each)

```diff
# packages/core/README.md
- Search is fully local: BM25 over enriched text + BGE-small-en-v1.5 embeddings + Reciprocal Rank Fusion. **86.7% on LongMemEval** — on par with cloud solutions that charge per query.
+ Search is fully local: BM25 over enriched text + BGE-small-en-v1.5 embeddings + Reciprocal Rank Fusion. Zero API calls, zero per-query cost. [Benchmark methodology →](https://plur.ai/benchmark.html)

# packages/mcp/README.md
- Knowledge is stored as **engrams** ... Search is fully local (BM25 + embeddings), so memory recall costs nothing and works offline. **86.7% on LongMemEval** — on par with cloud memory services.
+ Knowledge is stored as **engrams** ... Search is fully local (BM25 + embeddings), so memory recall costs nothing and works offline. [Benchmark methodology →](https://plur.ai/benchmark.html)

# packages/claw/README.md
- **86.7% on LongMemEval** — on par with cloud memory services that charge per query.
+ Search is independently benchmarked. [Methodology →](https://plur.ai/benchmark.html)
```

## What's preserved

- Architecture claims (BM25 + BGE + RRF, fully local, zero API calls) — the actual differentiator
- Credibility signal via methodology link — readers can verify the numbers
- Benchmark tables further down the READMEs — factual data, not positioning headlines
- Non-comparative claims (A/B win rate, house-rules, 2.6x Haiku-vs-Opus) — those are PLUR-vs-no-memory benefit claims, untouched

## Out of scope (deliberately)

- `CLAUDE.md` benchmark table — internal contributor reference, not reader-facing positioning
- `docs/reports/longmemeval-v0.2.1.md` — the doc analyzing the claim itself, must cite the exact number by design
- `docs/benchmarks/phase2-methodology.md` — F5 self-calibration anchor, explicitly needs the literal number
- `docs/enterprise/*` — separate positioning track, different audience dynamics

## Relation to issue #46 F5 gate

This PR is the natural execution of [#46](https://github.com/plur-ai/plur/issues/46)'s F5 "path 2" (restate-or-retire) for the user-facing surfaces. It does not force the harness F5 decision — the reference doc and methodology doc keep 86.7% as the literal anchor for the harness self-calibration gate. The decision about whether to re-run Opus-hybrid (path 1), restate to 83.33%/96.67% (path 2), or narrow F5 to Hit@10 (path 3) remains open for the ratification window through 2026-05-01.

## Test plan

- [x] Diff is 3 files, one line each
- [x] No other `86.7` / `on par with cloud` occurrences in the three package READMEs after the change
- [x] Methodology link matches the same target used in PR #57 (`https://plur.ai/benchmark.html`)
- [x] Benchmark tables (later in each README) are left intact as factual data