### PR TITLE
chore(cli): bump to 0.9.3 — fix bricked npm publish (refs #59)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "bin": {
     "plur": "dist/index.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { parseGlobalFlags, createPlur } from './plur.js'
 export type { GlobalFlags } from './plur.js'
 export { parseGlobalFlags, createPlur } from './plur.js'
 
-const VERSION = '0.9.2'
+const VERSION = '0.9.3'
 
 // --- Main ---
 const argv = process.argv.slice(2)


### PR DESCRIPTION
## Summary

Bumps `@plur-ai/cli` from `0.9.2` → `0.9.3` so the next published artifact repins `@plur-ai/core` to the fixed `0.9.3`. Closes the user-facing bricking documented in [#59 (cto heartbeat 2026-04-27)](https://github.com/plur-ai/plur/issues/59).

## Why this is urgent

Every `npx @plur-ai/cli <cmd>` against the current npm `latest` (`0.9.2`) crashes:

```
$ npx @plur-ai/cli status
{"error":"Dynamic require of \"os\" is not supported"}
```

Root cause: `cli@0.9.2` was published with `"@plur-ai/core": "workspace:*"`, which pnpm resolved at publish time to a hard pin `"@plur-ai/core": "0.9.2"` — the pre-fix version. The fix landed in `core@0.9.3` (584f11f, 2026-04-22) and is already on npm, but `cli/package.json` was never bumped to repin it.

This PR makes the next `pnpm --filter @plur-ai/cli publish ...` (per [RELEASING.md](https://github.com/plur-ai/plur/blob/main/RELEASING.md)) resolve `workspace:*` to `"@plur-ai/core": "0.9.3"` — unbricking every published CLI command.

## Diff

Two lines, both per `packages/cli/CLAUDE.md`-style version-bump rules (`package.json` + the `VERSION` constant in `src/index.ts` that the `version.test.ts` invariant guards):

- `packages/cli/package.json`: `"version": "0.9.2"` → `"0.9.3"`
- `packages/cli/src/index.ts`: `const VERSION = '0.9.2'` → `'0.9.3'`

## Test plan

- [x] `pnpm exec vitest run test/version.test.ts` passes (verified locally — version constant matches package.json)
- [ ] CI green on this PR
- [ ] Post-merge: maintainer with npm publish rights runs RELEASING.md `pnpm --filter @plur-ai/cli publish --access public --no-git-checks`
- [ ] Verify `npm view @plur-ai/cli@latest dependencies` resolves `@plur-ai/core: 0.9.3`
- [ ] Smoke test: `npx @plur-ai/cli@latest status` returns valid JSON (not the dynamic-require error)

## Out of scope

The structural publish-on-tag workflow (this issue's actual scope) and the "bump every consumer when a dep is bumped" workflow check are still needed and tracked in #59. This PR is the immediate manual unbrick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)