### PR TITLE
fix(cli): replace npx with local hook binary (#178)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,3 +176,42 @@ This project lives inside a Datacore space. Session lifecycle commands are avail
 | Org | `~/Data/5-plur/org/next_actions.org` |
 
 When `/wrap-up` runs, use the team journal schema: `## @contributor` narrative sections + `## Session Metadata` YAML block.
+
+## PLUR Memory
+
+You have persistent memory via PLUR. Corrections, preferences, and conventions persist across sessions as engrams.
+
+### Architecture
+
+PLUR is installed **globally** — one MCP server, one engram store (`~/.plur/`), available in every project. You do NOT need per-project installation. The `plur` MCP server provides tools named `plur_session_start`, `plur_learn`, `plur_recall_hybrid`, `plur_feedback`, `plur_session_end`, etc. If you cannot find these tools, run `plur doctor` to diagnose. Do **not** substitute tools from other MCP servers (e.g. `datacore_*`) — those belong to a different system.
+
+A PreToolUse guard enforces that `plur_session_start` is called at the beginning of every session. All other tools are blocked until this is done. The flow is: ToolSearch to load `plur_session_start` → call it with a task description → proceed.
+
+### Session Workflow
+
+1. **Start**: Call `plur_session_start` with task description — enforced by guard hook
+2. **Learn**: When corrected or discovering something new, call `plur_learn` immediately
+3. **Recall**: Before answering factual questions, call `plur_recall_hybrid` — check memory first
+4. **Feedback**: Rate injected engrams with `plur_feedback` (positive/negative) — trains relevance
+5. **End**: Call `plur_session_end` with summary + engram_suggestions
+
+Do not ask permission to use these tools — they are your memory system.
+
+### Multi-project scoping
+
+PLUR uses `domain` and `scope` fields on engrams to separate knowledge by project. When calling `plur_learn`, set `scope` (e.g. `project:my-app`) to namespace the engram. Scoped recall automatically includes global engrams.
+
+### When to check memory
+
+Before reaching for web search, file reads, or guessing — apply this priority:
+1. Is the answer already in engrams? → `plur_recall_hybrid`
+2. Is the answer in the local filesystem? → Read/Grep/Glob
+3. Is the answer derivable from context already loaded? → Just answer
+4. Only if 1-3 fail → Use external tools
+
+### When corrected
+
+When the user corrects you ("no, use X not Y", "that's wrong"):
+1. Call `plur_learn` immediately — before continuing the task
+2. Call `plur_feedback` with negative signal on the wrong engram if one was injected
+3. Then continue with the corrected approach

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ npx @plur-ai/cli@0.9.4 status
 ## Quick Start
 
 ```bash
-# Install Claude Code hooks (automatic memory injection)
+# Install Claude Code hooks + local hook binary (automatic memory injection)
 plur init
 
 # Store a learning
@@ -59,7 +59,8 @@ plur forget ENG-2026-0329-001
 | `plur sync` | Cross-device sync via git |
 | `plur packs list` | List installed engram packs |
 | `plur packs install <source>` | Install an engram pack |
-| `plur init` | Install Claude Code hooks for automatic injection |
+| `plur init` | Install Claude Code hooks + local hook binary for automatic injection |
+| `plur doctor` | Diagnose installation health (hooks, MCP, shim, embedder) |
 
 ## Global Flags
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,4 +1,7 @@
 import { spawn } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir, platform } from 'os'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { outputText, outputJson, shouldOutputJson } from '../output.js'
 import {
@@ -32,11 +35,19 @@ interface ConfigFileReport {
   hasPlurHooks: boolean
 }
 
+interface HookShimReport {
+  valid: boolean
+  shimPath: string
+  error?: string
+}
+
 interface DoctorReport {
   configs: ConfigFileReport[]
   hooksInstalled: boolean
   mcpRegistered: boolean
   datacoreCollision: boolean
+  staleNpxHooks: boolean
+  hookShim: HookShimReport
   handshake: { ok: boolean; serverName?: string; serverVersion?: string; error?: string }
   embedder: { available: boolean; loaded: boolean; lastError: string | null; modelLoaded: boolean; disabled: boolean; disabledReason: string | null }
   overall: 'ok' | 'fail'
@@ -47,11 +58,44 @@ function hasAnyPlurHook(config: Record<string, unknown>): boolean {
   for (const entries of Object.values(hooks)) {
     for (const entry of entries) {
       for (const h of entry.hooks ?? []) {
-        if (h.command && h.command.includes('@plur-ai/cli')) return true
+        if (h.command && (h.command.includes('@plur-ai/cli') || h.command.includes('.plur/bin/plur-hook'))) return true
       }
     }
   }
   return false
+}
+
+function hasStaleNpxHooks(config: Record<string, unknown>): boolean {
+  const hooks = (config.hooks ?? {}) as Record<string, Array<{ hooks?: Array<{ command?: string }> }>>
+  for (const entries of Object.values(hooks)) {
+    for (const entry of entries) {
+      for (const h of entry.hooks ?? []) {
+        if (h.command && h.command.includes('npx') && h.command.includes('@plur-ai/cli')) return true
+      }
+    }
+  }
+  return false
+}
+
+function validateHookShim(): HookShimReport {
+  const name = platform() === 'win32' ? 'plur-hook.cmd' : 'plur-hook'
+  const path = join(homedir(), '.plur', 'bin', name)
+
+  if (!existsSync(path)) {
+    return { valid: false, shimPath: path, error: 'shim not found — run `plur init` to create it' }
+  }
+
+  const content = readFileSync(path, 'utf-8')
+  const match = content.match(/"([^"]+index\.js)"/)
+  if (!match) {
+    return { valid: false, shimPath: path, error: 'shim has unexpected format' }
+  }
+
+  if (!existsSync(match[1])) {
+    return { valid: false, shimPath: path, error: `entrypoint missing: ${match[1]} — run \`plur init\` to fix` }
+  }
+
+  return { valid: true, shimPath: path }
 }
 
 function inspectConfigs(): ConfigFileReport[] {
@@ -206,6 +250,15 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
   const mcpRegistered = configs.some((c) => c.hasPlurMcp)
   const datacoreCollision = configs.some((c) => c.hasDatacoreMcp)
 
+  // Check for stale npx hooks across all existing configs (#178)
+  const staleNpxHooks = configs.some((c) => {
+    if (!c.exists) return false
+    const config = readConfig(c.path)
+    return hasStaleNpxHooks(config)
+  })
+
+  const hookShim = validateHookShim()
+
   const handshakePromise = skipHandshake
     ? Promise.resolve({ ok: false, error: 'skipped (--no-handshake)' })
     : mcpHandshake()
@@ -217,7 +270,7 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     // disabled until the model loads.
     const overall: 'ok' | 'fail' =
       hooksInstalled && mcpRegistered && (skipHandshake || handshake.ok) ? 'ok' : 'fail'
-    return { configs, hooksInstalled, mcpRegistered, datacoreCollision, handshake, embedder, overall }
+    return { configs, hooksInstalled, mcpRegistered, datacoreCollision, staleNpxHooks, hookShim, handshake, embedder, overall }
   })
 }
 
