### PR TITLE
feat: surface remote-store auth failures instead of failing silently (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ The client never asked the enterprise server which scopes a token can access, so
 
 One token → discover all authorized team scopes → register them in one action.
 
+### Surface remote-store auth failures instead of failing silently (#295)
+
+When an enterprise token expired, the client failed silently: team-scoped writes 401'd and queued to the local outbox, reads returned 0, and `plur_doctor` still reported "healthy". The only way the gap surfaced was a human noticing no new engrams. This makes the failure legible.
+
+- **`packages/core/src/jwt.ts`** (new) — `decodeJwtExpiry()` reads a token's `exp` claim (no signature verification) so the client can warn before/after expiry. Opaque (non-JWT) keys return all-null and callers fall back to the live probe.
+- **`packages/core/src/index.ts`** — `checkRemoteHealth()` probes `GET /api/v1/me` per configured remote (raced against a timeout) and combines it with the JWT-expiry read, classifying each endpoint as `ok` / `auth_expired` / `unreachable`. `remoteTokenExpiries()` is a local-only (no network) expiry read for the fast session-start path. `learnRouted()` now flags `_outbox.auth_failed` when a remote write fails with 401/403, so a queued engram is distinguishable from a transient network blip.
+- **`packages/mcp/src/tools.ts`** — `plur_doctor` adds a per-remote check (reachable / auth-expired / unreachable + "expires in N days"), so it no longer reports "healthy" when the remote auth is dead, with reauth remediation. `plur_session_start` surfaces a loud guide warning when discovery hits a 401/unreachable (reusing the discovery probe — no extra round-trip) and a proactive "token expires in N days" warning from the local JWT read.
+
+The reauth command itself (`plur login`) and longer-lived keys are tracked separately as a fast-follow.
+
 ## 0.9.11 (2026-05-26)
 
 Bug sweep — three independent fixes bundled.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ import { sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncSta
 import { detectSecrets } from './secrets.js'
 import { appendHistory, readHistoryForEngram, generateEventId } from './history.js'
 import { computeContentHash } from './content-hash.js'
+import { decodeJwtExpiry } from './jwt.js'
 import { RemoteStore } from './store/remote-store.js'
 import type { Engram } from './schemas/engram.js'
 import type { Episode } from './schemas/episode.js'
@@ -175,6 +176,28 @@ export interface RemoteScopeDiscovery {
   unregistered: string[]
   /** Present when `ok` is false. */
   error?: string
+}
+
+/**
+ * Health of one configured remote endpoint (#295). Combines a live `/me`
+ * probe with a local JWT-expiry read so callers can distinguish "auth
+ * expired" (actionable: reauth) from "unreachable" (network), and warn
+ * before a token expires rather than after.
+ */
+export interface RemoteHealth {
+  url: string
+  /** Scopes registered locally for this URL (for the report). */
+  scopes: string[]
+  /** 'ok' = /me succeeded; 'auth_expired' = 401/403 or JWT exp passed; 'unreachable' = network/timeout/5xx. */
+  status: 'ok' | 'auth_expired' | 'unreachable'
+  /** True only for status 'ok'. */
+  ok: boolean
+  /** Human-readable reason when not ok. */
+  reason?: string
+  /** From the token's JWT `exp` claim, if decodable (opaque keys → null). */
+  tokenExpiresAt?: string
+  /** Whole days until token expiry (negative if past), or null if unknown. */
+  tokenExpiresInDays?: number | null
 }
 
 /** Outcome of registering discovered scopes for one URL (#292). */
@@ -993,6 +1016,10 @@ export class Plur {
               last_attempt: now,
               attempt_count: 1,
               last_error: (err as Error).message,
+              // #295: flag auth failures distinctly so the queue isn't read as a
+              // transient network blip — a 401/403 means the token needs reauth,
+              // and surfacing it (session_start/doctor) is the actionable signal.
+              auth_failed: /\b40[13]\b/.test((err as Error).message),
             },
           }
         } else {
@@ -2703,6 +2730,67 @@ Generate an improved version of the procedure that prevents this failure. Return
           authorized: [], registered, unregistered: [],
           error: err instanceof Error ? err.message : String(err),
         }
