### PR TITLE
docs: add consumer-side bump section to RELEASING.md (#59 day-4)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,6 +52,46 @@ git tag "$TAG"
 git push origin "$TAG"
 ```
 
+## Consumer-side bump after a `core` (or other dependency) fix
+
+When a fix lands in a workspace package that other packages depend on — most often `core`,
+which `cli`, `mcp`, and `claw` all consume — bumping and publishing the dep alone is **not
+enough** to ship the fix to users.
+
+`workspace:*` pins are concretized at **publish time**, not at install time. So a consumer
+that was published before the fix carries a hard pin to the broken dep version, even after
+the fixed dep is on npm `latest`. `npm i @plur-ai/<consumer>@latest` will still pull the
+broken dep.
+
+This is what bricked `@plur-ai/cli@0.9.2` for 5 days (2026-04-22 → 2026-04-27): `core@0.9.3`
+shipped a fix for `autoDiscoverStores` (#59 thread), but `cli@0.9.2` had already been
+published with `@plur-ai/core: 0.9.2` baked into its `dependencies` field. Every
+`npx @plur-ai/cli@latest` invocation returned `Dynamic require of "os" is not supported`
+until `cli@0.9.3` was bumped (#64) and republished.
+
+### Recipe — after publishing a `core` fix
+
+1. For each workspace consumer of `core` (`cli`, `mcp`, `claw`), check the `core` pin baked
+   into the latest published artifact:
+   ```sh
+   for pkg in cli mcp claw; do
+     printf "%-20s -> " "@plur-ai/$pkg"
+     npm view "@plur-ai/$pkg@latest" dependencies.@plur-ai/core
+   done
+   ```
+2. If a consumer's published `core` pin is older than the fix, that consumer is shipping the
+   broken dep. Bump it: follow the nine-place version-bump checklist in `CLAUDE.md`
+   (package.json + in-source `VERSION` constants + test assertions), open a PR, merge.
+3. After merge, run the **Manual publish** recipe above for each bumped consumer.
+4. Verify the pin landed:
+   ```sh
+   npm view @plur-ai/cli@latest dependencies   # expect: { "@plur-ai/core": "<fixed-version>" }
+   ```
+
+The eventual publish-on-merge workflow (#59) should encode this auto-cascade: when `core`
+bumps, every workspace consumer also bumps in the same release so the published artifact
+graph stays internally consistent.
+
 ## Long-term: publish-on-merge workflow
 
 The right long-term shape is a GitHub Actions workflow that detects `packages/*/package.json`


### PR DESCRIPTION
## Summary

- Codifies the **`workspace:*` hard-pin trap** that bricked `@plur-ai/cli@0.9.2` for 5 days: a fix in `core` does not propagate to already-published consumers, because consumer dep pins are concretized at the consumer's own publish time, not at install time.
- Adds a recipe to detect drift (one-liner shell loop checking the `core` pin baked into each consumer's npm `latest`) and a step-by-step unblock path (cross-references `CLAUDE.md`'s nine-place version-bump checklist).
- Notes that the eventual publish-on-merge workflow (#59) should encode this auto-cascade so future `core` bumps automatically bump every workspace consumer in the same release.

Closes the day-4 follow-up ask on #59. Doc-only — no CI, no source, no version changes.

## Test plan

- [x] `RELEASING.md` renders cleanly (no broken markdown, code fences balanced).
- [x] One-liner detection loop returns expected output for current state:
  ```
  @plur-ai/cli         -> 0.9.2
  @plur-ai/mcp         -> 0.9.3
  @plur-ai/claw        -> 0.9.3
  ```
  (`cli` still pinned to broken `core@0.9.2` on npm `latest` even though `main` is at `0.9.3` per #64.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)