@@ -251,6 +304,20 @@ function printText(report: DoctorReport): void {
     outputText('   plur tools are prefixed plur_* (plur_learn, plur_recall_hybrid, etc.).')
     outputText('   datacore tools are prefixed datacore_*. They do NOT share memory.')
     outputText('   If your agent confuses them, this is the cause.')
+  }
+
+  // Hook shim status (#178)
+  outputText('')
+  if (report.hookShim.valid) {
+    outputText(`✓ Hook shim: ${report.hookShim.shimPath}`)
+  } else {
+    outputText(`✗ Hook shim: ${report.hookShim.error}`)
+  }
+
+  if (report.staleNpxHooks) {
+    outputText('')
+    outputText('⚠  Hooks still use npx — slow (200-2000ms per hook) and vulnerable to cache corruption.')
+    outputText('   Fix: run `plur init` to migrate to the local hook binary (<5ms per hook).')
   }
 
   outputText('')

--- a/packages/cli/src/commands/hook-session-guard.ts
+++ b/packages/cli/src/commands/hook-session-guard.ts
@@ -1,4 +1,4 @@
-import { readSync, existsSync } from 'fs'
+import { readSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { type GlobalFlags } from '../plur.js'
@@ -12,6 +12,12 @@ import { isPlurConfigured } from '../lib/plur-configured.js'
  * the session has been started. The sentinel is created by hook-session-mark
  * (PostToolUse on mcp__plur__plur_session_start).
  *
+ * Deadlock prevention (#199): if the guard has blocked more than
+ * MAX_BLOCKS_BEFORE_FALLBACK tool calls without a session starting (e.g.
+ * because the MCP server failed to start), it stops blocking and warns
+ * via stderr instead. This prevents permanent deadlock while still
+ * enforcing the session start flow under normal conditions.
+ *
  * Exempt tools (allowed without session): ToolSearch, mcp__plur__plur_session_start
  *
  * Input: JSON on stdin (Claude Code PreToolUse hook format)
@@ -22,6 +28,8 @@ const EXEMPT_TOOLS = new Set([
   'mcp__plur__plur_session_start',
   'ToolSearch',
 ])
+
+const MAX_BLOCKS_BEFORE_FALLBACK = 5
 
 function readStdinRaw(): string {
   try {
@@ -44,6 +52,23 @@ function readStdinRaw(): string {
 
 function sentinelPath(sessionId: string): string {
   return join(tmpdir(), `plur-session-${sessionId}`)
+}
+
+function blockCountPath(sessionId: string): string {
+  const dir = join(tmpdir(), 'plur-sessions')
+  mkdirSync(dir, { recursive: true })
+  return join(dir, `${sessionId}.guard-count`)
+}
+
+function incrementBlockCount(sessionId: string): number {
+  const path = blockCountPath(sessionId)
+  let count = 0
+  try {
+    count = parseInt(readFileSync(path, 'utf8'), 10) || 0
+  } catch { /* file doesn't exist yet */ }
+  count++
+  writeFileSync(path, String(count))
+  return count
 }
 
 export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
@@ -70,6 +95,18 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
 
   // Check sentinel
   if (existsSync(sentinelPath(sessionId))) return
+
+  // Deadlock prevention (#199): if we've blocked too many times without a
+  // session starting, the MCP server likely failed to load. Stop blocking
+  // to prevent permanent deadlock.
+  const blockCount = incrementBlockCount(sessionId)
+  if (blockCount > MAX_BLOCKS_BEFORE_FALLBACK) {
+    process.stderr.write(
+      `[plur] WARNING: session guard gave up after ${MAX_BLOCKS_BEFORE_FALLBACK} blocked calls. ` +
+      `The plur MCP server may not be running. Run \`plur doctor\` to diagnose.\n`,
+    )
+    return
+  }
 
   // Block
   const output = {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
-import { join } from 'path'
-import { homedir } from 'os'
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { homedir, platform } from 'os'
 import { type GlobalFlags } from '../plur.js'
 import { outputText } from '../output.js'
 import {
@@ -22,8 +23,9 @@ import {
  * Two things must be in place for plur to work in Claude Code:
  *
  *   1. The `plur` MCP server must be registered, so the `plur_*` tools exist.
- *   2. The lifecycle hooks must call `npx @plur-ai/cli hook-*` to inject
- *      relevant engrams into the conversation.
+ *   2. The lifecycle hooks must call the plur CLI to inject relevant engrams
+ *      into the conversation. A local shim at ~/.plur/bin/plur-hook is
+ *      created to avoid npx overhead and race conditions (#178).
  *
  * Usage:
  *   plur init              # default: creates .claude/settings.json in current directory
@@ -55,128 +57,177 @@ interface HookEntry {
   }>
 }
 
-// Hook commands — all use npx for zero-install compatibility
-const CLI = 'npx @plur-ai/cli'
+// ── Hook shim installation ──────────────────────────────────────────────────
+// Instead of using `npx @plur-ai/cli hook-*` (slow, races on version bumps),
+// plur init creates a local shim at ~/.plur/bin/plur-hook that calls
+// `node <resolved-path-to-dist/index.js>` directly. See #178.
+
+function resolveCliEntrypoint(): string {
+  // import.meta.url → file:///path/to/dist/commands/init.js
+  // CLI entrypoint is dist/index.js (parent of commands/)
+  const thisFile = fileURLToPath(import.meta.url)
+  return join(dirname(thisFile), '..', 'index.js')
+}
+
+function shimPath(): string {
+  const name = platform() === 'win32' ? 'plur-hook.cmd' : 'plur-hook'
+  return join(homedir(), '.plur', 'bin', name)
+}
+
+function installHookBinary(): { shimPath: string; status: string } {
+  const binDir = join(homedir(), '.plur', 'bin')
+  mkdirSync(binDir, { recursive: true })
+
+  const entrypoint = resolveCliEntrypoint()
+  const nodeBin = process.execPath
+
+  if (!existsSync(entrypoint)) {
+    return { shimPath: '', status: `error: CLI entrypoint not found at ${entrypoint}` }
+  }
+
+  const target = shimPath()
+
+  if (platform() === 'win32') {
+    writeFileSync(target, `@echo off\r\n"${nodeBin}" "${entrypoint}" %*\r\n`)
+  } else {
+    writeFileSync(target, `#!/bin/sh\nexec "${nodeBin}" "${entrypoint}" "$@"\n`, { mode: 0o755 })
+    try { chmodSync(target, 0o755) } catch { /* masked umask fallback */ }
+  }
+
+  // Metadata for doctor diagnostics
+  const meta = { entrypoint, node: nodeBin, installed: new Date().toISOString() }
+  writeFileSync(join(binDir, 'plur-hook.meta.json'), JSON.stringify(meta, null, 2) + '\n')
+
+  return { shimPath: target, status: 'installed' }
+}
+
+// ── Hook map builders ───────────────────────────────────────────────────────
+// Parameterized by command prefix so the same definitions work with both
+// the local shim (default) and npx fallback.
 
 // Enforcement hooks ensure plur_session_start is always called first.
 // Installed into global ~/.claude/settings.json unconditionally (issue #95) so
 // they fire from any subdirectory project. Each hook silent-passes when
 // isPlurConfigured() is false, so projects without plur are unaffected.
-const PLUR_HOOKS_ENFORCEMENT: Record<string, HookEntry[]> = {
-  SessionStart: [
-    {
-      hooks: [
-        { type: 'command', command: `${CLI} hook-session-remind`, timeout: 3 },
-      ],
-    },
-  ],
+function buildEnforcementHooks(cmd: string): Record<string, HookEntry[]> {
+  return {
+    SessionStart: [
+      {
+        hooks: [
+          { type: 'command', command: `${cmd} hook-session-remind`, timeout: 3 },
+        ],
+      },
+    ],
 
-  PreToolUse: [
-    // Session guard — blocks all tools until plur_session_start is called.
-    // Must be first so it runs before any other PreToolUse hook.
-    {
-      matcher: '*',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-session-guard`, timeout: 3 },
-      ],
-    },
-  ],
+    PreToolUse: [
+      // Session guard — blocks all tools until plur_session_start is called.
+      // Must be first so it runs before any other PreToolUse hook.
+      {
+        matcher: '*',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-session-guard`, timeout: 3 },
+        ],
+      },
+    ],
 
-  PostToolUse: [
-    // Session sentinel — creates marker file after plur_session_start succeeds
-    {
-      matcher: 'mcp__plur__plur_session_start',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-session-mark`, timeout: 3 },
-      ],
-    },
-  ],
+    PostToolUse: [
+      // Session sentinel — creates marker file after plur_session_start succeeds
+      {
+        matcher: 'mcp__plur__plur_session_start',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-session-mark`, timeout: 3 },
+        ],
+      },
+    ],
+  }
 }
 
 // Injection hooks pull relevant engrams into the conversation context. Installed
 // at the path chosen by --global/--project (default project) because per-project
 // domain/scope tuning may matter for what gets injected.
-const PLUR_HOOKS_INJECTION: Record<string, HookEntry[]> = {
-  // First message: inject engrams based on the prompt.
-  // Subsequent messages: periodic reminder to call plur_learn (~1ms skip).
-  UserPromptSubmit: [
-    {
-      hooks: [
-        { type: 'command', command: `${CLI} hook-inject`, timeout: 15 },
-      ],
-    },
-  ],
+function buildInjectionHooks(cmd: string): Record<string, HookEntry[]> {
+  return {
+    // First message: inject engrams based on the prompt.
+    // Subsequent messages: periodic reminder to call plur_learn (~1ms skip).
+    UserPromptSubmit: [
+      {
+        hooks: [
+          { type: 'command', command: `${cmd} hook-inject`, timeout: 15 },
+        ],
+      },
+    ],
 
-  // Re-inject after context compaction so engrams survive long conversations.
-  PostCompact: [
-    {
-      matcher: 'auto|manual',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-inject --rehydrate`, timeout: 15 },
-      ],
-    },
-  ],
+    // Re-inject after context compaction so engrams survive long conversations.
+    PostCompact: [
+      {
+        matcher: 'auto|manual',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-inject --rehydrate`, timeout: 15 },
+        ],
+      },
+    ],
 
-  PreToolUse: [
-    // Full injection when entering plan mode — planning needs broad context
-    {
-      matcher: 'EnterPlanMode',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-inject --event plan_mode`, timeout: 10 },
-      ],
-    },
-    // Domain-specific engrams when a skill is invoked
-    {
-      matcher: 'Skill',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-inject --event skill`, timeout: 10 },
-      ],
-    },
-    // Agent-scoped engrams when spawning an agent
-    {
-      matcher: 'Agent',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-inject --event agent`, timeout: 10 },
-      ],
-    },
-    // Observation capture — log tool calls for offline pattern extraction
-    {
-      matcher: 'Bash|Edit|Write|Agent',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-observe`, timeout: 3 },
-      ],
-    },
-  ],
+    PreToolUse: [
+      // Full injection when entering plan mode — planning needs broad context
+      {
+        matcher: 'EnterPlanMode',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-inject --event plan_mode`, timeout: 10 },
+        ],
+      },
+      // Domain-specific engrams when a skill is invoked
+      {
+        matcher: 'Skill',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-inject --event skill`, timeout: 10 },
+        ],
+      },
+      // Agent-scoped engrams when spawning an agent
+      {
+        matcher: 'Agent',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-inject --event agent`, timeout: 10 },
+        ],
+      },
+      // Observation capture — log tool calls for offline pattern extraction
+      {
+        matcher: 'Bash|Edit|Write|Agent',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-observe`, timeout: 3 },
+        ],
+      },
+    ],
 
