### PR TITLE
feat: session checkpoint + deferred wrap-up detection (#215, #216)

### DIFF
--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync, readFileSync, appendFileSync, mkdirSync, readSync, statSync } from 'fs'
+import { existsSync, writeFileSync, readFileSync, appendFileSync, mkdirSync, readSync, statSync, readdirSync, unlinkSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { tmpdir, homedir } from 'os'
 import { randomUUID } from 'crypto'
@@ -419,6 +419,65 @@ function extractEventTask(input: Record<string, unknown>, event: string): string
   }
 }
 
+/**
+ * Deferred wrap-up (#216): detect orphaned sessions from previous runs.
+ *
+ * Scans ~/.plur/sessions/ for checkpoint files without a matching
+ * session_end episode. If found, generates a brief recovery notice
+ * and cleans up the checkpoint. Returns a notice string or null.
+ *
+ * Conservative: only reports metadata (stop count, duration, cwd).
+ * Does not attempt LLM-quality summaries — that context is gone.
+ */
+function processDeferredWrapups(): string | null {
+  const plurDir = process.env.PLUR_PATH ?? join(homedir(), '.plur')
+  const sessionsDir = join(plurDir, 'sessions')
+  if (!existsSync(sessionsDir)) return null
+
+  const notices: string[] = []
+  try {
+    const files = readdirSync(sessionsDir).filter(f => f.endsWith('.checkpoint.json'))
+    const now = Date.now()
+    const STALE_THRESHOLD_MS = 5 * 60 * 1000 // 5 min — skip if possibly still active
+
+    for (const file of files) {
+      const path = join(sessionsDir, file)
+      try {
+        const checkpoint = JSON.parse(readFileSync(path, 'utf8'))
+        const lastCheckpoint = new Date(checkpoint.last_checkpoint).getTime()
+
+        // Skip if checkpoint is too recent (session may still be active elsewhere)
+        if (now - lastCheckpoint < STALE_THRESHOLD_MS) continue
+
+        // Calculate session duration
+        const started = new Date(checkpoint.started_at)
+        const ended = new Date(checkpoint.last_checkpoint)
+        const durationMin = Math.round((ended.getTime() - started.getTime()) / 60000)
+        const durationStr = durationMin >= 60
+          ? `${Math.floor(durationMin / 60)}h ${durationMin % 60}m`
+          : `${durationMin}m`
+
+        notices.push(
+          `Previous session (${durationStr}, ${checkpoint.stop_count} responses` +
+          `${checkpoint.cwd ? ', ' + checkpoint.cwd.split('/').slice(-2).join('/') : ''}) ` +
+          `ended without wrap-up.`,
+        )
+
+        // Clean up the checkpoint
+        unlinkSync(path)
+      } catch {
+        // Corrupt checkpoint — remove it
+        try { unlinkSync(path) } catch {}
+      }
+    }
+  } catch {
+    return null
+  }
+
+  if (notices.length === 0) return null
+  return `[PLUR] ${notices.join(' ')}\nConsider running plur_session_end with engram_suggestions when this session ends.`
+}
+
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const isRehydrate = args.includes('--rehydrate')
   const eventIdx = args.indexOf('--event')
@@ -571,6 +630,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (sessionId) parts.push(`Session ID: ${sessionId}`)
     if (projectConfig.domain) parts.push(`Project domain: ${projectConfig.domain}`)
     if (projectConfig.scope) parts.push(`Project scope: ${projectConfig.scope} — use this scope for plur_learn calls`)
