### PR TITLE
feat(hermes): injection feedback loop in post_llm_call (closes #118)

### DIFF
--- a/packages/hermes/plur_hermes/__init__.py
+++ b/packages/hermes/plur_hermes/__init__.py
@@ -20,6 +20,50 @@ except PackageNotFoundError:
 
 _session_state: dict[str, dict] = {}
 _PRUNE_AGE_SECONDS = 3600
+_FEEDBACK_MIN_CONFIDENCE = 0.6
+_CORRECTION_MARKERS = ("actually,", "actually ", "no,", "wrong,", "incorrect,",
+                        "that's wrong", "not correct", "that is wrong")
+
+
+def _get_trigrams(text: str) -> set[str]:
+    words = text.lower().split()
+    if len(words) < 3:
+        return set(words)
+    return {" ".join(words[i:i + 3]) for i in range(len(words) - 2)}
+
+
+def _detect_injection_signal(engram_text: str, response: str) -> tuple[str | None, float]:
+    """Heuristic signal detection for a single injected engram vs. assistant response.
+
+    Returns (signal, confidence) where signal is 'positive', 'negative', or None.
+    Only signals above _FEEDBACK_MIN_CONFIDENCE are meaningful.
+    """
+    response_lower = response.lower()
+    engram_lower = engram_text.lower().strip()
+    if not engram_lower:
+        return None, 0.0
+
+    if engram_lower in response_lower:
+        return "positive", 0.95
+
+    engram_tris = _get_trigrams(engram_lower)
+    if engram_tris:
+        response_tris = _get_trigrams(response_lower)
+        overlap = len(engram_tris & response_tris) / len(engram_tris)
+        if overlap >= 0.8:
+            return "positive", 0.7 + 0.3 * overlap
+
+    engram_words = {w for w in engram_lower.split() if len(w) > 4}
+    if engram_words:
+        for marker in _CORRECTION_MARKERS:
+            idx = response_lower.find(marker)
+            while idx != -1:
+                window = response_lower[max(0, idx - 100):idx + 200]
+                if any(w in window for w in engram_words):
+                    return "negative", 0.65
+                idx = response_lower.find(marker, idx + 1)
+
+    return None, 0.0
 
 
 def _prune_stale_sessions():
@@ -88,9 +132,16 @@ def register(ctx):
             if result.get("count", 0) == 0:
                 return
             injected_ids = result.get("injected_ids", [])
+            injected_engrams = [
+                {"id": e.get("id"), "statement": e.get("statement", "")}
+                for e in result.get("results", [])
+                if e.get("id") and e.get("statement")
+            ]
             if session_id in _session_state:
-                prev = _session_state[session_id].get("injected_ids", [])
-                _session_state[session_id]["injected_ids"] = prev + injected_ids
+                prev_ids = _session_state[session_id].get("injected_ids", [])
+                prev_engrams = _session_state[session_id].get("injected_engrams", [])
+                _session_state[session_id]["injected_ids"] = prev_ids + injected_ids
+                _session_state[session_id]["injected_engrams"] = prev_engrams + injected_engrams
             lines = ["<plur-memory>"]
             if result.get("directives"):
                 lines.append(result["directives"])
@@ -105,8 +156,9 @@ def register(ctx):
             return None
 
     def post_llm_call(session_id, assistant_response, **kwargs):
+        response = assistant_response or ""
         try:
-            learnings = extract_learning_patterns(assistant_response or "")
+            learnings = extract_learning_patterns(response)
             for statement in learnings:
                 bridge.learn(statement, source="hermes:auto",
                              rationale="Auto-extracted from assistant self-report")
@@ -114,6 +166,28 @@ def register(ctx):
                     _session_state[session_id]["count"] += 1
         except Exception as e:
             logger.debug(f"PLUR learning extraction failed: {e}")
+
+        if os.environ.get("PLUR_INJECTION_FEEDBACK", "true").lower() == "false":
+            return
+        try:
+            injected_engrams = (_session_state.get(session_id) or {}).get("injected_engrams", [])
+            if not injected_engrams or not response:
+                return
+            feedback_batch: list[tuple[str, str]] = []
+            for engram in injected_engrams:
+                eid = engram.get("id")
+                text = engram.get("statement", "")
+                if not eid or not text:
+                    continue
+                signal, confidence = _detect_injection_signal(text, response)
+                if signal and confidence >= _FEEDBACK_MIN_CONFIDENCE:
+                    feedback_batch.append((eid, signal))
+            if feedback_batch:
+                bridge.feedback(batch=feedback_batch)
+            if session_id in _session_state:
+                _session_state[session_id]["injected_engrams"] = []
+        except Exception as e:
+            logger.debug(f"PLUR injection feedback failed: {e}")
 
     def on_session_end(session_id, completed=False, interrupted=False, **kwargs):
         try:

--- a/packages/hermes/test/test_hooks.py
+++ b/packages/hermes/test/test_hooks.py
@@ -1,0 +1,184 @@
+"""Tests for injection feedback in post_llm_call and signal detection helpers."""
+
+import pytest
+from plur_hermes import _detect_injection_signal, _get_trigrams, _FEEDBACK_MIN_CONFIDENCE
+
+
+class TestGetTrigrams:
+    def test_standard_trigrams(self):
+        tris = _get_trigrams("always use pnpm not npm")
+        assert "always use pnpm" in tris
+        assert "use pnpm not" in tris
+        assert "pnpm not npm" in tris
+
+    def test_short_text_returns_words(self):
+        assert _get_trigrams("hello") == {"hello"}
+        assert _get_trigrams("hello world") == {"hello", "world"}
+
+    def test_empty_string(self):
+        assert _get_trigrams("") == set()
+
+
+class TestDetectInjectionSignal:
+    def test_positive_verbatim_match(self):
+        signal, confidence = _detect_injection_signal(
+            "always use pnpm not npm",
+            "Sure, I'll keep in mind to always use pnpm not npm for this project."
+        )
+        assert signal == "positive"
+        assert confidence >= _FEEDBACK_MIN_CONFIDENCE
+
+    def test_positive_trigram_overlap(self):
+        engram = "prefer TypeScript strict mode for all new files"
+        response = "I'll use TypeScript strict mode for all new files as requested."
+        signal, confidence = _detect_injection_signal(engram, response)
+        assert signal == "positive"
+        assert confidence >= _FEEDBACK_MIN_CONFIDENCE
+
+    def test_negative_correction_marker(self):
+        engram = "always commit with --no-verify to skip hooks"
+        response = "Actually, you should never skip hooks with --no-verify — they catch real bugs."
+        signal, confidence = _detect_injection_signal(engram, response)
+        assert signal == "negative"
+        assert confidence >= _FEEDBACK_MIN_CONFIDENCE
+
+    def test_no_signal_unrelated_response(self):
+        engram = "use snake_case for Python variables"
+        response = "The weather today is sunny with a high of 22 degrees."
+        signal, confidence = _detect_injection_signal(engram, response)
+        assert signal is None
+        assert confidence < _FEEDBACK_MIN_CONFIDENCE
+
+    def test_empty_engram_returns_no_signal(self):
+        signal, confidence = _detect_injection_signal("", "some response text")
+        assert signal is None
+
+    def test_case_insensitive_matching(self):
+        signal, confidence = _detect_injection_signal(
+            "Use PNPM not NPM",
+            "As a reminder I should use pnpm not npm."
+        )
+        assert signal == "positive"
+        assert confidence >= _FEEDBACK_MIN_CONFIDENCE
+
+    def test_negative_no_engram_topic_nearby(self):
+        # Correction marker present but engram topic words not in the window
+        engram = "deploy with rsync to production servers"
+        response = "Actually, that's wrong about completely unrelated topic X."
+        signal, _ = _detect_injection_signal(engram, response)
+        # rsync, deploy, production, servers — none likely in the window around marker
+        # Acceptable if None or negative; just check it doesn't crash
+        assert signal in (None, "negative")
+
+
+class TestPostLlmCallFeedback:
+    """Integration-style tests for the feedback path via mock bridge."""
+
+    def _make_ctx(self):
+        """Return a minimal ctx stub that records registered hooks."""
+        class Ctx:
+            def __init__(self):
+                self.hooks = {}
+                self.tools = {}
+
+            def register_hook(self, name, fn):
+                self.hooks[name] = fn
+
+            def register_tool(self, name, toolset, schema, handler):
+                self.tools[name] = handler
+
+        return Ctx()
+
+    def _make_bridge(self, mocker):
+        bridge = mocker.MagicMock()
+        bridge._plur_path = None
+        bridge.status.return_value = {"engram_count": 10}
+        bridge.inject.return_value = {
+            "count": 1,
+            "injected_ids": ["ENG-001"],
+            "results": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+            "directives": "always use pnpm not npm",
+        }
+        bridge.learn.return_value = {"id": "ENG-NEW"}
+        bridge.feedback.return_value = {"ok": True}
+        return bridge
+
+    def test_positive_feedback_sent(self, mocker):
+        import plur_hermes
+        bridge = self._make_bridge(mocker)
+        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
+        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "true"})
+
+        ctx = self._make_ctx()
+        plur_hermes.register(ctx)
+        plur_hermes._session_state["s1"] = {
+            "count": 0, "started": 0,
+            "injected_ids": ["ENG-001"],
+            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+        }
+
+        ctx.hooks["post_llm_call"](
+            "s1",
+            "Sure, I'll use always use pnpm not npm for this project."
+        )
+
+        bridge.feedback.assert_called_once()
+        batch = bridge.feedback.call_args[1]["batch"]
+        assert ("ENG-001", "positive") in batch
+
+    def test_feedback_disabled_by_env(self, mocker):
+        import plur_hermes
+        bridge = self._make_bridge(mocker)
+        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
+        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "false"})
+
+        ctx = self._make_ctx()
+        plur_hermes.register(ctx)
+        plur_hermes._session_state["s2"] = {
+            "count": 0, "started": 0,
+            "injected_ids": ["ENG-001"],
+            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+        }
+
+        ctx.hooks["post_llm_call"](
+            "s2",
+            "I'll use always use pnpm not npm for this project."
+        )
+
+        bridge.feedback.assert_not_called()
+
+    def test_no_feedback_on_unrelated_response(self, mocker):
+        import plur_hermes
+        bridge = self._make_bridge(mocker)
+        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
+        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "true"})
+
+        ctx = self._make_ctx()
+        plur_hermes.register(ctx)
+        plur_hermes._session_state["s3"] = {
+            "count": 0, "started": 0,
+            "injected_ids": ["ENG-001"],
+            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+        }
+
+        ctx.hooks["post_llm_call"]("s3", "The sky is blue and the sun is bright today.")
+
+        bridge.feedback.assert_not_called()
+
+    def test_engrams_cleared_after_feedback(self, mocker):
+        import plur_hermes
+        bridge = self._make_bridge(mocker)
+        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
+        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "true"})
+
+        ctx = self._make_ctx()
+        plur_hermes.register(ctx)
+        plur_hermes._session_state["s4"] = {
+            "count": 0, "started": 0,
+            "injected_ids": ["ENG-001"],
+            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+        }
+
+        ctx.hooks["post_llm_call"]("s4", "I will always use pnpm not npm.")
+
+        assert plur_hermes._session_state["s4"]["injected_engrams"] == []