-  PostToolUse: [
-    {
-      matcher: 'Bash|Edit|Write|Agent',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-observe --post`, timeout: 3 },
-      ],
-    },
-  ],
+    PostToolUse: [
+      {
+        matcher: 'Bash|Edit|Write|Agent',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-observe --post`, timeout: 3 },
+        ],
+      },
+    ],
 
-  // Inject agent-scoped engrams into subagent context
-  SubagentStart: [
-    {
-      matcher: '.*',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-inject --event subagent`, timeout: 10 },
-      ],
-    },
-  ],
+    // Inject agent-scoped engrams into subagent context
+    SubagentStart: [
+      {
+        matcher: '.*',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-inject --event subagent`, timeout: 10 },
+        ],
+      },
+    ],
 
-  // Learning reflection — nudge the LLM to call plur_learn after responses
-  // where it discovered or learned something. Fires every 3rd Stop to avoid fatigue.
-  Stop: [
-    {
-      matcher: '*',
-      hooks: [
-        { type: 'command', command: `${CLI} hook-learn-check`, timeout: 2 },
-      ],
-    },
-  ],
+    // Learning reflection — nudge the LLM to call plur_learn after responses
+    // where it discovered or learned something. Fires every 3rd Stop to avoid fatigue.
+    Stop: [
+      {
+        matcher: '*',
+        hooks: [
+          { type: 'command', command: `${cmd} hook-learn-check`, timeout: 2 },
+        ],
+      },
+    ],
+  }
 }
 
 function mergeHookMaps(
@@ -309,7 +360,9 @@ function loadSettings(path: string): Settings {
 }
 
 function isPlurHook(entry: HookEntry): boolean {
-  return (entry.hooks ?? []).some((h) => h.command.includes('@plur-ai/cli'))
+  return (entry.hooks ?? []).some((h) =>
+    h.command.includes('@plur-ai/cli') || h.command.includes('.plur/bin/plur-hook'),
+  )
 }
 
 function hasPlurHooks(settings: Settings): boolean {
@@ -381,6 +434,13 @@ function hooksStatusFor(before: string, after: string, hadHooks: boolean): strin
 }
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  // Install local hook shim FIRST — hook commands depend on it (#178)
+  const shim = installHookBinary()
+  const cmd = shim.shimPath || 'npx @plur-ai/cli' // fallback if shim failed
+
+  const PLUR_HOOKS_ENFORCEMENT = buildEnforcementHooks(cmd)
+  const PLUR_HOOKS_INJECTION = buildInjectionHooks(cmd)
+
   const injectionPath = findSettingsPath(flags, args)
   const enforcementPath = join(homedir(), '.claude', 'settings.json')
   const samePath = injectionPath === enforcementPath
@@ -450,6 +510,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const entry = buildMcpServerEntry()
 
   outputText('PLUR installed for Claude Code.')
+  outputText('')
+  outputText(`Hook binary: ${shim.status}${shim.shimPath ? ` (${shim.shimPath})` : ''}`)
   outputText('')
   outputText('Architecture: One global engram store (~/.plur/), enforcement hooks global, injection hooks project-scoped.')
   outputText('Multi-project scoping via domain/scope fields on engrams, not separate installs.')

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
@@ -137,5 +137,73 @@ describe('plur doctor', () => {
     expect(report.handshake.error).toContain('skipped')
     // ok overall because handshake is gated behind the skip flag
     expect(report.overall).toBe('ok')
+  })
+
+  // ── Stale npx hook detection (#178) ─────────────────────────────────────
+
+  it('detects stale npx hooks and recommends migration (#178)', () => {
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject' }] },
+        ],
+      },
+      mcpServers: {
+        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+      },
+    })
+
+    const { stdout } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(report.staleNpxHooks).toBe(true)
+    expect(report.hooksInstalled).toBe(true)
+  })
+
+  it('reports hookShim.valid=false when shim does not exist (#178)', () => {
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: `${join(home, '.plur', 'bin', 'plur-hook')} hook-inject` }] },
+        ],
+      },
+      mcpServers: {
+        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+      },
+    })
+
+    const { stdout } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(report.hookShim).toBeDefined()
+    expect(report.hookShim.valid).toBe(false)
+  })
+
+  it('reports staleNpxHooks=false with new-style shim hooks (#178)', () => {
+    // Create a valid shim pointing to the real CLI dist
+    const cliDist = join(__dirname, '..', 'dist', 'index.js')
+    const binDir = join(home, '.plur', 'bin')
+    mkdirSync(binDir, { recursive: true })
+    const shimPath = join(binDir, 'plur-hook')
+    writeFileSync(shimPath, `#!/bin/sh\nexec "${process.execPath}" "${cliDist}" "$@"\n`, { mode: 0o755 })
+    try { chmodSync(shimPath, 0o755) } catch {}
+
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: `${shimPath} hook-inject` }] },
+        ],
+      },
+      mcpServers: {
+        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+      },
+    })
+
+    const { stdout } = runDoctor()
+    const report = JSON.parse(stdout)
+
+    expect(report.staleNpxHooks).toBe(false)
+    expect(report.hooksInstalled).toBe(true)
+    expect(report.hookShim.valid).toBe(true)
   })
 })

