### PR TITLE
feat(cli): global install detection module (closes #152)

### DIFF
--- a/packages/cli/src/global-install.ts
+++ b/packages/cli/src/global-install.ts
@@ -1,0 +1,64 @@
+import { execSync } from 'child_process'
+
+export interface GlobalInstallResult {
+  found: boolean
+  packages: Array<{ name: string; version: string }>
+  plurBinaryPath: string | null
+}
+
+const GLOBAL_PATH_PATTERNS = ['/homebrew/', '/usr/local/', '/usr/bin/', '/usr/share/']
+
+/**
+ * Detect globally installed plur packages that shadow `npx @latest` resolution.
+ * Safe to call at startup — all subprocesses time out and failures are swallowed.
+ */
+export function checkGlobalInstall(): GlobalInstallResult {
+  const packages: Array<{ name: string; version: string }> = []
+
+  for (const pkg of ['@plur-ai/mcp', '@plur-ai/cli']) {
+    try {
+      const out = execSync(`npm list -g ${pkg} --depth=0`, {
+        encoding: 'utf8',
+        timeout: 5000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      // Output: /opt/homebrew/lib\n└── @plur-ai/mcp@0.7.7\n
+      const m = out.match(/@[\w-]+\/[\w-]+@([\w.+-]+)/)
+      if (m) packages.push({ name: pkg, version: m[1] })
+    } catch {
+      // not globally installed or npm unavailable
+    }
+  }
+
+  let plurBinaryPath: string | null = null
+  try {
+    const p = execSync('which plur', {
+      encoding: 'utf8',
+      timeout: 2000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    if (p && GLOBAL_PATH_PATTERNS.some((pat) => p.includes(pat))) plurBinaryPath = p
+  } catch {
+    // `which` failed or plur not on PATH
+  }
+
+  return { found: packages.length > 0 || plurBinaryPath !== null, packages, plurBinaryPath }
+}
+
+export function formatGlobalInstallWarning(result: GlobalInstallResult): string[] {
+  const lines: string[] = []
+  if (!result.found) return lines
+
+  lines.push('⚠  Global plur install detected — this shadows `npx @latest` and prevents auto-updates.')
+  lines.push('')
+  for (const pkg of result.packages) {
+    lines.push(`   Found: ${pkg.name}@${pkg.version}`)
+  }
+  if (result.plurBinaryPath) {
+    lines.push(`   Binary: ${result.plurBinaryPath}`)
+  }
+  lines.push('')
+  lines.push('   Fix: npm uninstall -g @plur-ai/mcp @plur-ai/cli')
+  lines.push('   Then: npx @plur-ai/mcp@latest  (fetches the latest version each run)')
+  return lines
+}

--- a/packages/cli/test/global-install.test.ts
+++ b/packages/cli/test/global-install.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+import { execSync } from 'child_process'
+import { checkGlobalInstall, formatGlobalInstallWarning } from '../src/global-install.js'
+
+const mockExecSync = vi.mocked(execSync)
+
+afterEach(() => vi.clearAllMocks())
+
+describe('checkGlobalInstall', () => {
+  it('returns found:false when no global packages installed', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not found')
+    })
+    const result = checkGlobalInstall()
+    expect(result.found).toBe(false)
+    expect(result.packages).toEqual([])
+    expect(result.plurBinaryPath).toBeNull()
+  })
+
+  it('detects a single globally installed package', () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = cmd as string
+      if (c.includes('@plur-ai/mcp') && !c.includes('which')) {
+        return '/opt/homebrew/lib\n└── @plur-ai/mcp@0.7.7\n'
+      }
+      throw new Error('not found')
+    })
+    const result = checkGlobalInstall()
+    expect(result.found).toBe(true)
+    expect(result.packages).toEqual([{ name: '@plur-ai/mcp', version: '0.7.7' }])
+  })
+
+  it('detects both packages when both are globally installed', () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = cmd as string
+      if (c.includes('@plur-ai/mcp') && !c.startsWith('which')) {
+        return '/opt/homebrew/lib\n└── @plur-ai/mcp@0.9.0\n'
+      }
+      if (c.includes('@plur-ai/cli') && !c.startsWith('which')) {
+        return '/opt/homebrew/lib\n└── @plur-ai/cli@0.9.0\n'
+      }
+      throw new Error('not found')
+    })
+    const result = checkGlobalInstall()
+    expect(result.found).toBe(true)
+    expect(result.packages).toHaveLength(2)
+    expect(result.packages[0]).toEqual({ name: '@plur-ai/mcp', version: '0.9.0' })
+    expect(result.packages[1]).toEqual({ name: '@plur-ai/cli', version: '0.9.0' })
+  })
+
+  it('detects global binary via which', () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = cmd as string
+      if (c.startsWith('which')) return '/opt/homebrew/bin/plur'
+      throw new Error('not found')
+    })
+    const result = checkGlobalInstall()
+    expect(result.found).toBe(true)
+    expect(result.plurBinaryPath).toBe('/opt/homebrew/bin/plur')
+  })
+
+  it('ignores which result that is not on a global path', () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = cmd as string
+      if (c.startsWith('which')) return '/home/user/.local/bin/plur'
+      throw new Error('not found')
+    })
+    const result = checkGlobalInstall()
+    expect(result.found).toBe(false)
+    expect(result.plurBinaryPath).toBeNull()
+  })
+})
+
+describe('formatGlobalInstallWarning', () => {
+  it('returns empty array when nothing found', () => {
+    const lines = formatGlobalInstallWarning({ found: false, packages: [], plurBinaryPath: null })
+    expect(lines).toHaveLength(0)
+  })
+
+  it('includes package name + version and remediation command', () => {
+    const lines = formatGlobalInstallWarning({
+      found: true,
+      packages: [{ name: '@plur-ai/mcp', version: '0.7.7' }],
+      plurBinaryPath: null,
+    })
+    const joined = lines.join('\n')
+    expect(joined).toContain('@plur-ai/mcp@0.7.7')
+    expect(joined).toContain('npm uninstall -g')
+  })
+
+  it('includes binary path when detected', () => {
+    const lines = formatGlobalInstallWarning({
+      found: true,
+      packages: [],
+      plurBinaryPath: '/opt/homebrew/bin/plur',
+    })
+    const joined = lines.join('\n')
+    expect(joined).toContain('/opt/homebrew/bin/plur')
+    expect(joined).toContain('npm uninstall -g')
+  })
+
+  it('lists all detected packages', () => {
+    const lines = formatGlobalInstallWarning({
+      found: true,
+      packages: [
+        { name: '@plur-ai/mcp', version: '0.7.7' },
+        { name: '@plur-ai/cli', version: '0.7.7' },
+      ],
+      plurBinaryPath: null,
+    })
+    const joined = lines.join('\n')
+    expect(joined).toContain('@plur-ai/mcp@0.7.7')
+    expect(joined).toContain('@plur-ai/cli@0.7.7')
+  })
+})


