### PR TITLE
feat(core): capsule v1 envelope writer/reader (#61 slice 2)

### DIFF
--- a/packages/core/src/capsule.ts
+++ b/packages/core/src/capsule.ts
@@ -1,0 +1,161 @@
+import { createHash } from 'node:crypto'
+import {
+  CAPSULE_FLAGS,
+  CAPSULE_SIZE_LIMITS,
+  CapsuleHeader,
+  CapsuleHeaderSchema,
+  ED25519_SIG_LEN,
+  FORMAT_VERSION_V1,
+  ManifestSummary,
+  PREAMBLE_LEN,
+  Producer,
+  Signer,
+  hasFlag,
+  parseCapsulePreamble,
+  serializeCapsulePreamble,
+} from './schemas/capsule.js'
+
+// .plur capsule v1 — envelope writer/reader.
+// Spec: plur-ai/plur#61 §1–§5 (slice 2 of 4-slice plan).
+// Slice 1 shipped the schema + preamble (PR #66 / e06fb08).
+// This slice adds writeCapsule / readCapsule around tar.gz payloads.
+//
+// Layout (LE throughout):
+//   MAGIC(4) | FormatVersion(2) | Flags(2) | HeaderLen(4)
+//   Header(JSON, utf-8, HeaderLen bytes)
+//   Payload(opaque bytes — typically tar.gz of {manifest.yaml + engrams.yaml})
+//   Signature(64 bytes, Ed25519 — only if Flags.SIGNED is set; deferred for MVP)
+
+export interface WriteCapsuleOptions {
+  payload: Buffer
+  manifestSummary: ManifestSummary
+  producer: Producer
+  productType?: 'engram-pack' | 'skill'
+  compression?: 'gzip' | 'none'
+  sizeUncompressed?: number
+  createdAt?: string
+  signer?: Signer | null
+  signature?: Buffer
+}
+
+export interface ReadCapsuleResult {
+  header: CapsuleHeader
+  payload: Buffer
+  signature: Buffer | null
+}
+
+export function writeCapsule(opts: WriteCapsuleOptions): Buffer {
+  const compression = opts.compression ?? 'gzip'
+  const productType = opts.productType ?? 'engram-pack'
+  const createdAt = opts.createdAt ?? new Date().toISOString()
+  const signer = opts.signer ?? null
+
+  if (signer !== null && (!opts.signature || opts.signature.length !== ED25519_SIG_LEN)) {
+    throw new Error(`writeCapsule: signer set but signature missing or not ${ED25519_SIG_LEN} bytes`)
+  }
+  if (signer === null && opts.signature) {
+    throw new Error('writeCapsule: signature provided without signer — refuse ambiguous envelope')
+  }
+
+  const sha256 = createHash('sha256').update(opts.payload).digest('hex')
+  const sizeCompressed = opts.payload.length
+  const sizeUncompressed = opts.sizeUncompressed ?? sizeCompressed
+
+  const header: CapsuleHeader = CapsuleHeaderSchema.parse({
+    schema: 'plur.capsule/1',
+    product_type: productType,
+    manifest_summary: opts.manifestSummary,
+    payload: {
+      compression,
+      size_compressed: sizeCompressed,
+      size_uncompressed: sizeUncompressed,
+      sha256,
+    },
+    created_at: createdAt,
+    producer: opts.producer,
+    signer,
+  })
+
+  const headerJson = Buffer.from(JSON.stringify(header), 'utf-8')
+
+  let flags = 0
+  if (compression === 'gzip') flags |= CAPSULE_FLAGS.COMPRESSED
+  if (signer !== null) flags |= CAPSULE_FLAGS.SIGNED
+
+  const preamble = serializeCapsulePreamble({
+    formatVersion: FORMAT_VERSION_V1,
+    flags,
+    headerLen: headerJson.length,
+  })
+
+  const totalLen =
+    PREAMBLE_LEN + headerJson.length + opts.payload.length + (signer !== null ? ED25519_SIG_LEN : 0)
+  if (totalLen > CAPSULE_SIZE_LIMITS.HARD_BYTES) {
+    throw new Error(`writeCapsule: capsule size ${totalLen} exceeds hard limit`)
+  }
+
+  const parts: Buffer[] = [preamble, headerJson, opts.payload]
+  if (signer !== null && opts.signature) parts.push(opts.signature)
+  return Buffer.concat(parts, totalLen)
+}
+
+export function readCapsule(buf: Buffer): ReadCapsuleResult {
+  if (buf.length > CAPSULE_SIZE_LIMITS.HARD_BYTES) {
+    throw new Error(`readCapsule: capsule size ${buf.length} exceeds hard limit`)
+  }
+
+  const preamble = parseCapsulePreamble(buf)
+  const headerStart = PREAMBLE_LEN
+  const headerEnd = headerStart + preamble.headerLen
+  if (buf.length < headerEnd) {
+    throw new Error(`readCapsule: truncated header (need ${headerEnd} bytes, got ${buf.length})`)
+  }
+
+  const headerJson = buf.subarray(headerStart, headerEnd).toString('utf-8')
+  let parsedHeader: unknown
+  try {
+    parsedHeader = JSON.parse(headerJson)
+  } catch (err) {
+    throw new Error(`readCapsule: malformed header JSON — ${(err as Error).message}`)
+  }
+  const header = CapsuleHeaderSchema.parse(parsedHeader)
+
+  const isSigned = hasFlag(preamble.flags, CAPSULE_FLAGS.SIGNED)
+  const sigLen = isSigned ? ED25519_SIG_LEN : 0
+  const payloadEnd = buf.length - sigLen
+  if (payloadEnd < headerEnd) {
+    throw new Error('readCapsule: payload region underflow')
+  }
+
+  const payload = buf.subarray(headerEnd, payloadEnd)
+  const signature = isSigned ? buf.subarray(payloadEnd) : null
+
+  if (payload.length !== header.payload.size_compressed) {
+    throw new Error(
+      `readCapsule: payload size mismatch (header=${header.payload.size_compressed}, actual=${payload.length})`,
+    )
+  }
+  const actualSha = createHash('sha256').update(payload).digest('hex')
+  if (actualSha !== header.payload.sha256) {
+    throw new Error(`readCapsule: integrity mismatch (header=${header.payload.sha256}, actual=${actualSha})`)
+  }
+
+  const compressionFlagSet = hasFlag(preamble.flags, CAPSULE_FLAGS.COMPRESSED)
+  const headerSaysCompressed = header.payload.compression === 'gzip'
+  if (compressionFlagSet !== headerSaysCompressed) {
+    throw new Error(
+      `readCapsule: COMPRESSED flag (${compressionFlagSet}) disagrees with header.payload.compression (${header.payload.compression})`,
+    )
+  }
+
+  return { header, payload: Buffer.from(payload), signature: signature ? Buffer.from(signature) : null }
+}
+
+export function verifyCapsuleIntegrity(buf: Buffer): boolean {
+  try {
+    readCapsule(buf)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,8 @@ export {
   serializeCapsulePreamble,
   hasFlag,
 } from './schemas/capsule.js'
+export { writeCapsule, readCapsule, verifyCapsuleIntegrity } from './capsule.js'
+export type { WriteCapsuleOptions, ReadCapsuleResult } from './capsule.js'
 export * from './types.js'
 
 export interface IngestOptions {

--- a/packages/core/test/capsule.test.ts
+++ b/packages/core/test/capsule.test.ts
@@ -1,0 +1,198 @@
+import { createHash } from 'node:crypto'
+import { describe, it, expect } from 'vitest'
+import { readCapsule, verifyCapsuleIntegrity, writeCapsule } from '../src/capsule.js'
+import {
+  CAPSULE_FLAGS,
+  CAPSULE_MAGIC,
+  ED25519_SIG_LEN,
+  FORMAT_VERSION_V1,
+  PREAMBLE_LEN,
+  hasFlag,
+  parseCapsulePreamble,
+  serializeCapsulePreamble,
+} from '../src/schemas/capsule.js'
+
+const baseSummary = {
+  name: 'engineering-conventions',
+  version: '0.3.1',
+  creator: 'plur9',
+  engram_count: 147,
+  domain: 'engineering',
+  license: 'cc-by-sa-4.0',
+}
+const baseProducer = { tool: '@plur-ai/core', version: '0.9.3' }
+
+describe('writeCapsule + readCapsule', () => {
+  it('round-trips an unsigned, gzip-flagged capsule', () => {
+    const payload = Buffer.from('pretend-this-is-a-tar-gz-archive')
+    const capsule = writeCapsule({
+      payload,
+      manifestSummary: baseSummary,
+      producer: baseProducer,
+      sizeUncompressed: 99999,
+      createdAt: '2026-04-30T20:30:00Z',
+    })
+
+    expect(capsule.subarray(0, 4).equals(CAPSULE_MAGIC)).toBe(true)
+
+    const result = readCapsule(capsule)
+    expect(result.header.schema).toBe('plur.capsule/1')
+    expect(result.header.product_type).toBe('engram-pack')
+    expect(result.header.manifest_summary.name).toBe('engineering-conventions')
+    expect(result.header.payload.compression).toBe('gzip')
+    expect(result.header.payload.size_compressed).toBe(payload.length)
+    expect(result.header.payload.size_uncompressed).toBe(99999)
+    expect(result.header.signer).toBeNull()
+    expect(result.payload.equals(payload)).toBe(true)
+    expect(result.signature).toBeNull()
+  })
+
+  it('sets COMPRESSED flag when compression=gzip and clears it for none', () => {
+    const payload = Buffer.from('plain-bytes')
+
+    const gz = writeCapsule({
+      payload,
+      manifestSummary: baseSummary,
+      producer: baseProducer,
+      compression: 'gzip',
+    })
+    expect(hasFlag(parseCapsulePreamble(gz).flags, CAPSULE_FLAGS.COMPRESSED)).toBe(true)
+
+    const plain = writeCapsule({
+      payload,
+      manifestSummary: baseSummary,
+      producer: baseProducer,
+      compression: 'none',
+    })
+    expect(hasFlag(parseCapsulePreamble(plain).flags, CAPSULE_FLAGS.COMPRESSED)).toBe(false)
+
+    const r = readCapsule(plain)
+    expect(r.header.payload.compression).toBe('none')
+  })
+
+  it('round-trips a signed capsule with a 64-byte signature', () => {
+    const payload = Buffer.from('signed-payload-bytes')
+    const signature = Buffer.alloc(ED25519_SIG_LEN, 0xab)
+    const capsule = writeCapsule({
+      payload,
+      manifestSummary: baseSummary,
+      producer: baseProducer,
+      signer: { algo: 'ed25519', public_key: 'k'.repeat(44), key_id: 'plur9/main' },
+      signature,
+    })
+
+    const preamble = parseCapsulePreamble(capsule)
+    expect(hasFlag(preamble.flags, CAPSULE_FLAGS.SIGNED)).toBe(true)
+
+    const r = readCapsule(capsule)
+    expect(r.header.signer?.algo).toBe('ed25519')
+    expect(r.signature?.length).toBe(ED25519_SIG_LEN)
+    expect(r.signature?.equals(signature)).toBe(true)
+    expect(r.payload.equals(payload)).toBe(true)
+  })
+
+  it('rejects writer signer-without-signature and signature-without-signer', () => {
+    expect(() =>
+      writeCapsule({
+        payload: Buffer.from('x'),
+        manifestSummary: baseSummary,
+        producer: baseProducer,
+        signer: { algo: 'ed25519', public_key: 'k'.repeat(44) },
+      }),
+    ).toThrow(/signer set but signature/)
+
+    expect(() =>
+      writeCapsule({
+        payload: Buffer.from('x'),
+        manifestSummary: baseSummary,
+        producer: baseProducer,
+        signature: Buffer.alloc(ED25519_SIG_LEN, 0xcd),
+      }),
+    ).toThrow(/signature provided without signer/)
+  })
+
+  it('readCapsule detects payload tampering via sha256', () => {
+    const payload = Buffer.from('original-bytes')
+    const capsule = writeCapsule({
+      payload,
+      manifestSummary: baseSummary,
+      producer: baseProducer,
+    })
+    const tampered = Buffer.from(capsule)
+    tampered[tampered.length - 1] ^= 0xff
+    expect(() => readCapsule(tampered)).toThrow(/integrity mismatch/)
+  })
+
+  it('readCapsule detects truncated header region', () => {
+    const payload = Buffer.from('tar-gz-stub')
+    const capsule = writeCapsule({
+      payload,
+      manifestSummary: baseSummary,
+      producer: baseProducer,
+    })
+    // Bump HeaderLen past the capsule's own length.
+    const preamble = parseCapsulePreamble(capsule)
+    const fakePreamble = serializeCapsulePreamble({
+      formatVersion: preamble.formatVersion,
+      flags: preamble.flags,
+      headerLen: capsule.length + 1024,
+    })
+    const tampered = Buffer.concat([fakePreamble, capsule.subarray(PREAMBLE_LEN)])
+    expect(() => readCapsule(tampered)).toThrow(/truncated header/)
+  })
+
+  it('readCapsule rejects malformed header JSON', () => {
+    const payload = Buffer.from('p')
+    const headerJson = Buffer.from('this-is-not-json{{{', 'utf-8')
+    const sha256 = createHash('sha256').update(payload).digest('hex')
+    const preamble = serializeCapsulePreamble({
+      formatVersion: FORMAT_VERSION_V1,
+      flags: 0,
+      headerLen: headerJson.length,
+    })
+    void sha256
+    const buf = Buffer.concat([preamble, headerJson, payload])
+    expect(() => readCapsule(buf)).toThrow(/malformed header JSON/)
+  })
+
+  it('readCapsule rejects flag/header compression disagreement', () => {
+    const payload = Buffer.from('p'.repeat(8))
+    // Build a capsule with COMPRESSED flag set but header.payload.compression='none'.
+    const sha256 = createHash('sha256').update(payload).digest('hex')
+    const headerObj = {
+      schema: 'plur.capsule/1',
+      product_type: 'engram-pack',
+      manifest_summary: baseSummary,
+      payload: {
+        compression: 'none',
+        size_compressed: payload.length,
+        size_uncompressed: payload.length,
+        sha256,
+      },
+      created_at: '2026-04-30T20:30:00Z',
+      producer: baseProducer,
+      signer: null,
+    }
+    const headerJson = Buffer.from(JSON.stringify(headerObj), 'utf-8')
+    const preamble = serializeCapsulePreamble({
+      formatVersion: FORMAT_VERSION_V1,
+      flags: CAPSULE_FLAGS.COMPRESSED,
+      headerLen: headerJson.length,
+    })
+    const buf = Buffer.concat([preamble, headerJson, payload])
+    expect(() => readCapsule(buf)).toThrow(/COMPRESSED flag/)
+  })
+
+  it('verifyCapsuleIntegrity returns true for round-trip and false for tamper', () => {
+    const payload = Buffer.from('verify-me')
+    const capsule = writeCapsule({
+      payload,
+      manifestSummary: baseSummary,
+      producer: baseProducer,
+    })
+    expect(verifyCapsuleIntegrity(capsule)).toBe(true)
+    const tampered = Buffer.from(capsule)
+    tampered[PREAMBLE_LEN + 5] ^= 0x01
+    expect(verifyCapsuleIntegrity(tampered)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Slice 2 of the 4-slice `.plur` capsule plan ([#61](https://github.com/plur-ai/plur/issues/61)). Adds `writeCapsule` / `readCapsule` / `verifyCapsuleIntegrity` around the schema + preamble parser that landed in slice 1 ([#66](https://github.com/plur-ai/plur/pull/66), e06fb08).

## Why this PR exists in draft form

Authored 2026-05-01T04:39Z by an autonomous nightshift session (Co-Authored-By: Claude Opus 4.7) and surfaced from a divergent local submodule pointer during the 2026-05-01T05:00Z CEO heartbeat. Same salvage pattern as PR #70 (HTTP/SSE transport, 2026-04-30): nightshift produces work product on a feature branch but no PR, so it sits invisible until the next heartbeat surfaces it. Submitting as draft so CI verifies and a human reviewer makes the merge call.

## What lands

- New `packages/core/src/capsule.ts` (161 lines) — `writeCapsule`, `readCapsule`, `verifyCapsuleIntegrity`
- `packages/core/src/index.ts` — re-exports the public surface (closes the same forward-compat gap caught on PR #66)
- `packages/core/test/capsule.test.ts` (+198 lines) — 9 new tests (round-trip signed+unsigned, compression flag parity, integrity tampering, truncated header, malformed JSON, flag/header compression disagreement)

## Acceptance criteria (from #61 slice 2 scope)

- [x] `writeCapsule`: assembles preamble + JSON header + payload (+ optional Ed25519 signature region)
- [x] computes payload sha256, derives flags from compression / signer state
- [x] validates envelope size against `CAPSULE_SIZE_LIMITS.HARD_BYTES`
- [x] refuses ambiguous signer/signature combinations
- [x] `readCapsule`: parses preamble, validates header against `CapsuleHeaderSchema`, verifies sha256 integrity
- [x] cross-checks COMPRESSED flag against `header.payload.compression`
- [x] splits signature region off the tail when SIGNED is set
- [x] `verifyCapsuleIntegrity`: convenience boolean for sniffers
- [x] All 22 capsule tests pass (9 new + 13 from slice 1)

## Verification

Local: `npx vitest run test/capsule.test.ts` from `packages/core/` — 9 passed (3.0s). The 17 failures in the full `pnpm --filter @plur-ai/core test` run are pre-existing better-sqlite3 native-binding env mismatches in `store-contract.test.ts` (unrelated to this slice).

## What's next (slice 3 + 4 of #61)

- **Slice 3:** CLI flag wiring (`plur capsule pack` / `plur capsule unpack`)
- **Slice 4:** End-to-end fixtures (golden files, cross-version interop)

## Strategic context

Per CTO Phase 4 priority (Exchange protocol implementation). Slice 1 + slice 2 together close the read/write half of the `.plur` capsule format; slices 3–4 expose it through the CLI and lock down format stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)