### PR TITLE
feat(spec): generate JSON Schemas from Zod source of truth (#315)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,13 @@ jobs:
       - run: git config --global user.email "ci@plur.ai"
       - run: git config --global user.name "PLUR CI"
       - run: pnpm build
+      # Spec JSON Schemas are generated from the Zod source of truth (#315).
+      # Regenerate and fail if the committed spec/*.json drifted.
+      - name: Check spec schemas are in sync with Zod
+        run: |
+          pnpm --filter @plur-ai/core gen:schemas
+          git diff --exit-code spec/ || {
+            echo "::error::spec/*.json is out of sync with the Zod schemas. Run 'pnpm --filter @plur-ai/core gen:schemas' and commit."
+            exit 1
+          }
       - run: pnpm test

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "vitest run"
+    "test": "vitest run",
+    "gen:schemas": "tsx scripts/gen-spec-schemas.ts"
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
@@ -22,7 +23,9 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
     "@types/js-yaml": "^4.0.0",
-    "@types/node": "^25.5.0"
+    "@types/node": "^25.5.0",
+    "tsx": "^4.22.4",
+    "zod-to-json-schema": "^3.25.2"
   },
   "license": "Apache-2.0",
   "description": "Shared memory engine for AI agents — learn, recall, forget, feedback",

