### PR TITLE
feat(claw): per-event counter plumbing (#51 slice D-2a)

### DIFF
--- a/packages/claw/src/telemetry-counters.ts
+++ b/packages/claw/src/telemetry-counters.ts
@@ -1,0 +1,188 @@
+// Per-event counters for telemetry (slice D-2a of #51).
+//
+// Pure file-local plumbing: increment hooks at plur_learn / plur_recall_hybrid
+// success persist to ~/.plur/telemetry-counters.json. NO network code lives here;
+// transport is D-2b's territory and imports getCounters/resetCounters from this
+// module.
+//
+// Privacy invariant: every public function MUST short-circuit on
+// !isTelemetryEnabled() BEFORE any filesystem call. A default-off install must
+// produce zero filesystem writes under ~/.plur/ for telemetry. The
+// "default-off install touches zero files" test is the load-bearing guard.
+//
+// Session semantics (silent-ratified default-pick B, 2026-05-02T12:00Z, #51):
+// 'session' fires on the first 'learn' or 'recall' recorded within a UTC day.
+// No standalone session call site.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+import { isTelemetryEnabled } from './telemetry.js'
+
+export type CounterEvent = 'learn' | 'recall' | 'session'
+
+export type CounterSnapshot = {
+  installId: string
+  date: string
+  learn: number
+  recall: number
+  session: number
+}
+
+export type CountersOpts = {
+  env?: NodeJS.ProcessEnv
+  configPath?: string
+  countersPath?: string
+  installIdPath?: string
+  now?: () => Date
+}
+
+function defaultCountersPath(): string {
+  return join(homedir(), '.plur', 'telemetry-counters.json')
+}
+
+function defaultInstallIdPath(): string {
+  return join(homedir(), '.plur', 'install-id')
+}
+
+function utcDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+function gateOpts(opts: CountersOpts): { env?: NodeJS.ProcessEnv; configPath?: string } {
+  return { env: opts.env, configPath: opts.configPath }
+}
+
+function ensureParentDir(path: string): void {
+  const dir = dirname(path)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+}
+
+function atomicWriteJson(path: string, data: unknown): void {
+  ensureParentDir(path)
+  const tmp = `${path}.tmp.${process.pid}`
+  writeFileSync(tmp, JSON.stringify(data), { encoding: 'utf8', mode: 0o600 })
+  renameSync(tmp, path)
+}
+
+function atomicWriteString(path: string, data: string): void {
+  ensureParentDir(path)
+  const tmp = `${path}.tmp.${process.pid}`
+  writeFileSync(tmp, data, { encoding: 'utf8', mode: 0o600 })
+  renameSync(tmp, path)
+}
+
+function readOrCreateInstallId(path: string): string {
+  if (existsSync(path)) {
+    const raw = readFileSync(path, 'utf8').trim()
+    if (raw.length > 0) return raw
+  }
+  const id = randomUUID()
+  atomicWriteString(path, id)
+  return id
+}
+
+type StoredCounters = {
+  date: string
+  learn: number
+  recall: number
+  session: number
+}
+
+function readStoredCounters(path: string): StoredCounters | null {
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'))
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.date === 'string' &&
+      typeof parsed.learn === 'number' &&
+      typeof parsed.recall === 'number' &&
+      typeof parsed.session === 'number'
+    ) {
+      return parsed as StoredCounters
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function freshCounters(date: string): StoredCounters {
+  return { date, learn: 0, recall: 0, session: 0 }
+}
+
+function rolloverIfNeeded(stored: StoredCounters | null, today: string): StoredCounters {
+  if (!stored || stored.date !== today) return freshCounters(today)
+  return stored
+}
+
+export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): void {
+  if (!isTelemetryEnabled(gateOpts(opts))) return
+
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const installIdPath = opts.installIdPath ?? defaultInstallIdPath()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+
+  readOrCreateInstallId(installIdPath)
+
+  const current = rolloverIfNeeded(readStoredCounters(countersPath), today)
+  const sessionAlreadyCounted = current.date === today && current.session > 0
+
+  if (event === 'learn') current.learn += 1
+  else if (event === 'recall') current.recall += 1
+  else if (event === 'session') current.session += 1
+
+  if ((event === 'learn' || event === 'recall') && !sessionAlreadyCounted) {
+    current.session += 1
+  }
+
+  atomicWriteJson(countersPath, current)
+}
+
+export function getCounters(opts: CountersOpts = {}): CounterSnapshot | null {
+  if (!isTelemetryEnabled(gateOpts(opts))) return null
+
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const installIdPath = opts.installIdPath ?? defaultInstallIdPath()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+
+  const installId = readOrCreateInstallId(installIdPath)
+  const stored = rolloverIfNeeded(readStoredCounters(countersPath), today)
+
+  return {
+    installId,
+    date: stored.date,
+    learn: stored.learn,
+    recall: stored.recall,
+    session: stored.session,
+  }
+}
+
+export function resetCounters(opts: CountersOpts = {}): CounterSnapshot | null {
+  if (!isTelemetryEnabled(gateOpts(opts))) return null
+
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const installIdPath = opts.installIdPath ?? defaultInstallIdPath()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+
+  const installId = readOrCreateInstallId(installIdPath)
+  const fresh = freshCounters(today)
+  atomicWriteJson(countersPath, fresh)
+
+  return {
+    installId,
+    date: fresh.date,
+    learn: fresh.learn,
+    recall: fresh.recall,
+    session: fresh.session,
+  }
+}

--- a/packages/claw/test/telemetry-counters.test.ts
+++ b/packages/claw/test/telemetry-counters.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  recordEvent,
+  getCounters,
+  resetCounters,
+  type CountersOpts,
+} from '../src/telemetry-counters.js'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-counters-'))
+}
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('telemetry counters (#51 slice D-2a)', () => {
+  let dir: string
+  let countersPath: string
+  let installIdPath: string
+  let configPath: string
+
+  beforeEach(() => {
+    dir = newDir()
+    countersPath = join(dir, 'counters.json')
+    installIdPath = join(dir, 'install-id')
+    configPath = join(dir, 'telemetry.json')
+  })
+
+  function offOpts(extra: Partial<CountersOpts> = {}): CountersOpts {
+    return { env: {}, configPath, countersPath, installIdPath, ...extra }
+  }
+
+  function onOpts(extra: Partial<CountersOpts> = {}): CountersOpts {
+    return { env: { PLUR_TELEMETRY: 'on' }, configPath, countersPath, installIdPath, ...extra }
+  }
+
+  it('default-off install touches zero files (recordEvent)', () => {
+    recordEvent('learn', offOpts())
+    recordEvent('recall', offOpts())
+    recordEvent('session', offOpts())
+    expect(readdirSync(dir)).toEqual([])
+  })
+
+  it('default-off install touches zero files (getCounters / resetCounters return null)', () => {
+    expect(getCounters(offOpts())).toBeNull()
+    expect(resetCounters(offOpts())).toBeNull()
+    expect(readdirSync(dir)).toEqual([])
+  })
+
+  it('env-on fresh install: recordEvent("learn") creates both files', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    expect(existsSync(installIdPath)).toBe(true)
+    expect(existsSync(countersPath)).toBe(true)
+    const installId = readFileSync(installIdPath, 'utf8')
+    expect(installId).toMatch(UUID_V4)
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on repeated events accumulate without re-counting session', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    recordEvent('learn', opts)
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+    recordEvent('recall', opts)
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 3, recall: 2, session: 1 })
+  })
+
+  it('env-on day rollover resets counters and re-arms session on next learn', () => {
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 5, recall: 2, session: 1 }),
+    )
+    const fixedNow = () => new Date('2026-05-02T00:30:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on malformed counters file: parse-fails treated as missing, fresh write', () => {
+    writeFileSync(countersPath, '{ this is not json')
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on install-id stable across recordEvent calls', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    const first = readFileSync(installIdPath, 'utf8')
+    recordEvent('recall', opts)
+    const second = readFileSync(installIdPath, 'utf8')
+
+    expect(first).toMatch(UUID_V4)
+    expect(second).toBe(first)
+  })
+
+  it('env-on stale .tmp file from prior crash does not poison next write', () => {
+    const stale = `${countersPath}.tmp.999999`
+    writeFileSync(stale, 'corrupt-half-written')
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('getCounters returns snapshot with installId and current state', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    recordEvent('learn', opts)
+
+    const snap = getCounters(opts)
+    expect(snap).not.toBeNull()
+    expect(snap!.installId).toMatch(UUID_V4)
+    expect(snap!.date).toBe('2026-05-02')
+    expect(snap!.learn).toBe(2)
+    expect(snap!.recall).toBe(0)
+    expect(snap!.session).toBe(1)
+  })
+
+  it('resetCounters zeroes the file but preserves installId', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+    const installIdBefore = readFileSync(installIdPath, 'utf8')
+
+    const after = resetCounters(opts)
+    expect(after).not.toBeNull()
+    expect(after!.learn).toBe(0)
+    expect(after!.recall).toBe(0)
+    expect(after!.session).toBe(0)
+    expect(after!.date).toBe('2026-05-02')
+    expect(after!.installId).toBe(installIdBefore)
+
+    const installIdAfter = readFileSync(installIdPath, 'utf8')
+    expect(installIdAfter).toBe(installIdBefore)
+  })
+})


