### PR TITLE
fix(core): optimistic cache insert after remote append

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,22 @@ If your PR improves any of these, mention it in the PR description.
 | `packages/claw/src/assembler.ts` | Context assembly for OpenClaw |
 | `packages/claw/src/learner.ts` | Auto-extraction of learnings from conversation |
 
+## Remote Store Test Plan
+
+A comprehensive test scenario matrix lives at `~/Data/3-plur/1-tracks/engineering/remote-store-test-plan.md`. It maps 62 scenarios across write routing, read merging, config resilience, network edge cases, and ID consistency.
+
+**When working on remote store issues (#78-#93):**
+- Use the test plan as a reference for which scenarios to cover
+- After implementing a fix, update the scenario's **Status** column (e.g. `**Untested**` → `Verified 0.9.9`)
+- After adding new tests, update the **Summary** table counts in section 9
+- If you discover new scenarios during implementation, add them to the appropriate table
+- The test plan is the source of truth for what's tested and what's not — keep it current
+
+Tracked epics:
+- #78 — Test infrastructure (Level 2/3/4)
+- #79 — Write routing bugs (forget, feedback, pin, promote)
+- #80 — Write resilience (retry, consistency, guards)
+
 ## Datacore Space Context
 
 This project lives inside a Datacore space. Session lifecycle commands are available:

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -121,8 +121,25 @@ export class RemoteStore implements EngramStore {
       const text = await r.text().catch(() => '')
       throw new Error(`Remote store append failed: ${r.status} ${text}`)
     }
-    // Invalidate cache so next load() picks up the new row
-    this.cache = null
+    // Optimistic cache insert: make the new engram visible to the next
+    // synchronous _loadRemoteCached() call immediately, instead of waiting
+    // for a background load() refresh. The next full load() after TTL
+    // expiry will replace this with the server-canonical version.
+    // See: https://github.com/plur-ai/plur/issues/89
+    let inserted: Engram = engram
+    try {
+      const row = await r.json() as any
+      if (row?.id) {
+        inserted = { id: row.id, scope: row.scope ?? engram.scope, status: row.status ?? 'active', ...(row.data ?? {}), ...(!row.data ? { statement: (engram as any).statement } : {}) } as unknown as Engram
+      }
+    } catch {
+      // Response may not be JSON (e.g. 201 with empty body) — use the input engram as-is
+    }
+    if (this.cache) {
+      this.cache.engrams.push(inserted)
+    } else {
+      this.cache = { ts: Date.now(), engrams: [inserted] }
+    }
   }
 
   /**

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -188,3 +188,115 @@ describe('learn() — remote routing (issue #25)', () => {
     consoleErr.mockRestore()
   })
 })
+
+/**
+ * Issue #89 — after a successful remote append, the engram should be
+ * visible in the RemoteStore's cache immediately (optimistic insert),
+ * so that the next synchronous _loadRemoteCached() call sees it without
+ * waiting for a background load() refresh.
+ */
+describe('RemoteStore — optimistic cache after append (issue #89)', () => {
+  let originalFetch: typeof globalThis.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  // Import RemoteStore directly for unit-level tests
+  async function getRemoteStore() {
+    const { RemoteStore } = await import('../src/store/remote-store.js')
+    return RemoteStore
+  }
+
+  it('engram is in cache immediately after successful append', async () => {
+    const RemoteStore = await getRemoteStore()
+
+    // Mock: POST returns server-assigned row
+    fetchMock.mockResolvedValueOnce({
+      ok: true, status: 201,
+      json: async () => ({ id: 'ENG-SRV-001', scope: 'group:test', status: 'active', data: { statement: 'hello' } }),
+      text: async () => '',
+    } as Response)
+
+    const store = new RemoteStore('https://example.com/sse', 'tok', 'group:test')
+    await store.append({ id: 'ENG-LOCAL-TMP', scope: 'group:test', status: 'active', statement: 'hello' } as any)
+
+    // Cache should contain the server-assigned engram — no additional fetch needed
+    const cached = (store as any).cache
+    expect(cached).not.toBeNull()
+    expect(cached.engrams.length).toBe(1)
+    expect(cached.engrams[0].id).toBe('ENG-SRV-001')
+  })
+
+  it('uses input engram if server response has no JSON body', async () => {
+    const RemoteStore = await getRemoteStore()
+
+    // Mock: POST returns 201 with empty body (no JSON)
+    fetchMock.mockResolvedValueOnce({
+      ok: true, status: 201,
+      json: async () => { throw new SyntaxError('Unexpected end of JSON input') },
+      text: async () => '',
+    } as Response)
+
+    const store = new RemoteStore('https://example.com/sse', 'tok', 'group:test')
+    const inputEngram = { id: 'ENG-LOCAL-TMP', scope: 'group:test', status: 'active', statement: 'fallback test' } as any
+    await store.append(inputEngram)
+
+    const cached = (store as any).cache
+    expect(cached).not.toBeNull()
+    expect(cached.engrams.length).toBe(1)
+    expect(cached.engrams[0].id).toBe('ENG-LOCAL-TMP') // input engram used as fallback
+  })
+
+  it('appends to existing cache without replacing it', async () => {
+    const RemoteStore = await getRemoteStore()
+
+    // First: seed the cache via a load()
+    fetchMock.mockResolvedValueOnce({
+      ok: true, status: 200,
+      json: async () => ({ rows: [{ id: 'ENG-EXISTING', scope: 'group:test', status: 'active', data: { statement: 'old' } }], total_count: 1 }),
+      text: async () => '',
+    } as Response)
+
+    const store = new RemoteStore('https://example.com/sse', 'tok', 'group:test')
+    await store.load()
+
+    // Then: append a new engram
+    fetchMock.mockResolvedValueOnce({
+      ok: true, status: 201,
+      json: async () => ({ id: 'ENG-NEW', scope: 'group:test', status: 'active', data: { statement: 'new' } }),
+      text: async () => '',
+    } as Response)
+
+    await store.append({ id: 'tmp', scope: 'group:test', status: 'active', statement: 'new' } as any)
+
+    const cached = (store as any).cache
+    expect(cached.engrams.length).toBe(2)
+    expect(cached.engrams[0].id).toBe('ENG-EXISTING')
+    expect(cached.engrams[1].id).toBe('ENG-NEW')
+  })
+
+  it('does not pollute cache on failed append', async () => {
+    const RemoteStore = await getRemoteStore()
+
+    // Mock: POST returns 500
+    fetchMock.mockResolvedValueOnce({
+      ok: false, status: 500,
+      json: async () => ({ error: 'boom' }),
+      text: async () => 'boom',
+    } as Response)
+
+    const store = new RemoteStore('https://example.com/sse', 'tok', 'group:test')
+    await expect(store.append({ id: 'tmp', scope: 'group:test', status: 'active' } as any)).rejects.toThrow('Remote store append failed')
+
+    // Cache must remain null — no pollution
+    expect((store as any).cache).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #89 — after writing an engram to a remote store via `learn()`, the engram was invisible to the immediately following `recall()` due to a 1-call blind spot in the cache.

**Root cause:** `_loadRemoteCached()` reads the `RemoteStore` cache synchronously and refreshes in the background. After `append()` invalidated the cache (`this.cache = null`), the next read returned `[]` while the background `load()` was in-flight. Only the second recall after the write saw the data.

**Fix:** Instead of nulling the cache after a successful POST, optimistically insert the engram:
- Parse the server response for the canonical row (server-assigned ID, status)
- Fall back to the input engram if the response has no JSON body
- Append to existing cache (don't replace it)
- Next full `load()` after TTL expiry corrects any drift

## Changes

- `packages/core/src/store/remote-store.ts` — replace `this.cache = null` with optimistic insert (~20 lines)
- `packages/core/test/remote-routing.test.ts` — 4 new tests for the cache behavior
- `CLAUDE.md` — reference to remote store test plan

## Test plan

- [x] Engram is in cache immediately after successful append
- [x] Falls back to input engram if server returns no JSON body
- [x] Appends to existing cache without replacing previous entries
- [x] Failed append does not pollute cache
- [x] All 8 remote-routing tests pass
- [x] All 503 core tests pass (17 pre-existing SQLite failures unrelated)
- [ ] Manual E2E: `plur_learn` with remote scope → immediate `plur_recall` returns the engram (post-merge)

## Test plan reference

Scenario RD7 in `3-plur/1-tracks/engineering/remote-store-test-plan.md`