### PR DESCRIPTION
## Summary

Extracts global install shadowing detection into a standalone, fully-tested module — replacing the inline snippets from the closed PR #155 with a proper abstraction callable from both `plur init` and `plur doctor`.

## Changes

| File | Purpose |
|------|---------|
| `packages/cli/src/global-install.ts` | Detection + warning formatting |
| `packages/cli/test/global-install.test.ts` | 9 unit tests |

## API

```typescript
checkGlobalInstall(): GlobalInstallResult
// Detects @plur-ai/mcp and @plur-ai/cli global installs.
// All subprocess calls timeout at 5s and swallow failures.
// Returns { found, packages, plurBinaryPath }

formatGlobalInstallWarning(result: GlobalInstallResult): string
// Canonical warning + remediation command for init/doctor call sites.
```

## Why not PR #155?

PR #155 embedded detection inline in `doctor.ts` and `mcp/src/index.ts` with 67 additions total and no tests. This PR extracts the logic into a proper module (184 additions, 9 tests), making it easy for `plur init` and `plur doctor` to share the same detection code.

## Integration points (follow-up)

- `packages/cli/src/commands/doctor.ts` — import `checkGlobalInstall` and add to diagnostic report
- `packages/cli/src/commands/init.ts` — warn on startup if global installs found
- These wire-ups are follow-up commits on this branch or a separate PR

## Test plan

- [x] 9 unit tests: detection, warning formatting, false positive paths, edge cases — all passing
- [ ] Wire into `plur doctor` (follow-up)
- [ ] Wire into `plur init` (follow-up)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)