--- a/packages/hermes/test/test_hooks.py
+++ b/packages/hermes/test/test_hooks.py
@@ -1,6 +1,8 @@
 """Tests for injection feedback in post_llm_call and signal detection helpers."""
 
+import os
 import pytest
+from unittest.mock import MagicMock, patch
 from plur_hermes import _detect_injection_signal, _get_trigrams, _FEEDBACK_MIN_CONFIDENCE
 
 
@@ -62,20 +64,38 @@ class TestDetectInjectionSignal:
         assert confidence >= _FEEDBACK_MIN_CONFIDENCE
 
     def test_negative_no_engram_topic_nearby(self):
-        # Correction marker present but engram topic words not in the window
         engram = "deploy with rsync to production servers"
         response = "Actually, that's wrong about completely unrelated topic X."
         signal, _ = _detect_injection_signal(engram, response)
-        # rsync, deploy, production, servers — none likely in the window around marker
-        # Acceptable if None or negative; just check it doesn't crash
-        assert signal in (None, "negative")
+        assert signal is None
+
+    def test_multi_engram_mixed_signals(self):
+        # Positive match
+        s1, c1 = _detect_injection_signal(
+            "always use pnpm not npm",
+            "I'll always use pnpm not npm. Actually, the deploy path is wrong."
+        )
+        assert s1 == "positive"
+
+        # Negative match — response contradicts engram without repeating it verbatim
+        s2, c2 = _detect_injection_signal(
+            "always commit with --no-verify to skip hooks",
+            "I'll always use pnpm not npm. Actually, skipping hooks with --no-verify is dangerous."
+        )
+        assert s2 == "negative"
+
+        # No signal
+        s3, c3 = _detect_injection_signal(
+            "use snake_case for Python variables",
+            "I'll always use pnpm not npm. Actually, the deploy path is wrong."
+        )
+        assert s3 is None
 
 
 class TestPostLlmCallFeedback:
     """Integration-style tests for the feedback path via mock bridge."""
 
     def _make_ctx(self):
