### PR TITLE
feat: client scope discovery via GET /api/v1/me (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ A user authorized for several team scopes on one enterprise instance could only 
 
 Token rotation is intentionally out of scope: re-adding the same URL+scope with a different token stays an `already_registered` no-op rather than silently swapping the stored token.
 
+### Client scope discovery — find & register all authorized scopes (#292)
+
+The client never asked the enterprise server which scopes a token can access, so a user authorized for N teams had to discover scopes out-of-band and hand-register each. The server already exposes the full resolved scope set at `GET /api/v1/me`; this wires the client to it. (Builds on #291 — registering N scopes under one URL is what makes auto-register meaningful.)
+
+- **`packages/core/src/store/remote-store.ts`** — new `RemoteStore.me()` calls `GET /api/v1/me` and returns the resolved identity + authorized scopes.
+- **`packages/core/src/index.ts`** — `discoverRemoteScopes()` reports, per configured remote URL, the authorized scopes split into `registered` vs `unregistered` (read-only, per-URL timeout, failures captured not thrown). `registerDiscoveredScopes()` registers every authorized-but-unregistered scope in one step.
+- **`packages/mcp/src/tools.ts`** — new `plur_scopes_discover` tool (read-only by default; `register: true` registers all). `plur_session_start` now surfaces a best-effort hint when the token is authorized for scopes that aren't registered yet — bounded by a short timeout and fully swallowed on error, so it never blocks or slows session start.
+- **`packages/cli/src/commands/stores.ts`** — new `plur stores discover [--register]`.
+
+One token → discover all authorized team scopes → register them in one action.
+
 ## 0.9.11 (2026-05-26)
 
 Bug sweep — three independent fixes bundled.

--- a/packages/cli/src/commands/stores.ts
+++ b/packages/cli/src/commands/stores.ts
@@ -26,6 +26,40 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
 
+  if (subcommand === 'discover') {
+    const register = args.includes('--register')
+    const discoveries = await plur.discoverRemoteScopes()
+    const registered = register ? await plur.registerDiscoveredScopes() : []
+
+    if (shouldOutputJson(flags)) {
+      outputJson({ discovered: discoveries, ...(register ? { registered } : {}) })
+      return
+    }
+    if (discoveries.length === 0) {
+      outputText('No remote stores configured. Add one scope with `plur stores add`, then run discover.')
+      return
+    }
+    discoveries.forEach(d => {
+      if (!d.ok) {
+        outputText(`${d.url}: discovery failed — ${d.error}`)
+        return
+      }
+      outputText(`${d.url} (${d.username || 'unknown'}, role ${d.role || 'unknown'})`)
+      outputText(`  registered:   ${d.registered.join(', ') || '(none)'}`)
+      outputText(`  unregistered: ${d.unregistered.join(', ') || '(none)'}`)
+    })
+    if (register) {
+      registered.forEach(r => {
+        if (!r.ok) { outputText(`${r.url}: register failed — ${r.error}`); return }
+        outputText(`${r.url}: added ${r.added.length} scope(s)${r.added.length ? ` (${r.added.join(', ')})` : ''}`)
+      })
+    } else {
+      const total = discoveries.reduce((n, d) => n + d.unregistered.length, 0)
+      if (total > 0) outputText(`\nRun \`plur stores discover --register\` to register all ${total} unregistered scope(s).`)
+    }
+    return
+  }
+
   if (!subcommand || subcommand === 'list') {
     // Async variant — accurate remote store engram_count (issue #184)
     const storeList = await plur.listStoresAsync()
@@ -44,5 +78,5 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
 
-  exit(1, 'Usage: plur stores <add|list>')
+  exit(1, 'Usage: plur stores <add|list|discover>')
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,6 +135,37 @@ export interface StatusResult {
   outbox_count?: number
 }
 
+/**
+ * Per-URL result of scope discovery against an enterprise server's `/api/v1/me`
+ * (#292). `unregistered` is the actionable set: scopes the token is authorized
+ * for but that aren't yet in local config.
+ */
+export interface RemoteScopeDiscovery {
+  url: string
+  /** True when `/me` responded; false on network error, 401, etc. */
+  ok: boolean
+  username?: string
+  org_id?: string
+  role?: string
+  /** All scopes the token is authorized for (from `/me`). Empty when `ok` is false. */
+  authorized: string[]
+  /** Scopes already registered in local config for this URL. */
+  registered: string[]
+  /** Authorized minus registered — the scopes a user could still add. */
+  unregistered: string[]
+  /** Present when `ok` is false. */
+  error?: string
+}
+
+/** Outcome of registering discovered scopes for one URL (#292). */
+export interface RegisterDiscoveredResult {
+  url: string
+  ok: boolean
+  added: string[]
+  already_registered: string[]
+  error?: string
+}
+
 /** Commitment level scoring multipliers for injection priority (Idea 6). */
 export const COMMITMENT_MULTIPLIER: Record<string, number> = {
   locked: 1.0,
@@ -2579,6 +2610,95 @@ Generate an improved version of the procedure that prevents this failure. Return
     return (this.config.stores ?? [])
       .filter(s => s.url && !s.readonly)
       .map(s => ({ scope: s.scope, url: s.url! }))
+  }
+
+  /**
+   * Group configured remote stores by distinct URL, returning one entry per URL
+   * with the token to query it. Tokens should be identical across a URL's
+   * entries (same user, same instance); the first is used.
+   */
+  private _distinctRemoteEndpoints(): Array<{ url: string; token?: string }> {
+    const byUrl = new Map<string, { url: string; token?: string }>()
+    for (const s of this.config.stores ?? []) {
+      if (s.url && !byUrl.has(s.url)) byUrl.set(s.url, { url: s.url, token: s.token })
+    }
+    return [...byUrl.values()]
+  }
+
+  /**
+   * Discover which scopes each configured remote token is authorized for, via
+   * `GET /api/v1/me` (#292). For each distinct remote URL, reports the
+   * server-authorized scope set and which of those are not yet registered
+   * locally — the gap that lets a user authorized for N teams see only the
+   * one(s) they happened to register.
+   *
+   * Read-only: never mutates config. Each `/me` is raced against a timeout and
+   * failures are captured per URL (`ok:false`) so one unreachable endpoint
+   * never sinks discovery for the others. Restricted to a single URL via
+   * `opts.url`.
+   */
+  async discoverRemoteScopes(opts?: { url?: string; timeoutMs?: number }): Promise<RemoteScopeDiscovery[]> {
+    const timeoutMs = opts?.timeoutMs ?? 5000
+    const endpoints = this._distinctRemoteEndpoints().filter(e => !opts?.url || e.url === opts.url)
+
+    return Promise.all(endpoints.map(async ({ url, token }) => {
+      const registered = (this.config.stores ?? []).filter(s => s.url === url).map(s => s.scope)
+      try {
+        const driver = this._getRemoteDriver({ url, token, scope: registered[0] ?? '' })
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+        const me = await Promise.race([
+          driver.me().finally(() => { if (timeoutHandle) clearTimeout(timeoutHandle) }),
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(() => reject(new Error(`/me timeout (${timeoutMs}ms)`)), timeoutMs)
+          }),
+        ])
+        const registeredSet = new Set(registered)
+        return {
+          url,
+          ok: true,
+          username: me.username,
+          org_id: me.org_id,
+          role: me.role,
+          authorized: me.scopes,
+          registered,
+          unregistered: me.scopes.filter(s => !registeredSet.has(s)),
+        }
+      } catch (err) {
+        return {
+          url, ok: false,
+          authorized: [], registered, unregistered: [],
+          error: err instanceof Error ? err.message : String(err),
+        }
+      }
+    }))
+  }
+
+  /**
+   * Register every authorized-but-unregistered scope discovered for the
+   * configured remote URL(s) (#292). One token → all the user's team scopes in
+   * a single action. Relies on URL+scope dedup (#291) so multiple scopes coexist
+   * under one URL.
+   *
+   * Returns per-URL what was newly `added` vs `already_registered`. A URL whose
+   * `/me` failed yields `ok:false` and registers nothing.
+   */
+  async registerDiscoveredScopes(opts?: { url?: string; timeoutMs?: number }): Promise<RegisterDiscoveredResult[]> {
+    const discoveries = await this.discoverRemoteScopes(opts)
+    return discoveries.map(d => {
+      if (!d.ok) return { url: d.url, ok: false, added: [], already_registered: [], error: d.error }
+      const token = (this.config.stores ?? []).find(s => s.url === d.url)?.token
+      const added: string[] = []
+      const already: string[] = []
+      // Attempt every authorized scope (not just the pre-computed unregistered
+      // set) and let addStore's url+scope idempotency (#291) classify each — so
+      // the result is accurate even if config changed between discover and now.
+      for (const scope of d.authorized) {
+        const { status } = this.addStore('', scope, { url: d.url, token })
+        if (status === 'added') added.push(scope)
+        else already.push(scope)
+      }
+      return { url: d.url, ok: true, added, already_registered: already }
+    })
   }
 
   /** Set a session-level default scope. Used as fallback in learn/learnRouted when no explicit scope is provided. */

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -45,6 +45,30 @@ export class RemoteStore implements EngramStore {
   }
 
   /**
+   * Resolve the identity behind this token — `GET /api/v1/me`. Returns the
+   * full authorized scope set the server resolved from group memberships, so
+   * the client can discover scopes a token can access without registering them
+   * out-of-band (#292). Scope-independent: `/me` is keyed on the token alone,
+   * so the driver's `scope` is irrelevant here.
+   *
+   * Throws on a non-2xx response (caller decides whether to swallow per URL).
+   */
+  async me(): Promise<{ username: string; org_id: string; role: string; scopes: string[] }> {
+    const r = await fetch(`${this.apiBase}/me`, { headers: this.headers() })
+    if (!r.ok) {
+      const text = await r.text().catch(() => '')
+      throw new Error(`Remote /me failed: ${r.status} ${text}`)
+    }
+    const body = await r.json().catch(() => ({})) as Partial<{ username: string; org_id: string; role: string; scopes: string[] }>
+    return {
+      username: body.username ?? '',
+      org_id:   body.org_id ?? '',
+      role:     body.role ?? '',
+      scopes:   Array.isArray(body.scopes) ? body.scopes : [],
+    }
+  }
+
+  /**
    * Load all engrams visible to this token at this scope. Cached up to
    * ttlMs; in-flight calls deduplicate to avoid thundering-herd on
    * the remote when 5 things ask for engrams at once.

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -17,6 +17,7 @@
  *
  * | Method | Path | Behavior |
  * |--------|------|----------|
+ * | GET | /api/v1/me | Resolved identity + authorized scopes (override via setMe) |
  * | GET | /api/v1/engrams?scope=...&limit=...&offset=... | List engrams by scope, paginated |
  * | GET | /api/v1/engrams/:id | Get single engram or 404 |
  * | POST | /api/v1/engrams | Create engram, assigns server ID |
@@ -62,8 +63,18 @@ export class StubServer {
   private engrams = new Map<string, StoredEngram>()
   private idCounter = 0
   private port = 0
+  // Identity returned by GET /api/v1/me (#292). Defaults to a single-scope
+  // user; override per-test with setMe() to simulate multi-team authorization.
+  private me: { username: string; org_id: string; role: string; scopes: string[] } = {
+    username: 'testuser', org_id: 'test-org', role: 'developer', scopes: ['group:test'],
+  }
 
   constructor(private readonly validToken: string) {}
+
+  /** Override the GET /api/v1/me response (authorized scope set, identity). */
+  setMe(me: Partial<{ username: string; org_id: string; role: string; scopes: string[] }>): void {
+    this.me = { ...this.me, ...me }
+  }
 
   /** Start the server on a random available port. Returns the base URL and token. */
   async start(): Promise<{ url: string; token: string }> {
@@ -130,6 +141,12 @@ export class StubServer {
     const url = new URL(req.url ?? '/', `http://127.0.0.1:${this.port}`)
     const path = url.pathname
     const method = req.method ?? 'GET'
+
+    // GET /api/v1/me — resolved identity + authorized scopes (#292)
+    if (method === 'GET' && path === '/api/v1/me') {
+      this.json(res, 200, this.me)
+      return
+    }
 
     // POST /api/v1/engrams — create
     if (method === 'POST' && path === '/api/v1/engrams') {

--- a/packages/core/test/scope-discovery.test.ts
+++ b/packages/core/test/scope-discovery.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Client scope discovery — closes plur-ai/plur#292.
+ *
+ * The client can now ask the enterprise server which scopes a token is
+ * authorized for (GET /api/v1/me) and register the ones it hasn't yet. These
+ * integration tests run against the in-process stub server (real HTTP), with
+ * setMe() simulating a multi-team authorization.
+ *
+ * Depends on the URL+scope dedup from #291 — registering N scopes under one URL
+ * is what makes auto-register meaningful.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { RemoteStore } from '../src/store/remote-store.js'
+import { Plur } from '../src/index.js'
+import { StubServer } from './helpers/stub-server.js'
+
+const TOKEN = 'discovery-test-token'
+let server: StubServer
+let baseUrl: string
+
+beforeAll(async () => {
+  server = new StubServer(TOKEN)
+  const info = await server.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => { await server.stop() })
+
+beforeEach(() => {
+  server.reset()
+  // Default identity: authorized for one base scope plus three team scopes.
+  server.setMe({
+    username: 'crtahlin',
+    org_id: 'plur',
+    role: 'developer',
+    scopes: [
+      'group:plur/plur-ai',
+      'group:plur/plur-ai/engineering',
+      'group:plur/plur-ai/comms',
+      'group:plur/plur-ai/research',
+    ],
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RemoteStore.me() — direct, real HTTP
+// ---------------------------------------------------------------------------
+
+describe('RemoteStore.me()', () => {
+  it('returns the resolved identity and authorized scopes', async () => {
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:plur/plur-ai/engineering')
+    const me = await store.me()
+    expect(me.username).toBe('crtahlin')
+    expect(me.org_id).toBe('plur')
+    expect(me.role).toBe('developer')
+    expect(me.scopes).toContain('group:plur/plur-ai/comms')
+  })
+
+  it('throws on an invalid token (401)', async () => {
+    const store = new RemoteStore(baseUrl, 'wrong-token', 'group:plur/plur-ai')
+    await expect(store.me()).rejects.toThrow(/\/me failed: 401/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Plur.discoverRemoteScopes()
+// ---------------------------------------------------------------------------
+
+describe('Plur.discoverRemoteScopes()', () => {
+  let dir: string
+
+  const writeConfig = (stores: unknown[]) => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-discover-'))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false }, { lineWidth: 120, noRefs: true }))
+    return new Plur({ path: dir })
+  }
+
+  afterAll(() => { if (dir) rmSync(dir, { recursive: true, force: true }) })
+
+  it('splits authorized scopes into registered vs unregistered', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    const [d] = await plur.discoverRemoteScopes()
+
+    expect(d.ok).toBe(true)
+    expect(d.url).toBe(baseUrl)
+    expect(d.username).toBe('crtahlin')
+    expect(d.registered).toEqual(['group:plur/plur-ai/engineering'])
+    expect(d.unregistered.sort()).toEqual([
+      'group:plur/plur-ai',
+      'group:plur/plur-ai/comms',
+      'group:plur/plur-ai/research',
+    ])
+  })
+
+  it('returns [] when no remote stores are configured', async () => {
+    const plur = writeConfig([])
+    expect(await plur.discoverRemoteScopes()).toEqual([])
+  })
+
+  it('reports ok:false with an error when /me fails, without throwing', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: 'bad-token', scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.ok).toBe(false)
+    expect(d.error).toMatch(/401/)
+    expect(d.unregistered).toEqual([])
+  })
+
+  it('groups multiple entries on the same URL into one discovery', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/comms', shared: true, readonly: false },
+    ])
+    const discoveries = await plur.discoverRemoteScopes()
+    expect(discoveries).toHaveLength(1)
+    expect(discoveries[0].registered.sort()).toEqual(['group:plur/plur-ai/comms', 'group:plur/plur-ai/engineering'])
+    expect(discoveries[0].unregistered.sort()).toEqual(['group:plur/plur-ai', 'group:plur/plur-ai/research'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Plur.registerDiscoveredScopes() — exercises the #291 URL+scope dedup
+// ---------------------------------------------------------------------------
+
+describe('Plur.registerDiscoveredScopes()', () => {
+  let dir: string
+
+  const freshPlur = () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-register-'))
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      yaml.dump({
+        stores: [{ url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+    return new Plur({ path: dir })
+  }
+
+  afterAll(() => { if (dir) rmSync(dir, { recursive: true, force: true }) })
+
+  it('registers every authorized-but-unregistered scope under the one URL', async () => {
+    const plur = freshPlur()
+    const [result] = await plur.registerDiscoveredScopes()
+
+    expect(result.ok).toBe(true)
+    // The three previously-unregistered scopes are newly added; the one already
+    // in config is reported as already_registered.
+    expect(result.added.sort()).toEqual([
+      'group:plur/plur-ai',
+      'group:plur/plur-ai/comms',
+      'group:plur/plur-ai/research',
+    ])
+    expect(result.already_registered).toEqual(['group:plur/plur-ai/engineering'])
+
+    // All four authorized scopes now persist as separate entries on the same URL.
+    const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(config.stores).toHaveLength(4)
+    expect(config.stores.every((s: any) => s.url === baseUrl)).toBe(true)
+    expect(config.stores.map((s: any) => s.scope).sort()).toEqual([
+      'group:plur/plur-ai',
+      'group:plur/plur-ai/comms',
+      'group:plur/plur-ai/engineering',
+      'group:plur/plur-ai/research',
+    ])
+  })
+
+  it('is idempotent — a second run reports everything already_registered', async () => {
+    const plur = freshPlur()
+    await plur.registerDiscoveredScopes()
+    const [second] = await plur.registerDiscoveredScopes()
+
+    expect(second.added).toEqual([])
+    expect(second.already_registered.sort()).toEqual([
+      'group:plur/plur-ai',
+      'group:plur/plur-ai/comms',
+      'group:plur/plur-ai/engineering',
+      'group:plur/plur-ai/research',
+    ])
+    const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(config.stores).toHaveLength(4)
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1202,6 +1202,20 @@ export function getToolDefinitions(): ToolDefinition[] {
               `(engineering patterns, architecture decisions, project conventions), set scope to the matching ` +
               `remote scope in plur_learn. Personal preferences, local project details, and corrections specific ` +
               `to your workflow should stay at default scope (local).`
+
+          // Surface authorized-but-unregistered scopes (#292). Best-effort:
+          // gated to enterprise users (remote stores configured), bounded by a
+          // short timeout, and fully swallowed on error — never blocks or fails
+          // session_start. Only hints when there's actually something to add.
+          try {
+            const discoveries = await plur.discoverRemoteScopes({ timeoutMs: 3000 })
+            const unregistered = [...new Set(discoveries.filter(d => d.ok).flatMap(d => d.unregistered))]
+            if (unregistered.length > 0) {
+              const list = unregistered.map(s => `"${s}"`).join(', ')
+              guide += `\n\n🔎 Your token is authorized for ${unregistered.length} more scope(s) not yet registered: ${list}. ` +
+                `Call plur_scopes_discover with register:true to add them all in one step.`
+            }
+          } catch { /* discovery is best-effort — never block session_start */ }
         }
 
         return {
@@ -1393,6 +1407,32 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           count: stores.length,
           ...(outboxCount > 0 ? { outbox_pending: outboxCount } : {}),
         }
+      },
+    },
+
+    {
+      name: 'plur_scopes_discover',
+      description: 'Discover which scopes your remote token is authorized for via the enterprise server (GET /api/v1/me), and which of those are not yet registered locally. Read-only by default; pass register:true to register all authorized-but-unregistered scopes in one step. Use this when you have access to multiple team scopes on one server.',
+      annotations: { title: 'Discover scopes', readOnlyHint: false, idempotentHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          url:      { type: 'string', description: 'Limit discovery to this remote URL (default: all configured remote stores)' },
+          register: { type: 'boolean', description: 'Register all authorized-but-unregistered scopes (default false — discovery is read-only)' },
+        },
+      },
+      handler: async (args, plur) => {
+        const url = args.url as string | undefined
+        const register = args.register === true
+        const discoveries = await plur.discoverRemoteScopes({ url })
+        if (discoveries.length === 0) {
+          return { discovered: [], note: 'No remote stores configured. Register one scope first with plur_stores_add, then discover the rest.' }
+        }
+        if (!register) {
+          return { discovered: discoveries }
+        }
+        const registered = await plur.registerDiscoveredScopes({ url })
+        return { discovered: discoveries, registered }
       },
     },
 

--- a/packages/mcp/test/e2e-remote.test.ts
+++ b/packages/mcp/test/e2e-remote.test.ts
@@ -247,3 +247,56 @@ describe('MCP config loading', () => {
     expect(remote.url).toBe(baseUrl)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Scope discovery (#292) — full MCP → core → RemoteStore.me() pipeline
+// ---------------------------------------------------------------------------
+
+describe('MCP plur_scopes_discover', () => {
+  it('discovers authorized-but-unregistered scopes (read-only by default)', async () => {
+    stub.setMe({ username: 'crtahlin', scopes: [REMOTE_SCOPE, 'team:e2e-other', 'team:e2e-third'] })
+    const { client } = await makeClient(dir)
+
+    const raw = await client.callTool({ name: 'plur_scopes_discover', arguments: {} })
+    const { discovered } = callResult(raw) as any
+
+    expect(discovered).toHaveLength(1)
+    expect(discovered[0].ok).toBe(true)
+    expect(discovered[0].registered).toEqual([REMOTE_SCOPE])
+    expect(discovered[0].unregistered.sort()).toEqual(['team:e2e-other', 'team:e2e-third'])
+
+    // Read-only: nothing new registered.
+    const listRaw = await client.callTool({ name: 'plur_stores_list', arguments: {} })
+    const remoteScopes = (callResult(listRaw) as any).stores.map((s: any) => s.scope)
+    expect(remoteScopes).not.toContain('team:e2e-other')
+  })
+
+  it('register:true registers every authorized scope under the one URL', async () => {
+    stub.setMe({ username: 'crtahlin', scopes: [REMOTE_SCOPE, 'team:e2e-other', 'team:e2e-third'] })
+    const { client } = await makeClient(dir)
+
+    const raw = await client.callTool({ name: 'plur_scopes_discover', arguments: { register: true } })
+    const { registered } = callResult(raw) as any
+    expect(registered[0].added.sort()).toEqual(['team:e2e-other', 'team:e2e-third'])
+
+    // Now all three scopes are visible in the listing.
+    const listRaw = await client.callTool({ name: 'plur_stores_list', arguments: {} })
+    const remoteScopes = (callResult(listRaw) as any).stores.map((s: any) => s.scope)
+    expect(remoteScopes).toContain(REMOTE_SCOPE)
+    expect(remoteScopes).toContain('team:e2e-other')
+    expect(remoteScopes).toContain('team:e2e-third')
+  })
+
+  it('returns a helpful note when no remote stores are configured', async () => {
+    const localOnlyDir = mkdtempSync(join(tmpdir(), 'plur-mcp-local-'))
+    try {
+      const { client } = await makeClient(localOnlyDir)
+      const raw = await client.callTool({ name: 'plur_scopes_discover', arguments: {} })
+      const result = callResult(raw) as any
+      expect(result.discovered).toEqual([])
+      expect(result.note).toMatch(/No remote stores configured/)
+    } finally {
+      rmSync(localOnlyDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/mcp/test/helpers/stub-server.ts
+++ b/packages/mcp/test/helpers/stub-server.ts
@@ -22,8 +22,17 @@ export class StubServer {
   private engrams = new Map<string, StoredEngram>()
   private idCounter = 0
   private port = 0
+  // Identity returned by GET /api/v1/me (#292). Override per-test with setMe().
+  private me: { username: string; org_id: string; role: string; scopes: string[] } = {
+    username: 'testuser', org_id: 'test-org', role: 'developer', scopes: ['group:test'],
+  }
 
   constructor(private readonly validToken: string) {}
+
+  /** Override the GET /api/v1/me response (authorized scope set, identity). */
+  setMe(me: Partial<{ username: string; org_id: string; role: string; scopes: string[] }>): void {
+    this.me = { ...this.me, ...me }
+  }
 
   async start(): Promise<{ url: string; token: string }> {
     return new Promise((resolve, reject) => {
@@ -72,6 +81,12 @@ export class StubServer {
     const url = new URL(req.url ?? '/', `http://127.0.0.1:${this.port}`)
     const path = url.pathname
     const method = req.method ?? 'GET'
+
+    // GET /api/v1/me — resolved identity + authorized scopes (#292)
+    if (method === 'GET' && path === '/api/v1/me') {
+      this.json(res, 200, this.me)
+      return
+    }
 
     if (method === 'POST' && path === '/api/v1/engrams') {
       this.readBody(req, (body) => {


### PR DESCRIPTION
Closes #292.

> ⚠️ **Stacked on #293 (fix for #291).** Base is `fix/stores-add-multi-scope-291`, not `main` — auto-register needs the URL+scope dedup from #291. Merge #293 first, then this retargets to `main`. The diff below is scoped to the discovery feature only.

## Problem

The client never asked the enterprise server which scopes a token can access, even though `GET /api/v1/me` already returns the full resolved set. A user authorized for 5 teams had to discover scopes out-of-band and hand-register each — and saw only the one(s) they happened to register. Pure client gap; no server change.

## Changes

- **`packages/core/src/store/remote-store.ts`** — `RemoteStore.me()` → `GET /api/v1/me`, returns `{ username, org_id, role, scopes }`. Scope-independent (keyed on the token).
- **`packages/core/src/index.ts`**
  - `discoverRemoteScopes(opts?)` — groups configured stores by distinct URL, calls `/me` per URL (each raced against a timeout, failures captured as `ok:false` not thrown), and splits authorized scopes into `registered` / `unregistered`. Read-only.
  - `registerDiscoveredScopes(opts?)` — registers every authorized scope via the #291 `addStore` path; returns per-URL `added` / `already_registered`.
- **`packages/mcp/src/tools.ts`** — new `plur_scopes_discover` (read-only by default; `register: true` registers all). `plur_session_start` appends a best-effort hint when the token is authorized for unregistered scopes — short timeout, fully swallowed on error, **never blocks or slows session start**.
- **`packages/cli/src/commands/stores.ts`** — `plur stores discover [--register]`.

## Tests

- **Stub servers** (core + mcp): added a configurable `GET /api/v1/me` handler (`setMe()`), keeping integration tests wire-level.
- **`packages/core/test/scope-discovery.test.ts`** — `RemoteStore.me()` (incl. 401), the registered/unregistered split, multi-URL grouping, per-URL failure isolation (one bad token doesn't sink the rest), no-remote → `[]`, register-all under one URL (exercises the #291 dedup end-to-end), and idempotency.
- **`packages/mcp/test/e2e-remote.test.ts`** — full MCP→core→`RemoteStore.me()`: read-only discover, `register:true` then scopes appear in `plur_stores_list`, and the no-remote note.

Runs: core scope-discovery 8 / store suites 47, full MCP 118, full CLI 184. All green.

## Decisions (conservative defaults, flagged for review)

- **Discover is read-only**; registration requires explicit `register:true` / `--register` — no silent config mutation on a read.
- **session_start stays fast**: discovery is best-effort behind a 3s timeout and only ever *adds a hint*; an unreachable server changes nothing.
- **Which scopes register:** all authorized-but-unregistered scopes from `/me` (incl. `user:`/`project:`, not just `group:`), since they're all usable by the token. Easy to filter to `group:` later if preferred.
- **Token per URL:** grouped by URL, using the token from the first matching config entry.

## Out of scope

No version bump / publish — leaving the release cut to @plur9.