### PR TITLE
fix: increase doctor embedder probe timeout to 60s (#273)

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -281,10 +281,11 @@ function resolveCliJsEntry(): string | null {
  * Subprocess isolation contains the crash — if the probe dies, parent reports
  * embedder as degraded and continues with the rest of the doctor checks.
  *
- * Timeout: 10s default. BGE model cold-load on slow hardware takes ~3-5s; 10s
- * is enough for honest cases without making doctor feel unresponsive.
+ * Timeout: 60s default (#273). Cold model downloads (130MB for bge-small,
+ * 325MB for embedding-gemma) need 60-300s on slow connections. Override via
+ * PLUR_DOCTOR_TIMEOUT env var (in seconds) if 60s is still too short.
  */
-async function checkEmbedder(_flags: GlobalFlags, timeoutMs = 10000): Promise<{ available: boolean; loaded: boolean; lastError: string | null; modelLoaded: boolean; disabled: boolean; disabledReason: string | null }> {
+async function checkEmbedder(_flags: GlobalFlags, timeoutMs = parseInt(process.env.PLUR_DOCTOR_TIMEOUT ?? '60', 10) * 1000): Promise<{ available: boolean; loaded: boolean; lastError: string | null; modelLoaded: boolean; disabled: boolean; disabledReason: string | null }> {
   return new Promise((resolve) => {
     const fallback = (lastError: string) => ({
       available: false,

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -285,7 +285,20 @@ function resolveCliJsEntry(): string | null {
  * 325MB for embedding-gemma) need 60-300s on slow connections. Override via
  * PLUR_DOCTOR_TIMEOUT env var (in seconds) if 60s is still too short.
  */
-async function checkEmbedder(_flags: GlobalFlags, timeoutMs = parseInt(process.env.PLUR_DOCTOR_TIMEOUT ?? '60', 10) * 1000): Promise<{ available: boolean; loaded: boolean; lastError: string | null; modelLoaded: boolean; disabled: boolean; disabledReason: string | null }> {
+const DEFAULT_PROBE_TIMEOUT_MS = 60_000
+
+/**
+ * Resolve the probe timeout from PLUR_DOCTOR_TIMEOUT (seconds). Invalid values
+ * (garbage, empty string, zero, negative) fall back to the 60s default — a NaN
+ * delay would make setTimeout fire after 1ms, instantly failing the probe with
+ * the very "probe timeout" symptom #273 fixes. Exported for tests.
+ */
+export function resolveProbeTimeoutMs(envValue = process.env.PLUR_DOCTOR_TIMEOUT): number {
+  const parsed = Number.parseInt(envValue ?? '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : DEFAULT_PROBE_TIMEOUT_MS
+}
+
+async function checkEmbedder(_flags: GlobalFlags, timeoutMs = resolveProbeTimeoutMs()): Promise<{ available: boolean; loaded: boolean; lastError: string | null; modelLoaded: boolean; disabled: boolean; disabledReason: string | null }> {
   return new Promise((resolve) => {
     const fallback = (lastError: string) => ({
       available: false,

--- a/packages/cli/test/doctor-timeout.test.ts
+++ b/packages/cli/test/doctor-timeout.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { resolveProbeTimeoutMs } from '../src/commands/doctor.js'
+
+// PLUR_DOCTOR_TIMEOUT parsing (#273, PR #303). Invalid values must fall back
+// to the 60s default: a NaN setTimeout delay is coerced to 1ms by Node, which
+// would instantly fail the probe with "probe timeout after NaNms" — the exact
+// symptom the configurable timeout exists to fix.
+describe('resolveProbeTimeoutMs (PLUR_DOCTOR_TIMEOUT)', () => {
+  it('defaults to 60s when the env var is unset', () => {
+    expect(resolveProbeTimeoutMs(undefined)).toBe(60_000)
+  })
+
+  it('converts a valid value from seconds to milliseconds', () => {
+    expect(resolveProbeTimeoutMs('120')).toBe(120_000)
+    expect(resolveProbeTimeoutMs('5')).toBe(5_000)
+  })
+
+  it('falls back to 60s on garbage input', () => {
+    expect(resolveProbeTimeoutMs('abc')).toBe(60_000)
+  })
+
+  it('falls back to 60s on empty string (PLUR_DOCTOR_TIMEOUT= in shell/CI)', () => {
+    expect(resolveProbeTimeoutMs('')).toBe(60_000)
+  })
+
+  it('falls back to 60s on zero and negative values', () => {
+    expect(resolveProbeTimeoutMs('0')).toBe(60_000)
+    expect(resolveProbeTimeoutMs('-30')).toBe(60_000)
+  })
+
+  it('tolerates trailing junk the way parseInt does (e.g. "90s")', () => {
+    // parseInt('90s') === 90 — accepted by design; documents the behavior.
+    expect(resolveProbeTimeoutMs('90s')).toBe(90_000)
+  })
+})


### PR DESCRIPTION
## Summary
- Increased default timeout from 10s to 60s for cold model downloads
- Made configurable via `PLUR_DOCTOR_TIMEOUT` env var (value in seconds)

First-time installs were seeing "embedder probe failed" because 10s wasn't enough to download the 130-325MB model files on slower connections.

Fixes #273

## Test plan
- [x] embedder-probe.test.ts passes
- [x] Timeout is now configurable via env var

🤖 Generated with [Claude Code](https://claude.ai/code)