### PR TITLE
fix(ci): stop flaky 5s test timeouts on cold embedder load (#311)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
     permissions:
       contents: read
     strategy:
+      # Don't let one node's failure cancel the other — we want the full signal
+      # from both Node versions, not a fail-fast cancellation (#311).
+      fail-fast: false
       matrix:
         node-version: [20, 22]
     steps:

--- a/packages/claw/vitest.config.ts
+++ b/packages/claw/vitest.config.ts
@@ -1,2 +1,5 @@
 import { defineConfig } from 'vitest/config'
-export default defineConfig({ test: { globals: true, exclude: ['**/openclaw-integration.test.mjs', '**/node_modules/**'] } })
+// testTimeout raised from the 5s default — same reason as core: the embedder
+// (reached transitively via @plur-ai/core) cold-loads lazily and can exceed 5s
+// under parallel suite import, causing flaky timeouts (#311).
+export default defineConfig({ test: { globals: true, testTimeout: 30000, hookTimeout: 30000, exclude: ['**/openclaw-integration.test.mjs', '**/node_modules/**'] } })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,2 +1,8 @@
 import { defineConfig } from 'vitest/config'
-export default defineConfig({ test: { globals: true } })
+// testTimeout raised from the 5s default: the BGE embedder (@huggingface/
+// transformers) cold-loads lazily on first use, and that one-time model init
+// can exceed 5s when several embedder-touching suites import in parallel under
+// `vitest run` — a slow-but-correct load, not a hang. The tight default caused
+// flaky CI timeouts (#311). hookTimeout matched so beforeAll/afterAll setup
+// that also triggers a cold load doesn't trip either.
+export default defineConfig({ test: { globals: true, testTimeout: 30000, hookTimeout: 30000 } })

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,2 +1,5 @@
 import { defineConfig } from 'vitest/config'
-export default defineConfig({ test: { globals: true } })
+// testTimeout raised from the 5s default — same reason as core: the embedder
+// (reached transitively via @plur-ai/core) cold-loads lazily and can exceed 5s
+// under parallel suite import, causing flaky timeouts (#311).
+export default defineConfig({ test: { globals: true, testTimeout: 30000, hookTimeout: 30000 } })


### PR DESCRIPTION
Fixes #311.

## Problem

CI was flaky-red on PRs (e.g. #310): `sp1-memory-intelligence > learnAsync … decides UPDATE` and `hybrid-search > returns results as a Promise` intermittently fail with `Test timed out in 5000ms`. The matrix fail-fast then cancels the healthy Node version, hiding the rest of the signal.

## Root cause

The BGE embedder (`@huggingface/transformers`) cold-loads lazily on first use. That one-time model init can exceed vitest's **5 s default `testTimeout`** when several embedder-touching suites import in parallel under a full `vitest run`. It's a slow-but-correct load, not a hang — evidence: the affected files pass in isolation in ~1.4 s, and only time out under parallel cold-load contention.

## Fix

- Raise `testTimeout`/`hookTimeout` to **30 s** in the `core`, `mcp`, and `claw` vitest configs, so a legitimately slow cold load isn't killed at 5 s.
- Set `fail-fast: false` on the CI matrix so one node's failure no longer cancels the other (full signal from both Node 20 and 22).

No production code changes — config only.

## Verification

Local full `pnpm test` (the condition that triggered the flake): the two previously-flaky tests now pass, and rerunning both files inside a full run is stable (51/51 in ~1.7 s). No timeouts.

> Note: `sync.test.ts` shows failures in my local macOS shell (git `no upstream`/`No such remote 'origin'`/identity in the tests' temp repos) — pre-existing and unrelated to this change (that file is untouched here); it passes in CI, which configures git identity and runs on Linux.

## Follow-ups (separate issues, non-blocking)
- #312 — miss-signal transmits scope/domain verbatim
- #313 — miss-signal endpoint doc drift
