### PR TITLE
feat(core): write-time scope-demotion leak guard (+ detectSensitive scanner)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,7 @@ import { installPack, uninstallPack, listPacks, exportPack, scanPrivacy, compute
 // import { exportVault, type VaultExportOptions, type VaultExportResult } from './vault-export.js'
 // import { fetchRegistry, discoverPacks, verifyPackIntegrity, DEFAULT_REGISTRY_URL, type PackRegistry, type RegistryPack } from './registry.js'
 import { sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncStatus } from './sync.js'
-import { detectSecrets } from './secrets.js'
+import { detectSecrets, detectSensitive } from './secrets.js'
 import { appendHistory, readHistoryForEngram, generateEventId } from './history.js'
 import { computeContentHash } from './content-hash.js'
 import { decodeJwtExpiry } from './jwt.js'
@@ -68,7 +68,20 @@ export { applyBatchDecay, strengthToStatus, type BatchDecayResult, type DecayTra
 export { computeContentHash, normalizeStatement } from './content-hash.js'
 export { parseDedupResponse, buildDedupPrompt, buildBatchDedupPrompt } from './dedup.js'
 export { runMigrations, rollbackMigrations, getSchemaVersion, setSchemaVersion, ALL_MIGRATIONS, CURRENT_SCHEMA_VERSION, type Migration, type MigrationResult } from './migrations/index.js'
-export { detectSecrets } from './secrets.js'
+export { detectSecrets, detectSensitive } from './secrets.js'
+
+/**
+ * Scopes whose engrams are visible to people *other than* the author — the team
+ * store (`group:`), repo/project stores (`project:`), space stores (`space:`),
+ * and org/public scopes. Personal scopes (`local`, `global`, `user:*`, `agent:*`)
+ * are NOT shared: they live on the author's own machine or under their own remote
+ * namespace. Used by the write-time leak guard to decide whether to scan + demote.
+ */
+const SHARED_SCOPE_PREFIXES = ['group:', 'project:', 'space:', 'team:', 'org:', 'public'] as const
+
+export function isSharedScope(scope: string): boolean {
+  return SHARED_SCOPE_PREFIXES.some(p => scope.startsWith(p))
+}
 export { detectPlurStorage, type PlurPaths } from './storage.js'
 export { IndexedStorage } from './storage-indexed.js'
 export { YamlStore, SqliteStore, createStore, migrateStore, type EngramStore, type StorageBackend, type StorageConfig } from './store/index.js'
@@ -739,6 +752,33 @@ export class Plur {
   /** Create engram with content hash + commitment + cognitive level.
    * Fast-path hash dedup returns existing on exact match.
    */
+  /**
+   * Write-time leak guard. If the target scope is one others can read
+   * (`isSharedScope`: group:/project:/space:/team:/org:/public) AND the statement
+   * trips `detectSensitive` (IPs, internal hosts, basic-auth, host:port, secrets),
+   * DEMOTE to a private local scope — the engram is kept but never written to a
+   * shared store — and warn. Personal scopes (local/global/user:/agent:) are
+   * exempt: infra notes legitimately live there. Called at the top of both
+   * `learn()` and `learnRouted()`, so every client (CLI, MCP, hooks, OpenClaw,
+   * Hermes) is covered, since they all route through one of those two.
+   */
+  private _guardSensitiveScope(
+    statement: string,
+    context?: LearnContext,
+  ): { scope: string; context: LearnContext | undefined } {
+    const scope = context?.scope ?? this._sessionScope ?? 'global'
+    if (!isSharedScope(scope)) return { scope, context }
+    const hits = detectSensitive(statement)
+    if (hits.length === 0) return { scope, context }
+    const patterns = [...new Set(hits.map(h => h.pattern))].join(', ')
+    logger.warning(
+      `[plur] sensitive content (${patterns}) held back from shared scope "${scope}" — ` +
+      `demoted to local/private so it is not written to a shared store. ` +
+      `Re-scope deliberately if this is a false positive.`,
+    )
+    return { scope: 'local', context: { ...context, scope: 'local', visibility: 'private' } }
+  }
+
   learn(statement: string, context?: LearnContext): Engram {
     if (typeof statement !== 'string' || statement.length === 0) {
       throw new TypeError(`plur.learn: statement must be a non-empty string, got ${typeof statement}`)
@@ -749,11 +789,13 @@ export class Plur {
         throw new Error(`Secret detected in statement: ${secrets[0].pattern}. Use config.allow_secrets to override.`)
       }
     }
+    const guarded = this._guardSensitiveScope(statement, context)
+    context = guarded.context
     return withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)
       const allEngrams = this._loadAllEngrams()
 
-      const scope = context?.scope ?? this._sessionScope ?? 'global'
+      const scope = guarded.scope
 
       // Idea 29: Content hash fast-path dedup (scope-aware — issue #136).
       // On dedup hit, mutate: increment reference_count, append source (#107).
@@ -959,7 +1001,9 @@ export class Plur {
         throw new Error(`Secret detected in statement: ${secrets[0].pattern}. Use config.allow_secrets to override.`)
       }
     }
-    const scope = context?.scope ?? this._sessionScope ?? 'global'
+    const guarded = this._guardSensitiveScope(statement, context)
+    const scope = guarded.scope
+    context = guarded.context
     const remoteDriver = this._resolveRemoteStoreForScope(scope)
     if (!remoteDriver) {
       // Local route — sync learn() owns dedup, build, write, history.

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -1,0 +1,87 @@
+/**
+ * Publish filter — materialize the *publishable* subset of an engram set for a
+ * public/shipped target (e.g. the committed `engrams.yaml` in the open-source
+ * repo, or a public pack).
+ *
+ * This exists because of the 2026-06 leak: `.plur/engrams.yaml` shipped 67
+ * engrams including prod droplet IPs and basic-auth for an internal host. The
+ * blunt fix was to gitignore the file. The real fix is here — a two-gate filter
+ * so the committed file can safely contain *only* what is meant to be public:
+ *
+ *   An engram is publishable IFF
+ *     (1) visibility === 'public', AND
+ *     (2) `detectSensitive` finds nothing in its serialized content.
+ *
+ * Gate (2) is not redundant with (1): in the leak, several of the worst engrams
+ * were *mistagged* `public`. The content scan is the ground truth that the tag
+ * is not. A `public`-tagged engram that trips the scan is rejected AND surfaced
+ * as a mistag, never silently shipped.
+ */
+import { detectSensitive } from './secrets.js'
+import type { Engram } from './schemas/engram.js'
+
+export interface PublishReject {
+  id: string
+  visibility: string
+  /** Why it was held back: non-public visibility and/or content-scan hits. */
+  reasons: string[]
+  /** True when the engram was tagged `public` but failed the content scan —
+   *  a mistag that would have leaked. Worth a loud warning. */
+  mistagged: boolean
+}
+
+export interface PublishResult {
+  /** Public + content-clean, sorted by id for deterministic output. */
+  publishable: Engram[]
+  /** Everything held back, with reasons. */
+  rejected: PublishReject[]
+}
+
+/** Serialize all of an engram's content for scanning (every field, not just the statement). */
+function engramText(e: Engram): string {
+  return JSON.stringify(e)
+}
+
+/**
+ * Split an engram set into the publishable public subset and the rejected rest.
+ * Pure and deterministic — no I/O, stable ordering — so callers (the `plur
+ * publish` command and the pre-push hook) and tests share one source of truth.
+ */
+export function filterPublishable(engrams: Engram[]): PublishResult {
+  const publishable: Engram[] = []
+  const rejected: PublishReject[] = []
+
+  for (const e of engrams) {
+    const visibility = (e as { visibility?: string }).visibility ?? 'private'
+    const reasons: string[] = []
+
+    if (visibility !== 'public') {
+      reasons.push(`visibility=${visibility} (not public)`)
+    }
+
+    const hits = detectSensitive(engramText(e))
+    const failedScan = hits.length > 0
+    if (failedScan) {
+      reasons.push(`content scan: ${[...new Set(hits.map(h => h.pattern))].join(', ')}`)
+    }
+
+    if (reasons.length === 0) {
+      publishable.push(e)
+    } else {
+      rejected.push({
+        id: (e as { id?: string }).id ?? '(no id)',
+        visibility,
+        reasons,
+        mistagged: visibility === 'public' && failedScan,
+      })
+    }
+  }
+
+  publishable.sort((a, b) => {
+    const ai = (a as { id?: string }).id ?? ''
+    const bi = (b as { id?: string }).id ?? ''
+    return ai < bi ? -1 : ai > bi ? 1 : 0
+  })
+
+  return { publishable, rejected }
+}

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -69,3 +69,55 @@ export function detectPromptInjection(text: string): InjectionMatch[] {
   }
   return matches
 }
+
+// Sensitive-but-not-classic-secret patterns. `detectSecrets` catches credentials
+// and tokens, but the 2026-06 engram leak was *infrastructure topology* — prod
+// droplet IPs, an internal staging host with basic-auth, deployment layout — none
+// of which `detectSecrets` matches. `detectSensitive` adds that layer; it gates
+// the public engram set in the publish filter. Patterns are deliberately
+// low-false-positive (an IP or a host:port in a *public* engram is the red flag).
+const SENSITIVE_PATTERNS: { name: string; regex: RegExp }[] = [
+  // user:pass@host inside a URL — e.g. https://team:secret@hub-staging.plur.ai
+  { name: 'basic_auth_url', regex: /[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^/\s@]+@/i },
+  // FQDN:port — e.g. hub-staging.plur.ai:443, db.internal:5432 (infra topology)
+  { name: 'fqdn_port', regex: /\b(?:[a-z0-9-]+\.)+[a-z]{2,}:\d{2,5}\b/i },
+  // IPv4:port — e.g. 139.59.155.82:8877
+  { name: 'ipv4_port', regex: /\b\d{1,3}(?:\.\d{1,3}){3}:\d{2,5}\b/ },
+]
+
+// Any IPv4 that is NOT private/loopback/link-local/documentation is treated as a
+// real (likely production) address — exactly the droplet-IP shape that leaked.
+const IPV4 = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g
+const NON_PUBLIC_IPV4 =
+  /^(?:10\.|127\.|0\.|169\.254\.|192\.168\.|192\.0\.2\.|198\.51\.100\.|203\.0\.113\.|172\.(?:1[6-9]|2\d|3[01])\.|255\.)/
+
+function isPublicIpv4(ip: string): boolean {
+  const octets = ip.split('.').map(Number)
+  if (octets.length !== 4 || octets.some(o => !Number.isInteger(o) || o < 0 || o > 255)) return false
+  return !NON_PUBLIC_IPV4.test(ip)
+}
+
+/**
+ * Scan text for secrets AND infrastructure-sensitive content (public IPs,
+ * basic-auth URLs, host:port topology). Superset of `detectSecrets` — this is
+ * the gate used before an engram is allowed into a public/shipped set, because
+ * the visibility tag alone is not trustworthy (in the 2026-06 leak, several of
+ * the worst engrams were mistagged `public`). Returns [] only when clean.
+ */
+export function detectSensitive(text: string): SecretMatch[] {
+  if (typeof text !== 'string') {
+    throw new TypeError(`detectSensitive: expected string, got ${typeof text}`)
+  }
+  const matches = detectSecrets(text)
+  for (const { name, regex } of SENSITIVE_PATTERNS) {
+    const m = text.match(regex)
+    if (m) matches.push({ pattern: name, match: m[0].slice(0, 30) + '...' })
+  }
+  for (const ip of text.match(IPV4) ?? []) {
+    if (isPublicIpv4(ip)) {
+      matches.push({ pattern: 'public_ipv4', match: ip })
+      break
+    }
+  }
+  return matches
+}

--- a/packages/core/test/publish.test.ts
+++ b/packages/core/test/publish.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Publish filter + sensitive-content scan — the guard that lets a public
+ * engrams.yaml ship safely after the 2026-06 leak. Tests use the actual shapes
+ * that leaked (prod droplet IPs, an internal staging host with basic-auth) to
+ * prove the scan would now catch them, plus the mistag case (visibility=public
+ * but sensitive content) that the visibility tag alone missed.
+ */
+import { describe, it, expect } from 'vitest'
+import { detectSensitive, detectSecrets } from '../src/secrets.js'
+import { filterPublishable } from '../src/publish.js'
+
+const eng = (over: Record<string, unknown>) => ({
+  id: 'ENG-test-0001',
+  statement: 'a harmless public fact',
+  visibility: 'public',
+  ...over,
+}) as never
+
+describe('detectSensitive — infra topology beyond detectSecrets', () => {
+  it('flags a public droplet IP (the leak shape) that detectSecrets misses', () => {
+    const text = 'deploy target is 139.59.155.82'
+    expect(detectSecrets(text)).toHaveLength(0)               // old scanner: clean
+    expect(detectSensitive(text).map(m => m.pattern)).toContain('public_ipv4') // new: caught
+  })
+
+  it('does NOT flag private / loopback / documentation IPs', () => {
+    for (const ip of ['10.0.0.1', '192.168.1.10', '127.0.0.1', '172.16.0.5', '203.0.113.9']) {
+      expect(detectSensitive(`host at ${ip}`)).toHaveLength(0)
+    }
+  })
+
+  it('flags a basic-auth URL (internal staging host with creds)', () => {
+    expect(detectSensitive('https://team:hunter2@hub-staging.plur.ai/api').map(m => m.pattern))
+      .toContain('basic_auth_url')
+  })
+
+  it('flags FQDN:port and IPv4:port topology', () => {
+    expect(detectSensitive('reach it at hub-staging.plur.ai:443').map(m => m.pattern)).toContain('fqdn_port')
+    expect(detectSensitive('dashboard on 139.59.155.82:8877').map(m => m.pattern)).toContain('ipv4_port')
+  })
+
+  it('still inherits all detectSecrets patterns', () => {
+    expect(detectSensitive('Bearer abcdefghijklmnopqrstuvwxyz123').map(m => m.pattern)).toContain('bearer_token')
+    expect(detectSensitive('password = supersecret123').map(m => m.pattern)).toContain('password_assignment')
+  })
+
+  it('returns [] for genuinely clean public text', () => {
+    expect(detectSensitive('SKILL.md is the canonical pack format; the body is a description.')).toHaveLength(0)
+  })
+})
+
+describe('filterPublishable — two-gate (visibility AND content)', () => {
+  it('ships a public, content-clean engram', () => {
+    const { publishable, rejected } = filterPublishable([eng({ id: 'ENG-ok-1' })])
+    expect(publishable.map(e => (e as { id: string }).id)).toEqual(['ENG-ok-1'])
+    expect(rejected).toHaveLength(0)
+  })
+
+  it('holds back a private engram (gate 1)', () => {
+    const { publishable, rejected } = filterPublishable([eng({ id: 'ENG-priv', visibility: 'private' })])
+    expect(publishable).toHaveLength(0)
+    expect(rejected[0].reasons.join()).toMatch(/not public/)
+    expect(rejected[0].mistagged).toBe(false)
+  })
+
+  it('holds back a PUBLIC-tagged engram with sensitive content, and flags the mistag (gate 2)', () => {
+    const leaky = eng({ id: 'ENG-leak', visibility: 'public', statement: 'prod droplet 139.59.155.82, auth https://t:p@hub-staging.plur.ai' })
+    const { publishable, rejected } = filterPublishable([leaky])
+    expect(publishable).toHaveLength(0)                  // NOT shipped despite public tag
+    expect(rejected[0].mistagged).toBe(true)             // surfaced as a mistag
+    expect(rejected[0].reasons.join()).toMatch(/content scan/)
+  })
+
+  it('is deterministic — publishable sorted by id', () => {
+    const { publishable } = filterPublishable([eng({ id: 'ENG-c' }), eng({ id: 'ENG-a' }), eng({ id: 'ENG-b' })])
+    expect(publishable.map(e => (e as { id: string }).id)).toEqual(['ENG-a', 'ENG-b', 'ENG-c'])
+  })
+})

--- a/packages/core/test/scope-guard.test.ts
+++ b/packages/core/test/scope-guard.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Write-time sensitivity demotion — the primary leak guard. When an engram is
+ * written to a *shared* scope (group/project/space/...) with infra-sensitive
+ * content, it is demoted to a private local scope rather than shared. This is
+ * what actually closes the leak class: it sits in learn()/learnRouted(), the
+ * paths every client (CLI, MCP, hooks, OpenClaw, Hermes) routes through.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur, isSharedScope } from '../src/index.js'
+
+describe('isSharedScope', () => {
+  it('treats group/project/space/team/org/public as shared (others can read)', () => {
+    for (const s of ['group:plur/engineering', 'project:plur', 'space:5-plur', 'team:x', 'org:y', 'public'])
+      expect(isSharedScope(s)).toBe(true)
+  })
+  it('treats local/global/user/agent as personal (not shared)', () => {
+    for (const s of ['local', 'global', 'user:plur:gregor', 'agent:abc123'])
+      expect(isSharedScope(s)).toBe(false)
+  })
+})
+
+describe('write-time sensitivity demotion (learn)', () => {
+  const dirs: string[] = []
+  const freshPlur = () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-guard-'))
+    dirs.push(dir)
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores: [], index: false }, { noRefs: true }))
+    return new Plur({ path: dir })
+  }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+  it('demotes a shared-scope write with a public IP to local/private', () => {
+    const e = freshPlur().learn('deploy target is 139.59.155.82', { scope: 'group:plur/engineering', domain: 'infra' }) as { scope: string; visibility: string }
+    expect(e.scope).toBe('local')
+    expect(e.visibility).toBe('private')
+  })
+
+  it('demotes a shared-scope write with a basic-auth internal host', () => {
+    const e = freshPlur().learn('login at https://team:pw1234@hub-staging.plur.ai', { scope: 'project:plur' }) as { scope: string; visibility: string }
+    expect(e.scope).toBe('local')
+    expect(e.visibility).toBe('private')
+  })
+
+  it('keeps a clean shared-scope write at its scope', () => {
+    const e = freshPlur().learn('SKILL.md is the canonical pack format', { scope: 'group:plur/engineering', domain: 'plur.packs' }) as { scope: string }
+    expect(e.scope).toBe('group:plur/engineering')
+  })
+
+  it('does NOT demote a personal (local) scope, even with an IP — infra notes live there legitimately', () => {
+    const e = freshPlur().learn('my droplet is 139.59.155.82', { scope: 'local' }) as { scope: string }
+    expect(e.scope).toBe('local')
+  })
+})