+      }
+    }))
+  }
+
+  /**
+   * Local-only read of each configured remote token's JWT expiry (#295). No
+   * network. Returns one entry per distinct remote URL; `expiresInDays`/`expired`
+   * are null/false for opaque (non-JWT) keys. Used by session_start to warn
+   * about imminent/past expiry without a round-trip.
+   */
+  remoteTokenExpiries(now: number = Date.now()): Array<{ url: string; scopes: string[]; expiresAt: string | null; expiresInDays: number | null; expired: boolean }> {
+    return this._distinctRemoteEndpoints().map(({ url, token }) => {
+      const scopes = (this.config.stores ?? []).filter(s => s.url === url).map(s => s.scope)
+      const exp = decodeJwtExpiry(token, now)
+      return {
+        url, scopes,
+        expiresAt: exp.expiresAt ? exp.expiresAt.toISOString() : null,
+        expiresInDays: exp.expiresInDays,
+        expired: exp.expired,
+      }
+    })
+  }
+
+  /**
+   * Probe each configured remote endpoint's auth/reachability (#295) by calling
+   * `GET /api/v1/me` (raced against a timeout), combined with a local JWT-expiry
+   * read. Distinguishes 'auth_expired' (token rejected or JWT exp passed →
+   * reauth) from 'unreachable' (network/timeout/5xx). Read-only; one bad
+   * endpoint never affects the others. Powers `plur_doctor`'s remote check so
+   * the doctor stops reporting "healthy" when the remote auth is dead.
+   */
+  async checkRemoteHealth(opts?: { timeoutMs?: number }): Promise<RemoteHealth[]> {
+    const timeoutMs = opts?.timeoutMs ?? 5000
+    const endpoints = this._distinctRemoteEndpoints()
+    return Promise.all(endpoints.map(async ({ url, token }) => {
+      const scopes = (this.config.stores ?? []).filter(s => s.url === url).map(s => s.scope)
+      const exp = decodeJwtExpiry(token)
+      const expiryFields = {
+        tokenExpiresAt: exp.expiresAt ? exp.expiresAt.toISOString() : undefined,
+        tokenExpiresInDays: exp.expiresInDays,
+      }
+      // A JWT we can already see is expired → don't bother probing; it's auth_expired.
+      if (exp.expired) {
+        return { url, scopes, status: 'auth_expired' as const, ok: false,
+          reason: `token expired ${exp.expiresAt?.toISOString() ?? ''}`.trim(), ...expiryFields }
+      }
+      try {
+        const driver = this._getRemoteDriver({ url, token, scope: scopes[0] ?? '' })
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+        await Promise.race([
+          driver.me().finally(() => { if (timeoutHandle) clearTimeout(timeoutHandle) }),
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(() => reject(new Error(`/me timeout (${timeoutMs}ms)`)), timeoutMs)
+          }),
+        ])
+        return { url, scopes, status: 'ok' as const, ok: true, ...expiryFields }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        const isAuth = /\b40[13]\b/.test(msg)
+        return { url, scopes, status: (isAuth ? 'auth_expired' : 'unreachable') as RemoteHealth['status'],
+          ok: false, reason: msg, ...expiryFields }
       }
     }))
   }

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal, dependency-free JWT inspection — we only ever READ the `exp`
+ * claim to warn about token expiry. We do NOT verify the signature (the
+ * server does that); this is purely for client-side "your token expires
+ * in N days" / "your token has expired" observability (#295).
+ *
+ * Enterprise tokens are HS256 JWTs (`iss: plur-enterprise`) with a 30-day
+ * TTL and no refresh, so silent expiry is a recurring failure mode. Opaque
+ * API keys (e.g. `plur_sk_...`) are not JWTs — those return all-null and the
+ * caller falls back to the live `/me` probe.
+ */
+
+export interface JwtExpiry {
+  /** When the token expires, or null if not a decodable JWT with an `exp`. */
+  expiresAt: Date | null
+  /** True only when we could read `exp` AND it is in the past. */
+  expired: boolean
+  /** Whole days until expiry (negative if already expired), or null if unknown. */
+  expiresInDays: number | null
+}
+
+const UNKNOWN: JwtExpiry = { expiresAt: null, expired: false, expiresInDays: null }
+
+function base64UrlDecode(segment: string): string | null {
+  try {
+    const pad = segment.length % 4 === 0 ? '' : '='.repeat(4 - (segment.length % 4))
+    const b64 = segment.replace(/-/g, '+').replace(/_/g, '/') + pad
+    return Buffer.from(b64, 'base64').toString('utf8')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the `exp` claim from a JWT without verifying it. Returns all-null for
+ * anything that is not a three-part JWT carrying a numeric `exp` (e.g. opaque
+ * API keys), so callers can cleanly skip expiry reasoning for those.
+ *
+ * @param now epoch millis to compare against (injectable for tests; defaults to Date.now()).
+ */
+export function decodeJwtExpiry(token: string | undefined | null, now: number = Date.now()): JwtExpiry {
+  if (!token || typeof token !== 'string') return UNKNOWN
+  const parts = token.split('.')
+  if (parts.length !== 3) return UNKNOWN
+  const json = base64UrlDecode(parts[1])
+  if (!json) return UNKNOWN
+  let payload: { exp?: unknown }
+  try {
+    payload = JSON.parse(json)
+  } catch {
+    return UNKNOWN
+  }
+  if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) return UNKNOWN
+  const expiresAt = new Date(payload.exp * 1000)
+  const msLeft = expiresAt.getTime() - now
+  return {
+    expiresAt,
+    expired: msLeft <= 0,
+    expiresInDays: Math.floor(msLeft / 86_400_000),
+  }
+}

--- a/packages/core/test/jwt.test.ts
+++ b/packages/core/test/jwt.test.ts
@@ -1,0 +1,49 @@
+/**
+ * decodeJwtExpiry — client-side token-expiry inspection (#295).
+ * No signature verification; we only read the `exp` claim to warn the user.
+ */
+import { describe, it, expect } from 'vitest'
+import { decodeJwtExpiry } from '../src/jwt.js'
+
+const b64url = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+const makeJwt = (payload: object) =>
+  `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url(payload)}.sig`
+
+const NOW = 1_780_000_000_000 // fixed epoch-ms for deterministic day math
+
+describe('decodeJwtExpiry', () => {
+  it('reads a future exp and reports days remaining', () => {
+    const exp = Math.floor(NOW / 1000) + 30 * 86_400 // +30 days
+    const r = decodeJwtExpiry(makeJwt({ sub: 'x', exp }), NOW)
+    expect(r.expired).toBe(false)
+    expect(r.expiresInDays).toBe(30)
+    expect(r.expiresAt?.getTime()).toBe(exp * 1000)
+  })
+
+  it('flags an expired token with negative days', () => {
+    const exp = Math.floor(NOW / 1000) - 4 * 86_400 // 4 days ago
+    const r = decodeJwtExpiry(makeJwt({ sub: 'x', exp }), NOW)
+    expect(r.expired).toBe(true)
+    expect(r.expiresInDays).toBe(-4)
+  })
+
+  it('returns all-null for an opaque (non-JWT) key like plur_sk_…', () => {
+    const r = decodeJwtExpiry('plur_sk_abc123def456', NOW)
+    expect(r.expiresAt).toBeNull()
+    expect(r.expired).toBe(false)
+    expect(r.expiresInDays).toBeNull()
+  })
+
+  it('returns all-null for a JWT without an exp claim', () => {
+    const r = decodeJwtExpiry(makeJwt({ sub: 'x' }), NOW)
+    expect(r.expiresAt).toBeNull()
+    expect(r.expiresInDays).toBeNull()
+  })
+
+  it('returns all-null for undefined / garbage', () => {
+    expect(decodeJwtExpiry(undefined, NOW).expiresAt).toBeNull()
+    expect(decodeJwtExpiry('', NOW).expiresAt).toBeNull()
+    expect(decodeJwtExpiry('not.a.jwt.with.too.many.parts', NOW).expiresAt).toBeNull()
+    expect(decodeJwtExpiry('two.parts', NOW).expiresAt).toBeNull()
+  })
+})

--- a/packages/core/test/remote-health.test.ts
+++ b/packages/core/test/remote-health.test.ts
@@ -108,3 +108,23 @@ describe('Plur.remoteTokenExpiries()', () => {
     expect(t.expired).toBe(false)
   })
 })
