### PR TITLE
release: core 0.9.10, mcp 0.9.10, claw 0.9.15 — heartbeat endpoint fix

### DIFF
--- a/packages/claw/openclaw.plugin.json
+++ b/packages/claw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plur-claw",
   "name": "PLUR Memory Engine",
   "description": "Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "kind": "memory",
   "enabledByDefault": true,
   "configSchema": {

--- a/packages/claw/package.json
+++ b/packages/claw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/claw",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -59,7 +59,7 @@ export class PlurContextEngine implements ContextEngine {
   readonly info: ContextEngineInfo = {
     id: 'plur-claw',
     name: 'PLUR Memory Engine',
-    version: '0.9.14',
+    version: '0.9.15',
     ownsCompaction: false,
   }
 

--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -44,7 +44,7 @@ const plugin = {
   id: 'plur-claw',
   name: 'PLUR Memory Engine',
   description: 'Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.',
-  version: '0.9.14',
+  version: '0.9.15',
   kind: 'memory' as const,
 
   register(api: any) {

--- a/packages/claw/test/hello.test.ts
+++ b/packages/claw/test/hello.test.ts
@@ -6,7 +6,7 @@ describe('PLUR ContextEngine plugin', () => {
   it('plugin has correct metadata', () => {
     expect(plugin.id).toBe('plur-claw')
     expect(plugin.kind).toBe('memory')
-    expect(plugin.version).toBe('0.9.14')
+    expect(plugin.version).toBe('0.9.15')
   })
 
   it('registers via plugin API', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/core",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/mcp",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "type": "module",
   "bin": {
     "plur-mcp": "dist/index.js"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
 
-const VERSION = '0.9.9'
+const VERSION = '0.9.10'
 
 const HELP = `plur-mcp v${VERSION} — persistent memory for AI agents
 

--- a/packages/mcp/src/version.ts
+++ b/packages/mcp/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.9.9'
+export const VERSION = '0.9.10'

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -32,7 +32,7 @@ describe('MCP server (wire protocol)', () => {
   it('returns server info with instructions on initialize', () => {
     const info = client.getServerVersion()
     expect(info?.name).toBe('plur-mcp')
-    expect(info?.version).toBe('0.9.9')
+    expect(info?.version).toBe('0.9.10')
   })
 
   // --- Tools ---
@@ -138,7 +138,7 @@ describe('MCP server (wire protocol)', () => {
     const result = await client.readResource({ uri: 'plur://status' })
     const data = JSON.parse((result.contents[0] as any).text)
     expect(data.engram_count).toBe(1)
-    expect(data.version).toBe('0.9.9')
+    expect(data.version).toBe('0.9.10')
     expect(data.storage_root).toBe(dir)
   })
 


### PR DESCRIPTION
## Summary

Version bumps for the heartbeat-endpoint fix shipped today. **Already published to npm** — this PR brings `main` in sync with what's already on the registry.

## What was shipped

| Package | Before | After | Tarball verified |
|---------|--------|-------|------------------|
| `@plur-ai/core` | 0.9.9 | **0.9.10** | ✅ `dist/index.js` contains `https://plur.ai/v1/heartbeat` |
| `@plur-ai/mcp` | 0.9.9 | **0.9.10** | ✅ Pulls in core@0.9.10 (exact pin replaces the broken core@0.9.9 dep) |
| `@plur-ai/claw` | 0.9.14 | **0.9.15** | ✅ `dist/index.js` contains `https://plur.ai/v1/heartbeat` |

`@plur-ai/cli` is unchanged — no telemetry endpoint refs in its source.

## Context

- PR #211 (merged earlier today): client-side `DEFAULT_ENDPOINT` change in source.
- `plur-ai/website#4` + live deploy: receiving endpoint at `https://plur.ai/v1/heartbeat`.
- This bump: publishes the source fix so existing opted-in installs migrate.

## Why publish before merging the bump?

The npm registry is the source of truth for installed clients. Merging the version bump after publish keeps `main` consistent with the registry. The alternative (PR → merge → publish) leaves a window where npm has a release that's not on main, which is uglier and harder to bisect later.

Publish was done from this branch (10 commits worth of version bump + previously-merged source changes), so the published tarballs match exactly what this PR contains.

## Test plan

- [x] `pnpm -r build` — all packages green
- [x] `pnpm test` — 1033 passed, 16 skipped, 0 failed
- [x] `npm publish` — three packages accepted by registry
- [x] Tarball verification: extracted `dist/index.js` from core@0.9.10 and claw@0.9.15, grepped for endpoint URL — both contain `https://plur.ai/v1/heartbeat`, neither contains `heartbeat.plur-ai.org`
- [x] End-to-end smoke (earlier today): `curl -X POST https://plur.ai/v1/heartbeat ...` returns 204 from external IP; JSONL line lands on campaigns server; no client IP in Caddy log

## Refs

- #132 — heartbeat endpoint (closed earlier today)
- #211 — client-side endpoint fix (merged earlier today)
- plur-ai/website#4 — server-side route (merged + deployed earlier today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)