### PR TITLE
feat(core): capsule v1 schema + preamble parser (#61 slice 1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,26 @@ export type { Episode } from './schemas/episode.js'
 export type { PackManifest } from './schemas/pack.js'
 export type { PreviewResult, RegistryEntry, PrivacyScanResult, PrivacyIssue } from './packs.js'
 export type { PlurConfig, StoreEntry } from './schemas/config.js'
+export type { ManifestSummary, PayloadDescriptor, Producer, Signer, CapsuleHeader, CapsulePreamble } from './schemas/capsule.js'
+export {
+  CAPSULE_MAGIC,
+  CAPSULE_MAGIC_HEX,
+  FORMAT_VERSION_V1,
+  SUPPORTED_FORMAT_VERSIONS,
+  CAPSULE_FLAGS,
+  CAPSULE_FLAG_RESERVED_MASK,
+  PREAMBLE_LEN,
+  CAPSULE_SIZE_LIMITS,
+  ED25519_SIG_LEN,
+  ManifestSummarySchema,
+  PayloadDescriptorSchema,
+  ProducerSchema,
+  SignerSchema,
+  CapsuleHeaderSchema,
+  parseCapsulePreamble,
+  serializeCapsulePreamble,
+  hasFlag,
+} from './schemas/capsule.js'
 export * from './types.js'
 
 export interface IngestOptions {

--- a/packages/core/src/schemas/capsule.ts
+++ b/packages/core/src/schemas/capsule.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod'
+
+// .plur capsule v1 — binary envelope for engram packs.
+// Spec: plur-ai/plur#61 §1–§6 (sketch becomes floor at 2026-04-29 window close).
+// Layout: MAGIC | FormatVersion | Flags | HeaderLen | Header(JSON) | Payload(tar.gz) | Sig?
+
+export const CAPSULE_MAGIC = Buffer.from([0x50, 0x4c, 0x55, 0x52])
+export const CAPSULE_MAGIC_HEX = '50 4c 55 52'
+
+export const FORMAT_VERSION_V1 = 0x0001
+export const SUPPORTED_FORMAT_VERSIONS = [FORMAT_VERSION_V1] as const
+
+export const CAPSULE_FLAGS = {
+  SIGNED: 1 << 0,
+  COMPRESSED: 1 << 1,
+} as const
+export const CAPSULE_FLAG_RESERVED_MASK = 0xfffc
+
+export const PREAMBLE_LEN = 12
+
+export const CAPSULE_SIZE_LIMITS = {
+  SOFT_BYTES: 100 * 1024 * 1024,
+  HARD_BYTES: 1024 * 1024 * 1024,
+} as const
+
+export const ED25519_SIG_LEN = 64
+
+export const ManifestSummarySchema = z.object({
+  name: z.string().min(1),
+  version: z.string().min(1),
+  creator: z.string().optional(),
+  engram_count: z.number().int().min(0),
+  domain: z.string().optional(),
+  license: z.string().default('cc-by-sa-4.0'),
+})
+export type ManifestSummary = z.infer<typeof ManifestSummarySchema>
+
+export const PayloadDescriptorSchema = z.object({
+  compression: z.enum(['gzip', 'none']),
+  size_compressed: z.number().int().min(0),
+  size_uncompressed: z.number().int().min(0),
+  sha256: z.string().regex(/^[0-9a-f]{64}$/, 'sha256 must be 64 lowercase hex chars'),
+})
+export type PayloadDescriptor = z.infer<typeof PayloadDescriptorSchema>
+
+export const ProducerSchema = z.object({
+  tool: z.string().min(1),
+  version: z.string().min(1),
+  agent_id: z.string().optional(),
+})
+export type Producer = z.infer<typeof ProducerSchema>
+
+export const SignerSchema = z.object({
+  algo: z.literal('ed25519'),
+  public_key: z.string().min(1),
+  key_id: z.string().optional(),
+})
+export type Signer = z.infer<typeof SignerSchema>
+
+export const CapsuleHeaderSchema = z.object({
+  schema: z.literal('plur.capsule/1'),
+  product_type: z.enum(['engram-pack', 'skill']),
+  manifest_summary: ManifestSummarySchema,
+  payload: PayloadDescriptorSchema,
+  created_at: z.string().datetime({ offset: true }),
+  producer: ProducerSchema,
+  signer: SignerSchema.nullable().default(null),
+})
+export type CapsuleHeader = z.infer<typeof CapsuleHeaderSchema>
+
+export interface CapsulePreamble {
+  formatVersion: number
+  flags: number
+  headerLen: number
+}
+
+export function parseCapsulePreamble(buf: Buffer): CapsulePreamble {
+  if (buf.length < PREAMBLE_LEN) {
+    throw new Error(`capsule: truncated preamble (got ${buf.length} bytes, need ${PREAMBLE_LEN})`)
+  }
+  if (buf.compare(CAPSULE_MAGIC, 0, 4, 0, 4) !== 0) {
+    throw new Error(`capsule: bad magic (expected ${CAPSULE_MAGIC_HEX})`)
+  }
+  const formatVersion = buf.readUInt16LE(4)
+  if (!SUPPORTED_FORMAT_VERSIONS.includes(formatVersion as typeof FORMAT_VERSION_V1)) {
+    throw new Error(`capsule: unsupported FormatVersion 0x${formatVersion.toString(16).padStart(4, '0')}`)
+  }
+  const flags = buf.readUInt16LE(6)
+  if ((flags & CAPSULE_FLAG_RESERVED_MASK) !== 0) {
+    throw new Error(`capsule: reserved flag bits set (flags=0x${flags.toString(16).padStart(4, '0')})`)
+  }
+  const headerLen = buf.readUInt32LE(8)
+  if (headerLen === 0) {
+    throw new Error('capsule: HeaderLen must be > 0')
+  }
+  if (headerLen > CAPSULE_SIZE_LIMITS.HARD_BYTES) {
+    throw new Error(`capsule: HeaderLen ${headerLen} exceeds hard size limit`)
+  }
+  return { formatVersion, flags, headerLen }
+}
+
+export function serializeCapsulePreamble(p: CapsulePreamble): Buffer {
+  const buf = Buffer.alloc(PREAMBLE_LEN)
+  CAPSULE_MAGIC.copy(buf, 0)
+  buf.writeUInt16LE(p.formatVersion, 4)
+  buf.writeUInt16LE(p.flags, 6)
+  buf.writeUInt32LE(p.headerLen, 8)
+  return buf
+}
+
+export function hasFlag(flags: number, flag: number): boolean {
+  return (flags & flag) === flag
+}

--- a/packages/core/test/capsule-schema.test.ts
+++ b/packages/core/test/capsule-schema.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CAPSULE_MAGIC,
+  CAPSULE_FLAGS,
+  FORMAT_VERSION_V1,
+  PREAMBLE_LEN,
+  CapsuleHeaderSchema,
+  parseCapsulePreamble,
+  serializeCapsulePreamble,
+  hasFlag,
+} from '../src/schemas/capsule.js'
+
+describe('capsule preamble', () => {
+  it('round-trips a valid preamble', () => {
+    const out = serializeCapsulePreamble({ formatVersion: FORMAT_VERSION_V1, flags: 0, headerLen: 256 })
+    expect(out.length).toBe(PREAMBLE_LEN)
+    expect(out.subarray(0, 4).equals(CAPSULE_MAGIC)).toBe(true)
+    const parsed = parseCapsulePreamble(out)
+    expect(parsed).toEqual({ formatVersion: FORMAT_VERSION_V1, flags: 0, headerLen: 256 })
+  })
+
+  it('rejects bad magic bytes', () => {
+    const buf = Buffer.alloc(PREAMBLE_LEN)
+    buf.write('XXXX', 0, 4)
+    buf.writeUInt32LE(64, 8)
+    expect(() => parseCapsulePreamble(buf)).toThrow(/bad magic/)
+  })
+
+  it('rejects truncated preamble', () => {
+    expect(() => parseCapsulePreamble(Buffer.alloc(8))).toThrow(/truncated preamble/)
+  })
+
+  it('rejects unsupported FormatVersion', () => {
+    const buf = serializeCapsulePreamble({ formatVersion: 0x0099, flags: 0, headerLen: 64 })
+    expect(() => parseCapsulePreamble(buf)).toThrow(/unsupported FormatVersion/)
+  })
+
+  it('rejects reserved flag bits', () => {
+    const buf = serializeCapsulePreamble({ formatVersion: FORMAT_VERSION_V1, flags: 0x0004, headerLen: 64 })
+    expect(() => parseCapsulePreamble(buf)).toThrow(/reserved flag bits/)
+  })
+
+  it('rejects zero HeaderLen', () => {
+    const buf = serializeCapsulePreamble({ formatVersion: FORMAT_VERSION_V1, flags: 0, headerLen: 0 })
+    expect(() => parseCapsulePreamble(buf)).toThrow(/HeaderLen must be > 0/)
+  })
+
+  it('accepts SIGNED and COMPRESSED flag bits', () => {
+    const flags = CAPSULE_FLAGS.SIGNED | CAPSULE_FLAGS.COMPRESSED
+    const buf = serializeCapsulePreamble({ formatVersion: FORMAT_VERSION_V1, flags, headerLen: 64 })
+    const parsed = parseCapsulePreamble(buf)
+    expect(hasFlag(parsed.flags, CAPSULE_FLAGS.SIGNED)).toBe(true)
+    expect(hasFlag(parsed.flags, CAPSULE_FLAGS.COMPRESSED)).toBe(true)
+  })
+})
+
+describe('CapsuleHeaderSchema', () => {
+  const validHeader = {
+    schema: 'plur.capsule/1',
+    product_type: 'engram-pack',
+    manifest_summary: {
+      name: 'engineering-conventions',
+      version: '0.3.1',
+      creator: 'plur9',
+      engram_count: 147,
+      domain: 'engineering',
+      license: 'cc-by-sa-4.0',
+    },
+    payload: {
+      compression: 'gzip',
+      size_compressed: 54321,
+      size_uncompressed: 198765,
+      sha256: 'a'.repeat(64),
+    },
+    created_at: '2026-04-29T19:30:00Z',
+    producer: { tool: '@plur-ai/core', version: '0.9.3' },
+    signer: null,
+  }
+
+  it('accepts a valid v1 header', () => {
+    const result = CapsuleHeaderSchema.parse(validHeader)
+    expect(result.schema).toBe('plur.capsule/1')
+    expect(result.signer).toBeNull()
+  })
+
+  it('rejects wrong schema string', () => {
+    expect(() => CapsuleHeaderSchema.parse({ ...validHeader, schema: 'plur.capsule/2' })).toThrow()
+  })
+
+  it('rejects malformed sha256', () => {
+    expect(() =>
+      CapsuleHeaderSchema.parse({ ...validHeader, payload: { ...validHeader.payload, sha256: 'not-hex' } }),
+    ).toThrow()
+  })
+
+  it('rejects unknown product_type', () => {
+    expect(() => CapsuleHeaderSchema.parse({ ...validHeader, product_type: 'mystery' })).toThrow()
+  })
+
+  it('defaults signer to null when omitted', () => {
+    const { signer: _, ...withoutSigner } = validHeader
+    const result = CapsuleHeaderSchema.parse(withoutSigner)
+    expect(result.signer).toBeNull()
+  })
+
+  it('accepts optional producer.agent_id slot (Hermes §7.1)', () => {
+    const result = CapsuleHeaderSchema.parse({
+      ...validHeader,
+      producer: { ...validHeader.producer, agent_id: 'hermes-1' },
+    })
+    expect(result.producer.agent_id).toBe('hermes-1')
+  })
+})


### PR DESCRIPTION
First of four slices for the `.plur` capsule format (#61). The 2026-04-29 sign-off window closed silent at 19:30 UTC ([window-closure comment](https://github.com/plur-ai/plur/issues/61#issuecomment-2766831)) — the spec sketch §1–§6 became the floor, slice 1 is now unblocked. This PR is that slice 1.

## Scope

- `packages/core/src/schemas/capsule.ts` — `CapsuleHeader` Zod schema, `CAPSULE_MAGIC` ("PLUR"), `FORMAT_VERSION_V1`, `CAPSULE_FLAGS` (`SIGNED`, `COMPRESSED`), 12-byte preamble (de)serializer, size-limit constants, `Ed25519` sig-len constant.
- `packages/core/test/capsule-schema.test.ts` — 13 tests: preamble round-trip, bad magic, truncated input, unsupported `FormatVersion`, reserved flag bits, zero `HeaderLen`, flag combinations, header valid/invalid cases, optional `producer.agent_id`.

Mirrors §2 of the spec sketch verbatim: `schema: 'plur.capsule/1'`, `product_type` enum, `manifest_summary` projection, `payload` descriptor with `gzip|none` compression and lowercase-hex `sha256`, ISO-8601 `created_at`, `producer`, nullable `signer`.

## §7 open questions

The three Hermes-side questions remain absorbable until slice 1 merges. Current take baked in:

- **§7.1 `producer.agent_id`** — shipped as an optional slot on `ProducerSchema`; test covers it. Cheap forward-compat if Tris wants to formalize it.
- **§7.2 `parent_sha256`** — not in the header; CTO-side lean is exchange-side metadata per §3 spec discussion. Reversible if Hermes pushes back.
- **§7.3 `skill` envelope reuse** — `product_type: z.enum(['engram-pack', 'skill'])`. Same envelope, different dispatch.

@tfius — door is still open. Comment on #61 before this merges if any of §7 needs a different default.

## Out of scope (future slices)

- Slice 2: `core/capsule/{reader,writer}.ts` — full envelope read/write around the existing `tar.gz(manifest.yaml + engrams.yaml)` payload.
- Slice 3: CLI flag wiring (`plur pack export --capsule`, magic-byte sniff in `install`).
- Slice 4: round-trip fixtures, malformed-header cases, version-bump forward-compat.

## Distribution

Lands on `main` regardless of #59 (npm publish bridge still escalated). Source-level work; consumers won't see it on `npm install` until the publish path resolves separately.

## Test plan

- [x] `vitest run test/capsule-schema.test.ts` — 13/13 pass locally
- [ ] CI `pnpm test` clean
- [ ] No new prod deps (Zod already in)

Draft until CI confirms green.