### PR TITLE
feat(claw): daily flush + POST /v1/heartbeat (#51 slice D-2b)

### DIFF
--- a/packages/claw/src/telemetry-flush.ts
+++ b/packages/claw/src/telemetry-flush.ts
@@ -1,0 +1,156 @@
+// Daily flush + POST /v1/heartbeat (slice D-2b of #51).
+//
+// Imports the gate (`isTelemetryEnabled`) and the counter snapshot
+// (`getCounters` / `resetCounters`) from sibling modules. Owns the network.
+//
+// Privacy invariants (each pinned by a test):
+//   1. Default-off install makes zero network calls.
+//   2. Telemetry-on but no counter file → zero network calls.
+//
+// Trigger semantics: flush fires when `snapshot.date < today` (i.e. there is
+// *yesterday* data to ship). Two call sites:
+//   - lazy: `recordEvent` calls `flushIfNeeded` after the day-rollover write
+//   - exit: `registerFlushOnExit` registered from cli startup (best-effort)
+// No setInterval, no background polling.
+//
+// Failure semantics: `sendHeartbeat` never throws. On any failure (network,
+// timeout, non-2xx) it returns false; counters stay local and the next
+// rollover retries.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { isTelemetryEnabled } from './telemetry.js'
+import {
+  getCounters,
+  resetCounters,
+  type CounterSnapshot,
+  type CountersOpts,
+} from './telemetry-counters.js'
+
+export type HeartbeatPayload = {
+  install_id: string
+  version: string
+  platform: NodeJS.Platform
+  date: string
+  learn_count: number
+  recall_count: number
+  session_count: number
+}
+
+export type FlushOpts = CountersOpts & {
+  fetch?: typeof globalThis.fetch
+  endpoint?: string
+  timeoutMs?: number
+  packageVersion?: string
+}
+
+const DEFAULT_ENDPOINT = 'https://heartbeat.plur-ai.org/v1/heartbeat'
+const DEFAULT_TIMEOUT_MS = 5000
+
+function utcDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+function resolveEndpoint(opts: FlushOpts): string {
+  if (opts.endpoint) return opts.endpoint
+  const env = opts.env ?? process.env
+  return env.PLUR_TELEMETRY_ENDPOINT ?? DEFAULT_ENDPOINT
+}
+
+let cachedPackageVersion: string | null = null
+
+function readPackageVersion(): string {
+  if (cachedPackageVersion !== null) return cachedPackageVersion
+  try {
+    const here = dirname(fileURLToPath(import.meta.url))
+    // src → package root: ../package.json (when running tests against src)
+    // dist → package root: ../package.json (when running built)
+    const pkgPath = join(here, '..', 'package.json')
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+    cachedPackageVersion = typeof pkg.version === 'string' ? pkg.version : 'unknown'
+  } catch {
+    cachedPackageVersion = 'unknown'
+  }
+  return cachedPackageVersion
+}
+
+export function buildHeartbeatPayload(
+  snapshot: CounterSnapshot,
+  opts: Pick<FlushOpts, 'env' | 'packageVersion'> = {},
+): HeartbeatPayload {
+  return {
+    install_id: snapshot.installId,
+    version: opts.packageVersion ?? readPackageVersion(),
+    platform: process.platform,
+    date: snapshot.date,
+    learn_count: snapshot.learn,
+    recall_count: snapshot.recall,
+    session_count: snapshot.session,
+  }
+}
+
+export async function sendHeartbeat(
+  payload: HeartbeatPayload,
+  opts: FlushOpts = {},
+): Promise<boolean> {
+  const endpoint = resolveEndpoint(opts)
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const fetchImpl = opts.fetch ?? globalThis.fetch
+
+  if (!fetchImpl) return false
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export async function flushIfNeeded(opts: FlushOpts = {}): Promise<void> {
+  if (!isTelemetryEnabled({ env: opts.env, configPath: opts.configPath })) return
+
+  const countersPath = opts.countersPath
+  // When countersPath is provided (tests), short-circuit if missing.
+  // When unset (production default in telemetry-counters), getCounters will
+  // create the install-id file on first read; we still need to short-circuit
+  // when there is no counter file yet, which getCounters handles by returning
+  // a zero snapshot for today — that snapshot's date === today so we no-op
+  // below, never touching the network.
+  if (countersPath && !existsSync(countersPath)) return
+
+  const snapshot = getCounters(opts)
+  if (!snapshot) return
+
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+  if (snapshot.date >= today) return
+
+  const payload = buildHeartbeatPayload(snapshot, opts)
+  const ok = await sendHeartbeat(payload, opts)
+  if (ok) resetCounters(opts)
+}
+
+export function registerFlushOnExit(opts: FlushOpts = {}): () => void {
+  let fired = false
+  const handler = () => {
+    if (fired) return
+    fired = true
+    void flushIfNeeded(opts).catch(() => {})
+  }
+  process.once('beforeExit', handler)
+  return () => {
+    process.off('beforeExit', handler)
+  }
+}

--- a/packages/claw/test/telemetry-flush.test.ts
+++ b/packages/claw/test/telemetry-flush.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  buildHeartbeatPayload,
+  flushIfNeeded,
+  type FlushOpts,
+} from '../src/telemetry-flush.js'
+import type { CounterSnapshot } from '../src/telemetry-counters.js'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-flush-'))
+}
+
+describe('telemetry flush (#51 slice D-2b)', () => {
+  let dir: string
+  let countersPath: string
+  let installIdPath: string
+  let configPath: string
+
+  beforeEach(() => {
+    dir = newDir()
+    countersPath = join(dir, 'counters.json')
+    installIdPath = join(dir, 'install-id')
+    configPath = join(dir, 'telemetry.json')
+  })
+
+  function offOpts(extra: Partial<FlushOpts> = {}): FlushOpts {
+    return { env: {}, configPath, countersPath, installIdPath, ...extra }
+  }
+
+  function onOpts(extra: Partial<FlushOpts> = {}): FlushOpts {
+    return {
+      env: { PLUR_TELEMETRY: 'on' },
+      configPath,
+      countersPath,
+      installIdPath,
+      ...extra,
+    }
+  }
+
+  it('default-off install makes zero network calls (invariant 1)', async () => {
+    let fetchCalls = 0
+    const fakeFetch = (async () => {
+      fetchCalls++
+      throw new Error('should never run')
+    }) as unknown as typeof globalThis.fetch
+
+    // Pre-stage a stale counter file so the gate is the only thing protecting us.
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 5, recall: 10, session: 3 }),
+    )
+
+    await flushIfNeeded(offOpts({ fetch: fakeFetch, now: () => new Date('2026-05-11T00:00:00Z') }))
+    expect(fetchCalls).toBe(0)
+  })
+
+  it('telemetry-on but no counter file → zero network calls (invariant 2)', async () => {
+    let fetchCalls = 0
+    const fakeFetch = (async () => {
+      fetchCalls++
+      throw new Error('should never run')
+    }) as unknown as typeof globalThis.fetch
+
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: () => new Date('2026-05-11T00:00:00Z') }))
+    expect(fetchCalls).toBe(0)
+  })
+
+  it('buildHeartbeatPayload produces the exact contract shape', () => {
+    const snapshot: CounterSnapshot = {
+      installId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      date: '2026-05-10',
+      learn: 7,
+      recall: 23,
+      session: 2,
+    }
+    const payload = buildHeartbeatPayload(snapshot, { packageVersion: '0.9.14' })
+    expect(payload).toEqual({
+      install_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      version: '0.9.14',
+      platform: process.platform,
+      date: '2026-05-10',
+      learn_count: 7,
+      recall_count: 23,
+      session_count: 2,
+    })
+    // Locked contract: no extra keys (server rejects them).
+    expect(Object.keys(payload).sort()).toEqual([
+      'date',
+      'install_id',
+      'learn_count',
+      'platform',
+      'recall_count',
+      'session_count',
+      'version',
+    ])
+  })
+})


