### PR TITLE
feat(claw): add PLUR_TELEMETRY opt-in gate (#51 slice D-1)

### DIFF
--- a/packages/claw/src/setup.ts
+++ b/packages/claw/src/setup.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
+import { resolveTelemetry } from './telemetry.js'
 
 type OpenclawConfig = {
   plugins?: {
@@ -143,6 +144,7 @@ export type SetupStep =
   | 'slot_selected'
   | 'reload_required'
   | 'runtime_registered'
+  | 'telemetry_optin'
 export type SetupStatus = 'ok' | 'skip' | 'fail' | 'pending'
 export type SetupReport = {
   path: string
@@ -261,7 +263,9 @@ export function runSetupCli(): number {
   return failed ? 1 : 0
 }
 
-export function runDoctor(opts: { configPath?: string } = {}): SetupReport {
+export function runDoctor(
+  opts: { configPath?: string; env?: NodeJS.ProcessEnv; telemetryConfigPath?: string } = {},
+): SetupReport {
   const path = opts.configPath ?? resolveConfigPath()
   const report: SetupReport = {
     path,
@@ -279,6 +283,7 @@ export function runDoctor(opts: { configPath?: string } = {}): SetupReport {
       status: 'pending',
       detail: 'automatic verification not yet implemented (tracked in #39)',
     })
+    report.steps.push(telemetryStep(opts))
   }
 
   if (!existsSync(path)) {
@@ -345,6 +350,18 @@ export function runDoctor(opts: { configPath?: string } = {}): SetupReport {
 
   tailPending()
   return report
+}
+
+function telemetryStep(opts: { env?: NodeJS.ProcessEnv; telemetryConfigPath?: string }): {
+  step: SetupStep
+  status: SetupStatus
+  detail?: string
+} {
+  const r = resolveTelemetry({ env: opts.env, configPath: opts.telemetryConfigPath })
+  const sourceLabel =
+    r.source === 'env' ? 'PLUR_TELEMETRY env' : r.source === 'config' ? r.configPath : 'default (off)'
+  if (r.state === 'on') return { step: 'telemetry_optin', status: 'ok', detail: `on — ${sourceLabel}` }
+  return { step: 'telemetry_optin', status: 'skip', detail: `off — ${sourceLabel}` }
 }
 
 export function runDoctorCli(): number {

--- a/packages/claw/src/telemetry.ts
+++ b/packages/claw/src/telemetry.ts
@@ -1,0 +1,62 @@
+// Opt-in telemetry gate.
+//
+// Resolution order (last writer wins on ties; only `on` activates the gate):
+//   1. PLUR_TELEMETRY env var — `on` | `off` (any other value is treated as unset)
+//   2. Persisted preference at ~/.plur/telemetry.json — { enabled: boolean }
+//   3. Default: 'off' (non-interactive installs never opt in implicitly)
+//
+// This file is the gate only. No counters, no flush, no transport — those land
+// in follow-up commits behind a state of `on`. See docs/telemetry-design.md.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export type TelemetryState = 'on' | 'off'
+export type TelemetrySource = 'env' | 'config' | 'default'
+
+export type TelemetryResolution = {
+  state: TelemetryState
+  source: TelemetrySource
+  configPath: string
+}
+
+function resolveConfigPath(): string {
+  return join(homedir(), '.plur', 'telemetry.json')
+}
+
+function readEnv(env: NodeJS.ProcessEnv): TelemetryState | null {
+  const raw = env.PLUR_TELEMETRY
+  if (raw === 'on') return 'on'
+  if (raw === 'off') return 'off'
+  return null
+}
+
+function readConfig(path: string): TelemetryState | null {
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'))
+    if (parsed && typeof parsed === 'object' && parsed.enabled === true) return 'on'
+    if (parsed && typeof parsed === 'object' && parsed.enabled === false) return 'off'
+    return null
+  } catch {
+    return null
+  }
+}
+
+export function resolveTelemetry(opts: { env?: NodeJS.ProcessEnv; configPath?: string } = {}): TelemetryResolution {
+  const env = opts.env ?? process.env
+  const configPath = opts.configPath ?? resolveConfigPath()
+
+  const fromEnv = readEnv(env)
+  if (fromEnv !== null) return { state: fromEnv, source: 'env', configPath }
+
+  const fromConfig = readConfig(configPath)
+  if (fromConfig !== null) return { state: fromConfig, source: 'config', configPath }
+
+  return { state: 'off', source: 'default', configPath }
+}
+
+export function isTelemetryEnabled(opts?: { env?: NodeJS.ProcessEnv; configPath?: string }): boolean {
+  return resolveTelemetry(opts).state === 'on'
+}

--- a/packages/claw/test/setup.test.ts
+++ b/packages/claw/test/setup.test.ts
@@ -263,6 +263,7 @@ describe('claw doctor command', () => {
       'slot_selected',
       'reload_required',
       'runtime_registered',
+      'telemetry_optin',
     ])
   })
 
@@ -277,6 +278,28 @@ describe('claw doctor command', () => {
     const r = runDoctor({ configPath: cfgPath })
     expect(r.steps.find((s) => s.step === 'reload_required')!.status).toBe('pending')
     expect(r.steps.find((s) => s.step === 'runtime_registered')!.status).toBe('pending')
+  })
+
+  it('surfaces telemetry as skip by default with no env or config', () => {
+    const telemetryCfg = join(dir, 'telemetry.json')
+    const r = runDoctor({ configPath: cfgPath, env: {}, telemetryConfigPath: telemetryCfg })
+    const step = r.steps.find((s) => s.step === 'telemetry_optin')!
+    expect(step.status).toBe('skip')
+    expect(step.detail).toContain('off')
+    expect(step.detail).toContain('default')
+  })
+
+  it('surfaces telemetry as ok when PLUR_TELEMETRY=on', () => {
+    const telemetryCfg = join(dir, 'telemetry.json')
+    const r = runDoctor({
+      configPath: cfgPath,
+      env: { PLUR_TELEMETRY: 'on' },
+      telemetryConfigPath: telemetryCfg,
+    })
+    const step = r.steps.find((s) => s.step === 'telemetry_optin')!
+    expect(step.status).toBe('ok')
+    expect(step.detail).toContain('on')
+    expect(step.detail).toContain('PLUR_TELEMETRY')
   })
 })
 

--- a/packages/claw/test/telemetry.test.ts
+++ b/packages/claw/test/telemetry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveTelemetry, isTelemetryEnabled } from '../src/telemetry.js'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-telemetry-'))
+}
+
+describe('telemetry gate', () => {
+  let dir: string
+  let cfg: string
+  beforeEach(() => {
+    dir = newDir()
+    cfg = join(dir, 'telemetry.json')
+  })
+
+  it('defaults to off with no env and no config file', () => {
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('default')
+  })
+
+  it('PLUR_TELEMETRY=on activates the gate', () => {
+    const r = resolveTelemetry({ env: { PLUR_TELEMETRY: 'on' }, configPath: cfg })
+    expect(r.state).toBe('on')
+    expect(r.source).toBe('env')
+    expect(isTelemetryEnabled({ env: { PLUR_TELEMETRY: 'on' }, configPath: cfg })).toBe(true)
+  })
+
+  it('PLUR_TELEMETRY=off forces the gate off even with config enabled', () => {
+    writeFileSync(cfg, JSON.stringify({ enabled: true }))
+    const r = resolveTelemetry({ env: { PLUR_TELEMETRY: 'off' }, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('env')
+  })
+
+  it('reads enabled:true from config when env is unset', () => {
+    writeFileSync(cfg, JSON.stringify({ enabled: true }))
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('on')
+    expect(r.source).toBe('config')
+  })
+
+  it('reads enabled:false from config', () => {
+    writeFileSync(cfg, JSON.stringify({ enabled: false }))
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('config')
+  })
+
+  it('treats unrecognized env values as unset', () => {
+    const r = resolveTelemetry({ env: { PLUR_TELEMETRY: 'maybe' }, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('default')
+  })
+
+  it('treats malformed config as unset (does not throw)', () => {
+    writeFileSync(cfg, '{ this is not json')
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('default')
+  })
+})


### PR DESCRIPTION
## Summary

Lands the **opt-in UX + `PLUR_TELEMETRY` gate** as the first build step of #51 Slice D, per the [2026-04-29 window-close comment](https://github.com/plur-ai/plur/issues/51#issuecomment-2766831) on Slice D resumption: *"the eventual code PR will open with the opt-in UX, not the counter plumbing."*

This PR is the gate only. **No counters, no flush, no transport** — those land in slice D-2 behind `isTelemetryEnabled()` so default-off installs never emit.

## Behavior

`packages/claw/src/telemetry.ts` resolves a single `TelemetryState` from three sources, last-writer-wins precedence:

| Order | Source | Activation |
|---|---|---|
| 1 | `PLUR_TELEMETRY` env var | `'on'` / `'off'` (other values ignored) |
| 2 | `~/.plur/telemetry.json` | `{ enabled: boolean }` |
| 3 | Default | `'off'` — non-interactive installs never opt in implicitly |

`runDoctor()` surfaces the resolved state via a new `telemetry_optin` `SetupStep` — `ok` when on, `skip` when off; `detail` names the source (`PLUR_TELEMETRY env`, the config path, or `default (off)`).

## Tests

- `packages/claw/test/telemetry.test.ts` — 7 tests: default-off, env on/off, config on/off, malformed config, unrecognized env value
- `packages/claw/test/setup.test.ts` — 2 new tests: doctor surfaces `telemetry_optin` as `skip` by default, `ok` under `PLUR_TELEMETRY=on`
- All 40 tests in the two suites green locally on Node 22.22.2

## Design alignment

Matches all five 2026-04-21 telemetry-design decisions ratified by silence on PR #23 (window closed clean 2026-04-29T20:55Z):

- **Opt-in default-off** ✅ — no transport without explicit `on`
- **No PII** ✅ — gate emits no data on its own
- Counter-only emission, daily flush, `/v1/heartbeat` endpoint shape — D-2 territory

## What this does NOT change

`npx @plur-ai/claw doctor` end-to-end testability is **still gated on #59 publish-bridge** — until 0.9.10+ ships to npm, this code only runs locally or via main-checkout.

## Test plan

- [ ] CI green on Node 20 + Node 22
- [ ] `npx @plur-ai/claw doctor` shows new `telemetry_optin` row with `skip — off — default (off)` on a fresh machine
- [ ] `PLUR_TELEMETRY=on npx @plur-ai/claw doctor` flips that row to `ok — on — PLUR_TELEMETRY env`
- [ ] `~/.plur/telemetry.json` with `{ "enabled": true }` activates the gate when env is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)