--- a/packages/core/scripts/gen-spec-schemas.ts
+++ b/packages/core/scripts/gen-spec-schemas.ts
@@ -1,0 +1,116 @@
+/**
+ * Generate the Open Engram Standard JSON Schemas from the Zod source of truth
+ * (#315). Closes the spec-drift gap: spec/engram.schema.json and
+ * spec/pack-manifest.schema.json are emitted from packages/core/src/schemas/*,
+ * so a field added to Zod can never silently go missing from the shipped spec.
+ *
+ *   pnpm --filter @plur-ai/core gen:schemas    # rewrite the spec/*.json files
+ *
+ * CI runs `gen:schemas` then `git diff --exit-code spec/` (see ci.yml), and
+ * spec-schema-drift.test.ts asserts committed === generated in `pnpm test`.
+ *
+ * The build* functions are pure (Zod -> object); only main() touches disk, so
+ * the drift test can import and compare without writing.
+ *
+ * Intentional, documented divergences from a naive zodToJsonSchema dump
+ * (kept here, not in the Zod source, because they are spec policy not data shape):
+ *   - root `additionalProperties: true` — the engram/manifest open-world rule
+ *     (EngramSchemaPassthrough); unknown top-level fields are preserved, not rejected.
+ *   - `activation.default.last_accessed` blanked to "" — the Zod default uses
+ *     `new Date()` (a runtime value); baking today's date into the spec would make
+ *     generation non-deterministic and churn the file daily.
+ *   - $schema/$id/title/top-level description — spec identity, injected here.
+ * Zod `.refine()` rules (DualCoding "at least one of", insight promote-requires-
+ * grounding) are NOT representable in JSON Schema and are intentionally omitted;
+ * they remain enforced at runtime by Zod.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+import { EngramSchema } from '../src/schemas/engram.js'
+import { PackManifestSchema } from '../src/schemas/pack.js'
+
+const DRAFT = 'https://json-schema.org/draft/2020-12/schema'
+
+// Repo root is three levels up from packages/core/scripts/.
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..')
+export const ENGRAM_SCHEMA_PATH = path.join(REPO_ROOT, 'spec', 'engram.schema.json')
+export const PACK_SCHEMA_PATH = path.join(REPO_ROOT, 'spec', 'pack-manifest.schema.json')
+
+type JsonObject = Record<string, unknown>
+
+/** Run zodToJsonSchema with the standard options and apply the shared
+ *  spec-header + open-world post-processing. */
+function generate(schema: Parameters<typeof zodToJsonSchema>[0], identity: {
+  $id: string; title: string; description: string
+}): JsonObject {
+  const raw = zodToJsonSchema(schema, {
+    $refStrategy: 'root',
+    definitionPath: '$defs',
+    target: 'jsonSchema7',
+  }) as JsonObject
+  delete raw.$schema // re-added below, pinned to 2020-12
+
+  // Open-world rule: the top-level object preserves unknown fields.
+  raw.additionalProperties = true
+
+  // Stable, readable key order with the spec identity first.
+  return {
+    $schema: DRAFT,
+    $id: identity.$id,
+    title: identity.title,
+    description: identity.description,
+    ...raw,
+  }
+}
+
+export function buildEngramSchema(): JsonObject {
+  const schema = generate(EngramSchema, {
+    $id: 'https://plur.ai/spec/v1/engram.schema.json',
+    title: 'Engram',
+    description:
+      'An engram is the atomic unit of learned knowledge in the Open Engram Standard v1. ' +
+      'Generated from the Zod EngramSchema in @plur-ai/core (packages/core/src/schemas/engram.ts) ' +
+      'by packages/core/scripts/gen-spec-schemas.ts — do not edit by hand. ' +
+      'See ENGRAM-STANDARD-v1.md for normative semantics.',
+  })
+
+  // Blank the runtime `new Date()` default so generation is deterministic.
+  const activation = (schema.properties as JsonObject | undefined)?.activation as JsonObject | undefined
+  const actDefault = activation?.default as JsonObject | undefined
+  if (actDefault && typeof actDefault.last_accessed === 'string') {
+    actDefault.last_accessed = ''
+  }
+  return schema
+}
+
+export function buildPackManifestSchema(): JsonObject {
+  return generate(PackManifestSchema, {
+    $id: 'https://plur.ai/spec/v1/pack-manifest.schema.json',
+    title: 'PackManifest',
+    description:
+      'Manifest for an engram pack in the Open Engram Standard v1. ' +
+      'Generated from the Zod PackManifestSchema in @plur-ai/core (packages/core/src/schemas/pack.ts) ' +
+      'by packages/core/scripts/gen-spec-schemas.ts — do not edit by hand. ' +
+      'In on-disk packs this object is the YAML frontmatter of SKILL.md, or a standalone manifest.yaml. ' +
+      'See ENGRAM-STANDARD-v1.md §5.',
+  })
+}
+
+/** Canonical serialization: 2-space indent, trailing newline. */
+export function serialize(schema: JsonObject): string {
+  return JSON.stringify(schema, null, 2) + '\n'
+}
+
+function main(): void {
+  fs.writeFileSync(ENGRAM_SCHEMA_PATH, serialize(buildEngramSchema()))
+  fs.writeFileSync(PACK_SCHEMA_PATH, serialize(buildPackManifestSchema()))
+  console.log(`Wrote ${path.relative(REPO_ROOT, ENGRAM_SCHEMA_PATH)} and ${path.relative(REPO_ROOT, PACK_SCHEMA_PATH)}`)
+}
+
+// Only write when run as a CLI, not when imported by the drift test.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main()
+}

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -6,16 +6,17 @@ export const ActivationSchema = z.object({
   retrieval_strength: z.number().min(0).max(1),
   storage_strength: z.number().min(0).max(1),
   frequency: z.number().int().min(0),
-  last_accessed: z.string(),
-})
+  last_accessed: z.string().describe('Date or ISO 8601 timestamp of last access.'),
+}).describe('ACT-R activation parameters driving decay and ranking. STABLE.')
 
 export const KnowledgeTypeSchema = z.object({
   memory_class: z.enum(['semantic', 'episodic', 'procedural', 'metacognitive']),
-  cognitive_level: z.enum(['remember', 'understand', 'apply', 'analyze', 'evaluate', 'create']),
+  cognitive_level: z.enum(['remember', 'understand', 'apply', 'analyze', 'evaluate', 'create'])
+    .describe("Bloom's taxonomy level."),
 })
 
 export const KnowledgeAnchorSchema = z.object({
-  path: z.string(),
+  path: z.string().describe('Path to a grounding document/file.'),
   relevance: z.enum(['primary', 'supporting', 'example']).default('supporting'),
   snippet: z.string().max(200).optional(),
   snippet_extracted_at: z.string().optional(),
@@ -23,7 +24,7 @@ export const KnowledgeAnchorSchema = z.object({
 
 export const AssociationSchema = z.object({
   target_type: z.enum(['engram', 'document']),
-  target: z.string(),
+  target: z.string().describe('ID or path of the association target.'),
   strength: z.number().min(0).max(0.95),
   type: z.enum(['semantic', 'temporal', 'causal', 'co_accessed']),
   updated_at: z.string().optional(),
@@ -32,7 +33,7 @@ export const AssociationSchema = z.object({
 export const DualCodingSchema = z.object({
   example: z.string().optional(),
   analogy: z.string().optional(),
-}).refine(
+}).describe('Worked example and/or analogy (dual coding). At least one of example or analogy MUST be provided (enforced at runtime by the Zod .refine below).').refine(
   d => d.example || d.analogy,
   'At least one of example or analogy must be provided'
 )
@@ -42,14 +43,15 @@ export const RelationsSchema = z.object({
   narrower: z.array(z.string()).default([]),
   related: z.array(z.string()).default([]),
   conflicts: z.array(z.string()).default([]),
-})
+}).describe('Typed graph edges between engram IDs.')
 
 export const ProvenanceSchema = z.object({
   origin: z.string(),
   chain: z.array(z.string()).default([]),
-  signature: z.string().nullable().default(null),
+  signature: z.string().nullable().default(null)
+    .describe('RESERVED. Detached signature over the engram. Algorithm and canonicalization not yet specified — see ENGRAM-STANDARD-v1.md §7.'),
   license: z.string().default('cc-by-sa-4.0'),
-})
+}).describe('Origin and signing chain. STABLE for origin/chain/license; signature is RESERVED (see ENGRAM-STANDARD-v1.md §7).')
 
 export const FeedbackSignalsSchema = z.object({
   positive: z.number().int().default(0),
@@ -76,7 +78,7 @@ export const TemporalSchema = z.object({
   valid_from: z.string().optional(),
   valid_until: z.string().optional(),
   ingested_at: z.string().optional(),
-})
+}).describe('Bi-temporal anchoring (Zep-inspired). When is this knowledge true?')
 
 // === NEW: Usage tracking (Softmax Engram-inspired hit/miss) ===
 
@@ -184,31 +186,37 @@ export const InsightFieldSchema = z.object({
 
 export const EngramSchema = z.object({
   // Identity
-  id: z.string().regex(/^(ENG|ABS|META)-[A-Za-z0-9-]+$/),
-  version: z.number().int().min(1).default(2),
-  status: z.enum(['active', 'dormant', 'retired', 'candidate']),
-  consolidated: z.boolean().default(false),
-  type: z.enum(['behavioral', 'terminological', 'procedural', 'architectural']),
-  scope: z.string(),
-  visibility: z.enum(['private', 'public', 'template']).default('private'),
+  id: z.string().regex(/^(ENG|ABS|META)-[A-Za-z0-9-]+$/)
+    .describe('Unique identifier. Class prefix ENG (concrete engram), ABS (abstraction), or META (meta-engram). Canonical concrete form: ENG-YYYY-MMDD-NNN; store-namespaced form: ENG-{PREFIX}-YYYY-MMDD-NNN.'),
+  version: z.number().int().min(1).default(2)
+    .describe('Schema-shape generation of this engram object (currently 2). Distinct from engram_version, which tracks content evolution.'),
+  status: z.enum(['active', 'dormant', 'retired', 'candidate']).describe('Lifecycle state.'),
+  consolidated: z.boolean().default(false)
+    .describe('Whether this engram has been through consolidation (sleep-like batch reprocessing).'),
+  type: z.enum(['behavioral', 'terminological', 'procedural', 'architectural'])
+    .describe('Top-level classification of the knowledge.'),
+  scope: z.string()
+    .describe("Hierarchical namespace, e.g. 'global', 'project:my-app', 'group:plur/test'. Free-form string; ':' separates scope kind from path."),
+  visibility: z.enum(['private', 'public', 'template']).default('private')
+    .describe("Sharing posture. 'private' engrams MUST NOT be exported in packs."),
 
   // Content
-  statement: z.string().min(1),
-  rationale: z.string().optional(),
-  contraindications: z.array(z.string()).optional(),
+  statement: z.string().min(1).describe('The assertion itself — the load-bearing content of the engram.'),
+  rationale: z.string().optional().describe('Why this is true / why it matters.'),
+  contraindications: z.array(z.string()).optional().describe('Conditions under which the statement does NOT apply.'),
 
   // Lineage
-  source: z.string().optional(),
-  source_patterns: z.array(z.string()).optional(),
-  derivation_count: z.number().int().min(0).default(1),
-  pack: z.string().nullable().default(null),
-  abstract: z.string().nullable().default(null),
-  derived_from: z.string().nullable().default(null),
+  source: z.string().optional().describe('Free-text origin (session, document, conversation).'),
+  source_patterns: z.array(z.string()).optional().describe('Pattern IDs that contributed to this engram.'),
+  derivation_count: z.number().int().min(0).default(1).describe('How many derivation steps produced this engram.'),
+  pack: z.string().nullable().default(null).describe('Name of the pack this engram belongs to, or null.'),
+  abstract: z.string().nullable().default(null).describe('ID of an ABS- abstraction this engram instantiates, or null.'),
+  derived_from: z.string().nullable().default(null).describe('ID of the engram this was derived from, or null.'),
 
   // Classification
   knowledge_type: KnowledgeTypeSchema.optional(),
-  domain: z.string().optional(),
-  tags: z.array(z.string()).default([]),
+  domain: z.string().optional().describe("Dotted domain path, e.g. 'dev/testing' or 'plur.session'."),
+  tags: z.array(z.string()).default([]).describe('Free-form tags used for matching and retrieval.'),
 
   // Activation (ACT-R model)
   activation: ActivationSchema.default({
@@ -233,7 +241,8 @@ export const EngramSchema = z.object({
   // === NEW OPTIONAL FIELDS (v2.1) ===
 
   /** Typed entity references extracted from statement. Enables graph queries. */
-  entities: z.array(EntityRefSchema).optional(),
+  entities: z.array(EntityRefSchema).optional()
+    .describe('Typed entity references extracted from statement. Enables graph queries.'),
 
   /** Temporal validity window. When is this knowledge true? */
   temporal: TemporalSchema.optional(),
@@ -248,7 +257,8 @@ export const EngramSchema = z.object({
   exchange: ExchangeMetadataSchema.optional(),
 
   /** Extensible key-value data for domain-specific fields. */
-  structured_data: z.record(z.string(), z.unknown()).optional(),
+  structured_data: z.record(z.string(), z.unknown()).optional()
+    .describe('Extensible key-value data for domain-specific fields.'),
 
   /** Memory-stream insight provenance (metacognition Phase 1). Orthogonal to
    *  `type`. Present iff this engram was synthesized by the metacognition memory
@@ -256,26 +266,29 @@ export const EngramSchema = z.object({
   insight: InsightFieldSchema.optional(),
 
   /** Polarity classification: 'do' for directives, 'dont' for prohibitions, null for unclassified. */
-  polarity: z.enum(['do', 'dont']).nullable().default(null),
+  polarity: z.enum(['do', 'dont']).nullable().default(null)
+    .describe("'do' for directives, 'dont' for prohibitions, null for unclassified."),
 
   // === SP1: Memory Intelligence fields ===
-  content_hash: z.string().optional(),
-  commitment: z.enum(['exploring', 'leaning', 'decided', 'locked']).optional(),
-  locked_at: z.string().optional(),
-  locked_reason: z.string().optional(),
+  content_hash: z.string().optional().describe('Hash of normalized statement content, used for dedup.'),
+  commitment: z.enum(['exploring', 'leaning', 'decided', 'locked']).optional()
+    .describe('Commitment level of the asserted knowledge.'),
+  locked_at: z.string().optional().describe("Timestamp when commitment reached 'locked'."),
+  locked_reason: z.string().optional().describe('Why this engram was locked.'),
 
   // === SP1: Reference counting (issue #107) ===
   /** Number of write attempts that resolved to this engram.
    * Incremented on every hash-dedup hit; decremented by forget().
    * Engram physically retires only when this reaches 0. */
-  reference_count: z.number().int().min(0).default(1),
+  reference_count: z.number().int().min(0).default(1)
+    .describe('Number of write attempts that resolved to this engram (same-scope re-learns). Engram retires only when this reaches 0.'),
   /** Provenance of each write attempt. One entry per write (including the
    * first). Migrated old engrams without this field start with []. */
   sources: z.array(z.object({
     scope: z.string(),
     session_id: z.string().nullable().default(null),
-    stored_at: z.string(),  // ISO timestamp of this write
-  })).default([]),
+    stored_at: z.string().describe('ISO 8601 timestamp of this write.'),
+  })).default([]).describe('Provenance of each write attempt; one entry per write.'),
 
   // === SP1: Cross-scope recurrence (issue #176) ===
   /** Number of times this engram's content was re-learned at a DIFFERENT
@@ -283,15 +296,18 @@ export const EngramSchema = z.object({
    * escalation when threshold is crossed. Distinct from reference_count
    * (which counts re-learns in the SAME scope) — recurrence_count is
    * evidence of universal applicability, not just repetition. */
-  recurrence_count: z.number().int().min(0).default(0),
+  recurrence_count: z.number().int().min(0).default(0)
+    .describe('Number of times this content was re-learned at a DIFFERENT scope than the original. Evidence of universal applicability.'),
 
   // === SP2: History & Evolution fields ===
-  engram_version: z.number().int().min(1).default(1),
+  engram_version: z.number().int().min(1).default(1)
+    .describe('Content-evolution version (incremented when the statement materially changes).'),
   previous_version_ref: PreviousVersionRefSchema.optional(),
-  episode_ids: z.array(z.string()).default([]),
+  episode_ids: z.array(z.string()).default([])
+    .describe('IDs of episodes (raw conversational events) that produced or reinforced this engram.'),
 
   // === SP3: Retrieval & Injection fields ===
-  summary: z.string().max(80).optional(),
+  summary: z.string().max(80).optional().describe('Short (<=80 char) injection-friendly summary.'),
 
   /**
    * Always-load flag. Pinned engrams bypass the term-hits gate in scoreEngram
@@ -302,7 +318,8 @@ export const EngramSchema = z.object({
    * per-domain fairness caps in fillTokenBudget so always-load behavior is
    * honored even if a single pack contributes many.
    */
-  pinned: z.boolean().optional(),
+  pinned: z.boolean().optional()
+    .describe('Always-load flag. Pinned engrams bypass the keyword-relevance gate and are eligible for injection every session. Use sparingly.'),
 })
 
 /**

--- a/packages/core/src/schemas/pack.ts
+++ b/packages/core/src/schemas/pack.ts
@@ -1,26 +1,31 @@
 import { z } from 'zod'
 
 export const PackManifestSchema = z.object({
-  name: z.string(),
-  version: z.string(),
+  name: z.string()
+    .describe('Human-readable pack name. Used as the registry key and capsule manifest_summary.name.'),
+  version: z.string()
+    .describe("Pack version. SemVer string recommended (e.g. '1.1.0'); validated as an opaque string, not range-checked."),
   description: z.string().optional(),
   creator: z.string().optional(),
-  license: z.string().default('cc-by-sa-4.0'),
+  license: z.string().default('cc-by-sa-4.0')
+    .describe('SPDX-style license identifier for the pack contents.'),
   tags: z.array(z.string()).default([]),
   metadata: z.object({
-    id: z.string().optional(),
-    injection_policy: z.enum(['on_match', 'on_request', 'always']).default('on_match'),
-    match_terms: z.array(z.string()).default([]),
+    id: z.string().optional().describe('Stable machine identifier for the pack.'),
+    injection_policy: z.enum(['on_match', 'on_request', 'always']).default('on_match')
+      .describe("When the loader is allowed to inject this pack's engrams."),
+    match_terms: z.array(z.string()).default([]).describe('Keywords that gate on_match injection.'),
     domain: z.string().optional(),
-    engram_count: z.number().optional(),
-  }).optional(),
+    engram_count: z.number().optional()
+      .describe('Declared number of engrams in the pack (advisory; loaders count the actual engrams.yaml).'),
+  }).optional().describe('Loader metadata. Preferred forward-looking location for injection policy and matching terms.'),
   'x-datacore': z.object({
     id: z.string(),
     injection_policy: z.enum(['on_match', 'on_request']),
     match_terms: z.array(z.string()).default([]),
     domain: z.string().optional(),
     engram_count: z.number().int().min(0),
-  }).optional(),
+  }).optional().describe("LEGACY namespace, retained for backward compatibility with Datacore-era packs. New packs SHOULD use 'metadata'. Note: injection_policy here does NOT include 'always'."),
 })
 
 export type PackManifest = z.infer<typeof PackManifestSchema>

--- a/packages/core/test/spec-schema-drift.test.ts
+++ b/packages/core/test/spec-schema-drift.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import {
+  buildEngramSchema,
+  buildPackManifestSchema,
+  serialize,
+  ENGRAM_SCHEMA_PATH,
+  PACK_SCHEMA_PATH,
+} from '../scripts/gen-spec-schemas.js'
+
+/**
+ * Spec-drift guard — closes plur-ai/plur#315.
+ *
+ * The committed JSON Schemas in spec/ are generated from the Zod source of
+ * truth (packages/core/src/schemas/*). This asserts they are in sync, so a
+ * field added to Zod that isn't regenerated fails locally in `pnpm test`
+ * (CI also runs `gen:schemas` + `git diff --exit-code spec/`).
+ *
+ * To fix a failure here: `pnpm --filter @plur-ai/core gen:schemas` and commit.
+ */
+describe('spec JSON Schema drift (#315)', () => {
+  it('spec/engram.schema.json matches the generated output', () => {
+    const committed = readFileSync(ENGRAM_SCHEMA_PATH, 'utf8')
+    expect(serialize(buildEngramSchema())).toBe(committed)
+  })
+
+  it('spec/pack-manifest.schema.json matches the generated output', () => {
+    const committed = readFileSync(PACK_SCHEMA_PATH, 'utf8')
+    expect(serialize(buildPackManifestSchema())).toBe(committed)
+  })
+
+  it('generation is deterministic (no runtime-dependent values leak in)', () => {
+    // Second build equals first — guards against e.g. the activation
+    // last_accessed `new Date()` default churning the file.
+    expect(serialize(buildEngramSchema())).toBe(serialize(buildEngramSchema()))
+  })
+
+  it('preserves the documented divergences from a naive dump', () => {
+    const engram = buildEngramSchema() as any
+    // Open-world rule.
+    expect(engram.additionalProperties).toBe(true)
+    // Deterministic placeholder for the runtime default.
+    expect(engram.properties.activation.default.last_accessed).toBe('')
+    // #310 insight sub-object is captured automatically from Zod.
+    expect(engram.properties.insight).toBeDefined()
+    // Draft 2020-12 identity.
+    expect(engram.$schema).toBe('https://json-schema.org/draft/2020-12/schema')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@6.0.2)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(typescript@6.0.2)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/claw:
     dependencies:
@@ -74,6 +74,12 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     optionalDependencies:
       '@huggingface/transformers':
         specifier: ^3.8.1
@@ -138,6 +144,7 @@ packages:
   '@aws-sdk/core@3.974.10':
     resolution: {integrity: sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg==}
     engines: {node: '>=20.0.0'}
+    deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.36':
     resolution: {integrity: sha512-gE+CGuPZD1eqUWGSrM8CXDjlwuPujIuwI+IlorD1wE2RcANKKT4jscB9GY1nTJbjmXzD18sycsYbgCG5m3n4/g==}
@@ -289,8 +296,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -301,8 +320,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -313,8 +344,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -325,8 +368,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -337,8 +392,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -349,8 +416,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -361,8 +440,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -373,8 +464,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -385,8 +488,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -397,8 +512,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -409,8 +536,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -421,8 +560,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -433,8 +584,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -519,105 +682,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -714,35 +861,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
     resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
@@ -816,35 +958,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -903,79 +1040,66 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -1509,6 +1633,11 @@ packages:
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2688,6 +2817,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -2933,6 +3067,11 @@ packages:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
       zod: ^3.25 || ^4
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3360,79 +3499,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@google/genai@1.46.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
@@ -3972,13 +4189,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.1(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.1':
     dependencies:
@@ -4396,6 +4613,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -5225,12 +5471,13 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.14
+      tsx: 4.22.4
       yaml: 2.9.0
 
   postcss@8.5.14:
@@ -5758,7 +6005,7 @@ snapshots:
 
   tslog@4.10.2: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@6.0.2)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(typescript@6.0.2)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -5769,7 +6016,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -5785,6 +6032,12 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -5830,7 +6083,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(yaml@2.9.0):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5842,12 +6095,13 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.1(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -5864,7 +6118,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -5984,6 +6238,10 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -43,37 +43,37 @@ The maturity index is Appendix B of the spec.
 
 ## How the JSON Schemas relate to the Zod source
 
-The schemas were **hand-authored** to faithfully mirror the Zod definitions in:
+The schemas are **generated from the Zod source of truth** (#315):
 
 - `packages/core/src/schemas/engram.ts` → `engram.schema.json`
 - `packages/core/src/schemas/pack.ts` → `pack-manifest.schema.json`
 
-**Why hand-authored, not generated:** `zod-to-json-schema` is not a dependency of
-this repo, and adding it (or building the package) would modify source/lockfiles
-— out of scope for a docs-only change. Each field, type, enum, range, default,
-and the `dual_coding` "at least one of example/analogy" refinement was
-transcribed directly from the Zod source.
+Regenerate with:
 
-**Divergence risk (read this).** Because the JSON Schema is not auto-generated,
-it can drift if the Zod schema changes and the JSON Schema is not updated. To
-keep them in lockstep:
+```bash
+pnpm --filter @plur-ai/core gen:schemas
+```
 
-1. Treat `packages/core/src/schemas/engram.ts` and `…/pack.ts` as the source of
-   truth; when they change, update the JSON Schema in the same PR.
-2. The proper fix is a **generation step** (the first fundable-remainder item
-   below): add `zod-to-json-schema`, emit these files in CI, and fail the build
-   if the committed schema differs from the generated one. That converts
-   "divergence risk" into "compile error."
+**Drift is a build error.** CI runs `gen:schemas` then `git diff --exit-code spec/`,
+and `spec-schema-drift.test.ts` asserts committed === generated in `pnpm test`. A
+field added to the Zod schema that isn't regenerated fails the build — the
+divergence risk that earlier hand-authored versions carried is gone. Field
+descriptions live as Zod `.describe()` calls, so the prose travels with the code.
 
-Intentional, documented differences from a naive Zod→JSON translation:
+Intentional, documented differences from a naive Zod→JSON dump (applied by the
+generator, see `packages/core/scripts/gen-spec-schemas.ts`):
 
 - `additionalProperties: true` on the engram object and manifest — encodes the
   Zod `.passthrough()` open-world rule (unknown fields preserved).
-- `activation.last_accessed` default is shown as `""`; the reference computes
+- `activation.last_accessed` default is emitted as `""`; the reference computes
   *today's date* at object-construction time, which a static schema cannot
-  express. Consumers materialize the runtime default per §2.3 of the spec.
-- `polarity` is `["string","null"]` with `enum: ["do","dont",null]` to model
-  Zod's nullable enum.
+  express (and would make generation non-deterministic). Consumers materialize
+  the runtime default per §2.3 of the spec.
+- `polarity` is modelled as a nullable enum (`anyOf` of the `["do","dont"]` enum
+  and `null`).
+- Zod `.refine()` rules (`dual_coding` "at least one of example/analogy", the
+  insight promote-requires-grounding rule) are not representable in JSON Schema
+  and are omitted; they remain enforced at runtime by Zod.
 
 ## Verifying the schemas
 
@@ -90,10 +90,10 @@ ajv validate -s spec/engram.schema.json -d my-engram.json --spec=draft2020
 v1 is a credible, implementable draft. Turning it into a ratified, interoperable
 standard is the NGI/NLnet-fundable scope:
 
-1. **Schema generation + drift CI.** Add `zod-to-json-schema`, generate
-   `engram.schema.json` / `pack-manifest.schema.json` from the Zod source in CI,
-   and gate the build on equality. Eliminates the divergence risk above.
-   *(small, do first)*
+1. ~~**Schema generation + drift CI.**~~ ✅ **Done (#315).** `engram.schema.json` /
+   `pack-manifest.schema.json` are generated from the Zod source via
+   `pnpm --filter @plur-ai/core gen:schemas`; CI gates the build on equality
+   (`git diff --exit-code spec/`). The divergence risk is eliminated.
 
 2. **Conformance test vectors.** A language-neutral corpus of canonical inputs +
    expected outcomes: valid/invalid engrams (one per invariant in §4.14), golden

--- a/spec/engram.schema.json
+++ b/spec/engram.schema.json
@@ -2,16 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://plur.ai/spec/v1/engram.schema.json",
   "title": "Engram",
-  "description": "An engram is the atomic unit of learned knowledge in the Open Engram Standard v1. Derived from the Zod EngramSchema in @plur-ai/core (packages/core/src/schemas/engram.ts). STABLE unless a field is annotated otherwise. See ENGRAM-STANDARD-v1.md for normative semantics.",
+  "description": "An engram is the atomic unit of learned knowledge in the Open Engram Standard v1. Generated from the Zod EngramSchema in @plur-ai/core (packages/core/src/schemas/engram.ts) by packages/core/scripts/gen-spec-schemas.ts — do not edit by hand. See ENGRAM-STANDARD-v1.md for normative semantics.",
   "type": "object",
-  "additionalProperties": true,
-  "required": [
-    "id",
-    "status",
-    "type",
-    "scope",
-    "statement"
-  ],
   "properties": {
     "id": {
       "type": "string",
@@ -26,7 +18,12 @@
     },
     "status": {
       "type": "string",
-      "enum": ["active", "dormant", "retired", "candidate"],
+      "enum": [
+        "active",
+        "dormant",
+        "retired",
+        "candidate"
+      ],
       "description": "Lifecycle state."
     },
     "consolidated": {
@@ -36,7 +33,12 @@
     },
     "type": {
       "type": "string",
-      "enum": ["behavioral", "terminological", "procedural", "architectural"],
+      "enum": [
+        "behavioral",
+        "terminological",
+        "procedural",
+        "architectural"
+      ],
       "description": "Top-level classification of the knowledge."
     },
     "scope": {
@@ -45,7 +47,11 @@
     },
     "visibility": {
       "type": "string",
-      "enum": ["private", "public", "template"],
+      "enum": [
+        "private",
+        "public",
+        "template"
+      ],
       "default": "private",
       "description": "Sharing posture. 'private' engrams MUST NOT be exported in packs."
     },
@@ -60,7 +66,9 @@
     },
     "contraindications": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Conditions under which the statement does NOT apply."
     },
     "source": {
@@ -69,7 +77,9 @@
     },
     "source_patterns": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Pattern IDs that contributed to this engram."
     },
     "derivation_count": {
@@ -79,74 +89,525 @@
       "description": "How many derivation steps produced this engram."
     },
     "pack": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "default": null,
       "description": "Name of the pack this engram belongs to, or null."
     },
     "abstract": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "default": null,
       "description": "ID of an ABS- abstraction this engram instantiates, or null."
     },
     "derived_from": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "default": null,
       "description": "ID of the engram this was derived from, or null."
     },
-    "knowledge_type": { "$ref": "#/$defs/KnowledgeType" },
+    "knowledge_type": {
+      "type": "object",
+      "properties": {
+        "memory_class": {
+          "type": "string",
+          "enum": [
+            "semantic",
+            "episodic",
+            "procedural",
+            "metacognitive"
+          ]
+        },
+        "cognitive_level": {
+          "type": "string",
+          "enum": [
+            "remember",
+            "understand",
+            "apply",
+            "analyze",
+            "evaluate",
+            "create"
+          ],
+          "description": "Bloom's taxonomy level."
+        }
+      },
+      "required": [
+        "memory_class",
+        "cognitive_level"
+      ],
+      "additionalProperties": false
+    },
     "domain": {
       "type": "string",
       "description": "Dotted domain path, e.g. 'dev/testing' or 'plur.session'."
     },
     "tags": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": [],
       "description": "Free-form tags used for matching and retrieval."
     },
     "activation": {
-      "$ref": "#/$defs/Activation",
+      "type": "object",
+      "properties": {
+        "retrieval_strength": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "storage_strength": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "frequency": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_accessed": {
+          "type": "string",
+          "description": "Date or ISO 8601 timestamp of last access."
+        }
+      },
+      "required": [
+        "retrieval_strength",
+        "storage_strength",
+        "frequency",
+        "last_accessed"
+      ],
+      "additionalProperties": false,
+      "description": "ACT-R activation parameters driving decay and ranking. STABLE.",
       "default": {
         "retrieval_strength": 0.7,
-        "storage_strength": 1.0,
+        "storage_strength": 1,
         "frequency": 0,
         "last_accessed": ""
       }
     },
-    "relations": { "$ref": "#/$defs/Relations" },
+    "relations": {
+      "type": "object",
+      "properties": {
+        "broader": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "narrower": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "related": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "conflicts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false,
+      "description": "Typed graph edges between engram IDs."
+    },
     "associations": {
       "type": "array",
-      "items": { "$ref": "#/$defs/Association" },
+      "items": {
+        "type": "object",
+        "properties": {
+          "target_type": {
+            "type": "string",
+            "enum": [
+              "engram",
+              "document"
+            ]
+          },
+          "target": {
+            "type": "string",
+            "description": "ID or path of the association target."
+          },
+          "strength": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 0.95
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "semantic",
+              "temporal",
+              "causal",
+              "co_accessed"
+            ]
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_type",
+          "target",
+          "strength",
+          "type"
+        ],
+        "additionalProperties": false
+      },
       "default": []
     },
     "knowledge_anchors": {
       "type": "array",
-      "items": { "$ref": "#/$defs/KnowledgeAnchor" },
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path to a grounding document/file."
+          },
+          "relevance": {
+            "type": "string",
+            "enum": [
+              "primary",
+              "supporting",
+              "example"
+            ],
+            "default": "supporting"
+          },
+          "snippet": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "snippet_extracted_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false
+      },
       "default": []
     },
-    "dual_coding": { "$ref": "#/$defs/DualCoding" },
-    "provenance": { "$ref": "#/$defs/Provenance" },
+    "dual_coding": {
+      "type": "object",
+      "properties": {
+        "example": {
+          "type": "string"
+        },
+        "analogy": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Worked example and/or analogy (dual coding). At least one of example or analogy MUST be provided (enforced at runtime by the Zod .refine below)."
+    },
+    "provenance": {
+      "type": "object",
+      "properties": {
+        "origin": {
+          "type": "string"
+        },
+        "chain": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "signature": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "RESERVED. Detached signature over the engram. Algorithm and canonicalization not yet specified — see ENGRAM-STANDARD-v1.md §7."
+        },
+        "license": {
+          "type": "string",
+          "default": "cc-by-sa-4.0"
+        }
+      },
+      "required": [
+        "origin"
+      ],
+      "additionalProperties": false,
+      "description": "Origin and signing chain. STABLE for origin/chain/license; signature is RESERVED (see ENGRAM-STANDARD-v1.md §7)."
+    },
     "feedback_signals": {
-      "$ref": "#/$defs/FeedbackSignals",
-      "default": { "positive": 0, "negative": 0, "neutral": 0 }
+      "type": "object",
+      "properties": {
+        "positive": {
+          "type": "integer",
+          "default": 0
+        },
+        "negative": {
+          "type": "integer",
+          "default": 0
+        },
+        "neutral": {
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "additionalProperties": false,
+      "default": {
+        "positive": 0,
+        "negative": 0,
+        "neutral": 0
+      }
     },
     "entities": {
       "type": "array",
-      "items": { "$ref": "#/$defs/EntityRef" },
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "person",
+              "organization",
+              "technology",
+              "concept",
+              "project",
+              "tool",
+              "place",
+              "event",
+              "standard",
+              "other"
+            ]
+          },
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "additionalProperties": false
+      },
       "description": "Typed entity references extracted from statement. Enables graph queries."
     },
-    "temporal": { "$ref": "#/$defs/Temporal" },
-    "usage": { "$ref": "#/$defs/UsageStats" },
-    "episodic": { "$ref": "#/$defs/EpisodicFields" },
-    "exchange": { "$ref": "#/$defs/ExchangeMetadata" },
+    "temporal": {
+      "type": "object",
+      "properties": {
+        "learned_at": {
+          "type": "string"
+        },
+        "valid_from": {
+          "type": "string"
+        },
+        "valid_until": {
+          "type": "string"
+        },
+        "ingested_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "learned_at"
+      ],
+      "additionalProperties": false,
+      "description": "Bi-temporal anchoring (Zep-inspired). When is this knowledge true?"
+    },
+    "usage": {
+      "type": "object",
+      "properties": {
+        "injections": {
+          "type": "integer",
+          "default": 0
+        },
+        "hits": {
+          "type": "integer",
+          "default": 0
+        },
+        "misses": {
+          "type": "integer",
+          "default": 0
+        },
+        "last_hit_at": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "episodic": {
+      "type": "object",
+      "properties": {
+        "emotional_weight": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "default": 5
+        },
+        "confidence": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "default": 5
+        },
+        "trigger_context": {
+          "type": "string"
+        },
+        "journal_ref": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "exchange": {
+      "type": "object",
+      "properties": {
+        "fitness_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "environmental_diversity": {
+          "type": "integer",
+          "default": 0
+        },
+        "adoption_count": {
+          "type": "integer",
+          "default": 0
+        },
+        "contradiction_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0
+        }
+      },
+      "additionalProperties": false
+    },
     "structured_data": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": {},
       "description": "Extensible key-value data for domain-specific fields."
     },
+    "insight": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "distill",
+            "consolidate",
+            "dream",
+            "connect",
+            "emerge",
+            "drift"
+          ]
+        },
+        "synthesized_at": {
+          "type": "string"
+        },
+        "grounding": {
+          "type": "string",
+          "enum": [
+            "verified",
+            "unverified",
+            "ungrounded",
+            "speculative"
+          ],
+          "default": "unverified"
+        },
+        "source_episode_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "serendipity": {
+          "type": "object",
+          "properties": {
+            "unexpectedness": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "relevance": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "score": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "required": [
+            "unexpectedness",
+            "relevance",
+            "score"
+          ],
+          "additionalProperties": false
+        },
+        "fate": {
+          "type": "string",
+          "enum": [
+            "surfaced",
+            "promoted",
+            "cited",
+            "tasked",
+            "dismissed",
+            "expired"
+          ],
+          "default": "surfaced"
+        },
+        "fate_ref": {
+          "type": "string"
+        },
+        "fate_at": {
+          "type": "string"
+        },
+        "surfaced_count": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "required": [
+        "operation",
+        "synthesized_at"
+      ],
+      "additionalProperties": false
+    },
     "polarity": {
-      "type": ["string", "null"],
-      "enum": ["do", "dont", null],
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "do",
+            "dont"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "'do' for directives, 'dont' for prohibitions, null for unclassified."
     },
