### PR TITLE
ci: cancel superseded runs on rapid pushes/PR updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `concurrency: cancel-in-progress` to CI so a new push to the same ref cancels in-flight runs on prior commits.
- Mirrors the pattern already in `plur-ai/enterprise/ci.yml`.
- Reduces wasted Actions minutes when iterating rapidly on a PR (matters less here since plur is public/free, but good hygiene and shorter feedback time).

## Test plan
- [ ] PR triggers exactly one CI run on `ci/add-concurrency-guard`
- [ ] Force-push a no-op commit, confirm prior run is cancelled
- [ ] Existing job matrix (node 20/22) still runs to completion on the latest ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)