### PR TITLE
fix(stores): config reload on external edits (#307) + token rotation (#305)

### DIFF
--- a/packages/cli/src/commands/stores.ts
+++ b/packages/cli/src/commands/stores.ts
@@ -20,7 +20,12 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       // local stores have path-only identity, so it may differ from the request.
       outputJson({ success: true, status: result.status, path, scope: result.scope })
     } else {
-      const verb = result.status === 'already_registered' ? 'Already registered' : result.status === 'overwritten' ? 'Reassigned' : 'Added'
+      const verb = {
+        already_registered: 'Already registered',
+        overwritten: 'Reassigned',
+        token_rotated: 'Rotated token for',
+        added: 'Added',
+      }[result.status] ?? 'Added'
       outputText(`${verb} store: ${path} (scope: ${result.scope})`)
     }
     return

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,6 +241,8 @@ export class Plur {
   private _llmFailureCount = 0
   private _llmDisabledUntil: number | null = null
   private _sessionScope: string | null = null
+  /** mtime (ms) of config.yaml at last load — drives reloadConfigIfChanged (#307). */
+  private configMtimeMs = 0
 
   constructor(options?: { path?: string }) {
     this.paths = detectPlurStorage(options?.path)
@@ -251,6 +253,7 @@ export class Plur {
     if (this.config.stores?.length !== loadConfig(this.paths.config).stores?.length) {
       this.config = loadConfig(this.paths.config)
     }
+    this.configMtimeMs = this.statConfigMtime()
     if (this.config.index) {
       this.indexedStorage = new IndexedStorage(this.paths.engrams, this.paths.db, this.config.stores)
     }
@@ -2391,11 +2394,54 @@ Generate an improved version of the procedure that prevents this failure. Return
    * requested one), or `overwritten` (same scope reassigned to this endpoint
    * via overwriteScope).
    */
+  /** mtime (ms) of config.yaml, or 0 if it cannot be stat'd. */
+  private statConfigMtime(): number {
+    try { return fs.statSync(this.paths.config).mtimeMs } catch { return 0 }
+  }
+
+  /**
+   * Reload this.config from disk if config.yaml changed since the last load (#307).
+   *
+   * The MCP server holds ONE long-lived Plur instance, so a store added by
+   * editing ~/.plur/config.yaml directly (or by another process) stays invisible
+   * until the server restarts — and nothing hints why. The stores operations call
+   * this first so a changed file is picked up on the next call instead of needing
+   * a restart. Cheap: one statSync, reload only on an actual mtime change.
+   *
+   * @returns true if the config was reloaded.
+   */
+  private reloadConfigIfChanged(): boolean {
+    const mtime = this.statConfigMtime()
+    if (mtime === 0 || mtime === this.configMtimeMs) return false
+    this.config = loadConfig(this.paths.config)
+    this.configMtimeMs = mtime
+    if (this.config.index) {
+      this.indexedStorage = new IndexedStorage(this.paths.engrams, this.paths.db, this.config.stores)
+    }
+    logger.info('[plur] Reloaded config.yaml (changed on disk since last load)')
+    return true
+  }
+
+  /** Persist a new stores list to config.yaml, preserving other keys, then
+   *  refresh the in-memory config + mtime. Shared by addStore's append and
+   *  token-rotation paths. */
+  private persistStores(stores: StoreEntry[]): void {
+    let configData: Record<string, unknown> = {}
+    try {
+      const raw = fs.readFileSync(this.paths.config, 'utf8')
+      if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
+    } catch {}
+    configData.stores = stores
+    fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
+    this.config = loadConfig(this.paths.config)
+    this.configMtimeMs = this.statConfigMtime()
+  }
+
   addStore(
     storePath: string,
     scope: string,
     options?: { shared?: boolean; readonly?: boolean; url?: string; token?: string; overwriteScope?: boolean },
-  ): { status: 'added' | 'already_registered' | 'overwritten'; scope: string } {
+  ): { status: 'added' | 'already_registered' | 'overwritten' | 'token_rotated'; scope: string } {
     const isRemote = Boolean(options?.url)
 
     // Validation gate (#93): catch malformed URLs and duplicate scopes at
@@ -2421,6 +2467,8 @@ Generate an improved version of the procedure that prevents this failure. Return
       throw new Error(`addStore: scope must be a non-empty string, got ${typeof scope}`)
     }
 
+    // Pick up any out-of-process config edit before we dedup/write (#307).
+    this.reloadConfigIfChanged()
     const config = loadConfig(this.paths.config)
 
     // Dedup (#291): for REMOTE stores the URL alone is NOT the identity — a
@@ -2436,7 +2484,22 @@ Generate an improved version of the procedure that prevents this failure. Return
       isRemote ? (s.url === options!.url && s.scope === scope)
                : (s.path === storePath),
     )
-    if (sameEntry) return { status: 'already_registered', scope: sameEntry.scope }
+    if (sameEntry) {
+      // Token rotation (#305): a matched remote endpoint with a NEW token means
+      // the server-side token was rotated/expired and the caller is re-supplying
+      // it. The old short-circuit returned 'already_registered' and silently kept
+      // the stale token — the only workaround was hand-editing config.yaml. Update
+      // the token in place instead.
+      if (isRemote && options?.token !== undefined && options.token !== sameEntry.token) {
+        const rotated = (config.stores ?? []).map(s =>
+          s === sameEntry ? { ...s, token: options.token } : s,
+        )
+        this.persistStores(rotated)
+        logger.info(`[plur:addStore] rotated token for ${options.url} (scope "${sameEntry.scope}")`)
+        return { status: 'token_rotated', scope: sameEntry.scope }
+      }
+      return { status: 'already_registered', scope: sameEntry.scope }
+    }
 
     // Different endpoint, same scope (#93): forbid by default to prevent
     // silent ambiguity ("which store does scope X belong to?"). Override
@@ -2471,14 +2534,7 @@ Generate an improved version of the procedure that prevents this failure. Return
     const stores = scopeConflict
       ? [...(config.stores ?? []).filter(s => s.scope !== scope), newEntry]
       : [...(config.stores ?? []), newEntry]
-    let configData: Record<string, unknown> = {}
-    try {
-      const raw = fs.readFileSync(this.paths.config, 'utf8')
-      if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
-    } catch {}
-    configData.stores = stores
-    fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
-    this.config = loadConfig(this.paths.config)
+    this.persistStores(stores)
     return { status: scopeConflict ? 'overwritten' : 'added', scope }
   }
 