### PR DESCRIPTION
First post-silent-ratify build of the D-track. Implements the [D-2a API contract](https://github.com/plur-ai/plur/issues/51#issuecomment-4352175858) ratified at `2026-05-02T12:00Z` (zero objections, [closure confirmation](https://github.com/plur-ai/plur/issues/51#issuecomment-4364129729)) with default-pick **Option B** for the [`session` call-site gap](https://github.com/plur-ai/plur/issues/51#issuecomment-4354199848).

## Scope (matches contract exactly)

In-process counter plumbing for `plur_learn` / `plur_recall_hybrid` / `session` events, persisted atomically to `~/.plur/telemetry-counters.json` under `PLUR_TELEMETRY=on`. **NO network code** — transport is D-2b's territory.

## Public API

```ts
recordEvent(event: 'learn' | 'recall' | 'session', opts?): void
getCounters(opts?): CounterSnapshot | null
resetCounters(opts?): CounterSnapshot | null   // used by D-2b post-flush
```

## Files (only touched when `isTelemetryEnabled()`)

| Path | Schema | Lifecycle |
|------|--------|-----------|
| `~/.plur/install-id` | raw uuid-v4 | created on first event when on; never rewritten |
| `~/.plur/telemetry-counters.json` | `{ date, learn, recall, session }` | atomic write mode `0o600`; resets on UTC day rollover |

## Session semantics — Option B

`recordEvent('session')` has no standalone call site. Instead, the first `learn` or `recall` recorded within a UTC day implicitly increments `session` to 1; subsequent same-day events leave `session` unchanged. Day rollover re-arms it.

## Privacy invariants (enforced by tests)

- default-off install: **zero filesystem writes** (all three public functions short-circuit before any FS call)
- `getCounters` / `resetCounters` return `null` when off
- `install-id` stable across calls
- malformed counters file → treated as missing → fresh write
- stale `.tmp.<pid>` from prior crash → does not poison next write

## Test footprint — 10 tests, all green locally

| # | Coverage |
|---|----------|
| 1 | default-off zero-files invariant — `recordEvent` |
| 2 | default-off zero-files invariant — `getCounters` / `resetCounters` |
| 3 | env-on fresh: `recordEvent('learn')` creates both files; counters = `{learn:1, recall:0, session:1}` (session auto-fires per Option B) |
| 4 | env-on accumulation: 3× `learn` + 2× `recall` → `{learn:3, recall:2, session:1}` (session NOT re-counted) |
| 5 | env-on day rollover: pre-seed yesterday's data → today's first `learn` resets to `{date:today, learn:1, session:1}` |
| 6 | env-on malformed counters file → fresh write |
| 7 | env-on `install-id` stable across `recordEvent` calls |
| 8 | env-on stale `.tmp.<pid>` from prior crash → next write succeeds |
| 9 | `getCounters` snapshot shape (installId + state) |
| 10 | `resetCounters` zeroes file but preserves `install-id` |

```
$ vitest run test/telemetry-counters.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)
```

## What this PR does **not** do (D-2b territory)

- `POST /v1/heartbeat` transport
- daily flush scheduling / process-exit hook
- endpoint URL config
- IP-stripping ingress concerns
- call-site wiring inside `@plur-ai/core` (`plur_learn` / `plur_recall_hybrid` success hooks) — that lands in a follow-up commit on this slice or D-2b; per the contract D-2a is the **module**, not its callers

If a reviewer prefers the call-site wiring inside this PR rather than as a follow-up, happy to fold it in — leaning out for now to keep the diff reviewable against the spec line-by-line.

## D-track status

- [x] D-1 — opt-in gate (#67 merged 2026-04-29)
- [x] D-2a — counter plumbing (this PR)
- [ ] D-2b — daily flush + `POST /v1/heartbeat` (queues behind this merge)

## Unblocks

- H004 E3 D-2b experiment (telemetry endpoint goes live)
- H005 E1 cohort-1 engagement baseline (currently blocked on `H004_E3_D2b` per `hypotheses.yaml`); earliest E1 readout re-pegs again on this PR's merge date

Closes the build half of #51 slice D-2a.

🤖 Posted by autonomous CTO heartbeat 2026-05-02T19:33Z