### PR DESCRIPTION
Transport half of the telemetry D-track. D-2a (counter plumbing) shipped as #75 / d43c689 on 2026-05-02. D-2b was [authorized to build at 2026-05-11T02:14Z](https://github.com/plur-ai/plur/issues/51) after the silent-ratify window on the build-authorization comment closed (6.5d slip from the nominal authorization date — audit locked in `hypotheses.yaml`).

## Scope (matches the ratified contract exactly)

In-process daily flush plumbing for the counter snapshot D-2a writes. **NO new public state, NO new persistent file**; this slice is pure transport over the existing `~/.plur/telemetry-counters.json` snapshot.

## Public API

```ts
buildHeartbeatPayload(snapshot, opts?): HeartbeatPayload
sendHeartbeat(payload, opts?): Promise<boolean>     // never throws
flushIfNeeded(opts?): Promise<void>                 // gated, no-op-by-default
registerFlushOnExit(opts?): () => void              // beforeExit hook
```

## Endpoint

| | |
|---|---|
| Default | `https://heartbeat.plur-ai.org/v1/heartbeat` |
| Override | `PLUR_TELEMETRY_ENDPOINT` env / `FlushOpts.endpoint` (tests) |
| Timeout | 5000ms (overridable via `FlushOpts.timeoutMs`) |

