### PR TITLE
core: export the embedding primitive (embed + EMBED_DIM) as public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### `@plur-ai/core` exports the embedding primitive (#289)
+
+`embed()`, `EMBED_DIM`, `embedderStatus()`, and `cosineSimilarity()` are now part of `@plur-ai/core`'s public API. Previously only the `SimilarityResult` type was re-exported, so the local BGE embedder (`BAAI/bge-small-en-v1.5`, 384-dim) was effectively internal. Alternative store backends that persist vectors and run similarity in a database can now compute embeddings identically to core's hybrid search instead of re-implementing the embedder and risking model/dimension drift.
+
+```ts
+import { embed, EMBED_DIM } from '@plur-ai/core'
+```
+
+- `EMBED_DIM` (384) is a new named constant. `embed()` asserts its first successful output against it once per process, so a model swap that changes the dimension fails loudly instead of silently corrupting persisted vectors.
+- **Breaking-change contract:** the embedding model identity and `EMBED_DIM` are a stable public contract. Changing either is a breaking change for any consumer that persists vectors — they must re-embed. Treat a model/dimension change accordingly.
+
+No new model and no external dependency — this only makes the existing capability reusable.
+
 ## 0.9.11 (2026-05-26)
 
 Bug sweep — three independent fixes bundled.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/core",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -32,6 +32,14 @@ import { atomicWrite } from './sync.js'
  */
 export const EMBED_DIM = 384
 
+/**
+ * Model identity behind the embeddings, half of the stable contract above.
+ * The ONNX/transformers.js port of BAAI/bge-small-en-v1.5. Named so the
+ * dimension-mismatch error can name the model a consumer must match, and so a
+ * model swap is a one-line, greppable change.
+ */
+const EMBED_MODEL_ID = 'Xenova/bge-small-en-v1.5'
+
 // Verifies the live model output matches EMBED_DIM exactly once per process —
 // see assertEmbedDim().
 let embedDimChecked = false
