### PR TITLE
fix(mcp): make invalid-arguments error self-correcting (#281)

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -228,12 +228,14 @@ export async function createServer(plur?: Plur): Promise<Server> {
           // memory content into client error logs. Keep this names-only.
           const receivedFields = Object.keys(args)
           const details = parsed.error.issues.map(i => `${i.path.join('.') || 'root'}: ${i.message}`).join(', ')
-          const receivedInfo = receivedFields.length > 0
+          const receivedNote = receivedFields.length > 0
             ? `Received fields: [${receivedFields.join(', ')}].`
-            : 'No fields received.'
+            : 'Received no fields (the arguments object was empty).'
           return {
             content: [{ type: 'text', text: JSON.stringify({
-              error: `Invalid arguments: ${details}. ${receivedInfo}`,
+              error: `Invalid arguments: ${details}. ${receivedNote} ` +
+                'The call reached the server — this is a malformed-arguments error, not a transport failure. ' +
+                'Fix the field(s) named above and retry; do not abandon the call.',
               success: false,
               received_fields: receivedFields,
             }) }],

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -117,7 +117,11 @@ export function getToolDefinitions(): ToolDefinition[] {
   return [
     {
       name: 'plur_learn',
-      description: 'Create an engram — record a reusable learning, preference, or correction',
+      description:
+        'Create an engram — record a reusable learning, preference, or correction. ' +
+        'Multi-agent note: in an orchestration that spawns subagents, have the PARENT session own plur_learn writes — ' +
+        'spawned subagents should return their findings as text for the parent to persist, rather than each calling ' +
+        'plur_learn (tool availability is not guaranteed in every subagent context). See plur-ai/plur#281.',
       annotations: { title: 'Learn', destructiveHint: false, idempotentHint: false },
       inputSchema: {
         type: 'object',

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -102,6 +102,36 @@ describe('MCP server (wire protocol)', () => {
     expect(fb.success).toBe(true)
   })
 
+  // Issue #281 — a missing required field used to return a bare
+  // "Invalid arguments: statement: Required", which agents misread as "my
+  // parameters aren't reaching the server" and abandoned persistence (silent
+  // memory loss). The error now echoes the received fields and states the call
+  // arrived, so the caller self-corrects instead of giving up.
+  it('missing required field error echoes received fields and is self-correcting (#281)', async () => {
+    const result = await client.callTool({
+      name: 'plur_learn',
+      // statement (required) omitted; other named fields present.
+      arguments: { scope: 'global', domain: 'software', type: 'behavioral' },
+    })
+    expect(result.isError).toBe(true)
+    const parsed = JSON.parse((result.content as any)[0].text)
+    expect(parsed.success).toBe(false)
+    expect(parsed.error).toContain('statement')
+    // Echoes the fields that DID arrive — proof the call was transmitted.
+    expect(parsed.error).toContain('Received fields:')
+    expect(parsed.error).toContain('scope')
+    expect(parsed.error).toContain('domain')
+    // Explicitly disambiguates malformed-args from a transport failure.
+    expect(parsed.error).toMatch(/not a transport failure/i)
+  })
+
+  it('empty arguments error says no fields were received (#281)', async () => {
+    const result = await client.callTool({ name: 'plur_learn', arguments: {} })
+    expect(result.isError).toBe(true)
+    const parsed = JSON.parse((result.content as any)[0].text)
+    expect(parsed.error).toContain('arguments object was empty')
+  })
+
   it('returns isError for unknown tools', async () => {
     const result = await client.callTool({ name: 'plur_nonexistent', arguments: {} })
     expect(result.isError).toBe(true)


### PR DESCRIPTION
Addresses #281 (lead item #1, plus the #2 documentation steer).

## The problem
When `plur_learn` was called with a missing required field, the server returned a bare:

```
{"error":"Invalid arguments: statement: Required","success":false}
```

In a real multi-agent run, two agents and the orchestrator misread this as *"my parameters aren't being transmitted to the server"* rather than *"I sent a malformed call."* One agent concluded the tool was broken and **stopped persisting its findings** — silent memory loss, not just a wasted call. That is the issue's highest-priority item.

## The fix (interpretation, not validation)
The shared argument validator in `server.ts` now makes the error self-correcting:
- **Echoes the fields that did arrive** — `Received fields: [scope, domain, type].` — which is direct evidence the call *was* transmitted.
- **States plainly** that this is a malformed-arguments error, **not a transport failure**, and to fix the named field and retry rather than abandon the call.

Because this is the generic dispatch layer, every tool gets the clearer error, not just `plur_learn`.

## Multi-agent guidance (#2)
The `plur_learn` description now steers orchestrations toward the safe pattern: **the parent session owns `plur_learn` writes; spawned subagents return findings as text** for the parent to persist, since a subagent's tool availability isn't guaranteed. This counters the default "call plur_learn whenever you learn something" guidance being inherited by every subagent and failing unevenly.

## Deliberately deferred to follow-ups
- **#2 determinism** — making subagent tool-schema resolution reliable is harness/session-start level (related to #283), not fixable in the MCP server here. Documented the pattern instead.
- **#3 `plur_learn_batch`** — a batch-write API is a useful enhancement for fan-out but is a new public tool with its own surface; worth a dedicated issue/PR.

## Tests
`server.test.ts`: a missing-`statement` call now asserts the error echoes the received fields and says "not a transport failure"; an empty-arguments call reports that no fields were received. Full mcp suite green (124).