### PR TITLE
fix(core): purgeTensions iterates all stores + auto-purge on startup

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -177,6 +177,24 @@ export class Plur {
     if (this.config.embeddings?.enabled === false) {
       setEmbeddingsEnabled(false, 'embeddings disabled in config.yaml (embeddings.enabled = false)')
     }
+    // Auto-purge legacy tension false positives (#156). PR #138 removed all
+    // conflict creation from the dedup prompt, so any remaining conflicts are
+    // false positives from the old system. Run once, mark with a sentinel file.
+    this._autoPurgeLegacyTensions()
+  }
+
+  private _autoPurgeLegacyTensions(): void {
+    const sentinel = join(this.paths.root, '.tensions-purged')
+    if (fs.existsSync(sentinel)) return
+    try {
+      const result = this.purgeTensions()
+      if (result.purged_count > 0) {
+        logger.info(`[plur] Auto-purged ${result.purged_count} legacy tension refs from ${result.engrams_modified} engrams across ${result.stores_cleaned} stores`)
+      }
+      fs.writeFileSync(sentinel, new Date().toISOString() + '\n', 'utf8')
+    } catch {
+      // Non-fatal — purge will retry next startup
+    }
   }
 
   /**
@@ -1562,22 +1580,39 @@ Generate an improved version of the procedure that prevents this failure. Return
    * Remove all conflict relations from every local engram.
    * Used after tension-detection redesign to clear accumulated false positives.
    */
