### PR TITLE
fix(core): route forget() to remote stores

### DIFF
--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -129,9 +129,9 @@ const plugin = {
         name: 'forget',
         description: 'Retire a PLUR memory by ID',
         acceptsArgs: true,
-        handler: (ctx: any) => {
+        handler: async (ctx: any) => {
           if (!ctx.args?.trim()) return { text: 'Usage: /forget <engram-id>' }
-          getEngine(path).plur.forget(ctx.args.trim())
+          await getEngine(path).plur.forget(ctx.args.trim())
           return { text: `Retired: ${ctx.args.trim()}` }
         },
       })

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -27,7 +27,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
         continue
       }
       try {
-        plur.feedback(item.id, item.signal as Signal)
+        await plur.feedback(item.id, item.signal as Signal)
         results.push({ id: item.id, signal: item.signal, success: true })
         summary[item.signal as Signal]++
       } catch (err: any) {
@@ -63,7 +63,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     exit(1, `Invalid signal: "${signal}". Must be one of: positive, negative, neutral`)
   }
 
-  plur.feedback(id, signal as Signal)
+  await plur.feedback(id, signal as Signal)
 
   if (shouldOutputJson(flags)) {
     outputJson({ id, signal, status: 'recorded' })

--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -27,7 +27,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const engram = plur.getById(target)
     if (!engram) exit(1, `Engram not found: ${target}`)
     if (engram.status === 'retired') exit(1, `Already retired: ${target}`)
-    plur.forget(target, reason)
+    await plur.forget(target, reason)
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: target, statement: engram.statement } })
     } else {
@@ -47,7 +47,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
   if (matches.length === 1) {
-    plur.forget(matches[0].id, reason)
+    await plur.forget(matches[0].id, reason)
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: matches[0].id, statement: matches[0].statement } })
     } else {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -823,7 +823,7 @@ export class Plur {
   }
 
   /** Update feedback_signals and adjust retrieval_strength. Searches primary, stores, then packs. */
-  feedback(id: string, signal: 'positive' | 'negative' | 'neutral'): void {
+  async feedback(id: string, signal: 'positive' | 'negative' | 'neutral'): Promise<void> {
     // Try primary engrams first
     const found = withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)
@@ -948,7 +948,7 @@ export class Plur {
   }
 
   /** Set engram status to 'retired'. Supports primary and store engrams. */
-  forget(id: string, reason?: string): void {
+  async forget(id: string, reason?: string): Promise<void> {
     // Check primary first
     const foundInPrimary = withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -260,12 +260,7 @@ export class Plur {
    */
   private _remoteStores = new Map<string, RemoteStore>()
   private _loadRemoteCached(store: StoreEntry): Engram[] {
-    const key = `${store.url}::${store.scope}`
-    let driver = this._remoteStores.get(key)
-    if (!driver) {
-      driver = new RemoteStore(store.url!, store.token ?? '', store.scope)
-      this._remoteStores.set(key, driver)
-    }
+    const driver = this._getRemoteDriver({ url: store.url!, token: store.token, scope: store.scope })
     // Synchronously read whatever the driver currently has cached.
     // Trigger a refresh in the background; the next call sees fresh data.
     const cached = (driver as unknown as { cache: { engrams: Engram[] } | null }).cache
@@ -289,6 +284,17 @@ export class Plur {
     this._engramCache.delete(path)
   }
 
+  /** Get or create a RemoteStore driver for a store config entry. */
+  private _getRemoteDriver(entry: { url: string; token?: string; scope: string }): RemoteStore {
+    const key = `${entry.url}::${entry.scope}`
+    let driver = this._remoteStores.get(key)
+    if (!driver) {
+      driver = new RemoteStore(entry.url, entry.token ?? '', entry.scope)
+      this._remoteStores.set(key, driver)
+    }
+    return driver
+  }
+
   /**
    * Resolve a remote store for a write scope. Returns the RemoteStore driver
    * if the engram's scope matches a registered remote entry, else null.
@@ -304,13 +310,7 @@ export class Plur {
       if (!entry.url) continue
       if (entry.readonly === true) continue
       if (entry.scope !== scope) continue
-      const key = `${entry.url}::${entry.scope}`
-      let driver = this._remoteStores.get(key)
-      if (!driver) {
-        driver = new RemoteStore(entry.url!, entry.token ?? '', entry.scope)
-        this._remoteStores.set(key, driver)
-      }
-      return driver
+      return this._getRemoteDriver({ url: entry.url!, token: entry.token, scope: entry.scope })
     }
     return null
   }
@@ -989,6 +989,34 @@ export class Plur {
         this._writeEngrams(storeInfo.path, storeEngrams)
         this._syncIndex()
         return
+      }
+    }
+
+    // Check remote stores — the engram may live on an enterprise server.
+    // See: https://github.com/plur-ai/plur/issues/84
+    for (const entry of (this.config.stores ?? [])) {
+      if (!entry.url) continue
+      if (entry.readonly === true) {
+        // Check if the engram exists here before throwing, so readonly
+        // errors are specific ("cannot retire from readonly") not generic.
+        const roDriver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
+        const roFound = await roDriver.getById(id)
+        if (roFound) throw new Error('Cannot retire engram from readonly store')
+        continue
+      }
+      const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
+      const found = await driver.getById(id)
+      if (found) {
+        const removed = await driver.remove(id)
+        if (removed) {
+          appendHistory(this.paths.root, {
+            event: 'engram_retired',
+            engram_id: id,
+            timestamp: new Date().toISOString(),
+            data: { reason: reason ?? null, routed_to: 'remote' },
+          })
+          return
+        }
       }
     }
 

--- a/packages/core/test/history-integration.test.ts
+++ b/packages/core/test/history-integration.test.ts
@@ -32,9 +32,9 @@ describe('history integration', () => {
     expect(created!.data.type).toBe('behavioral')
   })
 
-  it('records feedback_received event on feedback()', () => {
+  it('records feedback_received event on feedback()', async () => {
     const engram = plur.learn('Test feedback history')
-    plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
     const now = new Date().toISOString().slice(0, 7)
     const events = readHistory(dir, now)
     const feedback = events.find(e => e.event === 'feedback_received' && e.engram_id === engram.id)
@@ -42,9 +42,9 @@ describe('history integration', () => {
     expect(feedback!.data.signal).toBe('positive')
   })
 
-  it('records engram_retired event on forget()', () => {
+  it('records engram_retired event on forget()', async () => {
     const engram = plur.learn('Test retire history')
-    plur.forget(engram.id, 'No longer relevant')
+    await plur.forget(engram.id, 'No longer relevant')
     const now = new Date().toISOString().slice(0, 7)
     const events = readHistory(dir, now)
     const retired = events.find(e => e.event === 'engram_retired' && e.engram_id === engram.id)

--- a/packages/core/test/multi-store.test.ts
+++ b/packages/core/test/multi-store.test.ts
@@ -106,12 +106,12 @@ describe('Multi-store', () => {
     expect(second.id).toMatch(/^ENG-/)
   })
 
-  it('feedback on writable store engram persists', () => {
+  it('feedback on writable store engram persists', async () => {
     writeStoreEngrams([makeEngram({ statement: 'Writable store engram for feedback' })])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: false }])
     const plur = createPlur()
 
-    plur.feedback(NS_ID, 'positive')
+    await plur.feedback(NS_ID, 'positive')
 
     // Verify the store file was updated
     const storeRaw = yaml.load(readFileSync(storePath, 'utf8')) as any
@@ -120,32 +120,32 @@ describe('Multi-store', () => {
     expect(updated.activation.retrieval_strength).toBe(0.75)
   })
 
-  it('feedback on readonly store engram throws', () => {
+  it('feedback on readonly store engram throws', async () => {
     writeStoreEngrams([makeEngram()])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: true }])
     const plur = createPlur()
 
-    expect(() => plur.feedback(NS_ID, 'positive')).toThrow('readonly store')
+    await expect(plur.feedback(NS_ID, 'positive')).rejects.toThrow('readonly store')
   })
 
-  it('forget on writable store engram works', () => {
+  it('forget on writable store engram works', async () => {
     writeStoreEngrams([makeEngram()])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: false }])
     const plur = createPlur()
 
-    plur.forget(NS_ID, 'no longer needed')
+    await plur.forget(NS_ID, 'no longer needed')
 
     const storeRaw = yaml.load(readFileSync(storePath, 'utf8')) as any
     const retired = storeRaw.engrams.find((e: any) => e.id === 'ENG-2026-0401-001')
     expect(retired.status).toBe('retired')
   })
 
-  it('forget on readonly store engram throws', () => {
+  it('forget on readonly store engram throws', async () => {
     writeStoreEngrams([makeEngram()])
     writeConfig([{ path: storePath, scope: 'datafund', readonly: true }])
     const plur = createPlur()
 
-    expect(() => plur.forget(NS_ID, 'test')).toThrow('readonly store')
+    await expect(plur.forget(NS_ID, 'test')).rejects.toThrow('readonly store')
   })
 
   it('getById finds store engrams by namespaced ID', () => {
@@ -211,7 +211,7 @@ describe('Multi-store', () => {
     expect(st.engram_count).toBe(0)
   })
 
-  it('SQLite indexed path includes store engrams in recall and feedback', () => {
+  it('SQLite indexed path includes store engrams in recall and feedback', async () => {
     writeStoreEngrams([makeEngram({ statement: 'Indexed store engram about SQLite queries' })])
     // Enable index for this test
     writeFileSync(
@@ -232,7 +232,7 @@ describe('Multi-store', () => {
     // Feedback on the indexed store engram should persist
     const storeResult = results.find(e => e.id.startsWith('ENG-DFD-'))
     if (storeResult) {
-      plur.feedback(storeResult.id, 'positive')
+      await plur.feedback(storeResult.id, 'positive')
       const storeRaw = yaml.load(readFileSync(storePath, 'utf8')) as any
       expect(storeRaw.engrams[0].feedback_signals.positive).toBe(1)
     }
@@ -294,7 +294,7 @@ describe('Multi-store', () => {
     expect(storePrefix('x')).toBe('XXX')
   })
 
-  it('cache invalidates after feedback, next recall reflects change', () => {
+  it('cache invalidates after feedback, next recall reflects change', async () => {
     writeStoreEngrams([makeEngram({
       statement: 'Cache test engram with low strength',
       activation: { retrieval_strength: 0.3, storage_strength: 1.0, frequency: 0, last_accessed: '2026-04-01' },
@@ -308,7 +308,7 @@ describe('Multi-store', () => {
     expect(before!.activation.retrieval_strength).toBe(0.3)
 
     // Positive feedback bumps strength
-    plur.feedback(NS_ID, 'positive')
+    await plur.feedback(NS_ID, 'positive')
 
     // Next getById should reflect the updated strength (cache was invalidated)
     const after = plur.getById(NS_ID)

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -31,17 +31,17 @@ describe('Plur', () => {
     expect(result.tokens_used).toBeLessThanOrEqual(500)
   })
 
-  it('feedback strengthens engrams', () => {
+  it('feedback strengthens engrams', async () => {
     const engram = plur.learn('Use feature flags', { scope: 'global' })
-    plur.feedback(engram.id, 'positive')
-    plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
     const recalled = plur.recall('feature flags')
     expect(recalled[0].feedback_signals?.positive).toBe(2)
   })
 
-  it('forget retires engrams', () => {
+  it('forget retires engrams', async () => {
     const engram = plur.learn('Wrong info about something specific', { scope: 'global' })
-    plur.forget(engram.id, 'incorrect')
+    await plur.forget(engram.id, 'incorrect')
     const recalled = plur.recall('Wrong info specific')
     expect(recalled).toHaveLength(0)
   })
@@ -119,12 +119,12 @@ describe('Plur', () => {
     expect(results.length).toBeLessThanOrEqual(3)
   })
 
-  it('feedback throws on unknown id', () => {
-    expect(() => plur.feedback('ENG-9999-01-001', 'positive')).toThrow('Engram not found')
+  it('feedback throws on unknown id', async () => {
+    await expect(plur.feedback('ENG-9999-01-001', 'positive')).rejects.toThrow('Engram not found')
   })
 
-  it('forget throws on unknown id', () => {
-    expect(() => plur.forget('ENG-9999-01-001', 'test')).toThrow('Engram not found')
+  it('forget throws on unknown id', async () => {
+    await expect(plur.forget('ENG-9999-01-001', 'test')).rejects.toThrow('Engram not found')
   })
 
   it('status includes storage root', () => {
@@ -384,10 +384,10 @@ describe('Plur', () => {
     }
   })
 
-  it('compact removes retired engrams from storage', () => {
+  it('compact removes retired engrams from storage', async () => {
     plur.learn('Keep this one', { scope: 'global' })
     const toRetire = plur.learn('Remove this one', { scope: 'global' })
-    plur.forget(toRetire.id, 'test cleanup')
+    await plur.forget(toRetire.id, 'test cleanup')
     const result = plur.compact()
     expect(result.removed).toBe(1)
     expect(result.remaining).toBe(1)
@@ -483,9 +483,9 @@ describe('Plur', () => {
     expect(found!.status).toBe('active')
   })
 
-  it('getById finds retired engrams', () => {
+  it('getById finds retired engrams', async () => {
     const engram = plur.learn('Will be retired', { scope: 'global' })
-    plur.forget(engram.id, 'test')
+    await plur.forget(engram.id, 'test')
     const found = plur.getById(engram.id)
     expect(found).not.toBeNull()
     expect(found!.status).toBe('retired')
@@ -496,7 +496,7 @@ describe('Plur', () => {
     expect(found).toBeNull()
   })
 
-  it('feedback works on pack engrams', () => {
+  it('feedback works on pack engrams', async () => {
     // Create a temp pack directory with engrams
     const packsDir = join(dir, 'packs')
     mkdirSync(packsDir, { recursive: true })
@@ -533,7 +533,7 @@ describe('Plur', () => {
 
     // Re-create Plur instance so it picks up the pack
     const plurWithPacks = new Plur({ path: dir })
-    plurWithPacks.feedback('ENG-2026-0101-001', 'positive')
+    await plurWithPacks.feedback('ENG-2026-0101-001', 'positive')
 
     // Verify the feedback was written to the pack engrams.yaml
     const raw = yaml.load(readFileSync(join(packDir, 'engrams.yaml'), 'utf8')) as any
@@ -542,7 +542,7 @@ describe('Plur', () => {
     expect(updated.activation.retrieval_strength).toBe(0.75)
   })
 
-  it('feedback on pack engram throws for unknown id', () => {
-    expect(() => plur.feedback('ENG-9999-01-001', 'positive')).toThrow('Engram not found')
+  it('feedback on pack engram throws for unknown id', async () => {
+    await expect(plur.feedback('ENG-9999-01-001', 'positive')).rejects.toThrow('Engram not found')
   })
 })

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
@@ -186,5 +186,181 @@ describe('learn() — remote routing (issue #25)', () => {
     const errCall = consoleErr.mock.calls.find(c => String(c[1] ?? '').includes('remote append failed'))
     expect(errCall).toBeDefined()
     consoleErr.mockRestore()
+  })
+})
+
+/**
+ * Issue #84 — forget() must route to remote stores when the engram
+ * is not found locally. RemoteStore.getById() + .remove() handle the
+ * server-side retirement.
+ */
+describe('forget() — remote routing (issue #84)', () => {
+  let primaryDir: string
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    primaryDir = mkdtempSync(join(tmpdir(), 'plur-forget-'))
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(primaryDir, { recursive: true, force: true })
+  })
+
+  function postCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
+  }
+  function deleteCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'DELETE')
+  }
+  function getCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => !(init as any)?.method || (init as any)?.method === 'GET')
+  }
+
+  function mockRemoteWithEngram(id: string) {
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      // GET /engrams/:id — found
+      if (method === 'GET' && typeof url === 'string' && url.includes(`/engrams/${id}`)) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ id, scope: 'group:test', status: 'active', data: { statement: 'test' } }),
+          text: async () => '',
+        } as Response
+      }
+      // DELETE /engrams/:id — success
+      if (method === 'DELETE' && typeof url === 'string' && url.includes(`/engrams/${id}`)) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ id, status: 'retired' }),
+          text: async () => '',
+        } as Response
+      }
+      // GET /engrams?scope=... (load) — empty list
+      if (method === 'GET') {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: [], total_count: 0 }),
+          text: async () => '',
+        } as Response
+      }
+      return { ok: false, status: 404, text: async () => 'not found' } as Response
+    }) as any)
+  }
+
+  function mockRemoteEmpty() {
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && typeof url === 'string' && url.includes('/engrams/ENG-')) {
+        return { ok: false, status: 404, json: async () => null, text: async () => '' } as Response
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({ rows: [], total_count: 0 }),
+        text: async () => '',
+      } as Response
+    }) as any)
+  }
+
+  it('forget routes to remote when engram not found locally', async () => {
+    mockRemoteWithEngram('ENG-REMOTE-001')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    // Should NOT throw — the engram is on the remote
+    await plur.forget('ENG-REMOTE-001', 'no longer needed')
+
+    // Verify DELETE was called
+    const deletes = deleteCalls()
+    expect(deletes.length).toBe(1)
+    expect(deletes[0][0]).toContain('/engrams/ENG-REMOTE-001')
+  })
+
+  it('forget logs history with routed_to: remote', async () => {
+    mockRemoteWithEngram('ENG-REMOTE-002')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+    await plur.forget('ENG-REMOTE-002', 'test reason')
+
+    // Check history file
+    const historyDir = join(primaryDir, 'history')
+    const files = existsSync(historyDir) ? readdirSync(historyDir) : []
+    expect(files.length).toBeGreaterThan(0)
+
+    const historyContent = readFileSync(join(historyDir, files[0]), 'utf-8')
+    expect(historyContent).toContain('engram_retired')
+    expect(historyContent).toContain('ENG-REMOTE-002')
+    expect(historyContent).toContain('remote')
+  })
+
+  it('forget prefers local over remote', async () => {
+    // If the engram exists locally, it should retire locally without hitting remote
+    mockRemoteWithEngram('ENG-LOCAL-001')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    // Create a local engram first
+    const engram = plur.learn('local engram to retire', { scope: 'global' })
+
+    // Forget it — should retire locally, no remote calls for getById/DELETE
+    await plur.forget(engram.id)
+
+    // Only GET calls should be from the learn() dedup load, not from forget
+    const deletes = deleteCalls()
+    expect(deletes.length).toBe(0)
+
+    // Verify local retirement
+    const found = plur.getById(engram.id)
+    expect(found!.status).toBe('retired')
+  })
+
+  it('forget on readonly remote throws clear error', async () => {
+    mockRemoteWithEngram('ENG-READONLY-001')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: true },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    await expect(plur.forget('ENG-READONLY-001')).rejects.toThrow('Cannot retire engram from readonly store')
+  })
+
+  it('forget throws when engram not in local or remote', async () => {
+    mockRemoteEmpty()
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    await expect(plur.forget('ENG-NONEXISTENT-001')).rejects.toThrow('Engram not found')
+  })
+
+  it('forget handles remote server error gracefully', async () => {
+    // getById throws a network error
+    fetchMock.mockImplementation((async () => {
+      throw new Error('Network error: connection refused')
+    }) as any)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    // RemoteStore.getById catches errors and returns null, so this falls through to "not found"
+    await expect(plur.forget('ENG-NETERR-001')).rejects.toThrow('Engram not found')
   })
 })

