### PR TITLE
fix: isPlurConfigured() no longer falls back to global settings (#247)

### DIFF
--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from 'path'
 import { tmpdir, homedir } from 'os'
 import { randomUUID } from 'crypto'
 import { createPlur, type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
 
 // Hard cap on the prompt text sent to Enterprise. Engram retrieval only
 // needs enough signal to rank candidates; the rest is privacy bleed
@@ -344,6 +345,10 @@ function processDeferredWrapups(): string | null {
 }
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  // Silent pass-through for projects without plur configured (#247).
+  // Lets hooks be installed globally without affecting non-plur projects.
+  if (!isPlurConfigured()) return
+
   const isRehydrate = args.includes('--rehydrate')
   const eventIdx = args.indexOf('--event')
   const event = eventIdx >= 0 ? args[eventIdx + 1] : null

--- a/packages/cli/src/commands/hook-learn-check.ts
+++ b/packages/cli/src/commands/hook-learn-check.ts
@@ -2,6 +2,7 @@ import { readSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs
 import { join } from 'path'
 import { tmpdir, homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
 
 /**
  * plur hook-learn-check — Stop hook that prompts learning reflection
@@ -95,6 +96,13 @@ const LEARN_PROMPT = `[PLUR] Did you discover, learn, or get corrected on someth
 
 export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
   const raw = readStdinRaw()
+
+  // Silent pass-through for projects without plur configured (#247).
+  // Lets hooks be installed globally without affecting non-plur projects.
+  if (!isPlurConfigured()) {
+    process.stdout.write(raw)
+    return
+  }
 
   // Parse stdin for cwd (provided by Claude Code hook payload)
   let cwd = process.cwd()

--- a/packages/cli/src/commands/hook-observe.ts
+++ b/packages/cli/src/commands/hook-observe.ts
@@ -2,6 +2,7 @@ import { mkdirSync, appendFileSync, readSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
 
 /**
  * plur hook-observe — capture tool calls for offline pattern extraction.
@@ -59,6 +60,10 @@ export async function run(args: string[], _flags: GlobalFlags): Promise<void> {
 
   // Always passthrough stdin to stdout (hook contract)
   process.stdout.write(raw)
+
+  // Silent no-op for projects without plur configured (#247).
+  // Lets hooks be installed globally without affecting non-plur projects.
+  if (!isPlurConfigured()) return
 
   let data: Record<string, unknown>
   try {

--- a/packages/cli/src/lib/plur-configured.ts
+++ b/packages/cli/src/lib/plur-configured.ts
@@ -3,23 +3,33 @@ import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
 
 /**
- * Detect whether plur is registered as an MCP server for the current project.
+ * Detect whether plur is configured for the current project.
  *
- * Walks up from `cwd` looking for `.mcp.json` or `.claude/settings.json` with
- * a `plur` server entry. Does NOT fall back to global `~/.claude/settings.json`
- * because `plur init --global` puts the server there, making the guard useless
- * for distinguishing plur-enabled vs non-plur projects (#247).
+ * Walks up from `cwd` looking for a project-level plur marker:
+ *   - `.mcp.json`, `.claude/settings.json`, or `.claude/settings.local.json`
+ *     with a `plur` server entry
+ *   - `.plur.yaml` (project config — domain/scope defaults, remote config).
+ *     This lets `plur init --global` users opt individual projects in even
+ *     though their MCP server lives only in global settings.
+ *
+ * Does NOT fall back to global `~/.claude/settings.json` because
+ * `plur init --global` puts the server there, making the guard useless for
+ * distinguishing plur-enabled vs non-plur projects (#247).
  *
  * Used by the session enforcement hooks (`hook-session-guard`,
- * `hook-session-remind`, `hook-session-mark`) so they can be installed into
- * global Claude settings (issue #95) without firing for non-plur projects.
+ * `hook-session-remind`, `hook-session-mark`) and the injection hooks
+ * (`hook-inject`, `hook-observe`, `hook-learn-check`) so they can be
+ * installed into global Claude settings (issue #95) without firing for
+ * non-plur projects.
  *
  * Cheap — a few `existsSync` + JSON parses, terminates at the root or the
  * first match.
  */
 export function isPlurConfigured(
   cwd: string = process.cwd(),
-  _home: string = homedir(), // kept for signature compat, no longer used
+  // Kept so tests can inject a fake home and assert the global fallback
+  // stays gone (#247). Intentionally unused by the implementation.
+  _home: string = homedir(),
 ): boolean {
   const start = resolve(cwd)
   let dir = start
@@ -27,6 +37,7 @@ export function isPlurConfigured(
     if (configHasPlur(join(dir, '.mcp.json'))) return true
     if (configHasPlur(join(dir, '.claude', 'settings.json'))) return true
     if (configHasPlur(join(dir, '.claude', 'settings.local.json'))) return true
+    if (existsSync(join(dir, '.plur.yaml'))) return true
     const parent = dirname(dir)
     if (parent === dir) break
     dir = parent

--- a/packages/cli/src/lib/plur-configured.ts
+++ b/packages/cli/src/lib/plur-configured.ts
@@ -6,7 +6,9 @@ import { homedir } from 'os'
  * Detect whether plur is registered as an MCP server for the current project.
  *
  * Walks up from `cwd` looking for `.mcp.json` or `.claude/settings.json` with
- * a `plur` server entry, then falls back to the global `~/.claude/settings.json`.
+ * a `plur` server entry. Does NOT fall back to global `~/.claude/settings.json`
+ * because `plur init --global` puts the server there, making the guard useless
+ * for distinguishing plur-enabled vs non-plur projects (#247).
  *
  * Used by the session enforcement hooks (`hook-session-guard`,
  * `hook-session-remind`, `hook-session-mark`) so they can be installed into
@@ -17,7 +19,7 @@ import { homedir } from 'os'
  */
 export function isPlurConfigured(
   cwd: string = process.cwd(),
-  home: string = homedir(),
+  _home: string = homedir(), // kept for signature compat, no longer used
 ): boolean {
   const start = resolve(cwd)
   let dir = start
@@ -29,7 +31,9 @@ export function isPlurConfigured(
     if (parent === dir) break
     dir = parent
   }
-  return configHasPlur(join(home, '.claude', 'settings.json'))
+  // Fix #247: Do NOT fall back to ~/.claude/settings.json — that would always
+  // return true after `plur init --global`, blocking all non-plur projects.
+  return false
 }
 
 function configHasPlur(path: string): boolean {

--- a/packages/cli/test/hook-noop.test.ts
+++ b/packages/cli/test/hook-noop.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { spawnSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+/**
+ * Hooks installed globally must no-op silently in projects without plur
+ * configured (#247): no output changes, no side effects, no errors.
+ */
+describe('injection hooks no-op in non-plur projects (#247)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    // Serves as cwd, HOME, and PLUR_PATH parent — contains no plur config
+    dir = mkdtempSync(join(tmpdir(), 'plur-noop-test-'))
+    mkdirSync(join(dir, 'tmp'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function runHook(
+    cmd: string,
+    input: object,
+  ): { stdout: string; stderr: string; status: number } {
+    const result = spawnSync('node', [CLI, cmd], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        HOME: dir,
+        USERPROFILE: dir,
+        TMPDIR: join(dir, 'tmp'),
+        PLUR_PATH: join(dir, '.plur'),
+      },
+      cwd: dir,
+    })
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      status: result.status ?? 1,
+    }
+  }
+
+  function addPlurConfig(): void {
+    writeFileSync(
+      join(dir, '.mcp.json'),
+      JSON.stringify({ mcpServers: { plur: { command: 'plur-mcp' } } }),
+    )
+  }
+
+  it('hook-inject produces no output and exits cleanly', () => {
+    const result = runHook('hook-inject', { prompt: 'hello world' })
+    expect(result.stdout).toBe('')
+    expect(result.status).toBe(0)
+  })
+
+  it('hook-observe passes stdin through and writes no observations', () => {
+    const input = { session_id: 's1', tool_name: 'Bash', tool_input: { command: 'ls' } }
+    const result = runHook('hook-observe', input)
+    expect(result.stdout).toBe(JSON.stringify(input))
+    expect(result.status).toBe(0)
+    expect(existsSync(join(dir, '.plur'))).toBe(false)
+  })
+
+  it('hook-learn-check passes stdin through and writes no counter', () => {
+    const input = { session_id: 's1', cwd: dir }
+    const result = runHook('hook-learn-check', input)
+    expect(result.stdout).toBe(JSON.stringify(input))
+    expect(result.status).toBe(0)
+    expect(existsSync(join(dir, 'tmp', 'plur-sessions'))).toBe(false)
+  })
+
+  it('hook-observe still records observations when project has plur config', () => {
+    addPlurConfig()
+    const input = { session_id: 's1', tool_name: 'Bash', tool_input: { command: 'ls' } }
+    const result = runHook('hook-observe', input)
+    expect(result.stdout).toBe(JSON.stringify(input))
+    expect(existsSync(join(dir, '.plur', 'observations'))).toBe(true)
+  })
+
+  it('hook-learn-check still counts stops when project has plur config', () => {
+    addPlurConfig()
+    const input = { session_id: 's1', cwd: dir }
+    const result = runHook('hook-learn-check', input)
+    expect(result.stdout).toBe(JSON.stringify(input))
+    expect(existsSync(join(dir, 'tmp', 'plur-sessions'))).toBe(true)
+  })
+})

--- a/packages/cli/test/plur-configured.test.ts
+++ b/packages/cli/test/plur-configured.test.ts
@@ -58,4 +58,32 @@ describe('isPlurConfigured', () => {
     writeFileSync(join(root, '.mcp.json'), '{ not valid json')
     expect(isPlurConfigured(root, root)).toBe(false)
   })
+
+  it('returns false when only global ~/.claude/settings.json has a plur server (#247)', () => {
+    // Regression: the global fallback made this return true for every
+    // project after `plur init --global`, blocking tools everywhere.
+    const home = mkdtempSync(join(tmpdir(), 'plur-configured-home-'))
+    try {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      writeFileSync(
+        join(home, '.claude', 'settings.json'),
+        JSON.stringify({ mcpServers: { plur: { command: 'plur-mcp' } } }),
+      )
+      expect(isPlurConfigured(root, home)).toBe(false)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('returns true when .plur.yaml exists in cwd', () => {
+    writeFileSync(join(root, '.plur.yaml'), 'scope: "project:test"\n')
+    expect(isPlurConfigured(root, root)).toBe(true)
+  })
+
+  it('returns true when .plur.yaml exists in a parent', () => {
+    writeFileSync(join(root, '.plur.yaml'), 'scope: "project:test"\n')
+    const sub = join(root, 'a', 'b')
+    mkdirSync(sub, { recursive: true })
+    expect(isPlurConfigured(sub, sub)).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- Removed global `~/.claude/settings.json` fallback from `isPlurConfigured()`
- Added `isPlurConfigured()` guard to injection hooks: `hook-inject`, `hook-observe`, `hook-learn-check`

Previously hooks installed globally would fire in every project (blocking tools in non-plur projects, adding latency). Now they silently no-op when no project-level plur config is found.

Fixes #247

## Test plan
- [x] hook-session-guard tests still pass (guard was already present)
- [x] CLI builds successfully
- [x] Manually verified: hooks now check project config only, not global

🤖 Generated with [Claude Code](https://claude.ai/code)