### PR TITLE
feat: teach per-engram scope selection at install time (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ When an enterprise token expired, the client failed silently: team-scoped writes
 
 The reauth command itself (`plur login`) and longer-lived keys are tracked separately as a fast-follow.
 
+### Teach per-engram scope selection at install time (#296)
+
+Per-engram scoping was supported (every `plur_learn` takes a `scope`) but nothing taught agents to use it, so they routinely omitted `scope` → it fell back to `global` → team-relevant knowledge silently never reached the configured group store. This affects any install with a remote/group store. The capability worked; the guidance didn't.
+
+- **`packages/mcp/src/server.ts`** — the server `INSTRUCTIONS` block (advertised to every client on connect) gains a "SCOPE SELECTION" section: scope is content-driven and per-call; team/shared knowledge → the matching `group:<org>/<team>` scope; personal/local → default; never let team knowledge fall back to `global`. Exported for testing.
+- **`packages/cli/src/commands/init.ts`** — the CLAUDE.md section `plur init` generates replaces the thin "Multi-project scoping" note with a fuller "Scope selection (set scope PER engram, by content)" guide enumerating the team / project / personal routing and the global-fallback anti-pattern.
+
+`plur_session_start` already surfaces the live writable remote scopes prescriptively (#229), so this fills the always-on / install-time guidance gap. Relates to #291 (a comms/second scope can't be registered against the same URL until that lands) and #295 (silent auth-expiry).
+
 ## 0.9.11 (2026-05-26)
 
 Bug sweep — three independent fixes bundled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,14 @@ A PreToolUse guard enforces that `plur_session_start` is called at the beginning
 
 Do not ask permission to use these tools — they are your memory system.
 
-### Multi-project scoping
+### Scope selection (per engram, by content)
 
-PLUR uses `domain` and `scope` fields on engrams to separate knowledge by project. When calling `plur_learn`, set `scope` (e.g. `project:my-app`) to namespace the engram. Scoped recall automatically includes global engrams.
+PLUR uses `domain` and `scope` fields to separate knowledge. **Set `scope` on every `plur_learn` call, chosen by the engram's content** — one session spans multiple scopes. Scoped recall automatically includes global engrams.
+
+- Team/shared knowledge → the matching team scope (e.g. `group:<org>/<team>`); `plur_session_start` lists the writable ones.
+- This project's details → `project:my-app` (a `.plur.yaml` with `scope:` makes it the default).
+- Personal preferences / your workflow → leave at the default/local scope.
+- Don't omit `scope` for team-relevant knowledge — it falls back to `global`, which leaks into every project and never reaches the team store. Reserve `global` for genuinely cross-project facts.
 
 ### When to check memory
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npx @plur-ai/cli@0.9.4 init --domain myapp --scope project:my-app
 
 This creates a `.plur.yaml` in the project with defaults that hooks apply automatically. Engrams learned in that project are tagged; recall filters by scope but always includes global knowledge.
 
+**Set scope per engram, by content.** Scope is not a once-per-session setting — every `plur_learn` call takes its own `scope`, chosen from what the engram is about. Team/shared knowledge goes to a team scope (e.g. `group:<org>/<team>`, used by PLUR Enterprise); project details to `project:<name>`; personal preferences stay local. Don't let team-relevant knowledge fall back to `global` by omitting scope — `global` leaks into every project and (with a team store configured) never reaches the team. `plur_session_start` lists the remote scopes a token can write to.
+
 ### Global install (faster startup)
 
 ```bash

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -341,9 +341,14 @@ A PreToolUse guard enforces that \`plur_session_start\` is called at the beginni
 
 Do not ask permission to use these tools — they are your memory system.
 
-### Multi-project scoping
+### Scope selection (set scope PER engram, by content)
 
-PLUR uses \`domain\` and \`scope\` fields on engrams to separate knowledge by project. When calling \`plur_learn\`, set \`scope\` (e.g. \`project:my-app\`) to namespace the engram. Scoped recall automatically includes global engrams.
+PLUR uses \`domain\` and \`scope\` fields to separate knowledge. **Set \`scope\` on every \`plur_learn\` call, chosen by the engram's content** — a single session legitimately spans multiple scopes. Scoped recall automatically includes global engrams.
+
+- **Team / shared knowledge** (engineering patterns, architecture decisions, project conventions) → the matching team scope (e.g. \`group:<org>/<team>\`). \`plur_session_start\` lists the remote scopes your token can write to.
+- **This project's details** → \`project:<name>\` (a \`.plur.yaml\` with \`scope:\` makes this the default).
+- **Personal preferences / your own workflow** → leave at the default / local scope.
+- **Do NOT omit \`scope\` for team-relevant knowledge** — it falls back to \`global\`, which appears in every project's future sessions AND never reaches the team store. Prefer the project/local default over \`global\`; reserve \`global\` for genuinely cross-project facts (language gotchas, tool quirks).
 
 ### When to check memory
 

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -53,6 +53,16 @@ describe('plur init', () => {
     expect(settings.mcpServers?.plur).toBeDefined()
   })
 
+  it('writes per-engram scope-selection guidance into CLAUDE.md (#296)', () => {
+    runInit()
+    const claudeMd = readFileSync(join(home, 'CLAUDE.md'), 'utf-8')
+    expect(claudeMd).toContain('Scope selection')
+    expect(claudeMd).toMatch(/per engram/i)
+    expect(claudeMd).toContain('group:<org>/<team>')
+    // The key anti-pattern the issue is about: omitting scope → global → never reaches the team store.
+    expect(claudeMd).toMatch(/never reaches the team store/i)
+  })
+
   it('registers the MCP server with a platform-appropriate command', () => {
     runInit()
     const settings = readSettings()

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,7 +16,7 @@ import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
 import { z } from 'zod'
 
-const INSTRUCTIONS = `PLUR is your persistent memory. Corrections, preferences, and conventions persist across sessions as engrams.
+export const INSTRUCTIONS = `PLUR is your persistent memory. Corrections, preferences, and conventions persist across sessions as engrams.
 
 PLUR is a GLOBAL tool — one MCP server, one engram store (~/.plur/), available in every project. Multi-project scoping uses domain/scope fields on engrams, not separate installations.
 
@@ -32,6 +32,12 @@ DURING the session:
 OPTIONAL but improves quality:
 - Call plur_feedback to rate which injected engrams helped (positive/negative)
 - Call plur_recall_hybrid before answering factual questions — the answer may be in memory
+
+SCOPE SELECTION (set scope PER engram, by content — not once per session):
+- Every plur_learn call takes a "scope". Choose it from the engram's content; one session spans multiple scopes.
+- Team/shared knowledge (engineering patterns, architecture decisions, project conventions) → the matching team scope (e.g. group:<org>/<team>). session_start lists the scopes your token can write to.
+- Personal preferences, local workflow, project-specific details → leave at the default/local scope.
+- Do NOT let team-relevant knowledge fall back to "global" by omitting scope — global is the wrong default for shared knowledge and it never reaches the team store. If no scope fits, prefer the project/local default over global.
 
 Do not ask permission to use these tools — they are your memory system.
 

--- a/packages/mcp/test/instructions.test.ts
+++ b/packages/mcp/test/instructions.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Server INSTRUCTIONS advertise per-engram scope selection (#296).
+ *
+ * The instructions block is advertised to every client on connect, so it's the
+ * always-on place to teach agents that scope is content-driven and per-call —
+ * not a once-per-session default that lets team knowledge fall back to 'global'.
+ */
+import { describe, it, expect } from 'vitest'
+import { INSTRUCTIONS } from '../src/server.js'
+
+describe('server INSTRUCTIONS — scope selection (#296)', () => {
+  it('teaches per-engram scope selection by content', () => {
+    expect(INSTRUCTIONS).toMatch(/SCOPE SELECTION/i)
+    expect(INSTRUCTIONS).toMatch(/per engram/i)
+  })
+
+  it('names the team scope shape and warns against the global fallback', () => {
+    expect(INSTRUCTIONS).toContain('group:<org>/<team>')
+    expect(INSTRUCTIONS).toMatch(/never reaches the team store/i)
+  })
+})


### PR DESCRIPTION
Closes #296. Based on `main` (independent of the #293/#294/#295 stack).

## The gap

Per-engram scoping is supported — every `plur_learn` takes a `scope` — but **nothing teaches the agent to use it**, so agents routinely omit `scope`, it falls back to `global`, and team-relevant knowledge silently never reaches the configured group store. Affects any install with a remote/group store. The capability works; the defaults/guidance don't. (Observed in production: an entire multi-topic session's engrams all defaulted to `global` despite a configured `group:…/engineering` store.)

## What this does — teach it at the always-on / install surfaces

- **`packages/mcp/src/server.ts`** — the server `INSTRUCTIONS` block (advertised to every client on connect) gains a **SCOPE SELECTION** section: scope is content-driven and **per-call**; team/shared knowledge → the matching `group:<org>/<team>` scope (session_start lists the writable ones); personal/local → default; **never let team knowledge fall back to `global`**. Exported so it's unit-testable.
- **`packages/cli/src/commands/init.ts`** — the CLAUDE.md section `plur init` writes replaces the thin "Multi-project scoping" note with a fuller **"Scope selection (set scope PER engram, by content)"** guide that enumerates team / project / personal routing and calls out the global-fallback anti-pattern explicitly.

## Why not session_start

`plur_session_start` already surfaces the live writable remote scopes prescriptively (#229: "set scope to the matching remote scope … personal stays local"). The missing piece was the **always-on** guidance (the instructions block, present even before any recall) and the **install-time** guidance (generated CLAUDE.md). This PR fills those without touching session_start, so it stays independent of the in-flight #294/#295 work on that handler.

## Related

- **#291** — until that lands, a second/comms scope can't even be registered against the same URL, so "route comms → `group:…/comms`" is guidance the client can't yet honor. Cross-referenced, not blocked.
- **#295** — the auth-expiry side of the same "make memory legible" theme.

## Tests

- `packages/mcp/test/instructions.test.ts` — INSTRUCTIONS teaches per-engram selection, names `group:<org>/<team>`, and warns against the global fallback.
- `packages/cli/test/init.test.ts` — a fresh `plur init` writes the scope-selection guidance (incl. the "never reaches the team store" anti-pattern) into CLAUDE.md.

mcp + cli suites green. No version bump / publish — leaving the release cut to @plur9.