-  purgeTensions(): { purged_count: number; engrams_modified: number } {
-    const engrams = this._loadCached(this.paths.engrams)
+  purgeTensions(): { purged_count: number; engrams_modified: number; stores_cleaned: number } {
+    // Collect all filesystem store paths (primary + project-scoped + pack stores)
+    const storePaths = new Set<string>()
+    storePaths.add(this.paths.engrams)
+    for (const store of this.config.stores ?? []) {
+      if (store.path && !store.url) storePaths.add(store.path)
+    }
+
     let purgedCount = 0
     let modified = 0
-    for (const e of engrams) {
-      const len = e.relations?.conflicts?.length ?? 0
-      if (len > 0) {
-        e.relations!.conflicts = []
-        purgedCount += len
-        modified++
+    let storesCleaned = 0
+    for (const storePath of storePaths) {
+      try {
+        const engrams = this._loadCached(storePath)
+        let storeModified = 0
+        for (const e of engrams) {
+          const len = e.relations?.conflicts?.length ?? 0
+          if (len > 0) {
+            e.relations!.conflicts = []
+            purgedCount += len
+            modified++
+            storeModified++
+          }
+        }
+        if (storeModified > 0) {
+          this._writeEngrams(storePath, engrams)
+          storesCleaned++
+        }
+      } catch {
+        // Store file missing or unreadable — skip
       }
     }
-    if (modified > 0) {
-      this._writeEngrams(this.paths.engrams, engrams)
-    }
-    return { purged_count: purgedCount, engrams_modified: modified }
+    return { purged_count: purgedCount, engrams_modified: modified, stores_cleaned: storesCleaned }
   }
 
   /**

--- a/packages/core/test/purge-tensions.test.ts
+++ b/packages/core/test/purge-tensions.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-purge-'))
+}
+
+function writeEngrams(path: string, engrams: any[]): void {
+  mkdirSync(join(path, '..').replace(/\/\.\.$/, ''), { recursive: true })
+  writeFileSync(path, yaml.dump({ engrams }), 'utf8')
+}
+
+function readEngrams(path: string): any[] {
+  const raw = readFileSync(path, 'utf8')
+  const data = yaml.load(raw) as any
+  return data?.engrams ?? []
+}
+
+function makeEngram(id: string, conflicts: string[] = []): any {
+  return {
+    id,
+    version: 2,
+    status: 'active',
+    consolidated: false,
+    type: 'behavioral',
+    scope: 'global',
+    visibility: 'private',
+    statement: `Test engram ${id}`,
+    activation: {
+      retrieval_strength: 0.7,
+      storage_strength: 1,
+      frequency: 0,
+      last_accessed: '2026-05-15',
+    },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'apply' },
+    knowledge_anchors: [],
+    associations: [],
+    derivation_count: 1,
+    tags: [],
+    content_hash: id,
+    commitment: 'leaning',
+    engram_version: 1,
+    episode_ids: [],
+    relations: conflicts.length > 0 ? { conflicts } : undefined,
+  }
+}
+
+describe('purgeTensions', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = newDir()
+    mkdirSync(join(dir, 'packs'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('clears conflicts from primary store', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeEngrams(engramsPath, [
+      makeEngram('ENG-001', ['ENG-002', 'ENG-003']),
+      makeEngram('ENG-002', ['ENG-001']),
+      makeEngram('ENG-003'),
+    ])
+
+    const { Plur } = await import('../src/index.js')
+    const plur = new Plur({ path: dir })
+
+    // Auto-purge should have already run in constructor
+    const engrams = readEngrams(engramsPath)
+    const withConflicts = engrams.filter((e: any) => e.relations?.conflicts?.length > 0)
+    expect(withConflicts).toHaveLength(0)
+  })
+
+  it('clears conflicts from project-scoped stores', async () => {
+    // Primary store — no conflicts
+    const primaryPath = join(dir, 'engrams.yaml')
+    writeEngrams(primaryPath, [makeEngram('ENG-001')])
+
+    // Project store — has conflicts
+    const projectDir = join(dir, 'project-store')
+    mkdirSync(projectDir, { recursive: true })
+    const projectPath = join(projectDir, 'engrams.yaml')
+    writeEngrams(projectPath, [
+      makeEngram('ENG-PPL-001', ['ENG-001', 'ENG-PPL-002']),
+      makeEngram('ENG-PPL-002', ['ENG-PPL-001']),
+    ])
+
+    // Config with project store
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ scope: 'project:test', path: projectPath }],
+    }), 'utf8')
+
+    const { Plur } = await import('../src/index.js')
+    const plur = new Plur({ path: dir })
+
+    // Verify project store was cleaned
+    const projectEngrams = readEngrams(projectPath)
+    const withConflicts = projectEngrams.filter((e: any) => e.relations?.conflicts?.length > 0)
+    expect(withConflicts).toHaveLength(0)
+  })
+
+  it('tension_count reaches 0 after purge', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeEngrams(engramsPath, [
+      makeEngram('ENG-001', ['ENG-002']),
+      makeEngram('ENG-002', ['ENG-001']),
+    ])
+
+    const { Plur } = await import('../src/index.js')
+    const plur = new Plur({ path: dir })
+    const status = plur.status()
+    expect(status.tension_count).toBe(0)
+  })
+
+  it('creates sentinel file after auto-purge', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeEngrams(engramsPath, [makeEngram('ENG-001', ['ENG-002'])])
+
+    const { Plur } = await import('../src/index.js')
+    new Plur({ path: dir })
+
+    expect(existsSync(join(dir, '.tensions-purged'))).toBe(true)
+  })
+
+  it('skips auto-purge when sentinel exists', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeEngrams(engramsPath, [
+      makeEngram('ENG-001', ['ENG-002']),
+      makeEngram('ENG-002', ['ENG-001']),
+    ])
+
+    // Create sentinel BEFORE constructing Plur
+    writeFileSync(join(dir, '.tensions-purged'), '2026-05-15T00:00:00Z\n', 'utf8')
+
+    const { Plur } = await import('../src/index.js')
+    const plur = new Plur({ path: dir })
+
+    // Conflicts should still be there (purge was skipped)
+    const engrams = readEngrams(engramsPath)
+    const withConflicts = engrams.filter((e: any) => e.relations?.conflicts?.length > 0)
+    expect(withConflicts).toHaveLength(2)
+  })
+
+  it('preserves engram content after purge (only conflicts cleared)', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeEngrams(engramsPath, [
+      makeEngram('ENG-001', ['ENG-002']),
+    ])
+
+    const { Plur } = await import('../src/index.js')
+    const plur = new Plur({ path: dir })
+
+    const engrams = readEngrams(engramsPath)
+    expect(engrams[0].id).toBe('ENG-001')
+    expect(engrams[0].statement).toBe('Test engram ENG-001')
+    expect(engrams[0].type).toBe('behavioral')
+    expect(engrams[0].status).toBe('active')
+  })
+
+  it('manual purgeTensions returns correct counts', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeEngrams(engramsPath, [
+      makeEngram('ENG-001', ['ENG-002', 'ENG-003']),
+      makeEngram('ENG-002', ['ENG-001']),
+      makeEngram('ENG-003'),
+    ])
+
+    // Delete sentinel so auto-purge doesn't interfere
+    // (constructor will auto-purge, so we test via fresh call)
+    const { Plur } = await import('../src/index.js')
+
+    // Create sentinel to skip auto-purge
+    writeFileSync(join(dir, '.tensions-purged'), 'skip\n', 'utf8')
+    const plur = new Plur({ path: dir })
+
+    // Remove sentinel and re-purge manually
+    rmSync(join(dir, '.tensions-purged'))
+    const result = plur.purgeTensions()
+    expect(result.purged_count).toBe(3) // ENG-001 has 2 + ENG-002 has 1
+    expect(result.engrams_modified).toBe(2) // ENG-001 and ENG-002
+    expect(result.stores_cleaned).toBe(1) // primary store
+  })
+
+  it('skips remote stores (cannot write)', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeEngrams(engramsPath, [makeEngram('ENG-001')])
+
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ scope: 'group:test', url: 'https://plur.example.com', token: 'fake' }],
+    }), 'utf8')
+
+    const { Plur } = await import('../src/index.js')
+    // Should not throw trying to write to remote store
+    const plur = new Plur({ path: dir })
+    const result = plur.purgeTensions()
+    expect(result.stores_cleaned).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes incomplete tension purge from PR #138. The original fix prevented new false positives but `purgeTensions()` only cleaned the primary store. Project-scoped stores retained 12,918 legacy conflict refs across 25 pack engrams.

## Root cause

- `purgeTensions()` hardcoded `this.paths.engrams` (primary store only)
- Project stores (`project:plur`, `project:Data`) were never cleaned
- No auto-purge on upgrade — relied on manual `plur_tensions_purge` tool call
- User was on v0.7.7 (stale install), so conflicts kept accumulating

## Changes

| File | Change |
|------|--------|
| `packages/core/src/index.ts` | `purgeTensions()` iterates all filesystem stores. Auto-purge in constructor with sentinel file. |
| `packages/core/test/purge-tensions.test.ts` | **NEW** — 8 tests |

## What the fix does

1. **`purgeTensions()` cleans all stores**: primary + all `config.stores` with filesystem paths. Skips remote stores.
2. **Auto-purge migration**: On `Plur()` construction, if `~/.plur/.tensions-purged` doesn't exist, runs purge once and creates the sentinel. Idempotent — subsequent startups skip.
3. **Returns `stores_cleaned` count** in addition to existing `purged_count` and `engrams_modified`.

## Test plan

- [x] 8/8 purge-tensions tests pass
- [x] Build clean
- [ ] Verify on VM: tension_count = 0 after upgrade

Closes #156