### PR TITLE
fix(mcp): return structured JSON for tool errors (#207)

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -160,7 +160,7 @@ export async function createServer(plur?: Plur): Promise<Server> {
     const tool = tools.find(t => t.name === request.params.name)
     if (!tool) {
       return {
-        content: [{ type: 'text', text: `Unknown tool: ${request.params.name}` }],
+        content: [{ type: 'text', text: JSON.stringify({ error: `Unknown tool: ${request.params.name}`, success: false }) }],
         isError: true,
       }
     }
@@ -181,8 +181,9 @@ export async function createServer(plur?: Plur): Promise<Server> {
         }
         const parsed = z.object(shape).passthrough().safeParse(args)
         if (!parsed.success) {
+          const details = parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ')
           return {
-            content: [{ type: 'text', text: `Invalid arguments: ${parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ')}` }],
+            content: [{ type: 'text', text: JSON.stringify({ error: `Invalid arguments: ${details}`, success: false }) }],
             isError: true,
           }
         }
@@ -193,7 +194,7 @@ export async function createServer(plur?: Plur): Promise<Server> {
       const message = err?.message ?? String(err)
       server.sendLoggingMessage({ level: 'error', data: `Tool ${request.params.name} failed: ${message}` })
       return {
-        content: [{ type: 'text', text: `Error: ${message}` }],
+        content: [{ type: 'text', text: JSON.stringify({ error: message, success: false }) }],
         isError: true,
       }
     }

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -96,6 +96,15 @@ describe('MCP server (wire protocol)', () => {
     expect((result.content as any)[0].text).toContain('Unknown tool')
   })
 
+  it('error responses are valid JSON with success:false (#207)', async () => {
+    const result = await client.callTool({ name: 'plur_nonexistent', arguments: {} })
+    expect(result.isError).toBe(true)
+    const parsed = JSON.parse((result.content as any)[0].text)
+    expect(parsed.success).toBe(false)
+    expect(parsed.error).toBeDefined()
+    expect(typeof parsed.error).toBe('string')
+  })
+
   // --- Resources ---
 
   it('lists resources (guide + status)', async () => {


### PR DESCRIPTION
## Summary

- MCP tool error responses now return `{ error: message, success: false }` as JSON instead of plain text strings like `"Error: Engram not found"`
- `JSON.parse` on `content[0].text` now always works regardless of success/failure
- Three error paths fixed: unknown tool, validation failure, handler exception
- Added test verifying error responses are valid JSON with `success: false`

## Context

PR #175's `callResult()` helper does `JSON.parse(content[0].text)`. When a tool returns `isError: true`, the text was `"Error: ..."` (not JSON), producing a confusing `SyntaxError` instead of the actual error. This fix makes error responses machine-parseable.

## Test plan

- [x] `pnpm build` — passes
- [x] Existing `returns isError for unknown tools` test — still passes (`.toContain('Unknown tool')` works with JSON)
- [x] New test: `error responses are valid JSON with success:false` — passes

Closes #207.