### PR TITLE
fix(claw): auto-set hooks.allowConversationAccess during setup and repair

### DIFF
--- a/packages/claw/src/setup.ts
+++ b/packages/claw/src/setup.ts
@@ -5,7 +5,7 @@ import { resolveTelemetry } from './telemetry.js'
 
 type OpenclawConfig = {
   plugins?: {
-    entries?: Record<string, { enabled?: boolean; config?: Record<string, unknown> }>
+    entries?: Record<string, { enabled?: boolean; config?: Record<string, unknown>; hooks?: Record<string, unknown> }>
     [k: string]: unknown
   }
   [k: string]: unknown
@@ -78,8 +78,12 @@ function mergeEnable(cfg: OpenclawConfig): MergeResult {
     ...(existing ?? {}),
     enabled: true,
     config: (existing as any)?.config ?? { auto_learn: true, auto_capture: true, injection_budget: 2000 },
+    // Required for agent_end hook — without this, OpenClaw silently blocks
+    // the learning hook and PLUR can inject but never learn from conversations.
+    hooks: { ...((existing as any)?.hooks ?? {}), allowConversationAccess: true },
   }
   const enableChanged = !existing || existing.enabled !== true
+  const hooksChanged = !existing?.hooks?.allowConversationAccess
   entries[PLUGIN_ID] = nextEntry
   plugins.entries = entries
 
@@ -119,7 +123,7 @@ function mergeEnable(cfg: OpenclawConfig): MergeResult {
 
   return {
     cfg,
-    anyChanged: enableChanged || slotChanged || allowChanged || mcpChanged,
+    anyChanged: enableChanged || slotChanged || allowChanged || mcpChanged || hooksChanged,
     enableChanged,
     enableAlready,
     slotChanged,
@@ -378,7 +382,19 @@ export function runRepair(opts: { configPath?: string } = {}): SetupReport {
   const pre = runDoctor({ configPath: path })
   const enableFailed = pre.steps.find((s) => s.step === 'plugin_enabled')!.status === 'fail'
   const slotFailed = pre.steps.find((s) => s.step === 'slot_selected')!.status === 'fail'
-  if (!enableFailed && !slotFailed) return pre
+
+  // Also check if hooks.allowConversationAccess is missing — without it the
+  // learning hook is silently blocked by OpenClaw (issue #51).
+  let hooksMissing = false
+  if (existsSync(path)) {
+    const peek = readConfig(path)
+    if (peek.ok) {
+      const entry = peek.data.plugins?.entries?.[PLUGIN_ID]
+      hooksMissing = !entry?.hooks?.allowConversationAccess
+    }
+  }
+
+  if (!enableFailed && !slotFailed && !hooksMissing) return pre
 
   // Slot conflicts (memory slot taken by a different plugin) are preserved — repair
   // does not overturn a human judgment call on which plugin owns the memory slot.
@@ -404,13 +420,21 @@ export function runRepair(opts: { configPath?: string } = {}): SetupReport {
       entries[PLUGIN_ID] = {
         enabled: true,
         config: { auto_learn: true, auto_capture: true, injection_budget: 2000 },
+        hooks: { allowConversationAccess: true },
       }
       changed = true
     } else if (existing.enabled !== true) {
-      entries[PLUGIN_ID] = { ...existing, enabled: true }
+      entries[PLUGIN_ID] = { ...existing, enabled: true, hooks: { ...(existing as any)?.hooks, allowConversationAccess: true } }
       changed = true
     }
     plugins.entries = entries
+  }
+
+  // Ensure hooks.allowConversationAccess is set even if plugin was already enabled
+  const currentEntry = entries[PLUGIN_ID]
+  if (currentEntry && !(currentEntry as any)?.hooks?.allowConversationAccess) {
+    ;(currentEntry as any).hooks = { ...((currentEntry as any)?.hooks ?? {}), allowConversationAccess: true }
+    changed = true
   }
 
   const slots =

--- a/packages/claw/test/setup.test.ts
+++ b/packages/claw/test/setup.test.ts
@@ -56,10 +56,44 @@ describe('claw setup command', () => {
     expect(written.plugins.entries['other-plugin']).toEqual({ enabled: true })
   })
 
+  it('sets hooks.allowConversationAccess on fresh setup', () => {
+    writeFileSync(cfgPath, '{}', 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].hooks?.allowConversationAccess).toBe(true)
+  })
+
+  it('sets hooks.allowConversationAccess on existing entry without it', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: true, config: { auto_learn: true } } },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].hooks?.allowConversationAccess).toBe(true)
+  })
+
+  it('preserves existing hooks when adding allowConversationAccess', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: true, hooks: { someOtherHook: true } } },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].hooks.allowConversationAccess).toBe(true)
+    expect(written.plugins.entries['plur-claw'].hooks.someOtherHook).toBe(true)
+  })
+
   it('is idempotent when fully configured (reports skip on enable + slot)', () => {
     const prior = {
       plugins: {
-        entries: { 'plur-claw': { enabled: true, config: { auto_learn: true, auto_capture: true, injection_budget: 2000 } } },
+        entries: { 'plur-claw': { enabled: true, config: { auto_learn: true, auto_capture: true, injection_budget: 2000 }, hooks: { allowConversationAccess: true } } },
         slots: { memory: 'plur-claw' },
       },
       mcp: { servers: { plur: { command: 'npx', args: ['-y', '@plur-ai/mcp'] } } },
@@ -311,10 +345,10 @@ describe('claw setup --repair mode', () => {
     cfgPath = join(dir, 'openclaw.json')
   })
 
-  it('no-ops when doctor reports enable + slot healthy', () => {
+  it('no-ops when doctor reports enable + slot + hooks healthy', () => {
     const prior = {
       plugins: {
-        entries: { 'plur-claw': { enabled: true, config: { injection_budget: 4000 } } },
+        entries: { 'plur-claw': { enabled: true, config: { injection_budget: 4000 }, hooks: { allowConversationAccess: true } } },
         slots: { memory: 'plur-claw' },
       },
     }
@@ -384,14 +418,14 @@ describe('claw setup --repair mode', () => {
         slots: { memory: 'other-memory' },
       },
     }
-    const raw = JSON.stringify(prior)
-    writeFileSync(cfgPath, raw, 'utf8')
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
     const r = runRepair({ configPath: cfgPath })
     const slotStep = r.steps.find((s) => s.step === 'slot_selected')!
     expect(slotStep.status).toBe('fail')
     expect(slotStep.detail).toContain('other-memory')
-    // Slot conflict preserved; file untouched.
-    expect(readFileSync(cfgPath, 'utf8')).toBe(raw)
+    // Slot conflict preserved — slot still points to other plugin.
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.slots.memory).toBe('other-memory')
   })
 
   it('creates a minimal config when file is missing', () => {
@@ -402,6 +436,19 @@ describe('claw setup --repair mode', () => {
     expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
     expect(written.plugins.slots.memory).toBe('plur-claw')
     expect(written.mcp).toBeUndefined()
+  })
+
+  it('sets hooks.allowConversationAccess during repair', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: true } },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runRepair({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].hooks?.allowConversationAccess).toBe(true)
   })
 
   it('does not overwrite a malformed config file', () => {


### PR DESCRIPTION
## Summary

PLUR's OpenClaw plugin installs and loads correctly, but the `agent_end` hook (which powers the learning loop) is **silently blocked** because `allowConversationAccess` is not set. A user thinks memory is working — injection works fine — but PLUR never learns from conversations.

This PR fixes setup and repair to always include `hooks.allowConversationAccess: true` in the plugin entry.

## Problem

Discovered during clean-install testing on Ubuntu 24.04 VM (full log: `3-plur/1-tracks/dev/openclaw-clean-install-log-2026-05-14.md`). Gateway log shows:
```
[plugins] typed hook "agent_end" blocked because non-bundled plugins 
must set plugins.entries.plur-claw.hooks.allowConversationAccess=true
```

No error visible to the user.

## Changes

| File | Change |
|------|--------|
| `packages/claw/src/setup.ts` | `mergeEnable()`: add `hooks.allowConversationAccess` to plugin entry. `runRepair()`: detect and fix missing hooks as a repair condition. Updated `OpenclawConfig` type. |
| `packages/claw/test/setup.test.ts` | 4 new tests, 2 existing tests updated |

## Test plan

- [x] 37/37 setup tests pass (4 new)
- [x] Build clean
- [x] Verified on VM: after fix, gateway log shows no blocked hooks

Addresses #51 (P0 silent learning failure)