+
+    // Deferred wrap-up: notify about orphaned previous sessions (#216)
+    const deferredNotice = processDeferredWrapups()
+    if (deferredNotice) parts.push('', deferredNotice)
   }
 
   if (context) {

--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -438,7 +438,11 @@ function processDeferredWrapups(): string | null {
   try {
     const files = readdirSync(sessionsDir).filter(f => f.endsWith('.checkpoint.json'))
     const now = Date.now()
-    const STALE_THRESHOLD_MS = 5 * 60 * 1000 // 5 min — skip if possibly still active
+    // Skip checkpoints touched within the stale threshold — that session may
+    // still be active in another terminal. Default 5 min; override via
+    // PLUR_CHECKPOINT_STALE_MIN (minutes) for slower-cadence users.
+    const staleMin = parseInt(process.env.PLUR_CHECKPOINT_STALE_MIN ?? '5', 10)
+    const STALE_THRESHOLD_MS = Math.max(1, staleMin) * 60 * 1000
 
     for (const file of files) {
       const path = join(sessionsDir, file)

--- a/packages/cli/src/commands/hook-learn-check.ts
+++ b/packages/cli/src/commands/hook-learn-check.ts
@@ -1,30 +1,75 @@
-import { readSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { readSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
-import { tmpdir } from 'os'
+import { tmpdir, homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
 
 /**
- * plur hook-learn-check — Stop hook that prompts learning reflection.
+ * plur hook-learn-check — Stop hook that prompts learning reflection
+ * AND writes periodic session checkpoints for crash recovery (#215).
  *
- * Runs at the end of every response. Every 3rd Stop, injects a brief
- * reminder to check if anything worth remembering happened. This catches
- * reasoning moments that no tool-level hook can intercept.
+ * Runs at the end of every response:
+ * - Every 3rd Stop: injects a learning reflection nudge
+ * - Every 10th Stop: writes a session checkpoint to ~/.plur/sessions/
  *
- * The counter persists via a temp file keyed to the parent process (session).
+ * Checkpoints enable deferred wrap-up (#216): if a session exits without
+ * calling plur_session_end, the next session_start detects the orphaned
+ * checkpoint and processes observations retroactively.
+ *
+ * The counter persists via a temp file keyed to the session ID.
  *
  * Input: JSON on stdin (Claude Code Stop hook format)
  * Output: JSON on stdout with additionalContext (or passthrough)
  */
 
-const INTERVAL = 3 // Fire every N stops
+const LEARN_INTERVAL = 3 // Learning nudge every N stops
+const CHECKPOINT_INTERVAL = parseInt(process.env.PLUR_CHECKPOINT_INTERVAL || '10', 10)
+
+function sessionKey(): string {
+  const raw = process.env.CLAUDE_SESSION_ID || String(process.ppid || 'unknown')
+  return raw.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || 'default'
+}
 
 function counterPath(): string {
   const dir = join(tmpdir(), 'plur-sessions')
   mkdirSync(dir, { recursive: true })
-  // Use session ID (stable across all hooks in a session) with ppid fallback
-  const sessionKey = process.env.CLAUDE_SESSION_ID || String(process.ppid || 'unknown')
-  const safeKey = sessionKey.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || 'default'
-  return join(dir, `${safeKey}.stop-count`)
+  return join(dir, `${sessionKey()}.stop-count`)
+}
+
+function plurPath(): string {
+  return process.env.PLUR_PATH ?? join(homedir(), '.plur')
+}
+
+function checkpointDir(): string {
+  const dir = join(plurPath(), 'sessions')
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function writeCheckpoint(count: number, cwd: string): void {
+  const id = sessionKey()
+  const dir = checkpointDir()
+  const path = join(dir, `${id}.checkpoint.json`)
+
+  const now = new Date().toISOString()
+  const dateStr = now.slice(0, 10) // YYYY-MM-DD for observation file
+
+  // Read existing checkpoint to preserve started_at
+  let startedAt = now
+  try {
+    const existing = JSON.parse(readFileSync(path, 'utf8'))
+    if (existing.started_at) startedAt = existing.started_at
+  } catch { /* first checkpoint */ }
+
+  const checkpoint = {
+    session_id: id,
+    started_at: startedAt,
+    last_checkpoint: now,
+    stop_count: count,
+    cwd,
+    observation_file: `${dateStr}.jsonl`,
+  }
+
+  writeFileSync(path, JSON.stringify(checkpoint, null, 2) + '\n')
 }
 
 function readStdinRaw(): string {
@@ -51,6 +96,13 @@ const LEARN_PROMPT = `[PLUR] Did you discover, learn, or get corrected on someth
 export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
   const raw = readStdinRaw()
 
+  // Parse stdin for cwd (provided by Claude Code hook payload)
+  let cwd = process.cwd()
+  try {
+    const data = JSON.parse(raw)
+    if (data.cwd) cwd = data.cwd
+  } catch { /* use process.cwd fallback */ }
+
   // Read and increment persistent counter
   const cPath = counterPath()
   let count = 1
@@ -60,8 +112,13 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
   } catch {}
   try { writeFileSync(cPath, String(count)) } catch {}
 
-  // Only fire every Nth stop
-  if (count % INTERVAL !== 0) {
+  // Write session checkpoint periodically (#215)
+  if (count % CHECKPOINT_INTERVAL === 0) {
+    try { writeCheckpoint(count, cwd) } catch { /* never block on checkpoint failure */ }
+  }
+
+  // Learning nudge every Nth stop
+  if (count % LEARN_INTERVAL !== 0) {
     process.stdout.write(raw)
     return
   }

--- a/packages/cli/test/session-checkpoint.test.ts
+++ b/packages/cli/test/session-checkpoint.test.ts
@@ -111,6 +111,9 @@ describe('deferred wrap-up detection (#216)', () => {
       }),
     )
     mkdirSync(join(home, '.plur'), { recursive: true })
+    // Per-test TMPDIR so the session marker (keyed by ppid in tmpdir/plur-sessions)
+    // doesn't leak across tests sharing the test runner's PID.
+    mkdirSync(join(home, 'tmp'), { recursive: true })
   })
 
   afterEach(() => {
@@ -136,7 +139,7 @@ describe('deferred wrap-up detection (#216)', () => {
     )
   }
 
-  function runInject(prompt: string): { stdout: string } {
+  function runInject(prompt: string, extraEnv?: Record<string, string>): { stdout: string } {
     const result = spawnSync('node', [CLI, 'hook-inject'], {
       input: JSON.stringify({ prompt }),
       encoding: 'utf-8',
@@ -145,8 +148,10 @@ describe('deferred wrap-up detection (#216)', () => {
         ...process.env,
         HOME: home,
         USERPROFILE: home,
+        TMPDIR: join(home, 'tmp'),
         PLUR_PATH: join(home, '.plur'),
         CLAUDE_SESSION_ID: 'new-session-456',
+        ...extraEnv,
       },
       cwd: home,
     })
@@ -157,14 +162,14 @@ describe('deferred wrap-up detection (#216)', () => {
     createOrphanedCheckpoint('old-session-789', 30) // 30 min old — stale
 
     const { stdout } = runInject('hello, new session')
-    // hook-inject may output JSON or nothing (if no engrams to inject)
-    // The deferred notice is included when output exists
-    if (stdout.trim()) {
-      const output = JSON.parse(stdout)
-      expect(output.additionalContext).toContain('Previous session')
-      expect(output.additionalContext).toContain('ended without wrap-up')
-    }
-    // Checkpoint should be cleaned up regardless
+    // hook-inject always emits output on non-rehydrate path (session header
+    // is unconditional), so we can assert directly without a guard.
+    expect(stdout.trim()).not.toBe('')
+    const output = JSON.parse(stdout)
+    expect(output.additionalContext).toContain('Previous session')
+    expect(output.additionalContext).toContain('ended without wrap-up')
+
+    // Checkpoint was cleaned up after detection
     const checkpointPath = join(home, '.plur', 'sessions', 'old-session-789.checkpoint.json')
     expect(existsSync(checkpointPath)).toBe(false)
   })
@@ -175,12 +180,9 @@ describe('deferred wrap-up detection (#216)', () => {
 
     expect(existsSync(checkpointPath)).toBe(true)
     const { stdout } = runInject('start fresh')
-    // If injection mentions the orphaned session, the checkpoint should be gone
-    if (stdout.includes('Previous session')) {
-      expect(existsSync(checkpointPath)).toBe(false)
-    }
-    // If injection didn't run the deferred check (e.g. no engrams to inject),
-    // the checkpoint persists — that's acceptable, it'll be caught next time
+    // Session header is unconditional → output should mention the orphan
+    expect(stdout).toContain('Previous session')
+    expect(existsSync(checkpointPath)).toBe(false)
   })
 
   it('skips recent checkpoints (possibly still active)', () => {
@@ -194,10 +196,19 @@ describe('deferred wrap-up detection (#216)', () => {
 
   it('no orphaned checkpoints means no deferred notice', () => {
     const { stdout } = runInject('clean start')
-    // When no orphaned checkpoints, output should not mention "Previous session"
-    if (stdout.trim()) {
-      expect(stdout).not.toContain('Previous session')
-    }
-    // No crash — test passes if we get here
+    // Output is non-empty (session header) but must not mention the orphan path
+    expect(stdout.trim()).not.toBe('')
+    expect(stdout).not.toContain('Previous session')
+  })
+
+  it('PLUR_CHECKPOINT_STALE_MIN env var overrides 5-min default', () => {
+    // Create a 3-min-old checkpoint. With default 5-min threshold it would be
+    // skipped; with threshold lowered to 1 min via env, it should trigger.
+    createOrphanedCheckpoint('threshold-test', 3)
+    const checkpointPath = join(home, '.plur', 'sessions', 'threshold-test.checkpoint.json')
+
+    const { stdout } = runInject('with custom threshold', { PLUR_CHECKPOINT_STALE_MIN: '1' })
+    expect(stdout).toContain('Previous session')
+    expect(existsSync(checkpointPath)).toBe(false)
   })
 })

--- a/packages/cli/test/session-checkpoint.test.ts
+++ b/packages/cli/test/session-checkpoint.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { spawnSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('session checkpoint (#215)', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-checkpoint-test-'))
+    // Create plur config so isPlurConfigured doesn't short-circuit
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(
+      join(home, '.claude', 'settings.json'),
+      JSON.stringify({
+        mcpServers: {
+          plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        },
+      }),
+    )
+    // Create tmp dir for counter files so they don't leak between tests
+    mkdirSync(join(home, 'tmp', 'plur-sessions'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  function runLearnCheck(input: object, env?: Record<string, string>): { stdout: string; stderr: string } {
+    const result = spawnSync('node', [CLI, 'hook-learn-check'], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        TMPDIR: join(home, 'tmp'),
+        PLUR_PATH: join(home, '.plur'),
+        CLAUDE_SESSION_ID: 'test-session-123',
+        PLUR_CHECKPOINT_INTERVAL: '2', // every 2nd stop for test speed
+        ...env,
+      },
+      cwd: home,
+    })
+    return { stdout: result.stdout ?? '', stderr: result.stderr ?? '' }
+  }
+
+  it('writes checkpoint after PLUR_CHECKPOINT_INTERVAL stops', () => {
+    // Stop 1 — no checkpoint yet
+    runLearnCheck({})
+    const checkpointPath = join(home, '.plur', 'sessions', 'test-session-123.checkpoint.json')
+    expect(existsSync(checkpointPath)).toBe(false)
+
+    // Stop 2 — checkpoint written (interval = 2)
+    runLearnCheck({})
+    expect(existsSync(checkpointPath)).toBe(true)
+
+    const checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
+    expect(checkpoint.session_id).toBe('test-session-123')
+    expect(checkpoint.started_at).toBeDefined()
+    expect(checkpoint.last_checkpoint).toBeDefined()
+    expect(checkpoint.stop_count).toBe(2)
+  })
+
+  it('updates checkpoint on subsequent intervals', () => {
+    const checkpointPath = join(home, '.plur', 'sessions', 'test-session-123.checkpoint.json')
+
+    // Run 4 stops (2 checkpoints at interval=2)
+    for (let i = 0; i < 4; i++) runLearnCheck({})
+
+    const checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
+    expect(checkpoint.stop_count).toBe(4)
+    // started_at should be preserved from first checkpoint
+    expect(checkpoint.started_at).toBeDefined()
+  })
+
+  it('preserves started_at across updates', () => {
+    const checkpointPath = join(home, '.plur', 'sessions', 'test-session-123.checkpoint.json')
+
+    // First checkpoint
+    runLearnCheck({})
+    runLearnCheck({})
+    const first = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
+
+    // Wait a bit and do more stops
+    runLearnCheck({})
+    runLearnCheck({})
+    const second = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
+
+    expect(second.started_at).toBe(first.started_at)
+    expect(second.last_checkpoint).not.toBe(first.last_checkpoint)
+  })
+})
+
+describe('deferred wrap-up detection (#216)', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-deferred-test-'))
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(
+      join(home, '.claude', 'settings.json'),
+      JSON.stringify({
+        mcpServers: {
+          plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        },
+      }),
+    )
+    mkdirSync(join(home, '.plur'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  function createOrphanedCheckpoint(sessionId: string, ageMinutes: number): void {
+    const sessionsDir = join(home, '.plur', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const now = Date.now()
+    const checkpointTime = new Date(now - ageMinutes * 60000).toISOString()
+    const startTime = new Date(now - (ageMinutes + 60) * 60000).toISOString()
+    writeFileSync(
+      join(sessionsDir, `${sessionId}.checkpoint.json`),
+      JSON.stringify({
+        session_id: sessionId,
+        started_at: startTime,
+        last_checkpoint: checkpointTime,
+        stop_count: 25,
+        cwd: '/Users/test/project',
+        observation_file: '2026-05-22.jsonl',
+      }),
+    )
+  }
+
+  function runInject(prompt: string): { stdout: string } {
+    const result = spawnSync('node', [CLI, 'hook-inject'], {
+      input: JSON.stringify({ prompt }),
+      encoding: 'utf-8',
+      timeout: 15000,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        PLUR_PATH: join(home, '.plur'),
+        CLAUDE_SESSION_ID: 'new-session-456',
+      },
+      cwd: home,
+    })
+    return { stdout: result.stdout ?? '' }
+  }
+
+  it('detects orphaned checkpoint and includes notice in injection', () => {
+    createOrphanedCheckpoint('old-session-789', 30) // 30 min old — stale
+
+    const { stdout } = runInject('hello, new session')
+    // hook-inject may output JSON or nothing (if no engrams to inject)
+    // The deferred notice is included when output exists
+    if (stdout.trim()) {
+      const output = JSON.parse(stdout)
+      expect(output.additionalContext).toContain('Previous session')
+      expect(output.additionalContext).toContain('ended without wrap-up')
+    }
+    // Checkpoint should be cleaned up regardless
+    const checkpointPath = join(home, '.plur', 'sessions', 'old-session-789.checkpoint.json')
+    expect(existsSync(checkpointPath)).toBe(false)
+  })
+
+  it('cleans up orphaned checkpoint after detection', () => {
+    createOrphanedCheckpoint('cleanup-test', 30)
+    const checkpointPath = join(home, '.plur', 'sessions', 'cleanup-test.checkpoint.json')
+
+    expect(existsSync(checkpointPath)).toBe(true)
+    const { stdout } = runInject('start fresh')
+    // If injection mentions the orphaned session, the checkpoint should be gone
+    if (stdout.includes('Previous session')) {
+      expect(existsSync(checkpointPath)).toBe(false)
+    }
+    // If injection didn't run the deferred check (e.g. no engrams to inject),
+    // the checkpoint persists — that's acceptable, it'll be caught next time
+  })
+
+  it('skips recent checkpoints (possibly still active)', () => {
+    createOrphanedCheckpoint('active-session', 2) // only 2 min old
+    const checkpointPath = join(home, '.plur', 'sessions', 'active-session.checkpoint.json')
+
+    runInject('new session')
+    // Should NOT be cleaned up — too recent
+    expect(existsSync(checkpointPath)).toBe(true)
+  })
+
+  it('no orphaned checkpoints means no deferred notice', () => {
+    const { stdout } = runInject('clean start')
+    // When no orphaned checkpoints, output should not mention "Previous session"
+    if (stdout.trim()) {
+      expect(stdout).not.toContain('Previous session')
+    }
+    // No crash — test passes if we get here
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1236,6 +1236,23 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           channel: 'mcp',
         })
 
+        // Clean up session checkpoint (#215) — session ended cleanly
+        try {
+          const { existsSync, unlinkSync } = await import('fs')
+          const { join } = await import('path')
+          const { homedir } = await import('os')
+          const plurDir = process.env.PLUR_PATH ?? join(homedir(), '.plur')
+          const sessionsDir = join(plurDir, 'sessions')
+          // Try session_id first, then CLAUDE_SESSION_ID, then ppid
+          const keys = [session_id, process.env.CLAUDE_SESSION_ID, String(process.ppid)]
+            .filter(Boolean)
+            .map(k => k!.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64))
+          for (const key of keys) {
+            const cp = join(sessionsDir, `${key}.checkpoint.json`)
+            if (existsSync(cp)) { unlinkSync(cp); break }
+          }
+        } catch { /* cleanup is best-effort */ }
+
         const status = plur.status()
 
         return {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,3 +1,6 @@
+import { existsSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
 import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary } from '@plur-ai/core'
 import type { LlmFunction, MetaField } from '@plur-ai/core'
 import { VERSION } from './version.js'
@@ -1238,9 +1241,6 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
 
         // Clean up session checkpoint (#215) — session ended cleanly
         try {
-          const { existsSync, unlinkSync } = await import('fs')
-          const { join } = await import('path')
-          const { homedir } = await import('os')
           const plurDir = process.env.PLUR_PATH ?? join(homedir(), '.plur')
           const sessionsDir = join(plurDir, 'sessions')
           // Try session_id first, then CLAUDE_SESSION_ID, then ppid


### PR DESCRIPTION
## Summary

Two-layer defense against lost session-end engrams (enterprise#112):

**Layer 1 — Stop hook checkpoint (#215):**
- `hook-learn-check` now writes `~/.plur/sessions/{id}.checkpoint.json` every 10th Stop
- Tracks: session_id, started_at, last_checkpoint, stop_count, cwd
- Checkpoint deleted on clean `plur_session_end`
- Interval configurable via `PLUR_CHECKPOINT_INTERVAL` env var

**Layer 2 — Deferred wrap-up (#216):**
- `hook-inject` detects orphaned checkpoints on new session start
- Orphaned = checkpoint >5 min old without matching session_end
- User sees: "[PLUR] Previous session (2h 30m, 47 responses) ended without wrap-up."
- Checkpoint cleaned up after detection

**session_end cleanup:**
- `plur_session_end` MCP tool now deletes checkpoint on clean close

## What this doesn't solve (by design)

- LLM-quality session summaries at exit (requires conversation context, which is gone)
- Enterprise server-side timeout (separate issue: enterprise#162)
- Upstream SessionEnd hook event (filed: #217)

## Files changed

| File | What |
|------|------|
| `packages/cli/src/commands/hook-learn-check.ts` | Checkpoint writing every Nth Stop |
| `packages/cli/src/commands/hook-inject.ts` | `processDeferredWrapups()` on new session |
| `packages/mcp/src/tools.ts` | Checkpoint cleanup in session_end handler |
| `packages/cli/test/session-checkpoint.test.ts` | 7 new tests |

## Test plan

- [x] All 1040 tests passing
- [x] Checkpoint created after interval
- [x] Checkpoint updated, preserves started_at
- [x] Orphaned checkpoint detected on new session
- [x] Recent checkpoints skipped (< 5 min)
- [x] Clean session_end deletes checkpoint

Closes #215, closes #216. Part of enterprise#112.