--- a/packages/core/test/sp1-memory-intelligence.test.ts
+++ b/packages/core/test/sp1-memory-intelligence.test.ts
@@ -101,24 +101,24 @@ describe('SP1: Memory Intelligence', () => {
       expect(result.count).toBeGreaterThan(0)
     })
 
-    it('positive feedback promotes exploring → leaning', () => {
+    it('positive feedback promotes exploring → leaning', async () => {
       const engram = plur.learn('Maybe try Bun for build', { commitment: 'exploring' })
       expect((engram as any).commitment).toBe('exploring')
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
       const updated = plur.getById(engram.id)
       expect((updated as any).commitment).toBe('leaning')
     })
 
-    it('positive feedback promotes leaning → decided', () => {
+    it('positive feedback promotes leaning → decided', async () => {
       const engram = plur.learn('Prefer pnpm over npm', { commitment: 'leaning' })
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
       const updated = plur.getById(engram.id)
       expect((updated as any).commitment).toBe('decided')
     })
 
-    it('positive feedback does NOT promote decided → locked', () => {
+    it('positive feedback does NOT promote decided → locked', async () => {
       const engram = plur.learn('Use TypeScript always', { commitment: 'decided' })
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
       const updated = plur.getById(engram.id)
       // decided stays decided — locked requires explicit parameter
       expect((updated as any).commitment).toBe('decided')

--- a/packages/core/test/sp2-history-evolution.test.ts
+++ b/packages/core/test/sp2-history-evolution.test.ts
@@ -18,11 +18,11 @@ describe('SP2 Idea 7: Enhanced Event-Sourced History', () => {
     fs.rmSync(dir, { recursive: true })
   })
 
-  it('readHistoryForEngram returns events for specific engram', () => {
+  it('readHistoryForEngram returns events for specific engram', async () => {
     const plur = new Plur({ path: dir })
     const e1 = plur.learn('First statement')
     const e2 = plur.learn('Second statement')
-    plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
 
     const history = readHistoryForEngram(dir, e1.id)
     expect(history.length).toBe(2) // created + feedback
@@ -33,10 +33,10 @@ describe('SP2 Idea 7: Enhanced Event-Sourced History', () => {
     expect(history2.length).toBe(1) // created only
   })
 
-  it('getEngramHistory works via Plur instance', () => {
+  it('getEngramHistory works via Plur instance', async () => {
     const plur = new Plur({ path: dir })
     const engram = plur.learn('Test engram')
-    plur.feedback(engram.id, 'negative')
+    await plur.feedback(engram.id, 'negative')
 
     const history = plur.getEngramHistory(engram.id)
     expect(history.length).toBe(2)
@@ -55,10 +55,10 @@ describe('SP2 Idea 7: Enhanced Event-Sourced History', () => {
     expect(id1).not.toBe(id2)
   })
 
-  it('forget logs engram_retired in history', () => {
+  it('forget logs engram_retired in history', async () => {
     const plur = new Plur({ path: dir })
     const engram = plur.learn('Will be forgotten')
-    plur.forget(engram.id, 'No longer relevant')
+    await plur.forget(engram.id, 'No longer relevant')
 
     const history = plur.getEngramHistory(engram.id)
     const retiredEvent = history.find(e => e.event === 'engram_retired')

--- a/packages/core/test/storage-indexed.test.ts
+++ b/packages/core/test/storage-indexed.test.ts
@@ -49,19 +49,19 @@ describe.skipIf(!hasSqlite)('SQLite indexed storage', () => {
     expect(results.length).toBe(2)
   })
 
-  it('forget + compact works with index', () => {
+  it('forget + compact works with index', async () => {
     const e1 = plur.learn('Keep this', { scope: 'global' })
     const e2 = plur.learn('Remove this', { scope: 'global' })
-    plur.forget(e2.id, 'test')
+    await plur.forget(e2.id, 'test')
     plur.compact()
     const all = plur.list()
     expect(all.length).toBe(1)
     expect(all[0].id).toBe(e1.id)
   })
 
-  it('feedback persists through index', () => {
+  it('feedback persists through index', async () => {
     const engram = plur.learn('Use feature flags', { scope: 'global' })
-    plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'positive')
     const recalled = plur.recall('feature flags')
     expect(recalled[0].feedback_signals?.positive).toBe(1)
   })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -372,7 +372,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           const summary = { positive: 0, negative: 0, neutral: 0 }
           for (const { id, signal } of args.signals as Array<{ id: string; signal: 'positive' | 'negative' | 'neutral' }>) {
             try {
-              plur.feedback(id, signal)
+              await plur.feedback(id, signal)
               results.push({ id, signal, success: true })
               summary[signal]++
             } catch (err: any) {
@@ -383,7 +383,7 @@ export function getToolDefinitions(): ToolDefinition[] {
         }
         // Single mode
         try {
-          plur.feedback(args.id as string, args.signal as 'positive' | 'negative' | 'neutral')
+          await plur.feedback(args.id as string, args.signal as 'positive' | 'negative' | 'neutral')
           return { success: true, id: args.id, signal: args.signal }
         } catch (err: any) {
           if (err.message?.includes('readonly store')) {
@@ -442,14 +442,14 @@ export function getToolDefinitions(): ToolDefinition[] {
           const engram = plur.getById(args.id as string)
           if (!engram) throw new Error(`Engram not found: ${args.id}`)
           if (engram.status === 'retired') return { success: false, error: `Already retired: ${args.id}` }
-          plur.forget(args.id as string)
+          await plur.forget(args.id as string)
           return { success: true, retired: { id: engram.id, statement: engram.statement } }
         }
         if (args.search) {
           const matches = plur.recall(args.search as string, { limit: 100 })
           if (matches.length === 0) return { success: false, error: `No active engrams matching "${args.search}"` }
           if (matches.length === 1) {
-            plur.forget(matches[0].id)
+            await plur.forget(matches[0].id)
             return { success: true, retired: { id: matches[0].id, statement: matches[0].statement } }
           }
           return {

--- a/packages/mcp/test/e2e.test.ts
+++ b/packages/mcp/test/e2e.test.ts
@@ -14,7 +14,7 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
   })
   afterEach(() => { rmSync(dir, { recursive: true }) })
 
-  it('full lifecycle', () => {
+  it('full lifecycle', async () => {
     // Learn
     const e1 = plur.learn('Always run tests before deploying', { scope: 'global', type: 'procedural' })
     const e2 = plur.learn('Project X uses PostgreSQL', { scope: 'project:x', type: 'architectural' })
@@ -25,7 +25,7 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
     expect(injected.count).toBeGreaterThanOrEqual(1)
 
     // Feedback
-    plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
 
     // Capture episode
     plur.capture('Deployed project X to staging', { agent: 'claude-code' })
@@ -39,7 +39,7 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
     expect(episodes).toHaveLength(1)
 
     // Forget
-    plur.forget(e3.id, 'no longer relevant')
+    await plur.forget(e3.id, 'no longer relevant')
     const afterForget = plur.recall('verbose output')
     expect(afterForget).toHaveLength(0)
   })
@@ -57,17 +57,17 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
     expect(resultB.directives).toContain('Vue')
   })
 
-  it('feedback loop improves injection', () => {
+  it('feedback loop improves injection', async () => {
     const e1 = plur.learn('Use docker for deployment', { scope: 'global', type: 'procedural' })
     const e2 = plur.learn('Use kubernetes for deployment', { scope: 'global', type: 'procedural' })
 
     // Positive feedback on e1
-    plur.feedback(e1.id, 'positive')
-    plur.feedback(e1.id, 'positive')
-    plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
+    await plur.feedback(e1.id, 'positive')
     // Negative feedback on e2
-    plur.feedback(e2.id, 'negative')
-    plur.feedback(e2.id, 'negative')
+    await plur.feedback(e2.id, 'negative')
+    await plur.feedback(e2.id, 'negative')
 
     // e1 should score higher and appear before e2 in formatted directives string
     const result = plur.inject('deploy the application', { budget: 500 })

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -151,7 +151,7 @@ describe('Session & store tools', () => {
 
   it('plur_promote returns error for retired engrams', async () => {
     const engram = plur.learn('Soon retired', { scope: 'global' })
-    plur.forget(engram.id)
+    await plur.forget(engram.id)
     const result = await callTool('plur_promote', { id: engram.id }) as any
     expect(result.success).toBe(false)
     expect(result.errors).toHaveLength(1)

--- a/packages/mcp/test/sp2-tools.test.ts
+++ b/packages/mcp/test/sp2-tools.test.ts
@@ -60,7 +60,7 @@ describe('SP2 MCP Tools', () => {
 
     it('returns history for a specific engram', async () => {
       const engram = plur.learn('Test history')
-      plur.feedback(engram.id, 'positive')
+      await plur.feedback(engram.id, 'positive')
 
       const result = await getTool('plur_history').handler(
         { engram_id: engram.id },


### PR DESCRIPTION
## Summary

Closes #84 — `forget()` now checks remote stores when the engram is not found locally, retiring it via `DELETE /api/v1/engrams/:id`.

**Stacked on** #96 (async forget/feedback migration). Merge #96 first, then this.

## Changes

**`packages/core/src/index.ts`:**
- New `_getRemoteDriver()` helper — deduplicates driver get-or-create pattern (was copy-pasted in `_loadRemoteCached` and `_resolveRemoteStoreForScope`)
- `forget()` now has a third lookup stage after local + project stores: iterate all remote store entries, call `getById(id)`, then `remove(id)` if found
- Readonly remote stores throw "Cannot retire from readonly store" (same error as local readonly)
- History event includes `routed_to: 'remote'` for audit trail

**`packages/core/test/remote-routing.test.ts`:**
- 6 new tests for forget() remote routing

## Lookup order

```
1. Primary local store (unchanged)     → if found, retire locally
2. Project stores via _findEngramStore (unchanged) → if found, retire in store
3. NEW: Remote stores                  → for each writable remote:
   a. await driver.getById(id)
   b. if found → await driver.remove(id), log history
4. Throw "Engram not found"
```

Local always takes priority. Same ID can't exist in both local and remote in normal operation (different ID assignment schemes), but if it did, local wins.

## Test plan

- [x] forget routes to remote when engram not found locally
- [x] forget logs history with `routed_to: remote`
- [x] forget prefers local over remote (no remote DELETE when found locally)
- [x] forget on readonly remote throws clear error
- [x] forget throws when engram not in local or remote
- [x] forget handles remote server error gracefully (falls through to "not found")
- [x] All 10 remote-routing tests pass (4 learn + 6 forget)
- [x] All 88 broader core tests pass (1 pre-existing SQLite failure)

## Test plan reference

Scenario F2 in `3-plur/1-tracks/engineering/remote-store-test-plan.md` — updated to "Fixed #84"