### PR TITLE
feat(infra): H005 E1 cohort aggregation script (closes #133)

### DIFF
--- a/infra/heartbeat/aggregate.py
+++ b/infra/heartbeat/aggregate.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""H005 E1 cohort aggregation script.
+
+Reads /var/lib/plur-heartbeat/*.jsonl, derives cohort-1 install dates,
+computes per-install engagement metrics, and writes three readout artifacts:
+  cohort.csv, metrics.json, summary.md
+
+Usage:
+    python3 aggregate.py --data-dir /var/lib/plur-heartbeat \
+                         --out-dir /var/lib/plur-heartbeat/readouts/h005-e1-$(date +%Y-%m-%d)
+
+Cohort-1 window: [2026-05-14, 2026-06-13)
+"""
+
+import argparse
+import csv
+import json
+import pathlib
+import statistics
+import sys
+from collections import defaultdict
+from datetime import date, timedelta
+
+COHORT_START = date(2026, 5, 14)
+COHORT_END   = date(2026, 6, 13)  # exclusive
+
+VALIDATE_MEDIAN_DAYS   = 1.5
+VALIDATE_W4_RETENTION  = 0.30
+INVALIDATE_W4_RETENTION = 0.10
+INVALIDATE_MEDIAN_DAYS  = 0.50
+STRETCH_W4_RETENTION    = 0.50
+
+REQUIRED_FIELDS = {"install_id", "version", "platform", "date",
+                   "learn_count", "recall_count", "session_count"}
+
+
+def _parse_date(s: str) -> date:
+    return date.fromisoformat(s)
+
+
+def load_corpus(data_dir: pathlib.Path) -> dict:
+    """Return dict keyed by install_id, value = list of day-records."""
+    by_install: dict[str, list[dict]] = defaultdict(list)
+    for path in sorted(data_dir.glob("*.jsonl")):
+        with path.open() as fh:
+            for lineno, raw in enumerate(fh, 1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    rec = json.loads(raw)
+                except json.JSONDecodeError:
+                    print(f"WARN: {path.name}:{lineno} — invalid JSON, skipped", file=sys.stderr)
+                    continue
+                if not REQUIRED_FIELDS.issubset(rec):
+                    print(f"WARN: {path.name}:{lineno} — missing fields, skipped", file=sys.stderr)
+                    continue
+                rec["date"] = _parse_date(rec["date"])
+                by_install[rec["install_id"]].append(rec)
+    return by_install
+
+
+def derive_cohort(by_install: dict) -> dict:
+    """Filter to cohort-1: install_date in [COHORT_START, COHORT_END)."""
+    cohort = {}
+    for iid, records in by_install.items():
+        install_date = min(r["date"] for r in records)
+        if COHORT_START <= install_date < COHORT_END:
+            cohort[iid] = {"install_date": install_date, "records": records}
+    return cohort
+
+
+def _week_bounds(install_date: date, week: int) -> tuple[date, date]:
+    """Return [start, end) for week k (1-indexed)."""
+    start = install_date + timedelta(days=7 * (week - 1))
+    end   = install_date + timedelta(days=7 * week)
+    return start, end
+
+
+def _active_days_in_week(records: list, install_date: date, week: int) -> int:
+    """Count distinct active dates in the given week window.
+
+    A day counts as active if it has any learn, recall, or session event.
+    """
+    start, end = _week_bounds(install_date, week)
+    active = set()
+    for r in records:
+        if start <= r["date"] < end:
+            if r["learn_count"] + r["recall_count"] + r["session_count"] > 0:
+                active.add(r["date"])
+    return len(active)
+
+
+def _week4_engaged(records: list, install_date: date) -> bool:
+    """True if ≥1 learn or recall event in week 4 (engagement, not just presence)."""
+    start, end = _week_bounds(install_date, 4)
+    for r in records:
+        if start <= r["date"] < end:
+            if r["learn_count"] + r["recall_count"] > 0:
+                return True
+    return False
+
+
+def compute_install_metrics(cohort: dict) -> list[dict]:
+    rows = []
+    for iid, data in cohort.items():
+        install_date = data["install_date"]
+        records = data["records"]
+        w = [_active_days_in_week(records, install_date, k) for k in range(1, 5)]
+        rows.append({
+            "install_id":        iid,
+            "install_date":      install_date.isoformat(),
+            "platform":          records[0]["platform"],
+            "version_at_install": sorted(records, key=lambda r: r["date"])[0]["version"],
+            "active_days_w1":    w[0],
+            "active_days_w2":    w[1],
+            "active_days_w3":    w[2],
+            "active_days_w4":    w[3],
+            "learn_total":       sum(r["learn_count"] for r in records),
+            "recall_total":      sum(r["recall_count"] for r in records),
+            "week4_active":      _week4_engaged(records, install_date),
+        })
+    return rows
+
+
+def compute_cohort_metrics(rows: list[dict]) -> dict:
+    n = len(rows)
+    if n == 0:
+        return {
+            "cohort_size": 0,
+            "median_active_days_per_week": 0.0,
+            "week4_retention_pct": 0.0,
+            "validates_h005": False,
+            "invalidates_h005": True,
+            "verdict": "invalidate",
+            "platform_breakdown": {},
+            "version_breakdown": {},
+        }
+
+    active_per_week = [
+        (r["active_days_w1"] + r["active_days_w2"] +
+         r["active_days_w3"] + r["active_days_w4"]) / 4.0
+        for r in rows
+    ]
+    median_apw = statistics.median(active_per_week)
+    w4_count = sum(1 for r in rows if r["week4_active"])
+    w4_pct = w4_count / n
+
+    validates   = median_apw >= VALIDATE_MEDIAN_DAYS and w4_pct >= VALIDATE_W4_RETENTION
+    invalidates = w4_pct < INVALIDATE_W4_RETENTION or median_apw < INVALIDATE_MEDIAN_DAYS
+
+    if validates:
+        verdict = "validate"
+    elif invalidates:
+        verdict = "invalidate"
+    else:
+        verdict = "inconclusive"
+
+    platforms = defaultdict(int)
+    versions  = defaultdict(int)
+    for r in rows:
+        platforms[r["platform"]] += 1
+        versions[r["version_at_install"]] += 1
+
+    return {
+        "cohort_size":                n,
+        "median_active_days_per_week": round(median_apw, 4),
+        "week4_retention_pct":         round(w4_pct, 4),
+        "validates_h005":              validates,
+        "invalidates_h005":            invalidates,
+        "verdict":                     verdict,
+        "platform_breakdown":          dict(platforms),
+        "version_breakdown":           dict(versions),
+    }
+
+
+def write_cohort_csv(rows: list[dict], out_dir: pathlib.Path) -> None:
+    path = out_dir / "cohort.csv"
+    if not rows:
+        path.write_text("")
+        return
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def write_metrics_json(metrics: dict, out_dir: pathlib.Path) -> None:
+    (out_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+
+
+def write_summary_md(metrics: dict, out_dir: pathlib.Path, run_date: str) -> None:
+    n          = metrics["cohort_size"]
+    median_apw = metrics["median_active_days_per_week"]
+    w4_pct     = metrics["week4_retention_pct"]
+    verdict    = metrics["verdict"].upper()
+    validates  = metrics["validates_h005"]
+    invalidates = metrics["invalidates_h005"]
+
+    verdict_emoji = {"VALIDATE": "✅", "INVALIDATE": "❌", "INCONCLUSIVE": "⚠️"}.get(verdict, "")
+
+    platform_lines = "\n".join(
+        f"- {k}: {v}" for k, v in sorted(metrics["platform_breakdown"].items())
+    )
+    version_lines = "\n".join(
+        f"- {k}: {v}" for k, v in sorted(metrics["version_breakdown"].items())
+    )
+
+    summary = f"""# H005 E1 Readout — Cohort-1 Engagement Baseline
+Generated: {run_date}
+
+## Verdict: {verdict_emoji} {verdict}
+
+| Metric | Value | Threshold |
+|--------|-------|-----------|
+| Cohort size | {n} | — |
+| Median active-days/week | {median_apw:.2f} | ≥ 1.5 to validate |
+| Week-4 retention | {w4_pct * 100:.1f}% | ≥ 30% to validate / < 10% to invalidate |
+
+**Validates H005:** {"Yes" if validates else "No"}
+**Invalidates H005:** {"Yes" if invalidates else "No"}
+
+## Interpretation
+
+{"H005 confirmed: Hermes-channel installs convert to sustained engagement. Cohort-1 meets both the median active-days and week-4 retention floor. The Hermes channel ROI thesis is supported." if validates else ""}
+{"H005 falsified: install-and-forget pattern detected. Week-4 retention or median engagement is below the anti-metric floor. The Hermes channel needs diagnosis before further investment." if invalidates else ""}
+{"H005 inconclusive: cohort-1 is above the invalidation floor but below the validation threshold. More data (cohort-2 or extended window) needed before a decision." if not validates and not invalidates else ""}
+
+## Platform Breakdown
+
+{platform_lines if platform_lines else "— no data —"}
+
+## Version Breakdown
+
+{version_lines if version_lines else "— no data —"}
+
+## Notes
+
+- Cohort-1 window: {COHORT_START.isoformat()} – {COHORT_END.isoformat()} (install_date derived from earliest observed heartbeat)
+- Active-day: any date with learn_count + recall_count + session_count > 0
+- Week-4 engaged: ≥1 learn or recall event in install_date + [21d, 28d)
+- Stretch target (≥50% W4 retention): {"MET" if w4_pct >= STRETCH_W4_RETENTION else "not met"}
+"""
+    (out_dir / "summary.md").write_text(summary)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="H005 E1 cohort aggregation")
+    parser.add_argument("--data-dir",  default="/var/lib/plur-heartbeat",
+                        help="Directory containing YYYY-MM-DD.jsonl files")
+    parser.add_argument("--out-dir",   required=True,
+                        help="Output directory for readout artifacts")
+    parser.add_argument("--run-date",  default=date.today().isoformat(),
+                        help="Date label for summary (default: today)")
+    args = parser.parse_args(argv)
+
+    data_dir = pathlib.Path(args.data_dir)
+    out_dir  = pathlib.Path(args.out_dir)
+
+    if not data_dir.is_dir():
+        print(f"ERROR: data-dir {data_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    by_install = load_corpus(data_dir)
+    cohort     = derive_cohort(by_install)
+    rows       = compute_install_metrics(cohort)
+    metrics    = compute_cohort_metrics(rows)
+
+    write_cohort_csv(rows, out_dir)
+    write_metrics_json(metrics, out_dir)
+    write_summary_md(metrics, out_dir, args.run_date)
+
+    print(f"Cohort size: {metrics['cohort_size']}")
+    print(f"Median active-days/week: {metrics['median_active_days_per_week']}")
+    print(f"Week-4 retention: {metrics['week4_retention_pct']*100:.1f}%")
+    print(f"Verdict: {metrics['verdict'].upper()}")
+    print(f"Artifacts written to: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/heartbeat/test_aggregate.py
+++ b/infra/heartbeat/test_aggregate.py
@@ -1,0 +1,311 @@
+"""Unit tests for H005 E1 cohort aggregation script.
+
+Covers: empty corpus, single install, mixed retention, cohort boundary,
+week boundary math, week-4 engagement vs. presence distinction.
+"""
+
+import json
+import pathlib
+import tempfile
+import unittest
+from datetime import date
+
+from aggregate import (
+    COHORT_END,
+    COHORT_START,
+    compute_cohort_metrics,
+    compute_install_metrics,
+    derive_cohort,
+    load_corpus,
+    main,
+)
+
+
+def _rec(install_id, d, learn=0, recall=0, session=0, version="0.9.4", platform="linux"):
+    return {
+        "install_id":    install_id,
+        "version":       version,
+        "platform":      platform,
+        "date":          date.fromisoformat(d) if isinstance(d, str) else d,
+        "learn_count":   learn,
+        "recall_count":  recall,
+        "session_count": session,
+    }
+
+
+def _write_jsonl(tmp: pathlib.Path, records: list) -> None:
+    """Write records to per-date .jsonl files."""
+    by_date: dict = {}
+    for r in records:
+        d = r["date"] if isinstance(r["date"], str) else r["date"].isoformat()
+        by_date.setdefault(d, []).append({**r, "date": d})
+    for d, recs in by_date.items():
+        path = tmp / f"{d}.jsonl"
+        with path.open("a") as fh:
+            for rec in recs:
+                fh.write(json.dumps(rec) + "\n")
+
+
+class TestLoadCorpus(unittest.TestCase):
+    def test_empty_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            result = load_corpus(pathlib.Path(d))
+        self.assertEqual(result, {})
+
+    def test_skips_malformed_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "2026-05-14.jsonl"
+            p.write_text('{"bad": true}\nnot-json\n')
+            result = load_corpus(pathlib.Path(d))
+        self.assertEqual(result, {})
+
+    def test_parses_valid_records(self):
+        with tempfile.TemporaryDirectory() as d:
+            td = pathlib.Path(d)
+            _write_jsonl(td, [_rec("aaa", "2026-05-20", learn=1)])
+            result = load_corpus(td)
+        self.assertIn("aaa", result)
+        self.assertEqual(len(result["aaa"]), 1)
+        self.assertEqual(result["aaa"][0]["learn_count"], 1)
+
+
+class TestDeriveCohort(unittest.TestCase):
+    def _make(self, iid, dates):
+        return {iid: [_rec(iid, d) for d in dates]}
+
+    def test_inside_window(self):
+        by_install = self._make("x", ["2026-05-14"])
+        cohort = derive_cohort(by_install)
+        self.assertIn("x", cohort)
+
+    def test_before_window(self):
+        by_install = self._make("x", ["2026-05-13"])
+        cohort = derive_cohort(by_install)
+        self.assertNotIn("x", cohort)
+
+    def test_on_end_boundary_excluded(self):
+        by_install = self._make("x", ["2026-06-13"])
+        cohort = derive_cohort(by_install)
+        self.assertNotIn("x", cohort)
+
+    def test_install_date_is_earliest(self):
+        by_install = self._make("x", ["2026-05-20", "2026-05-15", "2026-05-18"])
+        cohort = derive_cohort(by_install)
+        self.assertEqual(cohort["x"]["install_date"], date(2026, 5, 15))
+
+    def test_install_before_window_but_activity_inside(self):
+        # install_date derived from corpus — if first seen heartbeat is before
+        # the cohort window, this install is excluded even if it also has
+        # heartbeats inside the window.
+        by_install = {"x": [_rec("x", "2026-05-13"), _rec("x", "2026-05-20")]}
+        cohort = derive_cohort(by_install)
+        self.assertNotIn("x", cohort)
+
+
+class TestComputeInstallMetrics(unittest.TestCase):
+    def _cohort(self, iid, records):
+        install_date = min(r["date"] if isinstance(r["date"], date)
+                          else date.fromisoformat(r["date"]) for r in records)
+        parsed = []
+        for r in records:
+            rc = dict(r)
+            if isinstance(rc["date"], str):
+                rc["date"] = date.fromisoformat(rc["date"])
+            parsed.append(rc)
+        return {iid: {"install_date": install_date, "records": parsed}}
+
+    def test_zero_activity(self):
+        cohort = self._cohort("a", [_rec("a", "2026-05-14", session=0)])
+        rows = compute_install_metrics(cohort)
+        self.assertEqual(rows[0]["active_days_w1"], 0)
+        self.assertEqual(rows[0]["week4_active"], False)
+
+    def test_active_day_counting(self):
+        # One active day each in W1, W2, W3, W4
+        cohort = self._cohort("a", [
+            _rec("a", "2026-05-14", session=1),           # W1 day 0
+            _rec("a", "2026-05-21", session=1),           # W2 day 7
+            _rec("a", "2026-05-28", session=1),           # W3 day 14
+            _rec("a", "2026-06-04", learn=1),             # W4 day 21
+        ])
+        rows = compute_install_metrics(cohort)
+        r = rows[0]
+        self.assertEqual(r["active_days_w1"], 1)
+        self.assertEqual(r["active_days_w2"], 1)
+        self.assertEqual(r["active_days_w3"], 1)
+        self.assertEqual(r["active_days_w4"], 1)
+
+    def test_week4_active_requires_learn_or_recall_not_session_only(self):
+        install_date = "2026-05-14"
+        cohort = self._cohort("a", [
+            _rec("a", "2026-06-04", session=1, learn=0, recall=0),  # W4 but session-only
+        ])
+        rows = compute_install_metrics(cohort)
+        self.assertFalse(rows[0]["week4_active"])
+
+    def test_week4_active_true_with_recall(self):
+        # install_date = 2026-05-14; W4 = [+21d, +28d) = [2026-06-04, 2026-06-11)
+        cohort = self._cohort("a", [
+            _rec("a", "2026-05-14", session=1),  # install anchor
+            _rec("a", "2026-06-04", recall=1),   # W4 day, recall event
+        ])
+        rows = compute_install_metrics(cohort)
+        self.assertTrue(rows[0]["week4_active"])
+
+    def test_week_boundary_math(self):
+        # install_date = 2026-05-14 (day 0); day 6 = W1 last; day 7 = W2 first
+        cohort = self._cohort("a", [
+            _rec("a", "2026-05-14", session=1),  # install anchor (W1 day 0)
+            _rec("a", "2026-05-20", session=1),  # install_date + 6 → W1
+            _rec("a", "2026-05-21", session=1),  # install_date + 7 → W2
+        ])
+        rows = compute_install_metrics(cohort)
+        r = rows[0]
+        self.assertEqual(r["active_days_w1"], 2)   # day 0 + day 6
+        self.assertEqual(r["active_days_w2"], 1)   # day 7 only
+
+    def test_totals_accumulated(self):
+        cohort = self._cohort("a", [
+            _rec("a", "2026-05-14", learn=3, recall=2),
+            _rec("a", "2026-05-15", learn=1, recall=0),
+        ])
+        rows = compute_install_metrics(cohort)
+        self.assertEqual(rows[0]["learn_total"], 4)
+        self.assertEqual(rows[0]["recall_total"], 2)
+
+
+class TestComputeCohortMetrics(unittest.TestCase):
+    def _row(self, w1=0, w2=0, w3=0, w4=0, w4_active=False):
+        return {
+            "install_id": "x", "install_date": "2026-05-14",
+            "platform": "linux", "version_at_install": "0.9.4",
+            "active_days_w1": w1, "active_days_w2": w2,
+            "active_days_w3": w3, "active_days_w4": w4,
+            "learn_total": 0, "recall_total": 0,
+            "week4_active": w4_active,
+        }
+
+    def test_empty_cohort(self):
+        m = compute_cohort_metrics([])
+        self.assertEqual(m["cohort_size"], 0)
+        self.assertEqual(m["verdict"], "invalidate")
+        self.assertTrue(m["invalidates_h005"])
+
+    def test_validates(self):
+        # 3 active days/week median, >30% W4 retention
+        rows = [
+            self._row(w1=7, w2=7, w3=7, w4=7, w4_active=True),   # 7 each week
+            self._row(w1=7, w2=7, w3=7, w4=7, w4_active=True),
+            self._row(w1=0, w2=0, w3=0, w4=0, w4_active=False),   # ghost
+        ]
+        m = compute_cohort_metrics(rows)
+        self.assertEqual(m["verdict"], "validate")
+        self.assertTrue(m["validates_h005"])
+        self.assertFalse(m["invalidates_h005"])
+
+    def test_invalidates_low_w4_retention(self):
+        # 0% W4 retention → invalidate regardless of median
+        rows = [
+            self._row(w1=7, w2=7, w3=7, w4=0, w4_active=False),
+            self._row(w1=7, w2=7, w3=7, w4=0, w4_active=False),
+        ]
+        m = compute_cohort_metrics(rows)
+        self.assertEqual(m["verdict"], "invalidate")
+        self.assertTrue(m["invalidates_h005"])
+
+    def test_invalidates_low_median(self):
+        rows = [
+            self._row(w1=0, w2=0, w3=0, w4=1, w4_active=True),  # median apw = 0.25
+        ]
+        m = compute_cohort_metrics(rows)
+        self.assertEqual(m["verdict"], "invalidate")
+
+    def test_inconclusive(self):
+        # median = 1.0 (above 0.5, below 1.5), w4_pct = 50% (above 10%, below 30%)
+        # 50% meets stretch but not validate threshold... let me recalculate:
+        # validate needs median>=1.5 AND w4_pct>=30%
+        # one row: w1=4,w2=4,w3=0,w4=0 → apw = (4+4+0+0)/4 = 2.0, w4_pct=0% → invalidate
+        # need: above anti-metric floor but below validate threshold
+        # w4_pct >=10%, <30%; median >= 0.5, < 1.5
+        rows = [
+            self._row(w1=1, w2=1, w3=1, w4=1, w4_active=True),   # apw=1.0, w4_active
+            self._row(w1=1, w2=1, w3=1, w4=1, w4_active=False),  # apw=1.0
+            self._row(w1=1, w2=1, w3=1, w4=1, w4_active=False),  # apw=1.0
+            self._row(w1=1, w2=1, w3=1, w4=1, w4_active=False),  # apw=1.0
+            self._row(w1=1, w2=1, w3=1, w4=1, w4_active=False),  # apw=1.0
+        ]
+        # median apw = 1.0 (< 1.5), w4_pct = 20% (>= 10%, < 30%) → inconclusive
+        m = compute_cohort_metrics(rows)
+        self.assertEqual(m["verdict"], "inconclusive")
+        self.assertFalse(m["validates_h005"])
+        self.assertFalse(m["invalidates_h005"])
+
+    def test_platform_breakdown(self):
+        rows = [
+            {**self._row(), "platform": "darwin"},
+            {**self._row(), "platform": "linux"},
+            {**self._row(), "platform": "linux"},
+        ]
+        m = compute_cohort_metrics(rows)
+        self.assertEqual(m["platform_breakdown"]["linux"], 2)
+        self.assertEqual(m["platform_breakdown"]["darwin"], 1)
+
+
+class TestEndToEnd(unittest.TestCase):
+    def _make_jsonl(self, tmp, records):
+        _write_jsonl(tmp, records)
+
+    def test_single_install_full_engagement(self):
+        with tempfile.TemporaryDirectory() as data_d, \
+             tempfile.TemporaryDirectory() as out_d:
+            data_dir = pathlib.Path(data_d)
+            out_dir  = pathlib.Path(out_d)
+            # Install on 2026-05-14, active every day for 4 weeks, W4 has learn event
+            for offset in range(28):
+                d = date(2026, 5, 14) + __import__("datetime").timedelta(days=offset)
+                ds = d.isoformat()
+                learn = 1 if offset >= 21 else 0
+                _write_jsonl(data_dir, [_rec("install-1", ds, session=1, learn=learn)])
+
+            main(["--data-dir", str(data_dir), "--out-dir", str(out_d)])
+
+            metrics = json.loads((out_dir / "metrics.json").read_text())
+            self.assertEqual(metrics["cohort_size"], 1)
+            self.assertEqual(metrics["verdict"], "validate")
+            self.assertGreaterEqual(metrics["median_active_days_per_week"], 1.5)
+            self.assertGreater(metrics["week4_retention_pct"], 0.0)
+
+            cohort_csv = (out_dir / "cohort.csv").read_text()
+            self.assertIn("install-1", cohort_csv)
+
+            summary = (out_dir / "summary.md").read_text()
+            self.assertIn("VALIDATE", summary)
+
+    def test_install_and_forget(self):
+        with tempfile.TemporaryDirectory() as data_d, \
+             tempfile.TemporaryDirectory() as out_d:
+            data_dir = pathlib.Path(data_d)
+            # One install, only W1 activity, nothing after
+            _write_jsonl(data_dir, [_rec("ghost", "2026-05-14", session=1)])
+
+            main(["--data-dir", str(data_dir), "--out-dir", str(out_d)])
+
+            metrics = json.loads((pathlib.Path(out_d) / "metrics.json").read_text())
+            self.assertEqual(metrics["verdict"], "invalidate")
+            self.assertTrue(metrics["invalidates_h005"])
+
+    def test_idempotent(self):
+        with tempfile.TemporaryDirectory() as data_d, \
+             tempfile.TemporaryDirectory() as out_d:
+            data_dir = pathlib.Path(data_d)
+            _write_jsonl(data_dir, [_rec("a", "2026-05-20", learn=1)])
+
+            main(["--data-dir", str(data_dir), "--out-dir", str(out_d)])
+            first  = json.loads((pathlib.Path(out_d) / "metrics.json").read_text())
+            main(["--data-dir", str(data_dir), "--out-dir", str(out_d)])
+            second = json.loads((pathlib.Path(out_d) / "metrics.json").read_text())
+            self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Stdlib-only Python script (`infra/heartbeat/aggregate.py`) that reads `YYYY-MM-DD.jsonl` from the heartbeat server and produces the three H005 E1 readout artifacts: `cohort.csv`, `metrics.json`, `summary.md`
- Cohort-1 window hardcoded to `[2026-05-14, 2026-06-13)` per hypotheses.yaml
- Verdict logic maps to validate / invalidate / inconclusive per spec thresholds (median ≥1.5 AND W4 ≥30% = validate; W4 <10% OR median <0.5 = invalidate)
- 23 unit tests covering: empty corpus, cohort boundary (before/after window), week boundary math, session-only vs. learn/recall for W4 engagement, validate/invalidate/inconclusive paths, platform breakdown, idempotency, and two end-to-end smoke tests

## Relationship to #132

- `aggregate.py` is the consumer of the JSONL that #132's `server.py` produces
- Can be deployed to nightshift alongside #132 (same `infra/heartbeat/` directory)
- Designed for ad-hoc readout: `python3 aggregate.py --data-dir /var/lib/plur-heartbeat --out-dir /var/lib/plur-heartbeat/readouts/h005-e1-$(date +%Y-%m-%d)`

## Test plan

- [x] 23/23 unit tests pass (`python3 -m pytest infra/heartbeat/test_aggregate.py -v`)
- [x] No external dependencies — stdlib only (csv, json, pathlib, statistics, datetime)
- [x] Idempotency verified: running twice over same input produces identical output

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)