--- a/packages/cli/test/hook-session-guard.test.ts
+++ b/packages/cli/test/hook-session-guard.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { spawnSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('hook-session-guard', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-guard-test-'))
+    // Create a settings.json with plur MCP so isPlurConfigured() returns true
+    const claudeDir = join(home, '.claude')
+    mkdirSync(claudeDir, { recursive: true })
+    writeFileSync(
+      join(claudeDir, 'settings.json'),
+      JSON.stringify({
+        mcpServers: {
+          plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        },
+      }),
+    )
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  function runGuard(input: object): { stdout: string; stderr: string; status: number } {
+    const result = spawnSync('node', [CLI, 'hook-session-guard'], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 10000,
+      env: { ...process.env, HOME: home, USERPROFILE: home, TMPDIR: join(home, 'tmp') },
+      cwd: home,
+    })
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      status: result.status ?? 1,
+    }
+  }
+
+  it('blocks tools when session not started', () => {
+    // Ensure TMPDIR exists for guard counter files
+    mkdirSync(join(home, 'tmp'), { recursive: true })
+
+    const result = runGuard({ session_id: 'test-123', tool_name: 'Bash' })
+    expect(result.stdout).toContain('permissionDecision')
+    expect(result.stdout).toContain('deny')
+  })
+
+  it('allows exempt tools without session', () => {
+    mkdirSync(join(home, 'tmp'), { recursive: true })
+
+    const result = runGuard({ session_id: 'test-123', tool_name: 'ToolSearch' })
+    expect(result.stdout).not.toContain('deny')
+  })
+
+  it('stops blocking after MAX_BLOCKS_BEFORE_FALLBACK calls (#199)', () => {
+    mkdirSync(join(home, 'tmp'), { recursive: true })
+
+    // First 5 calls should block
+    for (let i = 0; i < 5; i++) {
+      const result = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
+      expect(result.stdout).toContain('deny')
+    }
+
+    // 6th call should allow through with warning
+    const fallback = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
+    expect(fallback.stdout).not.toContain('deny')
+    expect(fallback.stderr).toContain('gave up')
+    expect(fallback.stderr).toContain('plur doctor')
+  })
+})

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'fs'
 import { join } from 'path'
 import { tmpdir, platform } from 'os'
 import { execSync } from 'child_process'
