### PR TITLE
docs(core,mcp): clarify batchDecay local-only scope and decay ownership (#91)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1271,9 +1271,15 @@ export class Plur {
   }
 
   /**
-   * Apply ACT-R decay to all primary store engrams.
+   * Apply ACT-R decay to all primary (local YAML) store engrams.
    * Scope-matched engrams are skipped, status transitions logged to history.
    * Modified engrams are saved back to the store.
+   *
+   * Decay ownership: the enterprise server does NOT run decay server-side
+   * (see plur-ai/enterprise ARCHITECTURE.md — decay belongs in @plur-ai/core).
+   * Remote-store engrams are intentionally excluded here because multiple
+   * clients decaying the same shared store would cause conflicts. A dedicated
+   * server-side decay endpoint is tracked separately.
    */
   batchDecay(options?: { contextScope?: string; lambda?: number; now?: Date }): BatchDecayResult {
     return withLock(this.paths.engrams, () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1557,7 +1557,7 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
 
     {
       name: 'plur_batch_decay',
-      description: 'Apply ACT-R decay to all engrams. Run weekly. Returns status transitions only.',
+      description: 'Apply ACT-R decay to all local engrams. Run weekly. Only decays engrams in the local YAML store — remote-store engrams are not decayed client-side. Returns status transitions only.',
       annotations: { title: 'Batch decay', destructiveHint: false, idempotentHint: false },
       inputSchema: {
         type: 'object',


### PR DESCRIPTION
## Summary

- Documents that `batchDecay()` only applies ACT-R decay to **local YAML engrams**, not remote-store engrams
- Explains the why: the enterprise server does not run server-side decay by design (per `plur-ai/enterprise ARCHITECTURE.md`), and client-side decay of shared remote stores would cause conflicts across clients
- Updates `plur_batch_decay` MCP tool description to say "local engrams" instead of "all engrams" — the current wording implies remote stores are included, which is incorrect

## Background

Closes the documentation gap from #91. Audited `plur-ai/enterprise` to confirm:
- No cron job, background task, or decay endpoint exists in the enterprise server
- `ARCHITECTURE.md` explicitly states decay belongs in `@plur-ai/core`
- Decay is an intentional client responsibility

A dedicated server-side decay endpoint (so clients can trigger decay on their remote-store engrams without conflicts) is the recommended follow-on — tracked as a separate enhancement per the comment posted on #91.

## Test plan

- [ ] No logic changes — doc update only, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)