### PR TITLE
fix(packs): require SKILL.md; unify §5.5 pack-hash on it (#316)

### DIFF
--- a/packages/cli/test/packs.test.ts
+++ b/packages/cli/test/packs.test.ts
@@ -39,7 +39,8 @@ describe('plur packs', () => {
     // Create a minimal pack directory with valid engrams
     const packDir = mkdtempSync(join(tmpdir(), 'test-pack-'))
     try {
-      writeFileSync(join(packDir, 'manifest.yaml'), 'name: test-pack\nversion: 1.0.0\n')
+      // A knowledge pack must ship a SKILL.md (manifest as YAML frontmatter) — #316.
+      writeFileSync(join(packDir, 'SKILL.md'), '---\nname: test-pack\nversion: 1.0.0\n---\n\n# Test Pack\n')
       // Write a valid engram YAML — loadEngrams expects { engrams: [...] }
       const engramYaml = [
         'engrams:',

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -44,17 +44,15 @@ function parseSkillMdFrontmatter(filePath: string): Record<string, any> {
 
 export function loadPack(packDir: string): LoadedPack {
   const skillMdPath = `${packDir}/SKILL.md`
-  const manifestYamlPath = `${packDir}/manifest.yaml`
   const engramsPath = `${packDir}/engrams.yaml`
 
-  let rawManifest: Record<string, any>
-  if (fs.existsSync(skillMdPath)) {
-    rawManifest = parseSkillMdFrontmatter(skillMdPath)
-  } else if (fs.existsSync(manifestYamlPath)) {
-    rawManifest = yaml.load(fs.readFileSync(manifestYamlPath, 'utf8')) as Record<string, any>
-  } else {
-    throw new Error(`No SKILL.md or manifest.yaml found in ${packDir}`)
+  // Knowledge packs MUST ship a SKILL.md; manifest.yaml is not a substitute (#316).
+  if (!fs.existsSync(skillMdPath)) {
+    throw new Error(
+      `No SKILL.md found in ${packDir} — a knowledge pack must ship a SKILL.md (manifest.yaml is not a substitute)`,
+    )
   }
+  const rawManifest = parseSkillMdFrontmatter(skillMdPath)
 
   const manifest = PackManifestSchema.parse(rawManifest)
   const engrams = loadEngrams(engramsPath)
@@ -67,7 +65,7 @@ export function loadAllPacks(packsDir: string): LoadedPack[] {
   for (const entry of fs.readdirSync(packsDir)) {
     const packDir = `${packsDir}/${entry}`
     if (!fs.statSync(packDir).isDirectory()) continue
-    if (!fs.existsSync(`${packDir}/SKILL.md`) && !fs.existsSync(`${packDir}/manifest.yaml`)) continue
+    if (!fs.existsSync(`${packDir}/SKILL.md`)) continue  // SKILL.md is mandatory (#316)
     try {
       packs.push(loadPack(packDir))
     } catch (err) {

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -524,20 +524,23 @@ export function exportPack(
 // --- Integrity ---
 
 /**
- * Compute SHA256 hash of pack contents (SKILL.md + engrams.yaml).
- * Deterministic — same content always produces same hash.
- * Can be used as a content-addressable identifier (like Swarm hash).
+ * Compute SHA256 hash of pack contents per ENGRAM-STANDARD-v1.md §5.5:
+ *   H = SHA256( bytes(SKILL.md) || bytes(engrams.yaml) )
+ * Deterministic — same content always produces same hash. Can be used as a
+ * content-addressable identifier (like a Swarm hash).
+ *
+ * Knowledge packs MUST ship a SKILL.md; `manifest.yaml` is NOT a substitute and
+ * does not contribute to the hash (#316). loadPack/installPack reject a pack
+ * without a SKILL.md, so in practice the SKILL.md is always present here; an
+ * absent one simply contributes nothing rather than falling back to manifest.yaml.
  */
 export function computePackHash(packDir: string): string {
   const hash = crypto.createHash('sha256')
 
-  // Hash manifest
+  // Hash the SKILL.md (the mandatory manifest). No manifest.yaml fallback.
   const skillMd = path.join(packDir, 'SKILL.md')
-  const manifestYaml = path.join(packDir, 'manifest.yaml')
   if (fs.existsSync(skillMd)) {
     hash.update(fs.readFileSync(skillMd))
-  } else if (fs.existsSync(manifestYaml)) {
-    hash.update(fs.readFileSync(manifestYaml))
   }
 
   // Hash engrams

--- a/packages/core/src/trust.ts
+++ b/packages/core/src/trust.ts
@@ -1,19 +1,28 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import * as crypto from 'crypto'
+import { computePackHash } from './packs.js'
 
+/**
+ * Pack integrity checksum per ENGRAM-STANDARD-v1.md §5.5:
+ *
+ *   H = SHA256( bytes(SKILL.md) || bytes(engrams.yaml) )
+ *
+ * Delegates to {@link computePackHash} so there is a SINGLE §5.5 hashing
+ * implementation (#316). Knowledge packs MUST ship a SKILL.md; there is no
+ * `manifest.yaml` fallback (the divergence this once had — a manifest-only pack
+ * hashing only `engrams.yaml` — is gone because manifest-only packs are rejected
+ * by loadPack and not hashed against manifest.yaml here).
+ *
+ * Keeps the `null`-on-empty contract: a directory with neither a SKILL.md nor an
+ * `engrams.yaml` has no content to attest, so verification callers get `null`
+ * rather than the hash of an empty input.
+ */
 export function computePackChecksum(packDir: string): string | null {
-  const files = ['SKILL.md', 'engrams.yaml']
-  const hash = crypto.createHash('sha256')
-  let hasContent = false
-  for (const file of files) {
-    const filePath = path.join(packDir, file)
-    if (fs.existsSync(filePath)) {
-      hash.update(fs.readFileSync(filePath))
-      hasContent = true
-    }
-  }
-  return hasContent ? hash.digest('hex') : null
+  const hasContent =
+    fs.existsSync(path.join(packDir, 'SKILL.md')) ||
+    fs.existsSync(path.join(packDir, 'engrams.yaml'))
+  if (!hasContent) return null
+  return computePackHash(packDir)
 }
 
 export function verifyPackChecksum(packDir: string, expected: string): { valid: boolean; actual: string | null } {

--- a/packages/core/test/pack-hash-reconcile.test.ts
+++ b/packages/core/test/pack-hash-reconcile.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import * as crypto from 'crypto'
+import { computePackHash } from '../src/packs.js'
+import { computePackChecksum, verifyPackChecksum } from '../src/trust.js'
+import { loadPack } from '../src/engrams.js'
+
+/**
+ * Single §5.5 hashing implementation + mandatory SKILL.md — closes #316 (#319).
+ *
+ * ENGRAM-STANDARD-v1.md §5.5:  H = SHA256( bytes(SKILL.md) || bytes(engrams.yaml) )
+ *
+ * Knowledge packs MUST ship a SKILL.md; manifest.yaml is not a substitute. The
+ * two hash helpers (computePackHash in packs.ts, computePackChecksum in trust.ts)
+ * compute the identical hash — computePackChecksum delegates to computePackHash —
+ * so they cannot diverge, and a manifest.yaml never enters the hash.
+ */
+describe('pack hash + mandatory SKILL.md (#316/#319)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-packhash-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  /** SHA256 over the raw concatenation of the given file byte-strings. */
+  const sha256 = (...parts: string[]) => {
+    const h = crypto.createHash('sha256')
+    for (const p of parts) h.update(Buffer.from(p))
+    return h.digest('hex')
+  }
+
+  it('SKILL.md pack: checksum equals the hash (single implementation)', () => {
+    writeFileSync(join(dir, 'SKILL.md'), '# Skill\nbody\n')
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+
+    expect(computePackChecksum(dir)).toBe(computePackHash(dir))
+  })
+
+  it('hashes SKILL.md + engrams.yaml over raw bytes (no re-serialization)', () => {
+    const skill = '# Skill\nbody\n'
+    const engrams = 'engrams: []\n'
+    writeFileSync(join(dir, 'SKILL.md'), skill)
+    writeFileSync(join(dir, 'engrams.yaml'), engrams)
+
+    expect(computePackChecksum(dir)).toBe(sha256(skill, engrams))
+  })
+
+  it('manifest.yaml does NOT contribute to the hash', () => {
+    const skill = '# Skill\nbody\n'
+    const engrams = 'engrams: []\n'
+    writeFileSync(join(dir, 'SKILL.md'), skill)
+    writeFileSync(join(dir, 'engrams.yaml'), engrams)
+    const withoutManifest = computePackHash(dir)
+
+    // Adding a manifest.yaml must not change the hash — only SKILL.md + engrams count.
+    writeFileSync(join(dir, 'manifest.yaml'), 'name: ignored\nversion: 9\n')
+    expect(computePackHash(dir)).toBe(withoutManifest)
+    expect(computePackChecksum(dir)).toBe(withoutManifest)
+  })
+
+  it('SKILL.md only (no engrams) still hashes deterministically', () => {
+    const skill = '# Skill only\n'
+    writeFileSync(join(dir, 'SKILL.md'), skill)
+    expect(computePackChecksum(dir)).toBe(sha256(skill))
+    expect(computePackChecksum(dir)).toBe(computePackHash(dir))
+  })
+
+  it('empty pack dir (no SKILL.md, no engrams): checksum is null (contract preserved)', () => {
+    expect(computePackChecksum(dir)).toBeNull()
+  })
+
+  it('loadPack REJECTS a manifest-only pack (SKILL.md is mandatory)', () => {
+    // A manifest.yaml without a SKILL.md used to load; it must now be rejected.
+    writeFileSync(join(dir, 'manifest.yaml'), 'name: demo\nversion: 1\n')
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+    expect(() => loadPack(dir)).toThrow(/must ship a SKILL\.md/i)
+  })
+
+  it('verifyPackChecksum: valid against its own checksum, invalid otherwise', () => {
+    writeFileSync(join(dir, 'SKILL.md'), '# Skill\n')
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+
+    const checksum = computePackChecksum(dir)!
+    expect(verifyPackChecksum(dir, checksum)).toEqual({ valid: true, actual: checksum })
+    expect(verifyPackChecksum(dir, 'sha256:wrong')).toEqual({ valid: false, actual: checksum })
+  })
+})

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -43,8 +43,8 @@ inner item is labelled otherwise.
    invariants of a single unit of knowledge.
 2. **The ID grammar** (§3) — how engram identifiers are formed and what their
    prefixes mean.
-3. **The Pack format** (§5) — the on-disk directory layout (`SKILL.md` /
-   `manifest.yaml` + `engrams.yaml` + `INTEGRITY`) and the manifest fields.
+3. **The Pack format** (§5) — the on-disk directory layout (`SKILL.md` +
+   `engrams.yaml` + `INTEGRITY`) and the manifest fields.
 4. **The `.plur` capsule** (§6) — the binary single-file envelope: header,
    format version, flags, payload, checksum.
 5. **The integrity model** (§6, §8) — how a receiver verifies that a pack or
@@ -391,15 +391,16 @@ an integrity file.
 
 ```
 <pack-name>/
-├── SKILL.md          (manifest as YAML frontmatter) — OR — manifest.yaml
+├── SKILL.md          (REQUIRED — manifest as YAML frontmatter)
 ├── engrams.yaml      (the engrams, top-level `engrams:` sequence)
 └── INTEGRITY         (pack content hash; see §5.5)
 ```
 
-- The manifest MAY be carried as the **YAML frontmatter of `SKILL.md`**
-  (delimited by `---` … `---`, with human-readable prose after it) OR as a
-  standalone **`manifest.yaml`**. If both exist, `SKILL.md` takes precedence (the
-  reference loader prefers it).
+- A pack **MUST** ship a `SKILL.md`. The manifest is carried as its **YAML
+  frontmatter** (delimited by `---` … `---`, with human-readable prose after it).
+  A standalone `manifest.yaml` is **not** an accepted substitute: the reference
+  loader rejects a pack without a `SKILL.md`, and a `manifest.yaml` does not
+  contribute to the integrity hash (§5.5).
 - `engrams.yaml` is a §2.1 store document.
 - `INTEGRITY` is OPTIONAL on disk but RECOMMENDED for distribution; the
   authoritative integrity record at install time is the registry entry (§5.5).
@@ -471,15 +472,15 @@ the recipient builds their own usage history. (This mirrors the reference
 
 ### 5.5 Pack integrity — STABLE
 
-Pack integrity is a **SHA-256** over the pack's manifest file followed by its
+Pack integrity is a **SHA-256** over the pack's `SKILL.md` followed by its
 engrams file:
 
 ```
-H = SHA256( bytes(SKILL.md or manifest.yaml)  ||  bytes(engrams.yaml) )
+H = SHA256( bytes(SKILL.md)  ||  bytes(engrams.yaml) )
 ```
 
-- If `SKILL.md` exists it is hashed; else `manifest.yaml`; the two are not
-  combined. `engrams.yaml` bytes are appended if present.
+- `SKILL.md` is REQUIRED (§5.1) and is always hashed; `engrams.yaml` bytes are
+  appended if present. A `manifest.yaml`, if any, does **not** contribute to `H`.
 - The hash is recorded as the string `sha256:<64-lowercase-hex>` — in the
   `INTEGRITY` file (single line, trailing newline) and/or in the consumer's
   install registry.
@@ -487,14 +488,12 @@ H = SHA256( bytes(SKILL.md or manifest.yaml)  ||  bytes(engrams.yaml) )
   to the recorded `sha256:` value. Mismatch MUST be treated as a failed
   integrity check.
 
-> **Interop note.** The reference contains two hash helpers with the same SHA-256
-> construction over the same two logical files: `computePackHash` in `packs.ts`
-> (used for the registry/`INTEGRITY`, manifest-precedence as above) and
-> `computePackChecksum` in `trust.ts` (always `SKILL.md` then `engrams.yaml`).
-> They agree whenever the pack uses `SKILL.md`. A conformant v1 implementation
-> MUST use the §5.5 construction (manifest-file precedence: `SKILL.md`, else
-> `manifest.yaml`). Hashing is over **raw file bytes**, so producers and
-> consumers MUST NOT re-serialize before hashing.
+> **Implementation note.** The reference exposes a single §5.5 construction:
+> `computePackHash` (`packs.ts`, used for the registry/`INTEGRITY`) and
+> `computePackChecksum` (`trust.ts`, used for trust verification) compute the
+> identical hash — `computePackChecksum` delegates to `computePackHash` — so they
+> cannot diverge. Hashing is over **raw file bytes**, so producers and consumers
+> MUST NOT re-serialize before hashing.
 
 ---
 
@@ -558,7 +557,7 @@ The header is a JSON object (`schema: "plur.capsule/1"`):
 ### 6.5 Payload
 
 The payload is opaque bytes — typically a **gzip-compressed tar** of a pack
-directory (`SKILL.md`/`manifest.yaml` + `engrams.yaml`). The capsule format does
+directory (`SKILL.md` + `engrams.yaml`). The capsule format does
 not constrain the internal payload structure beyond what `product_type` implies;
 unpacking yields a §5 pack.
 
@@ -653,7 +652,7 @@ Integrity (the payload is intact and unmodified) is **separate** from
 authenticity (who produced it). v1 delivers integrity; authenticity is §7.
 
 - **Hash:** SHA-256.
-- **Pack integrity:** §5.5 — `sha256:` over manifest-file bytes ‖ `engrams.yaml`
+- **Pack integrity:** §5.5 — `sha256:` over `SKILL.md` bytes ‖ `engrams.yaml`
   bytes, recorded in `INTEGRITY` / registry.
 - **Capsule integrity:** §6.4/§6.7 step 10 — `header.payload.sha256` over the
   payload bytes, checked on every read; plus the structural checks (magic,


### PR DESCRIPTION
Closes #316. **Reworked per @plur9's review** — reconciles the hash-helper divergence in the mandatory-`SKILL.md` direction instead of cementing the `manifest.yaml` fallback.

## Problem
`computePackHash` (`packs.ts`) and `computePackChecksum` (`trust.ts`) diverged for a manifest-only pack. The first version of this PR fixed that by standardizing both on the permissive §5.5 rule (`SKILL.md OR manifest.yaml`). Per the pack policy — **knowledge packs MUST ship a `SKILL.md`; `manifest.yaml` is not a substitute** — that was the wrong direction (it made the manifest-only path a first-class hashed citizen).

## Approach (this version)
Drop the `manifest.yaml` fallback everywhere, which makes the two helpers trivially identical and removes the path that could diverge:

- **`packs.ts` `computePackHash`** — hash `SKILL.md` + `engrams.yaml`; no `manifest.yaml` fallback.
- **`engrams.ts` `loadPack`** — throw a clear error when `SKILL.md` is missing; `loadAllPacks` discovery requires `SKILL.md`.
- **`trust.ts` `computePackChecksum`** — delegates to `computePackHash` (single implementation); `null`-on-empty keyed on `SKILL.md`/`engrams.yaml`.
- **`spec/ENGRAM-STANDARD-v1.md` §5.1/§5.5** — `SKILL.md` is REQUIRED; `H = SHA256(SKILL.md ‖ engrams.yaml)`; the interop note now states the helpers are unified (closing the spec-vs-impl gap in lockstep, not after).

This subsumes the #316 divergence fix *and* enforces the policy.

## Breaking change
A manifest-only pack (no `SKILL.md`) no longer loads — `loadPack` throws a clear, actionable error. **No in-repo pack is affected**: the bundled `effective-memory` pack ships a `SKILL.md`, and its integrity hash is unchanged (the hash never included `manifest.yaml` for SKILL-bearing packs). External/third-party manifest-only packs would need a `SKILL.md` added.

## Tests
`pack-hash-reconcile.test.ts` rewritten for the new model: checksum == hash, raw-byte construction, `manifest.yaml` does **not** contribute to the hash, `loadPack` rejects a manifest-only pack, `null`-on-empty, verify round-trip. Core suite green apart from the pre-existing `sync.test.ts` git-env failures; mcp builds + tests pass (124).