### PR TITLE
feat(core): telemetry gate, per-event counters, and daily flush (D-2 of #51, H005)

### DIFF
--- a/packages/core/src/telemetry-counters.ts
+++ b/packages/core/src/telemetry-counters.ts
@@ -1,0 +1,289 @@
+// Per-event counters for telemetry (slice D-2a of #51).
+//
+// Pure file-local plumbing: increment hooks at plur_learn / plur_recall_hybrid
+// success persist to ~/.plur/telemetry-counters.json. NO network code lives here;
+// transport is D-2b's territory and imports getCounters/resetCounters from this
+// module.
+//
+// Privacy invariant: every public function MUST short-circuit on
+// !isTelemetryEnabled() BEFORE any filesystem call. A default-off install must
+// produce zero filesystem writes under ~/.plur/ for telemetry. The
+// "default-off install touches zero files" test is the load-bearing guard.
+//
+// Session semantics (silent-ratified default-pick B, 2026-05-02T12:00Z, #51):
+// 'session' fires on the first 'learn' or 'recall' recorded within a UTC day.
+// No standalone session call site.
+//
+// Day-rollover safety (#128): on rollover, yesterday's snapshot is moved to a
+// pending-flush directory (~/.plur/telemetry-pending/<date>.json) BEFORE
+// counters.json is rewritten for today. flushIfNeeded drains that directory.
+// Without this, a long-lived process emitting an event after midnight would
+// silently overwrite yesterday's data on disk.
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+import { isTelemetryEnabled } from './telemetry.js'
+
+export type CounterEvent = 'learn' | 'recall' | 'session'
+
+export type CounterSnapshot = {
+  installId: string
+  date: string
+  learn: number
+  recall: number
+  session: number
+}
+
+export type CountersOpts = {
+  env?: NodeJS.ProcessEnv
+  configPath?: string
+  countersPath?: string
+  installIdPath?: string
+  pendingDir?: string
+  now?: () => Date
+}
+
+function defaultCountersPath(): string {
+  return join(homedir(), '.plur', 'telemetry-counters.json')
+}
+
+function defaultInstallIdPath(): string {
+  return join(homedir(), '.plur', 'install-id')
+}
+
+function defaultPendingDir(): string {
+  return join(homedir(), '.plur', 'telemetry-pending')
+}
+
+function utcDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+function gateOpts(opts: CountersOpts): { env?: NodeJS.ProcessEnv; configPath?: string } {
+  return { env: opts.env, configPath: opts.configPath }
+}
+
+function ensureParentDir(path: string): void {
+  const dir = dirname(path)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+}
+
+function atomicWriteJson(path: string, data: unknown): void {
+  ensureParentDir(path)
+  const tmp = `${path}.tmp.${process.pid}`
+  writeFileSync(tmp, JSON.stringify(data), { encoding: 'utf8', mode: 0o600 })
+  renameSync(tmp, path)
+}
+
+function atomicWriteString(path: string, data: string): void {
+  ensureParentDir(path)
+  const tmp = `${path}.tmp.${process.pid}`
+  writeFileSync(tmp, data, { encoding: 'utf8', mode: 0o600 })
+  renameSync(tmp, path)
+}
+
+function readOrCreateInstallId(path: string): string {
+  if (existsSync(path)) {
+    const raw = readFileSync(path, 'utf8').trim()
+    if (raw.length > 0) return raw
+  }
+  const id = randomUUID()
+  atomicWriteString(path, id)
+  return id
+}
+
+type StoredCounters = {
+  date: string
+  learn: number
+  recall: number
+  session: number
+}
+
+function readStoredCounters(path: string): StoredCounters | null {
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'))
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.date === 'string' &&
+      typeof parsed.learn === 'number' &&
+      typeof parsed.recall === 'number' &&
+      typeof parsed.session === 'number'
+    ) {
+      return parsed as StoredCounters
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function freshCounters(date: string): StoredCounters {
+  return { date, learn: 0, recall: 0, session: 0 }
+}
+
+// Synthesize a today-dated snapshot for callers that just want a current-day
+// view (getCounters). Never used by recordEvent — recordEvent moves stale
+// state to pending-dir before defaulting to fresh.
+function viewAsToday(stored: StoredCounters | null, today: string): StoredCounters {
+  if (!stored || stored.date !== today) return freshCounters(today)
+  return stored
+}
+
+function moveToPending(stored: StoredCounters, pendingDir: string): void {
+  const path = join(pendingDir, `${stored.date}.json`)
+  // If a pending file already exists for this date (e.g. multiple processes
+  // each detected the same rollover), merge counts so we don't double-count
+  // OR drop the smaller snapshot.
+  const existing = readStoredCounters(path)
+  const merged: StoredCounters =
+    existing && existing.date === stored.date
+      ? {
+          date: stored.date,
+          learn: existing.learn + stored.learn,
+          recall: existing.recall + stored.recall,
+          session: Math.max(existing.session, stored.session),
+        }
+      : stored
+  atomicWriteJson(path, merged)
+}
+
+export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): boolean {
+  if (!isTelemetryEnabled(gateOpts(opts))) return false
+
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const installIdPath = opts.installIdPath ?? defaultInstallIdPath()
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+
+  readOrCreateInstallId(installIdPath)
+
+  const stored = readStoredCounters(countersPath)
+  let current: StoredCounters
+  let rolledOver = false
+  if (stored && stored.date !== today) {
+    // Rollover: preserve yesterday's snapshot in pending-dir BEFORE overwriting
+    // counters.json with today's fresh state. This is the load-bearing fix for
+    // #128 — without it, a long-lived process emitting an event after midnight
+    // would silently discard yesterday's counts.
+    moveToPending(stored, pendingDir)
+    current = freshCounters(today)
+    rolledOver = true
+  } else {
+    current = stored ?? freshCounters(today)
+  }
+  const sessionAlreadyCounted = current.session > 0
+
+  if (event === 'learn') current.learn += 1
+  else if (event === 'recall') current.recall += 1
+  else if (event === 'session') current.session += 1
+
+  if ((event === 'learn' || event === 'recall') && !sessionAlreadyCounted) {
+    current.session += 1
+  }
+
+  atomicWriteJson(countersPath, current)
+  return rolledOver
+}
+
+// Pending-flush directory helpers (#128). flushIfNeeded uses these to drain
+// per-day snapshots that recordEvent stashed on rollover.
+
+export function listPendingDates(opts: CountersOpts = {}): string[] {
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  if (!existsSync(pendingDir)) return []
+  try {
+    return readdirSync(pendingDir)
+      .filter((f) => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
+      .map((f) => f.slice(0, -5))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+export function readPendingCounters(date: string, opts: CountersOpts = {}): StoredCounters | null {
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  return readStoredCounters(join(pendingDir, `${date}.json`))
+}
+
+export function deletePending(date: string, opts: CountersOpts = {}): void {
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  try {
+    unlinkSync(join(pendingDir, `${date}.json`))
+  } catch {
+    /* ignore — already gone */
+  }
+}
+
+// Migration helper: if counters.json holds a stale date (e.g. upgrade from a
+// pre-#128 install), shunt it into pending-dir so flushIfNeeded picks it up.
+// Returns true when migration ran.
+export function migrateStaleCounters(opts: CountersOpts = {}): boolean {
+  if (!isTelemetryEnabled(gateOpts(opts))) return false
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const pendingDir = opts.pendingDir ?? defaultPendingDir()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+  const stored = readStoredCounters(countersPath)
+  if (!stored || stored.date >= today) return false
+  moveToPending(stored, pendingDir)
+  atomicWriteJson(countersPath, freshCounters(today))
+  return true
+}
+
+export function getCounters(opts: CountersOpts = {}): CounterSnapshot | null {
+  if (!isTelemetryEnabled(gateOpts(opts))) return null
+
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const installIdPath = opts.installIdPath ?? defaultInstallIdPath()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+
+  const installId = readOrCreateInstallId(installIdPath)
+  const stored = viewAsToday(readStoredCounters(countersPath), today)
+
+  return {
+    installId,
+    date: stored.date,
+    learn: stored.learn,
+    recall: stored.recall,
+    session: stored.session,
+  }
+}
+
+export function resetCounters(opts: CountersOpts = {}): CounterSnapshot | null {
+  if (!isTelemetryEnabled(gateOpts(opts))) return null
+
+  const countersPath = opts.countersPath ?? defaultCountersPath()
+  const installIdPath = opts.installIdPath ?? defaultInstallIdPath()
+  const now = (opts.now ?? (() => new Date()))()
+  const today = utcDate(now)
+
+  const installId = readOrCreateInstallId(installIdPath)
+  const fresh = freshCounters(today)
+  atomicWriteJson(countersPath, fresh)
+
+  return {
+    installId,
+    date: fresh.date,
+    learn: fresh.learn,
+    recall: fresh.recall,
+    session: fresh.session,
+  }
+}

--- a/packages/core/src/telemetry-flush.ts
+++ b/packages/core/src/telemetry-flush.ts
@@ -1,0 +1,173 @@
+// Daily flush + POST /v1/heartbeat (slice D-2b of #51).
+//
+// Imports the gate (`isTelemetryEnabled`) and the counter snapshot
+// (`getCounters` / `resetCounters`) from sibling modules. Owns the network.
+//
+// Privacy invariants (each pinned by a test):
+//   1. Default-off install makes zero network calls.
+//   2. Telemetry-on but no counter file → zero network calls.
+//
+// Trigger semantics: flush drains the pending-flush directory written by
+// `recordEvent` on day-rollover (#128). Two call sites:
+//   - rollover: `recordEvent` returns `true` from its rollover branch; callers
+//     fire `flushIfNeeded` async
+//   - exit: `registerFlushOnExit` registered from cli startup (best-effort)
+// No setInterval, no background polling.
+//
+// Failure semantics: `sendHeartbeat` never throws. On any failure (network,
+// timeout, non-2xx) it returns false; pending files stay on disk for the next
+// rollover or process restart to retry.
+
+import { dirname, join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { isTelemetryEnabled } from './telemetry.js'
+import {
+  deletePending,
+  getCounters,
+  listPendingDates,
+  migrateStaleCounters,
+  readPendingCounters,
+  type CounterSnapshot,
+  type CountersOpts,
+} from './telemetry-counters.js'
+
+export type HeartbeatPayload = {
+  install_id: string
+  version: string
+  platform: NodeJS.Platform
+  date: string
+  learn_count: number
+  recall_count: number
+  session_count: number
+}
+
+export type FlushOpts = CountersOpts & {
+  fetch?: typeof globalThis.fetch
+  endpoint?: string
+  timeoutMs?: number
+  packageVersion?: string
+}
+
+const DEFAULT_ENDPOINT = 'https://heartbeat.plur-ai.org/v1/heartbeat'
+const DEFAULT_TIMEOUT_MS = 5000
+
+function resolveEndpoint(opts: FlushOpts): string {
+  if (opts.endpoint) return opts.endpoint
+  const env = opts.env ?? process.env
+  return env.PLUR_TELEMETRY_ENDPOINT ?? DEFAULT_ENDPOINT
+}
+
+let cachedPackageVersion: string | null = null
+
+function readPackageVersion(): string {
+  if (cachedPackageVersion !== null) return cachedPackageVersion
+  try {
+    const here = dirname(fileURLToPath(import.meta.url))
+    // src → package root: ../package.json (when running tests against src)
+    // dist → package root: ../package.json (when running built)
+    const pkgPath = join(here, '..', 'package.json')
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+    cachedPackageVersion = typeof pkg.version === 'string' ? pkg.version : 'unknown'
+  } catch {
+    cachedPackageVersion = 'unknown'
+  }
+  return cachedPackageVersion
+}
+
+export function buildHeartbeatPayload(
+  snapshot: CounterSnapshot,
+  opts: Pick<FlushOpts, 'env' | 'packageVersion'> = {},
+): HeartbeatPayload {
+  return {
+    install_id: snapshot.installId,
+    version: opts.packageVersion ?? readPackageVersion(),
+    platform: process.platform,
+    date: snapshot.date,
+    learn_count: snapshot.learn,
+    recall_count: snapshot.recall,
+    session_count: snapshot.session,
+  }
+}
+
+export async function sendHeartbeat(
+  payload: HeartbeatPayload,
+  opts: FlushOpts = {},
+): Promise<boolean> {
+  const endpoint = resolveEndpoint(opts)
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const fetchImpl = opts.fetch ?? globalThis.fetch
+
+  if (!fetchImpl) return false
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export async function flushIfNeeded(opts: FlushOpts = {}): Promise<void> {
+  if (!isTelemetryEnabled({ env: opts.env, configPath: opts.configPath })) return
+
+  const countersPath = opts.countersPath
+  // Privacy invariant 2: telemetry-on but no on-disk state → zero network.
+  // When countersPath is set (tests), if it's missing AND pending-dir has
+  // nothing, we have no data to ship. In production (no countersPath), the
+  // pending-dir check below handles the empty case.
+  if (countersPath && !existsSync(countersPath) && listPendingDates(opts).length === 0) return
+
+  // Migrate any stale counters.json (e.g. upgrade from pre-#128, or beforeExit
+  // firing after midnight on a process that never re-recorded). Adds an entry
+  // to pending-dir; the drain loop below ships it.
+  migrateStaleCounters(opts)
+
+  // getCounters gives us install_id; we ignore its date/counts and instead
+  // ship each pending file as its own heartbeat.
+  const baseSnapshot = getCounters(opts)
+  if (!baseSnapshot) return
+
+  for (const date of listPendingDates(opts)) {
+    const pending = readPendingCounters(date, opts)
+    if (!pending) {
+      // Malformed or already-removed; drop the file so we don't loop on it.
+      deletePending(date, opts)
+      continue
+    }
+    const snapshot: CounterSnapshot = {
+      installId: baseSnapshot.installId,
+      date: pending.date,
+      learn: pending.learn,
+      recall: pending.recall,
+      session: pending.session,
+    }
+    const payload = buildHeartbeatPayload(snapshot, opts)
+    const ok = await sendHeartbeat(payload, opts)
+    if (ok) deletePending(date, opts)
+    // On failure, file stays on disk and is retried on next flush.
+  }
+}
+
+export function registerFlushOnExit(opts: FlushOpts = {}): () => void {
+  let fired = false
+  const handler = () => {
+    if (fired) return
+    fired = true
+    void flushIfNeeded(opts).catch(() => {})
+  }
+  process.once('beforeExit', handler)
+  return () => {
+    process.off('beforeExit', handler)
+  }
+}

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -1,0 +1,62 @@
+// Opt-in telemetry gate.
+//
+// Resolution order (last writer wins on ties; only `on` activates the gate):
+//   1. PLUR_TELEMETRY env var — `on` | `off` (any other value is treated as unset)
+//   2. Persisted preference at ~/.plur/telemetry.json — { enabled: boolean }
+//   3. Default: 'off' (non-interactive installs never opt in implicitly)
+//
+// This file is the gate only. No counters, no flush, no transport — those land
+// in follow-up commits behind a state of `on`. See docs/telemetry-design.md.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export type TelemetryState = 'on' | 'off'
+export type TelemetrySource = 'env' | 'config' | 'default'
+
+export type TelemetryResolution = {
+  state: TelemetryState
+  source: TelemetrySource
+  configPath: string
+}
+
+function resolveConfigPath(): string {
+  return join(homedir(), '.plur', 'telemetry.json')
+}
+
+function readEnv(env: NodeJS.ProcessEnv): TelemetryState | null {
+  const raw = env.PLUR_TELEMETRY
+  if (raw === 'on') return 'on'
+  if (raw === 'off') return 'off'
+  return null
+}
+
+function readConfig(path: string): TelemetryState | null {
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'))
+    if (parsed && typeof parsed === 'object' && parsed.enabled === true) return 'on'
+    if (parsed && typeof parsed === 'object' && parsed.enabled === false) return 'off'
+    return null
+  } catch {
+    return null
+  }
+}
+
+export function resolveTelemetry(opts: { env?: NodeJS.ProcessEnv; configPath?: string } = {}): TelemetryResolution {
+  const env = opts.env ?? process.env
+  const configPath = opts.configPath ?? resolveConfigPath()
+
+  const fromEnv = readEnv(env)
+  if (fromEnv !== null) return { state: fromEnv, source: 'env', configPath }
+
+  const fromConfig = readConfig(configPath)
+  if (fromConfig !== null) return { state: fromConfig, source: 'config', configPath }
+
+  return { state: 'off', source: 'default', configPath }
+}
+
+export function isTelemetryEnabled(opts?: { env?: NodeJS.ProcessEnv; configPath?: string }): boolean {
+  return resolveTelemetry(opts).state === 'on'
+}

--- a/packages/core/test/telemetry-counters.test.ts
+++ b/packages/core/test/telemetry-counters.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  recordEvent,
+  getCounters,
+  resetCounters,
+  listPendingDates,
+  readPendingCounters,
+  type CountersOpts,
+} from '../src/telemetry-counters.js'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-counters-'))
+}
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('telemetry counters (#51 slice D-2a)', () => {
+  let dir: string
+  let countersPath: string
+  let installIdPath: string
+  let pendingDir: string
+  let configPath: string
+
+  beforeEach(() => {
+    dir = newDir()
+    countersPath = join(dir, 'counters.json')
+    installIdPath = join(dir, 'install-id')
+    pendingDir = join(dir, 'pending')
+    configPath = join(dir, 'telemetry.json')
+  })
+
+  function offOpts(extra: Partial<CountersOpts> = {}): CountersOpts {
+    return { env: {}, configPath, countersPath, installIdPath, pendingDir, ...extra }
+  }
+
+  function onOpts(extra: Partial<CountersOpts> = {}): CountersOpts {
+    return {
+      env: { PLUR_TELEMETRY: 'on' },
+      configPath,
+      countersPath,
+      installIdPath,
+      pendingDir,
+      ...extra,
+    }
+  }
+
+  it('default-off install touches zero files (recordEvent)', () => {
+    recordEvent('learn', offOpts())
+    recordEvent('recall', offOpts())
+    recordEvent('session', offOpts())
+    expect(readdirSync(dir)).toEqual([])
+  })
+
+  it('default-off install touches zero files (getCounters / resetCounters return null)', () => {
+    expect(getCounters(offOpts())).toBeNull()
+    expect(resetCounters(offOpts())).toBeNull()
+    expect(readdirSync(dir)).toEqual([])
+  })
+
+  it('env-on fresh install: recordEvent("learn") creates both files', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    expect(existsSync(installIdPath)).toBe(true)
+    expect(existsSync(countersPath)).toBe(true)
+    const installId = readFileSync(installIdPath, 'utf8')
+    expect(installId).toMatch(UUID_V4)
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on repeated events accumulate without re-counting session', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    recordEvent('learn', opts)
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+    recordEvent('recall', opts)
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 3, recall: 2, session: 1 })
+  })
+
+  it('env-on day rollover resets counters and re-arms session on next learn', () => {
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 5, recall: 2, session: 1 }),
+    )
+    const fixedNow = () => new Date('2026-05-02T00:30:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on rollover preserves yesterday in pending-dir (#128)', () => {
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 5, recall: 2, session: 1 }),
+    )
+    const fixedNow = () => new Date('2026-05-02T00:30:00Z')
+    const rolled = recordEvent('learn', onOpts({ now: fixedNow }))
+
+    expect(rolled).toBe(true)
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-01'])
+    const yesterday = readPendingCounters('2026-05-01', { pendingDir })
+    expect(yesterday).toEqual({ date: '2026-05-01', learn: 5, recall: 2, session: 1 })
+    // And today's counters.json starts fresh
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on within-day record does not signal rollover', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    expect(recordEvent('learn', opts)).toBe(false)
+    expect(recordEvent('recall', opts)).toBe(false)
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('env-on rollover merges with existing pending file for same date (#128)', () => {
+    // Scenario: pending/<day1>.json already exists (prior rollover whose flush
+    // failed), then counters.json gets rewritten to day1 again (e.g. crash
+    // restore from a backup) and another rollover fires. Pending should
+    // accumulate, not be overwritten.
+    const day2 = () => new Date('2026-05-02T00:30:00Z')
+
+    // First rollover: day1(3/1/1) → pending
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 3, recall: 1, session: 1 }),
+    )
+    recordEvent('learn', onOpts({ now: day2 }))
+
+    // Simulate counters.json reverting to a day1 state again (different counts)
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 2, recall: 4, session: 1 }),
+    )
+    recordEvent('learn', onOpts({ now: day2 }))
+
+    const merged = readPendingCounters('2026-05-01', { pendingDir })
+    expect(merged).toEqual({
+      date: '2026-05-01',
+      learn: 3 + 2,
+      recall: 1 + 4,
+      session: 1,
+    })
+  })
+
+  it('env-on malformed counters file: parse-fails treated as missing, fresh write', () => {
+    writeFileSync(countersPath, '{ this is not json')
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('env-on install-id stable across recordEvent calls', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    const first = readFileSync(installIdPath, 'utf8')
+    recordEvent('recall', opts)
+    const second = readFileSync(installIdPath, 'utf8')
+
+    expect(first).toMatch(UUID_V4)
+    expect(second).toBe(first)
+  })
+
+  it('env-on stale .tmp file from prior crash does not poison next write', () => {
+    const stale = `${countersPath}.tmp.999999`
+    writeFileSync(stale, 'corrupt-half-written')
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    recordEvent('learn', onOpts({ now: fixedNow }))
+
+    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
+    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+  })
+
+  it('getCounters returns snapshot with installId and current state', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    recordEvent('learn', opts)
+
+    const snap = getCounters(opts)
+    expect(snap).not.toBeNull()
+    expect(snap!.installId).toMatch(UUID_V4)
+    expect(snap!.date).toBe('2026-05-02')
+    expect(snap!.learn).toBe(2)
+    expect(snap!.recall).toBe(0)
+    expect(snap!.session).toBe(1)
+  })
+
+  it('resetCounters zeroes the file but preserves installId', () => {
+    const fixedNow = () => new Date('2026-05-02T18:00:00Z')
+    const opts = onOpts({ now: fixedNow })
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+    const installIdBefore = readFileSync(installIdPath, 'utf8')
+
+    const after = resetCounters(opts)
+    expect(after).not.toBeNull()
+    expect(after!.learn).toBe(0)
+    expect(after!.recall).toBe(0)
+    expect(after!.session).toBe(0)
+    expect(after!.date).toBe('2026-05-02')
+    expect(after!.installId).toBe(installIdBefore)
+
+    const installIdAfter = readFileSync(installIdPath, 'utf8')
+    expect(installIdAfter).toBe(installIdBefore)
+  })
+})