@@ -128,7 +136,7 @@ async function getEmbedder() {
   // transient (network, sandbox restrictions on first download).
   try {
     const { pipeline } = await import('@huggingface/transformers')
-    embedPipeline = await pipeline('feature-extraction', 'Xenova/bge-small-en-v1.5', {
+    embedPipeline = await pipeline('feature-extraction', EMBED_MODEL_ID, {
       dtype: 'fp32',
     })
     transformersUnavailable = false
@@ -141,7 +149,21 @@ async function getEmbedder() {
   }
 }
 
-/** Generate embedding for a text string. Returns Float32Array of EMBED_DIM (384) dims, or null if unavailable. */
+/**
+ * Generate an embedding for a text string. Returns a Float32Array of EMBED_DIM
+ * (384) dims.
+ *
+ * Two distinct non-success outcomes — consumers MUST treat them differently:
+ *
+ * - Returns `null` → embeddings are unavailable (model not loaded, download
+ *   failed, or disabled via config/PLUR_DISABLE_EMBEDDINGS). This is an
+ *   environment condition; callers should degrade to keyword/BM25 search.
+ * - Throws → the live model's output dimension does not match EMBED_DIM, i.e. a
+ *   model/contract violation. This must NOT be swallowed into the degrade path:
+ *   a catch-all that falls back to BM25 here re-introduces the exact silent
+ *   drift this contract prevents and lets incompatible vectors get persisted.
+ *   Let it surface.
+ */
 export async function embed(text: string): Promise<Float32Array | null> {
   const embedder = await getEmbedder()
   if (!embedder) return null
@@ -162,9 +184,11 @@ function assertEmbedDim(vector: Float32Array): void {
   embedDimChecked = true
   if (vector.length !== EMBED_DIM) {
     throw new Error(
-      `Embedding dimension mismatch: model produced ${vector.length} dims but EMBED_DIM is ${EMBED_DIM}. ` +
-        `The embedding model and EMBED_DIM must agree — update EMBED_DIM and treat this as a breaking change ` +
-        `for any consumer that persists vectors (they must re-embed).`,
+      `Embedding dimension mismatch: model "${EMBED_MODEL_ID}" produced ${vector.length} dims ` +
+        `but EMBED_DIM is ${EMBED_DIM}. The embedding model and EMBED_DIM must agree. ` +
+        `Remediation: update EMBED_DIM to ${vector.length} or revert the model change. ` +
+        `Either way this is a BREAKING change for any consumer that persists vectors — ` +
+        `they must re-embed, since vectors at the old dimension are incompatible.`,
     )
   }
 }

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -19,6 +19,23 @@ import { atomicWrite } from './sync.js'
  * re-computation on subsequent searches.
  */
 
+/**
+ * Embedding dimension produced by the model (BAAI/bge-small-en-v1.5 → 384).
+ *
+ * STABLE PUBLIC CONTRACT. Any backend that persists vectors must store them at
+ * this dimension and produced by this exact model — vectors of a different
+ * dimension or from a different model are incompatible and silently degrade
+ * recall. Changing the model or this value is therefore a BREAKING change:
+ * every consumer holding persisted vectors must re-embed. `embed()` asserts its
+ * first successful output against this constant so a model swap that changes the
+ * dimension fails loudly instead of drifting silently.
+ */
+export const EMBED_DIM = 384
+
+// Verifies the live model output matches EMBED_DIM exactly once per process —
+// see assertEmbedDim().
+let embedDimChecked = false
+
 // Lazy-loaded pipeline — only initialized when first needed
 let embedPipeline: any = null
 let lastLoadError: string | null = null
@@ -100,6 +117,7 @@ export function resetEmbedder(): void {
   transformersUnavailable = false
   lastLoadError = null
   embedPipeline = null
+  embedDimChecked = false
 }
 
 async function getEmbedder() {
@@ -123,12 +141,32 @@ async function getEmbedder() {
   }
 }
 
-/** Generate embedding for a text string. Returns Float32Array of 384 dims, or null if unavailable. */
+/** Generate embedding for a text string. Returns Float32Array of EMBED_DIM (384) dims, or null if unavailable. */
 export async function embed(text: string): Promise<Float32Array | null> {
   const embedder = await getEmbedder()
   if (!embedder) return null
   const result = await embedder(text, { pooling: 'cls', normalize: true })
-  return new Float32Array(result.data)
+  const vector = new Float32Array(result.data)
+  assertEmbedDim(vector)
+  return vector
+}
+
+/**
+ * Assert (once per process) that the live model's output dimension matches
+ * EMBED_DIM. A mismatch means the model changed without EMBED_DIM being updated
+ * (or vice versa) — a contract violation that would silently corrupt any
+ * persisted vectors, so we fail loudly here rather than let it drift.
+ */
+function assertEmbedDim(vector: Float32Array): void {
+  if (embedDimChecked) return
+  embedDimChecked = true
+  if (vector.length !== EMBED_DIM) {
+    throw new Error(
+      `Embedding dimension mismatch: model produced ${vector.length} dims but EMBED_DIM is ${EMBED_DIM}. ` +
+        `The embedding model and EMBED_DIM must agree — update EMBED_DIM and treat this as a breaking change ` +
+        `for any consumer that persists vectors (they must re-embed).`,
+    )
+  }
 }
 
 /** Cosine similarity between two vectors. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,11 @@ export { detectPlurStorage, type PlurPaths } from './storage.js'
 export { IndexedStorage } from './storage-indexed.js'
 export { YamlStore, SqliteStore, createStore, migrateStore, type EngramStore, type StorageBackend, type StorageConfig } from './store/index.js'
 export { withAsyncLock, asyncAtomicWrite } from './store/index.js'
+// Embedding primitive — public so alternative store backends can compute
+// vectors identically to core's hybrid search (same model + EMBED_DIM). The
+// model identity and EMBED_DIM are a stable contract; changing them is breaking
+// for any consumer that persists vectors. See embeddings.ts.
+export { embed, EMBED_DIM, embedderStatus, cosineSimilarity, type EmbedderStatus } from './embeddings.js'
 export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus } from './sync.js'
 export { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'

--- a/packages/core/test/embedding-primitive-export.test.ts
+++ b/packages/core/test/embedding-primitive-export.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { embed, EMBED_DIM, embedderStatus, cosineSimilarity } from '../src/index.js'
+
+/**
+ * Public embedding-primitive contract (#289).
+ *
+ * Alternative store backends that persist vectors must be able to compute
+ * embeddings identically to core's hybrid search. That requires the embedder
+ * and its dimension to be part of the package's public API (re-exported from
+ * `src/index.ts`, which `dist/index.js` — `@plur-ai/core`'s entry — is built
+ * from) rather than internal to `embeddings.ts`.
+ *
+ * These assertions are intentionally model-free (no ~130MB BGE download, no
+ * ONNX init) so they run in any CI environment. The dimension is enforced
+ * against the *live* model by the one-time assertion inside `embed()`
+ * (see embeddings.ts) rather than here.
+ */
+describe('embedding primitive public API (#289)', () => {
+  it('re-exports the committed contract: embed, EMBED_DIM, embedderStatus', () => {
+    expect(typeof embed).toBe('function')
+    expect(typeof embedderStatus).toBe('function')
+    expect(typeof EMBED_DIM).toBe('number')
+  })
+
+  it('re-exports cosineSimilarity as a convenience', () => {
+    expect(typeof cosineSimilarity).toBe('function')
+  })
+
+  it('EMBED_DIM is the bge-small-en-v1.5 dimension (384)', () => {
+    expect(EMBED_DIM).toBe(384)
+  })
+
+  it('cosineSimilarity computes dot product on normalized vectors', () => {
+    const a = new Float32Array([1, 0, 0])
+    const b = new Float32Array([1, 0, 0])
+    const c = new Float32Array([0, 1, 0])
+    expect(cosineSimilarity(a, b)).toBeCloseTo(1, 6)
+    expect(cosineSimilarity(a, c)).toBeCloseTo(0, 6)
+  })
+})

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plur-ai/mcp",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "type": "module",
   "bin": {
     "plur-mcp": "dist/index.js"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
 
-const VERSION = '0.9.12'
+const VERSION = '0.9.13'
 
 const HELP = `plur-mcp v${VERSION} — persistent memory for AI agents
 

--- a/packages/mcp/src/version.ts
+++ b/packages/mcp/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.9.12'
+export const VERSION = '0.9.13'

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -32,7 +32,7 @@ describe('MCP server (wire protocol)', () => {
   it('returns server info with instructions on initialize', () => {
     const info = client.getServerVersion()
     expect(info?.name).toBe('plur-mcp')
-    expect(info?.version).toBe('0.9.12')
+    expect(info?.version).toBe('0.9.13')
   })
 
   // --- Tools ---
@@ -169,7 +169,7 @@ describe('MCP server (wire protocol)', () => {
     const result = await client.readResource({ uri: 'plur://status' })
     const data = JSON.parse((result.contents[0] as any).text)
     expect(data.engram_count).toBe(1)
-    expect(data.version).toBe('0.9.12')
+    expect(data.version).toBe('0.9.13')
     expect(data.storage_root).toBe(dir)
   })
 


### PR DESCRIPTION
Closes #289.

## What

Promotes core's local BGE embedder from internal to public API so an alternative store backend can compute vectors **identically** to core's hybrid search (same model, same dimension) instead of re-implementing the embedder and risking silent model/dimension drift.

`@plur-ai/core` now re-exports:

- `embed(text): Promise<Float32Array | null>`
- `EMBED_DIM` (384) — new named constant
- `embedderStatus()` — so a consumer can surface "embeddings degraded (reason)" instead of silently dropping to keyword-only
- `cosineSimilarity()` — convenience, useful in tests

Previously only the `SimilarityResult` type was public.

```ts
import { embed, EMBED_DIM } from '@plur-ai/core'
```

## Enforcing the contract against the live model

Per the amended acceptance criteria, `embed()` checks its first successful output's length against `EMBED_DIM` once per process (`assertEmbedDim`). A model swap that changes the dimension fails loudly rather than silently corrupting any persisted vectors. The check resets on `resetEmbedder()`.

`EMBED_DIM` is **not** claimed as core's internal single-source-of-truth — core derives the dimension from model output and never referenced a literal `384` in code (only comments). The runtime assertion is what binds the constant to the actual model.

## Breaking-change contract

The model identity + `EMBED_DIM` are documented in CHANGELOG as a stable public contract: changing either is breaking for any consumer that persists vectors (they must re-embed).

## Tests

`packages/core/test/embedding-primitive-export.test.ts` — 5 model-free assertions (export surface, `EMBED_DIM === 384`, `cosineSimilarity` math). Kept model-free deliberately so it runs in any CI env (no ~130MB BGE download / ONNX init); the live-model dimension check is enforced by the in-`embed()` assertion.

Targeted run: `embedding-primitive-export` + `embeddings-optout` → 17 passed. (Pre-existing `sync.test.ts` failures in this environment are git-identity issues in ephemeral temp repos, unrelated to this change.)

## Out of scope

No version bump / publish — leaving the release cut to @plur9 to batch as desired.