### PR TITLE
feat(hermes): S3 sentence-level fallback extractor (closes #123)

### DIFF
--- a/packages/hermes/plur_hermes/__init__.py
+++ b/packages/hermes/plur_hermes/__init__.py
@@ -107,7 +107,7 @@ def register(ctx):
     def post_llm_call(session_id, assistant_response, **kwargs):
         try:
             learnings = extract_learning_patterns(assistant_response or "")
-            for statement in learnings:
+            for statement, _confidence in learnings:
                 bridge.learn(statement, source="hermes:auto",
                              rationale="Auto-extracted from assistant self-report")
                 if session_id in _session_state:

--- a/packages/hermes/plur_hermes/learner.py
+++ b/packages/hermes/plur_hermes/learner.py
@@ -1,14 +1,11 @@
 """
 Extract learnings from assistant messages.
 
-Multi-strategy extraction (first match wins):
-1. Brain-emoji block fenced by `---` delimiters (highest confidence, fast path)
-2. Alternative markers anywhere in the message — `🧠 I learned:`, `I learned:`,
-   `Key takeaway[s]:`, `Noted:`, `Correction noted:` — must start a line and be
-   followed by a newline; block ends at a blank line, `---`, or EOF.
-
-Conservative matching to avoid false positives: markers must be line-anchored
-and the captured body is split on lines with bullet/number prefixes stripped.
+Multi-strategy extraction (first match wins for S1/S2; S3 is sentence-level fallback):
+1. Brain-emoji block fenced by `---` delimiters (confidence 1.0)
+2. Alternative markers anywhere in the message (confidence 0.9)
+3. Sentence-level patterns — self-corrections, discoveries, first-person commitments
+   (confidence 0.75–0.85, filtered at >= 0.7 before returning)
 """
 
 import re
@@ -31,25 +28,71 @@ _ALT_MARKER_PATTERN = re.compile(
 
 _BULLET_PREFIX = re.compile(r'^[-*•]\s+|^\d+[.)]\s+')
 
+_SENTENCE_BREAK = re.compile(r'(?<=[.!?])\s+(?=[A-Z])')
+
+_S3_PATTERNS: list[tuple[re.Pattern, float]] = [
+    # Self-corrections: explicit acknowledgment of error
+    (re.compile(r'\bI was (wrong|mistaken|incorrect)\b', re.IGNORECASE), 0.85),
+    (re.compile(r'\bI (stand|was) corrected\b', re.IGNORECASE), 0.85),
+    (re.compile(r'\bI had\b.{0,60}\b(wrong|backwards|backward|reversed)\b', re.IGNORECASE), 0.85),
+    (re.compile(r'\bI need to correct\b', re.IGNORECASE), 0.85),
+    # "Correction: ..." prefix (distinct from "Correction noted:" which is Strategy 2)
+    (re.compile(r'^Correction(?! noted):\s', re.IGNORECASE), 0.85),
+    # Discovery: realisation or newly-confirmed fact
+    (re.compile(r'\bI (now know|see now|now see)\b', re.IGNORECASE), 0.75),
+    (re.compile(r'\bI see (now )?(that|why|how)\b', re.IGNORECASE), 0.75),
+    (re.compile(r'^I missed\b', re.IGNORECASE), 0.75),
+    (re.compile(r'\bLooking at this more carefully\b', re.IGNORECASE), 0.75),
+    (re.compile(r'^After checking\b', re.IGNORECASE), 0.80),
+    (re.compile(r'^Reviewing the (spec|code|source|docs)\b', re.IGNORECASE), 0.75),
+    (re.compile(r'^Actually, the\b', re.IGNORECASE), 0.80),
+    (re.compile(r'^The correct (way|approach|path|flag|format|answer|pattern)\b', re.IGNORECASE), 0.80),
+    (re.compile(r'^The actual \w+', re.IGNORECASE), 0.80),
+    # First-person forward commitments (I will/should/must never/always/remember)
+    (re.compile(r'^From now on I\b', re.IGNORECASE), 0.75),
+    (re.compile(r'^I (should|must|will) (never|always|remember|make sure|ensure)\b', re.IGNORECASE), 0.75),
+    (re.compile(r"^I'?ll? (make sure|remember|always|never)\b", re.IGNORECASE), 0.75),
+]
+
+_MIN_SENTENCE_LEN = 10
+
 
 def _extract_lines(block: str) -> list[str]:
     return [
         line.strip()
         for raw_line in block.split('\n')
         if (line := _BULLET_PREFIX.sub('', raw_line).strip())
-        and len(line) >= 10
+        and len(line) >= _MIN_SENTENCE_LEN
     ]
 
 
-def extract_learning_patterns(text: str) -> list[str]:
+def _match_strategy3(sentence: str) -> float:
+    """Return confidence if sentence matches a Strategy 3 pattern, else 0.0."""
+    for pattern, confidence in _S3_PATTERNS:
+        if pattern.search(sentence):
+            return confidence
+    return 0.0
+
+
+def extract_learning_patterns(text: str) -> list[tuple[str, float]]:
     """Extract self-reported learnings from assistant message.
 
-    Returns list of learning statements (min 10 chars each).
+    Returns (statement, confidence) pairs with confidence >= 0.7.
+    Strategy 1 (brain block) → 1.0, Strategy 2 (alt markers) → 0.9,
+    Strategy 3 (sentence-level) → 0.75–0.85. First match wins for S1/S2.
     """
     if (match := _BRAIN_PATTERN.search(text)):
-        return _extract_lines(match.group(1))
+        return [(line, 1.0) for line in _extract_lines(match.group(1))]
 
     if (match := _ALT_MARKER_PATTERN.search(text)):
-        return _extract_lines(match.group(1))
+        return [(line, 0.9) for line in _extract_lines(match.group(1))]
 
-    return []
+    results: list[tuple[str, float]] = []
+    for sentence in _SENTENCE_BREAK.split(text):
+        sentence = sentence.strip()
+        if len(sentence) < _MIN_SENTENCE_LEN:
+            continue
+        confidence = _match_strategy3(sentence)
+        if confidence >= 0.7:
+            results.append((sentence, confidence))
+    return results

--- a/packages/hermes/test/test_learner.py
+++ b/packages/hermes/test/test_learner.py
@@ -1,7 +1,18 @@
 """Tests for learning extraction."""
 
+import json
+from pathlib import Path
+
 import pytest
 from plur_hermes.learner import extract_learning_patterns
+
+
+def _texts(results: list[tuple[str, float]]) -> list[str]:
+    return [text for text, _ in results]
+
+
+def _confidences(results: list[tuple[str, float]]) -> list[float]:
+    return [conf for _, conf in results]
 
 
 class TestExtractLearningPatterns:
@@ -9,14 +20,15 @@ class TestExtractLearningPatterns:
         text = "Here is my response.\n\n---\n\U0001f9e0 I learned:\n- TypeScript tests need experimental flags\n- Always validate input at boundaries\n---"
         result = extract_learning_patterns(text)
         assert len(result) == 2
-        assert "TypeScript tests need experimental flags" in result
-        assert "Always validate input at boundaries" in result
+        assert "TypeScript tests need experimental flags" in _texts(result)
+        assert "Always validate input at boundaries" in _texts(result)
+        assert all(c == 1.0 for c in _confidences(result))
 
     def test_ignores_short_lines(self):
         text = "---\n\U0001f9e0 I learned:\n- Short\n- This is a valid learning statement\n---"
         result = extract_learning_patterns(text)
         assert len(result) == 1
-        assert "This is a valid learning statement" in result
+        assert "This is a valid learning statement" in _texts(result)
 
     def test_returns_empty_when_no_section(self):
         text = "Just a normal response without any learning section."
@@ -24,7 +36,7 @@ class TestExtractLearningPatterns:
         assert result == []
 
     def test_handles_bullet_variants(self):
-        text = "---\n\U0001f9e0 I learned:\n- Dash bullet learning here\n\u2022 Dot bullet learning here\n* Star bullet learning here\n---"
+        text = "---\n\U0001f9e0 I learned:\n- Dash bullet learning here\n• Dot bullet learning here\n* Star bullet learning here\n---"
         result = extract_learning_patterns(text)
         assert len(result) == 3
 
@@ -42,22 +54,23 @@ class TestExtractLearningPatterns:
         text = "Some response.\n\nI learned:\n- TypeScript tests need experimental flags\n- Always validate input at boundaries\n\nMoving on."
         result = extract_learning_patterns(text)
         assert len(result) == 2
-        assert "TypeScript tests need experimental flags" in result
+        assert "TypeScript tests need experimental flags" in _texts(result)
+        assert all(c == 0.9 for c in _confidences(result))
 
     def test_extracts_noted_marker(self):
         text = "Noted:\n- This is a valid learning statement worth keeping\n"
         result = extract_learning_patterns(text)
-        assert result == ["This is a valid learning statement worth keeping"]
+        assert _texts(result) == ["This is a valid learning statement worth keeping"]
 
     def test_extracts_correction_noted_marker(self):
         text = "Looking again.\n\nCorrection noted:\n- Use pnpm not npm for this monorepo always\n"
         result = extract_learning_patterns(text)
-        assert result == ["Use pnpm not npm for this monorepo always"]
+        assert _texts(result) == ["Use pnpm not npm for this monorepo always"]
 
     def test_extracts_key_takeaway_marker(self):
         text = "Key takeaway:\n- Workspace deps need explicit version bumps for publish\n"
         result = extract_learning_patterns(text)
-        assert result == ["Workspace deps need explicit version bumps for publish"]
+        assert _texts(result) == ["Workspace deps need explicit version bumps for publish"]
 
     def test_handles_numbered_bullets(self):
         text = "I learned:\n1. TypeScript tests need experimental flags\n2. Always validate input at boundaries\n"
@@ -67,10 +80,174 @@ class TestExtractLearningPatterns:
     def test_brain_block_wins_over_alt_marker(self):
         text = "---\n\U0001f9e0 I learned:\n- Fast path learning here please\n---\n\nI learned:\n- Alt path learning here please\n"
         result = extract_learning_patterns(text)
-        assert any("Fast path" in r for r in result)
-        assert not any("Alt path" in r for r in result)
+        assert any("Fast path" in r for r in _texts(result))
+        assert not any("Alt path" in r for r in _texts(result))
 
     def test_alt_marker_only_matches_at_line_start(self):
         text = "The phrase I learned: appears inline but not at line start with body."
         result = extract_learning_patterns(text)
         assert result == []
+
+
+class TestStrategy3:
+    """Strategy 3: sentence-level learning extraction."""
+
+    def test_self_correction_i_was_wrong(self):
+        text = "I was wrong about the publish order. Core must be published first since mcp and claw depend on it."
+        result = extract_learning_patterns(text)
+        assert len(result) >= 1
+        assert any("I was wrong" in t for t in _texts(result))
+        assert all(c >= 0.7 for c in _confidences(result))
+
+    def test_self_correction_i_was_mistaken(self):
+        text = "I was mistaken: `tsup` does tree-shake ES module bundles by default."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+        assert _confidences(result)[0] == 0.85
+
+    def test_self_correction_i_stand_corrected(self):
+        text = "I stand corrected — the right approach is to call `pnpm build` in core before running integration tests."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_self_correction_i_had_this_backwards(self):
+        text = "I had this backwards: `plur_forget` soft-deletes by marking `deleted: true`."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_correction_prefix(self):
+        text = "Correction: the `on_session_end` hook fires after the model's final message, not before."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+        assert _confidences(result)[0] == 0.85
+
+    def test_correction_prefix_not_confused_with_correction_noted(self):
+        # "Correction noted:" is Strategy 2 (alt marker); "Correction:" is Strategy 3
+        text = "Correction: the API path is wrong."
+        result = extract_learning_patterns(text)
+        texts = _texts(result)
+        assert len(result) == 1
+        assert texts[0].startswith("Correction:")
+
+    def test_i_now_know(self):
+        text = "I now know that the `workspace:*` dependency is rewritten to the exact version on publish."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_looking_at_this_more_carefully(self):
+        text = "Looking at this more carefully, I see I had the engram decay formula backwards."
+        result = extract_learning_patterns(text)
+        assert len(result) >= 1
+
+    def test_after_checking(self):
+        text = "After checking the source, the correct flag is `--access public`, not `--public`."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+        assert _confidences(result)[0] == 0.80
+
+    def test_the_correct_way(self):
+        text = "The correct way to run smoke tests is to set all three env vars first."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_the_actual(self):
+        text = "The actual return type of `plur_recall` is `EngramResult[]`, not `string[]`."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_from_now_on_i(self):
+        text = "From now on I will always verify day-of-week with python3 before writing org timestamps."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_i_should_never(self):
+        text = "I should never run `--help` on the publish scripts here."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_i_must_never(self):
+        text = "I must never use `git checkout <branch> -- <path>` when there are unstaged changes."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_i_will_remember(self):
+        text = "I will remember to check the stub server whenever adding a new remote store endpoint."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_ill_make_sure(self):
+        text = "I'll make sure to rebuild core before running claw tests."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_does_not_fire_on_you_should(self):
+        text = "You should always use `pnpm` for this monorepo."
+        result = extract_learning_patterns(text)
+        assert result == []
+
+    def test_does_not_fire_on_we_should(self):
+        text = "We should prefer RRF over weighted sum when the two distributions are different shapes."
+        result = extract_learning_patterns(text)
+        assert result == []
+
+    def test_does_not_fire_on_hypothetical(self):
+        text = "If we were to migrate to a relational database, we should never store engram text in a blob column."
+        result = extract_learning_patterns(text)
+        assert result == []
+
+    def test_does_not_fire_on_factual_description(self):
+        text = "BM25 uses term frequency and inverse document frequency to score matches."
+        result = extract_learning_patterns(text)
+        assert result == []
+
+    def test_multi_sentence_extracts_matching_sentence_only(self):
+        text = ("I had the ACL model backwards. Remote stores use scope-based access control, not per-engram ACL. "
+                "If you need per-engram ACL, you should use separate scopes.")
+        result = extract_learning_patterns(text)
+        texts = _texts(result)
+        assert any("I had the ACL model backwards" in t for t in texts)
+        assert not any("you should use separate scopes" in t for t in texts)
+
+    def test_strategy3_does_not_fire_when_s2_matches(self):
+        text = "I learned:\n- Correction: the real rule applies here as a bullet\n"
+        result = extract_learning_patterns(text)
+        assert all(c == 0.9 for c in _confidences(result))
+
+
+class TestCorpusFidelity:
+    """Precision/recall measured against the labeled corpus fixture."""
+
+    @classmethod
+    def _load_corpus(cls) -> list[dict]:
+        path = Path(__file__).parent / "fixtures" / "learning-corpus.jsonl"
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+    def test_recall_on_s3_positive_turns(self):
+        """S3 fires on turns with learning labels not caught by S1/S2."""
+        corpus = self._load_corpus()
+        # Entries 0-4 (turns 1-5) are S1/S2 targets with explicit block markers.
+        # Remaining learning-labeled entries are S3 targets.
+        s1s2_markers = ("---\n\U0001f9e0 I learned:", "I learned:\n", "Correction noted:\n",
+                        "Key takeaway:\n", "Noted:\n")
+        s3_targets = [
+            e for e in corpus[5:]
+            if any(l["kind"] == "learning" for l in e["labels"])
+            and not any(e["turn_text"].startswith(m) or f"\n{m}" in e["turn_text"]
+                        for m in s1s2_markers)
+        ]
+        assert s3_targets, "Expected S3 target turns in corpus"
+        fired = sum(1 for e in s3_targets if extract_learning_patterns(e["turn_text"]))
+        recall = fired / len(s3_targets)
+        assert recall >= 0.50, f"Strategy 3 recall {recall:.0%} < 50% on {len(s3_targets)} S3 targets"
+
+    def test_precision_on_negative_turns(self):
+        """S3 does not fire on instruction/hypothetical/reasoning/unlabeled turns."""
+        corpus = self._load_corpus()
+        negative_turns = [e for e in corpus if not any(l["kind"] == "learning" for l in e["labels"])]
+        assert negative_turns, "Expected negative turns in corpus"
+        false_positives = sum(1 for e in negative_turns if extract_learning_patterns(e["turn_text"]))
+        fp_rate = false_positives / len(negative_turns)
+        assert fp_rate < 0.15, (
+            f"Strategy 3 FP rate {fp_rate:.0%} >= 15% "
+            f"({false_positives}/{len(negative_turns)} negative turns fired)"
+        )


### PR DESCRIPTION
## Summary

- Implements Strategy 3 (sentence-level fallback) in the hermes learner — fires when S1 (brain block) and S2 (alt markers) both miss
- Adds 16 regex patterns covering self-corrections (`I was wrong`, `I stand corrected`, `I had X backwards`), discoveries (`After checking`, `Actually, the`, `The correct way`), and first-person commitments (`From now on I`, `I should never`)
- Changes `extract_learning_patterns` return type from `list[str]` → `list[tuple[str, float]]`; confidence: S1=1.0, S2=0.9, S3=0.75–0.85, threshold=0.7
- `__init__.py` updated to unpack the tuple (no behavior change for S1/S2 paths)

## Test plan

- [ ] 37 learner tests pass (`packages/hermes/` — `python3 -m pytest test/test_learner.py`)
- [ ] `TestCorpusFidelity` passes: S3 recall ≥50% on corpus S3 targets, FP rate <15% on negative turns
- [ ] Existing S1/S2 tests unchanged (confidence values validated)

Closes #123. Follow-up to #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)