--- a/packages/core/test/telemetry-flush.test.ts
+++ b/packages/core/test/telemetry-flush.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  buildHeartbeatPayload,
+  flushIfNeeded,
+  type FlushOpts,
+} from '../src/telemetry-flush.js'
+import {
+  listPendingDates,
+  recordEvent,
+  type CounterSnapshot,
+} from '../src/telemetry-counters.js'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-flush-'))
+}
+
+describe('telemetry flush (#51 slice D-2b)', () => {
+  let dir: string
+  let countersPath: string
+  let installIdPath: string
+  let pendingDir: string
+  let configPath: string
+
+  beforeEach(() => {
+    dir = newDir()
+    countersPath = join(dir, 'counters.json')
+    installIdPath = join(dir, 'install-id')
+    pendingDir = join(dir, 'pending')
+    configPath = join(dir, 'telemetry.json')
+  })
+
+  function offOpts(extra: Partial<FlushOpts> = {}): FlushOpts {
+    return { env: {}, configPath, countersPath, installIdPath, pendingDir, ...extra }
+  }
+
+  function onOpts(extra: Partial<FlushOpts> = {}): FlushOpts {
+    return {
+      env: { PLUR_TELEMETRY: 'on' },
+      configPath,
+      countersPath,
+      installIdPath,
+      pendingDir,
+      ...extra,
+    }
+  }
+
+  type CapturedPost = { body: any; ok: boolean }
+  function captureFetch(initial: { ok: boolean } = { ok: true }) {
+    const calls: CapturedPost[] = []
+    let nextOk = initial.ok
+    const fakeFetch = (async (_url: string, init: any) => {
+      const parsed = init?.body ? JSON.parse(init.body as string) : null
+      calls.push({ body: parsed, ok: nextOk })
+      return { ok: nextOk } as Response
+    }) as unknown as typeof globalThis.fetch
+    return { calls, fakeFetch, setNextOk: (v: boolean) => (nextOk = v) }
+  }
+
+  it('default-off install makes zero network calls (invariant 1)', async () => {
+    let fetchCalls = 0
+    const fakeFetch = (async () => {
+      fetchCalls++
+      throw new Error('should never run')
+    }) as unknown as typeof globalThis.fetch
+
+    // Pre-stage a stale counter file so the gate is the only thing protecting us.
+    writeFileSync(
+      countersPath,
+      JSON.stringify({ date: '2026-05-01', learn: 5, recall: 10, session: 3 }),
+    )
+
+    await flushIfNeeded(offOpts({ fetch: fakeFetch, now: () => new Date('2026-05-11T00:00:00Z') }))
+    expect(fetchCalls).toBe(0)
+  })
+
+  it('telemetry-on but no counter file → zero network calls (invariant 2)', async () => {
+    let fetchCalls = 0
+    const fakeFetch = (async () => {
+      fetchCalls++
+      throw new Error('should never run')
+    }) as unknown as typeof globalThis.fetch
+
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: () => new Date('2026-05-11T00:00:00Z') }))
+    expect(fetchCalls).toBe(0)
+  })
+
+  it('buildHeartbeatPayload produces the exact contract shape', () => {
+    const snapshot: CounterSnapshot = {
+      installId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      date: '2026-05-10',
+      learn: 7,
+      recall: 23,
+      session: 2,
+    }
+    const payload = buildHeartbeatPayload(snapshot, { packageVersion: '0.9.14' })
+    expect(payload).toEqual({
+      install_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      version: '0.9.14',
+      platform: process.platform,
+      date: '2026-05-10',
+      learn_count: 7,
+      recall_count: 23,
+      session_count: 2,
+    })
+    // Locked contract: no extra keys (server rejects them).
+    expect(Object.keys(payload).sort()).toEqual([
+      'date',
+      'install_id',
+      'learn_count',
+      'platform',
+      'recall_count',
+      'session_count',
+      'version',
+    ])
+  })
+
+  // -----------------------------------------------------------------------
+  // #128 acceptance: day-rollover flush race
+  // -----------------------------------------------------------------------
+
+  it('long-lived process across midnight: yesterday posted, not discarded (#128)', async () => {
+    const { calls, fakeFetch } = captureFetch()
+
+    // Day Y: emit events.
+    const dayY = () => new Date('2026-05-10T18:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+    recordEvent('recall', onOpts({ now: dayY }))
+    recordEvent('recall', onOpts({ now: dayY }))
+
+    // Sanity: counters.json holds day Y data.
+    expect(JSON.parse(readFileSync(countersPath, 'utf8'))).toEqual({
+      date: '2026-05-10',
+      learn: 1,
+      recall: 2,
+      session: 1,
+    })
+
+    // Cross midnight: emit event on day Y+1. Yesterday's snapshot moves to pending.
+    const dayY1 = () => new Date('2026-05-11T00:30:00Z')
+    const rolled = recordEvent('learn', onOpts({ now: dayY1 }))
+    expect(rolled).toBe(true)
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-10'])
+
+    // Flush fires; yesterday gets POSTed.
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(calls[0].body.learn_count).toBe(1)
+    expect(calls[0].body.recall_count).toBe(2)
+    expect(calls[0].body.session_count).toBe(1)
+
+    // Pending file is cleaned up after successful flush.
+    expect(listPendingDates({ pendingDir })).toEqual([])
+    // Today's counters intact (the learn that crossed midnight).
+    expect(JSON.parse(readFileSync(countersPath, 'utf8'))).toEqual({
+      date: '2026-05-11',
+      learn: 1,
+      recall: 0,
+      session: 1,
+    })
+  })
+
+  it('beforeExit on process that crossed midnight without re-recording posts yesterday (#128)', async () => {
+    const { calls, fakeFetch } = captureFetch()
+
+    // Day Y: emit events.
+    const dayY = () => new Date('2026-05-10T18:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+    recordEvent('learn', onOpts({ now: dayY }))
+
+    // Day Y+1: NO new recordEvent — beforeExit fires while counters.json
+    // still has yesterday's date.
+    const dayY1 = () => new Date('2026-05-11T03:00:00Z')
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(calls[0].body.learn_count).toBe(2)
+
+    // After migration, counters.json is empty-today, pending drained.
+    expect(listPendingDates({ pendingDir })).toEqual([])
+    expect(JSON.parse(readFileSync(countersPath, 'utf8'))).toEqual({
+      date: '2026-05-11',
+      learn: 0,
+      recall: 0,
+      session: 0,
+    })
+  })
+
+  it('process killed before midnight: next-startup flush drains pending (#128)', async () => {
+    // Day Y old process: emits events, gets killed (no beforeExit, no flush).
+    const dayY = () => new Date('2026-05-10T22:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+    recordEvent('recall', onOpts({ now: dayY }))
+
+    // Day Y+1 new process starts, records an event (triggers rollover to pending).
+    const dayY1 = () => new Date('2026-05-11T08:00:00Z')
+    recordEvent('recall', onOpts({ now: dayY1 }))
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-10'])
+
+    // Startup flush.
+    const { calls, fakeFetch } = captureFetch()
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('flush failure leaves pending file on disk for retry (#128)', async () => {
+    const { calls, fakeFetch, setNextOk } = captureFetch({ ok: false })
+
+    const dayY = () => new Date('2026-05-10T18:00:00Z')
+    recordEvent('learn', onOpts({ now: dayY }))
+
+    const dayY1 = () => new Date('2026-05-11T00:30:00Z')
+    recordEvent('learn', onOpts({ now: dayY1 }))
+
+    // First flush: server says no.
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.date).toBe('2026-05-10')
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-10']) // still there
+
+    // Server recovers. Retry: pending drains.
+    setNextOk(true)
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: dayY1 }))
+    expect(calls).toHaveLength(2)
+    expect(calls[1].body.date).toBe('2026-05-10')
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('multi-day gap: flush posts each pending date separately (#128)', async () => {
+    const { calls, fakeFetch } = captureFetch()
+
+    // Day Y: emit events
+    recordEvent('learn', onOpts({ now: () => new Date('2026-05-09T12:00:00Z') }))
+    // Day Y+1: rollover → pending(2026-05-09), record on Y+1
+    recordEvent('learn', onOpts({ now: () => new Date('2026-05-10T12:00:00Z') }))
+    // Day Y+2: rollover → pending(2026-05-10), record on Y+2
+    recordEvent('learn', onOpts({ now: () => new Date('2026-05-11T12:00:00Z') }))
+
+    expect(listPendingDates({ pendingDir })).toEqual(['2026-05-09', '2026-05-10'])
+
+    await flushIfNeeded(
+      onOpts({ fetch: fakeFetch, now: () => new Date('2026-05-11T12:30:00Z') }),
+    )
+
+    expect(calls.map((c) => c.body.date).sort()).toEqual(['2026-05-09', '2026-05-10'])
+    expect(listPendingDates({ pendingDir })).toEqual([])
+  })
+
+  it('flush no-op when no pending and counters.json is for today', async () => {
+    let fetchCalls = 0
+    const fakeFetch = (async () => {
+      fetchCalls++
+      return { ok: true } as Response
+    }) as unknown as typeof globalThis.fetch
+
+    const today = () => new Date('2026-05-11T12:00:00Z')
+    recordEvent('learn', onOpts({ now: today }))
+
+    await flushIfNeeded(onOpts({ fetch: fakeFetch, now: today }))
+    expect(fetchCalls).toBe(0)
+  })
+})

--- a/packages/core/test/telemetry.test.ts
+++ b/packages/core/test/telemetry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveTelemetry, isTelemetryEnabled } from '../src/telemetry.js'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-telemetry-'))
+}
+
+describe('telemetry gate', () => {
+  let dir: string
+  let cfg: string
+  beforeEach(() => {
+    dir = newDir()
+    cfg = join(dir, 'telemetry.json')
+  })
+
+  it('defaults to off with no env and no config file', () => {
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('default')
+  })
+
+  it('PLUR_TELEMETRY=on activates the gate', () => {
+    const r = resolveTelemetry({ env: { PLUR_TELEMETRY: 'on' }, configPath: cfg })
+    expect(r.state).toBe('on')
+    expect(r.source).toBe('env')
+    expect(isTelemetryEnabled({ env: { PLUR_TELEMETRY: 'on' }, configPath: cfg })).toBe(true)
+  })
+
+  it('PLUR_TELEMETRY=off forces the gate off even with config enabled', () => {
+    writeFileSync(cfg, JSON.stringify({ enabled: true }))
+    const r = resolveTelemetry({ env: { PLUR_TELEMETRY: 'off' }, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('env')
+  })
+
+  it('reads enabled:true from config when env is unset', () => {
+    writeFileSync(cfg, JSON.stringify({ enabled: true }))
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('on')
+    expect(r.source).toBe('config')
+  })
+
+  it('reads enabled:false from config', () => {
+    writeFileSync(cfg, JSON.stringify({ enabled: false }))
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('config')
+  })
+
+  it('treats unrecognized env values as unset', () => {
+    const r = resolveTelemetry({ env: { PLUR_TELEMETRY: 'maybe' }, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('default')
+  })
+
+  it('treats malformed config as unset (does not throw)', () => {
+    writeFileSync(cfg, '{ this is not json')
+    const r = resolveTelemetry({ env: {}, configPath: cfg })
+    expect(r.state).toBe('off')
+    expect(r.source).toBe('default')
+  })
+})


### PR DESCRIPTION
## Summary

Adds three layered telemetry modules to `@plur-ai/core`:

- **`telemetry.ts`** — opt-in gate with resolution order: env var → `~/.plur/telemetry.json` → default-off. Zero filesystem writes on default-off installs.
- **`telemetry-counters.ts`** — per-event counters (`learn`/`recall`/`session`) persisted to `~/.plur/telemetry-counters.json`. Day-rollover safety (#128): on rollover, yesterday's snapshot moves to pending-flush dir before counters.json is rewritten.
- **`telemetry-flush.ts`** — daily flush + `POST /v1/heartbeat`. Drains pending-flush directory. Triggered at process exit and on rollover (not via setInterval).

## Privacy invariants (each enforced by test)

1. Default-off install: zero filesystem writes, zero network calls
2. Telemetry-on but no counter file: zero network calls
3. `recordEvent` short-circuits on `!isTelemetryEnabled()` before any fs call

## Test plan

- [x] 29 unit tests in `packages/core/test/telemetry*.test.ts` — all green
- [x] Default-off filesystem isolation verified
- [ ] D-3 (ingress endpoint at heartbeat.plur-ai.org/v1/heartbeat) tracked in #132

## Relationship to #51 / H005

- D-2a = telemetry-counters (this PR)
- D-2b = telemetry-flush (this PR)
- D-1 = telemetry gate (this PR)
- D-3 = ingress endpoint (#132, separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)