-        """Return a minimal ctx stub that records registered hooks."""
         class Ctx:
             def __init__(self):
                 self.hooks = {}
@@ -89,8 +109,8 @@ class TestPostLlmCallFeedback:
 
         return Ctx()
 
-    def _make_bridge(self, mocker):
-        bridge = mocker.MagicMock()
+    def _make_bridge(self):
+        bridge = MagicMock()
         bridge._plur_path = None
         bridge.status.return_value = {"engram_count": 10}
         bridge.inject.return_value = {
@@ -103,82 +123,78 @@ class TestPostLlmCallFeedback:
         bridge.feedback.return_value = {"ok": True}
         return bridge
 
-    def test_positive_feedback_sent(self, mocker):
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_positive_feedback_sent(self):
         import plur_hermes
-        bridge = self._make_bridge(mocker)
-        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
-        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "true"})
+        bridge = self._make_bridge()
+        with patch("plur_hermes.PlurBridge", return_value=bridge):
+            ctx = self._make_ctx()
+            plur_hermes.register(ctx)
+            plur_hermes._session_state["s1"] = {
+                "count": 0, "started": 0,
+                "injected_ids": ["ENG-001"],
+                "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+            }
 
-        ctx = self._make_ctx()
-        plur_hermes.register(ctx)
-        plur_hermes._session_state["s1"] = {
-            "count": 0, "started": 0,
-            "injected_ids": ["ENG-001"],
-            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
-        }
+            ctx.hooks["post_llm_call"](
+                "s1",
+                "Sure, I'll use always use pnpm not npm for this project."
+            )
 
-        ctx.hooks["post_llm_call"](
-            "s1",
-            "Sure, I'll use always use pnpm not npm for this project."
-        )
+            bridge.feedback.assert_called_once()
+            batch = bridge.feedback.call_args[1]["batch"]
+            assert ("ENG-001", "positive") in batch
 
-        bridge.feedback.assert_called_once()
-        batch = bridge.feedback.call_args[1]["batch"]
-        assert ("ENG-001", "positive") in batch
-
-    def test_feedback_disabled_by_env(self, mocker):
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "false"})
+    def test_feedback_disabled_by_env(self):
         import plur_hermes
