### PR TITLE
feat(core): PGLite substrate + YAML-as-truth tests (opt-in backend) — PR-1 of #332

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,25 +1,43 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText } from '../output.js'
 
+/**
+ * `plur sync [remote] [--full]`
+ *
+ * Default: git pull/push + incremental syncFromYaml on the active index.
+ * --full: git pull/push + drop-and-rebuild the derived index from YAML.
+ *
+ * YAML is the source of truth. `--full` is the recovery path: it deletes
+ * every row in the index (SQLite or PGLite) and replays the YAML file. Use
+ * after upgrading the embedder, after a schema migration, or whenever the
+ * index looks out of sync with what `list()` and `recall()` report.
+ */
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
 
   let remote: string | undefined
+  let full = false
 
   let i = 0
   while (i < args.length) {
     const arg = args[i]
-    if (!remote && !arg.startsWith('--')) { remote = arg; i++ }
+    if (arg === '--full') { full = true; i++ }
+    else if (!remote && !arg.startsWith('--')) { remote = arg; i++ }
     else { i++ }
   }
 
-  const result = plur.sync(remote)
+  const result = plur.sync(remote, { full })
+  // Block on any background PGLite work so the CLI returns a quiescent state.
+  if (typeof (plur as { waitForIndex?: () => Promise<void> }).waitForIndex === 'function') {
+    await (plur as { waitForIndex: () => Promise<void> }).waitForIndex()
+  }
 
   if (shouldOutputJson(flags)) {
-    outputJson(result)
+    outputJson({ ...result, full })
   } else {
-    outputText(`Sync: ${result.action}`)
+    outputText(`Sync: ${result.action}${full ? ' (full reindex)' : ''}`)
     if (result.message) outputText(`  ${result.message}`)
     if (result.files_changed > 0) outputText(`  Files changed: ${result.files_changed}`)
+    if (full) outputText('  Index rebuilt from YAML.')
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "gen:schemas": "tsx scripts/gen-spec-schemas.ts"
   },
   "dependencies": {
+    "@electric-sql/pglite": "^0.4.6",
     "js-yaml": "^4.1.0",
     "zod": "^3.23.0"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ import { join, dirname, basename } from 'path'
 import yaml from 'js-yaml'
 import { detectPlurStorage, type PlurPaths } from './storage.js'
 import { IndexedStorage } from './storage-indexed.js'
+import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
 import { loadEngrams, saveEngrams, generateEngramId, loadAllPacks, storePrefix } from './engrams.js'
 import { logger } from './logger.js'
@@ -84,6 +85,8 @@ export function isSharedScope(scope: string): boolean {
 }
 export { detectPlurStorage, type PlurPaths } from './storage.js'
 export { IndexedStorage } from './storage-indexed.js'
+export { PGLiteAdapter, type PGLiteAdapterOptions } from './storage-pglite.js'
+export type { StorageAdapter, StorageFilter, VectorSearchHit } from './storage-adapter.js'
 export { YamlStore, SqliteStore, createStore, migrateStore, type EngramStore, type StorageBackend, type StorageConfig } from './store/index.js'
 export { withAsyncLock, asyncAtomicWrite } from './store/index.js'
 // Embedding primitive — public so alternative store backends can compute
@@ -250,6 +253,16 @@ export class Plur {
   private paths: PlurPaths
   private config: PlurConfig
   private indexedStorage: IndexedStorage | null = null
+  /**
+   * PGLite adapter (ADR-0001, Sprint 0 PR 2). Opt-in via
+   * PLUR_BACKEND=pglite env var or `backend: pglite` in config.yaml.
+   * When active, runs in parallel to the YAML write path: every YAML
+   * mutation triggers syncFromYaml on the PGLite index. The YAML file
+   * remains the source of truth — see yaml-truth-rebuild and
+   * yaml-truth-traceability tests for the invariant.
+   */
+  private pgliteAdapter: PGLiteAdapter | null = null
+  private _pgliteInitPromise: Promise<void> | null = null
   private _engramCache: Map<string, { mtime: bigint; engrams: Engram[] }> = new Map()
   private _llmFailureCount = 0
   private _llmDisabledUntil: number | null = null
@@ -267,7 +280,17 @@ export class Plur {
       this.config = loadConfig(this.paths.config)
     }
     this.configMtimeMs = this.statConfigMtime()
-    if (this.config.index) {
+    const backend = this._resolveBackend()
+    if (backend === 'pglite') {
+      // PGLite path. Keep SQLite indexedStorage null so we don't double-index.
+      this.pgliteAdapter = new PGLiteAdapter(this.paths.engrams, this.paths.pglite)
+      // Initial sync runs in the background — YAML is already authoritative,
+      // so reads served from the YAML fallthrough remain correct while the
+      // index warms up.
+      this._pgliteInitPromise = this.pgliteAdapter.syncFromYaml().catch((err: unknown) => {
+        logger.warning(`[plur] PGLite initial sync failed: ${(err as Error).message}. Run 'plur sync --full' to rebuild.`)
+      })
+    } else if (this.config.index) {
       this.indexedStorage = new IndexedStorage(this.paths.engrams, this.paths.db, this.config.stores)
     }
     // Wire config-level embeddings opt-out into the embedder module. The env
@@ -281,6 +304,20 @@ export class Plur {
     // conflict creation from the dedup prompt, so any remaining conflicts are
     // false positives from the old system. Run once, mark with a sentinel file.
     this._autoPurgeLegacyTensions()
+  }
+
+  /**
+   * Resolve the active index backend. Order:
+   *   1. PLUR_BACKEND env var (pglite|sqlite)
+   *   2. config.yaml `backend` field
+   *   3. default: sqlite (historical)
+   */
+  private _resolveBackend(): 'sqlite' | 'pglite' {
+    const env = process.env.PLUR_BACKEND
+    if (env === 'pglite' || env === 'sqlite') return env
+    const fromConfig = (this.config as { backend?: string }).backend
+    if (fromConfig === 'pglite' || fromConfig === 'sqlite') return fromConfig
+    return 'sqlite'
   }
 
   private _autoPurgeLegacyTensions(): void {
@@ -1318,6 +1355,12 @@ export class Plur {
         domain: options?.domain,
       })
     } else {
+      // PGLite path (or no-index path): read from YAML so this code stays
+      // synchronous. PGLite is currently used for vector/Cypher queries
+      // and remains in sync via _syncIndex on every write — but the
+      // filtered relational path here goes through the YAML cache for
+      // sync semantics. _loadAllEngrams reads through a mtime-based cache,
+      // so the cost is comparable.
       engrams = this._loadAllEngrams()
       engrams = engrams.filter(e => e.status === 'active')
       if (options?.domain) {
@@ -1918,18 +1961,63 @@ export class Plur {
     })
   }
 
-  /** Rebuild SQLite index from YAML source of truth. Only works when index: true. */
+  /**
+   * Rebuild the derived index from YAML source of truth.
+   * Works for both backends: SQLite (legacy) and PGLite (ADR-0001).
+   * Sync-shaped to preserve the existing public API; PGLite work is fired off
+   * and the promise tracked on the instance so `await plur.reindexAsync()` is
+   * available for code paths that need to block.
+   */
   reindex(): void {
+    if (this.pgliteAdapter) {
+      // Fire-and-track. Callers that need to block use reindexAsync().
+      this._pgliteInitPromise = this.pgliteAdapter.reindex()
+        .catch((err: unknown) => {
+          logger.warning(`[plur] PGLite reindex failed: ${(err as Error).message}`)
+        })
+      return
+    }
     if (!this.indexedStorage) {
       this.indexedStorage = new IndexedStorage(this.paths.engrams, this.paths.db, this.config.stores)
     }
     this.indexedStorage.reindex()
   }
 
-  /** Sync SQLite index after YAML write (no-op if index disabled) */
+  /**
+   * Async reindex that resolves when the index is fully rebuilt.
+   * Equivalent to `plur sync --full`: drop the index and rebuild from YAML.
+   */
+  async reindexAsync(): Promise<void> {
+    if (this.pgliteAdapter) {
+      await this.pgliteAdapter.reindex()
+      return
+    }
+    if (!this.indexedStorage) {
+      this.indexedStorage = new IndexedStorage(this.paths.engrams, this.paths.db, this.config.stores)
+    }
+    this.indexedStorage.reindex()
+  }
+
+  /** Sync index after YAML write (no-op if no index is active). */
   private _syncIndex(): void {
+    if (this.pgliteAdapter) {
+      // Synchronous-shaped path: kick off the sync, track the promise.
+      // The YAML write already happened — this is the index catching up.
+      this._pgliteInitPromise = this.pgliteAdapter.syncFromYaml()
+        .catch((err: unknown) => {
+          logger.warning(`[plur] PGLite syncFromYaml failed (YAML is still source of truth): ${(err as Error).message}`)
+        })
+      return
+    }
     if (this.indexedStorage) {
       this.indexedStorage.syncFromYaml()
+    }
+  }
+
+  /** Block until any in-flight PGLite background sync completes. Useful in tests. */
+  async waitForIndex(): Promise<void> {
+    if (this._pgliteInitPromise) {
+      await this._pgliteInitPromise
     }
   }
 
@@ -2055,9 +2143,28 @@ export class Plur {
     return this.paths.root
   }
 
-  /** Sync engrams to git. Initializes repo on first call, commits + push/pull on subsequent calls. */
-  sync(remote?: string): SyncResult {
-    return gitSync(this.paths.root, remote)
+  /**
+   * Sync engrams to git AND refresh the derived index from YAML.
+   *
+   * Behavior:
+   *   - default: git push/pull + incremental syncFromYaml on the active index
+   *   - { full: true }: git push/pull + drop-and-rebuild the index from YAML
+   *
+   * The `--full` mode is the recovery path for "the index is wrong" — it
+   * deletes every row in the derived index and replays YAML. YAML is never
+   * touched in either mode.
+   */
+  sync(remote?: string, options?: { full?: boolean }): SyncResult {
+    const result = gitSync(this.paths.root, remote)
+    // After git pull, YAML may have changed — refresh the index.
+    // PGLite path is the only backend that honors --full directly here; the
+    // legacy SQLite path also reindexes on full, otherwise calls syncFromYaml.
+    if (options?.full) {
+      this.reindex()
+    } else {
+      this._syncIndex()
+    }
+    return result
   }
 
   /** Get git sync status without making changes. */

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -78,6 +78,15 @@ export const PlurConfigSchema = z.object({
   decay_baseline: z.string().optional(),
   allow_secrets: z.boolean().default(false),
   index: z.boolean().default(true),
+  /**
+   * Index backend selector. `sqlite` is the historical default
+   * (better-sqlite3, in-process WAL). `pglite` opts in to the ADR-0001
+   * substrate — PGLite WASM + pgvector + Apache AGE. PGLite is opt-in until
+   * the bake-off completes; defaults remain sqlite to keep the existing
+   * test surface stable.
+   * Env override: PLUR_BACKEND=pglite|sqlite.
+   */
+  backend: z.enum(['sqlite', 'pglite']).default('sqlite'),
   storage: StorageConfigSchema.default({}),
   embeddings: EmbeddingsConfigSchema.default({}),
   stores: z.array(StoreEntrySchema).default([]),

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -1,0 +1,52 @@
+/**
+ * StorageAdapter — shared interface for derived-index backends.
+ *
+ * YAML on disk is the source of truth (#226 / ADR-0001 / Sprint 0 PR 1).
+ * The adapter is the index over YAML, never the primary store. Anything an
+ * adapter holds must be rebuildable by calling `reindex()` with no observable
+ * change in query results.
+ *
+ * Backends:
+ *   - IndexedStorage  (legacy, better-sqlite3, in-process WAL)
+ *   - PGLiteAdapter   (PGLite WASM, pgvector + AGE — ADR-0001)
+ *
+ * Both expose the same operations the Plur class calls today (`loadFiltered`,
+ * `count`, `reindex`, `syncFromYaml`, `close`). The PGLite path adds
+ * `searchBM25`, `searchVector`, and `upsertEmbedding` to support the Wave 1
+ * retrieval upgrades; the legacy SQLite path leaves those undefined and the
+ * caller falls back to the in-memory `fts`/`embeddings` modules.
+ */
+import type { Engram } from './schemas/engram.js'
+
+/** Filter shape shared by all adapters. */
+export interface StorageFilter {
+  status?: string
+  scope?: string
+  domain?: string
+}
+
+/** Scored vector-search result. */
+export interface VectorSearchHit {
+  engram: Engram
+  score: number
+}
+
+/** Async-style storage adapter. */
+export interface StorageAdapter {
+  /** Load all engrams from the index, applying a filter. */
+  loadFiltered(filter: StorageFilter): Promise<Engram[]>
+  /** Count engrams with optional status filter. */
+  count(filter?: { status?: string }): Promise<number>
+  /** Apply a YAML-to-index delta (incremental). */
+  syncFromYaml(): Promise<void>
+  /** Drop the index and rebuild from YAML. */
+  reindex(): Promise<void>
+  /** BM25 keyword search. */
+  searchBM25(query: string, opts: { limit: number }): Promise<Engram[]>
+  /** Vector similarity search (cosine). */
+  searchVector(query: Float32Array, limit: number): Promise<VectorSearchHit[]>
+  /** Upsert an embedding for a specific engram. */
+  upsertEmbedding(engramId: string, vector: Float32Array): Promise<void>
+  /** Release resources. */
+  close(): Promise<void>
+}

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -1,0 +1,456 @@
+/**
+ * PGLiteAdapter — PGLite-backed storage adapter (ADR-0001, Sprint 0 PR 2).
+ *
+ * Substrate: PGLite (WASM Postgres) + pgvector + Apache AGE. YAML on disk is
+ * the source of truth; this adapter is a rebuildable index.
+ *
+ * Write order (invariant):
+ *   1. caller writes YAML
+ *   2. caller calls syncFromYaml() to mirror into PGLite
+ * If step 2 fails, YAML still wins on next `plur sync`.
+ *
+ * Vector storage: when pgvector loads cleanly, we use a `vector(N)` column
+ * with a cosine-similarity ORDER BY. When pgvector isn't available (rare —
+ * the extension ships in PGLite as of 0.4.x), we fall back to BYTEA storage
+ * and compute cosine in TypeScript. Same external behavior either way.
+ *
+ * Concurrency: PGLite is single-writer per process. We serialize through a
+ * lightweight async mutex on this adapter so concurrent `reindex()` /
+ * `upsertEmbedding()` calls from the same process see a consistent final
+ * state.
+ *
+ * Graph (AGE / Cypher): loaded if available; the engram graph schema lands
+ * in a future PR. We initialize the extension so it's ready for #200, but
+ * the public adapter surface in this PR is relational + vector.
+ */
+import { existsSync } from 'fs'
+import type { Engram } from './schemas/engram.js'
+import { loadEngrams } from './engrams.js'
+import { searchEngrams } from './fts.js'
+import { logger } from './logger.js'
+import type { StorageAdapter, StorageFilter, VectorSearchHit } from './storage-adapter.js'
+
+/** Vector dimension used by the default BGE-small-en-v1.5 model. */
+const DEFAULT_VECTOR_DIM = 384
+
+/** Minimal async mutex — serializes writes inside the adapter. */
+class AsyncMutex {
+  private queue: Promise<void> = Promise.resolve()
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void
+    const wait = new Promise<void>((res) => { release = res })
+    const prev = this.queue
+    this.queue = wait
+    await prev
+    try {
+      return await fn()
+    } finally {
+      release!()
+    }
+  }
+}
+
+/** Lazy import wrapper so the PGLite WASM bundle only loads when needed. */
+async function loadPglite(): Promise<any> {
+  const mod = await import('@electric-sql/pglite')
+  return mod.PGlite
+}
+
+async function loadPgliteVector(): Promise<unknown | null> {
+  try {
+    const mod = await import('@electric-sql/pglite/vector')
+    return (mod as { vector: unknown }).vector
+  } catch (err) {
+    logger.debug(`[pglite] vector extension unavailable: ${(err as Error).message}`)
+    return null
+  }
+}
+
+async function loadPgliteAge(): Promise<unknown | null> {
+  try {
+    const mod = await import('@electric-sql/pglite/age')
+    return (mod as { age: unknown }).age
+  } catch (err) {
+    logger.debug(`[pglite] AGE extension unavailable: ${(err as Error).message}`)
+    return null
+  }
+}
+
+export interface PGLiteAdapterOptions {
+  /** Vector dimension for the embedding column (default: 384 — BGE-small). */
+  vectorDim?: number
+}
+
+export class PGLiteAdapter implements StorageAdapter {
+  private yamlPath: string
+  private dbPath: string
+  private vectorDim: number
+  private db: any = null
+  private initialized = false
+  private hasVector = false
+  private hasAge = false
+  private mutex = new AsyncMutex()
+
+  constructor(yamlPath: string, dbPath: string, opts?: PGLiteAdapterOptions) {
+    this.yamlPath = yamlPath
+    this.dbPath = dbPath
+    this.vectorDim = opts?.vectorDim ?? DEFAULT_VECTOR_DIM
+  }
+
+  /** Open the PGLite DB and create schema if needed. */
+  private async getDb(): Promise<any> {
+    if (this.db && this.initialized) return this.db
+    if (!this.db) {
+      const PGlite = await loadPglite()
+      const extensions: Record<string, unknown> = {}
+      const vector = await loadPgliteVector()
+      if (vector) extensions.vector = vector
+      const age = await loadPgliteAge()
+      if (age) extensions.age = age
+      // PGLite persists to a filesystem directory when given a path; falls
+      // back to in-memory when called with no path.
+      this.db = new PGlite(`file://${this.dbPath}`, { extensions })
+      await this.db.waitReady
+      this.hasVector = !!vector
+      this.hasAge = !!age
+    }
+    if (!this.initialized) {
+      await this.initSchema()
+      this.initialized = true
+    }
+    return this.db
+  }
+
+  private async initSchema(): Promise<void> {
+    const db = this.db
+    if (this.hasVector) {
+      try {
+        await db.exec('CREATE EXTENSION IF NOT EXISTS vector')
+      } catch (err) {
+        logger.debug(`[pglite] CREATE EXTENSION vector failed: ${(err as Error).message}`)
+        this.hasVector = false
+      }
+    }
+    if (this.hasAge) {
+      try {
+        await db.exec('CREATE EXTENSION IF NOT EXISTS age')
+        await db.exec("LOAD 'age'")
+        await db.exec('SET search_path = ag_catalog, public')
+      } catch (err) {
+        logger.debug(`[pglite] AGE init failed: ${(err as Error).message}`)
+        this.hasAge = false
+      }
+    }
+    // Engram table: mirrors YAML rows for fast filtered reads.
+    // The `data` JSONB column holds the full engram body; the other columns
+    // index the hot filter paths (status / scope / domain).
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS engrams (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        scope TEXT NOT NULL,
+        domain TEXT,
+        last_accessed TEXT,
+        data JSONB NOT NULL,
+        source TEXT NOT NULL DEFAULT 'primary'
+      );
+      CREATE INDEX IF NOT EXISTS idx_engrams_status ON engrams(status);
+      CREATE INDEX IF NOT EXISTS idx_engrams_scope ON engrams(scope);
+      CREATE INDEX IF NOT EXISTS idx_engrams_domain ON engrams(domain);
+      CREATE INDEX IF NOT EXISTS idx_engrams_source ON engrams(source);
+    `)
+    // Embedding table: separate so adding/replacing embeddings is cheap and
+    // doesn't churn engram rows. Use vector when available, BYTEA fallback.
+    if (this.hasVector) {
+      await db.exec(`
+        CREATE TABLE IF NOT EXISTS engram_embeddings (
+          engram_id TEXT PRIMARY KEY,
+          embedding vector(${this.vectorDim}) NOT NULL
+        );
+      `)
+    } else {
+      await db.exec(`
+        CREATE TABLE IF NOT EXISTS engram_embeddings (
+          engram_id TEXT PRIMARY KEY,
+          embedding BYTEA NOT NULL
+        );
+      `)
+    }
+    // AGE engram graph (#200 lands the actual edges; we just create the
+    // graph here so the schema is ready).
+    if (this.hasAge) {
+      try {
+        const exists = await db.query("SELECT 1 FROM ag_catalog.ag_graph WHERE name = 'engram_graph'")
+        if (exists.rows.length === 0) {
+          await db.exec("SELECT create_graph('engram_graph')")
+        }
+      } catch (err) {
+        logger.debug(`[pglite] AGE graph init skipped: ${(err as Error).message}`)
+      }
+    }
+  }
+
+  /** Apply a filter to a SELECT query. */
+  private buildFilterClause(filter: StorageFilter): { where: string; params: any[] } {
+    const conditions: string[] = []
+    const params: any[] = []
+    let i = 1
+    if (filter.status) {
+      conditions.push(`status = $${i++}`)
+      params.push(filter.status)
+    }
+    if (filter.scope) {
+      conditions.push(`(scope = 'global' OR scope = $${i++} OR scope LIKE $${i++} || '%')`)
+      params.push(filter.scope, filter.scope)
+    }
+    if (filter.domain) {
+      conditions.push(`domain LIKE $${i++} || '%'`)
+      params.push(filter.domain)
+    }
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+    return { where, params }
+  }
+
+  /** Parse a `data` row back to an Engram. PGLite returns JSONB as parsed JSON. */
+  private parseRow(row: { data: any }): Engram {
+    return typeof row.data === 'string' ? JSON.parse(row.data) : row.data
+  }
+
+  async loadFiltered(filter: StorageFilter): Promise<Engram[]> {
+    const db = await this.getDb()
+    const { where, params } = this.buildFilterClause(filter)
+    const res = await db.query(`SELECT data FROM engrams ${where}`, params)
+    return res.rows.map((r: any) => this.parseRow(r))
+  }
+
+  async count(filter?: { status?: string }): Promise<number> {
+    const db = await this.getDb()
+    if (filter?.status) {
+      const res = await db.query('SELECT COUNT(*)::int as c FROM engrams WHERE status = $1', [filter.status])
+      return Number(res.rows[0].c)
+    }
+    const res = await db.query('SELECT COUNT(*)::int as c FROM engrams')
+    return Number(res.rows[0].c)
+  }
+
+  /**
+   * Reindex: drop all engram rows and rebuild from YAML.
+   * Idempotent. Embeddings table is left intact unless the caller wipes the
+   * PGLite dir on disk (which is what nukeDerivedState in the rebuild test
+   * does).
+   */
+  async reindex(): Promise<void> {
+    return this.mutex.run(async () => {
+      const db = await this.getDb()
+      await db.exec('BEGIN')
+      try {
+        await db.exec('DELETE FROM engrams')
+        await this.insertEngramsTx(db)
+        await db.exec('COMMIT')
+      } catch (err) {
+        await db.exec('ROLLBACK').catch(() => {})
+        throw err
+      }
+    })
+  }
+
+  /**
+   * syncFromYaml: incremental — upsert what YAML says exists, delete
+   * primary-source rows that YAML no longer contains.
+   *
+   * This is the steady-state write path called after every YAML mutation
+   * (see Plur._syncIndex).
+   */
+  async syncFromYaml(): Promise<void> {
+    return this.mutex.run(async () => {
+      const db = await this.getDb()
+      await db.exec('BEGIN')
+      try {
+        const ids = new Set<string>()
+        if (existsSync(this.yamlPath)) {
+          const engrams = loadEngrams(this.yamlPath)
+          for (const e of engrams) {
+            await this.upsertEngramTx(db, e, 'primary')
+            ids.add(e.id)
+          }
+        }
+        // Drop primary-source rows that no longer exist in YAML.
+        if (ids.size > 0) {
+          const idArr = Array.from(ids)
+          // Use a JSONB array to avoid the parameterized-IN size limit.
+          await db.query(
+            `DELETE FROM engrams
+             WHERE source = 'primary'
+               AND id NOT IN (SELECT jsonb_array_elements_text($1::jsonb))`,
+            [JSON.stringify(idArr)],
+          )
+        } else {
+          await db.exec("DELETE FROM engrams WHERE source = 'primary'")
+        }
+        await db.exec('COMMIT')
+      } catch (err) {
+        await db.exec('ROLLBACK').catch(() => {})
+        throw err
+      }
+    })
+  }
+
+  private async insertEngramsTx(db: any): Promise<void> {
+    if (!existsSync(this.yamlPath)) return
+    const engrams = loadEngrams(this.yamlPath)
+    for (const e of engrams) {
+      await this.upsertEngramTx(db, e, 'primary')
+    }
+  }
+
+  private async upsertEngramTx(db: any, e: Engram, source: string): Promise<void> {
+    await db.query(
+      `INSERT INTO engrams (id, status, scope, domain, last_accessed, data, source)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
+       ON CONFLICT (id) DO UPDATE SET
+         status = EXCLUDED.status,
+         scope = EXCLUDED.scope,
+         domain = EXCLUDED.domain,
+         last_accessed = EXCLUDED.last_accessed,
+         data = EXCLUDED.data,
+         source = EXCLUDED.source`,
+      [
+        e.id,
+        e.status,
+        e.scope,
+        e.domain ?? null,
+        e.activation?.last_accessed ?? null,
+        JSON.stringify(e),
+        source,
+      ],
+    )
+  }
+
+  /**
+   * BM25 search. PGLite has full-text search, but at the corpus sizes we care
+   * about (a few thousand to a hundred thousand engrams) it's cheaper and
+   * yields identical results to load the candidate set into JS and run the
+   * existing BM25 scorer. This also keeps fts.ts as the single ranking
+   * authority (one tokenizer, one IDF computation).
+   */
+  async searchBM25(query: string, opts: { limit: number }): Promise<Engram[]> {
+    const candidates = await this.loadFiltered({ status: 'active' })
+    return searchEngrams(candidates, query, opts.limit)
+  }
+
+  /**
+   * Vector search. Uses pgvector when available, JS cosine otherwise.
+   * Returns scored results so callers can fuse with BM25 via RRF.
+   */
+  async searchVector(query: Float32Array, limit: number): Promise<VectorSearchHit[]> {
+    const db = await this.getDb()
+    const totalRes = await db.query('SELECT COUNT(*)::int AS c FROM engram_embeddings')
+    if (Number(totalRes.rows[0].c) === 0) return []
+    if (this.hasVector) {
+      // pgvector path. Cosine distance = 1 - cosine similarity.
+      const literal = vectorLiteral(query)
+      const res = await db.query(
+        `SELECT e.data, 1 - (em.embedding <=> $1::vector) AS score
+         FROM engram_embeddings em
+         JOIN engrams e ON e.id = em.engram_id
+         WHERE e.status = 'active'
+         ORDER BY em.embedding <=> $1::vector
+         LIMIT $2`,
+        [literal, limit],
+      )
+      return res.rows.map((r: any) => ({
+        engram: this.parseRow(r),
+        score: Number(r.score),
+      }))
+    }
+    // BYTEA fallback: read all embeddings, compute cosine in JS.
+    const res = await db.query(
+      `SELECT e.data, em.embedding
+       FROM engram_embeddings em
+       JOIN engrams e ON e.id = em.engram_id
+       WHERE e.status = 'active'`,
+    )
+    const scored: VectorSearchHit[] = res.rows.map((r: any) => {
+      const vec = bytesToFloat32(r.embedding)
+      return { engram: this.parseRow(r), score: cosine(query, vec) }
+    })
+    scored.sort((a, b) => b.score - a.score)
+    return scored.slice(0, limit)
+  }
+
+  async upsertEmbedding(engramId: string, vector: Float32Array): Promise<void> {
+    return this.mutex.run(async () => {
+      const db = await this.getDb()
+      if (this.hasVector) {
+        const literal = vectorLiteral(vector)
+        await db.query(
+          `INSERT INTO engram_embeddings (engram_id, embedding)
+           VALUES ($1, $2::vector)
+           ON CONFLICT (engram_id) DO UPDATE SET embedding = EXCLUDED.embedding`,
+          [engramId, literal],
+        )
+      } else {
+        const buf = float32ToBytes(vector)
+        await db.query(
+          `INSERT INTO engram_embeddings (engram_id, embedding)
+           VALUES ($1, $2)
+           ON CONFLICT (engram_id) DO UPDATE SET embedding = EXCLUDED.embedding`,
+          [engramId, buf],
+        )
+      }
+    })
+  }
+
+  async close(): Promise<void> {
+    if (this.db) {
+      try {
+        await this.db.close()
+      } catch {
+        // ignore — PGLite occasionally throws on shutdown when the WASM worker
+        // has already terminated. The on-disk state is durable.
+      }
+      this.db = null
+      this.initialized = false
+    }
+  }
+}
+
+function vectorLiteral(v: Float32Array): string {
+  // pgvector text format: "[0.1, 0.2, 0.3]"
+  // Numbers serialize at full precision; no NaN/Infinity allowed in pgvector
+  // so we substitute 0 to keep writes from throwing on malformed input.
+  const parts: string[] = []
+  for (let i = 0; i < v.length; i++) {
+    const n = v[i]
+    parts.push(Number.isFinite(n) ? String(n) : '0')
+  }
+  return '[' + parts.join(',') + ']'
+}
+
+function float32ToBytes(v: Float32Array): Uint8Array {
+  return new Uint8Array(v.buffer, v.byteOffset, v.byteLength)
+}
+
+function bytesToFloat32(b: Uint8Array | ArrayBuffer): Float32Array {
+  const arr = b instanceof Uint8Array ? b : new Uint8Array(b)
+  // Ensure 4-byte alignment for Float32Array view.
+  if ((arr.byteOffset % 4) === 0 && arr.byteLength % 4 === 0) {
+    return new Float32Array(arr.buffer, arr.byteOffset, arr.byteLength / 4)
+  }
+  const copy = new Uint8Array(arr)
+  return new Float32Array(copy.buffer)
+}
+
+function cosine(a: Float32Array, b: Float32Array): number {
+  let dot = 0
+  let na = 0
+  let nb = 0
+  const len = Math.min(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    dot += a[i] * b[i]
+    na += a[i] * a[i]
+    nb += b[i] * b[i]
+  }
+  if (na === 0 || nb === 0) return 0
+  return dot / (Math.sqrt(na) * Math.sqrt(nb))
+}

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -11,6 +11,8 @@ export interface PlurPaths {
   exchange: string
   config: string
   db: string
+  /** PGLite data directory (ADR-0001, opt-in via backend: pglite). */
+  pglite: string
 }
 
 export function detectPlurStorage(explicitPath?: string): PlurPaths {
@@ -31,5 +33,6 @@ export function detectPlurStorage(explicitPath?: string): PlurPaths {
     exchange: join(root, 'exchange'),
     config: join(root, 'config.yaml'),
     db: join(root, 'engrams.db'),
+    pglite: join(root, 'store.pglite'),
   }
 }

--- a/packages/core/test/pglite-adapter.test.ts
+++ b/packages/core/test/pglite-adapter.test.ts
@@ -1,0 +1,427 @@
+/**
+ * PGLiteAdapter test — substrate-level adapter for the YAML-as-truth invariant.
+ *
+ * Issue plur-ai/plur#226 (ADR-0001), Sprint 0 PR 2.
+ *
+ * Contract:
+ * - YAML stays the source of truth. PGLite is a rebuildable index.
+ * - The adapter implements the StorageAdapter interface (load filtered,
+ *   reindex from YAML, search BM25, search vector).
+ * - reindex() drops all rows and rebuilds from YAML idempotently.
+ * - syncFromYaml() applies incremental diffs from YAML to DB.
+ * - Vector search uses pgvector when available; falls back to JSONB-stored
+ *   embeddings with cosine computed in TypeScript otherwise.
+ * - Cosine search returns engrams ordered by similarity descending.
+ * - Concurrent writes are safe (PGLite is single-writer per process; we
+ *   serialize via the adapter).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function mkEngram(id: string, statement: string, opts: Partial<Engram> = {}): Engram {
+  return {
+    id,
+    statement,
+    type: opts.type ?? 'behavioral',
+    scope: opts.scope ?? 'project:plur',
+    domain: opts.domain ?? 'plur.test',
+    status: opts.status ?? 'active',
+    tags: opts.tags ?? [],
+    activation: {
+      retrieval_strength: 1.0,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-05-30',
+      ...((opts as any).activation ?? {}),
+    },
+    feedback_signals: opts.feedback_signals ?? { positive: 0, negative: 0, neutral: 0 },
+    ...(opts as any),
+  } as Engram
+}
+
+function seedYaml(path: string, engrams: Engram[]): void {
+  writeFileSync(path, yaml.dump({ engrams }), 'utf8')
+}
+
+// PGLite WASM startup can briefly exceed the 5s default under heavy
+// workspace-parallel test load (each test instantiates a fresh PGLite).
+// 30s is generous and only kicks in if the cold start is slow.
+const PGLITE_TIMEOUT = 30_000
+
+describe('PGLiteAdapter — substrate', () => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-pglite-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'store.pglite')
+  })
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  describe('lifecycle', () => {
+    it('initializes with no engrams when YAML is empty', async () => {
+      seedYaml(yamlPath, [])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const all = await adapter.loadFiltered({})
+      expect(all).toEqual([])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('creates a PGLite directory on first reindex', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0530-001', 'first')])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      expect(existsSync(dbPath)).toBe(true)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('reindex is idempotent — calling twice yields same row set', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'one'),
+        mkEngram('ENG-2026-0530-002', 'two'),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      await adapter.reindex()
+      const all = await adapter.loadFiltered({})
+      expect(all.map(e => e.id).sort()).toEqual(['ENG-2026-0530-001', 'ENG-2026-0530-002'])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('rebuild from YAML', () => {
+    it('rebuilds engrams from YAML on reindex', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'one'),
+        mkEngram('ENG-2026-0530-002', 'two'),
+        mkEngram('ENG-2026-0530-003', 'three'),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const all = await adapter.loadFiltered({})
+      expect(all.length).toBe(3)
+      expect(all.map(e => e.id).sort()).toEqual([
+        'ENG-2026-0530-001',
+        'ENG-2026-0530-002',
+        'ENG-2026-0530-003',
+      ])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('drops PGLite content and rebuilds from YAML when YAML changes', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0530-001', 'first')])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      expect((await adapter.loadFiltered({})).length).toBe(1)
+
+      // YAML changes (the user edited or pulled new state)
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-002', 'replacement'),
+      ])
+      await adapter.reindex()
+      const all = await adapter.loadFiltered({})
+      expect(all.map(e => e.id)).toEqual(['ENG-2026-0530-002'])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('survives nuking the PGLite dir — calling reindex rebuilds it', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'one'),
+        mkEngram('ENG-2026-0530-002', 'two'),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      await adapter.close()
+
+      // Simulate "nuke the db"
+      rmSync(dbPath, { recursive: true, force: true })
+      expect(existsSync(dbPath)).toBe(false)
+
+      const fresh = new PGLiteAdapter(yamlPath, dbPath)
+      await fresh.reindex()
+      const all = await fresh.loadFiltered({})
+      expect(all.map(e => e.id).sort()).toEqual(['ENG-2026-0530-001', 'ENG-2026-0530-002'])
+      await fresh.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('filtered queries', () => {
+    it('filters by status', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'active', { status: 'active' }),
+        mkEngram('ENG-2026-0530-002', 'retired', { status: 'retired' }),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const active = await adapter.loadFiltered({ status: 'active' })
+      expect(active.map(e => e.id)).toEqual(['ENG-2026-0530-001'])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('filters by scope with global fallback', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'project a', { scope: 'project:a' }),
+        mkEngram('ENG-2026-0530-002', 'project b', { scope: 'project:b' }),
+        mkEngram('ENG-2026-0530-003', 'universal', { scope: 'global' }),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const onlyA = await adapter.loadFiltered({ scope: 'project:a' })
+      const ids = onlyA.map(e => e.id).sort()
+      // project:a engrams plus global engrams
+      expect(ids).toEqual(['ENG-2026-0530-001', 'ENG-2026-0530-003'])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('filters by domain prefix', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'one', { domain: 'plur.architecture' }),
+        mkEngram('ENG-2026-0530-002', 'two', { domain: 'plur.retrieval' }),
+        mkEngram('ENG-2026-0530-003', 'three', { domain: 'workflow.testing' }),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const plurOnly = await adapter.loadFiltered({ domain: 'plur' })
+      expect(plurOnly.map(e => e.id).sort()).toEqual([
+        'ENG-2026-0530-001',
+        'ENG-2026-0530-002',
+      ])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('count', () => {
+    it('counts engrams', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'one'),
+        mkEngram('ENG-2026-0530-002', 'two', { status: 'retired' }),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      expect(await adapter.count()).toBe(2)
+      expect(await adapter.count({ status: 'active' })).toBe(1)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('vector search', () => {
+    it('stores embeddings and returns engrams ordered by cosine similarity', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'apple'),
+        mkEngram('ENG-2026-0530-002', 'banana'),
+        mkEngram('ENG-2026-0530-003', 'cherry'),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8 })
+      await adapter.reindex()
+
+      // Hand-build embeddings: identical to query for one engram, far for others
+      const targetVec = new Float32Array(8)
+      targetVec[0] = 1
+      const orthoVec = new Float32Array(8)
+      orthoVec[1] = 1
+      const partialVec = new Float32Array(8)
+      partialVec[0] = 0.8
+      partialVec[1] = 0.6
+
+      await adapter.upsertEmbedding('ENG-2026-0530-001', targetVec)
+      await adapter.upsertEmbedding('ENG-2026-0530-002', partialVec)
+      await adapter.upsertEmbedding('ENG-2026-0530-003', orthoVec)
+
+      const results = await adapter.searchVector(targetVec, 3)
+      expect(results.length).toBe(3)
+      expect(results[0].engram.id).toBe('ENG-2026-0530-001')
+      expect(results[1].engram.id).toBe('ENG-2026-0530-002')
+      expect(results[2].engram.id).toBe('ENG-2026-0530-003')
+      // scores: cosine similarity, 1.0 for identical, lower for others
+      expect(results[0].score).toBeCloseTo(1.0, 3)
+      expect(results[0].score).toBeGreaterThan(results[1].score)
+      expect(results[1].score).toBeGreaterThan(results[2].score)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('returns empty array when no embeddings have been stored', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0530-001', 'no embeds')])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const queryVec = new Float32Array(8)
+      queryVec[0] = 1
+      const results = await adapter.searchVector(queryVec, 5)
+      expect(results).toEqual([])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('BM25 search', () => {
+    it('returns engrams matching token query', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'always run tests before merging'),
+        mkEngram('ENG-2026-0530-002', 'yaml is the source of truth'),
+        mkEngram('ENG-2026-0530-003', 'embedding choice dominates fusion'),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const hits = await adapter.searchBM25('source of truth', { limit: 5 })
+      expect(hits.length).toBeGreaterThan(0)
+      expect(hits[0].id).toBe('ENG-2026-0530-002')
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('concurrent writes', () => {
+    it('serializes reindex calls so the final state is consistent', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0530-001', 'one')])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+
+      // Fire several reindex calls concurrently; the YAML stays the same.
+      // Final state must reflect that single engram exactly once.
+      await Promise.all([
+        adapter.reindex(),
+        adapter.reindex(),
+        adapter.reindex(),
+        adapter.reindex(),
+      ])
+      const all = await adapter.loadFiltered({})
+      expect(all.map(e => e.id)).toEqual(['ENG-2026-0530-001'])
+      expect(await adapter.count()).toBe(1)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('serializes concurrent embedding upserts without dropping rows', async () => {
+      const engrams: Engram[] = []
+      for (let i = 0; i < 10; i++) {
+        engrams.push(mkEngram(`ENG-2026-0530-${String(i).padStart(3, '0')}`, `e${i}`))
+      }
+      seedYaml(yamlPath, engrams)
+      const adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8 })
+      await adapter.reindex()
+
+      await Promise.all(engrams.map((e, i) => {
+        const v = new Float32Array(8)
+        v[i % 8] = 1
+        return adapter.upsertEmbedding(e.id, v)
+      }))
+
+      // searchVector against a zero vector should return all 10 rows
+      const queryVec = new Float32Array(8)
+      queryVec[0] = 1
+      const results = await adapter.searchVector(queryVec, 20)
+      expect(results.length).toBe(10)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('syncFromYaml — incremental', () => {
+    it('picks up new engrams added to YAML without dropping existing rows', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0530-001', 'one')])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+
+      // Append a new engram to YAML
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'one'),
+        mkEngram('ENG-2026-0530-002', 'two'),
+      ])
+      await adapter.syncFromYaml()
+      const all = await adapter.loadFiltered({})
+      expect(all.map(e => e.id).sort()).toEqual([
+        'ENG-2026-0530-001',
+        'ENG-2026-0530-002',
+      ])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('removes engrams that were deleted from YAML', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-001', 'one'),
+        mkEngram('ENG-2026-0530-002', 'two'),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0530-001', 'one')])
+      await adapter.syncFromYaml()
+      const all = await adapter.loadFiltered({})
+      expect(all.map(e => e.id)).toEqual(['ENG-2026-0530-001'])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+})
+
+/**
+ * Integration: Plur class with PLUR_BACKEND=pglite.
+ *
+ * Demonstrates the full path — Plur constructor wires in PGLite, learn()
+ * writes YAML first then mirrors into PGLite via _syncIndex, sync({ full })
+ * drops and rebuilds the index. YAML remains the source of truth.
+ */
+import { Plur } from '../src/index.js'
+
+describe('Plur — PGLite backend integration', () => {
+  let dir: string
+  const originalBackend = process.env.PLUR_BACKEND
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-pglite-integ-'))
+    process.env.PLUR_BACKEND = 'pglite'
+  })
+
+  afterEach(() => {
+    if (originalBackend) process.env.PLUR_BACKEND = originalBackend
+    else delete process.env.PLUR_BACKEND
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates a PGLite directory when constructed with PLUR_BACKEND=pglite', async () => {
+    const plur = new Plur({ path: dir })
+    plur.learn('YAML is the source of truth', {
+      scope: 'project:plur',
+      type: 'architectural',
+    })
+    await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(true)
+  }, PGLITE_TIMEOUT)
+
+  it('list and recall stay YAML-backed when PGLite is active', async () => {
+    const plur = new Plur({ path: dir })
+    plur.learn('first statement', { scope: 'project:plur', type: 'behavioral' })
+    plur.learn('second statement', { scope: 'project:plur', type: 'behavioral' })
+    await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
+    const all = plur.list()
+    expect(all.length).toBe(2)
+    const recalled = plur.recall('first')
+    expect(recalled.length).toBeGreaterThan(0)
+  }, PGLITE_TIMEOUT)
+
+  it('sync({ full: true }) survives a nuked PGLite dir', async () => {
+    const plur = new Plur({ path: dir })
+    plur.learn('one', { scope: 'project:plur', type: 'behavioral' })
+    plur.learn('two', { scope: 'project:plur', type: 'behavioral' })
+    await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
+    const before = plur.list().map(e => e.id).sort()
+
+    // Nuke the index — YAML is untouched.
+    rmSync(join(dir, 'store.pglite'), { recursive: true, force: true })
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(false)
+
+    // Construct a fresh Plur — should reinitialize PGLite, sync from YAML.
+    const fresh = new Plur({ path: dir })
+    await (fresh as unknown as { reindexAsync: () => Promise<void> }).reindexAsync()
+    await (fresh as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
+
+    const after = fresh.list().map(e => e.id).sort()
+    expect(after).toEqual(before)
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(true)
+  }, PGLITE_TIMEOUT)
+})

--- a/packages/core/test/sp1-memory-intelligence.test.ts
+++ b/packages/core/test/sp1-memory-intelligence.test.ts
@@ -275,7 +275,7 @@ REASON: More specific port configuration
       expect(['ADD', 'UPDATE']).toContain(result.decision)
 
       rmSync(llmDir, { recursive: true, force: true })
-    })
+    }, 30_000)  // explicit: this constructs a fresh Plur + learnAsync, paying the BGE embedder cold-load, which exceeds the 5s default on loaded CI runners (#311)
 
     it('learnAsync with mock LLM detects tensions', async () => {
       plur.learn('Always use REST APIs', { type: 'behavioral', tags: ['api'] })

--- a/packages/core/test/yaml-truth-rebuild.test.ts
+++ b/packages/core/test/yaml-truth-rebuild.test.ts
@@ -1,0 +1,155 @@
+/**
+ * YAML-as-truth invariant — Test A: nuke-the-db rebuild
+ *
+ * Issue plur-ai/plur#249, ADR-0001 (#226), engram ENG-2026-0530-019.
+ *
+ * Principle: YAML is the source of truth. Any derived state (in-memory cache,
+ * PGLite indexes, AGE graph, embedding vectors) must be rebuildable from YAML
+ * with no observable change in API behavior.
+ *
+ * This test seeds a realistic store, captures results from public methods,
+ * deletes all derived state, rebuilds from YAML alone, and asserts the
+ * results are identical.
+ *
+ * Today (pre-PGLite), "derived state" is just the in-memory cache, and
+ * "rebuild from YAML" is constructing a fresh Plur instance from the same
+ * path. After PR 2 (feat/pglite-adapter) lands, the helper below also wipes
+ * the PGLite directory and forces `plur sync` to rebuild it from YAML. The
+ * test contract does not change.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+
+/**
+ * Wipe all derived state under `dir`, leaving YAML untouched.
+ *
+ * Future-proofing: when PGLite lands, add `store.pglite` to the wiped paths.
+ * The contract is "anything that is NOT the YAML source goes."
+ */
+function nukeDerivedState(dir: string): void {
+  const derivedPaths = [
+    join(dir, 'store.pglite'),     // PR 2 (#226) — PGLite index dir
+    join(dir, '.fts-cache'),       // potential future BM25 disk cache
+    join(dir, '.embeddings-cache'),// potential future embedding cache
+  ]
+  for (const p of derivedPaths) {
+    if (existsSync(p)) rmSync(p, { recursive: true, force: true })
+  }
+}
+
+describe('yaml-as-truth: nuke-the-db rebuild (Test A)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-yaml-truth-rebuild-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('recall results survive a full rebuild from YAML', () => {
+    // 1. Seed a realistic store with engrams across types and scopes
+    const seed = new Plur({ path: dir })
+    seed.learn('always run tests before merging', {
+      scope: 'project:plur',
+      domain: 'workflow.testing',
+      type: 'procedural',
+    })
+    seed.learn('YAML is the source of truth', {
+      scope: 'project:plur',
+      domain: 'plur.architecture',
+      type: 'architectural',
+    })
+    seed.learn('embedding model influences recall quality more than fusion', {
+      scope: 'project:plur',
+      domain: 'plur.retrieval',
+      type: 'terminological',
+    })
+    seed.learn('the user prefers terse responses', {
+      scope: 'global',
+      domain: 'workflow.communication',
+      type: 'behavioral',
+    })
+
+    // 2. Capture results from every public read method
+    const beforeList = seed.list().map(e => e.id).sort()
+    const beforeRecall = seed.recall('source of truth').map(e => e.id)
+    const beforeInject = seed.inject('about to merge a PR').injected_ids
+    const firstId = beforeList[0]
+    const beforeGetById = seed.getById(firstId)?.id
+
+    // 3. Nuke derived state. YAML on disk is untouched.
+    nukeDerivedState(dir)
+
+    // 4. Rebuild — fresh Plur instance loads from YAML and reconstructs
+    //    every derived data structure (in-memory cache today, PGLite tomorrow).
+    const rebuilt = new Plur({ path: dir })
+
+    // 5. Recapture the same operations
+    const afterList = rebuilt.list().map(e => e.id).sort()
+    const afterRecall = rebuilt.recall('source of truth').map(e => e.id)
+    const afterInject = rebuilt.inject('about to merge a PR').injected_ids
+    const afterGetById = rebuilt.getById(firstId)?.id
+
+    // 6. Identical results — derived state is rebuildable
+    expect(afterList).toEqual(beforeList)
+    expect(afterRecall).toEqual(beforeRecall)
+    expect(afterInject).toEqual(beforeInject)
+    expect(afterGetById).toEqual(beforeGetById)
+  })
+
+  it('list returns same engrams in same order after rebuild', () => {
+    const seed = new Plur({ path: dir })
+    const ids: string[] = []
+    for (let i = 0; i < 10; i++) {
+      const e = seed.learn(`statement number ${i}`, {
+        scope: 'project:plur',
+        type: 'behavioral',
+      })
+      ids.push(e.id)
+    }
+
+    const before = seed.list().map(e => e.id)
+    nukeDerivedState(dir)
+    const after = new Plur({ path: dir }).list().map(e => e.id)
+
+    expect(after).toEqual(before)
+    expect(after).toEqual(expect.arrayContaining(ids))
+  })
+
+  it('forget persists across rebuild (YAML stores the tombstone)', () => {
+    const seed = new Plur({ path: dir })
+    const e1 = seed.learn('to be forgotten', { scope: 'global', type: 'behavioral' })
+    seed.learn('to be remembered', { scope: 'global', type: 'behavioral' })
+
+    // forget the first engram (marks it as inactive)
+    return seed.forget(e1.id, 'test cleanup').then(() => {
+      const before = seed.list().map(e => e.id)
+      expect(before).not.toContain(e1.id)
+
+      nukeDerivedState(dir)
+      const after = new Plur({ path: dir }).list().map(e => e.id)
+
+      // Forget must be a YAML-resident operation, not DB-only state
+      expect(after).toEqual(before)
+      expect(after).not.toContain(e1.id)
+    })
+  })
+
+  it('scope-filtered recall is identical after rebuild', () => {
+    const seed = new Plur({ path: dir })
+    seed.learn('project a fact', { scope: 'project:a', type: 'behavioral' })
+    seed.learn('project b fact', { scope: 'project:b', type: 'behavioral' })
+    seed.learn('global fact', { scope: 'global', type: 'behavioral' })
+
+    const before = seed.list({ scope: 'project:a' }).map(e => e.id)
+    nukeDerivedState(dir)
+    const after = new Plur({ path: dir }).list({ scope: 'project:a' }).map(e => e.id)
+
+    expect(after).toEqual(before)
+  })
+})

--- a/packages/core/test/yaml-truth-traceability.test.ts
+++ b/packages/core/test/yaml-truth-traceability.test.ts
@@ -1,0 +1,150 @@
+/**
+ * YAML-as-truth invariant — Test B: public API traceability
+ *
+ * Issue plur-ai/plur#249, ADR-0001 (#226), engram ENG-2026-0530-019.
+ *
+ * Principle: every engram returned by any PLUR public method must trace
+ * to a record in the YAML source on disk. If a future feature inserts
+ * engrams into the DB-only index without also writing them to YAML
+ * (e.g. materialized cache, "synthetic" engrams, reranker artifacts),
+ * this test fails.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { loadEngrams } from '../src/engrams.js'
+
+/**
+ * Read every YAML file under `dir` recursively and return a set of all
+ * engram IDs present.  This is the YAML ground truth — the universe of
+ * IDs any public method is allowed to return.
+ */
+function yamlGroundTruth(dir: string): Set<string> {
+  const ids = new Set<string>()
+  const primary = join(dir, 'engrams.yaml')
+  for (const e of loadEngrams(primary)) ids.add(e.id)
+  // Pack stores, secondary stores, scoped stores all live at well-known
+  // sub-paths or are configured.  Extending this set is the right move
+  // when a new YAML source is added.
+  return ids
+}
+
+describe('yaml-as-truth: public API traceability (Test B)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-yaml-truth-trace-'))
+    plur = new Plur({ path: dir })
+
+    plur.learn('verify dates with datacore.date', {
+      scope: 'project:plur',
+      domain: 'workflow.dates',
+      type: 'procedural',
+    })
+    plur.learn('YAML is the source of truth', {
+      scope: 'project:plur',
+      domain: 'plur.architecture',
+      type: 'architectural',
+    })
+    plur.learn('the user prefers terse responses', {
+      scope: 'global',
+      domain: 'workflow.communication',
+      type: 'behavioral',
+    })
+    plur.learn('embedding choice dominates fusion choice', {
+      scope: 'project:plur',
+      domain: 'plur.retrieval',
+      type: 'terminological',
+    })
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('list() returns only engrams present in YAML', () => {
+    const truth = yamlGroundTruth(dir)
+    const returned = plur.list()
+    expect(returned.length).toBeGreaterThan(0)
+    for (const e of returned) {
+      expect(truth.has(e.id),
+        `list returned ${e.id} which is NOT in YAML ground truth — ` +
+        `this is a YAML-as-truth invariant violation (#249)`
+      ).toBe(true)
+    }
+  })
+
+  it('recall() returns only engrams present in YAML', () => {
+    const truth = yamlGroundTruth(dir)
+    const returned = plur.recall('source of truth')
+    expect(returned.length).toBeGreaterThan(0)
+    for (const e of returned) {
+      expect(truth.has(e.id),
+        `recall returned ${e.id} which is NOT in YAML ground truth`
+      ).toBe(true)
+    }
+  })
+
+  it('recallHybrid() returns only engrams present in YAML', async () => {
+    const truth = yamlGroundTruth(dir)
+    const returned = await plur.recallHybrid('source of truth')
+    for (const e of returned) {
+      expect(truth.has(e.id),
+        `recallHybrid returned ${e.id} which is NOT in YAML ground truth`
+      ).toBe(true)
+    }
+  })
+
+  it('inject() returns only engrams present in YAML', () => {
+    const truth = yamlGroundTruth(dir)
+    const result = plur.inject('about to merge a PR')
+    for (const id of result.injected_ids) {
+      expect(truth.has(id),
+        `inject returned ${id} which is NOT in YAML ground truth`
+      ).toBe(true)
+    }
+  })
+
+  it('getById() returns only engrams present in YAML', () => {
+    const truth = yamlGroundTruth(dir)
+    const ids = Array.from(truth)
+    for (const id of ids) {
+      const e = plur.getById(id)
+      expect(e).not.toBeNull()
+      expect(truth.has(e!.id)).toBe(true)
+    }
+  })
+
+  it('getById() returns null for ids not in YAML', () => {
+    expect(plur.getById('ENG-9999-9999-999')).toBeNull()
+  })
+
+  it('list with scope filter returns only YAML-backed engrams', () => {
+    const truth = yamlGroundTruth(dir)
+    const returned = plur.list({ scope: 'project:plur' })
+    for (const e of returned) {
+      expect(truth.has(e.id)).toBe(true)
+    }
+  })
+
+  it('every returned engram has its YAML-derived fields intact', () => {
+    const truth = yamlGroundTruth(dir)
+    const yamlEngrams = loadEngrams(join(dir, 'engrams.yaml'))
+    const byId = new Map(yamlEngrams.map(e => [e.id, e]))
+
+    for (const returned of plur.list()) {
+      expect(truth.has(returned.id)).toBe(true)
+      const yaml = byId.get(returned.id)!
+      // Core authoritative fields must match YAML exactly — these cannot
+      // be DB-only because they're what gets shipped in packs / synced
+      // via git.
+      expect(returned.statement).toBe(yaml.statement)
+      expect(returned.scope).toBe(yaml.scope)
+      expect(returned.type).toBe(yaml.type)
+      expect(returned.status).toBe(yaml.status)
+    }
+  })
+})

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -15,5 +15,13 @@ export default defineConfig({
     'onnxruntime-common',
     'sharp',
     '@huggingface/jinja',
+    // PGLite ships pre-bundled WASM + extension .tar.gz files alongside its
+    // ESM entry point. Bundling it copies the .js chunks into core's dist
+    // but leaves the extension archives behind, which then fail at runtime
+    // ("Extension bundle not found: vector.tar.gz"). Keep external so
+    // Node's resolver locates the full PGLite tree under node_modules.
+    '@electric-sql/pglite',
+    '@electric-sql/pglite/vector',
+    '@electric-sql/pglite/age',
   ],
 })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,26 +1,8 @@
 import { defineConfig } from 'vitest/config'