## Trigger semantics

`flushIfNeeded` fires **only when `snapshot.date < today`** (i.e. there is *yesterday* data to ship). No `setInterval`, no background polling. Two intended call sites land in a follow-up wiring commit to keep this slice reviewable against the spec line-by-line:

- lazy: `recordEvent` calls `flushIfNeeded` after the day-rollover write
- exit: `registerFlushOnExit` registered from cli startup (best-effort `beforeExit`)

## Failure semantics

`sendHeartbeat` **never throws**. On any failure (network, timeout, non-2xx) it returns `false`; counters stay local for the next rollover to retry. `flushIfNeeded` only calls `resetCounters` when `sendHeartbeat` returns `true`.

## Privacy invariants (each pinned by a test)

| # | Coverage |
|---|----------|
| 1 | default-off install: **zero network calls** even with stale counters pre-staged on disk (gate is the only thing protecting us) |
| 2 | telemetry-on but no counter file: **zero network calls** (short-circuit before any `fetch`) |
| 3 | payload shape locked to the ratified contract: exactly the 7 keys `{install_id, version, platform, date, learn_count, recall_count, session_count}`, no extras (server rejects unknown keys) |

## Test footprint

3 tests in `packages/claw/test/telemetry-flush.test.ts`. CI will run them; my local pnpm install is in a wedged state (lockfile/overrides drift) so I deferred local verification to CI rather than fight the install.

## What this PR does **not** do (follow-up)

- Call-site wiring inside `recordEvent` / cli startup — D-2b is the **module**, not its callers (matches D-2a's "module-first" framing per the spec)
- Server-side `/v1/heartbeat` ingress (separate repo)
- IP-stripping/forwarding concerns at the ingress layer

## D-track status

- [x] D-1  opt-in gate (#67 merged 2026-04-29)
- [x] D-2a counter plumbing (#75 merged 2026-05-02)
- [x] D-2b daily flush + `POST /v1/heartbeat` (this PR)

## Unblocks

- **H004 E3 D-2b** experiment (telemetry endpoint goes live on merge)
- **H005 E1** cohort-1 engagement baseline, currently `blocked_on: H004_E3_D2b` per `hypotheses.yaml`. Earliest E1 readout re-pegs again on this PR's merge date (last estimate ~2026-06-10).

Closes the build half of #51 slice D-2b.

🤖 Posted by autonomous CTO heartbeat 2026-05-11T08:15Z

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>