### PR TITLE
fix(core): cold-cache append must not block load() refetch (#130)

### DIFF
--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -149,7 +149,10 @@ export class RemoteStore implements EngramStore {
     if (this.cache) {
       this.cache.engrams.push(stored)
     } else {
-      this.cache = { ts: Date.now(), engrams: [stored] }
+      // Cold cache (no prior load()): one engram is not "all engrams in
+      // this scope". Mark stale (ts: 0) so the next load() refetches
+      // from the server instead of treating the partial view as fresh.
+      this.cache = { ts: 0, engrams: [stored] }
     }
     return { id: data.id }
   }

--- a/packages/core/test/remote-store-cache.test.ts
+++ b/packages/core/test/remote-store-cache.test.ts
@@ -66,20 +66,34 @@ describe('RemoteStore — optimistic cache insert (issue #89)', () => {
     expect(getCallsAfter).toBe(getCallsBefore) // no extra GETs needed
   })
 
-  it('append() initialises the cache when no prior load() has happened', async () => {
+  it('cold-cache append does not block a subsequent full load() (issue #130)', async () => {
+    // Regression: a cold-cache append used to set ts: Date.now(), which made
+    // the partial single-engram cache look "fresh" for ttlMs and hid every
+    // other engram in the scope on the next load(). The fix marks the
+    // cold-cache entry stale (ts: 0) so load() refetches from the server.
     fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
       const method = init?.method ?? 'GET'
       if (method === 'POST') {
         return {
           ok: true, status: 201,
-          json: async () => ({ id: 'ENG-SERVER-002' }),
+          json: async () => ({ id: 'ENG-NEW' }),
           text: async () => '',
         } as Response
       }
-      // Should NOT be reached in this test — load() reads from the optimistic cache.
+      // Server-side listing — three pre-existing engrams the cold-cache append
+      // never knew about. (The just-appended engram would normally be here too,
+      // but omitting it lets the test assert that load() returns the server's
+      // view rather than the optimistic single-row cache.)
       return {
         ok: true, status: 200,
-        json: async () => ({ rows: [], total_count: 0 }),
+        json: async () => ({
+          rows: [
+            { id: 'ENG-A', scope: 'user:plur:tester', status: 'active', data: { statement: 'a' } },
+            { id: 'ENG-B', scope: 'user:plur:tester', status: 'active', data: { statement: 'b' } },
+            { id: 'ENG-C', scope: 'user:plur:tester', status: 'active', data: { statement: 'c' } },
+          ],
+          total_count: 3,
+        }),
         text: async () => '',
       } as Response
     }) as any)
@@ -95,14 +109,13 @@ describe('RemoteStore — optimistic cache insert (issue #89)', () => {
     } as any)
 
     const got = await store.load()
-    expect(got.length).toBe(1)
-    expect((got[0] as any).statement).toBe('first ever write')
-    expect(got[0].id).toBe('ENG-SERVER-002')
+    // Before the fix this returned 1 (the optimistic single-engram cache).
+    // After the fix it returns the full server list.
+    expect(got.map(e => e.id).sort()).toEqual(['ENG-A', 'ENG-B', 'ENG-C'])
 
-    // Only the POST should have hit the network — load() served from optimistic cache.
     const posts = fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
     const gets  = fetchMock.mock.calls.filter(([, init]) => !(init as any)?.method || (init as any)?.method === 'GET')
     expect(posts.length).toBe(1)
-    expect(gets.length).toBe(0)
+    expect(gets.length).toBe(1) // cold-cache must refetch on the next load()
   })
 })


### PR DESCRIPTION
## Summary

Fixes P2 regression #130 (originally surfaced by @plur9 on closed PR #94).

In `RemoteStore.append()`, when there was no prior `load()` (cold cache), the else branch set `this.cache = { ts: Date.now(), engrams: [stored] }`. The optimistic single-row cache then looked **fresh** to `load()` for up to `ttlMs` (60s), hiding every other engram in the scope on the server.

A fresh `RemoteStore` where the user calls `learn()` first (no prior `recall()`) saw only that one engram on the next `load()` for 60s, masking the rest of the scope.

## Fix

Mark the cold-cache entry stale (`ts: 0`) so the next `load()` refetches from the server. Warm-cache append (the #89 optimistic-insert path) is unchanged.

## Test

Rewrote the existing cold-cache test to assert the fix: server has `ENG-A/B/C`, `append(ENG-NEW)` runs with no prior `load()`, the next `load()` returns the three server rows and made exactly one GET. Before the fix it returned `[ENG-NEW]` with zero GETs.

Local: `npx vitest run test/remote-store-cache.test.ts test/remote-routing.test.ts` → 25/25 passing.

## Test plan

- [x] `remote-store-cache.test.ts` covers the regression
- [x] `remote-routing.test.ts` still passes (no warm-cache regression)
- [ ] CI green on this branch

Closes #130