### PR TITLE
feat(core): reference-counted content-addressed dedup (closes #107)

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import { join } from 'path'
 
 export interface HistoryEvent {
-  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed'
+  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed'
   engram_id: string
   timestamp: string // ISO
   data: Record<string, unknown> // event-specific payload

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -381,7 +381,9 @@ export class Plur {
     return id
   }
 
-  /** Content hash fast-path dedup. Scope-aware: same statement in a different scope is a promotion, not a duplicate. */
+  /** Content hash fast-path dedup. Scope-aware: same statement in a different
+   * scope is a promotion, not a duplicate. Retired engrams are excluded —
+   * re-learning a retired statement creates a fresh engram (issue #107). */
   private _hashDedup(statement: string, engrams: Engram[], scope?: string): Engram | null {
     const hash = computeContentHash(statement)
     for (const e of engrams) {
@@ -390,6 +392,44 @@ export class Plur {
       }
     }
     return null
+  }
+
+  /** Build the {scope, session_id, stored_at} source entry that gets appended
+   * to an engram's sources[] on every write (initial or duplicate). */
+  private _buildSourceEntry(scope: string, context?: LearnContext): {
+    scope: string; session_id: string | null; stored_at: string
+  } {
+    return {
+      scope,
+      session_id: context?.session_episode_id ?? null,
+      stored_at: new Date().toISOString(),
+    }
+  }
+
+  /** Apply a duplicate-write to an existing engram: increment reference_count,
+   * append source, persist to primary store if that's where the engram lives.
+   * Mutates the engram and (best-effort) writes back. See issue #107. */
+  private _recordDuplicate(
+    hit: Engram,
+    engrams: Engram[],
+    scope: string,
+    context: LearnContext | undefined,
+  ): Engram {
+    // Use defaults for engrams migrated without these fields.
+    const currentCount = (hit as any).reference_count ?? 1
+    const currentSources = (hit as any).sources ?? []
+    ;(hit as any).reference_count = currentCount + 1
+    ;(hit as any).sources = [...currentSources, this._buildSourceEntry(scope, context)]
+
+    // Persist if the engram is in the primary store. Cross-store duplicates
+    // (same scope across stores) are deduplicated but not persisted in v1.
+    const idx = engrams.findIndex(e => e.id === hit.id)
+    if (idx !== -1) {
+      engrams[idx] = hit
+      this._writeEngrams(this.paths.engrams, engrams)
+      this._syncIndex()
+    }
+    return hit
   }
 
   private _isLlmDedupAvailable(): boolean {
@@ -430,9 +470,10 @@ export class Plur {
 
       const scope = context?.scope ?? 'global'
 
-      // Idea 29: Content hash fast-path dedup (scope-aware — issue #136)
+      // Idea 29: Content hash fast-path dedup (scope-aware — issue #136).
+      // On dedup hit, mutate: increment reference_count, append source (#107).
       const hashMatch = this._hashDedup(statement, allEngrams, scope)
-      if (hashMatch) return hashMatch
+      if (hashMatch) return this._recordDuplicate(hashMatch, engrams, scope, context)
 
       const id = generateEngramId(allEngrams)
       const now = new Date().toISOString()
@@ -495,6 +536,8 @@ export class Plur {
         commitment,
         locked_at: commitment === 'locked' ? now : undefined,
         locked_reason: commitment === 'locked' ? context?.locked_reason : undefined,
+        reference_count: 1,
+        sources: [this._buildSourceEntry(scope, context)],
         summary: autoSummary(statement, undefined),
         engram_version: 1,
         episode_ids: episodeIds ?? [],
@@ -624,7 +667,13 @@ export class Plur {
     // local outbox for retry (issue #26).
     const allEngrams = this._loadAllEngrams()
     const hashMatch = this._hashDedup(statement, allEngrams, scope)
-    if (hashMatch) return hashMatch
+    if (hashMatch) {
+      // Mutate + persist if local; otherwise return mutated (best-effort)
+      return withLock(this.paths.engrams, () => {
+        const engrams = loadEngrams(this.paths.engrams)
+        return this._recordDuplicate(hashMatch, engrams, scope, context)
+      })
+    }
     const now = new Date().toISOString()
     const localPlaceholder = this._buildEngramShape(statement, scope, context, now)
     try {
@@ -727,6 +776,8 @@ export class Plur {
       commitment,
       locked_at: commitment === 'locked' ? now : undefined,
       locked_reason: commitment === 'locked' ? context?.locked_reason : undefined,
+      reference_count: 1,
+      sources: [this._buildSourceEntry(scope, context)],
       summary: autoSummary(statement, undefined),
       engram_version: 1,
       episode_ids: context?.session_episode_id ? [context.session_episode_id] : [],
@@ -1206,24 +1257,38 @@ export class Plur {
 
   /** Set engram status to 'retired'. Supports primary and store engrams. */
   async forget(id: string, reason?: string): Promise<void> {
-    // Check primary first
+    // Check primary first.
+    // Reference-counted retirement (#107): decrement reference_count; only
+    // physically retire when it reaches 0. forget() called N times on an
+    // engram with reference_count=N retires it; called fewer times, the
+    // engram stays active with a lower count.
     const foundInPrimary = withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)
       const engram = engrams.find(e => e.id === id)
       if (!engram) return false
 
-      engram.status = 'retired'
-      if (reason && !engram.rationale) {
-        engram.rationale = `Retired: ${reason}`
+      const currentCount = (engram as any).reference_count ?? 1
+      const newCount = Math.max(0, currentCount - 1)
+      ;(engram as any).reference_count = newCount
+
+      if (newCount === 0) {
+        engram.status = 'retired'
+        if (reason && !engram.rationale) {
+          engram.rationale = `Retired: ${reason}`
+        }
       }
 
       this._writeEngrams(this.paths.engrams, engrams)
       this._syncIndex()
       appendHistory(this.paths.root, {
-        event: 'engram_retired',
+        event: newCount === 0 ? 'engram_retired' : 'engram_decremented',
         engram_id: id,
         timestamp: new Date().toISOString(),
-        data: { reason: reason ?? null },
+        data: {
+          reason: reason ?? null,
+          reference_count_before: currentCount,
+          reference_count_after: newCount,
+        },
       })
       return true
     })

--- a/packages/core/src/meta/formulation.ts
+++ b/packages/core/src/meta/formulation.ts
@@ -173,6 +173,8 @@ Return ONLY valid JSON, no markdown fencing.`
       memory_class: 'metacognitive',
       cognitive_level: 'evaluate',
     },
+    reference_count: 1,
+    sources: [{ scope: 'global', session_id: null, stored_at: now }],
     structured_data: { meta: metaField },
   }
 

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -191,6 +191,19 @@ export const EngramSchema = z.object({
   locked_at: z.string().optional(),
   locked_reason: z.string().optional(),
 
+  // === SP1: Reference counting (issue #107) ===
+  /** Number of write attempts that resolved to this engram.
+   * Incremented on every hash-dedup hit; decremented by forget().
+   * Engram physically retires only when this reaches 0. */
+  reference_count: z.number().int().min(0).default(1),
+  /** Provenance of each write attempt. One entry per write (including the
+   * first). Migrated old engrams without this field start with []. */
+  sources: z.array(z.object({
+    scope: z.string(),
+    session_id: z.string().nullable().default(null),
+    stored_at: z.string(),  // ISO timestamp of this write
+  })).default([]),
+
   // === SP2: History & Evolution fields ===
   engram_version: z.number().int().min(1).default(1),
   previous_version_ref: PreviousVersionRefSchema.optional(),

--- a/packages/core/test/reference-count.test.ts
+++ b/packages/core/test/reference-count.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { loadEngrams, saveEngrams } from '../src/engrams.js'
+import { EngramSchema } from '../src/schemas/engram.js'
+import { computeContentHash } from '../src/content-hash.js'
+
+/**
+ * Reference-counted content-addressed deduplication (issue #107).
+ *
+ * Contract:
+ *   - First learn of a statement creates the engram with reference_count: 1
+ *     and a single source entry.
+ *   - Subsequent learns of the same normalized statement at the same scope
+ *     increment reference_count and append to sources[] — no new engram.
+ *   - forget() decrements reference_count; physical retirement only at 0.
+ *   - Old engrams without these fields get reference_count: 1, sources: []
+ *     on load (Zod defaults). Next re-learn appends.
+ *   - Retired engrams are excluded from dedup hits (re-learning a retired
+ *     statement creates a new engram).
+ */
+describe('reference-counted content-addressed dedup (#107)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-refcount-'))
+    plur = new Plur({ path: dir })
+  })
+
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  describe('first write', () => {
+    it('initializes reference_count to 1 and sources to one entry', () => {
+      const engram = plur.learn('always use semicolons', { scope: 'global' })
+
+      expect(engram.reference_count).toBe(1)
+      expect(engram.sources).toHaveLength(1)
+      expect(engram.sources![0].scope).toBe('global')
+      expect(engram.sources![0].stored_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('records session_episode_id in the source when provided', () => {
+      const engram = plur.learn('use trailing commas', {
+        scope: 'global',
+        session_episode_id: 'EP-12345',
+      })
+
+      expect(engram.sources![0].session_id).toBe('EP-12345')
+    })
+
+    it('records null session_id when no episode provided', () => {
+      const engram = plur.learn('prefer named exports', { scope: 'global' })
+      expect(engram.sources![0].session_id).toBeNull()
+    })
+  })
+
+  describe('duplicate writes', () => {
+    it('increments reference_count on second write of the same statement', () => {
+      const first = plur.learn('always use semicolons', { scope: 'global' })
+      const second = plur.learn('always use semicolons', { scope: 'global' })
+
+      expect(second.id).toBe(first.id)
+      expect(second.reference_count).toBe(2)
+      expect(second.sources).toHaveLength(2)
+    })
+
+    it('keeps incrementing on Nth duplicate write', () => {
+      let engram
+      for (let i = 0; i < 5; i++) {
+        engram = plur.learn('repeated correction', { scope: 'global' })
+      }
+      expect(engram!.reference_count).toBe(5)
+      expect(engram!.sources).toHaveLength(5)
+    })
+
+    it('persists the mutation — fresh Plur instance sees updated count', () => {
+      plur.learn('persisted correction', { scope: 'global' })
+      plur.learn('persisted correction', { scope: 'global' })
+      plur.learn('persisted correction', { scope: 'global' })
+
+      const fresh = new Plur({ path: dir })
+      const list = fresh.list({ scope: 'global' })
+      const found = list.find(e => e.statement === 'persisted correction')
+      expect(found?.reference_count).toBe(3)
+      expect(found?.sources).toHaveLength(3)
+    })
+
+    it('normalizes for dedup — punctuation/case/whitespace differences merge', () => {
+      const first = plur.learn('Always Use Semicolons!', { scope: 'global' })
+      const second = plur.learn('always use   semicolons', { scope: 'global' })
+      expect(second.id).toBe(first.id)
+      expect(second.reference_count).toBe(2)
+    })
+
+    it('creates separate engrams across different scopes (no cross-scope dedup)', () => {
+      const a = plur.learn('use 2-space indent', { scope: 'project:a' })
+      const b = plur.learn('use 2-space indent', { scope: 'project:b' })
+      expect(a.id).not.toBe(b.id)
+      expect(a.reference_count).toBe(1)
+      expect(b.reference_count).toBe(1)
+    })
+
+    it('records different session_ids across multiple write sources', () => {
+      plur.learn('rule X', { scope: 'global', session_episode_id: 'EP-A' })
+      plur.learn('rule X', { scope: 'global', session_episode_id: 'EP-B' })
+      const final = plur.learn('rule X', { scope: 'global', session_episode_id: 'EP-C' })
+
+      expect(final.reference_count).toBe(3)
+      const ids = final.sources!.map(s => s.session_id)
+      expect(ids).toEqual(['EP-A', 'EP-B', 'EP-C'])
+    })
+  })
+
+  describe('forget — decrement semantics', () => {
+    it('decrements reference_count, leaves engram active when count > 0', async () => {
+      const a = plur.learn('soon-to-be-forgotten', { scope: 'global' })
+      plur.learn('soon-to-be-forgotten', { scope: 'global' })
+      plur.learn('soon-to-be-forgotten', { scope: 'global' })
+      // count is now 3
+
+      await plur.forget(a.id)
+      const after = plur.getById(a.id)
+      expect(after).toBeTruthy()
+      expect(after!.status).toBe('active')
+      expect(after!.reference_count).toBe(2)
+    })
+
+    it('physically retires only when reference_count reaches 0', async () => {
+      const a = plur.learn('eventually-retired', { scope: 'global' })
+      plur.learn('eventually-retired', { scope: 'global' })
+
+      await plur.forget(a.id) // 2 → 1
+      expect(plur.getById(a.id)!.status).toBe('active')
+
+      await plur.forget(a.id) // 1 → 0 → retired
+      const final = plur.getById(a.id)
+      expect(final!.status).toBe('retired')
+      expect(final!.reference_count).toBe(0)
+    })
+
+    it('retired engrams are excluded from dedup — new write creates new engram', async () => {
+      const first = plur.learn('phoenix correction', { scope: 'global' })
+      await plur.forget(first.id) // 1 → 0 → retired
+      expect(plur.getById(first.id)!.status).toBe('retired')
+
+      const second = plur.learn('phoenix correction', { scope: 'global' })
+      expect(second.id).not.toBe(first.id)
+      expect(second.reference_count).toBe(1)
+      expect(second.sources).toHaveLength(1)
+    })
+  })
+
+  describe('migration — old engrams without these fields', () => {
+    it('loads pre-existing engrams with default reference_count: 1 and empty sources', () => {
+      // Hand-write an old-format engram (no reference_count, no sources)
+      const oldEngram = {
+        id: 'ENG-2024-LEGACY-001',
+        version: 2,
+        status: 'active',
+        consolidated: false,
+        type: 'behavioral',
+        scope: 'global',
+        visibility: 'private',
+        statement: 'legacy engram from before ref-counting',
+        activation: {
+          retrieval_strength: 0.7,
+          storage_strength: 1.0,
+          frequency: 0,
+          last_accessed: '2024-01-01',
+        },
+        feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+        content_hash: 'placeholder', // present but reference_count missing
+        episode_ids: [],
+      }
+      const path = join(dir, 'engrams.yaml')
+      saveEngrams(path, [EngramSchema.parse(oldEngram)])
+
+      const fresh = new Plur({ path: dir })
+      const loaded = fresh.getById('ENG-2024-LEGACY-001')
+      expect(loaded).toBeTruthy()
+      expect(loaded!.reference_count).toBe(1)
+      expect(loaded!.sources).toEqual([])
+    })
+
+    it('next re-learn after migration appends to sources (no resurrection of phantom history)', () => {
+      // Set up a legacy engram with proper hash for dedup match
+      const stmt = 'legacy correction with real hash'
+      const legacy = EngramSchema.parse({
+        id: 'ENG-2024-LEGACY-002',
+        version: 2,
+        status: 'active',
+        consolidated: false,
+        type: 'behavioral',
+        scope: 'global',
+        visibility: 'private',
+        statement: stmt,
+        activation: {
+          retrieval_strength: 0.7,
+          storage_strength: 1.0,
+          frequency: 0,
+          last_accessed: '2024-01-01',
+        },
+        feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+        episode_ids: [],
+      })
+      // computeContentHash matches what _hashDedup will compute
+      ;(legacy as any).content_hash = computeContentHash(stmt)
+
+      const path = join(dir, 'engrams.yaml')
+      saveEngrams(path, [legacy])
+
+      const fresh = new Plur({ path: dir })
+      const updated = fresh.learn(stmt, { scope: 'global' })
+
+      expect(updated.id).toBe('ENG-2024-LEGACY-002') // dedup hit
+      expect(updated.reference_count).toBe(2) // 1 (default) + 1 (new write)
+      expect(updated.sources).toHaveLength(1) // only the new source, no fabricated history
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements the full reference-counted content-addressed dedup spec from #107. The existing implementation had basic hash dedup (`_hashDedup` + `computeContentHash`) but did NOT track multiplicity or provenance — every duplicate write silently returned the existing engram with zero signal that the same correction was being re-learned across sessions/scopes.

This PR adds the missing semantics fully — no scope reduction.

Closes #107.

## Behavior

| Scenario | Before | After |
|---|---|---|
| First learn of statement S in scope X | Engram created | Engram created with `reference_count: 1`, `sources: [{X, session, now}]` |
| Second learn of S in scope X | Returns existing engram, no signal | Returns existing engram with `reference_count: 2`, `sources` appended with new entry |
| Nth learn of S in scope X | Same | `reference_count: N`, N source entries |
| `forget(id)` once on count=3 engram | Sets `status: retired` | Decrements to `reference_count: 2`, stays `active` |
| `forget(id)` three times on count=3 | Same | Decrements to 0, then retires |
| Old engrams without these fields | Already worked | Loaded with `reference_count: 1`, `sources: []` via Zod defaults — next re-learn appends |

## Schema changes

`packages/core/src/schemas/engram.ts`:

```ts
reference_count: z.number().int().min(0).default(1)
sources: z.array(z.object({
  scope: z.string(),
  session_id: z.string().nullable().default(null),
  stored_at: z.string(),
})).default([])
```

Both optional with safe defaults — backward compatible with v0.9.11 engrams.

## API changes

- `_hashDedup` (private): unchanged — still a pure find.
- `_buildSourceEntry` (new private): builds `{scope, session_id, stored_at}` from learn context.
- `_recordDuplicate` (new private): mutates the engram (increment + append), persists to primary store, returns mutated.
- `learn()`: on dedup hit, calls `_recordDuplicate` instead of bare return. On new engram, initializes ref-count + sources.
- `learnRouted()`: same pattern, wrapped in withLock for the dedup-hit path.
- `forget()`: decrement-first; only retire at count=0. History event is either \`engram_retired\` or new \`engram_decremented\` with pre/post counts in payload.
- `HistoryEvent` union: added \`engram_decremented\`.

## Test coverage

14 new tests in \`packages/core/test/reference-count.test.ts\` across 4 groups:

- **First write** (3): initializes count/sources correctly, with/without session_id
- **Duplicate writes** (6): 2nd write, Nth write, persistence across Plur instances, normalization (case/punctuation/whitespace), scope separation, multi-session source recording
- **Forget decrement semantics** (3): decrement keeps active when count > 0, physical retirement at count=0, retired engrams excluded from dedup
- **Migration** (2): old engrams load with defaults; re-learn appends without phantom history

Full suite: **1059 passed** (681 in core, 14 new for #107), 0 regressions.

## Test plan

- [x] All 1059 tests pass (\`pnpm -r test\`)
- [x] \`pnpm build\` clean across all packages
- [x] Backward compat: old engrams from 0.9.11 load and re-learn correctly
- [x] Retired engrams excluded from dedup (re-learn creates fresh engram)
- [x] Persistence verified — fresh Plur instance sees updated counts
- [x] Normalization unchanged — case/punctuation/whitespace differences still merge

## Known limitations (v1)

Cross-store duplicates (same scope across multiple registered stores) are deduplicated correctly but the mutation is only persisted when the hit lives in the primary store. Flagged in a code comment. Multi-store scope sharing is an unusual setup; if it becomes a real workflow, lift \`_recordDuplicate\` to know about all stores. Out of scope for #107.

## What this buys

- **Telemetry**: see how often the same correction is being re-learned across teams ("seen 40 times → boost retrieval_strength")
- **Clean pack-install semantics**: re-installing a pack that contains an engram already in the store increments the count instead of being a silent no-op
- **Predictable forget semantics**: forget(N) on a count=N engram is what actually retires; forget(1) on count=N is now a soft decrement

## Suggested follow-ups (separate issues)

None blocking this PR. If the cross-store gap surfaces as a real workflow need, file a focused follow-up. Otherwise the v1 here is the whole spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)