@@ -42,10 +42,11 @@ describe('plur init', () => {
 
     const settings = readSettings()
 
-    // Hooks installed
+    // Hooks installed — now using local shim instead of npx (#178)
     expect(settings.hooks).toBeDefined()
     expect(settings.hooks?.UserPromptSubmit).toBeDefined()
-    expect(settings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toContain('@plur-ai/cli hook-inject')
+    expect(settings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toContain('hook-inject')
+    expect(settings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toContain('.plur/bin/plur-hook')
 
     // MCP server registered
     expect(settings.mcpServers).toBeDefined()
@@ -186,5 +187,101 @@ describe('plur init', () => {
     } finally {
       rmSync(project, { recursive: true, force: true })
     }
+  })
+
+  // ── Local hook binary tests (#178) ──────────────────────────────────────
+
+  it('creates ~/.plur/bin/plur-hook shim on init', () => {
+    runInit()
+    const shim = join(home, '.plur', 'bin', platform() === 'win32' ? 'plur-hook.cmd' : 'plur-hook')
+    expect(existsSync(shim)).toBe(true)
+
+    const content = readFileSync(shim, 'utf-8')
+    expect(content).not.toContain('npx')
+    expect(content).toContain('index.js')
+
+    if (platform() !== 'win32') {
+      expect(content).toContain('#!/bin/sh')
+      expect(content).toContain('exec')
+      // Shim should be executable
+      const stat = statSync(shim)
+      expect(stat.mode & 0o111).toBeGreaterThan(0)
+    }
+  })
+
+  it('hooks use local shim path instead of npx (#178)', () => {
+    runInit()
+    const settings = readSettings()
+
+    const hookCommands: string[] = []
+    for (const entries of Object.values(settings.hooks ?? {})) {
+      for (const entry of entries) {
+        for (const h of entry.hooks) {
+          hookCommands.push(h.command)
+        }
+      }
+    }
+
+    // No hook should reference npx
+    for (const cmd of hookCommands) {
+      expect(cmd).not.toContain('npx')
+    }
+
+    // All plur hooks should reference the local shim
+    const plurCommands = hookCommands.filter((c) => c.includes('plur-hook') || c.includes('@plur-ai/cli'))
+    expect(plurCommands.length).toBeGreaterThan(0)
+    for (const cmd of plurCommands) {
+      expect(cmd).toContain('.plur/bin/plur-hook')
+    }
+  })
+
+  it('migration: re-init replaces npx hooks with local shim hooks (#178)', () => {
+    // Simulate old npx-style hooks
+    const settingsPath = join(home, '.claude', 'settings.json')
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject', timeout: 15 }] },
+          ],
+          PreToolUse: [
+            { matcher: '*', hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-session-guard', timeout: 3 }] },
+          ],
+        },
+        mcpServers: {
+          plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        },
+      }, null, 2),
+    )
+
+    runInit()
+    const settings = readSettings()
+
+    // Old npx hooks should be replaced
+    const hookCommands: string[] = []
+    for (const entries of Object.values(settings.hooks ?? {})) {
+      for (const entry of entries) {
+        for (const h of entry.hooks) hookCommands.push(h.command)
+      }
+    }
+
+    for (const cmd of hookCommands) {
+      expect(cmd).not.toContain('npx @plur-ai/cli')
+    }
+    expect(hookCommands.some((c) => c.includes('.plur/bin/plur-hook'))).toBe(true)
+  })
+
+  it('creates plur-hook.meta.json with entrypoint info (#178)', () => {
+    runInit()
+    const metaPath = join(home, '.plur', 'bin', 'plur-hook.meta.json')
+    expect(existsSync(metaPath)).toBe(true)
+
+    const meta = JSON.parse(readFileSync(metaPath, 'utf-8'))
+    expect(meta.entrypoint).toBeDefined()
+    expect(meta.entrypoint).toContain('index.js')
+    expect(meta.node).toBeDefined()
+    expect(meta.installed).toBeDefined()
   })
 })

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,7 +4,7 @@ export {}
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
 import { fileURLToPath } from 'url'
