### PR TITLE
fix(core): strip store prefix before remote getById/feedback/remove

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -364,6 +364,22 @@ export class Plur {
     return null
   }
 
+  /**
+   * Strip the store namespace prefix from an ID before sending to a remote server.
+   * _loadAllEngrams adds ENG-{PREFIX}- to avoid local ID collisions; the remote
+   * server only knows the original ID. If the ID doesn't match this store's prefix,
+   * return it unchanged (it may belong to a different store or be unprefixed).
+   * See: https://github.com/plur-ai/plur/issues/86
+   */
+  private _stripRemotePrefix(id: string, scope: string): string {
+    const prefix = storePrefix(scope)
+    const nsPattern = new RegExp(`^(ENG|ABS|META)-${prefix}-`)
+    if (nsPattern.test(id)) {
+      return id.replace(nsPattern, '$1-')
+    }
+    return id
+  }
+
   /** Content hash fast-path dedup. Scope-aware: same statement in a different scope is a promotion, not a duplicate. */
   private _hashDedup(statement: string, engrams: Engram[], scope?: string): Engram | null {
     const hash = computeContentHash(statement)
@@ -1095,18 +1111,21 @@ export class Plur {
 
     // Check remote stores — the engram may live on an enterprise server.
     // See: https://github.com/plur-ai/plur/issues/85
+    // The ID may be prefixed (ENG-GPL-...) from _loadAllEngrams namespacing.
+    // Strip the prefix before querying the remote server. See: #86
     for (const entry of (this.config.stores ?? [])) {
       if (!entry.url) continue
+      const serverId = this._stripRemotePrefix(id, entry.scope)
       if (entry.readonly === true) {
         const roDriver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
-        const roFound = await roDriver.getById(id)
+        const roFound = await roDriver.getById(serverId)
         if (roFound) throw new Error('Engram is in a readonly store')
         continue
       }
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
-      const found = await driver.getById(id)
+      const found = await driver.getById(serverId)
       if (found) {
-        await driver.feedback(id, signal)
+        await driver.feedback(serverId, signal)
         appendHistory(this.paths.root, {
           event: 'feedback_received',
           engram_id: id,
@@ -1228,20 +1247,22 @@ export class Plur {
 
     // Check remote stores — the engram may live on an enterprise server.
     // See: https://github.com/plur-ai/plur/issues/84
+    // Strip store prefix before querying remote. See: #86
     for (const entry of (this.config.stores ?? [])) {
       if (!entry.url) continue
+      const serverId = this._stripRemotePrefix(id, entry.scope)
       if (entry.readonly === true) {
         // Check if the engram exists here before throwing, so readonly
         // errors are specific ("cannot retire from readonly") not generic.
         const roDriver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
-        const roFound = await roDriver.getById(id)
+        const roFound = await roDriver.getById(serverId)
         if (roFound) throw new Error('Cannot retire engram from readonly store')
         continue
       }
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
-      const found = await driver.getById(id)
+      const found = await driver.getById(serverId)
       if (found) {
-        const removed = await driver.remove(id)
+        const removed = await driver.remove(serverId)
         if (removed) {
           appendHistory(this.paths.root, {
             event: 'engram_retired',

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -101,6 +101,18 @@ export class StubServer {
     return e ? { ...e } : undefined
   }
 
+  /** Seed an engram directly (for cold-start tests). */
+  seedEngram(engram: { id: string; scope: string; status: string; data: Record<string, unknown> }): void {
+    this.engrams.set(engram.id, {
+      id: engram.id,
+      scope: engram.scope,
+      status: engram.status,
+      data: engram.data,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+  }
+
   /** Reset all data without restarting. */
   reset(): void {
     this.engrams.clear()

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -272,3 +272,101 @@ describe('Plur integration with stub server', () => {
     expect(existsSync(localYaml)).toBe(true)
   })
 })
+
+// ---------------------------------------------------------------------------
+// ID prefix round-trip — the #86 regression test
+// ---------------------------------------------------------------------------
+
+describe('ID prefix round-trip (issue #86)', () => {
+  let primaryDir: string
+
+  beforeEach(() => {
+    primaryDir = mkdtempSync(join(tmpdir(), 'plur-prefix-'))
+    server.reset()
+    writeFileSync(
+      join(primaryDir, 'config.yaml'),
+      yaml.dump({
+        stores: [{
+          url: baseUrl,
+          token: TOKEN,
+          scope: 'group:test',
+          shared: true,
+          readonly: false,
+        }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+  })
+
+  afterAll(() => {
+    if (primaryDir && existsSync(primaryDir)) rmSync(primaryDir, { recursive: true, force: true })
+  })
+
+  it('feedback() works with prefixed ID from _loadAllEngrams', async () => {
+    const plur = new Plur({ path: primaryDir })
+
+    // Learn to remote
+    plur.learn('remote engram for feedback test', { scope: 'group:test', type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 100))
+    expect(server.engramCount).toBe(1)
+
+    // Load engrams — this adds the store prefix (e.g. ENG-GTE-...)
+    const loaded = plur.list({ scope: 'group:test' })
+
+    // Wait for remote cache to populate
+    await new Promise(r => setTimeout(r, 2000))
+    const loadedAfter = plur.list({ scope: 'group:test' })
+    const remoteEngrams = loadedAfter.filter(e => e.id.includes('-GTE-'))
+    expect(remoteEngrams.length).toBeGreaterThanOrEqual(1)
+
+    const prefixedId = remoteEngrams[0].id
+    expect(prefixedId).toMatch(/^ENG-GTE-/) // Prefixed
+
+    // Feedback with the prefixed ID — should succeed, not "Engram not found"
+    await plur.feedback(prefixedId, 'positive')
+
+    // Verify the server received the feedback (on the unprefixed ID)
+    const serverEngram = server.getEngram('ENG-SRV-001')
+    expect(serverEngram).toBeTruthy()
+    expect((serverEngram?.data as any)?.feedback_signals?.positive).toBeGreaterThanOrEqual(1)
+  })
+
+  it('forget() works with prefixed ID from _loadAllEngrams', async () => {
+    const plur = new Plur({ path: primaryDir })
+
+    // Learn to remote
+    plur.learn('remote engram for forget test', { scope: 'group:test', type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 100))
+    expect(server.engramCount).toBe(1)
+
+    // Wait for remote cache to populate
+    await new Promise(r => setTimeout(r, 2000))
+    const loaded = plur.list({ scope: 'group:test' })
+    const remoteEngrams = loaded.filter(e => e.id.includes('-GTE-'))
+    expect(remoteEngrams.length).toBeGreaterThanOrEqual(1)
+
+    const prefixedId = remoteEngrams[0].id
+    expect(prefixedId).toMatch(/^ENG-GTE-/)
+
+    // Forget with the prefixed ID — should succeed
+    await plur.forget(prefixedId)
+
+    // Verify the server retired it
+    const serverEngram = server.getEngram('ENG-SRV-001')
+    expect(serverEngram?.status).toBe('retired')
+  })
+
+  it('feedback() still works with unprefixed server ID', async () => {
+    const plur = new Plur({ path: primaryDir })
+
+    // Learn to remote
+    plur.learn('remote engram for unprefixed test', { scope: 'group:test', type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 100))
+
+    // Feedback with the server-side ID directly (no prefix)
+    await plur.feedback('ENG-SRV-001', 'positive')
+
+    const serverEngram = server.getEngram('ENG-SRV-001')
+    expect((serverEngram?.data as any)?.feedback_signals?.positive).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/core/test/remote-store-cache.test.ts
+++ b/packages/core/test/remote-store-cache.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
 import { RemoteStore } from '../src/store/remote-store.js'
+import { Plur } from '../src/index.js'
+import { StubServer } from './helpers/stub-server.js'
 
 /**
  * Issue #89 — write-then-read consistency. After append() succeeds,
@@ -117,5 +123,187 @@ describe('RemoteStore — optimistic cache insert (issue #89)', () => {
     const gets  = fetchMock.mock.calls.filter(([, init]) => !(init as any)?.method || (init as any)?.method === 'GET')
     expect(posts.length).toBe(1)
     expect(gets.length).toBe(1) // cold-cache must refetch on the next load()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cold-start behavior — Plur-level (issue #184, #185 gap 3)
+// ---------------------------------------------------------------------------
+
+const STUB_TOKEN = 'cache-test-token'
+let stubServer: StubServer
+let stubUrl: string
+
+beforeAll(async () => {
+  stubServer = new StubServer(STUB_TOKEN)
+  const info = await stubServer.start()
+  stubUrl = info.url
+})
+
+afterAll(async () => {
+  await stubServer.stop()
+})
+
+describe('Plur cold-start with remote store (issues #184, #185)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-cold-'))
+    stubServer.reset()
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      yaml.dump({
+        stores: [{
+          url: stubUrl,
+          token: STUB_TOKEN,
+          scope: 'group:test',
+          shared: true,
+          readonly: false,
+        }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('listStores returns 0 for remote store before cache populated (#184)', () => {
+    const plur = new Plur({ path: dir })
+
+    // Seed the stub with an engram so the remote is non-empty
+    stubServer.seedEngram({
+      id: 'ENG-SEED-001',
+      scope: 'group:test',
+      status: 'active',
+      data: { statement: 'seeded engram', scope: 'group:test', status: 'active' },
+    })
+
+    // On cold start, listStores reports 0 for remote (cache empty)
+    const stores = plur.listStores()
+    const remote = stores.find(s => s.url)
+    expect(remote).toBeTruthy()
+    // This documents the current (broken) behavior — #184
+    expect(remote!.engram_count).toBe(0)
+  })
+
+  it('listStores returns correct count after cache warms up', async () => {
+    const plur = new Plur({ path: dir })
+
+    stubServer.seedEngram({
+      id: 'ENG-SEED-001',
+      scope: 'group:test',
+      status: 'active',
+      data: { statement: 'seeded engram', scope: 'group:test', status: 'active' },
+    })
+
+    // Trigger cache population
+    plur.list({ scope: 'group:test' })
+    await new Promise(r => setTimeout(r, 2000))
+
+    const stores = plur.listStores()
+    const remote = stores.find(s => s.url)
+    expect(remote).toBeTruthy()
+    expect(remote!.engram_count).toBeGreaterThanOrEqual(1)
+  })
+
+  it('getById returns null for remote engram before cache populated', () => {
+    const plur = new Plur({ path: dir })
+
+    stubServer.seedEngram({
+      id: 'ENG-SEED-001',
+      scope: 'group:test',
+      status: 'active',
+      data: { statement: 'seeded engram', scope: 'group:test', status: 'active' },
+    })
+
+    // Cold start — cache not populated
+    const found = plur.getById('ENG-GTE-SEED-001') // prefixed
+    expect(found).toBeNull()
+  })
+
+  it('getById finds remote engram after cache warms up', async () => {
+    const plur = new Plur({ path: dir })
+
+    stubServer.seedEngram({
+      id: 'ENG-SEED-001',
+      scope: 'group:test',
+      status: 'active',
+      data: { statement: 'seeded engram', scope: 'group:test', status: 'active' },
+    })
+
+    plur.list()
+    await new Promise(r => setTimeout(r, 2000))
+
+    const found = plur.getById('ENG-GTE-SEED-001')
+    expect(found).toBeTruthy()
+    expect(found!.statement).toBe('seeded engram')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pin/promote on remote engrams — pinned failing tests (#86, #185 gap 2)
+// These will pass once enterprise server PATCH endpoint (enterprise#110)
+// and RemoteStore.update() are implemented.
+// ---------------------------------------------------------------------------
+
+describe.skip('updateEngram remote routing (blocked on enterprise#110)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-update-'))
+    stubServer.reset()
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      yaml.dump({
+        stores: [{
+          url: stubUrl,
+          token: STUB_TOKEN,
+          scope: 'group:test',
+          shared: true,
+          readonly: false,
+        }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('pin on remote engram reaches server', async () => {
+    const plur = new Plur({ path: dir })
+    plur.learn('remote engram for pin test', { scope: 'group:test', type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 2000))
+
+    const loaded = plur.list({ scope: 'group:test' })
+    const remote = loaded.find(e => e.id.includes('-GTE-'))
+    expect(remote).toBeTruthy()
+
+    remote!.pinned = true
+    plur.updateEngram(remote!)
+
+    // Verify server received the pin update
+    const serverEngram = stubServer.getEngram(remote!.id.replace(/^ENG-GTE-/, 'ENG-'))
+    expect((serverEngram?.data as any)?.pinned).toBe(true)
+  })
+
+  it('promote on remote engram reaches server', async () => {
+    const plur = new Plur({ path: dir })
+    plur.learn('remote candidate engram', { scope: 'group:test', type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 2000))
+
+    const loaded = plur.list({ scope: 'group:test' })
+    const remote = loaded.find(e => e.id.includes('-GTE-'))
+    expect(remote).toBeTruthy()
+
+    remote!.status = 'active'
+    remote!.activation.retrieval_strength = 0.7
+    plur.updateEngram(remote!)
+
+    const serverEngram = stubServer.getEngram(remote!.id.replace(/^ENG-GTE-/, 'ENG-'))
+    expect(serverEngram?.status).toBe('active')
   })
 })

--- a/packages/core/test/store-prefix.test.ts
+++ b/packages/core/test/store-prefix.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for storePrefix and ID prefix round-trip.
+ * These ensure the namespace prefix added by _loadAllEngrams can be
+ * correctly stripped by _stripRemotePrefix before sending to remote servers.
+ * See: https://github.com/plur-ai/plur/issues/86
+ */
+import { describe, it, expect } from 'vitest'
+import { storePrefix } from '../src/engrams.js'
+
+describe('storePrefix', () => {
+  it('group:plur/plur-ai/engineering → GPL', () => {
+    expect(storePrefix('group:plur/plur-ai/engineering')).toBe('GPL')
+  })
+
+  it('project:plur → PPL', () => {
+    expect(storePrefix('project:plur')).toBe('PPL')
+  })
+
+  it('project:Data → PDA', () => {
+    expect(storePrefix('project:Data')).toBe('PDA')
+  })
+
+  it('global → GBL', () => {
+    expect(storePrefix('global')).toBe('GBL')
+  })
+
+  it('group:datafund → GDA', () => {
+    expect(storePrefix('group:datafund')).toBe('GDA')
+  })
+
+  it('single short word → padded', () => {
+    // "ab" → A + B + A (padded)
+    expect(storePrefix('ab')).toBe('ABA')
+  })
+})
+
+describe('ID prefix round-trip', () => {
+  // Simulates what _loadAllEngrams does (add prefix) and what
+  // _stripRemotePrefix should undo (strip prefix)
+  const addPrefix = (id: string, scope: string): string => {
+    const prefix = storePrefix(scope)
+    return id.replace(/^(ENG|ABS|META)-/, `$1-${prefix}-`)
+  }
+
+  const stripPrefix = (id: string, scope: string): string => {
+    const prefix = storePrefix(scope)
+    const nsPattern = new RegExp(`^(ENG|ABS|META)-${prefix}-`)
+    if (nsPattern.test(id)) {
+      return id.replace(nsPattern, '$1-')
+    }
+    return id
+  }
+
+  it('ENG ID round-trips through prefix/strip', () => {
+    const original = 'ENG-2026-05-19-004'
+    const scope = 'group:plur/plur-ai/engineering'
+    const prefixed = addPrefix(original, scope)
+    expect(prefixed).toBe('ENG-GPL-2026-05-19-004')
+    expect(stripPrefix(prefixed, scope)).toBe(original)
+  })
+
+  it('ABS ID round-trips through prefix/strip', () => {
+    const original = 'ABS-2026-0501-001'
+    const scope = 'project:plur'
+    const prefixed = addPrefix(original, scope)
+    expect(prefixed).toBe('ABS-PPL-2026-0501-001')
+    expect(stripPrefix(prefixed, scope)).toBe(original)
+  })
+
+  it('META ID round-trips through prefix/strip', () => {
+    const original = 'META-2026-0501-001'
+    const scope = 'group:datafund'
+    const prefixed = addPrefix(original, scope)
+    expect(prefixed).toBe('META-GDA-2026-0501-001')
+    expect(stripPrefix(prefixed, scope)).toBe(original)
+  })
+
+  it('strip with wrong scope returns ID unchanged', () => {
+    const prefixed = 'ENG-GPL-2026-05-19-004'
+    // Wrong scope — prefix doesn't match
+    expect(stripPrefix(prefixed, 'project:plur')).toBe(prefixed)
+  })
+
+  it('strip on already-unprefixed ID returns it unchanged', () => {
+    const original = 'ENG-2026-05-19-004'
+    expect(stripPrefix(original, 'group:plur/plur-ai/engineering')).toBe(original)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the ID prefix translation bug that caused `plur_feedback` and `plur_forget` to fail on remote store engrams with "Engram not found".

## Root cause

`_loadAllEngrams()` adds a namespace prefix (e.g. `ENG-GPL-`) to remote engrams for local deduplication. MCP tools surface this prefixed ID to users. When the user passes it back to `feedback()` or `forget()`, those methods called `driver.getById(prefixedId)` — but the enterprise server only knows the original unprefixed ID. Result: 404, "Engram not found".

**Proof from live testing (May 19):**
```
feedback("ENG-2026-05-19-004", "positive")     → SUCCESS
feedback("ENG-GPL-2026-05-19-004", "positive")  → FAILED - Engram not found
```

## Fix

Added `_stripRemotePrefix(id, scope)` helper that reverses the namespace before sending to the remote API. Applied in both `feedback()` and `forget()` remote fallback paths.

The helper uses the same `storePrefix()` + regex pattern that `_findEngramStore()` uses for local stores — consistent behavior across local and remote paths.

## Tests added

**`store-prefix.test.ts`** (11 tests):
- `storePrefix()` for known scopes (group:plur/plur-ai/engineering → GPL, project:plur → PPL, etc.)
- ID prefix round-trip: add prefix → strip prefix → original ID
- Wrong scope doesn't strip, unprefixed ID returned unchanged

**`remote-integration.test.ts`** (3 tests against stub server):
- `feedback()` works with prefixed ID from `_loadAllEngrams`
- `forget()` works with prefixed ID from `_loadAllEngrams`
- `feedback()` still works with unprefixed server ID (backward compat)

## Test plan

- [x] 951 tests pass (+14 net from today's work)
- [x] New tests exercise the exact failure path from #86
- [x] Full pnpm test — zero failures

Partially addresses #86 (feedback + forget fixed). Pin/promote remain open — they need a PATCH endpoint on the enterprise server + RemoteStore.update() method.

Closes #84 (properly this time) and #85 (properly this time).