-        bridge = self._make_bridge(mocker)
-        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
-        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "false"})
+        bridge = self._make_bridge()
+        with patch("plur_hermes.PlurBridge", return_value=bridge):
+            ctx = self._make_ctx()
+            plur_hermes.register(ctx)
+            plur_hermes._session_state["s2"] = {
+                "count": 0, "started": 0,
+                "injected_ids": ["ENG-001"],
+                "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+            }
 
-        ctx = self._make_ctx()
-        plur_hermes.register(ctx)
-        plur_hermes._session_state["s2"] = {
-            "count": 0, "started": 0,
-            "injected_ids": ["ENG-001"],
-            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
-        }
+            ctx.hooks["post_llm_call"](
+                "s2",
+                "I'll use always use pnpm not npm for this project."
+            )
 
-        ctx.hooks["post_llm_call"](
-            "s2",
-            "I'll use always use pnpm not npm for this project."
-        )
+            bridge.feedback.assert_not_called()
 
-        bridge.feedback.assert_not_called()
-
-    def test_no_feedback_on_unrelated_response(self, mocker):
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_no_feedback_on_unrelated_response(self):
         import plur_hermes
-        bridge = self._make_bridge(mocker)
-        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
-        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "true"})
+        bridge = self._make_bridge()
+        with patch("plur_hermes.PlurBridge", return_value=bridge):
+            ctx = self._make_ctx()
+            plur_hermes.register(ctx)
+            plur_hermes._session_state["s3"] = {
+                "count": 0, "started": 0,
+                "injected_ids": ["ENG-001"],
+                "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+            }
 
-        ctx = self._make_ctx()
-        plur_hermes.register(ctx)
-        plur_hermes._session_state["s3"] = {
-            "count": 0, "started": 0,
-            "injected_ids": ["ENG-001"],
-            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
-        }
+            ctx.hooks["post_llm_call"]("s3", "The sky is blue and the sun is bright today.")
 
-        ctx.hooks["post_llm_call"]("s3", "The sky is blue and the sun is bright today.")
+            bridge.feedback.assert_not_called()
 
-        bridge.feedback.assert_not_called()
-
-    def test_engrams_cleared_after_feedback(self, mocker):
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_engrams_cleared_after_feedback(self):
         import plur_hermes
-        bridge = self._make_bridge(mocker)
-        mocker.patch("plur_hermes.PlurBridge", return_value=bridge)
-        mocker.patch.dict("os.environ", {"PLUR_INJECTION_FEEDBACK": "true"})
+        bridge = self._make_bridge()
+        with patch("plur_hermes.PlurBridge", return_value=bridge):
+            ctx = self._make_ctx()
+            plur_hermes.register(ctx)
+            plur_hermes._session_state["s4"] = {
+                "count": 0, "started": 0,
+                "injected_ids": ["ENG-001"],
+                "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
+            }
 
-        ctx = self._make_ctx()
-        plur_hermes.register(ctx)
-        plur_hermes._session_state["s4"] = {
-            "count": 0, "started": 0,
-            "injected_ids": ["ENG-001"],
-            "injected_engrams": [{"id": "ENG-001", "statement": "always use pnpm not npm"}],
-        }
+            ctx.hooks["post_llm_call"]("s4", "I will always use pnpm not npm.")
 
-        ctx.hooks["post_llm_call"]("s4", "I will always use pnpm not npm.")
-
-        assert plur_hermes._session_state["s4"]["injected_engrams"] == []
+            assert plur_hermes._session_state["s4"]["injected_engrams"] == []


### PR DESCRIPTION
## Summary

- `pre_llm_call` now stores injected engram bodies (id + statement) in `_session_state` alongside the existing `injected_ids`
- `post_llm_call` detects whether each injected engram was used or contradicted and sends a single batched `plur_feedback()` call per turn
- Disabled via `PLUR_INJECTION_FEEDBACK=false` env var
- Only signals with confidence ≥ 0.6 are sent — designed to avoid noise

## Detection logic

| Signal | Trigger | Confidence |
|--------|---------|-----------|
| positive | Engram text appears verbatim in response | 0.95 |
| positive | ≥80% trigram overlap between engram and response | 0.70–1.00 |
| negative | Correction marker (`actually,`, `no,`, `wrong,`, …) within 100 chars of engram topic words | 0.65 |
| none | No match → no feedback call | — |

## Changes

| File | What |
|------|------|
| `packages/hermes/plur_hermes/__init__.py` | `_get_trigrams()`, `_detect_injection_signal()` helpers; updated `pre_llm_call` to store engram bodies; updated `post_llm_call` to detect signals and call `bridge.feedback(batch=...)` |
| `packages/hermes/test/test_hooks.py` | 14 new tests (10 unit + 4 integration) covering trigrams, signal detection, and end-to-end feedback path with mock bridge |

## Test plan
- [x] 14/14 new tests pass
- [x] 64/64 full hermes suite passes (no regressions)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)