@@ -156,11 +617,22 @@
     },
     "commitment": {
       "type": "string",
-      "enum": ["exploring", "leaning", "decided", "locked"],
+      "enum": [
+        "exploring",
+        "leaning",
+        "decided",
+        "locked"
+      ],
       "description": "Commitment level of the asserted knowledge."
     },
-    "locked_at": { "type": "string", "description": "Timestamp when commitment reached 'locked'." },
-    "locked_reason": { "type": "string", "description": "Why this engram was locked." },
+    "locked_at": {
+      "type": "string",
+      "description": "Timestamp when commitment reached 'locked'."
+    },
+    "locked_reason": {
+      "type": "string",
+      "description": "Why this engram was locked."
+    },
     "reference_count": {
       "type": "integer",
       "minimum": 0,
@@ -169,17 +641,31 @@
     },
     "sources": {
       "type": "array",
-      "default": [],
       "items": {
         "type": "object",
-        "required": ["scope", "stored_at"],
-        "additionalProperties": true,
         "properties": {
-          "scope": { "type": "string" },
-          "session_id": { "type": ["string", "null"], "default": null },
-          "stored_at": { "type": "string", "description": "ISO 8601 timestamp of this write." }
-        }
+          "scope": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "stored_at": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of this write."
+          }
+        },
+        "required": [
+          "scope",
+          "stored_at"
+        ],
+        "additionalProperties": false
       },