### PR DESCRIPTION
**Phase 2 of the 2026-06 engram-leak remediation — the core, scope-agnostic piece.** Unblocks un-gitignoring `.plur/engrams.yaml` (so contributors get the public engrams) without re-leaking.

## The finding that shaped this
`detectSecrets` catches credentials/tokens — but **not** the infrastructure topology that actually leaked (prod droplet IPs, an internal staging host with basic-auth, deployment layout). **The old scanner would not have caught the original leak.** Extending the scan is the security crux, not the plumbing.

## What's here (the core)
- **`detectSensitive()`** — superset of `detectSecrets`: public IPv4 (excludes private/loopback/documentation ranges), basic-auth URLs (`scheme://user:pass@host`), and `FQDN:port` / `IPv4:port` topology.
- **`filterPublishable()`** — two-gate: an engram ships **IFF** `visibility === 'public'` **AND** `detectSensitive` is clean. A `public`-tagged engram that trips the scan is rejected **and flagged as a mistag** — the exact failure the visibility tag alone missed (3 of the 7 worst leaked engrams were mistagged `public`). Pure + deterministic, so the CLI, the pre-push hook, and tests share one source of truth.
- Tests use the **actual leak shapes** (droplet IP `139.59.155.82`, `https://t:p@hub-staging.plur.ai`) to prove the scan now catches them.

## Next increment (separate PR)
- `plur publish` CLI — materialize the public subset into the committed `engrams.yaml`.
- Visibility-aware **pre-push hook** — block private/sensitive engrams on push to public repos (belt-and-braces).
- Then **un-gitignore** `.plur/engrams.yaml`.

## Two design decisions to confirm
1. **Source/target:** publish *from* which store *into* the repo's `engrams.yaml`? (My lean: a designated public/maintainer source → committed file, with the pre-push hook as the universal guard.)
2. **Internal-hostname tuning:** `plur.ai` is both the public product apex *and* has internal subdomains. The current patterns catch host:port and basic-auth (low false-positive) but not a bare internal hostname — that residual still needs the visibility tag + human review. Worth an allow/deny list?

Local `vitest` is broken on my machine (rolldown native binary) — relying on CI to run the new tests. `tsc --noEmit` is clean.