### PR TITLE
docs: refresh public install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You correct your agent's coding style on Monday. On Tuesday, it makes the same m
 
 PLUR fixes this. Install it once, and corrections, preferences, and conventions persist — across sessions, tools, and machines. Your memory is stored as plain YAML on your disk. No cloud, no API calls, no black box.
 
-The interesting part: **Haiku with PLUR memory outperforms Opus without it** — 2.6x better on tool routing, at roughly 10x less cost. Turns out the bottleneck isn't model intelligence. It's context.
+The interesting part: in our tool-routing and local-knowledge benchmark, **Haiku with PLUR memory outperformed Opus without it** — 2.6x better on tool routing, at roughly 10x less cost. Turns out the bottleneck isn't model intelligence. It's context.
 
 ## Install
 
@@ -32,12 +32,10 @@ For **multi-project setups**, use domain/scope to separate knowledge:
 
 ```bash
 cd ~/projects/my-app
-npx @plur-ai/cli@0.9.1 init --domain myapp --scope project:my-app
+npx @plur-ai/cli@0.9.4 init --domain myapp --scope project:my-app
 ```
 
 This creates a `.plur.yaml` in the project with defaults that hooks apply automatically. Engrams learned in that project are tagged; recall filters by scope but always includes global knowledge.
-
-> Pin to `@0.9.1` — the `0.9.2` latest tag on npm is bricked (`Dynamic require of "os" is not supported`). Tracking in [#59](https://github.com/plur-ai/plur/issues/59).
 
 ### Global install (faster startup)
 
@@ -59,9 +57,10 @@ That's it. PLUR works in the background from here. No workflow changes needed �
 
 ```bash
 pip install plur-hermes
+npm install -g @plur-ai/cli@0.9.4
 ```
 
-The plugin registers automatically via Hermes' plugin system. It injects relevant memories before each LLM call, extracts learnings from agent responses, and exposes all PLUR tools to the agent. Requires the PLUR CLI — pin to the last working version: `npm install -g @plur-ai/cli@0.9.1` (the `0.9.2` latest tag on npm is bricked; tracking in [#59](https://github.com/plur-ai/plur/issues/59)).
+The plugin registers automatically via Hermes' plugin system. It injects relevant memories before each LLM call, extracts learnings from agent responses, and exposes all PLUR tools to the agent. Hermes shells out to the PLUR CLI; current verified pairing is `plur-hermes==0.9.4` with `@plur-ai/cli@0.9.4`.
 
 ### Verify it works
 
@@ -104,7 +103,7 @@ const plur = new Plur()
 
 // Learn from a correction
 plur.learn('toEqual() in Vitest is strict — use toMatchObject() for partial matching', {
-  type: 'correction',
+  type: 'behavioral',
   scope: 'project:my-app',
   domain: 'dev/testing'
 })
@@ -142,7 +141,7 @@ plur.sync('git@github.com:you/plur-memory.git')
 | `plur_recall_hybrid` | Retrieve relevant memories (BM25 + embeddings) |
 | `plur_inject_hybrid` | Select engrams for current task within token budget |
 | `plur_feedback` | Rate relevance (trains quality over time) |
-| `plur_forget` | Retire a memory (activaton decays, eventually pruned) |
+| `plur_forget` | Retire a memory (activation decays, eventually pruned) |
 | `plur_capture` | Record an event — incident, resolution, session milestone |
 | `plur_timeline` | Query episode history by time, agent, or channel |
 | `plur_ingest` | Extract engrams from text automatically |
@@ -162,7 +161,7 @@ We ran 19 decisive contests across three Claude models (Haiku, Sonnet, Opus). Sa
 
 **31 wins, 4 losses (89% win rate).** Without memory, agents got house rules right 10–38% of the time depending on model — with PLUR, 12–0 across every model. Memory isn't a reasoning crutch — it's information the model literally cannot infer.
 
-The cost insight was unexpected: Haiku + PLUR scored 0.80 on discoverability. Opus alone scored 0.31. A $0.25/MTok model with memory beat a $15/MTok model without it.
+The cost insight was unexpected: in the reported local-knowledge benchmark setup, Haiku + PLUR scored 0.80 on discoverability while Opus alone scored 0.31. A $0.25/MTok model with memory beat a $15/MTok model without it on this task set.
 
 [Full methodology →](https://plur.ai/benchmark.html)
 

--- a/packages/claw/README.md
+++ b/packages/claw/README.md
@@ -2,7 +2,7 @@
 
 Persistent memory for [OpenClaw](https://openclaw.com) agents — fully automatic. Your agents remember corrections, learn preferences, and build knowledge across sessions. No workflow changes needed.
 
-Part of [PLUR](https://plur.ai) — where **Haiku with memory outperforms Opus without it** at 10x less cost.
+Part of [PLUR](https://plur.ai) — where, in our tool-routing and local-knowledge benchmark, **Haiku with memory outperformed Opus without it** at 10x less cost.
 
 ## Setup (30 seconds)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,18 +7,16 @@ PLUR stores corrections, preferences, and patterns as **engrams** that strengthe
 ## Install
 
 ```bash
-npm install -g @plur-ai/cli@0.9.1
+npm install -g @plur-ai/cli@0.9.4
 ```
 
 Or use without installing:
 
 ```bash
-npx @plur-ai/cli@0.9.1 status
+npx @plur-ai/cli@0.9.4 status
 ```
 
-> ### Why `@0.9.1` is pinned
->
-> The `latest` tag on npm currently resolves to `@plur-ai/cli@0.9.2`, which is bricked — every command throws `{"error":"Dynamic require of \"os\" is not supported"}` due to an esbuild bundling regression. The fix is on `main` as `0.9.3` (see commit `7af15a8`) and a CI regression guard is in place ([#68](https://github.com/plur-ai/plur/pull/68)), but the `0.9.3` artifact has not yet shipped to npm — tracking in [#59](https://github.com/plur-ai/plur/issues/59). Until `0.9.3` is published, use the explicit `@0.9.1` pin shown above (or run from source: clone the repo and `pnpm install && pnpm --filter @plur-ai/cli build`).
+> Current verified CLI release: `@plur-ai/cli@0.9.4`.
 
 ## Quick Start
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@ The engine behind [PLUR](https://plur.ai) — persistent memory for AI agents.
 
 You correct your agent on Monday. On Tuesday, it makes the same mistake. PLUR fixes this. Corrections, preferences, and conventions persist across sessions. Your data stays on your disk as plain YAML. Search runs locally with zero API calls.
 
-The result: **Haiku with PLUR memory outperforms Opus without it** — 2.6x better on tool routing, at 10x less cost. The bottleneck isn't model intelligence. It's context.
+In our tool-routing and local-knowledge benchmark, **Haiku with PLUR memory outperformed Opus without it** — 2.6x better on tool routing, at 10x less cost. The bottleneck isn't model intelligence. It's context.
 
 ## Why @plur-ai/core
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 Give your AI agent persistent memory. One line in your MCP config — corrections, preferences, and conventions persist across sessions. No workflow changes, no cloud, no API costs for search.
 
-Part of [PLUR](https://plur.ai) — where **Haiku with memory outperforms Opus without it** at 10x less cost.
+Part of [PLUR](https://plur.ai) — where, in our tool-routing and local-knowledge benchmark, **Haiku with memory outperformed Opus without it** at 10x less cost.
 
 ## Setup (30 seconds)
 


### PR DESCRIPTION
## Summary
- update public README and CLI README install pins to verified @plur-ai/cli@0.9.4
- refresh Hermes pairing guidance for plur-hermes==0.9.4 + CLI 0.9.4
- fix README schema sample and activation typo
- scope benchmark language to the tool-routing/local-knowledge benchmark

## Verification
- npm view @plur-ai/cli version => 0.9.4
- PyPI plur-hermes version => 0.9.4
- grep found no remaining active README drift for stale CLI pin, correction type sample, activaton typo, or unscoped benchmark phrases