### PR TITLE
docs: add RELEASING.md with manual publish bridge

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,63 @@
+# Releasing
+
+This repo publishes four npm packages from `packages/`:
+
+| Package | npm name |
+|---|---|
+| `core` | `@plur-ai/core` |
+| `mcp` | `@plur-ai/mcp` |
+| `claw` | `@plur-ai/claw` |
+| `cli` | `@plur-ai/cli` |
+
+`hermes` (Python) ships through a separate PyPI pipeline and is out of scope for this guide.
+
+## Manual publish (one package)
+
+When `main` has a version bump that hasn't reached npm yet — e.g. `@plur-ai/claw@0.9.10` is on
+`main` but `npm view @plur-ai/claw version` still returns `0.9.9` — anyone with publish rights on
+the `@plur-ai` npm scope can ship it from a clean checkout in under a minute:
+
+```sh
+git checkout main && git pull
+pnpm install --frozen-lockfile
+pnpm --filter @plur-ai/claw build
+pnpm --filter @plur-ai/claw publish --access public --no-git-checks
+```
+
+Substitute the package name as needed (`@plur-ai/core`, `@plur-ai/mcp`, `@plur-ai/cli`).
+
+### Why `pnpm publish`, not `npm publish`
+
+- `packages/claw/package.json` declares dependencies like `"@plur-ai/core": "workspace:*"`.
+  `pnpm publish` rewrites those to the concrete published version on the way out;
+  `npm publish` would ship the literal `workspace:*` string and break the installed tarball.
+- `--no-git-checks` skips pnpm's clean-tree assertion so local build artifacts don't block the
+  publish.
+
+### Verify (no auth, ~2s)
+
+```sh
+npm view @plur-ai/claw version   # expect the version that's on main
+```
+
+Once the npm version matches `main`, the drift is closed.
+
+### Tag the release
+
+`pnpm publish` does not push a git tag. After a successful publish:
+
+```sh
+TAG="@plur-ai/claw@$(node -p "require('./packages/claw/package.json').version")"
+git tag "$TAG"
+git push origin "$TAG"
+```
+
+## Long-term: publish-on-merge workflow
+
+The right long-term shape is a GitHub Actions workflow that detects `packages/*/package.json`
+version bumps on `main` and publishes + tags them automatically. A draft is on file in
+[#59](https://github.com/plur-ai/plur/issues/59) and lands as `.github/workflows/publish.yml`
+when merged through the GitHub UI (the agent that drafted it lacks `workflow` token scope).
+
+This `RELEASING.md` is the durable bridge for the period before that workflow merges, and
+remains a useful reference for one-off / out-of-band publishes after it does.


### PR DESCRIPTION
## Summary

Captures the manual `pnpm publish` recipe that's been scattered across #59 comment threads as a permanent file in the repo, so the next contributor with `@plur-ai` npm rights doesn't have to dig through issue comments to ship a release.

- Documents the 30-sec manual bridge (`pnpm install` → `pnpm --filter X build` → `pnpm --filter X publish`)
- Explains *why* `pnpm publish` (not `npm publish`) — the `workspace:*` substitution that breaks tarballs otherwise
- Adds the post-publish verify (`npm view X version`) and git tag steps
- Points at #59 as the long-term publish-on-merge fix this is a bridge for

This is purely documentation — no CI changes, no workflow scope needed.

## Why now

`@plur-ai/claw@0.9.10` has been drifted on `main` vs npm `0.9.9` for 4 days (since 2026-04-24T07:03Z), blocking the `npx @plur-ai/claw doctor` ask on #51. The drift exposed that the publish procedure lives in a comment thread rather than the repo. This file fixes that.

## Test plan

- [ ] Read RELEASING.md as a first-time contributor — does the recipe work end-to-end against `main`?
- [ ] Confirm the `pnpm --filter @plur-ai/claw publish` command (run from clean checkout) ships `0.9.10` and `npm view @plur-ai/claw version` returns `0.9.10`. (This also closes the current drift.)

Refs: #59 #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)