### PR TITLE
docs(cli): warn about bricked @plur-ai/cli@0.9.2 on npm

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,6 +16,12 @@ Or use without installing:
 npx @plur-ai/cli status
 ```
 
+> ### Known issue: avoid `0.9.2` on npm
+>
+> The currently published `@plur-ai/cli@0.9.2` (latest tag on npm) is bricked — every command throws `{"error":"Dynamic require of \"os\" is not supported"}` due to an esbuild bundling regression. The fix is on `main` as `0.9.3` (see commit `7af15a8`) and a CI regression guard is now in place ([#68](https://github.com/plur-ai/plur/pull/68)), but the `0.9.3` artifact has not yet shipped to npm — tracking in [#59](https://github.com/plur-ai/plur/issues/59).
+>
+> **Workaround until `0.9.3` is published:** install the prior working version `npm install -g @plur-ai/cli@0.9.1`, or run from source by cloning the repo and `pnpm install && pnpm --filter @plur-ai/cli build`.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a 6-line "Known issue" callout to `packages/cli/README.md` immediately after the install instructions, warning that the currently published `@plur-ai/cli@0.9.2` on npm is bricked (every command throws `Dynamic require of "os" is not supported`).

The fix has been on `main` as `0.9.3` since #64 merged 2026-04-27, and a CI regression guard landed in #68 today, but the `0.9.3` artifact has not yet shipped to npm — tracked structurally in #59 (publish-on-tag workflow missing). Per #59 day-8 status, daily downloads of the bricked `cli@0.9.2` collapsed to **0** on 2026-04-29 and 2026-04-30, suggesting users are giving up rather than discovering the workaround.

This README change is purely defensive — anyone who lands on the GitHub repo over the next few days now sees the brick warning and a one-line install pin (`@plur-ai/cli@0.9.1`) or run-from-source escape hatch before they hit the failure mode.

The note will be removed by whoever ships `cli@0.9.3` to npm (one-line revert), so it's intentionally scoped narrow and time-bounded.

## Test plan

- [x] Markdown renders cleanly in GitHub preview (blockquote with H3 + two paragraphs)
- [x] Links resolve: #59, #68, commit `7af15a8`
- [x] No code changes, no test impact — docs-only
- [x] CI green expected on test (20) + test (22) jobs

Refs #59. Refs #68.