### PR TITLE
fix(core): route feedback() to remote stores

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -998,6 +998,30 @@ export class Plur {
       }
     }
 
+    // Check remote stores — the engram may live on an enterprise server.
+    // See: https://github.com/plur-ai/plur/issues/85
+    for (const entry of (this.config.stores ?? [])) {
+      if (!entry.url) continue
+      if (entry.readonly === true) {
+        const roDriver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
+        const roFound = await roDriver.getById(id)
+        if (roFound) throw new Error('Engram is in a readonly store')
+        continue
+      }
+      const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
+      const found = await driver.getById(id)
+      if (found) {
+        await driver.feedback(id, signal)
+        appendHistory(this.paths.root, {
+          event: 'feedback_received',
+          engram_id: id,
+          timestamp: new Date().toISOString(),
+          data: { signal, routed_to: 'remote' },
+        })
+        return
+      }
+    }
+
     // Search pack engrams by scanning pack directories
     this._feedbackPack(id, signal)
   }

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -177,6 +177,27 @@ export class RemoteStore implements EngramStore {
     return true
   }
 
+  /**
+   * Apply feedback to a remote engram. POST /api/v1/engrams/:id/feedback
+   * sends the raw signal; the server owns the mutation logic (strength
+   * adjustment, commitment promotion, counter increment).
+   *
+   * Not part of the EngramStore interface — RemoteStore-specific.
+   * Requires server support: see https://github.com/plur-ai/plur/issues/85
+   */
+  async feedback(id: string, signal: 'positive' | 'negative' | 'neutral'): Promise<void> {
+    const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}/feedback`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ signal }),
+    })
+    if (!r.ok) {
+      const text = await r.text().catch(() => '')
+      throw new Error(`Remote feedback failed: ${r.status} ${text}`)
+    }
+    this.cache = null
+  }
+
   async count(filter?: { status?: string }): Promise<number> {
     // Cheap-ish: load (cached) and filter client-side. The server has
     // a count column we could add an endpoint for, but at pilot scale

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -364,3 +364,177 @@ describe('forget() — remote routing (issue #84)', () => {
     await expect(plur.forget('ENG-NETERR-001')).rejects.toThrow('Engram not found')
   })
 })
+
+/**
+ * Issue #85 — feedback() must route to remote stores when the engram
+ * is not found locally. Sends the signal to the server via
+ * POST /api/v1/engrams/:id/feedback; server owns the mutation logic.
+ */
+describe('feedback() — remote routing (issue #85)', () => {
+  let primaryDir: string
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    primaryDir = mkdtempSync(join(tmpdir(), 'plur-feedback-'))
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(primaryDir, { recursive: true, force: true })
+  })
+
+  function feedbackPostCalls() {
+    return fetchMock.mock.calls.filter(
+      ([url, init]) => (init as any)?.method === 'POST' && typeof url === 'string' && url.includes('/feedback'),
+    )
+  }
+
+  function mockRemoteWithFeedback(id: string) {
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      // GET /engrams/:id — found
+      if (method === 'GET' && typeof url === 'string' && url.includes(`/engrams/${id}`)) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ id, scope: 'group:test', status: 'active', data: { statement: 'test' } }),
+          text: async () => '',
+        } as Response
+      }
+      // POST /engrams/:id/feedback — success
+      if (method === 'POST' && typeof url === 'string' && url.includes(`/engrams/${id}/feedback`)) {
+        return { ok: true, status: 200, json: async () => ({ success: true }), text: async () => '' } as Response
+      }
+      // GET /engrams?scope=... (load) — empty list
+      if (method === 'GET') {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: [], total_count: 0 }),
+          text: async () => '',
+        } as Response
+      }
+      return { ok: false, status: 404, text: async () => 'not found' } as Response
+    }) as any)
+  }
+
+  it('feedback routes to remote for server-assigned ID', async () => {
+    mockRemoteWithFeedback('ENG-REMOTE-FB-001')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    await plur.feedback('ENG-REMOTE-FB-001', 'positive')
+
+    const posts = feedbackPostCalls()
+    expect(posts.length).toBe(1)
+    expect(posts[0][0]).toContain('/engrams/ENG-REMOTE-FB-001/feedback')
+    const body = JSON.parse((posts[0][1] as any).body)
+    expect(body.signal).toBe('positive')
+  })
+
+  it('feedback logs history with routed_to: remote', async () => {
+    mockRemoteWithFeedback('ENG-REMOTE-FB-002')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+    await plur.feedback('ENG-REMOTE-FB-002', 'negative')
+
+    const historyDir = join(primaryDir, 'history')
+    const files = existsSync(historyDir) ? readdirSync(historyDir) : []
+    expect(files.length).toBeGreaterThan(0)
+
+    const historyContent = readFileSync(join(historyDir, files[0]), 'utf-8')
+    expect(historyContent).toContain('feedback_received')
+    expect(historyContent).toContain('ENG-REMOTE-FB-002')
+    expect(historyContent).toContain('remote')
+  })
+
+  it('feedback prefers local over remote', async () => {
+    mockRemoteWithFeedback('ENG-LOCAL-FB-001')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    const engram = plur.learn('local engram for feedback', { scope: 'global' })
+    await plur.feedback(engram.id, 'positive')
+
+    // No feedback POST to remote
+    const posts = feedbackPostCalls()
+    expect(posts.length).toBe(0)
+
+    // Local engram was updated
+    const found = plur.getById(engram.id)
+    expect(found!.feedback_signals?.positive).toBe(1)
+  })
+
+  it('feedback on readonly remote throws', async () => {
+    mockRemoteWithFeedback('ENG-READONLY-FB-001')
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: true },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    await expect(plur.feedback('ENG-READONLY-FB-001', 'positive')).rejects.toThrow('readonly store')
+  })
+
+  it('feedback throws when engram not in local or remote', async () => {
+    // Remote getById returns null
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && typeof url === 'string' && url.includes('/engrams/ENG-')) {
+        return { ok: false, status: 404, json: async () => null, text: async () => '' } as Response
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({ rows: [], total_count: 0 }),
+        text: async () => '',
+      } as Response
+    }) as any)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    await expect(plur.feedback('ENG-NONEXISTENT-001', 'positive')).rejects.toThrow('Engram not found')
+  })
+
+  it('feedback surfaces server error clearly', async () => {
+    // getById succeeds but feedback POST fails
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && typeof url === 'string' && url.includes('/engrams/ENG-SRV-ERR')) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ id: 'ENG-SRV-ERR', scope: 'group:test', status: 'active', data: { statement: 'test' } }),
+          text: async () => '',
+        } as Response
+      }
+      if (method === 'POST' && typeof url === 'string' && url.includes('/feedback')) {
+        return { ok: false, status: 500, json: async () => ({}), text: async () => 'internal server error' } as Response
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({ rows: [], total_count: 0 }),
+        text: async () => '',
+      } as Response
+    }) as any)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    await expect(plur.feedback('ENG-SRV-ERR', 'positive')).rejects.toThrow('Remote feedback failed')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #85 — `feedback()` now routes to remote stores when the engram is not found locally, sending the signal via `POST /api/v1/engrams/:id/feedback`.

**Stacked on** #97 (forget routing) → #96 (async migration). Merge order: #96 → #97 → this.

## Design: signal-only (Option A)

The client sends only `{ signal: "positive" }` — the **server owns the mutation logic**:
- Increment `feedback_signals[signal]`
- Adjust `retrieval_strength` (+0.05 positive, -0.1 negative)
- Promote `commitment` on positive (exploring→leaning→decided)

This avoids read-modify-write race conditions when multiple clients send feedback simultaneously.

## Server dependency

**@plur9** — the enterprise server needs a new endpoint:

```
POST /api/v1/engrams/:id/feedback
Content-Type: application/json
Authorization: Bearer <token>

