### PR TITLE
fix: SQLite test failures — enable better-sqlite3 native binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       "minimatch": ">=10.0.3",
       "path-to-regexp": ">=8.4.0",
       "fast-xml-builder": ">=1.1.7"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }


### PR DESCRIPTION
Resolves 17 pre-existing SQLite test failures across \`storage-indexed.test.ts\`, \`multi-store.test.ts\`, and \`store-contract.test.ts\`.

## Root cause

pnpm 10 disables postinstall scripts by default for security. \`better-sqlite3\` needs its postinstall to run \`node-gyp rebuild\` and produce \`build/Release/better_sqlite3.node\`. Without it, every \`new Database(path)\` call throws ENOENT — the \`bindings\` package walks 8 candidate paths and finds none of them:

\`\`\`
build/Release/better_sqlite3.node
build/Debug/better_sqlite3.node
build/default/better_sqlite3.node
compiled/24.10.0/darwin/arm64/better_sqlite3.node
addon-build/release/install-root/better_sqlite3.node
addon-build/debug/install-root/better_sqlite3.node
addon-build/default/install-root/better_sqlite3.node
lib/binding/node-v137-darwin-arm64/better_sqlite3.node
\`\`\`

## Fix

Add \`pnpm.onlyBuiltDependencies: ["better-sqlite3"]\` to root \`package.json\`. Whitelists the postinstall for just that one package. Other ignored build scripts (\`esbuild\`, \`openclaw\`, \`protobufjs\`, \`tree-sitter-bash\`, \`@google/genai\`) remain disabled — none have evidence of being needed for tests or builds.

## Verification

- \`pnpm install\` rebuilds the binary (~32s on first install — node-gyp full compile)
- Targeted SQLite tests: **43/43 passed** (was 0/17 before)
- Full \`pnpm test\` suite: **892 passed, 10 skipped, 0 failed** (was 875 passed, 17 failed)

## Test plan

- [ ] CI green on Node 20 + 22 matrix (postinstall must succeed in CI environment)
- [ ] Verify \`better_sqlite3.node\` is produced after fresh \`pnpm install\` on a clean checkout