### PR TITLE
infra: heartbeat ingress server for #132 (H005 E1)

### DIFF
--- a/infra/heartbeat/deploy.sh
+++ b/infra/heartbeat/deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# deploy.sh — run on nightshift as root (or via sudo)
+# Prereq: DNS A record heartbeat.plur-ai.org → 209.38.195.208 must already propagate
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> Creating system user"
+id plur-heartbeat &>/dev/null || useradd --system --no-create-home --shell /usr/sbin/nologin plur-heartbeat
+
+echo "==> Installing backend"
+mkdir -p /opt/plur-heartbeat
+cp "$SCRIPT_DIR/server.py" /opt/plur-heartbeat/server.py
+chown -R plur-heartbeat:plur-heartbeat /opt/plur-heartbeat
+
+echo "==> Creating data directory"
+mkdir -p /var/lib/plur-heartbeat
+chown plur-heartbeat:plur-heartbeat /var/lib/plur-heartbeat
+
+echo "==> Installing systemd unit"
+cp "$SCRIPT_DIR/plur-heartbeat.service" /etc/systemd/system/plur-heartbeat.service
+systemctl daemon-reload
+systemctl enable --now plur-heartbeat
+systemctl status plur-heartbeat --no-pager
+
+echo "==> Installing nginx config"
+cp "$SCRIPT_DIR/nginx-heartbeat.conf" /etc/nginx/sites-available/heartbeat.plur-ai.org
+ln -sf /etc/nginx/sites-available/heartbeat.plur-ai.org /etc/nginx/sites-enabled/
+nginx -t
+
+echo ""
+echo "==> Next: obtain TLS cert (DNS must have propagated first)"
+echo "    certbot --nginx -d heartbeat.plur-ai.org --non-interactive --agree-tos -m gregor@datafund.io"
+echo ""
+echo "==> After certbot succeeds:"
+echo "    systemctl reload nginx"
+echo ""
+echo "==> Smoke test:"
+echo "    curl -sS -o /dev/null -w '%{http_code}' -X POST https://heartbeat.plur-ai.org/v1/heartbeat \\"
+echo "      -H 'Content-Type: application/json' \\"
+echo "      -d '{\"install_id\":\"00000000-0000-4000-8000-000000000000\",\"version\":\"0.9.4\",\"platform\":\"linux\",\"date\":\"2026-05-12\",\"learn_count\":1,\"recall_count\":0,\"session_count\":1}'"