-// testTimeout/hookTimeout 30s: PGLite WASM startup AND the BGE embedder's lazy
-// cold-load (@huggingface/transformers) can each exceed the vitest 5s default
-// under parallel suite import (#311). hookTimeout matched so a cold load in
-// beforeAll/afterAll doesn't trip either.
-//
-// pool: 'forks' + maxForks: PGLite WASM is process-global and races on init
-// under the threaded pool / mass-parallel forks (mkdir ENOENT, "PGlite failed
-// to initialize properly"). Each test file gets its own process; the fork cap
-// keeps the count below the race threshold. Defaults to 4; override via
-// VITEST_MAX_FORKS.
-const maxForks = Number(process.env.VITEST_MAX_FORKS) || 4
-
-export default defineConfig({
-  test: {
-    globals: true,
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-    pool: 'forks',
-  },
-  poolOptions: {
-    forks: {
-      maxForks,
-    },
-  },
-})
+// testTimeout raised from the 5s default: the BGE embedder (@huggingface/
+// transformers) cold-loads lazily on first use, and that one-time model init
+// can exceed 5s when several embedder-touching suites import in parallel under
+// `vitest run` — a slow-but-correct load, not a hang. The tight default caused
+// flaky CI timeouts (#311). hookTimeout matched so beforeAll/afterAll setup
+// that also triggers a cold load doesn't trip either.
+export default defineConfig({ test: { globals: true, testTimeout: 30000, hookTimeout: 30000 } })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,8 +1,26 @@
 import { defineConfig } from 'vitest/config'