@@ -2565,6 +2621,7 @@ Generate an improved version of the procedure that prevents this failure. Return
   listStores(): Array<{
     path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
   }> {
+    this.reloadConfigIfChanged()  // pick up out-of-process config edits (#307)
     const stores = this.config.stores ?? []
     const additional = stores.map(s => {
       let count = 0
@@ -2596,6 +2653,7 @@ Generate an improved version of the procedure that prevents this failure. Return
   async listStoresAsync(): Promise<Array<{
     path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
   }>> {
+    this.reloadConfigIfChanged()  // pick up out-of-process config edits (#307)
     const stores = this.config.stores ?? []
     const REMOTE_LOAD_TIMEOUT_MS = 5000
 

--- a/packages/core/test/store-validation.test.ts
+++ b/packages/core/test/store-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, utimesSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
@@ -179,14 +179,39 @@ describe('addStore validation (#93)', () => {
       })).toEqual({ status: 'overwritten', scope: 'group:plur/plur-ai/comms' })
     })
 
-    it('same URL + same scope + different token stays an idempotent no-op (no silent token swap)', () => {
-      plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'original' })
-      const result = plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'rotated' })
+    it('same URL + same scope + same token is an idempotent no-op (no spurious rotation)', () => {
+      plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'tok' })
+      const result = plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'tok' })
 
       expect(result).toEqual({ status: 'already_registered', scope: 'group:plur/plur-ai/engineering' })
       const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
       expect(config.stores).toHaveLength(1)
-      expect(config.stores[0].token).toBe('original')
+      expect(config.stores[0].token).toBe('tok')
+    })
+
+    it('same URL + same scope + NEW token rotates the token in place (#305)', () => {
+      plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'original' })
+      const result = plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'rotated' })
+
+      // Reported as a rotation (not 'already_registered', not silent) so the
+      // caller can see the token actually changed.
+      expect(result).toEqual({ status: 'token_rotated', scope: 'group:plur/plur-ai/engineering' })
+      const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+      expect(config.stores).toHaveLength(1)
+      expect(config.stores[0].token).toBe('rotated')
+    })
+
+    it('rotation leaves OTHER scopes on the same URL untouched (#305)', () => {
+      plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'eng-old' })
+      plur.addStore('', 'group:plur/plur-ai/comms', { url: URL, token: 'comms-tok' })
+
+      const result = plur.addStore('', 'group:plur/plur-ai/engineering', { url: URL, token: 'eng-new' })
+      expect(result.status).toBe('token_rotated')
+
+      const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+      const byScope = Object.fromEntries(config.stores.map((s: any) => [s.scope, s.token]))
+      expect(byScope['group:plur/plur-ai/engineering']).toBe('eng-new')
+      expect(byScope['group:plur/plur-ai/comms']).toBe('comms-tok')
     })
   })
 