+
+describe('learnRouted outbox auth flag (#295)', () => {
+  it('flags _outbox.auth_failed when a remote write is rejected with 401', async () => {
+    const plur = writeConfig([{ url: baseUrl, token: 'wrong-token', scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const e: any = await plur.learnRouted('Team convention: prefix feature branches with the issue number', { scope: 'group:plur/plur-ai/engineering' })
+    expect(e.structured_data?._outbox).toBeDefined()
+    expect(e.structured_data._outbox.auth_failed).toBe(true)
+    expect(e.structured_data._outbox.last_error).toMatch(/401/)
+  })
+
+  it('does NOT flag auth_failed for a non-auth (unreachable) failure', async () => {
+    const down = new StubServer(TOKEN)
+    const info = await down.start()
+    await down.stop() // port closed → network error, not 401
+    const plur = writeConfig([{ url: info.url, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const e: any = await plur.learnRouted('Team convention: rebase, do not merge-commit, onto main', { scope: 'group:plur/plur-ai/engineering' })
+    expect(e.structured_data?._outbox).toBeDefined()
+    expect(e.structured_data._outbox.auth_failed).toBe(false)
+  })
+})

--- a/packages/core/test/remote-health.test.ts
+++ b/packages/core/test/remote-health.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Remote auth/reachability health — closes part of plur-ai/plur#295.
+ *
+ * checkRemoteHealth() probes GET /api/v1/me per configured remote and decodes
+ * the token's JWT expiry, so callers (plur_doctor, plur_session_start) can
+ * distinguish 'auth_expired' (reauth) from 'unreachable' (network) instead of
+ * the old silent failure. Runs against the in-process stub server (real HTTP).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { StubServer } from './helpers/stub-server.js'
+
+const TOKEN = 'health-test-token'
+let server: StubServer
+let baseUrl: string
+const dirs: string[] = []
+
+beforeAll(async () => {
+  server = new StubServer(TOKEN)
+  const info = await server.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => {
+  await server.stop()
+  for (const d of dirs) rmSync(d, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  server.reset()
+  server.setMe({ username: 'crtahlin', org_id: 'plur', role: 'developer', scopes: ['group:plur/plur-ai/engineering'] })
+})
+
+const writeConfig = (stores: unknown[]): Plur => {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-health-'))
+  dirs.push(dir)
+  writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false }, { lineWidth: 120, noRefs: true }))
+  return new Plur({ path: dir })
+}
+
+describe('Plur.checkRemoteHealth()', () => {
+  it('reports ok for a reachable endpoint with a valid token', async () => {
+    const plur = writeConfig([{ url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const [h] = await plur.checkRemoteHealth()
+    expect(h.status).toBe('ok')
+    expect(h.ok).toBe(true)
+    expect(h.url).toBe(baseUrl)
+    expect(h.scopes).toContain('group:plur/plur-ai/engineering')
+  })
+
+  it('reports auth_expired on a 401 (rejected token)', async () => {
+    const plur = writeConfig([{ url: baseUrl, token: 'wrong-token', scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const [h] = await plur.checkRemoteHealth()
+    expect(h.status).toBe('auth_expired')
+    expect(h.ok).toBe(false)
+    expect(h.reason).toMatch(/401/)
+  })
+
+  it('short-circuits to auth_expired for an already-expired JWT (no probe needed)', async () => {
+    const exp = Math.floor(Date.now() / 1000) - 86_400 // yesterday
+    const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+    const expiredJwt = `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 'crtahlin', exp })}.sig`
+    const plur = writeConfig([{ url: baseUrl, token: expiredJwt, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const [h] = await plur.checkRemoteHealth()
+    expect(h.status).toBe('auth_expired')
+    expect(h.tokenExpiresInDays).toBeLessThan(0)
+  })
+
+  it('reports unreachable when the endpoint is down', async () => {
+    const down = new StubServer(TOKEN)
+    const info = await down.start()
+    await down.stop() // started then stopped → port closed
+    const plur = writeConfig([{ url: info.url, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const [h] = await plur.checkRemoteHealth({ timeoutMs: 1500 })
+    expect(h.status).toBe('unreachable')
+    expect(h.ok).toBe(false)
+  })
+
+  it('returns [] when no remote stores are configured', async () => {
+    const plur = writeConfig([])
+    expect(await plur.checkRemoteHealth()).toEqual([])
+  })
+})
+
+describe('Plur.remoteTokenExpiries()', () => {
+  it('decodes JWT expiry locally with no network call', () => {
+    const exp = Math.floor(Date.now() / 1000) + 5 * 86_400
+    const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+    const jwt = `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 'crtahlin', exp })}.sig`
+    const plur = writeConfig([{ url: baseUrl, token: jwt, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const [t] = plur.remoteTokenExpiries()
+    expect(t.expired).toBe(false)
+    // floor of ~4.999 days (now is truncated to whole seconds) → 4 or 5; floor is
+    // intentionally conservative for an expiry warning.
+    expect(t.expiresInDays).toBeGreaterThanOrEqual(4)
+    expect(t.expiresInDays).toBeLessThanOrEqual(5)
+    expect(t.url).toBe(baseUrl)
+  })
+
+  it('yields null expiry fields for an opaque key', () => {
+    const plur = writeConfig([{ url: baseUrl, token: 'plur_sk_opaque', scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }])
+    const [t] = plur.remoteTokenExpiries()
+    expect(t.expiresInDays).toBeNull()
+    expect(t.expired).toBe(false)
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -972,7 +972,7 @@ export function getToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_doctor',
-      description: 'Diagnose the PLUR install. Reports whether the embedding model loaded, whether hybrid search is fully operational, and what to do if it is degraded. Run this first when recall feels off.',
+      description: 'Diagnose the PLUR install. Reports whether the embedding model loaded, whether hybrid search is fully operational, and — for any configured enterprise/remote store — whether its auth is valid (probes /api/v1/me and decodes token expiry), so a dead or soon-to-expire token surfaces instead of hiding behind a "healthy" report. Run this first when recall feels off or team engrams stop syncing.',
       annotations: { title: 'Doctor', readOnlyHint: false, idempotentHint: false },
       inputSchema: {
         type: 'object',

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1054,6 +1054,34 @@ export function getToolDefinitions(): ToolDefinition[] {
             if (cs.warning) remediation.push(cs.warning)
           }
         }
+        // Remote store auth/reachability (#295) — without this, doctor reports
+        // "healthy" while the enterprise token is expired and writes silently
+        // queue. Probe /me per configured remote and decode token expiry.
+        try {
+          const remotes = await plur.checkRemoteHealth({ timeoutMs: 5000 })
+          for (const h of remotes) {
+            const expiresNote = typeof h.tokenExpiresInDays === 'number'
+              ? ` — token ${h.tokenExpiresInDays < 0 ? `expired ${-h.tokenExpiresInDays}d ago` : `expires in ${h.tokenExpiresInDays}d`}`
+              : ''
+            if (h.status === 'ok') {
+              const soon = typeof h.tokenExpiresInDays === 'number' && h.tokenExpiresInDays <= 7
+              checks.push({
+                check: `remote store: ${h.url}`,
+                ok: !soon,
+                detail: soon
+                  ? `Reachable, but token expires in ${h.tokenExpiresInDays}d — reauth soon`
+                  : `Reachable, auth valid${expiresNote}`,
+              })
+              if (soon) remediation.push(`Remote ${h.url}: token expires in ${h.tokenExpiresInDays}d — mint a new token (<host>/me/api-keys), update ~/.plur/config.yaml, restart.`)
+            } else if (h.status === 'auth_expired') {
+              checks.push({ check: `remote store: ${h.url}`, ok: false, detail: `AUTH FAILED${expiresNote} — team-scoped writes are queuing to the outbox, not syncing. (${h.reason ?? ''})` })
+              remediation.push(`Remote ${h.url}: re-authenticate — open <host>/auth/github (or <host>/me/api-keys) in a browser, paste the token into ~/.plur/config.yaml, then restart Claude/MCP so it reloads. Queued engrams flush on next session_start.`)
+            } else {
+              checks.push({ check: `remote store: ${h.url}`, ok: false, detail: `Unreachable (${h.reason ?? 'network error'}) — writes queue locally until it recovers.` })
+              remediation.push(`Remote ${h.url}: unreachable — check connectivity/VPN. Reads fall back to local; writes queue in the outbox.`)
+            }
+          }
+        } catch { /* best-effort — never let the remote probe break doctor */ }
         return {
           ok: checks.every(c => c.ok),
           checks,
@@ -1221,6 +1249,23 @@ export function getToolDefinitions(): ToolDefinition[] {
           // session_start. Only hints when there's actually something to add.
           try {
             const discoveries = await plur.discoverRemoteScopes({ timeoutMs: 3000 })
+            // #295: surface auth/reachability failures LOUDLY. discoverRemoteScopes
+            // already probed /me per URL — a failure here means team-scoped writes
+            // are silently queuing to the outbox. Don't swallow it.
+            const failures = discoveries.filter(d => !d.ok)
+            if (failures.length > 0) {
+              const authExpired = failures.some(f => /\b40[13]\b/.test(f.error ?? ''))
+              const pending = outbox_result?.failed ?? 0
+              const urls = [...new Set(failures.map(f => f.url))].join(', ')
+              guide += authExpired
+                ? `\n\n⚠️ ENTERPRISE STORE AUTH FAILED (token expired/invalid): ${urls}. ` +
+                  `Team-scoped engrams are NOT syncing` + (pending > 0 ? ` — ${pending} queued in the outbox` : '') +
+                  `. Reauth: open <host>/auth/github (or <host>/me/api-keys) in a browser, paste the token into ` +
+                  `~/.plur/config.yaml, then restart Claude/MCP. Queued engrams flush on the next session_start.`
+                : `\n\n⚠️ ENTERPRISE STORE UNREACHABLE: ${urls}. ` +
+                  `Reads fall back to local; team-scoped writes queue in the outbox` +
+                  (pending > 0 ? ` (${pending} pending)` : '') + ` until it recovers. Check connectivity/VPN.`
+            }
             const unregistered = [...new Set(discoveries.filter(d => d.ok).flatMap(d => d.unregistered))]
             if (unregistered.length > 0) {
               const list = unregistered.map(s => `"${s}"`).join(', ')
@@ -1228,6 +1273,18 @@ export function getToolDefinitions(): ToolDefinition[] {
                 `Call plur_scopes_discover with register:true to add them all in one step.`
             }
           } catch { /* discovery is best-effort — never block session_start */ }
+
+          // #295: proactive token-expiry warning — purely local JWT decode, no
+          // network round-trip. Catches the 30-day silent-expiry before it bites.
+          try {
+            for (const t of plur.remoteTokenExpiries()) {
+              if (t.expired) {
+                guide += `\n\n⚠️ Enterprise token for ${t.url} EXPIRED ${t.expiresAt ?? ''}. Reauth and restart to resume team sync.`
+              } else if (typeof t.expiresInDays === 'number' && t.expiresInDays <= 7) {
+                guide += `\n\n⏳ Enterprise token for ${t.url} expires in ${t.expiresInDays}d. Mint a fresh one (<host>/me/api-keys) before it lapses.`
+              }
+            }
+          } catch { /* best-effort */ }
         }
 
         return {

--- a/packages/mcp/test/remote-health.test.ts
+++ b/packages/mcp/test/remote-health.test.ts
@@ -1,0 +1,114 @@
+/**
+ * MCP surfacing of remote auth/expiry state — closes part of plur-ai/plur#295.
+ *
+ * Before this, an expired enterprise token failed silently: writes queued to the
+ * outbox, reads returned 0, and plur_doctor still said "healthy". These tests
+ * assert the loud surfacing: plur_doctor flags the dead remote, and
+ * plur_session_start warns in its guide text. Full MCP → core → /me pipeline
+ * against the in-process stub (real HTTP). Embeddings disabled to keep the
+ * doctor probe fast and deterministic (no model download in CI).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { Plur } from '@plur-ai/core'
+import { createServer } from '../src/server.js'
+import { StubServer } from './helpers/stub-server.js'
+
+const TOKEN = 'health-mcp-token'
+const SCOPE = 'group:plur/plur-ai/engineering'
+
+let stub: StubServer
+let baseUrl: string
+const dirs: string[] = []
+
+const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+const makeJwt = (expSecondsFromNow: number) =>
+  `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 'crtahlin', org_id: 'plur', exp: Math.floor(Date.now() / 1000) + expSecondsFromNow })}.sig`
+
+async function makeClient(plurPath: string): Promise<Client> {
+  const plur = new Plur({ path: plurPath })
+  const server = await createServer(plur)
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  const client = new Client({ name: 'test-client', version: '1.0.0' })
+  await client.connect(clientTransport)
+  return client
+}
+
+function callResult(raw: Awaited<ReturnType<Client['callTool']>>): any {
+  return JSON.parse((raw.content as any)[0].text)
+}
+
+function writeConfig(token: string, url = baseUrl): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-mcp-health-'))
+  dirs.push(dir)
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    `embeddings:\n  enabled: false\nstores:\n  - url: "${url}"\n    token: "${token}"\n    scope: "${SCOPE}"\n`,
+  )
+  return dir
+}
+
+beforeAll(async () => {
+  stub = new StubServer(TOKEN)
+  const info = await stub.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => {
+  await stub.stop()
+  for (const d of dirs) rmSync(d, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  stub.reset()
+  stub.setMe({ username: 'crtahlin', org_id: 'plur', role: 'developer', scopes: [SCOPE] })
+})
+
+describe('plur_doctor remote check (#295)', () => {
+  it('reports the remote as reachable with a valid token', async () => {
+    const client = await makeClient(writeConfig(TOKEN))
+    const res = callResult(await client.callTool({ name: 'plur_doctor', arguments: {} }))
+    const remote = res.checks.find((c: any) => String(c.check).startsWith('remote store:'))
+    expect(remote).toBeDefined()
+    expect(remote.ok).toBe(true)
+    expect(remote.detail).toMatch(/Reachable/)
+  })
+
+  it('flags AUTH FAILED (not healthy) when the token is rejected', async () => {
+    const client = await makeClient(writeConfig('wrong-token'))
+    const res = callResult(await client.callTool({ name: 'plur_doctor', arguments: {} }))
+    const remote = res.checks.find((c: any) => String(c.check).startsWith('remote store:'))
+    expect(remote).toBeDefined()
+    expect(remote.ok).toBe(false)
+    expect(remote.detail).toMatch(/AUTH FAILED/)
+    expect(res.ok).toBe(false) // overall doctor must NOT be healthy
+    expect(res.remediation.join(' ')).toMatch(/re-authenticate/i)
+  })
+})
+
+describe('plur_session_start remote auth surfacing (#295)', () => {
+  it('warns loudly in the guide when the enterprise token is rejected', async () => {
+    const client = await makeClient(writeConfig('wrong-token'))
+    const res = callResult(await client.callTool({ name: 'plur_session_start', arguments: { task: 'anything' } }))
+    expect(res.guide).toMatch(/ENTERPRISE STORE (AUTH FAILED|UNREACHABLE)/)
+  })
+
+  it('warns proactively when a valid token expires soon (≤7d)', async () => {
+    const soonJwt = makeJwt(3 * 86_400) // 3 days out
+    const stubSoon = new StubServer(soonJwt)
+    const info = await stubSoon.start()
+    try {
+      stubSoon.setMe({ username: 'crtahlin', org_id: 'plur', role: 'developer', scopes: [SCOPE] })
+      const client = await makeClient(writeConfig(soonJwt, info.url))
+      const res = callResult(await client.callTool({ name: 'plur_session_start', arguments: { task: 'anything' } }))
+      expect(res.guide).toMatch(/expires in \dd/)
+    } finally {
+      await stubSoon.stop()
+    }
+  })
+})


### PR DESCRIPTION
Closes #295.

> ⚠️ **Stacked on #294 (which is stacked on #293).** Base is `feat/client-scope-discovery-292`, not `main` — the remote-health check reuses `RemoteStore.me()` / the per-URL probe added in #294. Merge #293 → #294 → this, retargeting to `main` as each lands. The diff below is scoped to the observability work only.

## The incident this fixes

A real expiry: the enterprise JWT (30-day TTL, no refresh) lapsed. From then on, team-scoped `plur_learn` calls 401'd and queued to the local outbox, remote reads returned `engram_count: 0`, and `plur_doctor` still reported **"All checks passed — healthy."** The only signal was a human noticing no new engrams had reached the team store for days. Silent loss of exactly the thing the enterprise store exists for.

## What this does — make the failure legible

- **`packages/core/src/jwt.ts`** (new) — `decodeJwtExpiry()` reads a token's `exp` claim (no signature verification — the server verifies; this is purely for "expires in N days" / "expired" warnings). Opaque, non-JWT keys (`plur_sk_…`) return all-null so callers fall back to the live probe.
- **`packages/core/src/index.ts`**
  - `checkRemoteHealth()` — probes `GET /api/v1/me` per configured remote (raced against a timeout, reusing #294's `me()`), combined with the JWT-expiry read, and classifies each endpoint `ok` / `auth_expired` (401/403 or `exp` passed) / `unreachable` (network/timeout/5xx). An already-expired JWT short-circuits without a network call.
  - `remoteTokenExpiries()` — local-only (no network) expiry read, for the fast session-start path.
  - `learnRouted()` — flags `_outbox.auth_failed` when a remote write fails with 401/403, so a queued engram is distinguishable from a transient network blip.
- **`packages/mcp/src/tools.ts`**
  - `plur_doctor` — adds a per-remote check: reachable / **AUTH FAILED** / unreachable, plus "token expires in N days", with reauth remediation. The doctor's overall `ok` now goes `false` when a remote is dead instead of lying.
  - `plur_session_start` — surfaces a loud guide warning on 401/unreachable (**reusing the discovery probe #294 already runs — no extra round-trip**) including the outbox-pending count, plus a proactive "token expires in N days" warning from the local JWT read.

## Out of scope (fast-follow)

The reauth UX itself — a `plur login` command (browser/OAuth token mint + config write + hot-reload) and longer-lived API keys to reduce silent-expiry frequency — is filed separately. This PR is the observability half: you'll now *know* the token died and what to do, even if fixing it is still a manual step for now.

## Tests

- `packages/core/test/jwt.test.ts` — `decodeJwtExpiry` across future/expired/opaque/no-exp/garbage.
- `packages/core/test/remote-health.test.ts` — `checkRemoteHealth` ok / auth_expired (401) / expired-JWT short-circuit / unreachable / no-remotes; `remoteTokenExpiries` local decode.
- `packages/mcp/test/remote-health.test.ts` — full MCP→core: `plur_doctor` flags AUTH FAILED (overall not healthy) and reports reachable when valid; `plur_session_start` warns on rejected token and on a ≤7-day expiry.

Targeted runs green. Note: the 5 pre-existing failures in `test/sync.test.ts` (git cross-machine sync harness — "No such remote 'origin'" / commit) reproduce identically on the base branch and are unrelated to this change.

No version bump / publish — leaving the release cut to @plur9.
