### PR TITLE
chore: claw 0.9.16 + hermes 0.9.10 — pick up 0.9.11 core/CLI

### DIFF
--- a/packages/claw/openclaw.plugin.json
+++ b/packages/claw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "plur-claw",
   "name": "PLUR Memory Engine",
   "description": "Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "kind": "memory",
   "enabledByDefault": true,
   "configSchema": {

--- a/packages/claw/package.json
+++ b/packages/claw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/claw",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -59,7 +59,7 @@ export class PlurContextEngine implements ContextEngine {
   readonly info: ContextEngineInfo = {
     id: 'plur-claw',
     name: 'PLUR Memory Engine',
-    version: '0.9.15',
+    version: '0.9.16',
     ownsCompaction: false,
   }
 

--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -44,7 +44,7 @@ const plugin = {
   id: 'plur-claw',
   name: 'PLUR Memory Engine',
   description: 'Persistent, learnable memory for OpenClaw agents. Local-first, no cloud required.',
-  version: '0.9.15',
+  version: '0.9.16',
   kind: 'memory' as const,
 
   register(api: any) {

--- a/packages/claw/test/hello.test.ts
+++ b/packages/claw/test/hello.test.ts
@@ -6,7 +6,7 @@ describe('PLUR ContextEngine plugin', () => {
   it('plugin has correct metadata', () => {
     expect(plugin.id).toBe('plur-claw')
     expect(plugin.kind).toBe('memory')
-    expect(plugin.version).toBe('0.9.15')
+    expect(plugin.version).toBe('0.9.16')
   })
 
   it('registers via plugin API', () => {

--- a/packages/hermes/plur_hermes/bridge.py
+++ b/packages/hermes/plur_hermes/bridge.py
@@ -18,7 +18,7 @@ from typing import Any
 
 logger = logging.getLogger("plur_hermes.bridge")
 
-_NPX_CLI_VERSION = "0.9.4"
+_NPX_CLI_VERSION = "0.9.11"
 
 _DEFAULT_DEDUP_CACHE_SIZE = 256
 _DEFAULT_TIMEOUT = 30

--- a/packages/hermes/plur_hermes/skills/plur-memory.SKILL.md
+++ b/packages/hermes/plur_hermes/skills/plur-memory.SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plur-memory
 description: Persistent learning for AI agents. Open engram format. Your agent learns from corrections, remembers across sessions, and transfers knowledge across domains.
-version: 0.9.4
+version: 0.9.10
 metadata:
   hermes:
     tags: [memory, learning, knowledge, engrams]

--- a/packages/hermes/pyproject.toml
+++ b/packages/hermes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plur-hermes"
-version = "0.9.9"
+version = "0.9.10"
 description = "PLUR persistent memory plugin for Hermes Agent"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Picks up the 0.9.11 patch release across the two PLUR adapter packages that weren't auto-served by the npm publish.

- **`@plur-ai/claw` 0.9.15 → 0.9.16**: Mechanical bump so published claw refreshes its `@plur-ai/core` pin from 0.9.10 to 0.9.11. Brings the new `TypeError` guards in `plur.learn` and `detectSecrets` to OpenClaw ContextEngine users. No claw code changes.

- **`plur-hermes` 0.9.9 → 0.9.10**: Bumps `_NPX_CLI_VERSION` in `bridge.py` from `0.9.4` → `0.9.11`. The Python bridge has been seven minor CLI versions stale; this picks up #184 (`listStores` async, used by `bridge.stores_list()`) plus accumulated fixes between 0.9.4 and 0.9.11. SKILL.md version bumped to satisfy `check_version_sync.py` invariant.

OpenClaw users of `mcporter` + PLUR-MCP and Hermes users who configure PLUR via MCP `config.yaml` were already picked up by the 0.9.11 MCP publish (#232). This PR closes the gap for the two adapter-specific code paths.

## Versions

- `@plur-ai/claw`: 0.9.15 → 0.9.16 (refreshes core dep)
- `plur-hermes`: 0.9.9 → 0.9.10 (CLI pin bump)

## Test plan

- [x] Claw unit tests pass (`pnpm --filter @plur-ai/claw test` — 103 tests)
- [x] Hermes version sync passes (`python3 scripts/check_version_sync.py`)
- [x] Hermes pytest suite passes (`python3 -m pytest test/` — 129 tests)
- [x] Real-CLI smoke test: `PlurBridge` against locally-installed `@plur-ai/cli@0.9.11` round-trips `status`, `learn`, `recall`, `stores_list` correctly
- [x] No source code changes in either package — only version constants

## Risk

Low. Claw is a pin-refresh with no code change. Hermes ships one constant change (the CLI version pin); the bridge contract is unchanged. Real-CLI smoke validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)