-import { homedir } from 'os'
+import { homedir, platform } from 'os'
 
 const VERSION = '0.9.9'
 
@@ -92,8 +92,11 @@ export function extractManifestVersion(skillMdPath: string): string | null {
   }
 }
 
-// Hook commands — all use npx for zero-install compatibility
-const CLI = 'npx @plur-ai/cli'
+// Prefer local hook shim if available (installed by `plur init`, see #178).
+// Fall back to npx for first-time users who haven't run `plur init` yet.
+const _shimName = platform() === 'win32' ? 'plur-hook.cmd' : 'plur-hook'
+const _shimCandidate = join(homedir(), '.plur', 'bin', _shimName)
+const CLI = existsSync(_shimCandidate) ? _shimCandidate : 'npx @plur-ai/cli'
 
 const PLUR_HOOKS: Record<string, HookEntry[]> = {
   // --- Session lifecycle ---


### PR DESCRIPTION
## Summary

- Eliminates `npx @plur-ai/cli` from all hook commands — replaces with a local shim at `~/.plur/bin/plur-hook` that calls `node <resolved-path>` directly
- Hooks drop from 200-2000ms to <5ms per invocation (no npm resolution, no cache, no network)
- Eliminates ENOTEMPTY race condition that corrupted npx cache on version bumps and blocked all Claude Code tools
- `plur doctor` now detects stale npx hooks and validates hook shim health
- Migration is automatic: re-run `plur init` to switch from npx to local shim

## Changes

| File | What |
|------|------|
| `packages/cli/src/commands/init.ts` | `installHookBinary()`, hook maps as builder functions, dual-pattern `isPlurHook()` |
| `packages/cli/src/commands/doctor.ts` | `hasStaleNpxHooks()`, `validateHookShim()`, extended `DoctorReport` |
| `packages/mcp/src/index.ts` | Legacy init prefers existing shim, falls back to npx |
| `packages/cli/test/init.test.ts` | +4 tests (shim creation, no-npx hooks, migration, meta file) |
| `packages/cli/test/doctor.test.ts` | +3 tests (stale npx, invalid shim, healthy new-style) |
| `packages/cli/README.md` | Updated init/doctor descriptions |

## Test plan

- [x] `pnpm build` — all packages build
- [x] `pnpm test` — 982 tests passing, 0 failures
- [ ] Manual: run `plur init --global`, verify `~/.plur/bin/plur-hook` created
- [ ] Manual: verify settings.json hooks reference shim path, not npx
- [ ] Manual: run `plur doctor`, verify hookShim and staleNpxHooks fields

Closes #193, closes #194, closes #195.
Fixes #178.