-// testTimeout raised from the 5s default: the BGE embedder (@huggingface/
-// transformers) cold-loads lazily on first use, and that one-time model init
-// can exceed 5s when several embedder-touching suites import in parallel under
-// `vitest run` — a slow-but-correct load, not a hang. The tight default caused
-// flaky CI timeouts (#311). hookTimeout matched so beforeAll/afterAll setup
-// that also triggers a cold load doesn't trip either.
-export default defineConfig({ test: { globals: true, testTimeout: 30000, hookTimeout: 30000 } })
+// testTimeout/hookTimeout 30s: PGLite WASM startup AND the BGE embedder's lazy
+// cold-load (@huggingface/transformers) can each exceed the vitest 5s default
+// under parallel suite import (#311). hookTimeout matched so a cold load in
+// beforeAll/afterAll doesn't trip either.
+//
+// pool: 'forks' + maxForks: PGLite WASM is process-global and races on init
+// under the threaded pool / mass-parallel forks (mkdir ENOENT, "PGlite failed
+// to initialize properly"). Each test file gets its own process; the fork cap
+// keeps the count below the race threshold. Defaults to 4; override via
+// VITEST_MAX_FORKS.
+const maxForks = Number(process.env.VITEST_MAX_FORKS) || 4
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    pool: 'forks',
+  },
+  poolOptions: {
+    forks: {
+      maxForks,
+    },
+  },
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -744,7 +744,7 @@ export function getToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_sync',
-      description: 'Sync engrams via git — initializes repo on first call, commits and pushes/pulls on subsequent calls. Provide a remote URL on first call to enable cross-device sync.',
+      description: 'Sync engrams via git AND refresh the derived index from YAML. Initializes repo on first call, commits and pushes/pulls on subsequent calls. Provide a remote URL on first call to enable cross-device sync. Pass full=true to drop-and-rebuild the index from YAML (recovery path; YAML stays untouched).',
       annotations: { title: 'Sync', openWorldHint: true, destructiveHint: false, idempotentHint: true },
       inputSchema: {
         type: 'object',
@@ -753,10 +753,14 @@ export function getToolDefinitions(): ToolDefinition[] {
             type: 'string',
             description: 'Git remote URL (e.g. git@github.com:user/plur-engrams.git). Only needed on first call to set up remote.',
           },
+          full: {
+            type: 'boolean',
+            description: 'Full reindex: drop the derived index (PGLite/SQLite) and rebuild from YAML. YAML is never modified. Use to recover from an out-of-sync index.',
+          },
         },
       },
       handler: async (args, plur) => {
-        const result = plur.sync(args.remote as string | undefined)
+        const result = plur.sync(args.remote as string | undefined, { full: args.full === true })
 
         // Flush outbox after git sync (issue #26)
         let outbox_result: { flushed: number; failed: number; expired_warnings: string[] } | undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.6
+        version: 0.4.6
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -286,6 +289,9 @@ packages:
   '@earendil-works/pi-tui@0.74.0':
     resolution: {integrity: sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==}
     engines: {node: '>=20.0.0'}
+
+  '@electric-sql/pglite@0.4.6':
+    resolution: {integrity: sha512-qmlmfN8UyKCee35qkV0r/MBp+Znl8FjBz7OpoglNvww3GJpw0/DLP0o1ZymvLNmcD5DTLOQdzKPtF8Hd3mdl1w==}
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
@@ -3490,6 +3496,8 @@ snapshots:
       mime-types: 3.0.2
     optionalDependencies:
       koffi: 2.15.2
+
+  '@electric-sql/pglite@0.4.6': {}
 
   '@emnapi/runtime@1.9.1':
     dependencies:


### PR DESCRIPTION
**PR-1 of the Sprint 0 unbundle (#332)** — re-lands the PGLite substrate from the retired epic #276 onto current `main`, as a small, independently-reviewable, CI-able PR. Cherry-picked from `epic/sprint-0-substrate` (plur9 authorship preserved).

## Scope (deliberately minimal)
- **PGLite adapter** (`storage-pglite.ts`, `storage-adapter.ts`) — PGLite + pgvector storage adapter, with `syncFromYaml()` rebuild. Closes #226.
- **Backend opt-in** — `PLUR_BACKEND=pglite` (env or `config.yaml`) wires the adapter in the `Plur` constructor; CLI/MCP flag plumbing included. **Default stays `sqlite`/indexed — no behavior change unless you opt in.**
- **YAML-as-truth invariant tests** — Test A (nuke-the-db rebuild) + Test B (public-API traceability).

## Explicitly NOT in this PR (later in #332)
- Wiring PGLite **into recall** + the default-backend flip → **PR-4** (#334).
- Embedder adapters / factory / **EMBED_DIM** decision → **PR-3** (#335).
- Benchmark harness + data move → **PR-2** (#336).

So the adapter ships and is fully unit-tested + the YAML-truth contract holds, but recall still runs the existing path until PR-4.

## Tests
- New: `pglite-adapter.test.ts`, `yaml-truth-rebuild.test.ts`, `yaml-truth-traceability.test.ts` — **32/32**.
- Full `@plur-ai/core` **887 passed** (only `sync.test.ts` failing — the unrelated #329 global-gitignore flake); `@plur-ai/mcp` 130/130; `@plur-ai/cli` 199 pass/4 skip; `pnpm build` clean.
- This branch gets a real CI run (the epic never did).

Part of #332. Excludes the default-flip and recall wiring on purpose so this is a safe, reversible foundation.