### PR TITLE
Wedge: telemetry→MCP, failed-recall miss-signal, doc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ pnpm build
 pnpm test
 ```
 
-~150 tests across 22 files. All must pass before committing.
+~1045 tests across ~120 files (117 Vitest + Python suites). All must pass before committing.
 
 ## Package dependency
 
@@ -126,16 +126,23 @@ Search modes: `fast` (BM25), `agentic` (LLM rerank), `hybrid` (BM25 + embeddings
 
 **A/B bench** (end-to-end): Same task given to an agent with and without PLUR memory, scored by LLM judge. Scenarios in `datacore-bench/scenarios/`.
 
-### Current numbers (v0.2.1)
+### Current numbers (v0.9.13)
+
+Latest in-repo hybrid run is `benchmark/results/2026-04-07-hybrid.json`
+(LongMemEval n=30 sanity subset). A/B figures are the README's published run.
 
 | Metric | Score |
 |--------|-------|
-| LongMemEval overall (Opus hybrid, n=30) | 86.7% |
-| Hit@10 | 93.3% |
+| LongMemEval Hit@10 (hybrid, n=30) | 96.7% |
+| LongMemEval Hit@5 (hybrid, n=30) | 80.0% |
+| LongMemEval accuracy (keywords in top 10) | 83.3% |
 | A/B win rate (31W/4L) | 89% |
 | House rules | 12–0 |
 
-If your PR improves any of these, mention it in the PR description.
+The earlier v0.2.1 baseline (86.7% overall / 93.3% Hit@10) is still cited in
+`docs/benchmarks/phase2-methodology.md` as the self-calibration target for the
+not-yet-built reproducible Phase 2 harness — that doc tracks methodology, not
+current scores. If your PR improves any of these, mention it in the PR description.
 
 ## Conventions
 

--- a/docs/telemetry-design.md
+++ b/docs/telemetry-design.md
@@ -1,10 +1,60 @@
-# Opt-in Engagement Telemetry — Design Proposal
+# Opt-in Engagement Telemetry — Design & Implementation
 
-**Status:** Proposal — open for community comment
+**Status:** Implemented (opt-in, default-off) — design preserved below
 **Target release:** v0.9.x
-**Comment window:** 7 days from the date this doc lands on `main`
 
-This document describes a proposed opt-in engagement telemetry mechanism for PLUR. No code has been written. We are publishing the design first, deliberately, to invite criticism before building. If blocking feedback surfaces during the comment window, the design will be revised or dropped.
+This document originally proposed an opt-in engagement telemetry mechanism for
+PLUR, published design-first to invite criticism before building. The design
+held up and the mechanism is now implemented. The design rationale below is kept
+verbatim as the record of intent; this section tracks what actually shipped.
+
+## Implementation status
+
+The gate, daily counters, flush/transport, and a failed-recall miss-signal are
+implemented and wired. All of it is **opt-in / default-off** and **content-free**
+— exactly as the design below specifies.
+
+| Piece | Where | What it does |
+|-------|-------|--------------|
+| Opt-in gate | `packages/core/src/telemetry.ts` | `isTelemetryEnabled()` — `PLUR_TELEMETRY=on\|off` env, then `~/.plur/telemetry.json`, default **off**. Every public telemetry function short-circuits on this before any FS or network call. |
+| Daily counters | `packages/core/src/telemetry-counters.ts` | `recordEvent('learn'\|'recall'\|'session')` persists per-day counts to `~/.plur/telemetry-counters.json`; day-rollover safety stashes yesterday's snapshot to a pending dir (#128). |
+| Flush / transport | `packages/core/src/telemetry-flush.ts` | `POST /v1/heartbeat` of the daily record; never throws; drains the pending dir on rollover or process exit. |
+| Miss-signal | `packages/core/src/telemetry-miss-signal.ts` | Failed-recall demand signal (see below). |
+
+**Call sites.** `@plur-ai/claw` records `learn`/`recall` in `context-engine.ts`
+and `index.ts` and registers flush-on-exit. `@plur-ai/mcp` — the widest install
+surface — records `learn`/`recall` in `tools.ts` and registers flush-on-exit in
+`server.ts`, reusing the same core implementation (no vendored copy). Both
+wrappers go through the same gate, so an opted-out install does nothing.
+
+### Failed-recall miss-signal (WS5 demand flywheel)
+
+Beyond the counters, `recallHybridWithMeta()` (core) emits a **miss-signal** when
+a hybrid recall returns **zero engrams** OR a **top RRF score below a configurable
+floor** (`PLUR_MISS_SCORE_THRESHOLD`). A miss means memory was asked something it
+could not answer — a demand signal. The emit is opt-in/default-off and carries
+**only** these fields, never raw query or engram text:
+
+```json
+{
+  "install_id": "opaque uuid",
+  "query_fingerprint": "sha256 of the normalized query (irreversible)",
+  "scope": "project:x | null",
+  "domain": "trading | null",
+  "reason": "no_results | low_score",
+  "result_count": 0,
+  "date": "2026-06-14"
+}
+```
+
+The fingerprint lets identical misses across installs cluster without disclosing
+content. Clustering and pack-bounty logic are deliberately downstream and out of
+scope here — this module only emits. Endpoint defaults to `/v1/miss-signal`,
+overridable via `PLUR_MISS_SIGNAL_ENDPOINT`.
+
+---
+
+The original design proposal follows, unchanged.
 
 ## Why this exists
 

--- a/packages/core/src/hybrid-search.ts
+++ b/packages/core/src/hybrid-search.ts
@@ -14,6 +14,15 @@ export interface HybridSearchResult {
    */
   mode: 'hybrid' | 'hybrid-degraded' | 'bm25-only'
   embedderError: string | null
+  /**
+   * RRF fusion score of the top-ranked result, or null when no engrams
+   * matched. Surfaced (not computed anew) so callers can apply a relevance
+   * threshold — e.g. the WS5 failed-recall miss-signal treats a low top
+   * score as a miss even when ≥1 engram came back. Exposing this value does
+   * NOT change the retrieval algorithm; it only stops discarding a number
+   * rrfMerge already produced.
+   */
+  topScore: number | null
 }
 
 /**
@@ -25,7 +34,7 @@ export interface HybridSearchResult {
  * This gives high-ranked results from ANY method a boost, while naturally
  * handling the case where a result appears in multiple lists (scores add up).
  */
-function rrfMerge(resultSets: Engram[][], k = 60): Engram[] {
+function rrfMerge(resultSets: Engram[][], k = 60): Array<{ engram: Engram; score: number }> {
   const scores = new Map<string, { engram: Engram; score: number }>()
 
   for (const results of resultSets) {
@@ -41,9 +50,7 @@ function rrfMerge(resultSets: Engram[][], k = 60): Engram[] {
     }
   }
 
-  return Array.from(scores.values())
-    .sort((a, b) => b.score - a.score)
-    .map(s => s.engram)
+  return Array.from(scores.values()).sort((a, b) => b.score - a.score)
 }
 
 /** Detect aggregation queries that need exhaustive retrieval */
@@ -94,7 +101,7 @@ export async function hybridSearchWithMeta(
   storagePath?: string,
 ): Promise<HybridSearchResult> {
   if (engrams.length === 0) {
-    return { engrams: [], mode: 'hybrid', embedderError: null }
+    return { engrams: [], mode: 'hybrid', embedderError: null, topScore: null }
   }
 
   const exhaustive = isAggregationQuery(query)
@@ -126,9 +133,11 @@ export async function hybridSearchWithMeta(
   }
 
   const merged = rrfMerge([bm25Results, embResults])
+  const ranked = merged.slice(0, effectiveLimit)
   return {
-    engrams: merged.slice(0, effectiveLimit),
+    engrams: ranked.map(s => s.engram),
     mode,
     embedderError,
+    topScore: ranked.length > 0 ? ranked[0].score : null,
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ import { captureEpisode, queryTimeline } from './episodes.js'
 import { agenticSearch } from './agentic-search.js'
 import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } from './embeddings.js'
 import { hybridSearch, hybridSearchWithMeta, type HybridSearchResult } from './hybrid-search.js'
+import { emitMissSignal } from './telemetry-miss-signal.js'
 import { embedderStatus, resetEmbedder, setEmbeddingsEnabled, type EmbedderStatus } from './embeddings.js'
 import { expandedSearch } from './query-expansion.js'
 import { recallAuto, type AutoSearchResult } from './search-orchestrator.js'
@@ -108,6 +109,25 @@ export {
 } from './schemas/capsule.js'
 export { writeCapsule, readCapsule, verifyCapsuleIntegrity } from './capsule.js'
 export type { WriteCapsuleOptions, ReadCapsuleResult } from './capsule.js'
+
+// Opt-in, content-free telemetry. Exported so wrappers (@plur-ai/mcp,
+// @plur-ai/claw) reuse one implementation instead of vendoring copies.
+export { resolveTelemetry, isTelemetryEnabled, type TelemetryState, type TelemetrySource, type TelemetryResolution } from './telemetry.js'
+export { recordEvent, getCounters, resetCounters, readOrCreateInstallId, type CounterEvent, type CounterSnapshot, type CountersOpts } from './telemetry-counters.js'
+export { flushIfNeeded, registerFlushOnExit, buildHeartbeatPayload, sendHeartbeat, type HeartbeatPayload, type FlushOpts } from './telemetry-flush.js'
+// Failed-recall miss-signal — feeds the WS5 demand flywheel (opt-in, content-free).
+export {
+  emitMissSignal,
+  classifyMiss,
+  fingerprintQuery,
+  buildMissSignalPayload,
+  DEFAULT_MISS_SCORE_THRESHOLD,
+  type MissReason,
+  type MissSignalInput,
+  type MissSignalOpts,
+  type MissSignalPayload,
+} from './telemetry-miss-signal.js'
+
 export * from './types.js'
 
 export interface IngestOptions {
@@ -1117,6 +1137,20 @@ export class Plur {
     const limit = options?.limit ?? 20
     const result = await hybridSearchWithMeta(filtered, query, limit, this.paths.root)
     this._reactivateResults(result.engrams)
+    // WS5 demand flywheel: a zero-result or low-top-score recall is a demand
+    // signal — the user asked memory something it could not answer. Emit an
+    // anonymized, content-free miss-signal (query fingerprint hash + scope/
+    // domain + timestamp; never the raw query). Opt-in/default-off and
+    // fire-and-forget: emitMissSignal self-gates on telemetry opt-in and never
+    // throws, so an opted-out install does nothing and the recall path is never
+    // disturbed.
+    void emitMissSignal({
+      query,
+      scope: options?.scope,
+      domain: options?.domain,
+      resultCount: result.engrams.length,
+      topScore: result.topScore,
+    }).catch(() => {})
     return result
   }
 

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -112,6 +112,74 @@ export const ExchangeMetadataSchema = z.object({
   contradiction_rate: z.number().min(0).max(1).default(0),
 })
 
+// === NEW: Memory-stream insight engrams (metacognition Phase 1) ===
+//
+// An "insight engram" is a normal engram carrying an optional `insight` sub-object.
+// Following the #110 failure-engram pattern, this is ORTHOGONAL to `type`: `type`
+// stays the cognitive class (behavioral/terminological/procedural/architectural),
+// while `insight` records that the engram was synthesized by the metacognition
+// memory stream — its synthesis origin, source grounding, serendipity, and
+// downstream fate. The "episodic insight buffer" is simply the set of engrams
+// where `insight != null`. Source citations reuse `knowledge_anchors[]`; lifecycle
+// reuses `status`/`activation` decay; gist consolidation reuses the meta-engram
+// pipeline. Decisions: 5-plur/3-knowledge/pages/insight-engram-schema-2026-06-14.md
+
+/** Serendipity objective for connect/emerge/dream insights = unexpectedness × relevance
+ *  (Kotkov et al., JCST 2020). Scored on existing embeddings + buffer novelty —
+ *  NOT a learned link predictor. */
+export const SerendipitySchema = z.object({
+  unexpectedness: z.number().min(0).max(1),
+  relevance: z.number().min(0).max(1),
+  score: z.number().min(0).max(1),
+})
+
+/** Downstream fate of a surfaced insight — the substrate for the primary
+ *  evaluation metric "insight acted-upon rate" (NOT engagement). */
+export const InsightFateSchema = z.enum([
+  'surfaced',   // shown in a briefing; no downstream action yet
+  'promoted',   // became a durable engram / zettel
+  'cited',      // referenced in later journal/work
+  'tasked',     // converted to a GTD task
+  'dismissed',  // user/LLM rejected it
+  'expired',    // decayed out of the buffer unused
+])
+
+export const InsightFieldSchema = z.object({
+  /** Which memory-stream operation produced this insight. Nightly arc:
+   *  `distill` (episode→insight synthesis) → `consolidate` (convergent gist
+   *  abstraction over the buffer) → `dream` (divergent REM-style recombination —
+   *  speculative, never auto-promoted). `connect`/`emerge`/`drift` are on-demand lenses. */
+  operation: z.enum(['distill', 'consolidate', 'dream', 'connect', 'emerge', 'drift']),
+  synthesized_at: z.string(),
+
+  /** Anti-hallucination grounding. Cited source notes live in the parent engram's
+   *  `knowledge_anchors[]`; this flags whether the claim was verified against those
+   *  snippets. `ungrounded` = couldn't cite sources → quarantined (`candidate`, never
+   *  surfaced). `speculative` = a `dream`: its recombined INPUTS are cited but its
+   *  CONCLUSION is an explicit hypothesis — surfaced only as inspiration, and (per the
+   *  promote-requires-grounding refine below) it must be re-grounded to `verified`
+   *  before it can be promoted to a durable engram. */
+  grounding: z.enum(['verified', 'unverified', 'ungrounded', 'speculative']).default('unverified'),
+  /** The episode-log slice this insight was distilled from (evidence trail). */
+  source_episode_ids: z.array(z.string()).default([]),
+
+  /** Distinct objective for connect/emerge/dream insights. */
+  serendipity: SerendipitySchema.optional(),
+
+  fate: InsightFateSchema.default('surfaced'),
+  /** Engram id / zettel path / task id the insight became, if acted upon. */
+  fate_ref: z.string().optional(),
+  fate_at: z.string().optional(),
+  /** How many briefings have surfaced this insight (acted-upon-rate denominator). */
+  surfaced_count: z.number().int().min(0).default(0),
+}).refine(
+  // Promote-requires-grounding (user rule 2026-06-15): a dream is inspiration, not
+  // fact. A speculative/ungrounded insight can only become a durable promotion once
+  // it has been re-grounded in reality (grounding=verified).
+  i => i.fate !== 'promoted' || i.grounding === 'verified',
+  { message: 'A promoted insight must be grounded (grounding=verified); speculative dreams cannot be promoted until re-grounded.', path: ['grounding'] },
+)
+
 // === Main Engram Schema ===
 
 export const EngramSchema = z.object({
@@ -182,6 +250,11 @@ export const EngramSchema = z.object({
   /** Extensible key-value data for domain-specific fields. */
   structured_data: z.record(z.string(), z.unknown()).optional(),
 
+  /** Memory-stream insight provenance (metacognition Phase 1). Orthogonal to
+   *  `type`. Present iff this engram was synthesized by the metacognition memory
+   *  stream; the episodic insight buffer is the set of engrams where this is set. */
+  insight: InsightFieldSchema.optional(),
+
   /** Polarity classification: 'do' for directives, 'dont' for prohibitions, null for unclassified. */
   polarity: z.enum(['do', 'dont']).nullable().default(null),
 
@@ -249,3 +322,6 @@ export type UsageStats = z.infer<typeof UsageStatsSchema>
 export type EpisodicFields = z.infer<typeof EpisodicFieldsSchema>
 export type ExchangeMetadata = z.infer<typeof ExchangeMetadataSchema>
 export type PreviousVersionRef = z.infer<typeof PreviousVersionRefSchema>
+export type Serendipity = z.infer<typeof SerendipitySchema>
+export type InsightFate = z.infer<typeof InsightFateSchema>
+export type InsightField = z.infer<typeof InsightFieldSchema>

--- a/packages/core/src/telemetry-counters.ts
+++ b/packages/core/src/telemetry-counters.ts
@@ -95,7 +95,7 @@ function atomicWriteString(path: string, data: string): void {
   renameSync(tmp, path)
 }
 
-function readOrCreateInstallId(path: string): string {
+export function readOrCreateInstallId(path: string): string {
   if (existsSync(path)) {
     const raw = readFileSync(path, 'utf8').trim()
     if (raw.length > 0) return raw

--- a/packages/core/src/telemetry-flush.ts
+++ b/packages/core/src/telemetry-flush.ts
@@ -63,17 +63,19 @@ let cachedPackageVersion: string | null = null
 
 function readPackageVersion(): string {
   if (cachedPackageVersion !== null) return cachedPackageVersion
+  let resolved: string
   try {
     const here = dirname(fileURLToPath(import.meta.url))
     // src → package root: ../package.json (when running tests against src)
     // dist → package root: ../package.json (when running built)
     const pkgPath = join(here, '..', 'package.json')
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
-    cachedPackageVersion = typeof pkg.version === 'string' ? pkg.version : 'unknown'
+    resolved = typeof pkg.version === 'string' ? pkg.version : 'unknown'
   } catch {
-    cachedPackageVersion = 'unknown'
+    resolved = 'unknown'
   }
-  return cachedPackageVersion
+  cachedPackageVersion = resolved
+  return resolved
 }
 
 export function buildHeartbeatPayload(

--- a/packages/core/src/telemetry-miss-signal.ts
+++ b/packages/core/src/telemetry-miss-signal.ts
@@ -1,0 +1,202 @@
+// Failed-recall miss-signal (WS5 demand flywheel).
+//
+// When a hybrid recall returns zero engrams OR a top RRF score below a
+// configurable relevance floor, that is a *demand signal*: the user asked
+// memory something it could not answer. Aggregated across installs, the shape
+// of those misses tells us what knowledge the ecosystem is hungry for — the
+// input to the WS5 demand flywheel (pack bounties, gap clustering). This module
+// only EMITS the anonymized miss; clustering/bounty logic lives downstream and
+// is deliberately out of scope here.
+//
+// Privacy invariants (shared with telemetry-counters / telemetry-flush):
+//   1. Opt-in, default-off. Every public function short-circuits on
+//      !isTelemetryEnabled() BEFORE any network call. A default-off install
+//      makes zero network calls and writes zero files for miss-signals.
+//   2. Content-free. The raw query NEVER leaves the process. We ship a
+//      SHA-256 fingerprint of the normalized query (irreversible), the scope
+//      and domain filters (coarse routing labels the user already chose), a
+//      reason code, and a UTC timestamp. No query text, no engram text, no
+//      result bodies, no paths, no identity beyond the opaque install id.
+//   3. Never throws. On any failure (network, timeout, non-2xx) emit() resolves
+//      to false; the caller's recall path is never disturbed.
+//
+// Transport mirrors telemetry-flush's heartbeat: a single small JSON POST to a
+// documented endpoint, AbortController timeout, errors swallowed. Unlike the
+// daily counter heartbeat, a miss is emitted at the moment it happens (fire-
+// and-forget) because the signal is the event, not a daily aggregate.
+
+import { createHash } from 'node:crypto'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { isTelemetryEnabled } from './telemetry.js'
+import { readOrCreateInstallId } from './telemetry-counters.js'
+
+/** Why a recall counted as a miss. */
+export type MissReason = 'no_results' | 'low_score'
+
+export type MissSignalOpts = {
+  env?: NodeJS.ProcessEnv
+  configPath?: string
+  installIdPath?: string
+  fetch?: typeof globalThis.fetch
+  endpoint?: string
+  timeoutMs?: number
+  now?: () => Date
+}
+
+export type MissSignalInput = {
+  /** Raw query — hashed locally, NEVER transmitted. */
+  query: string
+  /** Scope filter the caller passed, if any (coarse routing label). */
+  scope?: string
+  /** Domain filter the caller passed, if any (coarse routing label). */
+  domain?: string
+  /** Number of engrams the recall returned (0 ⇒ no_results). */
+  resultCount: number
+  /** Top RRF score, or null when no engrams matched. */
+  topScore: number | null
+}
+
+/** Exact wire shape — these fields and nothing else. */
+export type MissSignalPayload = {
+  install_id: string
+  query_fingerprint: string
+  scope: string | null
+  domain: string | null
+  reason: MissReason
+  result_count: number
+  date: string
+}
+
+const DEFAULT_ENDPOINT = 'https://plur.ai/v1/miss-signal'
+const DEFAULT_TIMEOUT_MS = 5000
+
+// Below this top RRF score we treat a non-empty result set as a miss: the
+// engrams that came back are too weakly related to the query to be a real hit.
+// Tunable via PLUR_MISS_SCORE_THRESHOLD. RRF scores are small (1/(k+rank+1),
+// k=60 ⇒ a single top-1 hit scores ~0.0164; the floor sits just under that so a
+// lone weak match still registers as a miss while genuine multi-list hits pass.
+export const DEFAULT_MISS_SCORE_THRESHOLD = 0.015
+
+function resolveThreshold(env: NodeJS.ProcessEnv): number {
+  const raw = env.PLUR_MISS_SCORE_THRESHOLD
+  if (raw === undefined) return DEFAULT_MISS_SCORE_THRESHOLD
+  const parsed = Number.parseFloat(raw)
+  return Number.isFinite(parsed) ? parsed : DEFAULT_MISS_SCORE_THRESHOLD
+}
+
+function resolveEndpoint(opts: MissSignalOpts, env: NodeJS.ProcessEnv): string {
+  if (opts.endpoint) return opts.endpoint
+  return env.PLUR_MISS_SIGNAL_ENDPOINT ?? DEFAULT_ENDPOINT
+}
+
+function defaultInstallIdPath(): string {
+  return join(homedir(), '.plur', 'install-id')
+}
+
+function utcDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+/**
+ * Normalize then SHA-256-hash the query. Irreversible: there is no way to
+ * recover the query from the fingerprint, but two installs that miss on the
+ * same normalized phrasing produce the same fingerprint — which is exactly the
+ * clustering key WS5 needs, with zero content disclosure.
+ */
+export function fingerprintQuery(query: string): string {
+  const normalized = query.trim().toLowerCase().replace(/\s+/g, ' ')
+  return createHash('sha256').update(normalized, 'utf8').digest('hex')
+}
+
+/**
+ * Classify a recall result as a hit or a miss. Pure, side-effect-free, gate-
+ * independent — the gate is checked in emitMissSignal, not here, so this stays
+ * unit-testable in isolation.
+ */
+export function classifyMiss(
+  input: Pick<MissSignalInput, 'resultCount' | 'topScore'>,
+  threshold: number = DEFAULT_MISS_SCORE_THRESHOLD,
+): MissReason | null {
+  if (input.resultCount === 0) return 'no_results'
+  if (input.topScore === null) return 'no_results'
+  if (input.topScore < threshold) return 'low_score'
+  return null
+}
+
+export function buildMissSignalPayload(
+  input: MissSignalInput,
+  reason: MissReason,
+  installId: string,
+  now: Date,
+): MissSignalPayload {
+  return {
+    install_id: installId,
+    query_fingerprint: fingerprintQuery(input.query),
+    scope: input.scope ?? null,
+    domain: input.domain ?? null,
+    reason,
+    result_count: input.resultCount,
+    date: utcDate(now),
+  }
+}
+
+async function postMissSignal(
+  payload: MissSignalPayload,
+  opts: MissSignalOpts,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const endpoint = resolveEndpoint(opts, env)
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const fetchImpl = opts.fetch ?? globalThis.fetch
+  if (!fetchImpl) return false
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Emit a failed-recall miss-signal if (a) telemetry is opted-in AND (b) the
+ * recall classifies as a miss. Returns true only when a signal was actually
+ * sent and acknowledged; false in every other case (opted-out, hit, or send
+ * failure). Never throws.
+ *
+ * Fire-and-forget from the recall path: callers do `void emitMissSignal(...)`.
+ */
+export async function emitMissSignal(
+  input: MissSignalInput,
+  opts: MissSignalOpts = {},
+): Promise<boolean> {
+  const env = opts.env ?? process.env
+  // Privacy invariant 1: opted-out ⇒ no fingerprinting, no install-id read,
+  // no network. Short-circuit before touching anything.
+  if (!isTelemetryEnabled({ env, configPath: opts.configPath })) return false
+
+  const threshold = resolveThreshold(env)
+  const reason = classifyMiss(input, threshold)
+  if (reason === null) return false // a hit — nothing to signal
+
+  try {
+    const installId = readOrCreateInstallId(opts.installIdPath ?? defaultInstallIdPath())
+    const now = (opts.now ?? (() => new Date()))()
+    const payload = buildMissSignalPayload(input, reason, installId, now)
+    return await postMissSignal(payload, opts, env)
+  } catch {
+    // Never disturb the recall path.
+    return false
+  }
+}

--- a/packages/core/test/hybrid-search.test.ts
+++ b/packages/core/test/hybrid-search.test.ts
@@ -62,4 +62,18 @@ describe('hybrid search (BM25 + embeddings via RRF)', () => {
     const unique = new Set(ids)
     expect(ids.length).toBe(unique.size) // No duplicates
   })
+
+  it('surfaces a numeric topScore on a hit (for the miss-signal threshold)', async () => {
+    const meta = await plur.recallHybridWithMeta('PostgreSQL database')
+    expect(meta.engrams.length).toBeGreaterThanOrEqual(1)
+    expect(typeof meta.topScore).toBe('number')
+    expect(meta.topScore as number).toBeGreaterThan(0)
+  })
+
+  it('topScore is null when no engrams exist at all', async () => {
+    const empty = new Plur({ path: mkdtempSync(join(tmpdir(), 'plur-empty-')) })
+    const meta = await empty.recallHybridWithMeta('anything')
+    expect(meta.engrams).toHaveLength(0)
+    expect(meta.topScore).toBeNull()
+  })
 })

--- a/packages/core/test/schemas.test.ts
+++ b/packages/core/test/schemas.test.ts
@@ -25,6 +25,112 @@ describe('EngramSchema', () => {
     const result = EngramSchema.safeParse({ id: 'ENG-2026-0319-001', type: 'behavioral' })
     expect(result.success).toBe(false)
   })
+
+  it('parses an insight engram (orthogonal sub-object) and defaults fate/grounding', () => {
+    const result = EngramSchema.safeParse({
+      id: 'ENG-2026-0614-042',
+      statement: 'Wyckoff invalidation discipline recurs across losing trades',
+      type: 'behavioral',
+      scope: 'project:trading',
+      status: 'candidate',
+      knowledge_type: { memory_class: 'metacognitive', cognitive_level: 'analyze' },
+      knowledge_anchors: [
+        { path: '0-personal/notes/journals/2026-06-10.md', relevance: 'primary', snippet: 'closed early, ignored my own rule' },
+      ],
+      insight: {
+        operation: 'distill',
+        synthesized_at: '2026-06-14T03:00:00Z',
+        source_episode_ids: ['EP-1', 'EP-2'],
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      // type stays the cognitive class; insight is orthogonal
+      expect(result.data.type).toBe('behavioral')
+      expect(result.data.insight?.grounding).toBe('unverified') // default
+      expect(result.data.insight?.fate).toBe('surfaced')        // default
+      expect(result.data.insight?.surfaced_count).toBe(0)       // default
+    }
+  })
+
+  it('accepts a serendipity-scored connect insight', () => {
+    const result = EngramSchema.safeParse({
+      id: 'ENG-2026-0614-043',
+      statement: 'Trading risk discipline and health HRV recovery share a pre-commitment pattern',
+      type: 'behavioral',
+      scope: 'global',
+      status: 'candidate',
+      insight: {
+        operation: 'connect',
+        synthesized_at: '2026-06-14T03:00:00Z',
+        grounding: 'verified',
+        serendipity: { unexpectedness: 0.8, relevance: 0.6, score: 0.48 },
+        fate: 'promoted',
+        fate_ref: 'ENG-2026-0614-099',
+        surfaced_count: 3,
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a speculative dream insight (operation=dream)', () => {
+    const result = EngramSchema.safeParse({
+      id: 'ENG-2026-0615-001',
+      statement: 'Maybe Wyckoff accumulation phases rhyme with HRV recovery curves',
+      type: 'behavioral',
+      scope: 'global',
+      status: 'candidate',
+      insight: {
+        operation: 'dream',
+        synthesized_at: '2026-06-15T03:00:00Z',
+        grounding: 'speculative',
+        serendipity: { unexpectedness: 0.9, relevance: 0.4, score: 0.36 },
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.insight?.fate).toBe('surfaced')
+  })
+
+  it('rejects promoting a speculative dream (promote-requires-grounding)', () => {
+    const result = EngramSchema.safeParse({
+      id: 'ENG-2026-0615-002',
+      statement: 'speculative leap',
+      type: 'behavioral',
+      scope: 'global',
+      status: 'candidate',
+      insight: {
+        operation: 'dream',
+        synthesized_at: '2026-06-15T03:00:00Z',
+        grounding: 'speculative',
+        fate: 'promoted',
+      },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('still parses an engram with no insight sub-object (backward compat)', () => {
+    const result = EngramSchema.safeParse({
+      id: 'ENG-2026-0319-001',
+      statement: 'API uses snake_case',
+      type: 'behavioral',
+      scope: 'global',
+      status: 'active',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.insight).toBeUndefined()
+  })
+
+  it('rejects an invalid insight operation', () => {
+    const result = EngramSchema.safeParse({
+      id: 'ENG-2026-0614-044',
+      statement: 'x',
+      type: 'behavioral',
+      scope: 'global',
+      status: 'candidate',
+      insight: { operation: 'hallucinate', synthesized_at: '2026-06-14T03:00:00Z' },
+    })
+    expect(result.success).toBe(false)
+  })
 })
 
 describe('EpisodeSchema', () => {

--- a/packages/core/test/telemetry-miss-signal.test.ts
+++ b/packages/core/test/telemetry-miss-signal.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  classifyMiss,
+  emitMissSignal,
+  fingerprintQuery,
+  buildMissSignalPayload,
+  DEFAULT_MISS_SCORE_THRESHOLD,
+  type MissSignalOpts,
+  type MissSignalInput,
+} from '../src/telemetry-miss-signal.js'
+
+function newDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-miss-'))
+}
+
+type CapturedPost = { body: any }
+function captureFetch(ok = true) {
+  const calls: CapturedPost[] = []
+  const fakeFetch = (async (_url: string, init: any) => {
+    calls.push({ body: init?.body ? JSON.parse(init.body as string) : null })
+    return { ok } as Response
+  }) as unknown as typeof globalThis.fetch
+  return { calls, fakeFetch }
+}
+
+describe('telemetry miss-signal (WS5 demand flywheel)', () => {
+  let dir: string
+  let configPath: string
+  let installIdPath: string
+
+  beforeEach(() => {
+    dir = newDir()
+    configPath = join(dir, 'telemetry.json')
+    installIdPath = join(dir, 'install-id')
+  })
+
+  function offOpts(extra: Partial<MissSignalOpts> = {}): MissSignalOpts {
+    return { env: {}, configPath, installIdPath, ...extra }
+  }
+  function onOpts(extra: Partial<MissSignalOpts> = {}): MissSignalOpts {
+    return { env: { PLUR_TELEMETRY: 'on' }, configPath, installIdPath, ...extra }
+  }
+
+  const hit: MissSignalInput = { query: 'q', resultCount: 5, topScore: 0.05 }
+  const noResults: MissSignalInput = { query: 'q', resultCount: 0, topScore: null }
+  const lowScore: MissSignalInput = { query: 'q', resultCount: 3, topScore: 0.001 }
+
+  describe('classifyMiss (pure)', () => {
+    it('returns null for a real hit (results + score above floor)', () => {
+      expect(classifyMiss(hit)).toBeNull()
+    })
+    it('returns no_results for zero results', () => {
+      expect(classifyMiss(noResults)).toBe('no_results')
+    })
+    it('returns no_results when topScore is null despite a count', () => {
+      expect(classifyMiss({ resultCount: 2, topScore: null })).toBe('no_results')
+    })
+    it('returns low_score when top score is below the floor', () => {
+      expect(classifyMiss(lowScore)).toBe('low_score')
+    })
+    it('respects a custom threshold', () => {
+      expect(classifyMiss({ resultCount: 1, topScore: 0.02 }, 0.05)).toBe('low_score')
+      expect(classifyMiss({ resultCount: 1, topScore: 0.02 }, 0.01)).toBeNull()
+    })
+  })
+
+  describe('fingerprintQuery (privacy)', () => {
+    it('is a 64-char hex SHA-256 digest, not the query', () => {
+      const fp = fingerprintQuery('how do I deploy the trading bot')
+      expect(fp).toMatch(/^[0-9a-f]{64}$/)
+      expect(fp).not.toContain('deploy')
+    })
+    it('is stable across whitespace/case normalization', () => {
+      expect(fingerprintQuery('Deploy  The  Bot')).toBe(fingerprintQuery('deploy the bot'))
+    })
+    it('differs for different queries', () => {
+      expect(fingerprintQuery('alpha')).not.toBe(fingerprintQuery('beta'))
+    })
+  })
+
+  describe('buildMissSignalPayload (wire shape)', () => {
+    it('carries ONLY fingerprint + coarse labels + reason + count + date — never raw query', () => {
+      const now = new Date('2026-06-14T10:00:00Z')
+      const payload = buildMissSignalPayload(
+        { query: 'secret query text', scope: 'project:x', domain: 'trading', resultCount: 0, topScore: null },
+        'no_results',
+        'install-abc',
+        now,
+      )
+      expect(payload).toEqual({
+        install_id: 'install-abc',
+        query_fingerprint: fingerprintQuery('secret query text'),
+        scope: 'project:x',
+        domain: 'trading',
+        reason: 'no_results',
+        result_count: 0,
+        date: '2026-06-14',
+      })
+      // No raw query anywhere in the serialized payload.
+      expect(JSON.stringify(payload)).not.toContain('secret query text')
+    })
+    it('nulls absent scope/domain', () => {
+      const payload = buildMissSignalPayload(noResults, 'no_results', 'id', new Date())
+      expect(payload.scope).toBeNull()
+      expect(payload.domain).toBeNull()
+    })
+  })
+
+  describe('emitMissSignal gating', () => {
+    it('default-off install makes zero network calls (a miss is still silent)', async () => {
+      const { calls, fakeFetch } = captureFetch()
+      const sent = await emitMissSignal(noResults, offOpts({ fetch: fakeFetch }))
+      expect(sent).toBe(false)
+      expect(calls).toHaveLength(0)
+    })
+
+    it('opted-out via PLUR_TELEMETRY=off makes zero network calls', async () => {
+      const { calls, fakeFetch } = captureFetch()
+      const sent = await emitMissSignal(noResults, { env: { PLUR_TELEMETRY: 'off' }, configPath, installIdPath, fetch: fakeFetch })
+      expect(sent).toBe(false)
+      expect(calls).toHaveLength(0)
+    })
+
+    it('opted-in + hit emits nothing (not a miss)', async () => {
+      const { calls, fakeFetch } = captureFetch()
+      const sent = await emitMissSignal(hit, onOpts({ fetch: fakeFetch }))
+      expect(sent).toBe(false)
+      expect(calls).toHaveLength(0)
+    })
+
+    it('opted-in + no-results emits exactly one content-free signal', async () => {
+      const { calls, fakeFetch } = captureFetch()
+      const sent = await emitMissSignal(
+        { query: 'unanswerable', scope: 's', domain: 'd', resultCount: 0, topScore: null },
+        onOpts({ fetch: fakeFetch }),
+      )
+      expect(sent).toBe(true)
+      expect(calls).toHaveLength(1)
+      const body = calls[0].body
+      expect(body.reason).toBe('no_results')
+      expect(body.query_fingerprint).toBe(fingerprintQuery('unanswerable'))
+      expect(JSON.stringify(body)).not.toContain('unanswerable')
+    })
+
+    it('opted-in + low-score emits a low_score signal', async () => {
+      const { calls, fakeFetch } = captureFetch()
+      const sent = await emitMissSignal(lowScore, onOpts({ fetch: fakeFetch }))
+      expect(sent).toBe(true)
+      expect(calls[0].body.reason).toBe('low_score')
+    })
+
+    it('respects PLUR_MISS_SCORE_THRESHOLD override', async () => {
+      const { calls, fakeFetch } = captureFetch()
+      // score 0.02 is a hit at default floor (0.015) but a miss at 0.05.
+      const input: MissSignalInput = { query: 'q', resultCount: 1, topScore: 0.02 }
+      await emitMissSignal(input, onOpts({ fetch: fakeFetch, env: { PLUR_TELEMETRY: 'on', PLUR_MISS_SCORE_THRESHOLD: '0.05' } }))
+      expect(calls).toHaveLength(1)
+      expect(calls[0].body.reason).toBe('low_score')
+    })
+
+    it('never throws on transport failure — resolves false', async () => {
+      const throwingFetch = (async () => {
+        throw new Error('network down')
+      }) as unknown as typeof globalThis.fetch
+      const sent = await emitMissSignal(noResults, onOpts({ fetch: throwingFetch }))
+      expect(sent).toBe(false)
+    })
+
+    it('returns false when endpoint responds non-2xx', async () => {
+      const { fakeFetch } = captureFetch(false)
+      const sent = await emitMissSignal(noResults, onOpts({ fetch: fakeFetch }))
+      expect(sent).toBe(false)
+    })
+  })
+
+  it('DEFAULT_MISS_SCORE_THRESHOLD sits just under a single top-1 RRF hit (~0.0164)', () => {
+    expect(DEFAULT_MISS_SCORE_THRESHOLD).toBeLessThan(1 / 61)
+    expect(DEFAULT_MISS_SCORE_THRESHOLD).toBeGreaterThan(0)
+  })
+})

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -12,6 +12,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { Plur, checkForUpdate } from '@plur-ai/core'
 import { getToolDefinitions } from './tools.js'
+import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
 import { z } from 'zod'
 
@@ -357,6 +358,12 @@ Please:
 
 export async function runStdio(): Promise<void> {
   const server = await createServer()
+  // Opt-in, content-free telemetry: ship any pending daily counter snapshot on
+  // process exit (best-effort). Self-gates on telemetry opt-in — an opted-out
+  // install registers the handler but flushes nothing. Registered in runStdio,
+  // not createServer, so the per-test servers in the suite don't each attach a
+  // beforeExit handler.
+  registerFlushOnExit({})
   const transport = new StdioServerTransport()
   await server.connect(transport)
 }

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -1,0 +1,38 @@
+// Telemetry wiring for the MCP server.
+//
+// @plur-ai/mcp is the widest install surface, but historically emitted no
+// engagement counters — only @plur-ai/claw did. This module wires the SAME
+// opt-in, content-free counters into the MCP server by reusing the
+// implementation exported from @plur-ai/core (recordEvent / flushIfNeeded /
+// registerFlushOnExit). No vendored copy lives here — one implementation,
+// imported.
+//
+// Privacy guarantees are inherited unchanged from core:
+//   - Default-off. recordEvent self-gates on isTelemetryEnabled(); an opted-out
+//     install writes zero telemetry files and makes zero network calls.
+//   - Content-free. Only daily per-event counts + an opaque install UUID +
+//     version/platform/date are ever transmitted. No engram text, no query
+//     text. Opt out with PLUR_TELEMETRY=off.
+//
+// Call sites live in tools.ts (recordEvent at learn/recall) and server.ts
+// (registerFlushOnExit at startup). recordEvent returns true on a UTC-day
+// rollover; maybeFlushAfter ships yesterday's pending snapshot then.
+
+import { recordEvent, flushIfNeeded, registerFlushOnExit } from '@plur-ai/core'
+import type { CounterEvent } from '@plur-ai/core'
+
+export { registerFlushOnExit }
+
+/**
+ * Record an engagement counter event and, if recording rolled the UTC day,
+ * fire-and-forget the pending-snapshot flush. Mirrors claw's wiring. Never
+ * throws; an opted-out install is a no-op.
+ */
+export function recordTelemetry(event: CounterEvent): void {
+  try {
+    const rolledOver = recordEvent(event)
+    if (rolledOver) void flushIfNeeded({}).catch(() => {})
+  } catch {
+    // Telemetry must never disturb a tool call.
+  }
+}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig } from '@plur-ai/core'
 import type { LlmFunction, MetaField } from '@plur-ai/core'
+import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
 
 /** Create an OpenAI-compatible LLM function from a base URL + API key */
@@ -172,6 +173,8 @@ export function getToolDefinitions(): ToolDefinition[] {
           const engram = await plur.learnRouted(statement, context)
           const isOutbox = !!(engram as any).structured_data?._outbox
           mcpCanary.signal('learn_activity')
+          // Opt-in, content-free engagement counter (default-off; no statement text).
+          recordTelemetry('learn')
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type,
@@ -185,6 +188,8 @@ export function getToolDefinitions(): ToolDefinition[] {
           const engram = plur.learn(statement, context)
           const isOutbox = !!(engram as any).structured_data?._outbox
           mcpCanary.signal('learn_activity')
+          // Opt-in, content-free engagement counter (default-off; no statement text).
+          recordTelemetry('learn')
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type, decision: 'ADD',
@@ -256,6 +261,13 @@ export function getToolDefinitions(): ToolDefinition[] {
           domain: args.domain as string | undefined,
           limit: effectiveLimit,
         })
+        // Opt-in, content-free engagement counter (default-off; no query text).
+        recordTelemetry('recall')
+        // Failed-recall miss-signal (WS5 demand flywheel) is emitted from the
+        // core recallHybridWithMeta() this handler delegates to — it fires once
+        // there for ALL consumers (MCP, claw, CLI, direct API), so we do NOT
+        // re-emit here and double-count. It is opt-in/default-off and ships only
+        // a query fingerprint hash + scope/domain + timestamp, never raw text.
         const results = meta.engrams
         let truncated = false
         let boundedResults = results


### PR DESCRIPTION
Wires existing telemetry into @plur-ai/mcp (opt-in, content-free). Emits anonymized failed-recall miss-signal from core (feeds WS5 demand flywheel). Corrects stale docs (version/benchmark/tests). core 778 / mcp 113 / claw 103 pass.