### PR TITLE
fix(core): retry + local fallback on remote learn() failure

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import { join } from 'path'
 
 export interface HistoryEvent {
-  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review'
+  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed'
   engram_id: string
   timestamp: string // ISO
   data: Record<string, unknown> // event-specific payload

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -472,16 +472,38 @@ export class Plur {
       // audit trail of what they wrote where.
       //
       // Sync/async impedance: learn() is sync, RemoteStore.append() is
-      // async. We fire-and-forget here — the caller gets the engram object
-      // back immediately, and the network write completes in the background.
-      // Failures are logged loudly. See issue #26 for the proper outbox
-      // pattern (queue + retry + reconcile) — this is the minimum viable
-      // routing that unblocks the pilot.
+      // async. The background task retries once on failure, then falls
+      // back to local with _routed:false metadata so the outbox (#26)
+      // can re-publish when the server is reachable.
       const remoteDriver = this._resolveRemoteStoreForScope(scope)
       if (remoteDriver) {
-        void remoteDriver.append(engram).catch(err => {
-          logger.error(`[plur:learn] remote append failed for ${engram.id} (scope=${scope}): ${(err as Error).message}`)
-        })
+        void (async () => {
+          for (let attempt = 1; attempt <= 2; attempt++) {
+            try {
+              await remoteDriver.append(engram)
+              return // success
+            } catch (err) {
+              logger.warning(`[plur:learn] remote append attempt ${attempt}/2 failed for ${engram.id}: ${(err as Error).message}`)
+            }
+          }
+          // Both attempts failed — save locally for outbox retry (#26).
+          // See: https://github.com/plur-ai/plur/issues/88
+          withLock(this.paths.engrams, () => {
+            const fallbackEngrams = loadEngrams(this.paths.engrams)
+            ;(engram as any)._routed = false
+            ;(engram as any)._intended_scope = scope
+            ;(engram as any)._route_attempts = 2
+            fallbackEngrams.push(engram)
+            this._writeEngrams(this.paths.engrams, fallbackEngrams)
+          })
+          appendHistory(this.paths.root, {
+            event: 'engram_route_failed',
+            engram_id: engram.id,
+            timestamp: new Date().toISOString(),
+            data: { scope, reason: 'remote append failed after 2 attempts', routed_to: 'local_fallback' },
+          })
+          logger.warning(`[plur:learn] saved ${engram.id} locally with _routed:false — outbox will retry`)
+        })()
         appendHistory(this.paths.root, {
           event: 'engram_created',
           engram_id: engram.id,

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
@@ -151,15 +151,13 @@ describe('learn() — remote routing (issue #25)', () => {
     expect(local.engrams.find(e => e.statement === 'readonly-store engram')).toBeTruthy()
   })
 
-  it('logs but does not throw if remote append fails', async () => {
+  it('does not throw if remote append fails — saves locally with _routed:false', async () => {
     fetchMock.mockResolvedValue({
       ok: false,
       status: 500,
       json: async () => ({ error: 'server boom' }),
       text: async () => 'server boom',
     } as Response)
-
-    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     writeStoresConfig(primaryDir, [
       {
@@ -173,18 +171,156 @@ describe('learn() — remote routing (issue #25)', () => {
     const plur = new Plur({ path: primaryDir })
 
     // Should NOT throw — the engram object still comes back.
-    expect(() => {
-      plur.learn('engram-with-failing-remote', {
-        scope: 'group:plur/plur-ai/engineering',
-        type: 'behavioral',
-      })
-    }).not.toThrow()
+    const engram = plur.learn('engram-with-failing-remote', {
+      scope: 'group:plur/plur-ai/engineering',
+      type: 'behavioral',
+    })
+    expect(engram.statement).toBe('engram-with-failing-remote')
 
-    // Wait for the fire-and-forget rejection handler to run.
-    await new Promise(r => setTimeout(r, 10))
-    expect(consoleErr).toHaveBeenCalled()
-    const errCall = consoleErr.mock.calls.find(c => String(c[1] ?? '').includes('remote append failed'))
-    expect(errCall).toBeDefined()
-    consoleErr.mockRestore()
+    // Wait for the background retry (2 attempts) + local fallback to complete.
+    await new Promise(r => setTimeout(r, 50))
+
+    // Engram should now be in local store with outbox metadata.
+    const localYaml = join(primaryDir, 'engrams.yaml')
+    expect(existsSync(localYaml)).toBe(true)
+    const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams: any[] }
+    const saved = local.engrams.find(e => e.statement === 'engram-with-failing-remote')
+    expect(saved).toBeDefined()
+    expect(saved._routed).toBe(false)
+    expect(saved._intended_scope).toBe('group:plur/plur-ai/engineering')
+    expect(saved._route_attempts).toBe(2)
+  })
+})
+
+/**
+ * Issue #88 — learn() retry + local fallback for remote store failures.
+ * When remote append fails, retry once, then save locally with outbox
+ * metadata (_routed:false) so #26 can re-publish later.
+ */
+describe('learn() — retry + local fallback (issue #88)', () => {
+  let primaryDir: string
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    primaryDir = mkdtempSync(join(tmpdir(), 'plur-retry-'))
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(primaryDir, { recursive: true, force: true })
+  })
+
+  it('retries once and succeeds — no local fallback', async () => {
+    let callCount = 0
+    fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'POST') {
+        callCount++
+        if (callCount === 1) {
+          // First attempt fails
+          return { ok: false, status: 500, json: async () => ({}), text: async () => 'server error' } as Response
+        }
+        // Second attempt succeeds
+        return { ok: true, status: 201, json: async () => ({ id: 'ENG-SRV-RETRY' }), text: async () => '' } as Response
+      }
+      return { ok: true, status: 200, json: async () => ({ rows: [], total_count: 0 }), text: async () => '' } as Response
+    }) as any)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+    plur.learn('retry-success', { scope: 'group:test', type: 'behavioral' })
+
+    await new Promise(r => setTimeout(r, 50))
+
+    // Two POST calls made (initial + retry)
+    const posts = fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
+    expect(posts.length).toBe(2)
+
+    // NOT saved locally — remote succeeded on retry
+    const localYaml = join(primaryDir, 'engrams.yaml')
+    if (existsSync(localYaml)) {
+      const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams?: any[] } | null
+      const found = (local?.engrams ?? []).find((e: any) => e.statement === 'retry-success')
+      expect(found).toBeUndefined()
+    }
+  })
+
+  it('succeeds on first attempt — no retry, no fallback', async () => {
+    fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'POST') {
+        return { ok: true, status: 201, json: async () => ({ id: 'ENG-SRV-OK' }), text: async () => '' } as Response
+      }
+      return { ok: true, status: 200, json: async () => ({ rows: [], total_count: 0 }), text: async () => '' } as Response
+    }) as any)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+    plur.learn('first-attempt-ok', { scope: 'group:test', type: 'behavioral' })
+
+    await new Promise(r => setTimeout(r, 50))
+
+    // Only one POST call
+    const posts = fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
+    expect(posts.length).toBe(1)
+
+    // NOT saved locally
+    const localYaml = join(primaryDir, 'engrams.yaml')
+    if (existsSync(localYaml)) {
+      const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams?: any[] } | null
+      const found = (local?.engrams ?? []).find((e: any) => e.statement === 'first-attempt-ok')
+      expect(found).toBeUndefined()
+    }
+  })
+
+  it('fallback logs engram_route_failed history event', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false, status: 503,
+      json: async () => ({}), text: async () => 'service unavailable',
+    } as Response)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+    plur.learn('history-fallback-test', { scope: 'group:test', type: 'behavioral' })
+
+    await new Promise(r => setTimeout(r, 50))
+
+    const historyDir = join(primaryDir, 'history')
+    const files = existsSync(historyDir) ? readdirSync(historyDir) : []
+    expect(files.length).toBeGreaterThan(0)
+
+    // Should have both engram_created (optimistic) and engram_route_failed
+    const allHistory = files.map(f => readFileSync(join(historyDir, f), 'utf-8')).join('\n')
+    expect(allHistory).toContain('engram_route_failed')
+    expect(allHistory).toContain('local_fallback')
+  })
+
+  it('network error triggers fallback (not just HTTP errors)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+    plur.learn('network-error-test', { scope: 'group:test', type: 'behavioral' })
+
+    await new Promise(r => setTimeout(r, 50))
+
+    const localYaml = join(primaryDir, 'engrams.yaml')
+    expect(existsSync(localYaml)).toBe(true)
+    const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams: any[] }
+    const saved = local.engrams.find(e => e.statement === 'network-error-test')
+    expect(saved).toBeDefined()
+    expect(saved._routed).toBe(false)
   })
 })

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -214,6 +214,28 @@ describe('learn() — retry + local fallback (issue #88)', () => {
     rmSync(primaryDir, { recursive: true, force: true })
   })
 
