### PR TITLE
fix: 0.9.11 bug sweep — session_end shape (#231), listStores async (#184), doctor isolation (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.9.11 (2026-05-26)
+
+Bug sweep — three independent fixes bundled.
+
+### `plur_session_end` no longer crashes on string-array suggestions (#231)
+
+Calling `plur_session_end` with `engram_suggestions: ["a", "b"]` (bare strings rather than `{statement, type}` objects) used to crash with the cryptic `Cannot read properties of undefined (reading 'match')`. The MCP JSON-Schema→Zod converter ignored nested `items` shape, the handler dereferenced `s.statement` on a string, and `detectSecrets()` exploded inside `plur.learn` with no context. Fixed at every layer:
+
+- **`packages/mcp/src/server.ts`** — schema-to-Zod converter now recurses into array `items` and supports `anyOf`/`oneOf` via `z.union`.
+- **`packages/mcp/src/tools.ts`** — `engram_suggestions` schema declares `items` as `anyOf: [string, object]`. Handler coerces bare strings into `{statement: s}` (LLM-friendly recovery) and throws a clear error for non-string non-object items.
+- **`packages/core/src/secrets.ts`** + **`packages/core/src/index.ts`** — `detectSecrets()` and `plur.learn()` throw clear `TypeError` when called with non-strings, instead of letting `undefined.match()` propagate.
+
+### `plur_stores_list` reports accurate remote engram counts (#184)
+
+`plur_stores_list` used to return `engram_count: 0` for remote stores on the first call of a fresh MCP server session because `_loadRemoteCached` is synchronous and returns whatever's in the driver cache (empty on first call) while triggering an async load in the background. New `Plur.listStoresAsync()` awaits each remote driver's `load()` with a per-store 5-second timeout race so a hung remote can never block the listing call. The MCP `plur_stores_list` handler and the `plur stores list` CLI command both call the async variant. Sync `listStores()` is retained with `@deprecated` for callers that cannot await.
+
+### `plur doctor` exits cleanly even when the embedder crashes (#197)
+
+`onnxruntime-node` has a known SIGABRT crash on macOS during libc++ thread-pool cleanup on process exit, which caused `plur doctor` itself to exit with code 134 even when everything else was healthy. The embedder probe now runs in an isolated subprocess (`plur _embedder-probe`, an internal subcommand guarded by `PLUR_INTERNAL_PROBE=1`) — if it crashes, only the subprocess dies and the doctor reports `embedder: degraded` with the parent's exit code intact. Handles compiled binaries (pkg, bun --compile, nexe) gracefully by skipping the probe when the CLI entry isn't a JS file.
+
+### Tests
+
+11 new tests across `packages/core/test/secrets.test.ts`, `packages/core/test/remote-store-cache.test.ts`, `packages/mcp/test/server.test.ts`, `packages/mcp/test/session.test.ts`, and `packages/cli/test/embedder-probe.test.ts`. Full suite: 1045 passed, 19 skipped.
+
+### Packages bumped
+
+- `@plur-ai/core`: 0.9.10 → 0.9.11
+- `@plur-ai/mcp`: 0.9.10 → 0.9.11
+- `@plur-ai/cli`: 0.9.10 → 0.9.11
+- `@plur-ai/claw`: unchanged (no claw-side changes)
+
 ## 0.9.9 (2026-05-14)
 
 Concurrent writes — hardened.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/cli",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "type": "module",
   "bin": {
     "plur": "dist/index.js"

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process'
-import { existsSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { existsSync, readFileSync, realpathSync } from 'fs'
+import { join, extname } from 'path'
 import { homedir, platform } from 'os'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { outputText, outputJson, shouldOutputJson } from '../output.js'
@@ -207,41 +207,124 @@ async function mcpHandshake(timeoutMs = 20000): Promise<{ ok: boolean; serverNam
   })
 }
 
-async function checkEmbedder(flags: GlobalFlags): Promise<{ available: boolean; loaded: boolean; lastError: string | null; modelLoaded: boolean; disabled: boolean; disabledReason: string | null }> {
+/**
+ * Resolve the CLI's JavaScript entry path for subprocess spawning.
+ *
+ * `process.argv[1]` is the script Node was told to run, but:
+ *   - npx/global installs route through bin shims (often symlinks)
+ *   - pkg/bun/nexe compile the entire CLI into a single binary — no .js file exists
+ *
+ * Strategy: realpath the argv[1] symlink chain, then check the extension.
+ * If the resolved path is not a Node-executable script, return null and let
+ * the caller fall back gracefully.
+ */
+function resolveCliJsEntry(): string | null {
+  const argv1 = process.argv[1]
+  if (!argv1) return null
+  let resolved: string
   try {
-    const plur = createPlur(flags)
-    // Skip the load probe when explicitly disabled — calling recallSemantic
-    // would still short-circuit (getEmbedder returns null) but the probe is
-    // misleading noise in that case.
-    const preStatus = plur.embedderStatus()
-    if (!preStatus.disabled) {
-      // Force a probe so we get a real load attempt rather than just the cached state
-      plur.resetEmbedder()
-      try {
-        await plur.recallSemantic('plur doctor probe', { limit: 1 })
-      } catch {
-        // best effort
-      }
-    }
-    const status = plur.embedderStatus()
-    return {
-      available: status.available,
-      loaded: status.loaded,
-      lastError: status.lastError,
-      modelLoaded: status.available && status.loaded,
-      disabled: status.disabled,
-      disabledReason: status.disabledReason,
-    }
-  } catch (err) {
-    return {
+    resolved = realpathSync(argv1)
+  } catch {
+    return null
+  }
+  const ext = extname(resolved).toLowerCase()
+  if (ext !== '.js' && ext !== '.mjs' && ext !== '.cjs') return null
+  return resolved
+}
+
+/**
+ * Probe the embedder in an isolated subprocess (issue #197).
+ *
+ * Why subprocess: onnxruntime-node has a known SIGABRT crash on macOS during
+ * thread pool cleanup on process exit. Running the probe in-process makes
+ * `plur doctor` itself exit with code 134 even when everything is healthy.
+ * Subprocess isolation contains the crash — if the probe dies, parent reports
+ * embedder as degraded and continues with the rest of the doctor checks.
+ *
+ * Timeout: 10s default. BGE model cold-load on slow hardware takes ~3-5s; 10s
+ * is enough for honest cases without making doctor feel unresponsive.
+ */
+async function checkEmbedder(_flags: GlobalFlags, timeoutMs = 10000): Promise<{ available: boolean; loaded: boolean; lastError: string | null; modelLoaded: boolean; disabled: boolean; disabledReason: string | null }> {
+  return new Promise((resolve) => {
+    const fallback = (lastError: string) => ({
       available: false,
       loaded: false,
-      lastError: err instanceof Error ? err.message : String(err),
+      lastError,
       modelLoaded: false,
       disabled: false,
       disabledReason: null,
+    })
+
+    const cliEntry = resolveCliJsEntry()
+    if (!cliEntry) {
+      // Compiled binary, missing entry, or unresolvable symlink. We can't spawn
+      // a subprocess that re-enters the CLI. Report skipped — the user will
+      // see this in the doctor output and know to investigate manually.
+      resolve(fallback('embedder probe skipped: CLI entry is not a JS file (compiled binary?)'))
+      return
     }
-  }
+
+    let resolved = false
+    const finish = (result: ReturnType<typeof fallback>) => {
+      if (resolved) return
+      resolved = true
+      try { proc.kill() } catch { /* ignore */ }
+      resolve(result)
+    }
+
+    let proc: ReturnType<typeof spawn>
+    try {
+      proc = spawn(process.execPath, [cliEntry, '_embedder-probe'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // Mark the subprocess as the parent-spawned probe — the probe checks
+        // this and refuses to run if invoked directly by a curious user.
+        env: { ...process.env, PLUR_INTERNAL_PROBE: '1' },
+      })
+    } catch (err: unknown) {
+      finish(fallback(`spawn failed: ${(err as Error).message}`))
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      finish(fallback(`probe timeout after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    let stdoutBuf = ''
+    let stderrBuf = ''
+    proc.stdout?.on('data', (chunk: Buffer) => { stdoutBuf += chunk.toString('utf8') })
+    proc.stderr?.on('data', (chunk: Buffer) => { stderrBuf += chunk.toString('utf8') })
+
+    proc.on('error', (err: Error) => {
+      clearTimeout(timeout)
+      finish(fallback(`probe spawn error: ${err.message}`))
+    })
+
+    proc.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+      clearTimeout(timeout)
+      // Parse the LAST line starting with `{` — defends against any stdout
+      // pollution (logs, warnings) that might precede the result line.
+      const lines = stdoutBuf.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('{'))
+      const resultLine = lines[lines.length - 1]
+      if (resultLine) {
+        try {
+          const parsed = JSON.parse(resultLine)
+          finish({
+            available: !!parsed.available,
+            loaded: !!parsed.loaded,
+            lastError: parsed.lastError ?? null,
+            modelLoaded: !!parsed.modelLoaded,
+            disabled: !!parsed.disabled,
+            disabledReason: parsed.disabledReason ?? null,
+          })
+          return
+        } catch { /* fall through */ }
+      }
+      // No parseable output — crash or timeout. Report degraded with diagnostics.
+      const detail = signal ? `signal ${signal}` : `exit ${code}`
+      const stderrTrim = stderrBuf.trim().slice(0, 200)
+      finish(fallback(`embedder probe failed (${detail})${stderrTrim ? `: ${stderrTrim}` : ''}`))
+    })
+  })
 }
 
 function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<DoctorReport> {

--- a/packages/cli/src/commands/embedder-probe.ts
+++ b/packages/cli/src/commands/embedder-probe.ts
@@ -1,0 +1,61 @@
+import { createPlur, type GlobalFlags } from '../plur.js'
+
+/**
+ * Hidden subcommand: spawn-target for `plur doctor`'s embedder probe.
+ *
+ * Why this exists: onnxruntime-node has a known SIGABRT crash on macOS during
+ * thread pool cleanup on process exit (issue #197). When that happens in the
+ * doctor process itself, doctor exits with code 134 even though everything else
+ * is healthy. Running the probe in a subprocess isolates the crash — the
+ * subprocess dies, parent stays alive, doctor reports embedder status
+ * gracefully and exits with the correct overall code.
+ *
+ * Contract: writes a single line of JSON to stdout, then exits 0. If the
+ * underlying probe crashes (SIGABRT, OOM, etc.) the parent detects the
+ * non-zero exit code and reports the embedder as degraded.
+ *
+ * JSON shape matches the `embedder` field of DoctorReport.
+ */
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  // Refuse to run when not invoked by the parent `plur doctor` process.
+  // This is checked first so that curious users discovering the command
+  // (e.g. via tab-complete) get a clear message instead of opaque JSON.
+  if (process.env.PLUR_INTERNAL_PROBE !== '1') {
+    process.stderr.write(
+      '_embedder-probe is an internal subcommand spawned by `plur doctor`. ' +
+      'Run `plur doctor` instead.\n',
+    )
+    process.exit(1)
+  }
+
+  try {
+    const plur = createPlur(flags)
+    const preStatus = plur.embedderStatus()
+    if (!preStatus.disabled) {
+      plur.resetEmbedder()
+      try {
+        await plur.recallSemantic('plur doctor probe', { limit: 1 })
+      } catch { /* best effort — probe completing is enough signal */ }
+    }
+    const status = plur.embedderStatus()
+    process.stdout.write(JSON.stringify({
+      available: status.available,
+      loaded: status.loaded,
+      lastError: status.lastError,
+      modelLoaded: status.available && status.loaded,
+      disabled: status.disabled,
+      disabledReason: status.disabledReason,
+    }) + '\n')
+    process.exit(0)
+  } catch (err) {
+    process.stdout.write(JSON.stringify({
+      available: false,
+      loaded: false,
+      lastError: err instanceof Error ? err.message : String(err),
+      modelLoaded: false,
+      disabled: false,
+      disabledReason: null,
+    }) + '\n')
+    process.exit(0)
+  }
+}

--- a/packages/cli/src/commands/stores.ts
+++ b/packages/cli/src/commands/stores.ts
@@ -24,7 +24,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   }
 
   if (!subcommand || subcommand === 'list') {
-    const storeList = plur.listStores()
+    // Async variant — accurate remote store engram_count (issue #184)
+    const storeList = await plur.listStoresAsync()
     if (shouldOutputJson(flags)) {
       outputJson({ stores: storeList, count: storeList.length })
     } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { parseGlobalFlags, createPlur } from './plur.js'
 export type { GlobalFlags } from './plur.js'
 export { parseGlobalFlags, createPlur } from './plur.js'
 
-const VERSION = '0.9.10'
+const VERSION = '0.9.11'
 
 // --- Main ---
 const argv = process.argv.slice(2)
@@ -99,6 +99,10 @@ const COMMANDS: Record<string, string> = {
   'hook-session-remind': './commands/hook-session-remind.js',
   'hook-correction-detect': './commands/hook-correction-detect.js',
   'hook-revert-detect': './commands/hook-revert-detect.js',
+  // Hidden internal subcommand — spawned by `plur doctor` to isolate the
+  // ONNX embedder probe (issue #197). If the probe crashes with SIGABRT
+  // on libc++ thread pool cleanup, only the subprocess dies; doctor stays alive.
+  '_embedder-probe': './commands/embedder-probe.js',
 }
 
 if (!command || !COMMANDS[command]) {

--- a/packages/cli/test/embedder-probe.test.ts
+++ b/packages/cli/test/embedder-probe.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('plur _embedder-probe (issue #197)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-probe-test-')) })
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  it('refuses to run when called directly (no PLUR_INTERNAL_PROBE env var)', () => {
+    // Should exit 1 with a stderr explanation. We expect execSync to throw.
+    let threw = false
+    let stderr = ''
+    try {
+      execSync(`node ${CLI} _embedder-probe --path ${dir}`, {
+        encoding: 'utf-8',
+        timeout: 10000,
+        env: { ...process.env, PLUR_INTERNAL_PROBE: '' },
+      })
+    } catch (err: any) {
+      threw = true
+      stderr = (err.stderr ?? '').toString()
+    }
+    expect(threw).toBe(true)
+    expect(stderr).toMatch(/internal subcommand/i)
+    expect(stderr).toMatch(/plur doctor/i)
+  })
+
+  it('runs and emits JSON status when invoked with PLUR_INTERNAL_PROBE=1', () => {
+    // Force embeddings off so the probe completes quickly without loading
+    // the BGE model — we're testing the contract (JSON shape + exit 0),
+    // not the actual embedder.
+    const output = execSync(`node ${CLI} _embedder-probe --path ${dir}`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, PLUR_INTERNAL_PROBE: '1', PLUR_DISABLE_EMBEDDINGS: '1' },
+    })
+    const lastJsonLine = output.split('\n').map(l => l.trim()).filter(l => l.startsWith('{')).pop()
+    expect(lastJsonLine).toBeDefined()
+    const parsed = JSON.parse(lastJsonLine!)
+    expect(parsed).toHaveProperty('available')
+    expect(parsed).toHaveProperty('loaded')
+    expect(parsed).toHaveProperty('modelLoaded')
+    expect(parsed).toHaveProperty('disabled')
+    expect(parsed).toHaveProperty('disabledReason')
+    // When PLUR_DISABLE_EMBEDDINGS=1, the embedder is disabled by design.
+    expect(parsed.disabled).toBe(true)
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/core",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -415,6 +415,9 @@ export class Plur {
    * Fast-path hash dedup returns existing on exact match.
    */
   learn(statement: string, context?: LearnContext): Engram {
+    if (typeof statement !== 'string' || statement.length === 0) {
+      throw new TypeError(`plur.learn: statement must be a non-empty string, got ${typeof statement}`)
+    }
     if (!this.config.allow_secrets) {
       const secrets = detectSecrets(statement)
       if (secrets.length > 0) {
@@ -1891,19 +1894,30 @@ Generate an improved version of the procedure that prevents this failure. Return
     return discovered
   }
 
-  /** List all configured stores. */
-  listStores(): Array<{
+  /** Build the primary-store summary row. Shared by listStores +
+   * listStoresAsync to keep them in lockstep. */
+  private _primaryStoreRow(): {
     path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
-  }> {
-    const stores = this.config.stores ?? []
-    // Always include the primary store
-    const primary = {
+  } {
+    return {
       path: this.paths.engrams,
       scope: 'global',
       shared: false,
       readonly: false,
       engram_count: this._loadCached(this.paths.engrams).filter(e => e.status !== 'retired').length,
     }
+  }
+
+  /**
+   * @deprecated Use {@link listStoresAsync} for accurate remote engram counts.
+   * The sync variant returns engram_count: 0 for remote stores on the first
+   * call after server start because the remote cache hasn't populated yet
+   * (issue #184). Retained for callers that cannot await.
+   */
+  listStores(): Array<{
+    path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
+  }> {
+    const stores = this.config.stores ?? []
     const additional = stores.map(s => {
       let count = 0
       if (s.url) {
@@ -1920,6 +1934,57 @@ Generate an improved version of the procedure that prevents this failure. Return
         engram_count: count,
       }
     })
-    return [primary, ...additional]
+    return [this._primaryStoreRow(), ...additional]
+  }
+
+  /**
+   * List all configured stores with accurate remote engram counts. Awaits
+   * remote driver loads with a 5s per-store timeout so a single slow or
+   * unreachable remote can never hang the entire call (issue #184).
+   *
+   * Use for `plur_stores_list` and CLI diagnostics where freshness matters
+   * more than latency.
+   */
+  async listStoresAsync(): Promise<Array<{
+    path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
+  }>> {
+    const stores = this.config.stores ?? []
+    const REMOTE_LOAD_TIMEOUT_MS = 5000
+
+    const additional = await Promise.all(stores.map(async s => {
+      let count = 0
+      if (s.url) {
+        try {
+          const driver = this._getRemoteDriver({ url: s.url, token: s.token, scope: s.scope })
+          // Race driver.load() against a timeout — a hung remote must not
+          // hang the listing call. On timeout, count stays 0. The clearTimeout
+          // in finally is critical: in a long-lived MCP server, uncleaned
+          // timers per remote × per call would keep the event loop active.
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+          const loadWithTimeout = Promise.race([
+            driver.load().finally(() => { if (timeoutHandle) clearTimeout(timeoutHandle) }),
+            new Promise<never>((_, reject) => {
+              timeoutHandle = setTimeout(
+                () => reject(new Error(`remote load timeout (${REMOTE_LOAD_TIMEOUT_MS}ms)`)),
+                REMOTE_LOAD_TIMEOUT_MS,
+              )
+            }),
+          ])
+          const engrams = await loadWithTimeout
+          count = engrams.filter(e => e.status !== 'retired').length
+        } catch { /* network/auth failure or timeout — report 0, don't crash */ }
+      } else if (s.path) {
+        try { count = this._loadCached(s.path).filter(e => e.status !== 'retired').length } catch {}
+      }
+      return {
+        path:     s.path,
+        url:      s.url,
+        scope:    s.scope,
+        shared:   s.shared,
+        readonly: s.readonly,
+        engram_count: count,
+      }
+    }))
+    return [this._primaryStoreRow(), ...additional]
   }
 }

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -17,6 +17,9 @@ const SECRET_PATTERNS: { name: string; regex: RegExp }[] = [
 
 /** Scan text for potential secrets. Returns empty array if clean. */
 export function detectSecrets(text: string): SecretMatch[] {
+  if (typeof text !== 'string') {
+    throw new TypeError(`detectSecrets: expected string, got ${typeof text}`)
+  }
   const matches: SecretMatch[] = []
   for (const { name, regex } of SECRET_PATTERNS) {
     const m = text.match(regex)

--- a/packages/core/test/remote-store-cache.test.ts
+++ b/packages/core/test/remote-store-cache.test.ts
@@ -208,6 +208,69 @@ describe('Plur cold-start with remote store (issues #184, #185)', () => {
     expect(remote!.engram_count).toBeGreaterThanOrEqual(1)
   })
 
+  // Issue #184 — fix: listStoresAsync awaits driver.load() so cold-start
+  // diagnostics report accurate counts on the first call.
+  it('listStoresAsync returns correct count on first call (#184)', async () => {
+    const plur = new Plur({ path: dir })
+
+    stubServer.seedEngram({
+      id: 'ENG-SEED-001',
+      scope: 'group:test',
+      status: 'active',
+      data: { statement: 'seeded engram', scope: 'group:test', status: 'active' },
+    })
+
+    // No cache warm-up — the fix is to await driver.load() inside listStoresAsync
+    const stores = await plur.listStoresAsync()
+    const remote = stores.find(s => s.url)
+    expect(remote).toBeTruthy()
+    expect(remote!.engram_count).toBeGreaterThanOrEqual(1)
+  })
+
+  it('listStoresAsync reports 0 (not crash) when remote is empty (#184)', async () => {
+    const plur = new Plur({ path: dir })
+    // Empty stub, no engrams. Should report 0, not throw.
+    const stores = await plur.listStoresAsync()
+    const remote = stores.find(s => s.url)
+    expect(remote).toBeTruthy()
+    expect(remote!.engram_count).toBe(0)
+  })
+
+  // Issue #184 evaluator finding (Data) — a hung remote must not hang
+  // the entire MCP server. listStoresAsync wraps each driver.load() in a
+  // 5s timeout race.
+  it('listStoresAsync recovers from network failure within timeout window (#184)', async () => {
+    // Configure a deliberately unreachable URL (TCP-rejected port).
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      yaml.dump({
+        stores: [{
+          url: 'http://127.0.0.1:1',  // port 1 → connection refused
+          scope: 'group:unreachable',
+          token: 'fake',
+          shared: true,
+          readonly: false,
+        }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+    const plur = new Plur({ path: dir })
+
+    const start = Date.now()
+    const stores = await plur.listStoresAsync()
+    const elapsed = Date.now() - start
+
+    const remote = stores.find(s => s.url)
+    expect(remote).toBeTruthy()
+    expect(remote!.engram_count).toBe(0)
+    // Must complete within the 5s timeout window plus generous buffer.
+    // We're validating the timeout mechanism, not localhost RTT.
+    // Connection-refused on localhost is normally sub-millisecond; if a
+    // loaded CI host takes longer to deliver the RST, we still pass as
+    // long as the timeout fires within its window.
+    expect(elapsed).toBeLessThan(6000)
+  }, 15000)
+
   it('getById returns null for remote engram before cache populated', () => {
     const plur = new Plur({ path: dir })
 

--- a/packages/core/test/secrets.test.ts
+++ b/packages/core/test/secrets.test.ts
@@ -63,4 +63,17 @@ describe('detectSecrets', () => {
     const matches = detectSecrets('Store API keys in environment variables, never in code')
     expect(matches).toHaveLength(0)
   })
+
+  // Issue #231 — detectSecrets used to crash with cryptic
+  // "Cannot read properties of undefined (reading 'match')" when called with
+  // a non-string. Now throws a clear TypeError at the front door.
+  it('throws TypeError when called with undefined (#231)', () => {
+    expect(() => detectSecrets(undefined as unknown as string))
+      .toThrow(/expected string, got undefined/)
+  })
+
+  it('throws TypeError when called with a number (#231)', () => {
+    expect(() => detectSecrets(42 as unknown as string))
+      .toThrow(/expected string, got number/)
+  })
 })

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/mcp",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "type": "module",
   "bin": {
     "plur-mcp": "dist/index.js"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
 
-const VERSION = '0.9.10'
+const VERSION = '0.9.11'
 
 const HELP = `plur-mcp v${VERSION} — persistent memory for AI agents
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -121,6 +121,39 @@ Use \`scope\` to namespace engrams per project:
 Override with \`PLUR_PATH\` environment variable.
 `
 
+// Recursive JSON-Schema → Zod converter for tool input validation.
+// Handles nested array items + anyOf/oneOf so callers can't pass strings
+// where objects are expected (issue #231). When the schema allows multiple
+// item shapes via anyOf, the handler is expected to coerce — see tools.ts
+// session_end handler for an example.
+function jsonSchemaPropToZod(prop: any): z.ZodTypeAny {
+  if (!prop || typeof prop !== 'object') return z.unknown()
+  const variants = (prop.anyOf as any[] | undefined) ?? (prop.oneOf as any[] | undefined)
+  if (Array.isArray(variants) && variants.length > 0) {
+    const zodVariants = variants.map(jsonSchemaPropToZod)
+    if (zodVariants.length === 1) return zodVariants[0]
+    // z.union requires a 2+ tuple at the type level. We've guaranteed >= 2
+    // via the length check above, so the cast carries a real invariant.
+    return z.union(zodVariants as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+  }
+  if (prop.type === 'string') return prop.enum ? z.enum(prop.enum) : z.string()
+  if (prop.type === 'number' || prop.type === 'integer') return z.number()
+  if (prop.type === 'boolean') return z.boolean()
+  if (prop.type === 'array') {
+    const itemSchema = prop.items ? jsonSchemaPropToZod(prop.items) : z.unknown()
+    return z.array(itemSchema)
+  }
+  if (prop.type === 'object' && prop.properties) {
+    const shape: Record<string, z.ZodTypeAny> = {}
+    for (const [k, p] of Object.entries(prop.properties) as [string, any][]) {
+      const field = jsonSchemaPropToZod(p)
+      shape[k] = prop.required?.includes(k) ? field : field.optional()
+    }
+    return z.object(shape).passthrough()
+  }
+  return z.unknown()
+}
+
 export async function createServer(plur?: Plur): Promise<Server> {
   const instance = plur ?? new Plur()
   const tools = getToolDefinitions()
@@ -171,12 +204,7 @@ export async function createServer(plur?: Plur): Promise<Server> {
       if (schema?.properties) {
         const shape: Record<string, z.ZodTypeAny> = {}
         for (const [key, prop] of Object.entries(schema.properties) as [string, any][]) {
-          let field: z.ZodTypeAny
-          if (prop.type === 'string') field = prop.enum ? z.enum(prop.enum) : z.string()
-          else if (prop.type === 'number') field = z.number()
-          else if (prop.type === 'boolean') field = z.boolean()
-          else if (prop.type === 'array') field = z.array(z.unknown())
-          else field = z.unknown()
+          const field = jsonSchemaPropToZod(prop)
           shape[key] = schema.required?.includes(key) ? field : field.optional()
         }
         const parsed = z.object(shape).passthrough().safeParse(args)

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1182,14 +1182,21 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           engram_suggestions: {
             type: 'array',
             items: {
-              type: 'object',
-              properties: {
-                statement: { type: 'string', description: 'A concise, reusable assertion. Write it as advice to your future self.' },
-                type: { type: 'string', enum: ['behavioral', 'terminological', 'procedural', 'architectural'] },
-              },
-              required: ['statement'],
+              // Prefer {statement, type} objects. Bare strings are tolerated
+              // and treated as {statement: <string>} (issue #231).
+              anyOf: [
+                { type: 'string' },
+                {
+                  type: 'object',
+                  properties: {
+                    statement: { type: 'string', description: 'A concise, reusable assertion. Write it as advice to your future self.' },
+                    type: { type: 'string', enum: ['behavioral', 'terminological', 'procedural', 'architectural'] },
+                  },
+                  required: ['statement'],
+                },
+              ],
             },
-            description: 'Learnings from this session. Review the conversation for corrections, preferences, patterns, and technical facts before calling.',
+            description: 'Learnings from this session. Preferred shape is {statement: "...", type?: "..."}; bare strings are also accepted and treated as the statement. Review the conversation for corrections, preferences, patterns, and technical facts before calling.',
           },
         },
         required: ['summary', 'engram_suggestions'],
@@ -1197,13 +1204,28 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
       handler: async (args, plur) => {
         const summary = args.summary as string
         const session_id = args.session_id as string | undefined
-        const suggestions = args.engram_suggestions as Array<{ statement: string; type?: string }> | undefined
+        const suggestions = args.engram_suggestions as unknown[] | undefined
 
-        // Create engrams from suggestions
+        // Create engrams from suggestions. Tolerate bare strings (a common
+        // LLM mistake — see issue #231) by coercing them into {statement} objects.
         let engrams_created = 0
-        if (suggestions?.length) {
-          for (const s of suggestions) {
-            plur.learn(s.statement, { type: s.type as any })
+        if (Array.isArray(suggestions) && suggestions.length) {
+          for (let i = 0; i < suggestions.length; i++) {
+            const s = suggestions[i]
+            let statement: string | undefined
+            let type: string | undefined
+            if (typeof s === 'string') {
+              statement = s
+            } else if (s && typeof s === 'object') {
+              statement = (s as any).statement
+              type = (s as any).type
+            }
+            if (typeof statement !== 'string' || statement.length === 0) {
+              throw new Error(
+                `engram_suggestions[${i}] must be a string or {statement: string, type?: string}, got ${typeof s}`,
+              )
+            }
+            plur.learn(statement, { type: type as any })
             engrams_created++
           }
         }
@@ -1269,7 +1291,9 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
       annotations: { title: 'List stores', readOnlyHint: true, idempotentHint: true },
       inputSchema: { type: 'object', properties: {} },
       handler: async (_args, plur) => {
-        const stores = plur.listStores()
+        // Use async variant so remote store engram_count reflects real data
+        // even on first call after server start (issue #184).
+        const stores = await plur.listStoresAsync()
         const outboxCount = plur.outboxCount()
         return {
           stores,

--- a/packages/mcp/src/version.ts
+++ b/packages/mcp/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.9.10'
+export const VERSION = '0.9.11'

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -32,7 +32,7 @@ describe('MCP server (wire protocol)', () => {
   it('returns server info with instructions on initialize', () => {
     const info = client.getServerVersion()
     expect(info?.name).toBe('plur-mcp')
-    expect(info?.version).toBe('0.9.10')
+    expect(info?.version).toBe('0.9.11')
   })
 
   // --- Tools ---
@@ -105,6 +105,37 @@ describe('MCP server (wire protocol)', () => {
     expect(typeof parsed.error).toBe('string')
   })
 
+  // Issue #231 — plur_session_end used to crash with unhelpful
+  // "Cannot read properties of undefined (reading 'match')" when callers passed
+  // engram_suggestions as an array of strings. The schema validator now
+  // recursively validates array items; the handler coerces bare strings.
+  it('session_end tolerates string-array engram_suggestions through wire protocol (#231)', async () => {
+    const result = await client.callTool({
+      name: 'plur_session_end',
+      arguments: {
+        summary: 'wire-level string array test',
+        engram_suggestions: ['a learning', 'another learning'],
+      },
+    })
+    expect(result.isError).toBeFalsy()
+    const parsed = JSON.parse((result.content as any)[0].text)
+    expect(parsed.engrams_created).toBe(2)
+  })
+
+  it('session_end rejects invalid item types with clear error (#231)', async () => {
+    const result = await client.callTool({
+      name: 'plur_session_end',
+      arguments: {
+        summary: 'wire-level invalid types',
+        engram_suggestions: [42],
+      },
+    })
+    expect(result.isError).toBe(true)
+    const parsed = JSON.parse((result.content as any)[0].text)
+    expect(parsed.success).toBe(false)
+    expect(parsed.error).toMatch(/engram_suggestions/)
+  })
+
   // --- Resources ---
 
   it('lists resources (guide + status)', async () => {
@@ -138,7 +169,7 @@ describe('MCP server (wire protocol)', () => {
     const result = await client.readResource({ uri: 'plur://status' })
     const data = JSON.parse((result.contents[0] as any).text)
     expect(data.engram_count).toBe(1)
-    expect(data.version).toBe('0.9.10')
+    expect(data.version).toBe('0.9.11')
     expect(data.storage_root).toBe(dir)
   })
 

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -88,6 +88,34 @@ describe('Session & store tools', () => {
     expect(result.total_engrams).toBe(0)
   })
 
+  // Issue #231 — handler used to crash with cryptic
+  // "Cannot read properties of undefined (reading 'match')"
+  // when callers passed bare strings instead of {statement, type} objects.
+  it('plur_session_end coerces string-array engram_suggestions (#231)', async () => {
+    const result = await callTool('plur_session_end', {
+      summary: 'Session with string-shaped suggestions',
+      engram_suggestions: ['First learning as a bare string', 'Second learning as a bare string'],
+    }) as any
+    expect(result.engrams_created).toBe(2)
+    expect(result.episode_id).toBeDefined()
+    const status = plur.status()
+    expect(status.engram_count).toBe(2)
+  })
+
+  it('plur_session_end throws a clear error for non-string non-object items (#231)', async () => {
+    await expect(callTool('plur_session_end', {
+      summary: 'Session with malformed suggestions',
+      engram_suggestions: [42, true],
+    })).rejects.toThrow(/engram_suggestions\[0\] must be a string or \{statement/)
+  })
+
+  it('plur_session_end throws a clear error for object items missing statement (#231)', async () => {
+    await expect(callTool('plur_session_end', {
+      summary: 'Session with empty objects',
+      engram_suggestions: [{ type: 'behavioral' }],
+    })).rejects.toThrow(/must be a string or \{statement/)
+  })
+
   it('plur_stores_add registers a store in config', async () => {
     const storePath = join(dir, 'extra-store', 'engrams.yaml')
     const storeDir = join(dir, 'extra-store')


### PR DESCRIPTION
## Summary

Three independent bug fixes bundled into a single patch release.

- **#231** — `plur_session_end` no longer crashes with `Cannot read properties of undefined (reading 'match')` when callers pass `engram_suggestions` as bare strings. Three-layer fix (validator, handler, secrets/learn guards).
- **#184** — `plur_stores_list` reports accurate `engram_count` for remote stores on cold start via new `listStoresAsync()` with per-store 5s timeout.
- **#197** — `plur doctor` exits cleanly even when the BGE embedder crashes with SIGABRT, via subprocess isolation in a new `_embedder-probe` hidden subcommand.

Closes #231, #184, #197.

## Versions

- `@plur-ai/core`: 0.9.10 → 0.9.11
- `@plur-ai/mcp`:  0.9.10 → 0.9.11
- `@plur-ai/cli`:  0.9.10 → 0.9.11
- `@plur-ai/claw`: unchanged (no claw-side changes)

## Test plan

- [x] All 1045 tests pass (`pnpm -r test`); +11 new tests covering each fix's contract
- [x] Build clean (`pnpm build`)
- [x] Manual smoke: `pnpm --filter @plur-ai/cli test embedder-probe` (direct-invocation guard + JSON contract)
- [x] Manual smoke: `pnpm --filter @plur-ai/core test remote-store-cache` (unreachable-remote 5s timeout)
- [x] Manual smoke: `pnpm --filter @plur-ai/mcp test session` (string-array coercion + wire-protocol)

## Evaluator audit

Three iterations of multi-evaluator review (CTO, Critic, Dijkstra, Data, Taleb):

**Pass 1** raised 9 issues across all evaluators.
**Pass 2** addressed: subprocess argv via `realpathSync`+extension check, z.union safety, `_primaryStoreRow()` shared helper, `@deprecated` JSDoc on `listStores()`, `PLUR_INTERNAL_PROBE` env-var guard on probe, last-`{`-line stdout parser, 10s probe timeout, 5s per-store driver.load timeout.
**Pass 3** addressed: `clearTimeout` on Promise.race success path (prevents timer leak in long-lived MCP server), loosened flaky wall-clock test assertion.

Final consensus: CTO 0.94 SHIP, Critic 0.80 SHIP, Data 0.93 SAFE. Taleb's "ship narrow" preference (split releases) was a process recommendation, not a code blocker — noted but user explicitly requested bundled patch.

## Files changed

| File | Reason |
|------|--------|
| `packages/mcp/src/server.ts` | Recursive JSON-Schema→Zod with anyOf support |
| `packages/mcp/src/tools.ts` | `engram_suggestions` anyOf schema + handler coercion |
| `packages/mcp/test/{server,session}.test.ts` | Wire-level + direct handler coverage for #231 |
| `packages/core/src/secrets.ts` | TypeError on non-string input |
| `packages/core/src/index.ts` | TypeError on `plur.learn(non-string)`; new `listStoresAsync()` + `_primaryStoreRow()`; `@deprecated` on sync `listStores()` |
| `packages/core/test/{secrets,remote-store-cache}.test.ts` | Coverage for new guards + unreachable-remote timeout |
| `packages/cli/src/commands/doctor.ts` | Subprocess isolation, `resolveCliJsEntry`, last-line JSON parse |
| `packages/cli/src/commands/embedder-probe.ts` | NEW — hidden probe subcommand |
| `packages/cli/src/commands/stores.ts` | Use `listStoresAsync()` |
| `packages/cli/src/index.ts` | Register `_embedder-probe` command |
| `packages/cli/test/embedder-probe.test.ts` | NEW — direct-invocation guard + JSON contract |
| `CHANGELOG.md` | 0.9.11 entry |
| `packages/{core,mcp,cli}/package.json` + `packages/mcp/src/{index,version}.ts` | Version bumps |

## Release risk

Single risk worth flagging: the `_embedder-probe` subprocess path is new code that fires on every `plur doctor` invocation, including on platforms not covered in tests (Alpine musl, Windows, snap-confined). The graceful fallback (`embedder probe skipped: CLI entry is not a JS file`) handles compiled binaries, and the realpath+extension check catches shell shims. Worth watching for issues post-publish; rollback is `npm install -g @plur-ai/mcp@0.9.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)