### PR TITLE
feat(core): cross-scope recurrence detection — engrams graduate to universal (closes #176)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -434,6 +434,102 @@ export class Plur {
     return hit
   }
 
+  /** Find an active engram with the same content_hash but a DIFFERENT scope.
+   * A hit indicates cross-context recurrence — the same knowledge is being
+   * re-learned across scopes, which is evidence of universal applicability.
+   * See issue #176. */
+  private _crossScopeRecurrenceDetect(
+    statement: string,
+    engrams: Engram[],
+    currentScope: string,
+  ): Engram | null {
+    const hash = computeContentHash(statement)
+    for (const e of engrams) {
+      if (e.status === 'active'
+          && (e as any).content_hash === hash
+          && e.scope !== currentScope) {
+        return e
+      }
+    }
+    return null
+  }
+
+  /** Record a cross-scope recurrence: append source, increment counters,
+   * escalate commitment, and broaden scope to 'global' once the threshold
+   * is crossed. Returns the (possibly broadened) engram.
+   *
+   * Escalation ladder (graduated, not all-at-once):
+   * - 1st cross-scope hit:   record source + recurrence_count++  (no scope/commitment change)
+   * - 2nd+ cross-scope hit:  + broaden scope → 'global'
+   *                          + escalate commitment one step (leaning → decided → locked)
+   *
+   * Locked engrams stop escalating (you can't promote past locked).
+   *
+   * See issue #176.
+   */
+  private _recordCrossScopeRecurrence(
+    hit: Engram,
+    engrams: Engram[],
+    scope: string,
+    context: LearnContext | undefined,
+  ): Engram {
+    const previousScope = hit.scope
+    const previousCommitment = hit.commitment
+
+    // Counters always advance
+    const newRecurrence = ((hit as any).recurrence_count ?? 0) + 1
+    ;(hit as any).recurrence_count = newRecurrence
+    ;(hit as any).reference_count = ((hit as any).reference_count ?? 1) + 1
+    ;(hit as any).sources = [
+      ...((hit as any).sources ?? []),
+      this._buildSourceEntry(scope, context),
+    ]
+
+    // Threshold-based broadening + escalation
+    if (newRecurrence >= 2) {
+      if (hit.scope !== 'global') hit.scope = 'global'
+
+      if (hit.commitment !== 'locked') {
+        hit.commitment = hit.commitment === 'leaning'
+          ? 'decided'
+          : hit.commitment === 'decided'
+            ? 'locked'
+            : (hit.commitment ?? 'leaning')
+        if (hit.commitment === 'locked' && !hit.locked_at) {
+          const now = new Date().toISOString()
+          hit.locked_at = now
+          hit.locked_reason = `Auto-locked: cross-scope recurrence detected (${newRecurrence}x)`
+        }
+      }
+    }
+
+    // Persist (best-effort, primary store only — same limitation as _recordDuplicate)
+    const idx = engrams.findIndex(e => e.id === hit.id)
+    if (idx !== -1) {
+      engrams[idx] = hit
+      this._writeEngrams(this.paths.engrams, engrams)
+      this._syncIndex()
+    }
+
+    // Append history event for observability — distinct event so consumers
+    // can pattern on "this engram graduated to universal."
+    appendHistory(this.paths.root, {
+      event: 'recurrence_detected',
+      engram_id: hit.id,
+      timestamp: new Date().toISOString(),
+      data: {
+        previous_scope: previousScope,
+        new_scope: hit.scope,
+        previous_commitment: previousCommitment ?? null,
+        new_commitment: hit.commitment ?? null,
+        recurrence_count: newRecurrence,
+        from_scope: scope,
+      },
+    })
+
+    return hit
+  }
+
   private _isLlmDedupAvailable(): boolean {
     if (this._llmDisabledUntil !== null) {
       if (Date.now() < this._llmDisabledUntil) return false
@@ -476,6 +572,13 @@ export class Plur {
       // On dedup hit, mutate: increment reference_count, append source (#107).
       const hashMatch = this._hashDedup(statement, allEngrams, scope)
       if (hashMatch) return this._recordDuplicate(hashMatch, engrams, scope, context)
+
+      // #176: cross-scope recurrence — same statement, different scope.
+      // Treated as evidence of universal applicability: graduates the
+      // existing engram toward 'global' + 'locked' commitment instead of
+      // creating a new scope-bound duplicate.
+      const crossMatch = this._crossScopeRecurrenceDetect(statement, allEngrams, scope)
+      if (crossMatch) return this._recordCrossScopeRecurrence(crossMatch, engrams, scope, context)
 
       const id = generateEngramId(allEngrams)
       const now = new Date().toISOString()
@@ -540,6 +643,7 @@ export class Plur {
         locked_reason: commitment === 'locked' ? context?.locked_reason : undefined,
         reference_count: 1,
         sources: [this._buildSourceEntry(scope, context)],
+        recurrence_count: 0,
         summary: autoSummary(statement, undefined),
         engram_version: 1,
         episode_ids: episodeIds ?? [],
@@ -676,6 +780,14 @@ export class Plur {
         return this._recordDuplicate(hashMatch, engrams, scope, context)
       })
     }
+    // #176: cross-scope recurrence (same semantics as the local learn() path).
+    const crossMatch = this._crossScopeRecurrenceDetect(statement, allEngrams, scope)
+    if (crossMatch) {
+      return withLock(this.paths.engrams, () => {
+        const engrams = loadEngrams(this.paths.engrams)
+        return this._recordCrossScopeRecurrence(crossMatch, engrams, scope, context)
+      })
+    }
     const now = new Date().toISOString()
     const localPlaceholder = this._buildEngramShape(statement, scope, context, now)
     try {
@@ -780,6 +892,7 @@ export class Plur {
       locked_reason: commitment === 'locked' ? context?.locked_reason : undefined,
       reference_count: 1,
       sources: [this._buildSourceEntry(scope, context)],
+      recurrence_count: 0,
       summary: autoSummary(statement, undefined),
       engram_version: 1,
       episode_ids: context?.session_episode_id ? [context.session_episode_id] : [],

--- a/packages/core/src/meta/formulation.ts
+++ b/packages/core/src/meta/formulation.ts
@@ -175,6 +175,7 @@ Return ONLY valid JSON, no markdown fencing.`
     },
     reference_count: 1,
     sources: [{ scope: 'global', session_id: null, stored_at: now }],
+    recurrence_count: 0,
     structured_data: { meta: metaField },
   }
 

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -204,6 +204,14 @@ export const EngramSchema = z.object({
     stored_at: z.string(),  // ISO timestamp of this write
   })).default([]),
 
+  // === SP1: Cross-scope recurrence (issue #176) ===
+  /** Number of times this engram's content was re-learned at a DIFFERENT
+   * scope than the original. Triggers auto-broadening + commitment
+   * escalation when threshold is crossed. Distinct from reference_count
+   * (which counts re-learns in the SAME scope) — recurrence_count is
+   * evidence of universal applicability, not just repetition. */
+  recurrence_count: z.number().int().min(0).default(0),
+
   // === SP2: History & Evolution fields ===
   engram_version: z.number().int().min(1).default(1),
   previous_version_ref: PreviousVersionRefSchema.optional(),

--- a/packages/core/test/cross-scope-recurrence.test.ts
+++ b/packages/core/test/cross-scope-recurrence.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { readHistoryForEngram } from '../src/history.js'
+
+/**
+ * Cross-scope recurrence detection (issue #176).
+ *
+ * Contract:
+ *   - First learn of statement S at scope X: creates engram with
+ *     reference_count: 1, recurrence_count: 0, scope: X
+ *   - Re-learn of S at SAME scope X: scope-aware hash dedup hit
+ *     (the #107 path) → reference_count++, recurrence_count unchanged
+ *   - Re-learn of S at DIFFERENT scope Y: cross-scope recurrence
+ *     → recurrence_count goes 0→1, scope unchanged (no broadening yet,
+ *       1 cross-scope hit isn't enough evidence)
+ *   - Re-learn of S at scope Z (or back at Y): recurrence_count goes 1→2
+ *     → scope broadens to 'global', commitment escalates one step
+ *   - Once scope='global' and commitment='locked': stops escalating
+ *     (further recurrences still increment the counter for telemetry)
+ */
+describe('cross-scope recurrence (#176)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-cross-scope-'))
+    plur = new Plur({ path: dir })
+  })
+
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  describe('detection thresholds', () => {
+    it('1st cross-scope re-learn: recurrence_count=1, scope unchanged', () => {
+      const first = plur.learn('always verify days programmatically', { scope: 'project:a' })
+      expect(first.scope).toBe('project:a')
+      expect(first.recurrence_count).toBe(0)
+
+      const second = plur.learn('always verify days programmatically', { scope: 'project:b' })
+
+      // SAME engram, mutated — not a new one
+      expect(second.id).toBe(first.id)
+      // Scope stays project:a — 1 hit isn't enough evidence to broaden
+      expect(second.scope).toBe('project:a')
+      expect(second.recurrence_count).toBe(1)
+      // sources should now have 2 entries (original + cross-scope hit)
+      expect(second.sources).toHaveLength(2)
+      expect(second.sources![1].scope).toBe('project:b')
+    })
+
+    it('2nd cross-scope re-learn: scope broadens to global, commitment escalates', () => {
+      const first = plur.learn('rule', { scope: 'project:a' })
+      expect(first.commitment).toBe('leaning')  // default
+
+      plur.learn('rule', { scope: 'project:b' })  // 1st cross-scope, recurrence=1
+      const third = plur.learn('rule', { scope: 'project:c' })  // 2nd cross-scope → broaden + escalate
+
+      expect(third.id).toBe(first.id)
+      expect(third.recurrence_count).toBe(2)
+      expect(third.scope).toBe('global')                       // broadened
+      expect(third.commitment).toBe('decided')                  // leaning → decided
+      expect(third.sources).toHaveLength(3)
+    })
+
+    it('3rd+ cross-scope recurrence: commitment continues escalating', () => {
+      plur.learn('repeated mistake', { scope: 'project:a' })
+      plur.learn('repeated mistake', { scope: 'project:b' })  // recurrence=1
+      plur.learn('repeated mistake', { scope: 'project:c' })  // recurrence=2: decided
+      const fourth = plur.learn('repeated mistake', { scope: 'project:d' })  // recurrence=3: locked
+
+      expect(fourth.recurrence_count).toBe(3)
+      expect(fourth.commitment).toBe('locked')
+      expect(fourth.locked_at).toBeDefined()
+      expect(fourth.locked_reason).toMatch(/cross-scope recurrence/i)
+    })
+
+    it('locked engrams keep recording recurrences but do not re-escalate', () => {
+      plur.learn('important rule', { scope: 'project:a' })
+      plur.learn('important rule', { scope: 'project:b' })
+      plur.learn('important rule', { scope: 'project:c' })
+      plur.learn('important rule', { scope: 'project:d' })  // locked
+
+      const fifth = plur.learn('important rule', { scope: 'project:e' })
+      expect(fifth.commitment).toBe('locked')  // still locked
+      expect(fifth.recurrence_count).toBe(4)  // counter still increments
+      // No additional locked_at updates after first lock
+    })
+  })
+
+  describe('does not trigger when it should not', () => {
+    it('same-scope re-learn does NOT count as recurrence (uses #107 path instead)', () => {
+      const first = plur.learn('rule', { scope: 'project:a' })
+      const second = plur.learn('rule', { scope: 'project:a' })
+
+      expect(second.id).toBe(first.id)
+      expect(second.recurrence_count).toBe(0)   // unchanged — not a cross-scope event
+      expect(second.reference_count).toBe(2)    // #107 path bumped this
+      expect(second.scope).toBe('project:a')    // no broadening
+    })
+
+    it('different content at different scope creates a fresh engram', () => {
+      const a = plur.learn('rule X', { scope: 'project:a' })
+      const b = plur.learn('rule Y', { scope: 'project:b' })
+
+      expect(b.id).not.toBe(a.id)
+      expect(b.recurrence_count).toBe(0)
+      expect(b.scope).toBe('project:b')
+    })
+
+    it('retired engrams are NOT candidates for cross-scope recurrence — re-learning creates fresh', async () => {
+      const first = plur.learn('phoenix rule', { scope: 'project:a' })
+      // Retire (force count to 0 then forget)
+      await plur.forget(first.id)
+      expect(plur.getById(first.id)!.status).toBe('retired')
+
+      // Cross-scope re-learn should create a NEW engram, not resurrect
+      const fresh = plur.learn('phoenix rule', { scope: 'project:b' })
+      expect(fresh.id).not.toBe(first.id)
+      expect(fresh.recurrence_count).toBe(0)
+    })
+
+    it('normalization-equivalent statements (punct/case) match across scopes', () => {
+      plur.learn('Always Use Semicolons!', { scope: 'project:a' })
+      const second = plur.learn('always use   semicolons', { scope: 'project:b' })
+      expect(second.recurrence_count).toBe(1)
+    })
+  })
+
+  describe('persistence + observability', () => {
+    it('persists recurrence_count + broadened scope across Plur instances', () => {
+      plur.learn('persisted rule', { scope: 'project:a' })
+      plur.learn('persisted rule', { scope: 'project:b' })
+      plur.learn('persisted rule', { scope: 'project:c' })
+
+      const fresh = new Plur({ path: dir })
+      const found = fresh.list({ scope: 'global' }).find(e => e.statement === 'persisted rule')
+      expect(found).toBeDefined()
+      expect(found!.recurrence_count).toBe(2)
+      expect(found!.commitment).toBe('decided')
+    })
+
+    it('emits a recurrence_detected history event with before/after state', () => {
+      const first = plur.learn('history-watched rule', { scope: 'project:a' })
+      plur.learn('history-watched rule', { scope: 'project:b' })
+
+      const events = readHistoryForEngram(plur.getStorageRoot(), first.id)
+      const recurrence = events.find(e => e.event === 'recurrence_detected')
+      expect(recurrence).toBeDefined()
+      expect(recurrence!.data.from_scope).toBe('project:b')
+      expect(recurrence!.data.previous_scope).toBe('project:a')
+      expect(recurrence!.data.recurrence_count).toBe(1)
+    })
+
+    it('emits history events for each subsequent recurrence', () => {
+      const first = plur.learn('multi-recurrence rule', { scope: 'project:a' })
+      plur.learn('multi-recurrence rule', { scope: 'project:b' })
+      plur.learn('multi-recurrence rule', { scope: 'project:c' })
+
+      const events = readHistoryForEngram(plur.getStorageRoot(), first.id)
+      const recurrences = events.filter(e => e.event === 'recurrence_detected')
+      expect(recurrences.length).toBe(2)
+
+      // Second recurrence event should show the scope BROADENED transition
+      const second = recurrences[1]
+      expect(second.data.previous_scope).toBe('project:a')  // before broadening
+      expect(second.data.new_scope).toBe('global')           // after broadening
+      expect(second.data.previous_commitment).toBe('leaning')
+      expect(second.data.new_commitment).toBe('decided')
+    })
+  })
+})

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -80,14 +80,20 @@ describe('Plur', () => {
     expect(conflicting.relations?.conflicts ?? []).toHaveLength(0)
   })
 
-  it('same statement in a different scope is a promotion, not a duplicate (issue #136)', () => {
+  it('same statement in a different scope is a cross-scope recurrence (#136 superseded by #176)', () => {
+    // ORIGINAL #136 semantics: cross-scope re-learn created a NEW engram —
+    // scopes were strict isolation boundaries.
+    // SUPERSEDED by #176: cross-scope re-learn is now evidence of universal
+    // applicability and is recorded as a recurrence on the existing engram
+    // (recurrence_count++) instead of creating a duplicate at the new scope.
+    // The 2nd cross-scope hit auto-broadens scope to 'global' and escalates
+    // commitment; this first-hit case still preserves the original scope.
     const local = plur.learn('pnpm build before tests', { scope: 'global' })
-    const promoted = plur.learn('pnpm build before tests', { scope: 'group:team/eng' })
-    // Different scope → new engram, not a dedup hit
-    expect(promoted.id).not.toBe(local.id)
-    expect(promoted.id).toMatch(/^ENG-/)
-    expect(promoted.scope).toBe('group:team/eng')
-    expect(plur.status().engram_count).toBe(2)
+    const recurrence = plur.learn('pnpm build before tests', { scope: 'group:team/eng' })
+    expect(recurrence.id).toBe(local.id)              // SAME engram, mutated
+    expect(recurrence.recurrence_count).toBe(1)       // 1st cross-scope hit
+    expect(recurrence.scope).toBe('global')           // unchanged on 1st hit
+    expect(plur.status().engram_count).toBe(1)        // no duplicate created
   })
 
   it('inject returns empty result when no engrams match', () => {

--- a/packages/core/test/reference-count.test.ts
+++ b/packages/core/test/reference-count.test.ts
@@ -95,12 +95,17 @@ describe('reference-counted content-addressed dedup (#107)', () => {
       expect(second.reference_count).toBe(2)
     })
 
-    it('creates separate engrams across different scopes (no cross-scope dedup)', () => {
+    it('cross-scope re-learn merges into existing engram as recurrence (#107 superseded by #176)', () => {
+      // ORIGINAL #107 semantics: cross-scope was NOT deduplicated — fresh engram per scope.
+      // SUPERSEDED by #176: cross-scope re-learn is treated as evidence of
+      // universal applicability and merges into the existing engram with
+      // recurrence_count++ instead of creating a duplicate.
       const a = plur.learn('use 2-space indent', { scope: 'project:a' })
       const b = plur.learn('use 2-space indent', { scope: 'project:b' })
-      expect(a.id).not.toBe(b.id)
-      expect(a.reference_count).toBe(1)
-      expect(b.reference_count).toBe(1)
+      expect(b.id).toBe(a.id)                         // SAME engram, mutated
+      expect(b.recurrence_count).toBe(1)              // 1st cross-scope hit
+      expect(b.reference_count).toBe(2)               // also bumped by recurrence path
+      expect(b.scope).toBe('project:a')               // unchanged on 1st hit (no broadening)
     })
 
     it('records different session_ids across multiple write sources', () => {


### PR DESCRIPTION
## Summary

Implements approach C from #176 ("confidence escalation on recurrence"): when a correction is re-learned at a DIFFERENT scope than the original, that's evidence the rule is universal, not scope-specific. The system graduates the engram toward 'global' scope and 'locked' commitment instead of silently creating per-scope duplicates that never re-surface in cross-context sessions.

Closes #176.

## Behavior

| Trigger | Effect |
|---|---|
| 1st \`learn(S)\` at scope A | New engram, \`scope=A\`, \`recurrence_count=0\` |
| 2nd \`learn(S)\` at scope A | \`reference_count++\` (existing #107 path) |
| 1st \`learn(S)\` at scope B | Existing engram mutated: \`recurrence_count=1\`, scope unchanged (1 hit is anecdote, not pattern) |
| 2nd \`learn(S)\` at scope C | \`recurrence_count=2\` → scope broadens to \`global\`, commitment leaning → decided |
| 3rd cross-scope hit | \`recurrence_count=3\`, commitment decided → locked + \`locked_reason\` set |
| Further cross-scope hits on locked engram | counter increments, no further escalation |

## Why "no shortcuts" matters here

Two existing tests asserted the OLD semantics — that cross-scope re-learn creates a new engram (#136 "promotion" + #107 "no cross-scope dedup"). #176's spec explicitly reverses this design call. Both tests updated with explanatory comments naming the supersession (\`packages/core/test/plur.test.ts\`, \`packages/core/test/reference-count.test.ts\`).

#136's isolation semantic still applies INSIDE a single scope. What changes is how the system interprets repeated learns of the same rule ACROSS scopes — that's the very signal #176 was filed to catch.

## Tests

**11 new** in \`packages/core/test/cross-scope-recurrence.test.ts\`:

- Detection thresholds (4): 1st hit no broadening, 2nd hit broadens + escalates, 3rd locks, locked stops re-escalating
- Does-not-trigger (4): same-scope (uses #107), different content (fresh), retired (no resurrection), normalization-equivalent (matches)
- Persistence + observability (3): mutations persist across Plur instances, \`recurrence_detected\` history event emitted, sequential events show before/after transition

Full suite: **1145 passing** (745 in core, 11 new + 2 superseded test rewrites), 0 unrelated regressions.

## Test plan

- [x] \`pnpm -r test\` — 1145 passing, 0 unrelated regressions
- [x] \`pnpm build\` clean across all packages
- [x] Schema migration: old engrams without \`recurrence_count\` load with default 0
- [x] Graduated escalation: 1 hit ≠ broaden; 2+ hits broaden + escalate
- [x] Locked engrams stop re-escalating but continue counting (telemetry)
- [x] History event has before/after snapshot for observability
- [x] Both \`learn()\` (sync) and \`learnRouted()\` (remote) call sites wired

## Limitations (v1)

- **Cross-store recurrences** (different stores, same scope-string) detected but persisted only to primary store. Same gap as #107 cross-store dedup. Documented in code.
- **No retroactive sweep**: existing engrams won't be auto-broadened from past learns. A future \`plur consolidate\` command could scan history and propose broadenings.
- **Hash-based equivalence only**: "verify dates" vs "always check the day of week" requires LLM dedup. Deferred — \`learnAsync\` already has the LLM dedup pipeline; future work could feed cross-scope into it.

## What this does NOT close

- Action-type tagging (approach B in #176) — bigger surface area, separate issue.
- Pre-action hooks (approach D) — requires runtime infrastructure, separate issue.
- The timing gap part of #176 (engrams in context but not surfaced at moment-of-action) — would need point-of-action recall, separate from this scope graduation work.

This PR addresses the SCOPE gap. The TIMING gap remains as a follow-up — file a separate issue if it's worth tackling next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)