### PR TITLE
fix(core): guard against private visibility with remote scope

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -478,7 +478,11 @@ export class Plur {
       // pattern (queue + retry + reconcile) — this is the minimum viable
       // routing that unblocks the pilot.
       const remoteDriver = this._resolveRemoteStoreForScope(scope)
-      if (remoteDriver) {
+      if (remoteDriver && context?.visibility === 'private') {
+        // Private engrams stay local — sending to a shared remote contradicts
+        // the "only I see this" semantics. See: https://github.com/plur-ai/plur/issues/90
+        logger.warning(`[plur:learn] private engram not routed to remote (scope=${scope}), writing locally`)
+      } else if (remoteDriver) {
         void remoteDriver.append(engram).catch(err => {
           logger.error(`[plur:learn] remote append failed for ${engram.id} (scope=${scope}): ${(err as Error).message}`)
         })

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -187,4 +187,97 @@ describe('learn() — remote routing (issue #25)', () => {
     expect(errCall).toBeDefined()
     consoleErr.mockRestore()
   })
+
+  it('private visibility + remote scope writes locally, not to remote (#90)', async () => {
+    mockSuccessfulAppend()
+
+    writeStoresConfig(primaryDir, [
+      {
+        url: 'https://plur.example.com/sse',
+        token: 'plur_sk_test',
+        scope: 'group:plur/plur-ai/engineering',
+        shared: true,
+        readonly: false,
+      },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    const engram = plur.learn('private team thought', {
+      scope: 'group:plur/plur-ai/engineering',
+      type: 'behavioral',
+      visibility: 'private',
+    })
+
+    expect(engram.visibility).toBe('private')
+
+    // No POST to remote
+    await new Promise(r => setTimeout(r, 10))
+    expect(postCalls().length).toBe(0)
+
+    // Saved locally
+    const localYaml = join(primaryDir, 'engrams.yaml')
+    expect(existsSync(localYaml)).toBe(true)
+    const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams: Array<{ statement: string; visibility?: string }> }
+    const saved = local.engrams.find(e => e.statement === 'private team thought')
+    expect(saved).toBeTruthy()
+    expect(saved!.visibility).toBe('private')
+  })
+
+  it('public visibility + remote scope routes to server normally', async () => {
+    mockSuccessfulAppend()
+
+    writeStoresConfig(primaryDir, [
+      {
+        url: 'https://plur.example.com/sse',
+        token: 'plur_sk_test',
+        scope: 'group:plur/plur-ai/engineering',
+        shared: true,
+        readonly: false,
+      },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    plur.learn('public team engram', {
+      scope: 'group:plur/plur-ai/engineering',
+      type: 'behavioral',
+      visibility: 'public',
+    })
+
+    await new Promise(r => setTimeout(r, 10))
+    expect(postCalls().length).toBe(1)
+
+    // NOT in local
+    const localYaml = join(primaryDir, 'engrams.yaml')
+    if (existsSync(localYaml)) {
+      const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams?: Array<{ statement: string }> } | null
+      expect((local?.engrams ?? []).find(e => e.statement === 'public team engram')).toBeUndefined()
+    }
+  })
+
+  it('private visibility + no remote scope writes locally (baseline)', () => {
+    writeStoresConfig(primaryDir, [
+      {
+        url: 'https://plur.example.com/sse',
+        token: 'plur_sk_test',
+        scope: 'group:plur/plur-ai/engineering',
+        shared: true,
+        readonly: false,
+      },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    const engram = plur.learn('private global note', {
+      scope: 'global',
+      type: 'behavioral',
+      visibility: 'private',
+    })
+
+    expect(engram.visibility).toBe('private')
+    expect(postCalls().length).toBe(0)
+
+    const localYaml = join(primaryDir, 'engrams.yaml')
+    expect(existsSync(localYaml)).toBe(true)
+    const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams: Array<{ statement: string }> }
+    expect(local.engrams.find(e => e.statement === 'private global note')).toBeTruthy()
+  })
 })


### PR DESCRIPTION
## Summary

Closes #90 — `learn()` with `visibility: 'private'` and a remote scope now writes locally instead of sending to the shared server.

## Change

2 lines in `learn()` — add a guard before the remote routing block:

```typescript
if (remoteDriver && context?.visibility === 'private') {
  logger.warning('private engram not routed to remote, writing locally')
} else if (remoteDriver) {
  // ... existing remote routing
}
```

Falls through to the local write path. The engram keeps its original scope for context.

## Key design decision

Guards on `context?.visibility === 'private'` (**explicitly passed**), not `engram.visibility === 'private'` (**includes default**).

Why: the default visibility is `'private'` when no domain is set (line 427). If we guarded on `engram.visibility`, every `plur_learn` with a team scope but no explicit visibility would be blocked — breaking the normal flow. The guard only triggers when the user explicitly says "this is private."

## Merge conflict with #99

Both #99 (retry + fallback) and this PR modify the `if (remoteDriver)` block in `learn()`. If #99 merges first, resolve by adding `&& context?.visibility !== 'private'` to the `if (remoteDriver)` condition in #99's version, and moving the private guard + logger.warning before the `else if`. The logic is the same either way — check private first, then route.

## Test plan

- [x] Private + remote scope → written locally, 0 POST calls to remote
- [x] Public + remote scope → routed to server normally (1 POST)
- [x] Private + global scope → written locally (unchanged baseline)
- [x] Existing tests pass (no regression from default visibility)
- [x] All 7 remote-routing tests pass
- [x] All 55 broader core tests pass

## Test plan reference

Scenario W9 in `3-plur/1-tracks/engineering/remote-store-test-plan.md` — updated to "Fixed #90"