### PR TITLE
fix(hermes): sentence-level fallback for learner extraction (#115)

### DIFF
--- a/packages/hermes/plur_hermes/learner.py
+++ b/packages/hermes/plur_hermes/learner.py
@@ -6,9 +6,14 @@ Multi-strategy extraction (first match wins):
 2. Alternative markers anywhere in the message — `🧠 I learned:`, `I learned:`,
    `Key takeaway[s]:`, `Noted:`, `Correction noted:` — must start a line and be
    followed by a newline; block ends at a blank line, `---`, or EOF.
+3. Sentence-level fallback — when no marker is found, scan for sentences that
+   match correction/preference patterns: "Correction: ...", "The correct way is ...",
+   "I/We should/must/always/never/prefer/avoid ...".
 
 Conservative matching to avoid false positives: markers must be line-anchored
 and the captured body is split on lines with bullet/number prefixes stripped.
+Sentence fallback requires "I" or "We" subject or explicit "Correction:" prefix
+to keep false-positive rate below 15%.
 """
 
 import re
@@ -27,6 +32,19 @@ _ALT_MARKERS = (
 _ALT_MARKER_PATTERN = re.compile(
     r'(?:^|\n)\s*(?:' + '|'.join(_ALT_MARKERS) + r')[ \t]*\n'
     r'([\s\S]*?)(?:\n[ \t]*\n|\n---|$)'
+)
+
+# Sentence-level fallback: conservative patterns that strongly signal a correction
+# or stated preference. Minimum 25 chars to filter noise.
+# Anchor: line start OR after ". " (sentence boundary within a paragraph).
+_SENTENCE_PATTERN = re.compile(
+    r'(?:(?:^|\n)[ \t]*|(?<=\. ))'
+    r'('
+    r'Correction:\s+\S[^\n]{14,}'
+    r'|The (?:correct|proper|best) way (?:is|to) \S[^\n]{9,}'
+    r'|(?:I|We) (?:should|must|will|prefer|avoid|always|never) \S[^\n]{9,}'
+    r')',
+    re.IGNORECASE,
 )
 
 _BULLET_PREFIX = re.compile(r'^[-*•]\s+|^\d+[.)]\s+')
@@ -52,4 +70,6 @@ def extract_learning_patterns(text: str) -> list[str]:
     if (match := _ALT_MARKER_PATTERN.search(text)):
         return _extract_lines(match.group(1))
 
-    return []
+    # Sentence-level fallback: no marker found, scan for correction/preference sentences
+    sentences = _SENTENCE_PATTERN.findall(text)
+    return [s.strip() for s in sentences if len(s.strip()) >= 25]

--- a/packages/hermes/test/test_learner.py
+++ b/packages/hermes/test/test_learner.py
@@ -74,3 +74,82 @@ class TestExtractLearningPatterns:
         text = "The phrase I learned: appears inline but not at line start with body."
         result = extract_learning_patterns(text)
         assert result == []
+
+
+class TestSentenceFallback:
+    """Strategy 3: sentence-level fallback when no explicit marker found."""
+
+    def test_correction_prefix_sentence(self):
+        text = "Let me fix that.\nCorrection: use pnpm not npm in this monorepo for all package operations."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+        assert "pnpm" in result[0]
+
+    def test_the_correct_way_is(self):
+        text = "I had it wrong. The correct way is to call pnpm build before running tests."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+        assert "pnpm build" in result[0]
+
+    def test_the_best_way_to(self):
+        text = "The best way to handle this is to use workspace:* for internal deps."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_i_should_sentence(self):
+        text = "I should always run pnpm test before committing changes to the repo."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+        assert "pnpm test" in result[0]
+
+    def test_i_must_sentence(self):
+        text = "I must rebuild core before testing claw since claw imports from dist not source."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_we_should_sentence(self):
+        text = "We should bump all nine version locations when releasing a new version."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_i_never_sentence(self):
+        text = "I never use npm publish directly here — always authenticate as plur9 first."
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+
+    def test_multiple_sentences(self):
+        text = (
+            "Looking back at my work.\n"
+            "I should run pnpm build after changing core package files.\n"
+            "I must use workspace:* for internal package dependencies always.\n"
+        )
+        result = extract_learning_patterns(text)
+        assert len(result) == 2
+
+    def test_marker_wins_over_sentence_fallback(self):
+        # Alt marker present — sentence fallback must NOT run
+        text = (
+            "I learned:\n- Use pnpm not npm for workspace operations\n\n"
+            "I should also rebuild core before claw tests every time."
+        )
+        result = extract_learning_patterns(text)
+        assert len(result) == 1
+        assert "pnpm not npm" in result[0]
+
+    def test_short_sentences_excluded(self):
+        # Sentence under 25 chars should not appear
+        text = "I should fix it."
+        result = extract_learning_patterns(text)
+        assert result == []
+
+    def test_plain_opinion_no_subject_not_matched(self):
+        # "should" without I/We subject — must not match (keeps false-positive rate low)
+        text = "This approach should work fine for the use case."
+        result = extract_learning_patterns(text)
+        assert result == []
+
+    def test_correction_inline_not_matched(self):
+        # "Correction:" not at line start — issue is indented flow, not standalone
+        text = "After review (Correction: this is not what was meant) we proceed normally."
+        result = extract_learning_patterns(text)
+        assert result == []


### PR DESCRIPTION
## Summary

- Adds strategy 3 (sentence-level fallback) to `plur_hermes/learner.py`
- Fires only when no explicit marker (🧠/I learned:/Noted: etc.) is found
- Three conservative patterns: `Correction: ...`, `The correct/proper/best way is/to ...`, `I/We should/must/will/prefer/avoid/always/never ...`
- Sentence boundary anchor (`(?<=\. )`) catches mid-paragraph occurrences, not just line starts
- 25 tests total: 13 pre-existing (all pass) + 12 new sentence-fallback cases

## Acceptance criteria coverage

- ✅ Original fast-path regex remains first strategy
- ✅ Alt-marker strategy unchanged
- ✅ Sentence fallback fires when no marker present
- ✅ False-positive guard: modal patterns require I/We subject; "should" inline without subject does not match
- ✅ Short sentences (<25 chars) excluded

## What's NOT included yet

- Confidence scoring API (the public return type stays `list[str]`; confidence is implicit by strategy ordering — callers can assume strategy-1 > strategy-2 > strategy-3 if they need to distinguish)
- Labeled corpus evaluation (20 real session logs) — that measurement can be done separately to validate the <15% FP bound in production

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)