--- a/infra/heartbeat/nginx-heartbeat.conf
+++ b/infra/heartbeat/nginx-heartbeat.conf
@@ -1,0 +1,50 @@
+# /etc/nginx/sites-available/heartbeat.plur-ai.org
+# Enable: ln -s /etc/nginx/sites-available/heartbeat.plur-ai.org /etc/nginx/sites-enabled/
+# Prereq: DNS A record heartbeat.plur-ai.org → 209.38.195.208 must propagate before certbot
+
+limit_req_zone $binary_remote_addr zone=heartbeat:10m rate=60r/m;
+
+server {
+    listen 80;
+    server_name heartbeat.plur-ai.org;
+    # Let certbot ACME challenge through; redirect everything else
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {
+    listen 443 ssl;
+    server_name heartbeat.plur-ai.org;
+
+    # certbot will populate these after: certbot --nginx -d heartbeat.plur-ai.org
+    ssl_certificate     /etc/letsencrypt/live/heartbeat.plur-ai.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/heartbeat.plur-ai.org/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # IP privacy: strip client address before it ever reaches access log or backend
+    log_format heartbeat_privacy '$time_iso8601 "$request" $status $body_bytes_sent';
+    access_log /var/log/nginx/heartbeat.plur-ai.org.access.log heartbeat_privacy;
+
+    limit_req zone=heartbeat burst=10 nodelay;
+
+    location /v1/heartbeat {
+        limit_except POST { return 405; }
+
+        client_max_body_size 1k;
+
+        proxy_pass         http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+
+        # Strip all IP-identifying headers
+        proxy_set_header   X-Real-IP "";
+        proxy_set_header   X-Forwarded-For "";
+        proxy_set_header   X-Forwarded-Proto "";
+        proxy_set_header   Host $host;
+
+        proxy_read_timeout 10s;
+        proxy_connect_timeout 5s;
+    }
+
+    location / { return 404; }
+}

--- a/infra/heartbeat/plur-heartbeat.service
+++ b/infra/heartbeat/plur-heartbeat.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=plur heartbeat ingress
+After=network.target
+
+[Service]
+Type=simple
+User=plur-heartbeat
+Group=plur-heartbeat
+ExecStart=/usr/bin/python3 /opt/plur-heartbeat/server.py
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=plur-heartbeat
+
+Environment=HEARTBEAT_DATA_DIR=/var/lib/plur-heartbeat
+Environment=HEARTBEAT_HOST=127.0.0.1
+Environment=HEARTBEAT_PORT=8001
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/heartbeat/server.py
+++ b/infra/heartbeat/server.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+plur heartbeat ingress — listens on 127.0.0.1:8001
+Appends validated payloads to /var/lib/plur-heartbeat/YYYY-MM-DD.jsonl
+No external dependencies beyond stdlib.
+"""
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+DATA_DIR = Path(os.environ.get("HEARTBEAT_DATA_DIR", "/var/lib/plur-heartbeat"))
+BIND_HOST = os.environ.get("HEARTBEAT_HOST", "127.0.0.1")
+BIND_PORT = int(os.environ.get("HEARTBEAT_PORT", "8001"))
+MAX_BODY = 1024  # bytes
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-[\w.]+)?$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+PLATFORMS = {"linux", "darwin", "win32"}
+
+
+def validate(payload: dict) -> str | None:
+    """Return error string or None if valid."""
+    required = {"install_id", "version", "platform", "date", "learn_count", "recall_count", "session_count"}
+    missing = required - payload.keys()
+    if missing:
+        return f"missing fields: {', '.join(sorted(missing))}"
+    if not isinstance(payload["install_id"], str) or not UUID_RE.match(payload["install_id"]):
+        return "install_id must be UUID v4"
+    if not isinstance(payload["version"], str) or not VERSION_RE.match(payload["version"]):
+        return "version must match semver"
+    if payload["platform"] not in PLATFORMS:
+        return f"platform must be one of {PLATFORMS}"
+    if not isinstance(payload["date"], str) or not DATE_RE.match(payload["date"]):
+        return "date must be YYYY-MM-DD"
+    for field in ("learn_count", "recall_count", "session_count"):
+        if not isinstance(payload[field], int) or payload[field] < 0:
+            return f"{field} must be non-negative integer"
+    return None
+
+
+class HeartbeatHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        # Suppress default access log (contains client IP)
+        pass
+
+    def send_plain(self, code: int, body: str = ""):
+        encoded = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        if encoded:
+            self.wfile.write(encoded)
+
+    def do_POST(self):
+        if self.path != "/v1/heartbeat":
+            self.send_plain(404, "not found")
+            return
+
+        ct = self.headers.get("Content-Type", "")
+        if "application/json" not in ct:
+            self.send_plain(400, "Content-Type must be application/json")
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        if length > MAX_BODY:
+            self.send_plain(400, "payload too large")
+            return
+
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            self.send_plain(400, "invalid JSON")
+            return
+
+        if not isinstance(payload, dict):
+            self.send_plain(400, "payload must be a JSON object")
+            return
+
+        err = validate(payload)
+        if err:
+            self.send_plain(400, err)
+            return
+
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        out_path = DATA_DIR / f"{date_str}.jsonl"
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        line = json.dumps(payload, separators=(",", ":")) + "\n"
+        with open(out_path, "a") as f:
+            f.write(line)
+
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        self.send_plain(405, "method not allowed")
+
+    def do_HEAD(self):
+        self.send_plain(405, "method not allowed")
+
+
+def main():
+    server = HTTPServer((BIND_HOST, BIND_PORT), HeartbeatHandler)
+    print(f"plur-heartbeat listening on {BIND_HOST}:{BIND_PORT}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #132 (server-side artifact; DNS + certbot steps remain human-gated).

## What's here

`infra/heartbeat/` — four files, zero external dependencies:

| File | Purpose |
|------|---------|
| `server.py` | stdlib Python HTTP server on `127.0.0.1:8001`; validates schema, appends to `/var/lib/plur-heartbeat/YYYY-MM-DD.jsonl`, returns 204 |
| `plur-heartbeat.service` | systemd unit (dedicated `plur-heartbeat` system user, auto-restart) |
| `nginx-heartbeat.conf` | nginx vhost with IP stripping, rate-limit zone (60r/m), POST-only, `client_max_body_size 1k` |
| `deploy.sh` | step-by-step deployment script (run as root on nightshift) |

Schema validated: `install_id` (UUID v4), `version` (semver), `platform` (linux/darwin/win32), `date` (YYYY-MM-DD), `learn_count`/`recall_count`/`session_count` (non-negative int). Anything else → 400.

## Remaining steps (human-gated)

1. **DNS** — add A record: `heartbeat.plur-ai.org → 209.38.195.208` at domain registrar
2. **SSH access** — `ssh nightshift` returning `Permission denied (publickey)` as of this heartbeat; key needs re-authorizing on the server before deploy.sh can run
3. **Deploy** — once SSH is up: `sudo bash infra/heartbeat/deploy.sh` (pulls from this branch after merge, or run directly from checkout)
4. **certbot** — `certbot --nginx -d heartbeat.plur-ai.org --non-interactive --agree-tos -m gregor@datafund.io` after DNS propagates
5. **Smoke test** — acceptance criteria curl from the issue

## Note on IP stripping

nginx `access_log` uses a custom format that omits `$remote_addr`. The backend never sees `X-Real-IP` or `X-Forwarded-For` (both stripped at proxy level). Privacy design is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)