### PR TITLE
fix(claw): preserve yesterday's counters on day-rollover (#128)

### DIFF
--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -8,6 +8,14 @@ import type {
 import { extractLearnings, isCorrection } from './learner.js'
 import { assembleContext } from './assembler.js'
 import { recordEvent } from './telemetry-counters.js'
+import { flushIfNeeded } from './telemetry-flush.js'
+
+// #128: if recordEvent rolled the day, ship yesterday's pending snapshot now
+// (rather than waiting for process exit — long-lived plugin sessions might
+// span multiple days otherwise). Fire-and-forget; flushIfNeeded swallows.
+function maybeFlushAfter(rolledOver: boolean): void {
+  if (rolledOver) void flushIfNeeded({}).catch(() => {})
+}
 
 /**
  * Extract text from message content — handles string and array-of-blocks formats.
@@ -155,7 +163,7 @@ export class PlurContextEngine implements ContextEngine {
           // Fall back to BM25 when embeddings unavailable
           injection = this.plur.inject(task, injectOpts)
         }
-        recordEvent('recall')
+        maybeFlushAfter(recordEvent('recall'))
       }
 
       return assembleContext({
@@ -334,6 +342,6 @@ export class PlurContextEngine implements ContextEngine {
     if (seen.has(key)) return
     seen.add(key)
     this.plur.learn(statement, context)
-    recordEvent('learn')
+    maybeFlushAfter(recordEvent('learn'))
   }
 }

--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -2,7 +2,14 @@ import { PlurContextEngine, type PlurContextEngineOptions } from './context-engi
 import { ensureSystemPrompt, PLUR_SYSTEM_SECTION } from './system-prompt.js'
 import { checkForUpdate } from '@plur-ai/core'
 import { recordEvent } from './telemetry-counters.js'
-import { registerFlushOnExit } from './telemetry-flush.js'
+import { flushIfNeeded, registerFlushOnExit } from './telemetry-flush.js'
+
+// #128: when recordEvent rolls the day, ship yesterday's pending snapshot
+// immediately. Without this, a long-lived plugin process would only flush on
+// `beforeExit`, which can be days away.
+function maybeFlushAfter(rolledOver: boolean): void {
+  if (rolledOver) void flushIfNeeded({}).catch(() => {})
+}
 
 // Re-export everything consumers might need
 export { PlurContextEngine, type PlurContextEngineOptions }
@@ -80,7 +87,7 @@ const plugin = {
       const task = typeof event?.prompt === 'string' ? event.prompt : ''
       if (!task) return
       const injection = e.plur.inject(task, { budget: 2000 })
-      recordEvent('recall')
+      maybeFlushAfter(recordEvent('recall'))
       if (injection.count === 0) return
       const lines = ['<plur-memory>']
       if (injection.directives) lines.push(injection.directives)
@@ -112,7 +119,7 @@ const plugin = {
         handler: (ctx: any) => {
           if (!ctx.args?.trim()) return { text: 'Usage: /learn <statement to remember>' }
           const engram = getEngine(path).plur.learn(ctx.args.trim(), { source: 'openclaw:slash', rationale: 'user explicitly saved via /learn command' })
-          recordEvent('learn')
+          maybeFlushAfter(recordEvent('learn'))
           return { text: `Remembered: "${ctx.args.trim()}" (${engram.id})` }
         },
       })
@@ -124,7 +131,7 @@ const plugin = {
         handler: (ctx: any) => {
           if (!ctx.args?.trim()) return { text: 'Usage: /recall <search query>' }
           const results = getEngine(path).plur.recall(ctx.args.trim(), { limit: 10 })
-          recordEvent('recall')
+          maybeFlushAfter(recordEvent('recall'))
           if (!Array.isArray(results) || !results.length) return { text: 'No matching memories.' }
           return { text: `Found ${results.length} memories:\n${results.map((r: any, i: number) => `${i + 1}. [${r.id}] ${r.statement}`).join('\n')}` }
         },

--- a/packages/claw/src/telemetry-counters.ts
+++ b/packages/claw/src/telemetry-counters.ts
@@ -13,8 +13,22 @@
 // Session semantics (silent-ratified default-pick B, 2026-05-02T12:00Z, #51):
 // 'session' fires on the first 'learn' or 'recall' recorded within a UTC day.
 // No standalone session call site.
+//
+// Day-rollover safety (#128): on rollover, yesterday's snapshot is moved to a
+// pending-flush directory (~/.plur/telemetry-pending/<date>.json) BEFORE
+// counters.json is rewritten for today. flushIfNeeded drains that directory.
+// Without this, a long-lived process emitting an event after midnight would
+// silently overwrite yesterday's data on disk.
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
@@ -36,6 +50,7 @@ export type CountersOpts = {
   configPath?: string
   countersPath?: string
   installIdPath?: string
+  pendingDir?: string
   now?: () => Date
 }
 
@@ -45,6 +60,10 @@ function defaultCountersPath(): string {
 
 function defaultInstallIdPath(): string {
   return join(homedir(), '.plur', 'install-id')
+}
+
+function defaultPendingDir(): string {
+  return join(homedir(), '.plur', 'telemetry-pending')
 }
 
 function utcDate(d: Date): string {
@@ -117,23 +136,58 @@ function freshCounters(date: string): StoredCounters {
   return { date, learn: 0, recall: 0, session: 0 }
 }
 
-function rolloverIfNeeded(stored: StoredCounters | null, today: string): StoredCounters {
+// Synthesize a today-dated snapshot for callers that just want a current-day
+// view (getCounters). Never used by recordEvent — recordEvent moves stale
+// state to pending-dir before defaulting to fresh.
+function viewAsToday(stored: StoredCounters | null, today: string): StoredCounters {
   if (!stored || stored.date !== today) return freshCounters(today)
   return stored
 }
 
-export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): void {
-  if (!isTelemetryEnabled(gateOpts(opts))) return
+function moveToPending(stored: StoredCounters, pendingDir: string): void {
+  const path = join(pendingDir, `${stored.date}.json`)
+  // If a pending file already exists for this date (e.g. multiple processes
+  // each detected the same rollover), merge counts so we don't double-count
+  // OR drop the smaller snapshot.
+  const existing = readStoredCounters(path)
+  const merged: StoredCounters =
+    existing && existing.date === stored.date
+      ? {
+          date: stored.date,
+          learn: existing.learn + stored.learn,
+          recall: existing.recall + stored.recall,
+          session: Math.max(existing.session, stored.session),
+        }
+      : stored
+  atomicWriteJson(path, merged)
+}
+
+export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): boolean {
+  if (!isTelemetryEnabled(gateOpts(opts))) return false
 
   const countersPath = opts.countersPath ?? defaultCountersPath()
   const installIdPath = opts.installIdPath ?? defaultInstallIdPath()
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
   const now = (opts.now ?? (() => new Date()))()
   const today = utcDate(now)
 
   readOrCreateInstallId(installIdPath)
 
-  const current = rolloverIfNeeded(readStoredCounters(countersPath), today)
-  const sessionAlreadyCounted = current.date === today && current.session > 0
+  const stored = readStoredCounters(countersPath)
+  let current: StoredCounters
+  let rolledOver = false
+  if (stored && stored.date !== today) {
+    // Rollover: preserve yesterday's snapshot in pending-dir BEFORE overwriting
+    // counters.json with today's fresh state. This is the load-bearing fix for
+    // #128 — without it, a long-lived process emitting an event after midnight
+    // would silently discard yesterday's counts.
+    moveToPending(stored, pendingDir)
+    current = freshCounters(today)
+    rolledOver = true
+  } else {
+    current = stored ?? freshCounters(today)
+  }
+  const sessionAlreadyCounted = current.session > 0
 
   if (event === 'learn') current.learn += 1
   else if (event === 'recall') current.recall += 1
@@ -144,6 +198,53 @@ export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): void 
   }
 
   atomicWriteJson(countersPath, current)
+  return rolledOver
+}
+
+// Pending-flush directory helpers (#128). flushIfNeeded uses these to drain
+// per-day snapshots that recordEvent stashed on rollover.
+
+export function listPendingDates(opts: CountersOpts = {}): string[] {
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  if (!existsSync(pendingDir)) return []
+  try {
+    return readdirSync(pendingDir)
+      .filter((f) => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
+      .map((f) => f.slice(0, -5))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+export function readPendingCounters(date: string, opts: CountersOpts = {}): StoredCounters | null {
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  return readStoredCounters(join(pendingDir, `${date}.json`))
+}
+
+export function deletePending(date: string, opts: CountersOpts = {}): void {
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  try {
+    unlinkSync(join(pendingDir, `${date}.json`))
+  } catch {
+    /* ignore — already gone */
+  }
+}
+
+// Migration helper: if counters.json holds a stale date (e.g. upgrade from a
+// pre-#128 install), shunt it into pending-dir so flushIfNeeded picks it up.
+// Returns true when migration ran.
+export function migrateStaleCounters(opts: CountersOpts = {}): boolean {
+  if (!isTelemetryEnabled(gateOpts(opts))) return false
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+  const stored = readStoredCounters(countersPath)
+  if (!stored || stored.date >= today) return false
+  moveToPending(stored, pendingDir)
+  atomicWriteJson(countersPath, freshCounters(today))
+  return true
 }
 
 export function getCounters(opts: CountersOpts = {}): CounterSnapshot | null {
@@ -155,7 +256,7 @@ export function getCounters(opts: CountersOpts = {}): CounterSnapshot | null {
   const today = utcDate(now)
 
   const installId = readOrCreateInstallId(installIdPath)
-  const stored = rolloverIfNeeded(readStoredCounters(countersPath), today)
+  const stored = viewAsToday(readStoredCounters(countersPath), today)
 
   return {
     installId,

--- a/packages/claw/src/telemetry-flush.ts
+++ b/packages/claw/src/telemetry-flush.ts
@@ -7,24 +7,28 @@
 //   1. Default-off install makes zero network calls.
 //   2. Telemetry-on but no counter file → zero network calls.
 //
-// Trigger semantics: flush fires when `snapshot.date < today` (i.e. there is
-// *yesterday* data to ship). Two call sites:
-//   - lazy: `recordEvent` calls `flushIfNeeded` after the day-rollover write
+// Trigger semantics: flush drains the pending-flush directory written by
+// `recordEvent` on day-rollover (#128). Two call sites:
+//   - rollover: `recordEvent` returns `true` from its rollover branch; callers
+//     fire `flushIfNeeded` async
 //   - exit: `registerFlushOnExit` registered from cli startup (best-effort)
 // No setInterval, no background polling.
 //
 // Failure semantics: `sendHeartbeat` never throws. On any failure (network,
-// timeout, non-2xx) it returns false; counters stay local and the next
-// rollover retries.
+// timeout, non-2xx) it returns false; pending files stay on disk for the next
+// rollover or process restart to retry.
 
-import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import { isTelemetryEnabled } from './telemetry.js'
 import {
+  deletePending,
   getCounters,
-  resetCounters,
+  listPendingDates,
+  migrateStaleCounters,
+  readPendingCounters,
   type CounterSnapshot,
   type CountersOpts,
 } from './telemetry-counters.js'
@@ -48,10 +52,6 @@ export type FlushOpts = CountersOpts & {
 
 const DEFAULT_ENDPOINT = 'https://heartbeat.plur-ai.org/v1/heartbeat'
 const DEFAULT_TIMEOUT_MS = 5000
-
-function utcDate(d: Date): string {
-  return d.toISOString().slice(0, 10)
-}
 
 function resolveEndpoint(opts: FlushOpts): string {
   if (opts.endpoint) return opts.endpoint
@@ -122,24 +122,41 @@ export async function flushIfNeeded(opts: FlushOpts = {}): Promise<void> {
   if (!isTelemetryEnabled({ env: opts.env, configPath: opts.configPath })) return
 
   const countersPath = opts.countersPath
-  // When countersPath is provided (tests), short-circuit if missing.
-  // When unset (production default in telemetry-counters), getCounters will
-  // create the install-id file on first read; we still need to short-circuit
-  // when there is no counter file yet, which getCounters handles by returning
-  // a zero snapshot for today — that snapshot's date === today so we no-op
-  // below, never touching the network.
-  if (countersPath && !existsSync(countersPath)) return
+  // Privacy invariant 2: telemetry-on but no on-disk state → zero network.
+  // When countersPath is set (tests), if it's missing AND pending-dir has
+  // nothing, we have no data to ship. In production (no countersPath), the
+  // pending-dir check below handles the empty case.
+  if (countersPath && !existsSync(countersPath) && listPendingDates(opts).length === 0) return
 
-  const snapshot = getCounters(opts)
-  if (!snapshot) return
+  // Migrate any stale counters.json (e.g. upgrade from pre-#128, or beforeExit
+  // firing after midnight on a process that never re-recorded). Adds an entry
+  // to pending-dir; the drain loop below ships it.
+  migrateStaleCounters(opts)
 
-  const now = (opts.now ?? (() => new Date()))()
-  const today = utcDate(now)
-  if (snapshot.date >= today) return
+  // getCounters gives us install_id; we ignore its date/counts and instead
+  // ship each pending file as its own heartbeat.
+  const baseSnapshot = getCounters(opts)
+  if (!baseSnapshot) return
 
-  const payload = buildHeartbeatPayload(snapshot, opts)
-  const ok = await sendHeartbeat(payload, opts)
-  if (ok) resetCounters(opts)
+  for (const date of listPendingDates(opts)) {
+    const pending = readPendingCounters(date, opts)
+    if (!pending) {
+      // Malformed or already-removed; drop the file so we don't loop on it.
+      deletePending(date, opts)
+      continue
+    }
+    const snapshot: CounterSnapshot = {
+      installId: baseSnapshot.installId,
+      date: pending.date,
+      learn: pending.learn,
+      recall: pending.recall,
+      session: pending.session,
+    }
+    const payload = buildHeartbeatPayload(snapshot, opts)
+    const ok = await sendHeartbeat(payload, opts)
+    if (ok) deletePending(date, opts)
+    // On failure, file stays on disk and is retried on next flush.
+  }
 }
 
 export function registerFlushOnExit(opts: FlushOpts = {}): () => void {

--- a/packages/claw/test/telemetry-counters.test.ts
+++ b/packages/claw/test/telemetry-counters.test.ts
@@ -6,6 +6,8 @@ import {
   recordEvent,
   getCounters,
   resetCounters,
+  listPendingDates,
+  readPendingCounters,
   type CountersOpts,
 } from '../src/telemetry-counters.js'
 
@@ -19,21 +21,30 @@ describe('telemetry counters (#51 slice D-2a)', () => {
   let dir: string
   let countersPath: string
   let installIdPath: string
+  let pendingDir: string
   let configPath: string
 
   beforeEach(() => {
     dir = newDir()
     countersPath = join(dir, 'counters.json')
     installIdPath = join(dir, 'install-id')
+    pendingDir = join(dir, 'pending')
     configPath = join(dir, 'telemetry.json')
   })
 
   function offOpts(extra: Partial<CountersOpts> = {}): CountersOpts {
-    return { env: {}, configPath, countersPath, installIdPath, ...extra }
+    return { env: {}, configPath, countersPath, installIdPath, pendingDir, ...extra }
   }
 
   function onOpts(extra: Partial<CountersOpts> = {}): CountersOpts {
-    return { env: { PLUR_TELEMETRY: 'on' }, configPath, countersPath, installIdPath, ...extra }
+    return {
+      env: { PLUR_TELEMETRY: 'on' },
+      configPath,
+      countersPath,
+      installIdPath,
+      pendingDir,
+      ...extra,
+    }
   }
 
   it('default-off install touches zero files (recordEvent)', () => {
@@ -85,6 +96,61 @@ describe('telemetry counters (#51 slice D-2a)', () => {
 
     const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
     expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on rollover preserves yesterday in pending-dir (#128)', () => {
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 5, recall: 2, session: 1 }),
+    )
+    const fixedNow = () => new Date('2026-05-02T00:30:00Z')
+    const rolled = recordEvent('learn', onOpts({ now: fixedNow }))
+
+    expect(rolled).toBe(true)
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-01'])
+    const yesterday = readPendingCounters('2026-05-01', { pendingDir })
+    expect(yesterday).toEqual({ date: '2026-05-01', learn: 5, recall: 2, session: 1 })
+    // And today's counters.json starts fresh
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on within-day record does not signal rollover', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    expect(recordEvent('learn', opts)).toBe(false)
+    expect(recordEvent('recall', opts)).toBe(false)
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('env-on rollover merges with existing pending file for same date (#128)', () => {
+    // Scenario: pending/<day1>.json already exists (prior rollover whose flush
+    // failed), then counters.json gets rewritten to day1 again (e.g. crash
+    // restore from a backup) and another rollover fires. Pending should
+    // accumulate, not be overwritten.
+    const day2 = () => new Date('2026-05-02T00:30:00Z')
+
+    // First rollover: day1(3/1/1) → pending
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 3, recall: 1, session: 1 }),
+    )
+    recordEvent('learn', onOpts({ now: day2 }))
+
+    // Simulate counters.json reverting to a day1 state again (different counts)
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 2, recall: 4, session: 1 }),
+    )
+    recordEvent('learn', onOpts({ now: day2 }))
+
+    const merged = readPendingCounters('2026-05-01', { pendingDir })
+    expect(merged).toEqual({
+      date: '2026-05-01',
+      learn: 3 + 2,
+      recall: 1 + 4,
+      session: 1,
+    })
   })
 
   it('env-on malformed counters file: parse-fails treated as missing, fresh write', () => {

--- a/packages/claw/test/telemetry-flush.test.ts
+++ b/packages/claw/test/telemetry-flush.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,7 +8,11 @@ import {
   flushIfNeeded,
   type FlushOpts,
 } from '../src/telemetry-flush.js'
-import type { CounterSnapshot } from '../src/telemetry-counters.js'
+import {
+  listPendingDates,
+  recordEvent,
+  type CounterSnapshot,
+} from '../src/telemetry-counters.js'
 
 function newDir(): string {
   return mkdtempSync(join(tmpdir(), 'plur-flush-'))
@@ -18,17 +22,19 @@ describe('telemetry flush (#51 slice D-2b)', () => {
   let dir: string
   let countersPath: string
   let installIdPath: string
+  let pendingDir: string
   let configPath: string
 
   beforeEach(() => {
     dir = newDir()
     countersPath = join(dir, 'counters.json')
     installIdPath = join(dir, 'install-id')
+    pendingDir = join(dir, 'pending')
     configPath = join(dir, 'telemetry.json')
   })
 
   function offOpts(extra: Partial<FlushOpts> = {}): FlushOpts {
-    return { env: {}, configPath, countersPath, installIdPath, ...extra }
+    return { env: {}, configPath, countersPath, installIdPath, pendingDir, ...extra }
   }
 
   function onOpts(extra: Partial<FlushOpts> = {}): FlushOpts {
@@ -37,8 +43,21 @@ describe('telemetry flush (#51 slice D-2b)', () => {
       configPath,
       countersPath,
       installIdPath,
+      pendingDir,
       ...extra,
     }
+  }
+
+  type CapturedPost = { body: any; ok: boolean }
+  function captureFetch(initial: { ok: boolean } = { ok: true }) {
+    const calls: CapturedPost[] = []
+    let nextOk = initial.ok
+    const fakeFetch = (async (_url: string, init: any) => {
+      const parsed = init?.body ? JSON.parse(init.body as string) : null
+      calls.push({ body: parsed, ok: nextOk })
+      return { ok: nextOk } as Response
+    }) as unknown as typeof globalThis.fetch
+    return { calls, fakeFetch, setNextOk: (v: boolean) => (nextOk = v) }
   }
 
   it('default-off install makes zero network calls (invariant 1)', async () => {
@@ -97,5 +116,155 @@ describe('telemetry flush (#51 slice D-2b)', () => {
       'session_count',
       'version',
     ])
+  })
+
+  // -----------------------------------------------------------------------
+  // #128 acceptance: day-rollover flush race
+  // -----------------------------------------------------------------------
+
+  it('long-lived process across midnight: yesterday posted, not discarded (#128)', async () => {
+    const { calls, fakeFetch } = captureFetch()
+
+    // Day Y: emit events.
+    const dayY = () => new Date('2026-05-10T18:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+    recordEvent('recall', onOpts({ now: dayY }))
+    recordEvent('recall', onOpts({ now: dayY }))
+
+    // Sanity: counters.json holds day Y data.
+    expect(JSON.parse(readFileSync(countersPath, 'utf8'))).toEqual({
+      date: '2026-05-10',
+      learn: 1,
+      recall: 2,
+      session: 1,
+    })
+
+    // Cross midnight: emit event on day Y+1. Yesterday's snapshot moves to pending.
+    const dayY1 = () => new Date('2026-05-11T00:30:00Z')
+    const rolled = recordEvent('learn', onOpts({ now: dayY1 }))
+    expect(rolled).toBe(true)
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-10'])
+
+    // Flush fires; yesterday gets POSTed.
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(calls[0].body.learn_count).toBe(1)
+    expect(calls[0].body.recall_count).toBe(2)
+    expect(calls[0].body.session_count).toBe(1)
+
+    // Pending file is cleaned up after successful flush.
+    expect(listPendingDates({ pendingDir })).toEqual([])
+    // Today's counters intact (the learn that crossed midnight).
+    expect(JSON.parse(readFileSync(countersPath, 'utf8'))).toEqual({
+      date: '2026-05-11',
+      learn: 1,
+      recall: 0,
+      session: 1,
+    })
+  })
+
+  it('beforeExit on process that crossed midnight without re-recording posts yesterday (#128)', async () => {
+    const { calls, fakeFetch } = captureFetch()
+
+    // Day Y: emit events.
+    const dayY = () => new Date('2026-05-10T18:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+    recordEvent('learn', onOpts({ now: dayY }))
+
+    // Day Y+1: NO new recordEvent — beforeExit fires while counters.json
+    // still has yesterday's date.
+    const dayY1 = () => new Date('2026-05-11T03:00:00Z')
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(calls[0].body.learn_count).toBe(2)
+
+    // After migration, counters.json is empty-today, pending drained.
+    expect(listPendingDates({ pendingDir })).toEqual([])
+    expect(JSON.parse(readFileSync(countersPath, 'utf8'))).toEqual({
+      date: '2026-05-11',
+      learn: 0,
+      recall: 0,
+      session: 0,
+    })
+  })
+
+  it('process killed before midnight: next-startup flush drains pending (#128)', async () => {
+    // Day Y old process: emits events, gets killed (no beforeExit, no flush).
+    const dayY = () => new Date('2026-05-10T22:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+    recordEvent('recall', onOpts({ now: dayY }))
+
+    // Day Y+1 new process starts, records an event (triggers rollover to pending).
+    const dayY1 = () => new Date('2026-05-11T08:00:00Z')
+    recordEvent('recall', onOpts({ now: dayY1 }))
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-10'])
+
+    // Startup flush.
+    const { calls, fakeFetch } = captureFetch()
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('flush failure leaves pending file on disk for retry (#128)', async () => {
+    const { calls, fakeFetch, setNextOk } = captureFetch({ ok: false })
+
+    const dayY = () => new Date('2026-05-10T18:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+
+    const dayY1 = () => new Date('2026-05-11T00:30:00Z')
+    recordEvent('learn', onOpts({ now: dayY1 }))
+
+    // First flush: server says no.
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-10']) // still there
+
+    // Server recovers. Retry: pending drains.
+    setNextOk(true)
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+    expect(calls).toHaveLength(2)
+    expect(calls[1].body.date).toBe('2026-05-10')
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('multi-day gap: flush posts each pending date separately (#128)', async () => {
+    const { calls, fakeFetch } = captureFetch()
+
+    // Day Y: emit events
+    recordEvent('learn', onOpts({ now: () => new Date('2026-05-09T12:00:00Z') }))
+    // Day Y+1: rollover → pending(2026-05-09), record on Y+1
+    recordEvent('learn', onOpts({ now: () => new Date('2026-05-10T12:00:00Z') }))
+    // Day Y+2: rollover → pending(2026-05-10), record on Y+2
+    recordEvent('learn', onOpts({ now: () => new Date('2026-05-11T12:00:00Z') }))
+
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-09', '2026-05-10'])
+
+    await flushIfNeeded(
+      onOpts({ fetch: fakeFetch, now: () => new Date('2026-05-11T12:30:00Z') }),
+    )
+
+    expect(calls.map((c) => c.body.date).sort()).toEqual(['2026-05-09', '2026-05-10'])
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('flush no-op when no pending and counters.json is for today', async () => {
+    let fetchCalls = 0
+    const fakeFetch = (async () => {
+      fetchCalls++
+      return { ok: true } as Response
+    }) as unknown as typeof globalThis.fetch
+
+    const today = () => new Date('2026-05-11T12:00:00Z')
+    recordEvent('learn', onOpts({ now: today }))
+
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: today }))
+    expect(fetchCalls).toBe(0)
   })
 })


### PR DESCRIPTION
Closes #128.

## Bug

`rolloverIfNeeded` discarded yesterday's snapshot **before** `flushIfNeeded` could read and POST it. Long-lived plugin processes that emit a `recordEvent` across midnight silently lost the previous day's counts. The only path that flushed yesterday correctly was `beforeExit` on a process that exited *without* firing any new event after midnight — i.e. the opposite of typical claw plugin usage.

## Fix

Option 2 from #128 (separate yesterday-pending file — cleaner for the long-lived case):

- On rollover, `recordEvent` moves yesterday's snapshot to `~/.plur/telemetry-pending/<date>.json` **before** rewriting `counters.json` for today.
- `flushIfNeeded` drains the pending directory, posting each date as its own heartbeat.
- Pending files persist on flush failure for retry on next rollover or process startup.
- `recordEvent` now returns `true` when it just rolled the day; call sites in `context-engine` + `index` fire `flushIfNeeded` async on that signal so yesterday's data ships immediately rather than waiting for `beforeExit`.

`migrateStaleCounters` handles two upgrade/recovery cases that bypass `recordEvent`:
1. Pre-#128 installs whose `counters.json` already holds a stale date.
2. `beforeExit` firing after midnight on a process that never recorded a post-midnight event.

## Privacy invariants preserved

1. ✅ Default-off install makes zero network calls (telemetry-off short-circuit unchanged).
2. ✅ Telemetry-on but no on-disk state → zero network calls (extended check covers both `counters.json` *and* pending-dir empty).

## Tests

All three #128 acceptance scenarios:

- `long-lived process across midnight` — yesterday POSTed, not discarded
- `beforeExit on process that crossed midnight without re-recording` — `migrateStaleCounters` path
- `process killed before midnight, next-startup drains pending` — startup recovery

Plus:
- Flush failure retains pending for retry, then drains on success
- Multi-day gap: each pending date posts separately
- Same-date pending merges (crash/restore safety: doesn't double-discard if rollover fires twice for same day)

Results: **22/22** telemetry tests, **94/94** full claw suite.

## Refs

- Closes #128
- Refs #51 (telemetry epic)
- plur-H005 E1 cohort measurement validity (per-day attribution required for `days-with-≥1-event` metric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)