### PR TITLE
chore: gitignore benchmark/data — belongs in plur-bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ docs/architecture/vertical-extensions.md
 # Runtime engram store — must not be published (contains infra/deployment context)
 # Scrubbed from history 2026-06-03 after Crt's leak review (67 engrams, 3 prod IPs, basic-auth creds)
 .plur/
+
+# Benchmark data belongs in plur-bench, not the monorepo (DO NOT commit here)
+benchmark/data/


### PR DESCRIPTION
Benchmark data was accidentally committed to a local `main` (now dropped). This gitignores `benchmark/data/` so it can't recur — benchmarking artifacts live in `plur-bench`, not the monorepo. One line, no code.