+      "default": [],
       "description": "Provenance of each write attempt; one entry per write."
     },
     "recurrence_count": {
@@ -194,10 +680,27 @@
       "default": 1,
       "description": "Content-evolution version (incremented when the statement materially changes)."
     },
-    "previous_version_ref": { "$ref": "#/$defs/PreviousVersionRef" },
+    "previous_version_ref": {
+      "type": "object",
+      "properties": {
+        "event_id": {
+          "type": "string"
+        },
+        "changed_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "event_id",
+        "changed_at"
+      ],
+      "additionalProperties": false
+    },
     "episode_ids": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": [],
       "description": "IDs of episodes (raw conversational events) that produced or reinforced this engram."
     },
@@ -211,178 +714,12 @@
       "description": "Always-load flag. Pinned engrams bypass the keyword-relevance gate and are eligible for injection every session. Use sparingly."
     }
   },
-  "$defs": {
-    "Activation": {
-      "type": "object",
-      "description": "ACT-R activation parameters driving decay and ranking. STABLE.",
-      "additionalProperties": false,
-      "required": ["retrieval_strength", "storage_strength", "frequency", "last_accessed"],
-      "properties": {
-        "retrieval_strength": { "type": "number", "minimum": 0, "maximum": 1 },
-        "storage_strength": { "type": "number", "minimum": 0, "maximum": 1 },
-        "frequency": { "type": "integer", "minimum": 0 },
-        "last_accessed": { "type": "string", "description": "Date or ISO 8601 timestamp of last access." }
-      }
-    },
-    "KnowledgeType": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["memory_class", "cognitive_level"],
-      "properties": {
-        "memory_class": {
-          "type": "string",
-          "enum": ["semantic", "episodic", "procedural", "metacognitive"]
-        },
-        "cognitive_level": {
-          "type": "string",
-          "enum": ["remember", "understand", "apply", "analyze", "evaluate", "create"],
-          "description": "Bloom's taxonomy level."
-        }
-      }
-    },
-    "KnowledgeAnchor": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["path"],
-      "properties": {
-        "path": { "type": "string", "description": "Path to a grounding document/file." },
-        "relevance": {
-          "type": "string",
-          "enum": ["primary", "supporting", "example"],
-          "default": "supporting"
-        },
-        "snippet": { "type": "string", "maxLength": 200 },
-        "snippet_extracted_at": { "type": "string" }
-      }
-    },
-    "Association": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["target_type", "target", "strength", "type"],
-      "properties": {
-        "target_type": { "type": "string", "enum": ["engram", "document"] },
-        "target": { "type": "string", "description": "ID or path of the association target." },
-        "strength": { "type": "number", "minimum": 0, "maximum": 0.95 },
-        "type": { "type": "string", "enum": ["semantic", "temporal", "causal", "co_accessed"] },
-        "updated_at": { "type": "string" }
-      }
-    },
-    "DualCoding": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "At least one of example or analogy MUST be provided (Zod .refine). JSON Schema enforces this via anyOf/required.",
-      "properties": {
-        "example": { "type": "string" },
-        "analogy": { "type": "string" }
-      },
-      "anyOf": [
-        { "required": ["example"] },
-        { "required": ["analogy"] }
-      ]
-    },
-    "Relations": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Typed graph edges between engram IDs.",
-      "properties": {
-        "broader": { "type": "array", "items": { "type": "string" }, "default": [] },
-        "narrower": { "type": "array", "items": { "type": "string" }, "default": [] },
-        "related": { "type": "array", "items": { "type": "string" }, "default": [] },
-        "conflicts": { "type": "array", "items": { "type": "string" }, "default": [] }
-      }
-    },
-    "Provenance": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Origin and signing chain. STABLE for origin/chain/license; signature is RESERVED (see ENGRAM-STANDARD-v1.md §7).",
-      "required": ["origin"],
-      "properties": {
-        "origin": { "type": "string" },
-        "chain": { "type": "array", "items": { "type": "string" }, "default": [] },
-        "signature": {
-          "type": ["string", "null"],
-          "default": null,
-          "description": "RESERVED. Detached signature over the engram. Algorithm and canonicalization not yet specified — see §7."
-        },
-        "license": { "type": "string", "default": "cc-by-sa-4.0" }
-      }
-    },
-    "FeedbackSignals": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "positive": { "type": "integer", "default": 0 },
-        "negative": { "type": "integer", "default": 0 },
-        "neutral": { "type": "integer", "default": 0 }
-      }
-    },
-    "EntityRef": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "type"],
-      "properties": {
-        "name": { "type": "string" },
-        "type": {
-          "type": "string",
-          "enum": [
-            "person", "organization", "technology", "concept",
-            "project", "tool", "place", "event", "standard", "other"
-          ]
-        },
-        "uri": { "type": "string", "format": "uri" }
-      }
-    },
-    "Temporal": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Bi-temporal anchoring (Zep-inspired). When is this knowledge true?",
-      "required": ["learned_at"],
-      "properties": {
-        "learned_at": { "type": "string" },
-        "valid_from": { "type": "string" },
-        "valid_until": { "type": "string" },
-        "ingested_at": { "type": "string" }
-      }
-    },
-    "UsageStats": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "injections": { "type": "integer", "default": 0 },
-        "hits": { "type": "integer", "default": 0 },
-        "misses": { "type": "integer", "default": 0 },
-        "last_hit_at": { "type": "string" }
-      }
-    },
-    "EpisodicFields": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "emotional_weight": { "type": "integer", "minimum": 1, "maximum": 10, "default": 5 },
-        "confidence": { "type": "integer", "minimum": 1, "maximum": 10, "default": 5 },
-        "trigger_context": { "type": "string" },
-        "journal_ref": { "type": "string" }
-      }
-    },
-    "ExchangeMetadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Marketplace fitness metadata. PROPOSED — semantics may change as the exchange protocol stabilizes.",
-      "properties": {
-        "fitness_score": { "type": "number", "minimum": 0, "maximum": 1 },
-        "environmental_diversity": { "type": "integer", "default": 0 },
-        "adoption_count": { "type": "integer", "default": 0 },
-        "contradiction_rate": { "type": "number", "minimum": 0, "maximum": 1, "default": 0 }
-      }
-    },
-    "PreviousVersionRef": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["event_id", "changed_at"],
-      "properties": {
-        "event_id": { "type": "string" },
-        "changed_at": { "type": "string" }
-      }
-    }
-  }
+  "required": [
+    "id",
+    "status",
+    "type",
+    "scope",
+    "statement"
+  ],
+  "additionalProperties": true
 }

