### PR TITLE
refactor(core): make forget() and feedback() async

### DIFF
--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -129,9 +129,9 @@ const plugin = {
         name: 'forget',
         description: 'Retire a PLUR memory by ID',
         acceptsArgs: true,
-        handler: (ctx: any) => {
+        handler: async (ctx: any) => {
           if (!ctx.args?.trim()) return { text: 'Usage: /forget <engram-id>' }
-          getEngine(path).plur.forget(ctx.args.trim())
+          await getEngine(path).plur.forget(ctx.args.trim())
           return { text: `Retired: ${ctx.args.trim()}` }
         },
       })

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -27,7 +27,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
         continue
       }
       try {
-        plur.feedback(item.id, item.signal as Signal)
+        await plur.feedback(item.id, item.signal as Signal)
         results.push({ id: item.id, signal: item.signal, success: true })
         summary[item.signal as Signal]++
       } catch (err: any) {
@@ -63,7 +63,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     exit(1, `Invalid signal: "${signal}". Must be one of: positive, negative, neutral`)
   }
 
-  plur.feedback(id, signal as Signal)
+  await plur.feedback(id, signal as Signal)
 
   if (shouldOutputJson(flags)) {
     outputJson({ id, signal, status: 'recorded' })

--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -27,7 +27,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const engram = plur.getById(target)
     if (!engram) exit(1, `Engram not found: ${target}`)
     if (engram.status === 'retired') exit(1, `Already retired: ${target}`)
-    plur.forget(target, reason)
+    await plur.forget(target, reason)
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: target, statement: engram.statement } })
     } else {
@@ -47,7 +47,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
   if (matches.length === 1) {
-    plur.forget(matches[0].id, reason)
+    await plur.forget(matches[0].id, reason)
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: matches[0].id, statement: matches[0].statement } })
     } else {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -823,7 +823,7 @@ export class Plur {
   }
 
   /** Update feedback_signals and adjust retrieval_strength. Searches primary, stores, then packs. */
-  feedback(id: string, signal: 'positive' | 'negative' | 'neutral'): void {
+  async feedback(id: string, signal: 'positive' | 'negative' | 'neutral'): Promise<void> {
     // Try primary engrams first
     const found = withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)
@@ -948,7 +948,7 @@ export class Plur {
   }
 
   /** Set engram status to 'retired'. Supports primary and store engrams. */
-  forget(id: string, reason?: string): void {
+  async forget(id: string, reason?: string): Promise<void> {
     // Check primary first
     const foundInPrimary = withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)

--- a/packages/core/test/history-integration.test.ts
+++ b/packages/core/test/history-integration.test.ts
@@ -32,9 +32,9 @@ describe('history integration', () => {
     expect(created!.data.type).toBe('behavioral')
   })
 
-  it('records feedback_received event on feedback()', () => {
+  it('records feedback_received event on feedback()', async () => {
     const engram = plur.learn('Test feedback history')
-    plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
     const now = new Date().toISOString().slice(0, 7)
     const events = readHistory(dir, now)
     const feedback = events.find(e => e.event === 'feedback_received' && e.engram_id === engram.id)
@@ -42,9 +42,9 @@ describe('history integration', () => {
     expect(feedback!.data.signal).toBe('positive')
   })
 
-  it('records engram_retired event on forget()', () => {
+  it('records engram_retired event on forget()', async () => {
     const engram = plur.learn('Test retire history')
-    plur.forget(engram.id, 'No longer relevant')
+    await plur.forget(engram.id, 'No longer relevant')
     const now = new Date().toISOString().slice(0, 7)
     const events = readHistory(dir, now)
     const retired = events.find(e => e.event === 'engram_retired' && e.engram_id === engram.id)

--- a/packages/core/test/multi-store.test.ts
+++ b/packages/core/test/multi-store.test.ts
@@ -106,12 +106,12 @@ describe('Multi-store', () => {
     expect(second.id).toMatch(/^ENG-/)
   })
 
-  it('feedback on writable store engram persists', () => {
+  it('feedback on writable store engram persists', async () => {
     writeStoreEngrams([makeEngram({ statement: 'Writable store engram for feedback' })])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: false }])
     const plur = createPlur()
 
-    plur.feedback(NS_ID, 'positive')
+    await plur.feedback(NS_ID, 'positive')
 
     // Verify the store file was updated
     const storeRaw = yaml.load(readFileSync(storePath, 'utf8')) as any
@@ -120,32 +120,32 @@ describe('Multi-store', () => {
     expect(updated.activation.retrieval_strength).toBe(0.75)
   })
 
-  it('feedback on readonly store engram throws', () => {
+  it('feedback on readonly store engram throws', async () => {
     writeStoreEngrams([makeEngram()])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: true }])
     const plur = createPlur()
 
-    expect(() => plur.feedback(NS_ID, 'positive')).toThrow('readonly store')
+    await expect(plur.feedback(NS_ID, 'positive')).rejects.toThrow('readonly store')
   })
 
-  it('forget on writable store engram works', () => {
+  it('forget on writable store engram works', async () => {
     writeStoreEngrams([makeEngram()])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: false }])
     const plur = createPlur()
 
-    plur.forget(NS_ID, 'no longer needed')
+    await plur.forget(NS_ID, 'no longer needed')
 
     const storeRaw = yaml.load(readFileSync(storePath, 'utf8')) as any
     const retired = storeRaw.engrams.find((e: any) => e.id === 'ENG-2026-0401-001')
     expect(retired.status).toBe('retired')
   })
 
-  it('forget on readonly store engram throws', () => {
+  it('forget on readonly store engram throws', async () => {
     writeStoreEngrams([makeEngram()])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: true }])
     const plur = createPlur()
 
-    expect(() => plur.forget(NS_ID, 'test')).toThrow('readonly store')
+    await expect(plur.forget(NS_ID, 'test')).rejects.toThrow('readonly store')
   })
 
   it('getById finds store engrams by namespaced ID', () => {
@@ -211,7 +211,7 @@ describe('Multi-store', () => {
     expect(st.engram_count).toBe(0)
   })
 
-  it('SQLite indexed path includes store engrams in recall and feedback', () => {
+  it('SQLite indexed path includes store engrams in recall and feedback', async () => {
     writeStoreEngrams([makeEngram({ statement: 'Indexed store engram about SQLite queries' })])
     // Enable index for this test
     writeFileSync(
@@ -232,7 +232,7 @@ describe('Multi-store', () => {
     // Feedback on the indexed store engram should persist
     const storeResult = results.find(e => e.id.startsWith('ENG-DFD-'))
     if (storeResult) {
-      plur.feedback(storeResult.id, 'positive')
+      await plur.feedback(storeResult.id, 'positive')
       const storeRaw = yaml.load(readFileSync(storePath, 'utf8')) as any
       expect(storeRaw.engrams[0].feedback_signals.positive).toBe(1)
     }
@@ -294,7 +294,7 @@ describe('Multi-store', () => {
     expect(storePrefix('x')).toBe('XXX')
   })
 
-  it('cache invalidates after feedback, next recall reflects change', () => {
+  it('cache invalidates after feedback, next recall reflects change', async () => {
     writeStoreEngrams([makeEngram({
       statement: 'Cache test engram with low strength',
       activation: { retrieval_strength: 0.3, storage_strength: 1.0, frequency: 0, last_accessed: '2026-04-01' },
@@ -308,7 +308,7 @@ describe('Multi-store', () => {
     expect(before!.activation.retrieval_strength).toBe(0.3)
 
     // Positive feedback bumps strength
-    plur.feedback(NS_ID, 'positive')
+    await plur.feedback(NS_ID, 'positive')
 
     // Next getById should reflect the updated strength (cache was invalidated)
     const after = plur.getById(NS_ID)

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -31,17 +31,17 @@ describe('Plur', () => {
     expect(result.tokens_used).toBeLessThanOrEqual(500)
   })
 
-  it('feedback strengthens engrams', () => {
+  it('feedback strengthens engrams', async () => {
     const engram = plur.learn('Use feature flags', { scope: 'global' })
-    plur.feedback(engram.id, 'positive')
-    plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
     const recalled = plur.recall('feature flags')
     expect(recalled[0].feedback_signals?.positive).toBe(2)
   })
 
-  it('forget retires engrams', () => {
+  it('forget retires engrams', async () => {
     const engram = plur.learn('Wrong info about something specific', { scope: 'global' })
-    plur.forget(engram.id, 'incorrect')
+    await plur.forget(engram.id, 'incorrect')
     const recalled = plur.recall('Wrong info specific')
     expect(recalled).toHaveLength(0)
   })
@@ -119,12 +119,12 @@ describe('Plur', () => {
     expect(results.length).toBeLessThanOrEqual(3)
   })
 
-  it('feedback throws on unknown id', () => {
-    expect(() => plur.feedback('ENG-9999-01-001', 'positive')).toThrow('Engram not found')
+  it('feedback throws on unknown id', async () => {
+    await expect(plur.feedback('ENG-9999-01-001', 'positive')).rejects.toThrow('Engram not found')
   })
 
-  it('forget throws on unknown id', () => {
-    expect(() => plur.forget('ENG-9999-01-001', 'test')).toThrow('Engram not found')
+  it('forget throws on unknown id', async () => {
+    await expect(plur.forget('ENG-9999-01-001', 'test')).rejects.toThrow('Engram not found')
   })
 
   it('status includes storage root', () => {
@@ -384,10 +384,10 @@ describe('Plur', () => {
     }
   })
 
-  it('compact removes retired engrams from storage', () => {
+  it('compact removes retired engrams from storage', async () => {
     plur.learn('Keep this one', { scope: 'global' })
     const toRetire = plur.learn('Remove this one', { scope: 'global' })
-    plur.forget(toRetire.id, 'test cleanup')
+    await plur.forget(toRetire.id, 'test cleanup')
     const result = plur.compact()
     expect(result.removed).toBe(1)
     expect(result.remaining).toBe(1)
@@ -483,9 +483,9 @@ describe('Plur', () => {
     expect(found!.status).toBe('active')
   })
 
-  it('getById finds retired engrams', () => {
+  it('getById finds retired engrams', async () => {
     const engram = plur.learn('Will be retired', { scope: 'global' })
-    plur.forget(engram.id, 'test')
+    await plur.forget(engram.id, 'test')
     const found = plur.getById(engram.id)
     expect(found).not.toBeNull()
     expect(found!.status).toBe('retired')
@@ -496,7 +496,7 @@ describe('Plur', () => {
     expect(found).toBeNull()
   })
 
-  it('feedback works on pack engrams', () => {
+  it('feedback works on pack engrams', async () => {
     // Create a temp pack directory with engrams
     const packsDir = join(dir, 'packs')
     mkdirSync(packsDir, { recursive: true })
@@ -533,7 +533,7 @@ describe('Plur', () => {
 
     // Re-create Plur instance so it picks up the pack
     const plurWithPacks = new Plur({ path: dir })
-    plurWithPacks.feedback('ENG-2026-0101-001', 'positive')
+    await plurWithPacks.feedback('ENG-2026-0101-001', 'positive')
 
     // Verify the feedback was written to the pack engrams.yaml
     const raw = yaml.load(readFileSync(join(packDir, 'engrams.yaml'), 'utf8')) as any
@@ -542,7 +542,7 @@ describe('Plur', () => {
     expect(updated.activation.retrieval_strength).toBe(0.75)
   })
 
-  it('feedback on pack engram throws for unknown id', () => {
-    expect(() => plur.feedback('ENG-9999-01-001', 'positive')).toThrow('Engram not found')
+  it('feedback on pack engram throws for unknown id', async () => {
+    await expect(plur.feedback('ENG-9999-01-001', 'positive')).rejects.toThrow('Engram not found')
   })
 })

--- a/packages/core/test/sp1-memory-intelligence.test.ts
+++ b/packages/core/test/sp1-memory-intelligence.test.ts
@@ -101,24 +101,24 @@ describe('SP1: Memory Intelligence', () => {
       expect(result.count).toBeGreaterThan(0)
     })
 
-    it('positive feedback promotes exploring → leaning', () => {
+    it('positive feedback promotes exploring → leaning', async () => {
       const engram = plur.learn('Maybe try Bun for build', { commitment: 'exploring' })
       expect((engram as any).commitment).toBe('exploring')
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
       const updated = plur.getById(engram.id)
       expect((updated as any).commitment).toBe('leaning')
     })
 
-    it('positive feedback promotes leaning → decided', () => {
+    it('positive feedback promotes leaning → decided', async () => {
       const engram = plur.learn('Prefer pnpm over npm', { commitment: 'leaning' })
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
       const updated = plur.getById(engram.id)
       expect((updated as any).commitment).toBe('decided')
     })
 
-    it('positive feedback does NOT promote decided → locked', () => {
+    it('positive feedback does NOT promote decided → locked', async () => {
       const engram = plur.learn('Use TypeScript always', { commitment: 'decided' })
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
       const updated = plur.getById(engram.id)
       // decided stays decided — locked requires explicit parameter
       expect((updated as any).commitment).toBe('decided')

--- a/packages/core/test/sp2-history-evolution.test.ts
+++ b/packages/core/test/sp2-history-evolution.test.ts
@@ -18,11 +18,11 @@ describe('SP2 Idea 7: Enhanced Event-Sourced History', () => {
     fs.rmSync(dir, { recursive: true })
   })
 
-  it('readHistoryForEngram returns events for specific engram', () => {
+  it('readHistoryForEngram returns events for specific engram', async () => {
     const plur = new Plur({ path: dir })
     const e1 = plur.learn('First statement')
     const e2 = plur.learn('Second statement')
-    plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
 
     const history = readHistoryForEngram(dir, e1.id)
     expect(history.length).toBe(2) // created + feedback
@@ -33,10 +33,10 @@ describe('SP2 Idea 7: Enhanced Event-Sourced History', () => {
     expect(history2.length).toBe(1) // created only
   })
 
-  it('getEngramHistory works via Plur instance', () => {
+  it('getEngramHistory works via Plur instance', async () => {
     const plur = new Plur({ path: dir })
     const engram = plur.learn('Test engram')
-    plur.feedback(engram.id, 'negative')
+    await plur.feedback(engram.id, 'negative')
 
     const history = plur.getEngramHistory(engram.id)
     expect(history.length).toBe(2)
@@ -55,10 +55,10 @@ describe('SP2 Idea 7: Enhanced Event-Sourced History', () => {
     expect(id1).not.toBe(id2)
   })
 
-  it('forget logs engram_retired in history', () => {
+  it('forget logs engram_retired in history', async () => {
     const plur = new Plur({ path: dir })
     const engram = plur.learn('Will be forgotten')
-    plur.forget(engram.id, 'No longer relevant')
+    await plur.forget(engram.id, 'No longer relevant')
 
     const history = plur.getEngramHistory(engram.id)
     const retiredEvent = history.find(e => e.event === 'engram_retired')

--- a/packages/core/test/storage-indexed.test.ts
+++ b/packages/core/test/storage-indexed.test.ts
@@ -49,19 +49,19 @@ describe.skipIf(!hasSqlite)('SQLite indexed storage', () => {
     expect(results.length).toBe(2)
   })
 
-  it('forget + compact works with index', () => {
+  it('forget + compact works with index', async () => {
     const e1 = plur.learn('Keep this', { scope: 'global' })
     const e2 = plur.learn('Remove this', { scope: 'global' })
-    plur.forget(e2.id, 'test')
+    await plur.forget(e2.id, 'test')
     plur.compact()
     const all = plur.list()
     expect(all.length).toBe(1)
     expect(all[0].id).toBe(e1.id)
   })
 
-  it('feedback persists through index', () => {
+  it('feedback persists through index', async () => {
     const engram = plur.learn('Use feature flags', { scope: 'global' })
-    plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
     const recalled = plur.recall('feature flags')
     expect(recalled[0].feedback_signals?.positive).toBe(1)
   })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -372,7 +372,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           const summary = { positive: 0, negative: 0, neutral: 0 }
           for (const { id, signal } of args.signals as Array<{ id: string; signal: 'positive' | 'negative' | 'neutral' }>) {
             try {
-              plur.feedback(id, signal)
+              await plur.feedback(id, signal)
               results.push({ id, signal, success: true })
               summary[signal]++
             } catch (err: any) {
@@ -383,7 +383,7 @@ export function getToolDefinitions(): ToolDefinition[] {
         }
         // Single mode
         try {
-          plur.feedback(args.id as string, args.signal as 'positive' | 'negative' | 'neutral')
+          await plur.feedback(args.id as string, args.signal as 'positive' | 'negative' | 'neutral')
           return { success: true, id: args.id, signal: args.signal }
         } catch (err: any) {
           if (err.message?.includes('readonly store')) {
@@ -442,14 +442,14 @@ export function getToolDefinitions(): ToolDefinition[] {
           const engram = plur.getById(args.id as string)
           if (!engram) throw new Error(`Engram not found: ${args.id}`)
           if (engram.status === 'retired') return { success: false, error: `Already retired: ${args.id}` }
-          plur.forget(args.id as string)
+          await plur.forget(args.id as string)
           return { success: true, retired: { id: engram.id, statement: engram.statement } }
         }
         if (args.search) {
           const matches = plur.recall(args.search as string, { limit: 100 })
           if (matches.length === 0) return { success: false, error: `No active engrams matching "${args.search}"` }
           if (matches.length === 1) {
-            plur.forget(matches[0].id)
+            await plur.forget(matches[0].id)
             return { success: true, retired: { id: matches[0].id, statement: matches[0].statement } }
           }
           return {

--- a/packages/mcp/test/e2e.test.ts
+++ b/packages/mcp/test/e2e.test.ts
@@ -14,7 +14,7 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
   })
   afterEach(() => { rmSync(dir, { recursive: true }) })
 
-  it('full lifecycle', () => {
+  it('full lifecycle', async () => {
     // Learn
     const e1 = plur.learn('Always run tests before deploying', { scope: 'global', type: 'procedural' })
     const e2 = plur.learn('Project X uses PostgreSQL', { scope: 'project:x', type: 'architectural' })
@@ -25,7 +25,7 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
     expect(injected.count).toBeGreaterThanOrEqual(1)
 
     // Feedback
-    plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
 
     // Capture episode
     plur.capture('Deployed project X to staging', { agent: 'claude-code' })
@@ -39,7 +39,7 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
     expect(episodes).toHaveLength(1)
 
     // Forget
-    plur.forget(e3.id, 'no longer relevant')
+    await plur.forget(e3.id, 'no longer relevant')
     const afterForget = plur.recall('verbose output')
     expect(afterForget).toHaveLength(0)
   })
@@ -57,17 +57,17 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
     expect(resultB.directives).toContain('Vue')
   })
 
-  it('feedback loop improves injection', () => {
+  it('feedback loop improves injection', async () => {
     const e1 = plur.learn('Use docker for deployment', { scope: 'global', type: 'procedural' })
     const e2 = plur.learn('Use kubernetes for deployment', { scope: 'global', type: 'procedural' })
 
     // Positive feedback on e1
-    plur.feedback(e1.id, 'positive')
-    plur.feedback(e1.id, 'positive')
-    plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
     // Negative feedback on e2
-    plur.feedback(e2.id, 'negative')
-    plur.feedback(e2.id, 'negative')
+    await plur.feedback(e2.id, 'negative')
+    await plur.feedback(e2.id, 'negative')
 
     // e1 should score higher and appear before e2 in formatted directives string
     const result = plur.inject('deploy the application', { budget: 500 })

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -151,7 +151,7 @@ describe('Session & store tools', () => {
 
   it('plur_promote returns error for retired engrams', async () => {
     const engram = plur.learn('Soon retired', { scope: 'global' })
-    plur.forget(engram.id)
+    await plur.forget(engram.id)
     const result = await callTool('plur_promote', { id: engram.id }) as any
     expect(result.success).toBe(false)
     expect(result.errors).toHaveLength(1)

--- a/packages/mcp/test/sp2-tools.test.ts
+++ b/packages/mcp/test/sp2-tools.test.ts
@@ -60,7 +60,7 @@ describe('SP2 MCP Tools', () => {
 
     it('returns history for a specific engram', async () => {
       const engram = plur.learn('Test history')
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
 
       const result = await getTool('plur_history').handler(
         { engram_id: engram.id },


### PR DESCRIPTION
## Summary

Closes #87 — makes `forget()` and `feedback()` async (`Promise<void>`) to enable remote store routing in #84 and #85.

**Breaking change** — all callers must `await` these methods. Since MCP tool handlers, Claw command handlers, and CLI commands are already in async contexts, the migration is mechanical: add `await`.

## Changes

**Core** (`packages/core/src/index.ts`):
- `forget(id, reason): void` → `async forget(id, reason): Promise<void>`
- `feedback(id, signal): void` → `async feedback(id, signal): Promise<void>`

**Callers** (4 packages, 14 files):
- `packages/mcp/src/tools.ts` — 4 calls: added `await`
- `packages/claw/src/index.ts` — 1 call: added `await`, handler → `async`
- `packages/cli/src/commands/forget.ts` — 2 calls: added `await`
- `packages/cli/src/commands/feedback.ts` — 2 calls: added `await`

**Tests** (9 files, ~40 call sites):
- Added `await` to all `plur.forget()` / `plur.feedback()` calls
- Made test callbacks `async` where needed
- Converted `expect(() => ...).toThrow()` → `await expect(...).rejects.toThrow()` for async error assertions

## What this does NOT do

- No remote routing added (that's #84, #85)
- No version bump (release concern)
- No functional change — methods behave identically, just wrapped in Promise

## Test plan

- [x] 155 tests pass across all affected files (core, mcp, claw)
- [x] 1 pre-existing SQLite failure (better-sqlite3 binding, unrelated)
- [x] Core built, MCP tests import from dist successfully
- [x] Error assertions use `.rejects.toThrow()` pattern

## Enables

- #84 — forget() remote routing (can now `await remoteStore.getById()` + `await remoteStore.remove()`)
- #85 — feedback() remote routing

## Test plan reference

Scenarios F2, FB2 in `3-plur/1-tracks/engineering/remote-store-test-plan.md` — status updated to "API now async, routing pending"