+  function mockSuccessfulAppend() {
+    fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'POST') {
+        return {
+          ok: true, status: 201,
+          json: async () => ({ id: 'ENG-REMOTE-001' }),
+          text: async () => '',
+        } as Response
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({ rows: [], total_count: 0 }),
+        text: async () => '',
+      } as Response
+    }) as any)
+  }
+
+  function postCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
+  }
+
   it('retries once and succeeds — no local fallback', async () => {
     let callCount = 0
     fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {


### PR DESCRIPTION
## Summary

Closes #88 — when `learn()` routes to a remote store and the POST fails, the engram was silently lost. Now it retries once and falls back to local storage with outbox metadata.

## Before / After

| | Before (0.9.8) | After |
|--|----------------|-------|
| Remote POST fails | Engram lost, error logged | Retry once |
| Retry also fails | N/A | Save locally with `_routed: false` |
| Engram recoverable? | No | Yes — outbox (#26) will re-publish |
| learn() API | Sync, returns `Engram` | Unchanged — still sync |

## Outbox metadata

Locally saved fallback engrams include:

| Field | Value | Purpose |
|-------|-------|---------|
| `_routed` | `false` | Scanner flag for outbox |
| `_intended_scope` | `"group:plur/..."` | Where it should have gone |
| `_route_attempts` | `2` | How many times tried |

Convention documented on plur-ai/enterprise#26.

## Changes

**`packages/core/src/index.ts`:**
- Replace fire-and-forget `void append().catch(log)` with background retry + fallback
- On failure: `withLock` → `loadEngrams` → push with outbox metadata → `_writeEngrams`
- Log `engram_route_failed` history event with `routed_to: 'local_fallback'`
- Uses `logger.warning` (not `logger.warn` — caught in tests)

**`packages/core/test/remote-routing.test.ts`:**
- Updated existing "does not throw if remote fails" test → now verifies local fallback with `_routed: false`
- 4 new tests: retry success, first-attempt success, history event, network error fallback

## Test plan

- [x] Both attempts fail → saved locally with `_routed: false`, `_intended_scope`, `_route_attempts`
- [x] First attempt fails, retry succeeds → no local fallback, 2 POST calls
- [x] First attempt succeeds → 1 POST call, no fallback
- [x] Fallback logs `engram_route_failed` history event
- [x] Network errors (ECONNREFUSED) trigger fallback same as HTTP errors
- [x] All 8 remote-routing tests pass
- [x] All 76 broader core tests pass (1 pre-existing SQLite failure)

## Test plan reference

Scenario W5 in `3-plur/1-tracks/engineering/remote-store-test-plan.md` — updated to "Fixed #88"