### PR TITLE
fix(mcp): teach per-engram scope selection so team knowledge stops defaulting to global (#296)

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -29,6 +29,19 @@ DURING the session:
 - When user states a preference ("always X", "never Y") → call plur_learn immediately
 - When you discover a codebase convention or pattern → call plur_learn
 
+SCOPE SELECTION (choose per engram, by content — not once per session):
+A single session can produce engrams that belong in different stores. Set the
+'scope' field on EACH plur_learn call based on what the engram is:
+- Team / engineering / architecture knowledge → the matching team store scope
+  (e.g. "group:<org>/<team>"). plur_session_start lists the scopes this install
+  can write to — use them.
+- Personal preferences, workflow, or details specific to one project → your
+  default/local or "project:<name>" scope.
+- "global" is for genuinely cross-project knowledge only (language gotchas, tool
+  quirks). Do NOT let team knowledge fall back to "global" — if a team store is
+  configured, team-relevant engrams must carry its scope or they never reach the
+  shared store.
+
 OPTIONAL but improves quality:
 - Call plur_feedback to rate which injected engrams helped (positive/negative)
 - Call plur_recall_hybrid before answering factual questions — the answer may be in memory

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -168,6 +168,24 @@ export function getToolDefinitions(): ToolDefinition[] {
         // learnRouted defers to sync learn() so dedup behavior is
         // unchanged. We try learnAsync second only as a fallback for
         // the LLM-driven dedup pathway (local routes).
+        // Runtime scope nudge (#296): when the caller passes no scope and the
+        // engram lands at "global" while a team store IS configured, team
+        // knowledge silently never reaches the shared store. Surface that at the
+        // moment it happens — non-fatal, informational, and only when there is a
+        // team store to route to (stays silent on personal installs).
+        const explicitScope = typeof args.scope === 'string' && args.scope.length > 0
+        const scopeHint = (engramScope: string): { scope_hint?: string } => {
+          if (explicitScope || engramScope !== 'global') return {}
+          let remote: Array<{ scope: string }> = []
+          try { remote = plur.getWritableRemoteScopes() } catch { return {} }
+          if (remote.length === 0) return {}
+          const scopes = remote.map(s => `"${s.scope}"`).join(', ')
+          return { scope_hint:
+            `Stored at "global" because no scope was passed, but a team store is configured (${scopes}). ` +
+            `If this is team/engineering knowledge, re-learn it with an explicit scope so it reaches the shared ` +
+            `store; keep genuinely personal notes at the default scope.` }
+        }
+
         const statement = sanitizeStatement(args.statement as string)
         try {
           const engram = await plur.learnRouted(statement, context)
@@ -180,6 +198,7 @@ export function getToolDefinitions(): ToolDefinition[] {
             scope: engram.scope, type: engram.type,
             pinned: (engram as any).pinned === true,
             decision: 'ADD',
+            ...scopeHint(engram.scope),
             ...(isOutbox ? { outbox: true, warning: 'Remote write failed; engram queued locally for retry on next session start or plur_sync.' } : {}),
           }
         } catch (err) {
@@ -193,6 +212,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type, decision: 'ADD',
+            ...scopeHint(engram.scope),
             ...(isOutbox ? { outbox: true } : {}),
             warning: `Remote write failed (${(err as Error).message}); engram queued for retry.`,
           }
@@ -1238,10 +1258,11 @@ export function getToolDefinitions(): ToolDefinition[] {
           guide += default_scope
             ? `\n\nSession default scope is set to "${default_scope}". To route an engram to a remote ` +
               `enterprise store instead, pass scope explicitly to plur_learn (available remote scopes: ${scopeList}).`
-            : `\n\nRemote store scopes available: ${scopeList}. When an engram is relevant to the team ` +
-              `(engineering patterns, architecture decisions, project conventions), set scope to the matching ` +
-              `remote scope in plur_learn. Personal preferences, local project details, and corrections specific ` +
-              `to your workflow should stay at default scope (local).`
+            : `\n\nRemote store scopes available: ${scopeList}. Set scope PER ENGRAM by content: when an engram is ` +
+              `relevant to the team (engineering patterns, architecture decisions, project conventions), set scope to ` +
+              `the matching remote scope in plur_learn. Personal preferences, local project details, and corrections ` +
+              `specific to your workflow should stay at default scope (local). Do NOT let team knowledge fall back to ` +
+              `"global" — without an explicit scope it will, and it will never reach the shared store.`
 
           // Surface authorized-but-unregistered scopes (#292). Best-effort:
           // gated to enterprise users (remote stores configured), bounded by a

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -44,6 +44,39 @@ describe('MCP tools', () => {
     expect(result.statement).toBe('Test learning')
   })
 
+  // #296 — team knowledge silently defaulting to 'global'. When a team store is
+  // configured and no scope is passed, surface a hint at the moment of the write.
+  describe('scope hint when a team store is configured (#296)', () => {
+    beforeEach(() => {
+      plur.addStore('', 'group:acme/engineering', { url: 'https://plur.example.com', token: 'tok' })
+    })
+
+    it('hints to use the team scope when scope is omitted and engram lands at global', async () => {
+      const result = await callTool('plur_learn', { statement: 'We use trunk-based development' }) as any
+      expect(result.scope).toBe('global')
+      expect(result.scope_hint).toBeDefined()
+      expect(result.scope_hint).toContain('group:acme/engineering')
+    })
+
+    it('no hint when an explicit scope is passed', async () => {
+      const result = await callTool('plur_learn', {
+        statement: 'We use trunk-based development', scope: 'group:acme/engineering',
+      }) as any
+      expect(result.scope_hint).toBeUndefined()
+    })
+
+    it('no hint when the explicit scope is global on purpose', async () => {
+      const result = await callTool('plur_learn', { statement: 'TS enums are slow', scope: 'global' }) as any
+      expect(result.scope_hint).toBeUndefined()
+    })
+  })
+
+  it('plur_learn does NOT hint on a personal install (no team store configured)', async () => {
+    const result = await callTool('plur_learn', { statement: 'Personal note' }) as any
+    expect(result.scope).toBe('global')
+    expect(result.scope_hint).toBeUndefined()
+  })
+
   it('plur_learn strips XML envelope artifacts from statement (#145)', async () => {
     // Reproduce the corruption: LLM generates old XML tool-call format where the
     // statement value contains the closing tag + duplicated parameter body.


### PR DESCRIPTION
Closes #296.

## The problem
Per-engram scoping is supported — every `plur_learn` call takes a `scope` — but nothing taught agents to set it. So `scope` was routinely omitted, fell back to `global`, and **team-relevant engrams silently never reached a configured group store.** On any install with a remote/team store, agents "learn" but the shared store stays empty and nobody notices. The capability worked; the defaults and guidance didn't.

## The change (guidance + a safety net, no new capability)
1. **Static server instructions** gain a `SCOPE SELECTION` section — the block every agent receives. It teaches: choose scope *per engram* by content; team/engineering/architecture knowledge → the team store scope; personal/project notes → default/local; and **don't let team knowledge fall back to `global`**.
2. **`session_start` remote-scope guidance** is sharpened with the same explicit rule (it already lists the writable scopes; now it states the rule prescriptively).
3. **`plur_learn` returns a non-fatal `scope_hint`** when a call omits `scope`, the engram lands at `global`, **and** a team store is configured — surfacing the silent default at the exact moment it happens. It stays silent on personal installs (no team store) and when a scope was passed (including `global` chosen on purpose), so it never nags.

## Deliberately deferred to follow-ups
- `plur-mcp init` generating scope guidance (with the install's configured scopes enumerated) into the project's CLAUDE.md.
- A server-side `scope: auto` that infers the best-matching configured scope from engram content.

Both are larger product/onboarding changes; this PR fixes the silent-default behaviour for every install with the lower-risk guidance + runtime nudge.

## Tests
`tools.test.ts`: `scope_hint` fires on an omitted scope when a team store is configured and names that scope; absent when an explicit scope is passed, when `global` is chosen on purpose, and on a personal install with no team store. Full mcp suite green (126).