### PR TITLE
fix(telemetry): send scope kind, not the private scope path, in miss-signal (#312)

### DIFF
--- a/docs/telemetry-design.md
+++ b/docs/telemetry-design.md
@@ -39,7 +39,7 @@ could not answer — a demand signal. The emit is opt-in/default-off and carries
 {
   "install_id": "opaque uuid",
   "query_fingerprint": "sha256 of the normalized query (irreversible)",
-  "scope": "project:x | null",
+  "scope_type": "project | group | space | global | local | other | null",
   "domain": "trading | null",
   "reason": "no_results | low_score",
   "result_count": 0,
@@ -48,8 +48,14 @@ could not answer — a demand signal. The emit is opt-in/default-off and carries
 ```
 
 The fingerprint lets identical misses across installs cluster without disclosing
-content. Clustering and pack-bounty logic are deliberately downstream and out of
-scope here — this module only emits. Endpoint defaults to `/v1/miss-signal`,
+content. `scope_type` is the scope KIND only — the user-defined scope *path*
+(e.g. `project:acme-secret`, which can name a private project or client) is never
+transmitted (#312); only the kind, which is all that has routing-analytics value.
+`domain` is a generic topic label (e.g. `trading`) and **is** sent in readable
+form, because the topic of a miss is the actual demand signal the flywheel needs
+to act on; opt-in consent text should state that the domain label is transmitted.
+Clustering and pack-bounty logic are deliberately downstream and out of scope
+here — this module only emits. Endpoint defaults to `/v1/miss-signal`,
 overridable via `PLUR_MISS_SIGNAL_ENDPOINT`.
 
 ---

--- a/packages/core/src/telemetry-miss-signal.ts
+++ b/packages/core/src/telemetry-miss-signal.ts
@@ -12,11 +12,14 @@
 //   1. Opt-in, default-off. Every public function short-circuits on
 //      !isTelemetryEnabled() BEFORE any network call. A default-off install
 //      makes zero network calls and writes zero files for miss-signals.
-//   2. Content-free. The raw query NEVER leaves the process. We ship a
-//      SHA-256 fingerprint of the normalized query (irreversible), the scope
-//      and domain filters (coarse routing labels the user already chose), a
-//      reason code, and a UTC timestamp. No query text, no engram text, no
-//      result bodies, no paths, no identity beyond the opaque install id.
+//   2. Content-free AND identifier-free. The raw query NEVER leaves the process
+//      — we ship a SHA-256 fingerprint of the normalized query (irreversible).
+//      The scope is reduced to its KIND only (#312): 'project:acme-secret'
+//      becomes 'project', so a user's private project/client name in the scope
+//      path is never transmitted. The domain (a generic topic label such as
+//      'trading' — the actual demand signal) and a reason code and UTC date
+//      round out the payload. No query text, no engram text, no result bodies,
+//      no scope paths, no identity beyond the opaque install id.
 //   3. Never throws. On any failure (network, timeout, non-2xx) emit() resolves
 //      to false; the caller's recall path is never disturbed.
 //
@@ -62,11 +65,29 @@ export type MissSignalInput = {
 export type MissSignalPayload = {
   install_id: string
   query_fingerprint: string
-  scope: string | null
+  /** Scope KIND only (e.g. 'project', 'group', 'global') — never the user-defined
+   *  scope path, which can carry private project/client names (#312). */
+  scope_type: string | null
   domain: string | null
   reason: MissReason
   result_count: number
   date: string
+}
+
+/** Recognized scope kinds. Anything else collapses to 'other' so no free-text
+ *  label can ride along disguised as a kind. */
+const KNOWN_SCOPE_KINDS = ['global', 'local', 'project', 'group', 'space', 'user', 'org', 'team']
+
+/**
+ * Reduce a scope label to its KIND, dropping the user-defined path (#312).
+ * 'project:acme-secret' → 'project'; 'global' → 'global'. The scope path has no
+ * analytics value (only the kind matters for routing), but it can identify a
+ * user's private projects or clients, so only the kind is transmitted.
+ */
+export function scopeType(scope: string | undefined | null): string | null {
+  if (!scope) return null
+  const kind = (scope.includes(':') ? scope.slice(0, scope.indexOf(':')) : scope).trim().toLowerCase()
+  return KNOWN_SCOPE_KINDS.includes(kind) ? kind : 'other'
 }
 
 const DEFAULT_ENDPOINT = 'https://plur.ai/v1/miss-signal'
@@ -134,7 +155,7 @@ export function buildMissSignalPayload(
   return {
     install_id: installId,
     query_fingerprint: fingerprintQuery(input.query),
-    scope: input.scope ?? null,
+    scope_type: scopeType(input.scope),
     domain: input.domain ?? null,
     reason,
     result_count: input.resultCount,

--- a/packages/core/test/telemetry-miss-signal.test.ts
+++ b/packages/core/test/telemetry-miss-signal.test.ts
@@ -8,6 +8,7 @@ import {
   emitMissSignal,
   fingerprintQuery,
   buildMissSignalPayload,
+  scopeType,
   DEFAULT_MISS_SCORE_THRESHOLD,
   type MissSignalOpts,
   type MissSignalInput,
@@ -82,11 +83,31 @@ describe('telemetry miss-signal (WS5 demand flywheel)', () => {
     })
   })
 
+  describe('scopeType (privacy: kind only, #312)', () => {
+    it('reduces a scope path to its kind, dropping the private name', () => {
+      expect(scopeType('project:acme-secret')).toBe('project')
+      expect(scopeType('group:plur/plur-ai/engineering')).toBe('group')
+      expect(scopeType('space:1-datafund')).toBe('space')
+    })
+    it('passes through bare kinds', () => {
+      expect(scopeType('global')).toBe('global')
+      expect(scopeType('local')).toBe('local')
+    })
+    it('collapses an unrecognized kind to "other" (no free text leaks)', () => {
+      expect(scopeType('acme-internal:topsecret')).toBe('other')
+      expect(scopeType('weirdbarescope')).toBe('other')
+    })
+    it('returns null for absent scope', () => {
+      expect(scopeType(undefined)).toBeNull()
+      expect(scopeType(null)).toBeNull()
+    })
+  })
+
   describe('buildMissSignalPayload (wire shape)', () => {
-    it('carries ONLY fingerprint + coarse labels + reason + count + date — never raw query', () => {
+    it('carries ONLY fingerprint + scope KIND + domain + reason + count + date — never raw query or scope path', () => {
       const now = new Date('2026-06-14T10:00:00Z')
       const payload = buildMissSignalPayload(
-        { query: 'secret query text', scope: 'project:x', domain: 'trading', resultCount: 0, topScore: null },
+        { query: 'secret query text', scope: 'project:acme-secret', domain: 'trading', resultCount: 0, topScore: null },
         'no_results',
         'install-abc',
         now,
@@ -94,18 +115,20 @@ describe('telemetry miss-signal (WS5 demand flywheel)', () => {
       expect(payload).toEqual({
         install_id: 'install-abc',
         query_fingerprint: fingerprintQuery('secret query text'),
-        scope: 'project:x',
+        scope_type: 'project',
         domain: 'trading',
         reason: 'no_results',
         result_count: 0,
         date: '2026-06-14',
       })
-      // No raw query anywhere in the serialized payload.
-      expect(JSON.stringify(payload)).not.toContain('secret query text')
+      // Neither the raw query nor the private scope name appears in the payload.
+      const wire = JSON.stringify(payload)
+      expect(wire).not.toContain('secret query text')
+      expect(wire).not.toContain('acme-secret')
     })
     it('nulls absent scope/domain', () => {
       const payload = buildMissSignalPayload(noResults, 'no_results', 'id', new Date())
-      expect(payload.scope).toBeNull()
+      expect(payload.scope_type).toBeNull()
       expect(payload.domain).toBeNull()
     })
   })


### PR DESCRIPTION
Closes #312.

## What this fixes
PLUR's optional, off-by-default "miss-signal" reports when a memory search returns nothing, so we can learn what knowledge is in demand. It was meant to contain no readable user content, but it sent the **full scope label** verbatim — and scope labels often contain private names (e.g. `project:acme-secret`). An opted-in customer could therefore disclose their private project/client names to the telemetry endpoint.

## The change
- **Scope is reduced to its kind before transmission.** `scopeType()` maps `project:acme-secret` → `project`, `global` → `global`, etc., against an allowlist of known kinds; anything unrecognized collapses to `other`, so no free-text label can ride along disguised as a kind. The wire field is renamed `scope` → `scope_type`. The scope *path* had no analytics value beyond its kind, so nothing useful is lost.
- **`domain` stays readable, by design.** Unlike the scope path, `domain` is a generic topic label (`trading`, `dev/testing`) and is the actual demand signal the flywheel needs to act on — clustering misses by topic is the whole point. Hashing or dropping it would defeat the feature. Instead the transmission is now documented in `telemetry-design.md` so opt-in consent is informed.
- Query text remains an irreversible SHA-256 fingerprint (unchanged).

## Result
The payload is now free of user-defined identifiers: query is fingerprinted, scope is kind-only, and the only readable label is a generic topic. The feature's "content-free / identifier-free" promise holds.

## Tests
`telemetry-miss-signal.test.ts` (23 pass): `scopeType` cases (path→kind, bare kinds, unknown→`other`, null), and the payload test now asserts `scope_type` plus that the private scope name (`acme-secret`) never appears on the wire.

The 5 `sync.test.ts` failures are the pre-existing git-commit sandbox issue, unrelated.