### PR TITLE
fix(core): PLUR_DISABLE_REACTIVATION env to skip per-recall YAML rewrite

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1576,6 +1576,14 @@ export class Plur {
   /** Reactivate accessed engrams and update co-access associations */
   private _reactivateResults(results: Engram[]): void {
     if (results.length === 0) return
+    // Benchmark-mode opt-out: each call to this method loads, mutates, and
+    // rewrites the entire engrams.yaml. With 30k engrams that's ~60 MB
+    // per call — enough to OOM V8 (ConsString growth) within a few hundred
+    // queries. Benchmarks don't care about activation tracking; set
+    // PLUR_DISABLE_REACTIVATION=1 to short-circuit.
+    if (process.env.PLUR_DISABLE_REACTIVATION === '1' || process.env.PLUR_DISABLE_REACTIVATION === 'true') {
+      return
+    }
     // Filter out store engrams — they're managed by their source.
     // Via YAML path: store engrams have _originalId. Via SQLite path: namespaced IDs (ENG-XX-...).
     const isStoreEngram = (e: Engram) =>


### PR DESCRIPTION
Q2 Run A OOM root cause: `_reactivateResults` runs on every `recall*` call and rewrites the full engrams.yaml. For 30k engrams = ~60MB write per call. 500 queries OOM V8 even with 12GB heap.

This patch adds `PLUR_DISABLE_REACTIVATION=1` to short-circuit during benchmark mode. The full fix (batch activation updates in memory + flush periodically) is a follow-on.