### PR TITLE
feat: teach per-engram scope selection so team knowledge stops defaulting to global (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@ When an enterprise token expired, the client failed silently: team-scoped writes
 
 The reauth command itself (`plur login`) and longer-lived keys are tracked separately as a fast-follow.
 
+### Teach per-engram scope selection so team knowledge stops defaulting to global (#296)
+
+Per-engram scoping was supported (every `plur_learn` takes a `scope`) but nothing taught agents to use it, so they routinely omitted `scope` → it fell back to `global` → team-relevant knowledge silently never reached the configured group store. This affects any install with a remote/group store. The capability worked; the guidance and the defaults didn't. Fixed at three layers — always-on instructions, install-time guidance, and a runtime safety net:
+
+- **`packages/mcp/src/server.ts`** — the server `INSTRUCTIONS` block (advertised to every client on connect) gains a single "SCOPE SELECTION" section: scope is content-driven and per-call; team/shared knowledge → the matching `group:<org>/<team>` scope (`plur_session_start` lists the writable ones); personal/local → default; never let team knowledge fall back to `global`. Exported for testing.
+- **`packages/cli/src/commands/init.ts`** (+ repo `CLAUDE.md`, `README.md`) — the CLAUDE.md `plur init` generates replaces the thin "Multi-project scoping" note with a fuller "Scope selection (set scope PER engram, by content)" guide enumerating the team / project / personal routing and the global-fallback anti-pattern.
+- **`packages/mcp/src/tools.ts`** — runtime safety net: when a `plur_learn` call omits `scope`, lands at `global`, **and** a team store is configured, the response carries a non-fatal `scope_hint` naming the writable team scopes (silent on personal installs). `plur_session_start` guidance is also made prescriptive about per-engram routing.
+
+`plur_session_start` already surfaces the live writable remote scopes (#229); this adds the always-on, install-time, and at-write-time guidance around it. Relates to #291 (a comms/second scope can't be registered against the same URL until that lands) and #295 (silent auth-expiry). Consolidates #299 (install surfaces) and #324 (runtime).
+
 ## 0.9.11 (2026-05-26)
 
 Bug sweep — three independent fixes bundled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,14 @@ A PreToolUse guard enforces that `plur_session_start` is called at the beginning
 
 Do not ask permission to use these tools — they are your memory system.
 
-### Multi-project scoping
+### Scope selection (per engram, by content)
 
-PLUR uses `domain` and `scope` fields on engrams to separate knowledge by project. When calling `plur_learn`, set `scope` (e.g. `project:my-app`) to namespace the engram. Scoped recall automatically includes global engrams.
+PLUR uses `domain` and `scope` fields to separate knowledge. **Set `scope` on every `plur_learn` call, chosen by the engram's content** — one session spans multiple scopes. Scoped recall automatically includes global engrams.
+
+- Team/shared knowledge → the matching team scope (e.g. `group:<org>/<team>`); `plur_session_start` lists the writable ones.
+- This project's details → `project:my-app` (a `.plur.yaml` with `scope:` makes it the default).
+- Personal preferences / your workflow → leave at the default/local scope.
+- Don't omit `scope` for team-relevant knowledge — it falls back to `global`, which leaks into every project and never reaches the team store. Reserve `global` for genuinely cross-project facts.
 
 ### When to check memory
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npx @plur-ai/cli@0.9.4 init --domain myapp --scope project:my-app
 
 This creates a `.plur.yaml` in the project with defaults that hooks apply automatically. Engrams learned in that project are tagged; recall filters by scope but always includes global knowledge.
 
+**Set scope per engram, by content.** Scope is not a once-per-session setting — every `plur_learn` call takes its own `scope`, chosen from what the engram is about. Team/shared knowledge goes to a team scope (e.g. `group:<org>/<team>`, used by PLUR Enterprise); project details to `project:<name>`; personal preferences stay local. Don't let team-relevant knowledge fall back to `global` by omitting scope — `global` leaks into every project and (with a team store configured) never reaches the team. `plur_session_start` lists the remote scopes a token can write to.
+
 ### Global install (faster startup)
 
 ```bash

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -341,9 +341,14 @@ A PreToolUse guard enforces that \`plur_session_start\` is called at the beginni
 
 Do not ask permission to use these tools — they are your memory system.
 
-### Multi-project scoping
+### Scope selection (set scope PER engram, by content)
 
-PLUR uses \`domain\` and \`scope\` fields on engrams to separate knowledge by project. When calling \`plur_learn\`, set \`scope\` (e.g. \`project:my-app\`) to namespace the engram. Scoped recall automatically includes global engrams.
+PLUR uses \`domain\` and \`scope\` fields to separate knowledge. **Set \`scope\` on every \`plur_learn\` call, chosen by the engram's content** — a single session legitimately spans multiple scopes. Scoped recall automatically includes global engrams.
+
+- **Team / shared knowledge** (engineering patterns, architecture decisions, project conventions) → the matching team scope (e.g. \`group:<org>/<team>\`). \`plur_session_start\` lists the remote scopes your token can write to.
+- **This project's details** → \`project:<name>\` (a \`.plur.yaml\` with \`scope:\` makes this the default).
+- **Personal preferences / your own workflow** → leave at the default / local scope.
+- **Do NOT omit \`scope\` for team-relevant knowledge** — it falls back to \`global\`, which appears in every project's future sessions AND never reaches the team store. Prefer the project/local default over \`global\`; reserve \`global\` for genuinely cross-project facts (language gotchas, tool quirks).
 
 ### When to check memory
 

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -53,6 +53,16 @@ describe('plur init', () => {
     expect(settings.mcpServers?.plur).toBeDefined()
   })
 
+  it('writes per-engram scope-selection guidance into CLAUDE.md (#296)', () => {
+    runInit()
+    const claudeMd = readFileSync(join(home, 'CLAUDE.md'), 'utf-8')
+    expect(claudeMd).toContain('Scope selection')
+    expect(claudeMd).toMatch(/per engram/i)
+    expect(claudeMd).toContain('group:<org>/<team>')
+    // The key anti-pattern the issue is about: omitting scope → global → never reaches the team store.
+    expect(claudeMd).toMatch(/never reaches the team store/i)
+  })
+
   it('registers the MCP server with a platform-appropriate command', () => {
     runInit()
     const settings = readSettings()

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,7 +16,7 @@ import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
 import { z } from 'zod'
 
-const INSTRUCTIONS = `PLUR is your persistent memory. Corrections, preferences, and conventions persist across sessions as engrams.
+export const INSTRUCTIONS = `PLUR is your persistent memory. Corrections, preferences, and conventions persist across sessions as engrams.
 
 PLUR is a GLOBAL tool — one MCP server, one engram store (~/.plur/), available in every project. Multi-project scoping uses domain/scope fields on engrams, not separate installations.
 
@@ -28,6 +28,19 @@ DURING the session:
 - When user corrects you ("no, use X not Y") → call plur_learn immediately
 - When user states a preference ("always X", "never Y") → call plur_learn immediately
 - When you discover a codebase convention or pattern → call plur_learn
+
+SCOPE SELECTION (set scope PER engram, by content — not once per session):
+A single session produces engrams that belong in different stores. Choose the
+"scope" on EACH plur_learn call from what the engram is about:
+- Team / engineering / architecture / shared-convention knowledge → the matching
+  team store scope (e.g. "group:<org>/<team>"). plur_session_start lists the
+  scopes this install can write to — use them.
+- Personal preferences, your workflow, or details specific to one project → the
+  default/local scope (or "project:<name>").
+- "global" is for genuinely cross-project facts only (language gotchas, tool
+  quirks). Do NOT let team-relevant knowledge fall back to "global" by omitting
+  scope — with a team store configured it never reaches the team store. If no
+  scope fits, prefer the project/local default over global.
 
 OPTIONAL but improves quality:
 - Call plur_feedback to rate which injected engrams helped (positive/negative)

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -168,6 +168,24 @@ export function getToolDefinitions(): ToolDefinition[] {
         // learnRouted defers to sync learn() so dedup behavior is
         // unchanged. We try learnAsync second only as a fallback for
         // the LLM-driven dedup pathway (local routes).
+        // Runtime scope nudge (#296): when the caller passes no scope and the
+        // engram lands at "global" while a team store IS configured, team
+        // knowledge silently never reaches the shared store. Surface that at the
+        // moment it happens — non-fatal, informational, and only when there is a
+        // team store to route to (stays silent on personal installs).
+        const explicitScope = typeof args.scope === 'string' && args.scope.length > 0
+        const scopeHint = (engramScope: string): { scope_hint?: string } => {
+          if (explicitScope || engramScope !== 'global') return {}
+          let remote: Array<{ scope: string }> = []
+          try { remote = plur.getWritableRemoteScopes() } catch { return {} }
+          if (remote.length === 0) return {}
+          const scopes = remote.map(s => `"${s.scope}"`).join(', ')
+          return { scope_hint:
+            `Stored at "global" because no scope was passed, but a team store is configured (${scopes}). ` +
+            `If this is team/engineering knowledge, re-learn it with an explicit scope so it reaches the shared ` +
+            `store; keep genuinely personal notes at the default scope.` }
+        }
+
         const statement = sanitizeStatement(args.statement as string)
         try {
           const engram = await plur.learnRouted(statement, context)
@@ -180,6 +198,7 @@ export function getToolDefinitions(): ToolDefinition[] {
             scope: engram.scope, type: engram.type,
             pinned: (engram as any).pinned === true,
             decision: 'ADD',
+            ...scopeHint(engram.scope),
             ...(isOutbox ? { outbox: true, warning: 'Remote write failed; engram queued locally for retry on next session start or plur_sync.' } : {}),
           }
         } catch (err) {
@@ -193,6 +212,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type, decision: 'ADD',
+            ...scopeHint(engram.scope),
             ...(isOutbox ? { outbox: true } : {}),
             warning: `Remote write failed (${(err as Error).message}); engram queued for retry.`,
           }
@@ -1238,10 +1258,11 @@ export function getToolDefinitions(): ToolDefinition[] {
           guide += default_scope
             ? `\n\nSession default scope is set to "${default_scope}". To route an engram to a remote ` +
               `enterprise store instead, pass scope explicitly to plur_learn (available remote scopes: ${scopeList}).`
-            : `\n\nRemote store scopes available: ${scopeList}. When an engram is relevant to the team ` +
-              `(engineering patterns, architecture decisions, project conventions), set scope to the matching ` +
-              `remote scope in plur_learn. Personal preferences, local project details, and corrections specific ` +
-              `to your workflow should stay at default scope (local).`
+            : `\n\nRemote store scopes available: ${scopeList}. Set scope PER ENGRAM by content: when an engram is ` +
+              `relevant to the team (engineering patterns, architecture decisions, project conventions), set scope to ` +
+              `the matching remote scope in plur_learn. Personal preferences, local project details, and corrections ` +
+              `specific to your workflow should stay at default scope (local). Do NOT let team knowledge fall back to ` +
+              `"global" — without an explicit scope it will, and it will never reach the shared store.`
 
           // Surface authorized-but-unregistered scopes (#292). Best-effort:
           // gated to enterprise users (remote stores configured), bounded by a

--- a/packages/mcp/test/instructions.test.ts
+++ b/packages/mcp/test/instructions.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Server INSTRUCTIONS advertise per-engram scope selection (#296).
+ *
+ * The instructions block is advertised to every client on connect, so it's the
+ * always-on place to teach agents that scope is content-driven and per-call —
+ * not a once-per-session default that lets team knowledge fall back to 'global'.
+ */
+import { describe, it, expect } from 'vitest'
+import { INSTRUCTIONS } from '../src/server.js'
+
+describe('server INSTRUCTIONS — scope selection (#296)', () => {
+  it('teaches per-engram scope selection by content', () => {
+    expect(INSTRUCTIONS).toMatch(/SCOPE SELECTION/i)
+    expect(INSTRUCTIONS).toMatch(/per engram/i)
+  })
+
+  it('names the team scope shape and warns against the global fallback', () => {
+    expect(INSTRUCTIONS).toContain('group:<org>/<team>')
+    expect(INSTRUCTIONS).toMatch(/never reaches the team store/i)
+  })
+})

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -44,6 +44,39 @@ describe('MCP tools', () => {
     expect(result.statement).toBe('Test learning')
   })
 
+  // #296 — team knowledge silently defaulting to 'global'. When a team store is
+  // configured and no scope is passed, surface a hint at the moment of the write.
+  describe('scope hint when a team store is configured (#296)', () => {
+    beforeEach(() => {
+      plur.addStore('', 'group:acme/engineering', { url: 'https://plur.example.com', token: 'tok' })
+    })
+
+    it('hints to use the team scope when scope is omitted and engram lands at global', async () => {
+      const result = await callTool('plur_learn', { statement: 'We use trunk-based development' }) as any
+      expect(result.scope).toBe('global')
+      expect(result.scope_hint).toBeDefined()
+      expect(result.scope_hint).toContain('group:acme/engineering')
+    })
+
+    it('no hint when an explicit scope is passed', async () => {
+      const result = await callTool('plur_learn', {
+        statement: 'We use trunk-based development', scope: 'group:acme/engineering',
+      }) as any
+      expect(result.scope_hint).toBeUndefined()
+    })
+
+    it('no hint when the explicit scope is global on purpose', async () => {
+      const result = await callTool('plur_learn', { statement: 'TS enums are slow', scope: 'global' }) as any
+      expect(result.scope_hint).toBeUndefined()
+    })
+  })
+
+  it('plur_learn does NOT hint on a personal install (no team store configured)', async () => {
+    const result = await callTool('plur_learn', { statement: 'Personal note' }) as any
+    expect(result.scope).toBe('global')
+    expect(result.scope_hint).toBeUndefined()
+  })
+
   it('plur_learn strips XML envelope artifacts from statement (#145)', async () => {
     // Reproduce the corruption: LLM generates old XML tool-call format where the
     // statement value contains the closing tag + duplicated parameter body.


### PR DESCRIPTION
Closes #296. **Consolidates #299 + #324** into one PR, as requested in the #299/#324 review — single source of truth for the `SCOPE SELECTION` guidance so `server.ts` and the generated `CLAUDE.md` can't drift. Based on current `main`.

## The gap

Per-engram scoping is supported (every `plur_learn` takes a `scope`) but nothing taught agents to use it, so they routinely omitted `scope` → it fell back to `global` → team-relevant knowledge silently never reached the configured group store. The capability worked; the guidance and the defaults didn't. (Observed in production: a whole multi-topic session's engrams all defaulted to `global` despite a configured `group:…/engineering` store.)

## What this does — fix it at three layers

- **Always-on (`packages/mcp/src/server.ts`)** — the server `INSTRUCTIONS` block (advertised to every client on connect) gains **one** `SCOPE SELECTION` section: scope is content-driven and per-call; team/shared knowledge → the matching `group:<org>/<team>` scope (`plur_session_start` lists the writable ones); personal/local → default; never let team knowledge fall back to `global`. `INSTRUCTIONS` is exported so it's unit-testable.
- **Install-time (`packages/cli/src/commands/init.ts`, + repo `CLAUDE.md`, `README.md`)** — the CLAUDE.md `plur init` generates replaces the thin "Multi-project scoping" note with a fuller "Scope selection (set scope PER engram, by content)" guide enumerating team / project / personal routing and the global-fallback anti-pattern.
- **At write-time (`packages/mcp/src/tools.ts`)** — runtime safety net: when a `plur_learn` call omits `scope`, lands at `global`, **and** a team store is configured, the response carries a non-fatal `scope_hint` naming the writable team scopes — surfacing the mistake at the moment it happens. Silent on personal installs (no team store). `plur_session_start` guidance is also made prescriptive about per-engram routing.

## Consolidation notes

- The two original PRs each added their own `SCOPE SELECTION` block to `server.ts` (different wording/placement) — they conflicted. This PR keeps **one** unified block (placed in the core "during the session" guidance, before the OPTIONAL items).
- #299's install surfaces and #324's runtime safety net are otherwise disjoint and are both included unchanged in intent.
- ⚠️ **@plur9 — the agent-facing wording is a product call; please sign off on the `SCOPE SELECTION` phrasing before merge.**

## Related (not blocking)

- **#291** — until a second/comms scope can register against the same URL, multi-team routing (`group:…/comms`) is partly aspirational; cross-referenced, not blocked.
- **#295** — the auth-expiry side of the same "make memory legible" theme.

## Tests

- `packages/mcp/test/instructions.test.ts` — INSTRUCTIONS teaches per-engram selection, names `group:<org>/<team>`, warns against the global fallback.
- `packages/mcp/test/tools.test.ts` — `scope_hint` appears when scope omitted + team store configured + lands at global; absent on explicit scope, explicit `global`, and personal installs.
- `packages/cli/test/init.test.ts` — a fresh `plur init` writes the scope-selection guidance into CLAUDE.md.

Local: `pnpm build` clean; `@plur-ai/mcp` 130/130 and `@plur-ai/cli` 199 pass / 4 skipped. No version bump / publish — leaving the release cut to @plur9.