### PR TITLE
fix: include received fields in validation error messages (#281)

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -209,6 +209,9 @@ export async function createServer(plur?: Plur): Promise<Server> {
         }
         const parsed = z.object(shape).passthrough().safeParse(args)
         if (!parsed.success) {
+          // Echo field NAMES only, never values (#281). Values may contain
+          // engram content (statements, rationale) — echoing them would leak
+          // memory content into client error logs. Keep this names-only.
           const receivedFields = Object.keys(args)
           const details = parsed.error.issues.map(i => `${i.path.join('.') || 'root'}: ${i.message}`).join(', ')
           const receivedInfo = receivedFields.length > 0

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -209,9 +209,17 @@ export async function createServer(plur?: Plur): Promise<Server> {
         }
         const parsed = z.object(shape).passthrough().safeParse(args)
         if (!parsed.success) {
-          const details = parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ')
+          const receivedFields = Object.keys(args)
+          const details = parsed.error.issues.map(i => `${i.path.join('.') || 'root'}: ${i.message}`).join(', ')
+          const receivedInfo = receivedFields.length > 0
+            ? `Received fields: [${receivedFields.join(', ')}].`
+            : 'No fields received.'
           return {
-            content: [{ type: 'text', text: JSON.stringify({ error: `Invalid arguments: ${details}`, success: false }) }],
+            content: [{ type: 'text', text: JSON.stringify({
+              error: `Invalid arguments: ${details}. ${receivedInfo}`,
+              success: false,
+              received_fields: receivedFields,
+            }) }],
             isError: true,
           }
         }

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -62,6 +62,18 @@ describe('MCP server (wire protocol)', () => {
     expect(data.storage_root).toBe(dir)
   })
 
+  // Issue #297 — plur_learn with tags array should work
+  it('plur_learn accepts tags array (#297)', async () => {
+    const result = await client.callTool({
+      name: 'plur_learn',
+      arguments: { statement: 'Test with tags', tags: ['test', 'array'] },
+    })
+    expect(result.isError).toBeFalsy()
+    const parsed = JSON.parse((result.content as any)[0].text)
+    expect(parsed.id).toBeDefined()
+    expect(parsed.statement).toBe('Test with tags')
+  })
+
   it('learn → recall → feedback roundtrip', async () => {
     // Learn
     const learnResult = await client.callTool({
@@ -103,6 +115,23 @@ describe('MCP server (wire protocol)', () => {
     expect(parsed.success).toBe(false)
     expect(parsed.error).toBeDefined()
     expect(typeof parsed.error).toBe('string')
+  })
+
+  // Issue #281 — validation errors should echo received fields for debugging
+  it('validation errors include received_fields for self-correction (#281)', async () => {
+    // Call plur_learn with missing required 'statement' but other fields present
+    const result = await client.callTool({
+      name: 'plur_learn',
+      arguments: { scope: 'global', type: 'behavioral', tags: ['test'] },
+    })
+    expect(result.isError).toBe(true)
+    const parsed = JSON.parse((result.content as any)[0].text)
+    expect(parsed.success).toBe(false)
+    expect(parsed.received_fields).toBeDefined()
+    expect(parsed.received_fields).toContain('scope')
+    expect(parsed.received_fields).toContain('type')
+    expect(parsed.received_fields).toContain('tags')
+    expect(parsed.error).toContain('Received fields:')
   })
 
   // Issue #231 — plur_session_end used to crash with unhelpful


### PR DESCRIPTION
## Summary
- Validation errors now echo which fields were received so callers can self-correct
- Adds `received_fields` array to JSON response for programmatic access
- Example error: `Invalid arguments: statement: Required. Received fields: [scope, type, tags].`

Part of #281 — implements item 1 (misleading validation error). Items 2 (subagent tool-schema determinism, the root cause) and 3 (`plur_learn_batch`) remain open in #281.

## Test plan
- [x] Added test `validation errors include received_fields for self-correction (#281)`
- [x] All 23 MCP server tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)