@@ -229,6 +254,59 @@ describe('addStore validation (#93)', () => {
       const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
       expect(config.stores).toHaveLength(1)
       expect(config.stores[0].readonly).toBe(true)
+    })
+  })
+
+  /**
+   * Out-of-process config reload — closes plur-ai/plur#307.
+   *
+   * The MCP server holds one long-lived Plur instance and read config.yaml once
+   * at startup, so a store added by editing the file directly (a documented
+   * onboarding step) stayed invisible until a server restart, with no hint why.
+   * The stores operations now reload when the file's mtime changed.
+   */
+  describe('out-of-process config reload (#307)', () => {
+    const cfgPath = () => join(dir, 'config.yaml')
+
+    /** Simulate another process editing config.yaml, forcing a newer mtime so
+     *  the change is detectable regardless of filesystem clock granularity. */
+    function externallyEdit(mutate: (cfg: any) => void): void {
+      const cfg = (yaml.load(readFileSync(cfgPath(), 'utf8')) as any) ?? {}
+      mutate(cfg)
+      writeFileSync(cfgPath(), yaml.dump(cfg))
+      const future = new Date(Date.now() + 2000)
+      utimesSync(cfgPath(), future, future)
+    }
+
+    it('listStores picks up a store added by an external config edit (no restart)', () => {
+      plur.addStore('', 'group:a', { url: 'https://a.example.com', token: 'tok' })
+      expect(plur.listStores().map(s => s.scope)).toContain('group:a')
+      expect(plur.listStores().map(s => s.scope)).not.toContain('group:b')
+
+      externallyEdit(cfg => {
+        cfg.stores.push({ url: 'https://b.example.com', token: 'tok', scope: 'group:b', shared: true, readonly: false })
+      })
+
+      // Same instance, no restart — the externally-added store is now visible.
+      expect(plur.listStores().map(s => s.scope)).toContain('group:b')
+    })
+
+    it('listStoresAsync also reloads on an external edit', async () => {
+      plur.addStore('', 'group:a', { url: 'https://a.example.com', token: 'tok' })
+      externallyEdit(cfg => {
+        cfg.stores.push({ url: 'https://b.example.com', token: 'tok', scope: 'group:b', shared: true, readonly: false })
+      })
+
+      const scopes = (await plur.listStoresAsync()).map(s => s.scope)
+      expect(scopes).toContain('group:b')
+    })
+
+    it('does not reload when the file is unchanged (mtime stable)', () => {
+      plur.addStore('', 'group:a', { url: 'https://a.example.com', token: 'tok' })
+      const before = plur.listStores().length
+      // No edit — repeated calls are stable, no spurious reload churn.
+      expect(plur.listStores().length).toBe(before)
+      expect(plur.listStores().map(s => s.scope)).toContain('group:a')
     })
   })
 })


### PR DESCRIPTION
Closes #307, closes #305. Two enterprise remote-store onboarding bugs, both in the stores config path, fixed together.

## #307 — config changes invisible until MCP restart
The MCP server holds one long-lived `Plur` instance that read `config.yaml` once at startup. A store added by editing `~/.plur/config.yaml` directly (a documented onboarding step) stayed invisible until a server restart — and nothing hinted why. Hit during a real onboarding.

**Fix:** track the config file mtime (`configMtimeMs`) and reload `this.config` when it changed on disk. `reloadConfigIfChanged()` is called by `listStores`, `listStoresAsync`, and `addStore` (cheap: one `statSync`, reload only on an actual mtime change; rebuilds the index if `config.index` is set).

## #305 — cannot rotate a token for an existing URL+scope
`addStore()` matched an existing `url+scope` and returned `already_registered` **before** any token check, silently keeping the stale token. A server-side-rotated token could never be updated through the normal path — the only workaround was hand-editing `config.yaml`.

**Fix:** when a matched remote endpoint is re-supplied with a **different** token, rotate it in place and return a new status `token_rotated` — reported and logged, *not* silent (addresses the original "no silent token swap" safety concern while enabling rotation). Same token stays an idempotent no-op; other scopes on the same URL are untouched.

Also: extracted the config write into a `persistStores()` helper shared by the append and rotation paths; CLI `stores add` prints `Rotated token for …` on rotation; MCP `plur_stores_add` surfaces `status` (already wired on main).

## Tests
6 new in `packages/core/test/store-validation.test.ts`:
- token rotation updates the token + returns `token_rotated`
- same token → no spurious rotation (idempotent)
- rotation leaves other scopes on the same URL untouched
- `listStores` / `listStoresAsync` pick up an external config edit with no restart
- mtime-stable → no reload churn

`pnpm --filter @plur-ai/core test` → 1114 passed. The 5 `sync.test.ts` failures are a pre-existing git-commit environment issue (reproduces on a clean `origin/main`), unrelated to this change.