### PR TITLE
fix(cli): bound session guard to one nudge + calm reminder (fixes #283)

### DIFF
--- a/packages/cli/src/commands/hook-session-guard.ts
+++ b/packages/cli/src/commands/hook-session-guard.ts
@@ -29,7 +29,14 @@ const EXEMPT_TOOLS = new Set([
   'ToolSearch',
 ])
 
-const MAX_BLOCKS_BEFORE_FALLBACK = 5
+// Nudge at most once per session, then fail open. A hard deny-everything
+// guard collapses the agent's action space to the single exempt call
+// (plur_session_start); under the deferred-tool flow that call can fail with
+// "task required" if its schema isn't loaded yet, and the agent then retries
+// it in a tight loop. Bounding the guard to one nudge makes that impossible:
+// session-start memory is best-effort (hook-inject already injects on
+// UserPromptSubmit), never worth trapping or pressuring a session.
+const MAX_BLOCKS_BEFORE_FALLBACK = 1
 
 function readStdinRaw(): string {
   try {
@@ -102,21 +109,26 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
   const blockCount = incrementBlockCount(sessionId)
   if (blockCount > MAX_BLOCKS_BEFORE_FALLBACK) {
     process.stderr.write(
-      `[plur] WARNING: session guard gave up after ${MAX_BLOCKS_BEFORE_FALLBACK} blocked calls. ` +
-      `The plur MCP server may not be running. Run \`plur doctor\` to diagnose.\n`,
+      `[plur] session guard: allowing tools after ${MAX_BLOCKS_BEFORE_FALLBACK} nudge(s) ` +
+      `without a session start. If plur_session_start never ran, the MCP server ` +
+      `may be down — run \`plur doctor\` to diagnose. Memory injection is best-effort.\n`,
     )
     return
   }
 
-  // Block
+  // Nudge once (calm, anti-batching), then fail open on the next call.
   const output = {
     hookSpecificOutput: {
       hookEventName: 'PreToolUse',
       permissionDecision: 'deny',
       permissionDecisionReason:
-        'BLOCKED: plur_session_start has not been called yet. ' +
-        'You MUST call mcp__plur__plur_session_start before using any other tool. ' +
-        'Use ToolSearch to load it first if needed.',
+        'Reminder: call mcp__plur__plur_session_start once before other tools ' +
+        'so this session has memory. It is a deferred tool — first run ' +
+        "ToolSearch 'select:mcp__plur__plur_session_start' as its own step, " +
+        'then call it a single time with a short task description. Do not batch ' +
+        'the ToolSearch with the call, and do not repeat it. This reminder fires ' +
+        'only once; your next tool call proceeds normally whether or not ' +
+        'session_start succeeded.',
     },
   }
   process.stdout.write(JSON.stringify(output))

--- a/packages/cli/src/commands/hook-session-remind.ts
+++ b/packages/cli/src/commands/hook-session-remind.ts
@@ -20,12 +20,16 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
     hookSpecificOutput: {
       hookEventName: 'SessionStart',
       additionalContext:
-        'MANDATORY FIRST ACTION — DO THIS NOW BEFORE ANYTHING ELSE:\n' +
-        "1. Call ToolSearch with query 'select:mcp__plur__plur_session_start'\n" +
-        "2. Call mcp__plur__plur_session_start with the user's task description\n" +
-        '3. Only THEN proceed with any other work\n\n' +
-        'A PreToolUse guard will BLOCK all other tool calls until this is done. ' +
-        'This is not optional. This is not a suggestion. Do it now.',
+        "Before other work, start this session's memory with plur:\n" +
+        "1. Run ToolSearch 'select:mcp__plur__plur_session_start' on its own " +
+        'and wait for the result. It is a deferred tool — its schema must ' +
+        'load before it can be called.\n' +
+        '2. Then call mcp__plur__plur_session_start exactly once with a short ' +
+        'task description.\n' +
+        'Do not batch steps 1 and 2 in the same turn, and do not repeat the ' +
+        "call. A 'task required' error only means the schema wasn't loaded " +
+        'yet — run ToolSearch, then call it once. A guard nudges you once if ' +
+        'you start with another tool, but it never blocks your work.',
     },
   }
   process.stdout.write(JSON.stringify(output))

--- a/packages/cli/test/hook-session-guard.test.ts
+++ b/packages/cli/test/hook-session-guard.test.ts
@@ -59,19 +59,23 @@ describe('hook-session-guard', () => {
     expect(result.stdout).not.toContain('deny')
   })
 
-  it('stops blocking after MAX_BLOCKS_BEFORE_FALLBACK calls (#199)', () => {
+  it('nudges once then fails open (#199, #283)', () => {
     mkdirSync(join(home, 'tmp'), { recursive: true })
 
-    // First 5 calls should block
-    for (let i = 0; i < 5; i++) {
-      const result = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
-      expect(result.stdout).toContain('deny')
-    }
+    // First call nudges (deny). Bounding to a single nudge prevents the
+    // deferred-tool retry spiral on the exempt session_start call.
+    const first = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
+    expect(first.stdout).toContain('deny')
 
-    // 6th call should allow through with warning
+    // Second call falls through with the fallback warning.
     const fallback = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
     expect(fallback.stdout).not.toContain('deny')
-    expect(fallback.stderr).toContain('gave up')
     expect(fallback.stderr).toContain('plur doctor')
+
+    // Every subsequent call also allows through — no spiral possible.
+    for (let i = 0; i < 4; i++) {
+      const result = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
+      expect(result.stdout).not.toContain('deny')
+    }
   })
 })


### PR DESCRIPTION
Fixes #283

## Problem

The session-start enforcement hooks could push the agent into a burst of repeated `plur_session_start` calls (observed ~150 in one turn before user interrupt) now that `plur_session_start` is a **deferred MCP tool** — its schema must be loaded via `ToolSearch` before it is callable.

The spiral: `hook-session-remind` injects a maximalist "MANDATORY / DO IT NOW / will BLOCK" directive; `hook-session-guard` hard-denies every non-exempt tool until the session sentinel exists. `plur_session_start` is exempt — so if the agent batches `ToolSearch` + the call into one turn, the call fires before its schema loads and errors `task: Required`, and under the maximal pressure with all other tools denied, the agent retries the *exempt-but-failing* call in a tight loop. The existing #199 fallback bounded non-exempt blocks at 5 but did nothing for this retry loop driven by the reminder framing.

This is model-agnostic — any agent that batches the two calls or feels the pressure to retry can trip it. The hooks were stable for weeks; the harness change to deferred tools exposed the fragility.

## Changes

- **`hook-session-guard.ts`** — `MAX_BLOCKS_BEFORE_FALLBACK` 5 → **1**: nudge once, then fail open. Deny reason rewritten to be calm and anti-batching (run `ToolSearch` as its own step; call `session_start` once; a `task: Required` error just means the schema wasn't loaded — re-run `ToolSearch`, don't repeat).
- **`hook-session-remind.ts`** — drop the "MANDATORY / BLOCK / not optional / DO IT NOW" framing for calm, explicit anti-batching guidance.
- **`test/hook-session-guard.test.ts`** — update the #199 case to the new nudge-once-then-fail-open contract.

Session-start memory is best-effort (`hook-inject` already injects engrams on `UserPromptSubmit`), so enforcement should never trap or pressure-spiral a session.

## Testing

- Full CLI suite green: **188 passed, 4 skipped**.
- Verified via the real `plur-hook` wrapper against the rebuilt `dist`: fresh session → call 1 **deny** (one calm nudge), calls 2–5 **allow** (fail open). Reminder now emits the calm anti-batching text. Exempt tools (`ToolSearch`, `session_start`) always pass.

## Related

Mirror of the same fix in datacore's parallel hook layer (datacore-one/datacore#23, PR #24). The two systems are redundant — both wire a SessionStart reminder and a PreToolUse guard. Worth deciding longer-term whether datacore should defer entirely to these plur-package hooks.
