### PR TITLE
feat(packs): require valid SKILL.md; deprecate manifest.yaml with auto-upgrade (#325)

### DIFF
--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -47,16 +47,31 @@ export function loadPack(packDir: string): LoadedPack {
   const manifestYamlPath = `${packDir}/manifest.yaml`
   const engramsPath = `${packDir}/engrams.yaml`
 
+  // SKILL.md is the canonical manifest. manifest.yaml is DEPRECATED (#325): it
+  // still loads (with a warning) and installPack auto-upgrades the installed copy
+  // to SKILL.md — we don't hard-break existing manifest.yaml packs.
   let rawManifest: Record<string, any>
   if (fs.existsSync(skillMdPath)) {
     rawManifest = parseSkillMdFrontmatter(skillMdPath)
   } else if (fs.existsSync(manifestYamlPath)) {
+    logger.warning(
+      `[plur:packs] ${packDir} ships a manifest.yaml — deprecated; use SKILL.md frontmatter. ` +
+      `It is read for now and auto-upgraded to SKILL.md on install.`,
+    )
     rawManifest = yaml.load(fs.readFileSync(manifestYamlPath, 'utf8')) as Record<string, any>
   } else {
-    throw new Error(`No SKILL.md or manifest.yaml found in ${packDir}`)
+    throw new Error(`No SKILL.md found in ${packDir} — a knowledge pack must ship a SKILL.md (manifest.yaml is deprecated)`)
   }
 
-  const manifest = PackManifestSchema.parse(rawManifest)
+  // Validate the frontmatter, not just its presence (#325): a SKILL.md with no
+  // (or an invalid) manifest must fail with a clear error, not load empty.
+  const result = PackManifestSchema.safeParse(rawManifest)
+  if (!result.success) {
+    const why = result.error.issues.map(i => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ')
+    throw new Error(`Invalid pack manifest in ${packDir} — SKILL.md frontmatter failed validation: ${why}`)
+  }
+
+  const manifest = result.data
   const engrams = loadEngrams(engramsPath)
   return { manifest, engrams }
 }

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -174,6 +174,23 @@ export interface InstallOptions {
   allowInjection?: boolean
 }
 
+/**
+ * Serialize a parsed manifest back to SKILL.md content (frontmatter + body).
+ * Used to auto-upgrade a deprecated `manifest.yaml` pack to the canonical
+ * SKILL.md form on install (#325). 1:1 with PackManifestSchema, so it re-parses.
+ */
+function manifestToSkillMd(m: PackManifest): string {
+  const fm: Record<string, unknown> = { name: m.name, version: m.version }
+  if (m.description) fm.description = m.description
+  if (m.creator) fm.creator = m.creator
+  if (m.license) fm.license = m.license
+  if (m.tags && m.tags.length) fm.tags = m.tags
+  if (m.metadata) fm.metadata = m.metadata
+  const legacy = (m as Record<string, unknown>)['x-datacore']
+  if (legacy) fm['x-datacore'] = legacy
+  return `---\n${yaml.dump(fm)}---\n\n# ${m.name}\n\n${m.description ?? ''}\n`
+}
+
 export function installPack(
   packsDir: string,
   source: string,
@@ -212,6 +229,21 @@ export function installPack(
     if (fs.statSync(srcPath).isFile()) {
       fs.copyFileSync(srcPath, destPath)
     }
+  }
+
+  // Auto-upgrade a deprecated manifest.yaml pack to SKILL.md in the installed
+  // copy (#325). manifest.yaml still LOADS (loadPack reads it with a deprecation
+  // warning), but the managed copy is normalized to the canonical SKILL.md so
+  // the integrity hash below is computed over SKILL.md + engrams.yaml. Done
+  // before computePackHash so the recorded integrity reflects the upgrade.
+  const destSkillMd = path.join(destDir, 'SKILL.md')
+  const destManifestYaml = path.join(destDir, 'manifest.yaml')
+  if (!fs.existsSync(destSkillMd) && fs.existsSync(destManifestYaml)) {
+    fs.writeFileSync(destSkillMd, manifestToSkillMd(preview.manifest))
+    fs.rmSync(destManifestYaml)
+    logger.warning(
+      `installPack: pack '${preview.manifest.name}' shipped a deprecated manifest.yaml — upgraded to SKILL.md in the installed copy`,
+    )
   }
 
   // Load engrams, then clamp host-overriding fields (pinned / locked commitment)
@@ -610,20 +642,23 @@ export function exportPack(
 // --- Integrity ---
 
 /**
- * Compute SHA256 hash of pack contents (SKILL.md + engrams.yaml).
- * Deterministic — same content always produces same hash.
- * Can be used as a content-addressable identifier (like Swarm hash).
+ * Compute SHA256 hash of pack contents per ENGRAM-STANDARD-v1.md §5.5:
+ *   H = SHA256( bytes(SKILL.md) || bytes(engrams.yaml) )
+ * Deterministic — same content always produces same hash; usable as a
+ * content-addressable identifier (like a Swarm hash).
+ *
+ * SKILL.md is the canonical pack manifest. `manifest.yaml` is deprecated (#325)
+ * and does NOT contribute to the hash; installPack auto-upgrades a manifest.yaml
+ * pack to SKILL.md before this is computed over the installed copy, so the
+ * integrity hash always reflects SKILL.md + engrams.yaml.
  */
 export function computePackHash(packDir: string): string {
   const hash = crypto.createHash('sha256')
 
-  // Hash manifest
+  // Hash the SKILL.md manifest. No manifest.yaml fallback.
   const skillMd = path.join(packDir, 'SKILL.md')
-  const manifestYaml = path.join(packDir, 'manifest.yaml')
   if (fs.existsSync(skillMd)) {
     hash.update(fs.readFileSync(skillMd))
-  } else if (fs.existsSync(manifestYaml)) {
-    hash.update(fs.readFileSync(manifestYaml))
   }
 
   // Hash engrams

--- a/packages/core/src/trust.ts
+++ b/packages/core/src/trust.ts
@@ -1,19 +1,25 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import * as crypto from 'crypto'
+import { computePackHash } from './packs.js'
 
+/**
+ * Pack integrity checksum per ENGRAM-STANDARD-v1.md §5.5:
+ *   H = SHA256( bytes(SKILL.md) || bytes(engrams.yaml) )
+ *
+ * Delegates to {@link computePackHash} so there is a SINGLE §5.5 hashing
+ * implementation (#316/#325) — the two helpers cannot drift. SKILL.md is the
+ * canonical manifest; manifest.yaml is deprecated and does not enter the hash.
+ *
+ * Keeps the `null`-on-empty contract: a directory with neither a SKILL.md nor an
+ * `engrams.yaml` has no content to attest, so callers get `null` rather than the
+ * hash of an empty input.
+ */
 export function computePackChecksum(packDir: string): string | null {
-  const files = ['SKILL.md', 'engrams.yaml']
-  const hash = crypto.createHash('sha256')
-  let hasContent = false
-  for (const file of files) {
-    const filePath = path.join(packDir, file)
-    if (fs.existsSync(filePath)) {
-      hash.update(fs.readFileSync(filePath))
-      hasContent = true
-    }
-  }
-  return hasContent ? hash.digest('hex') : null
+  const hasContent =
+    fs.existsSync(path.join(packDir, 'SKILL.md')) ||
+    fs.existsSync(path.join(packDir, 'engrams.yaml'))
+  if (!hasContent) return null
+  return computePackHash(packDir)
 }
 
 export function verifyPackChecksum(packDir: string, expected: string): { valid: boolean; actual: string | null } {

--- a/packages/core/test/pack-skill-md-policy.test.ts
+++ b/packages/core/test/pack-skill-md-policy.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { join, basename } from 'path'
+import { tmpdir } from 'os'
+import * as crypto from 'crypto'
+import { computePackHash, installPack } from '../src/packs.js'
+import { computePackChecksum, verifyPackChecksum } from '../src/trust.js'
+import { loadPack } from '../src/engrams.js'
+
+/**
+ * Require a valid SKILL.md; deprecate manifest.yaml with auto-upgrade — #325.
+ *
+ * SKILL.md is the canonical pack manifest. manifest.yaml is deprecated: it still
+ * loads (with a warning) and installPack auto-upgrades the installed copy to
+ * SKILL.md. The §5.5 hash is SHA256(SKILL.md || engrams.yaml) — manifest.yaml
+ * never enters it — and computePackChecksum delegates to computePackHash so the
+ * two helpers cannot diverge (#316).
+ */
+describe('pack SKILL.md policy + manifest.yaml deprecation (#325)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-skillmd-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  const sha256 = (...parts: string[]) => {
+    const h = crypto.createHash('sha256')
+    for (const p of parts) h.update(Buffer.from(p))
+    return h.digest('hex')
+  }
+  const skillMd = (name = 'demo', version = '1.0.0') =>
+    `---\nname: ${name}\nversion: ${version}\n---\n\n# ${name}\n\nA demo pack.\n`
+  const validEngrams = [
+    'engrams:',
+    '  - id: ENG-0001',
+    '    version: 2',
+    '    status: active',
+    '    type: behavioral',
+    '    scope: global',
+    '    statement: test engram from pack',
+    '    activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 0, last_accessed: "2024-01-01" }',
+    '    feedback_signals: { positive: 0, negative: 0, neutral: 0 }',
+  ].join('\n') + '\n'
+
+  describe('hashing', () => {
+    it('checksum equals hash (single implementation) over SKILL.md + engrams.yaml', () => {
+      const s = skillMd(); const e = validEngrams
+      writeFileSync(join(dir, 'SKILL.md'), s)
+      writeFileSync(join(dir, 'engrams.yaml'), e)
+      expect(computePackChecksum(dir)).toBe(computePackHash(dir))
+      expect(computePackChecksum(dir)).toBe(sha256(s, e))
+    })
+
+    it('manifest.yaml does NOT contribute to the hash', () => {
+      writeFileSync(join(dir, 'SKILL.md'), skillMd())
+      writeFileSync(join(dir, 'engrams.yaml'), validEngrams)
+      const before = computePackHash(dir)
+      writeFileSync(join(dir, 'manifest.yaml'), 'name: ignored\nversion: 9\n')
+      expect(computePackHash(dir)).toBe(before)
+    })
+
+    it('null-on-empty contract preserved', () => {
+      expect(computePackChecksum(dir)).toBeNull()
+    })
+
+    it('verifyPackChecksum round-trips', () => {
+      writeFileSync(join(dir, 'SKILL.md'), skillMd())
+      writeFileSync(join(dir, 'engrams.yaml'), validEngrams)
+      const c = computePackChecksum(dir)!
+      expect(verifyPackChecksum(dir, c)).toEqual({ valid: true, actual: c })
+      expect(verifyPackChecksum(dir, 'sha256:wrong')).toEqual({ valid: false, actual: c })
+    })
+  })
+
+  describe('loadPack manifest validation', () => {
+    it('loads a SKILL.md pack', () => {
+      writeFileSync(join(dir, 'SKILL.md'), skillMd('my-pack', '2.1.0'))
+      writeFileSync(join(dir, 'engrams.yaml'), validEngrams)
+      const pack = loadPack(dir)
+      expect(pack.manifest.name).toBe('my-pack')
+      expect(pack.manifest.version).toBe('2.1.0')
+      expect(pack.engrams).toHaveLength(1)
+    })
+
+    it('LOADS a manifest.yaml-only pack (deprecated, not rejected)', () => {
+      writeFileSync(join(dir, 'manifest.yaml'), 'name: legacy\nversion: 1.0.0\n')
+      writeFileSync(join(dir, 'engrams.yaml'), validEngrams)
+      expect(() => loadPack(dir)).not.toThrow()
+      expect(loadPack(dir).manifest.name).toBe('legacy')
+    })
+
+    it('rejects a SKILL.md with no frontmatter (empty manifest)', () => {
+      writeFileSync(join(dir, 'SKILL.md'), '# Just a heading, no frontmatter\n')
+      writeFileSync(join(dir, 'engrams.yaml'), validEngrams)
+      expect(() => loadPack(dir)).toThrow(/frontmatter/i)
+    })
+
+    it('rejects a SKILL.md whose frontmatter fails manifest validation (missing version)', () => {
+      writeFileSync(join(dir, 'SKILL.md'), '---\nname: incomplete\n---\n\n# incomplete\n')
+      writeFileSync(join(dir, 'engrams.yaml'), validEngrams)
+      expect(() => loadPack(dir)).toThrow(/failed validation|version/i)
+    })
+
+    it('rejects a pack with neither SKILL.md nor manifest.yaml', () => {
+      writeFileSync(join(dir, 'engrams.yaml'), validEngrams)
+      expect(() => loadPack(dir)).toThrow(/must ship a SKILL\.md/i)
+    })
+  })
+
+  describe('installPack auto-upgrade', () => {
+    it('upgrades a manifest.yaml-only pack to SKILL.md in the installed copy', () => {
+      const source = mkdtempSync(join(tmpdir(), 'plur-src-'))
+      const packsDir = join(dir, 'packs')
+      try {
+        writeFileSync(join(source, 'manifest.yaml'), 'name: legacy-pack\nversion: 1.0.0\n')
+        writeFileSync(join(source, 'engrams.yaml'), validEngrams)
+
+        const result = installPack(packsDir, source)
+        expect(result.installed).toBe(1)
+
+        // installPack names the installed dir after the source basename.
+        const dest = join(packsDir, basename(source))
+        expect(existsSync(join(dest, 'SKILL.md'))).toBe(true)
+        expect(existsSync(join(dest, 'manifest.yaml'))).toBe(false)
+        // The upgraded SKILL.md re-parses to the same manifest.
+        expect(loadPack(dest).manifest.name).toBe('legacy-pack')
+        // Integrity recorded over SKILL.md + engrams.yaml.
+        expect(result.registry.integrity).toBe(`sha256:${computePackHash(dest)}`)
+      } finally {
+        rmSync(source, { recursive: true, force: true })
+      }
+    })
+  })
+})

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -43,8 +43,8 @@ inner item is labelled otherwise.
    invariants of a single unit of knowledge.
 2. **The ID grammar** (§3) — how engram identifiers are formed and what their
    prefixes mean.
-3. **The Pack format** (§5) — the on-disk directory layout (`SKILL.md` /
-   `manifest.yaml` + `engrams.yaml` + `INTEGRITY`) and the manifest fields.
+3. **The Pack format** (§5) — the on-disk directory layout (`SKILL.md` +
+   `engrams.yaml` + `INTEGRITY`) and the manifest fields.
 4. **The `.plur` capsule** (§6) — the binary single-file envelope: header,
    format version, flags, payload, checksum.
 5. **The integrity model** (§6, §8) — how a receiver verifies that a pack or
@@ -391,15 +391,20 @@ an integrity file.
 
 ```
 <pack-name>/
-├── SKILL.md          (manifest as YAML frontmatter) — OR — manifest.yaml
+├── SKILL.md          (REQUIRED — manifest as YAML frontmatter)
 ├── engrams.yaml      (the engrams, top-level `engrams:` sequence)
 └── INTEGRITY         (pack content hash; see §5.5)
 ```
 
-- The manifest MAY be carried as the **YAML frontmatter of `SKILL.md`**
-  (delimited by `---` … `---`, with human-readable prose after it) OR as a
-  standalone **`manifest.yaml`**. If both exist, `SKILL.md` takes precedence (the
-  reference loader prefers it).
+- A pack **MUST** ship a `SKILL.md`, carrying the manifest as its **YAML
+  frontmatter** (delimited by `---` … `---`, with human-readable prose after it).
+  The frontmatter MUST be a valid manifest (§5.2) — presence of an empty or
+  invalid `SKILL.md` is not conformant.
+- A standalone **`manifest.yaml`** is **DEPRECATED**. The reference loader still
+  reads a `manifest.yaml`-only pack (emitting a deprecation warning) and
+  **auto-upgrades it to `SKILL.md` frontmatter on install**; new packs MUST be
+  published with a `SKILL.md`. `manifest.yaml` does not contribute to the
+  integrity hash (§5.5).
 - `engrams.yaml` is a §2.1 store document.
 - `INTEGRITY` is OPTIONAL on disk but RECOMMENDED for distribution; the
   authoritative integrity record at install time is the registry entry (§5.5).
@@ -471,15 +476,17 @@ the recipient builds their own usage history. (This mirrors the reference
 
 ### 5.5 Pack integrity — STABLE
 
-Pack integrity is a **SHA-256** over the pack's manifest file followed by its
+Pack integrity is a **SHA-256** over the pack's `SKILL.md` followed by its
 engrams file:
 
 ```
-H = SHA256( bytes(SKILL.md or manifest.yaml)  ||  bytes(engrams.yaml) )
+H = SHA256( bytes(SKILL.md)  ||  bytes(engrams.yaml) )
 ```
 
-- If `SKILL.md` exists it is hashed; else `manifest.yaml`; the two are not
-  combined. `engrams.yaml` bytes are appended if present.
+- `SKILL.md` is REQUIRED (§5.1) and is always hashed; `engrams.yaml` bytes are
+  appended if present. A deprecated `manifest.yaml`, if any, does **not**
+  contribute to `H` (the reference auto-upgrades it to `SKILL.md` on install, so
+  the recorded integrity is over `SKILL.md` + `engrams.yaml`).
 - The hash is recorded as the string `sha256:<64-lowercase-hex>` — in the
   `INTEGRITY` file (single line, trailing newline) and/or in the consumer's
   install registry.
@@ -487,14 +494,12 @@ H = SHA256( bytes(SKILL.md or manifest.yaml)  ||  bytes(engrams.yaml) )
   to the recorded `sha256:` value. Mismatch MUST be treated as a failed
   integrity check.
 
-> **Interop note.** The reference contains two hash helpers with the same SHA-256
-> construction over the same two logical files: `computePackHash` in `packs.ts`
-> (used for the registry/`INTEGRITY`, manifest-precedence as above) and
-> `computePackChecksum` in `trust.ts` (always `SKILL.md` then `engrams.yaml`).
-> They agree whenever the pack uses `SKILL.md`. A conformant v1 implementation
-> MUST use the §5.5 construction (manifest-file precedence: `SKILL.md`, else
-> `manifest.yaml`). Hashing is over **raw file bytes**, so producers and
-> consumers MUST NOT re-serialize before hashing.
+> **Implementation note.** The reference exposes a single §5.5 construction:
+> `computePackHash` (`packs.ts`, used for the registry/`INTEGRITY`) and
+> `computePackChecksum` (`trust.ts`, used for trust verification) compute the
+> identical hash — `computePackChecksum` delegates to `computePackHash` — so they
+> cannot diverge. Hashing is over **raw file bytes**, so producers and consumers
+> MUST NOT re-serialize before hashing.
 
 ---
 
@@ -558,7 +563,7 @@ The header is a JSON object (`schema: "plur.capsule/1"`):
 ### 6.5 Payload
 
 The payload is opaque bytes — typically a **gzip-compressed tar** of a pack
-directory (`SKILL.md`/`manifest.yaml` + `engrams.yaml`). The capsule format does
+directory (`SKILL.md` + `engrams.yaml`). The capsule format does
 not constrain the internal payload structure beyond what `product_type` implies;
 unpacking yields a §5 pack.
 
@@ -653,7 +658,7 @@ Integrity (the payload is intact and unmodified) is **separate** from
 authenticity (who produced it). v1 delivers integrity; authenticity is §7.
 
 - **Hash:** SHA-256.
-- **Pack integrity:** §5.5 — `sha256:` over manifest-file bytes ‖ `engrams.yaml`
+- **Pack integrity:** §5.5 — `sha256:` over `SKILL.md` bytes ‖ `engrams.yaml`
   bytes, recorded in `INTEGRITY` / registry.
 - **Capsule integrity:** §6.4/§6.7 step 10 — `header.payload.sha256` over the
   payload bytes, checked on every read; plus the structural checks (magic,


### PR DESCRIPTION
Closes #325 and #316. Supersedes #319 (closed) — implements @plur9/gregor's refined design from #325 rather than the blunter "hard-require SKILL.md" of #319.

## Policy
A knowledge pack MUST ship a **valid** `SKILL.md`; `manifest.yaml` is **deprecated**. SKILL.md frontmatter already *is* the manifest (`PackManifestSchema`), every real pack is a SKILL.md, and `manifest.yaml` was a redundant second serialization — the direct cause of the §5.5 hash divergence (#316).

## Changes
- **`computePackHash` (`packs.ts`)** — `H = SHA256(SKILL.md ‖ engrams.yaml)`; no `manifest.yaml` fallback.
- **`computePackChecksum` (`trust.ts`)** — delegates to `computePackHash`; single §5.5 implementation, so the two can't drift. This **subsumes the #316/#319 fix** (no manifest path left to diverge on).
- **`loadPack` (`engrams.ts`)** — validates the SKILL.md frontmatter against `PackManifestSchema` (an empty/invalid manifest fails with a clear error, not "passes because the file exists"). A `manifest.yaml`-only pack still loads, **with a deprecation warning** — no hard break.
- **`installPack`** — **auto-upgrades** a `manifest.yaml`-only pack to `SKILL.md` in the installed copy (writes SKILL.md from the parsed manifest, drops `manifest.yaml`) before the integrity hash is computed, so the recorded integrity is always over `SKILL.md` + `engrams.yaml`.
- **Spec** `ENGRAM-STANDARD-v1.md` §5.1/§5.5 (+ §1.1, capsule, appendix) — SKILL.md REQUIRED; `manifest.yaml` deprecated + auto-upgraded; `H = SHA256(SKILL.md ‖ engrams.yaml)`; interop note now states the helpers are unified. Updated in lockstep with the code.

## Graceful, per #325 (the three things to get right)
1. **Validate frontmatter, not just existence** — ✅ `PackManifestSchema.safeParse` with a clear error.
2. **Deprecate `manifest.yaml` with auto-upgrade, don't hard-throw** — ✅ loads with a warning; install upgrades the managed copy; only *new publishes* require SKILL.md (export already writes SKILL.md).
3. **The SKILL.md body is a description, not forced instructions** — ✅ unchanged; the manifest lives in frontmatter.

## Blast radius
Zero in-repo `manifest.yaml` packs — all ship `SKILL.md`, so no integrity hash changes and nothing breaks. External `manifest.yaml` packs keep working (warned + auto-upgraded on install). Optional `plur pack migrate` for batch conversion is **not** in this PR (deferred — #325 marks it optional).

## Tests
New `pack-skill-md-policy.test.ts`: hashing (manifest ignored, checksum==hash, null-on-empty, verify round-trip), `loadPack` validation (frontmatter required, manifest-only loads, missing-`version` rejected, neither-file rejected), and `installPack` auto-upgrade (manifest.yaml → SKILL.md, integrity over the upgraded copy). The existing CLI `packs install` test (a `manifest.yaml` fixture) passes unchanged — exercising the graceful auto-upgrade end-to-end. Full suite green apart from the pre-existing `sync.test.ts` git-env failures; built all packages.