--- a/spec/pack-manifest.schema.json
+++ b/spec/pack-manifest.schema.json
@@ -2,10 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://plur.ai/spec/v1/pack-manifest.schema.json",
   "title": "PackManifest",
-  "description": "Manifest for an engram pack in the Open Engram Standard v1. Derived from the Zod PackManifestSchema in @plur-ai/core (packages/core/src/schemas/pack.ts). In on-disk packs this object is carried as the YAML frontmatter of SKILL.md, or as a standalone manifest.yaml. STABLE. See ENGRAM-STANDARD-v1.md §5.",
+  "description": "Manifest for an engram pack in the Open Engram Standard v1. Generated from the Zod PackManifestSchema in @plur-ai/core (packages/core/src/schemas/pack.ts) by packages/core/scripts/gen-spec-schemas.ts — do not edit by hand. In on-disk packs this object is the YAML frontmatter of SKILL.md, or a standalone manifest.yaml. See ENGRAM-STANDARD-v1.md §5.",
   "type": "object",
-  "additionalProperties": true,
-  "required": ["name", "version"],
   "properties": {
     "name": {
       "type": "string",
@@ -15,8 +13,12 @@
       "type": "string",
       "description": "Pack version. SemVer string recommended (e.g. '1.1.0'); validated as an opaque string, not range-checked."
     },
-    "description": { "type": "string" },
-    "creator": { "type": "string" },
+    "description": {
+      "type": "string"
+    },
+    "creator": {
+      "type": "string"
+    },
     "license": {
       "type": "string",
       "default": "cc-by-sa-4.0",
@@ -24,56 +26,87 @@
     },
     "tags": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": []
     },
     "metadata": {
       "type": "object",
-      "additionalProperties": true,
-      "description": "Loader metadata. Preferred forward-looking location for injection policy and matching terms.",
       "properties": {
-        "id": { "type": "string", "description": "Stable machine identifier for the pack." },
+        "id": {
+          "type": "string",
+          "description": "Stable machine identifier for the pack."
+        },
         "injection_policy": {
           "type": "string",
-          "enum": ["on_match", "on_request", "always"],
+          "enum": [
+            "on_match",
+            "on_request",
+            "always"
+          ],
           "default": "on_match",
           "description": "When the loader is allowed to inject this pack's engrams."
         },
         "match_terms": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Keywords that gate on_match injection."
         },
-        "domain": { "type": "string" },
+        "domain": {
+          "type": "string"
+        },
         "engram_count": {
           "type": "number",
           "description": "Declared number of engrams in the pack (advisory; loaders count the actual engrams.yaml)."
         }
-      }
+      },
+      "additionalProperties": false,
+      "description": "Loader metadata. Preferred forward-looking location for injection policy and matching terms."
     },
     "x-datacore": {
       "type": "object",
-      "additionalProperties": true,
-      "description": "LEGACY namespace, retained for backward compatibility with Datacore-era packs. New packs SHOULD use 'metadata'. Note: injection_policy here does NOT include 'always'.",
-      "required": ["id", "injection_policy"],
       "properties": {
-        "id": { "type": "string" },
+        "id": {
+          "type": "string"
+        },
         "injection_policy": {
           "type": "string",
-          "enum": ["on_match", "on_request"]
+          "enum": [
+            "on_match",
+            "on_request"
+          ]
         },
         "match_terms": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": []
         },
-        "domain": { "type": "string" },
+        "domain": {
+          "type": "string"
+        },
         "engram_count": {
           "type": "integer",
           "minimum": 0
         }
-      }
+      },
+      "required": [
+        "id",
+        "injection_policy",
+        "engram_count"
+      ],
+      "additionalProperties": false,
+      "description": "LEGACY namespace, retained for backward compatibility with Datacore-era packs. New packs SHOULD use 'metadata'. Note: injection_policy here does NOT include 'always'."
     }
