### PR TITLE
fix: isPlurConfigured() no longer falls back to global settings

### DIFF
--- a/packages/cli/src/lib/plur-configured.ts
+++ b/packages/cli/src/lib/plur-configured.ts
@@ -6,7 +6,9 @@ import { homedir } from 'os'
  * Detect whether plur is registered as an MCP server for the current project.
  *
  * Walks up from `cwd` looking for `.mcp.json` or `.claude/settings.json` with
- * a `plur` server entry, then falls back to the global `~/.claude/settings.json`.
+ * a `plur` server entry. Does NOT fall back to `~/.claude/settings.json` —
+ * when hooks are installed globally, that file always contains plur, which
+ * would defeat the purpose of this check.
  *
  * Used by the session enforcement hooks (`hook-session-guard`,
  * `hook-session-remind`, `hook-session-mark`) so they can be installed into
@@ -17,7 +19,7 @@ import { homedir } from 'os'
  */
 export function isPlurConfigured(
   cwd: string = process.cwd(),
-  home: string = homedir(),
+  _home: string = homedir(),
 ): boolean {
   const start = resolve(cwd)
   let dir = start
@@ -29,7 +31,10 @@ export function isPlurConfigured(
     if (parent === dir) break
     dir = parent
   }
-  return configHasPlur(join(home, '.claude', 'settings.json'))
+  // Do NOT fall back to ~/.claude/settings.json — when hooks are installed
+  // globally, that file always has plur in mcpServers, which makes this
+  // return true for every project regardless of whether it uses plur (#95).
+  return false
 }
 
 function configHasPlur(path: string): boolean {

--- a/packages/cli/test/plur-configured.test.ts
+++ b/packages/cli/test/plur-configured.test.ts
@@ -58,4 +58,18 @@ describe('isPlurConfigured', () => {
     writeFileSync(join(root, '.mcp.json'), '{ not valid json')
     expect(isPlurConfigured(root, root)).toBe(false)
   })
+
+  it('returns false even when global ~/.claude/settings.json has plur', () => {
+    // Simulate a home dir with plur in global settings
+    const fakeHome = join(root, 'fakehome')
+    mkdirSync(join(fakeHome, '.claude'), { recursive: true })
+    writeFileSync(
+      join(fakeHome, '.claude', 'settings.json'),
+      JSON.stringify({ mcpServers: { plur: { command: 'plur-mcp' } } }),
+    )
+    // cwd has no plur config — should return false despite global having it
+    const projectDir = join(root, 'some-project')
+    mkdirSync(projectDir)
+    expect(isPlurConfigured(projectDir, fakeHome)).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

- Remove the `~/.claude/settings.json` fallback from `isPlurConfigured()` — it always returns true for anyone who ran `plur init`, causing the session guard to block tool calls in every project, even ones without plur
- Add test verifying global settings don't produce a false positive

Closes #247

## Test plan

- [x] All 1150 existing tests pass
- [x] New test: `isPlurConfigured()` returns `false` when only global `~/.claude/settings.json` has plur but no project-level config exists
- [x] Existing tests confirm projects with plur in `.mcp.json` or `.claude/settings.json` still return `true`
- [ ] Manual: open Claude Code in a non-plur project — session guard should not block
- [ ] Manual: open Claude Code in a plur project — session guard should enforce `plur_session_start` as before