### PR TITLE
feat(claw): wire recordEvent + registerFlushOnExit (#51 slice D-2c, claw-side)

### DIFF
--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -7,6 +7,7 @@ import type {
 } from './types.js'
 import { extractLearnings, isCorrection } from './learner.js'
 import { assembleContext } from './assembler.js'
+import { recordEvent } from './telemetry-counters.js'
 
 /**
  * Extract text from message content — handles string and array-of-blocks formats.
@@ -154,6 +155,7 @@ export class PlurContextEngine implements ContextEngine {
           // Fall back to BM25 when embeddings unavailable
           injection = this.plur.inject(task, injectOpts)
         }
+        recordEvent('recall')
       }
 
       return assembleContext({
@@ -332,5 +334,6 @@ export class PlurContextEngine implements ContextEngine {
     if (seen.has(key)) return
     seen.add(key)
     this.plur.learn(statement, context)
+    recordEvent('learn')
   }
 }

--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -1,6 +1,8 @@
 import { PlurContextEngine, type PlurContextEngineOptions } from './context-engine.js'
 import { ensureSystemPrompt, PLUR_SYSTEM_SECTION } from './system-prompt.js'
 import { checkForUpdate } from '@plur-ai/core'
+import { recordEvent } from './telemetry-counters.js'
+import { registerFlushOnExit } from './telemetry-flush.js'
 
 // Re-export everything consumers might need
 export { PlurContextEngine, type PlurContextEngineOptions }
@@ -78,6 +80,7 @@ const plugin = {
       const task = typeof event?.prompt === 'string' ? event.prompt : ''
       if (!task) return
       const injection = e.plur.inject(task, { budget: 2000 })
+      recordEvent('recall')
       if (injection.count === 0) return
       const lines = ['<plur-memory>']
       if (injection.directives) lines.push(injection.directives)
@@ -109,6 +112,7 @@ const plugin = {
         handler: (ctx: any) => {
           if (!ctx.args?.trim()) return { text: 'Usage: /learn <statement to remember>' }
           const engram = getEngine(path).plur.learn(ctx.args.trim(), { source: 'openclaw:slash', rationale: 'user explicitly saved via /learn command' })
+          recordEvent('learn')
           return { text: `Remembered: "${ctx.args.trim()}" (${engram.id})` }
         },
       })
@@ -120,6 +124,7 @@ const plugin = {
         handler: (ctx: any) => {
           if (!ctx.args?.trim()) return { text: 'Usage: /recall <search query>' }
           const results = getEngine(path).plur.recall(ctx.args.trim(), { limit: 10 })
+          recordEvent('recall')
           if (!Array.isArray(results) || !results.length) return { text: 'No matching memories.' }
           return { text: `Found ${results.length} memories:\n${results.map((r: any, i: number) => `${i + 1}. [${r.id}] ${r.statement}`).join('\n')}` }
         },
@@ -235,6 +240,11 @@ const plugin = {
       start: () => api.logger.info(`PLUR: started (path: ${path})`),
       stop: () => api.logger.info('PLUR: stopped'),
     })
+
+    // 9. Telemetry flush on process exit (no-op when PLUR_TELEMETRY != 'on').
+    // beforeExit fires once per long-lived OpenClaw process — flushes yesterday's
+    // counters to heartbeat.plur-ai.org when day-rollover left a snapshot behind.
+    registerFlushOnExit({})
 
     api.logger.info(`PLUR registered: context engine + hooks + slash commands + CLI`)
 


### PR DESCRIPTION
## Summary

D-2c per #125. Implements **Option D** from the structural audit on #125: land the claw-side wiring now, defer CLI startup wiring to a follow-up that resolves the cli→claw dependency question.

## Call sites wired

`packages/claw/src/context-engine.ts`
- `recordEvent('recall')` after `assemble()` injection (hybrid + BM25-fallback path)
- `recordEvent('learn')` after `_learnIfNew` commits via `plur.learn`

`packages/claw/src/index.ts`
- `recordEvent('recall')` in `before_agent_start` hook after `plur.inject`
- `recordEvent('learn')` / `recordEvent('recall')` in `/learn` and `/recall` slash commands
- `registerFlushOnExit({})` at end of plugin `register()` — fires `beforeExit` for the long-lived OpenClaw process

## Privacy invariant

Every `recordEvent` / `flushIfNeeded` short-circuits inside on `!isTelemetryEnabled()` **before** any filesystem or network call. The "default-off install touches zero files" test in `telemetry-counters.test.ts` continues to guard this.

## Out of scope (follow-up tickets)

1. **CLI startup wiring of `registerFlushOnExit`** — blocked on the `cli`→`claw` dependency question raised in #125 audit (Option A: move telemetry to core; Option B: add claw dep to cli; Option C: extract telemetry package).
2. **Day-rollover flush correctness** — `getCounters` / `rolloverIfNeeded` discards yesterday's snapshot before `flushIfNeeded` can read it. Only `beforeExit` on a process that hasn't yet `recordEvent`'d today actually flushes. The wiring above is correct for what the merged D-2b module supports; the rollover bug deserves its own ticket.

## Test plan

- [ ] CI passes (existing telemetry privacy-invariant tests must remain green — they were the load-bearing guard for D-2a/D-2b)
- [ ] `pnpm test --filter @plur-ai/claw` locally green (`context-engine.test.ts`, `telemetry-counters.test.ts`, `telemetry-flush.test.ts`)
- [ ] Smoke: with `PLUR_TELEMETRY=off`, run a claw session — no writes under `~/.plur/telemetry-counters.json`
- [ ] Smoke: with `PLUR_TELEMETRY=on`, run a claw learn + recall — counter file increments

Refs: #51 (parent telemetry epic), #125 (D-2c spec). Unblocks H005 E1 cohort once ingress goes live.