-  }
+  },
+  "required": [
+    "name",
+    "version"
+  ],
+  "additionalProperties": true
 }


### PR DESCRIPTION
Closes #315.

## Problem
`spec/engram.schema.json` and `spec/pack-manifest.schema.json` were **hand-authored** from the Zod schemas, with a documented "divergence risk." That risk already materialized: #310 added an `insight` sub-object (+ `Serendipity`/`InsightFate`/`InsightField`) to `EngramSchema`, but the committed "STABLE" spec never got it.

## Fix — Zod is the single source of truth
- Add `zod-to-json-schema` + `tsx` (dev deps).
- **`packages/core/scripts/gen-spec-schemas.ts`** emits both schema files from the Zod schemas: `pnpm --filter @plur-ai/core gen:schemas`.
- **Descriptions moved into Zod `.describe()`** (engram.ts, pack.ts) so the prose is generated, not hand-maintained — kills semantic drift too, not just structural.
- **Documented divergences applied by the generator** (the ones #315 called out):
  - root `additionalProperties: true` — the open-world `.passthrough()` rule
  - `activation.default.last_accessed` → `""` — the Zod default is a runtime `new Date()`; baking today's date would make generation non-deterministic and churn the file daily
  - 2020-12 `$schema`/`$id`/`title`/top-level description
  - `EntityRef.uri` normalized via Zod `.url()` → `format: "uri"`
  - Zod `.refine()` rules (`dual_coding` "at least one of", insight promote-requires-grounding) aren't representable in JSON Schema and are omitted — still enforced at runtime by Zod.
- **Drift is now a build error:** CI regenerates and `git diff --exit-code spec/`; `spec-schema-drift.test.ts` asserts committed === generated in `pnpm test`. Generation is idempotent.
- Regenerated schemas now include the **#310 insight fields automatically** — the original drift is closed and can't recur.
- Updated `spec/README.md` (was "hand-authored / divergence risk"; fundable-remainder item 1 marked done).

## Why the spec/*.json diff is large
The committed files are now the **generated canonical output** (inlined nested objects, stable key order, descriptions from `.describe()`, the new insight fields). Replacing the artisanal JSON with generated JSON is the point — from here it's automatic.

## Tests
- New `spec-schema-drift.test.ts`: committed === generated for both files, determinism, and the documented divergences (root `additionalProperties`, blanked `last_accessed`, `insight` present, 2020-12).
- `packs.test.ts` green; full `pnpm build` green. The 5 `sync.test.ts` failures are the pre-existing git-commit sandbox issue (reproduces on clean `origin/main`), unrelated.

## Note
Leaves the `ENGRAM-STANDARD-v1.md` §4 prose (normative doc) as-is and the "two hash helpers" interop note for #316 (PR #319). This PR is the generator + drift gate.