### PR TITLE
fix(mcp): sanitize XML envelope artifacts from plur_learn statement (#145)

### DIFF
--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -80,6 +80,23 @@ function getLlmFunction(): LlmFunction | undefined {
   return undefined
 }
 
+/**
+ * Strip XML parameter-envelope artifacts from a statement string.
+ * When an LLM generates tool calls in the old XML format, the raw statement
+ * value sometimes contains the closing tag followed by the full duplicated body:
+ *   "clean text</statement>\n\n<parameter name="statement">clean text..."
+ * Truncate at whichever marker appears first.
+ */
+function sanitizeStatement(raw: string): string {
+  const markers = ['</statement>', '<parameter name=']
+  let cut = raw.length
+  for (const m of markers) {
+    const pos = raw.indexOf(m)
+    if (pos !== -1 && pos < cut) cut = pos
+  }
+  return raw.slice(0, cut).trimEnd()
+}
+
 export function getToolDefinitions(): ToolDefinition[] {
   return [
     {
@@ -135,8 +152,9 @@ export function getToolDefinitions(): ToolDefinition[] {
         // learnRouted defers to sync learn() so dedup behavior is
         // unchanged. We try learnAsync second only as a fallback for
         // the LLM-driven dedup pathway (local routes).
+        const statement = sanitizeStatement(args.statement as string)
         try {
-          const engram = await plur.learnRouted(args.statement as string, context)
+          const engram = await plur.learnRouted(statement, context)
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type,
@@ -148,7 +166,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           // 5xx, etc). Fall back to sync learn() so the user gets
           // *something* recorded locally — but warn loudly that the
           // returned id is local-only and will not match the server.
-          const engram = plur.learn(args.statement as string, context)
+          const engram = plur.learn(statement, context)
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type, decision: 'ADD',

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -44,6 +44,22 @@ describe('MCP tools', () => {
     expect(result.statement).toBe('Test learning')
   })
 
+  it('plur_learn strips XML envelope artifacts from statement (#145)', async () => {
+    // Reproduce the corruption: LLM generates old XML tool-call format where the
+    // statement value contains the closing tag + duplicated parameter body.
+    const corrupted = 'Use snake_case for all identifiers.</statement>\n\n<parameter name="statement">Use snake_case for all identifiers.</parameter>\n<parameter name="type">behavioral</parameter>'
+    const result = await callTool('plur_learn', { statement: corrupted }) as any
+    expect(result.statement).toBe('Use snake_case for all identifiers.')
+    expect(result.statement).not.toContain('</statement>')
+    expect(result.statement).not.toContain('<parameter name=')
+  })
+
+  it('plur_learn does not truncate clean statements', async () => {
+    const clean = 'Always verify timestamps with python before committing.'
+    const result = await callTool('plur_learn', { statement: clean }) as any
+    expect(result.statement).toBe(clean)
+  })
+
   it('plur_recall finds learned engrams', async () => {
     await callTool('plur_learn', { statement: 'API uses snake_case', scope: 'global' })
     const result = await callTool('plur_recall', { query: 'API snake' }) as any


### PR DESCRIPTION
## Summary

- Adds `sanitizeStatement()` to `plur_learn` handler — truncates the statement at the first `</statement>` or `<parameter name=` marker if found
- Prevents future engram corruption when Claude generates tool calls in legacy XML format
- Two new regression tests: one verifying the corrupted envelope is stripped, one verifying clean statements are unchanged

## Root cause

When Claude Code (some versions/call shapes) uses legacy XML tool-call serialization, the `statement` parameter value sometimes contains the closing `</statement>` tag plus the full duplicated parameter body. The structured fields (`type`, `domain`, etc.) still parse correctly — but also get echoed into the raw statement string. 25 engrams were affected in production across 2026-04-08 to 2026-05-12.

## Impact before this fix

Any injection or recall of affected engrams surfaced partially garbled content. The user's `engrams.yaml` has since been cleaned manually; this PR prevents recurrence.

## Test plan
- [x] `plur_learn strips XML envelope artifacts from statement (#145)` — passes
- [x] `plur_learn does not truncate clean statements` — passes
- [x] All 10 tools.test.ts tests pass

## Notes

- Backfill for AC3: user's `~/.plur/engrams.yaml` already clean (0 corruption markers). No other users affected.
- AC4 (server-side write-time validator) deferred — not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)