{ "signal": "positive" | "negative" | "neutral" }
```

The client will throw `"Remote feedback failed: 404"` (or similar) until this endpoint exists. The mutation rules should match the client-side logic in `Plur.feedback()`:
- `positive`: strength += 0.05, commitment exploring→leaning→decided
- `negative`: strength -= 0.1
- `neutral`: counter only, no strength change

## Changes

**`packages/core/src/store/remote-store.ts`:**
- New `feedback(id, signal)` method — POSTs to `/api/v1/engrams/:id/feedback`, invalidates cache

**`packages/core/src/index.ts`:**
- `feedback()` now checks remote stores between project stores and packs
- Same pattern as forget(): `getById()` to verify, then `driver.feedback()` to apply
- Readonly remote → throws "Engram is in a readonly store"
- History event includes `routed_to: 'remote'`

**`packages/core/test/remote-routing.test.ts`:**
- 6 new tests for feedback remote routing

## Test plan

- [x] feedback routes to remote for server-assigned ID
- [x] feedback logs history with `routed_to: remote`
- [x] feedback prefers local over remote
- [x] feedback on readonly remote throws
- [x] feedback throws when engram not in local or remote (falls through to packs → "not found")
- [x] feedback surfaces server error clearly (500 → "Remote feedback failed")
- [x] All 16 remote-routing tests pass (4 learn + 6 forget + 6 feedback)
- [x] All 84 broader core tests pass (1 pre-existing SQLite failure)

## Test plan reference

Scenario FB2 in `3-plur/1-tracks/engineering/remote-store-test-plan.md` — updated to "Fixed #85"