### PR TITLE
fix(cli): silent pass-through for session hooks in non-plur projects (#95 prep)

### DIFF
--- a/packages/cli/src/commands/hook-session-guard.ts
+++ b/packages/cli/src/commands/hook-session-guard.ts
@@ -2,6 +2,7 @@ import { readSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
 
 /**
  * plur hook-session-guard — PreToolUse hook that blocks all tools until
@@ -46,6 +47,10 @@ function sentinelPath(sessionId: string): string {
 }
 
 export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
+  // Silent pass-through for projects without plur configured. Lets the hook
+  // be installed globally without blocking tools in unrelated projects (#95).
+  if (!isPlurConfigured()) return
+
   const raw = readStdinRaw()
   let data: { session_id?: string; tool_name?: string }
   try {

--- a/packages/cli/src/commands/hook-session-mark.ts
+++ b/packages/cli/src/commands/hook-session-mark.ts
@@ -2,6 +2,7 @@ import { readSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
 
 /**
  * plur hook-session-mark — PostToolUse hook on mcp__plur__plur_session_start.
@@ -32,6 +33,9 @@ function readStdinRaw(): string {
 }
 
 export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
+  // Silent pass-through for projects without plur configured (#95).
+  if (!isPlurConfigured()) return
+
   const raw = readStdinRaw()
   let data: { session_id?: string }
   try {

--- a/packages/cli/src/commands/hook-session-remind.ts
+++ b/packages/cli/src/commands/hook-session-remind.ts
@@ -1,4 +1,5 @@
 import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
 
 /**
  * plur hook-session-remind — SessionStart hook.
@@ -12,6 +13,9 @@ import { type GlobalFlags } from '../plur.js'
  */
 
 export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
+  // Silent pass-through for projects without plur configured (#95).
+  if (!isPlurConfigured()) return
+
   const output = {
     hookSpecificOutput: {
       hookEventName: 'SessionStart',

--- a/packages/cli/src/lib/plur-configured.ts
+++ b/packages/cli/src/lib/plur-configured.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import { homedir } from 'os'
+
+/**
+ * Detect whether plur is registered as an MCP server for the current project.
+ *
+ * Walks up from `cwd` looking for `.mcp.json` or `.claude/settings.json` with
+ * a `plur` server entry, then falls back to the global `~/.claude/settings.json`.
+ *
+ * Used by the session enforcement hooks (`hook-session-guard`,
+ * `hook-session-remind`, `hook-session-mark`) so they can be installed into
+ * global Claude settings (issue #95) without firing for non-plur projects.
+ *
+ * Cheap — a few `existsSync` + JSON parses, terminates at the root or the
+ * first match.
+ */
+export function isPlurConfigured(
+  cwd: string = process.cwd(),
+  home: string = homedir(),
+): boolean {
+  const start = resolve(cwd)
+  let dir = start
+  while (true) {
+    if (configHasPlur(join(dir, '.mcp.json'))) return true
+    if (configHasPlur(join(dir, '.claude', 'settings.json'))) return true
+    if (configHasPlur(join(dir, '.claude', 'settings.local.json'))) return true
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return configHasPlur(join(home, '.claude', 'settings.json'))
+}
+
+function configHasPlur(path: string): boolean {
+  if (!existsSync(path)) return false
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
+    if (!parsed || typeof parsed !== 'object') return false
+    const servers = (parsed as { mcpServers?: Record<string, unknown> }).mcpServers
+    if (!servers || typeof servers !== 'object') return false
+    return Object.prototype.hasOwnProperty.call(servers, 'plur')
+  } catch {
+    return false
+  }
+}

--- a/packages/cli/test/plur-configured.test.ts
+++ b/packages/cli/test/plur-configured.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { isPlurConfigured } from '../src/lib/plur-configured.js'
+
+describe('isPlurConfigured', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'plur-configured-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('returns false when no .mcp.json or settings exists', () => {
+    expect(isPlurConfigured(root, root)).toBe(false)
+  })
+
+  it('returns true when .mcp.json in cwd has a plur server', () => {
+    writeFileSync(
+      join(root, '.mcp.json'),
+      JSON.stringify({ mcpServers: { plur: { command: 'plur-mcp' } } }),
+    )
+    expect(isPlurConfigured(root, root)).toBe(true)
+  })
+
+  it('returns true when .mcp.json in a parent has a plur server', () => {
+    writeFileSync(
+      join(root, '.mcp.json'),
+      JSON.stringify({ mcpServers: { plur: { command: 'plur-mcp' } } }),
+    )
+    const sub = join(root, 'a', 'b', 'c')
+    mkdirSync(sub, { recursive: true })
+    expect(isPlurConfigured(sub, sub)).toBe(true)
+  })
+
+  it('returns true when project .claude/settings.json has a plur server', () => {
+    mkdirSync(join(root, '.claude'), { recursive: true })
+    writeFileSync(
+      join(root, '.claude', 'settings.json'),
+      JSON.stringify({ mcpServers: { plur: { command: 'plur-mcp' } } }),
+    )
+    expect(isPlurConfigured(root, root)).toBe(true)
+  })
+
+  it('returns false when .mcp.json exists but has no plur server', () => {
+    writeFileSync(
+      join(root, '.mcp.json'),
+      JSON.stringify({ mcpServers: { other: { command: 'other-mcp' } } }),
+    )
+    expect(isPlurConfigured(root, root)).toBe(false)
+  })
+
+  it('returns false on malformed JSON', () => {
+    writeFileSync(join(root, '.mcp.json'), '{ not valid json')
+    expect(isPlurConfigured(root, root)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds an `isPlurConfigured()` walk-up check and uses it to silent-exit the three session enforcement hooks (`hook-session-remind`, `hook-session-guard`, `hook-session-mark`) when plur isn't configured for the current project.

This is the **prerequisite** for the actual fix to #95 (moving session enforcement hooks into the global `~/.claude/settings.json` so they fire in subdirectory projects). Without this conditional guard, a global install would break Claude in non-plur projects — `hook-session-guard` would block every tool waiting for `plur_session_start`.

## Why this first

The triage on #95 [explicitly called this out](https://github.com/plur-ai/plur/issues/95#issuecomment-) as the safety mechanism that has to land before the global-install change:

> **Conditional guard requirement:** Global enforcement hooks would fire in non-PLUR Claude projects too, which is unacceptable. The guard needs the `plur_configured()` walk-up logic the issue body sketches — cheap (single fs.exists per parent dir, terminates at root or first `.mcp.json` with `plur` server) and silent pass-through when absent.

Landing the guard separately keeps the diff reviewable and risk-isolated.

## What this does NOT do (follow-up)

- Does **not** change `init.ts` — enforcement hooks still install at project scope today, so subdirectory projects still skip them. The actual #95 fix is the next PR: split `PLUR_HOOKS_ENFORCEMENT` from `PLUR_HOOKS_INJECTION`, install enforcement globally unconditionally.

## Test plan

- [x] New `test/plur-configured.test.ts` — 6 cases (cwd / parent / project settings / negative / malformed)
- [x] All pass: `vitest run test/plur-configured.test.ts` (6/6)
- [x] Pre-existing TS errors only — no new errors introduced by these files

## Closes / Refs

- Refs #95 (this is part 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)