### PR TITLE
feat(core): pluggable embedder adapters + factory + EMBED_DIM (Option A) — PR-3 of #332

### DIFF
--- a/packages/core/src/embedders/bge-base.ts
+++ b/packages/core/src/embedders/bge-base.ts
@@ -1,0 +1,24 @@
+/**
+ * BGE-base adapter — BAAI/bge-base-en-v1.5 via @huggingface/transformers.
+ *
+ * 768-dim, ~110M params, ~440MB on disk. MIT.
+ *
+ * The larger BGE sibling. Roughly +1.5pp MTEB over bge-small at ~3x the
+ * compute cost. Included so the bake-off can pin whether the dim bump is
+ * worth the latency/RAM hit on LongMemEval.
+ */
+import { makeTransformersAdapter } from './transformers-base.js'
+import type { EmbedderAdapter } from './types.js'
+
+export const BGE_BASE_MODEL_ID = 'Xenova/bge-base-en-v1.5'
+
+export function makeBgeBaseAdapter(): EmbedderAdapter {
+  return makeTransformersAdapter({
+    name: 'bge-base',
+    dim: 768,
+    modelId: BGE_BASE_MODEL_ID,
+    pooling: 'cls',
+    normalize: true,
+    dtype: 'fp32',
+  })
+}

--- a/packages/core/src/embedders/bge-small.ts
+++ b/packages/core/src/embedders/bge-small.ts
@@ -1,0 +1,24 @@
+/**
+ * BGE-small adapter — BAAI/bge-small-en-v1.5 via @huggingface/transformers.
+ *
+ * 384-dim, ~33M params, ~130MB on disk. MIT.
+ *
+ * This is the model PLUR currently ships in embeddings.ts. Wrapping it
+ * behind the adapter interface lets the bake-off measure the v0.9.x default
+ * against the new candidates without a behavioral change at the engine layer.
+ */
+import { makeTransformersAdapter } from './transformers-base.js'
+import type { EmbedderAdapter } from './types.js'
+
+export const BGE_SMALL_MODEL_ID = 'Xenova/bge-small-en-v1.5'
+
+export function makeBgeSmallAdapter(): EmbedderAdapter {
+  return makeTransformersAdapter({
+    name: 'bge-small',
+    dim: 384,
+    modelId: BGE_SMALL_MODEL_ID,
+    pooling: 'cls',
+    normalize: true,
+    dtype: 'fp32',
+  })
+}

--- a/packages/core/src/embedders/dim-check.ts
+++ b/packages/core/src/embedders/dim-check.ts
@@ -1,0 +1,128 @@
+/**
+ * Embedder dim mismatch detection — Sprint 0 PR 5 (#219), extended in iter-2
+ * audit B-3.
+ *
+ * The configured embedder controls the dim of the PGLite `vector(N)` column
+ * AND the JSON `.embeddings-cache.json` entries. If a user upgrades from a
+ * 384d embedder to a 768d one (or vice versa) and never runs the migration:
+ *
+ *   - PGLite path: pgvector ORDER BY throws a dim-mismatch error.
+ *   - JSON cache path: cosineSimilarity iterates min(a, b) and silently
+ *     returns garbage scores.
+ *
+ * `checkEmbedderDimMismatch()` checks both paths and reports the worst
+ * discrepancy as a structured warning so callers (CLI `plur doctor`, MCP
+ * session-start) can render it consistently and point at the fix command.
+ *
+ * Stateless and safe to call on every doctor run.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { PGLiteAdapter } from '../storage-pglite.js'
+
+export interface DimMismatchWarning {
+  indexedDim: number
+  activeDim: number
+  /** Where the mismatch was detected. */
+  source: 'pglite' | 'json-cache'
+  message: string
+}
+
+export interface DimCheckInputs {
+  pglitePath: string
+  yamlPath: string
+  activeEmbedderDim: number
+  /** Path to the JSON embeddings cache (default: `<root>/.embeddings-cache.json`). */
+  jsonCachePath?: string
+  /** Active embedder name for cache-header comparison (B-3 — same-dim, different-family case). */
+  activeEmbedderName?: string
+}
+
+/**
+ * Compare the indexed PGLite vector column dim against the active embedder's
+ * dim. Returns a warning object when they differ; null otherwise. Never
+ * throws — a missing or corrupt PGLite store returns null so the doctor
+ * command can continue running its other checks.
+ *
+ * When `jsonCachePath` is provided AND `pglitePath` is not active, falls
+ * back to the JSON-cache check (closes RC-3 for default users).
+ */
+export async function checkEmbedderDimMismatch(inputs: DimCheckInputs): Promise<DimMismatchWarning | null> {
+  // PGLite path first — it's the wired-in production index.
+  if (existsSync(inputs.pglitePath)) {
+    let adapter: PGLiteAdapter | null = null
+    try {
+      adapter = new PGLiteAdapter(inputs.yamlPath, inputs.pglitePath, { vectorDim: inputs.activeEmbedderDim })
+      // Touch the DB once so the schema exists.
+      await adapter.loadFiltered({})
+      const indexedDim = await adapter.getVectorColumnDim()
+      if (indexedDim !== null && indexedDim !== inputs.activeEmbedderDim) {
+        const message =
+          `PGLite vector column is ${indexedDim}d but active embedder produces ${inputs.activeEmbedderDim}d vectors. ` +
+          `Hybrid recall will fall back to BM25 until you run: plur sync --reembed --full`
+        return { indexedDim, activeDim: inputs.activeEmbedderDim, source: 'pglite', message }
+      }
+    } catch {
+      // ignore — continue to JSON cache check
+    } finally {
+      if (adapter) {
+        try { await adapter.close() } catch { /* ignore */ }
+      }
+    }
+  }
+
+  // JSON cache path — for default (non-PGLite) installs (iter-2 audit B-3).
+  const cachePath = inputs.jsonCachePath
+  if (cachePath && existsSync(cachePath)) {
+    try {
+      const raw = JSON.parse(readFileSync(cachePath, 'utf8'))
+      // Legacy flat-object format counts as a hard mismatch — recommend
+      // the migration so the user moves to the stamped format.
+      if (raw && typeof raw === 'object' && !raw.meta) {
+        const message =
+          `Embeddings cache is in legacy format (no embedder identity). ` +
+          `Run: plur sync --reembed --full to rebuild against the active embedder ` +
+          `(${inputs.activeEmbedderDim}d).`
+        return {
+          indexedDim: 0,
+          activeDim: inputs.activeEmbedderDim,
+          source: 'json-cache',
+          message,
+        }
+      }
+      const meta = raw?.meta as { embedder_dim?: number; embedder_name?: string } | undefined
+      if (meta && typeof meta.embedder_dim === 'number') {
+        const dimMismatch = meta.embedder_dim !== inputs.activeEmbedderDim
+        const nameMismatch =
+          inputs.activeEmbedderName !== undefined &&
+          typeof meta.embedder_name === 'string' &&
+          meta.embedder_name !== inputs.activeEmbedderName
+        if (dimMismatch || nameMismatch) {
+          const message =
+            `Embeddings cache is ${meta.embedder_dim}d (${meta.embedder_name ?? 'unknown embedder'}) ` +
+            `but active embedder produces ${inputs.activeEmbedderDim}d vectors` +
+            (inputs.activeEmbedderName ? ` (${inputs.activeEmbedderName})` : '') +
+            `. Run: plur sync --reembed --full to rebuild the cache.`
+          return {
+            indexedDim: meta.embedder_dim,
+            activeDim: inputs.activeEmbedderDim,
+            source: 'json-cache',
+            message,
+          }
+        }
+      }
+    } catch {
+      // Unreadable JSON cache — let the rebuild path repair it on the next recall.
+    }
+  }
+
+  return null
+}
+
+/**
+ * Helper that callers can use to derive the default JSON cache path.
+ * Mirrors the path used by `embeddings.ts`.
+ */
+export function defaultJsonCachePath(storageRoot: string): string {
+  return join(storageRoot, '.embeddings-cache.json')
+}

--- a/packages/core/src/embedders/embedding-gemma.ts
+++ b/packages/core/src/embedders/embedding-gemma.ts
@@ -1,0 +1,39 @@
+/**
+ * EmbeddingGemma adapter — Google EmbeddingGemma-300M via @huggingface/transformers.
+ *
+ * 768-dim native (with Matryoshka tiers at 512/256/128), ~300M params, ~300MB
+ * on disk with int8/q8 quantisation. Apache 2.0.
+ *
+ * Model id: onnx-community/embeddinggemma-300m-ONNX — the community ONNX
+ * conversion that ships with text/embed pipeline metadata. Recent
+ * @huggingface/transformers releases (3.x) handle the gemma3_text model_type
+ * via the feature-extraction pipeline. Pooling for EmbeddingGemma is the
+ * "last token" / mean of the prompt+content tokens; we use mean here as the
+ * pipeline's `mean` pooling matches the encoder semantics for this model.
+ *
+ * Disk cost (FYI): q8 weights ~ 300 MB, fp32 ~ 1.2 GB. We prefer q8 here so
+ * the bake-off lines up with the published EmbeddingGemma benchmarks (which
+ * report numbers at q8) and so first-time download stays within reach on
+ * laptop bandwidth.
+ *
+ * If a future @huggingface/transformers version drops gemma3_text support
+ * the adapter still loads — the lazy import will throw a descriptive error
+ * at first embed() call rather than at module import time.
+ */
+import { makeTransformersAdapter } from './transformers-base.js'
+import type { EmbedderAdapter } from './types.js'
+
+export const EMBEDDING_GEMMA_MODEL_ID = 'onnx-community/embeddinggemma-300m-ONNX'
+
+export function makeEmbeddingGemmaAdapter(): EmbedderAdapter {
+  return makeTransformersAdapter({
+    name: 'embedding-gemma',
+    dim: 768,
+    modelId: EMBEDDING_GEMMA_MODEL_ID,
+    pooling: 'mean',
+    normalize: true,
+    // q8 picked to match the published EmbeddingGemma benchmark numbers and
+    // keep the first-run download manageable (~300MB instead of ~1.2GB).
+    dtype: 'q8',
+  })
+}

--- a/packages/core/src/embedders/index.ts
+++ b/packages/core/src/embedders/index.ts
@@ -1,0 +1,129 @@
+/**
+ * Embedder factory — Sprint 0 PR 4 (feat/embedder-bake-off) + PR 5
+ * (feat/embedding-gemma-default).
+ *
+ * One uniform interface (`EmbedderAdapter`) across the candidate models:
+ *
+ *   - minilm            sentence-transformers/all-MiniLM-L6-v2     (384d, 22M)
+ *   - bge-small         BAAI/bge-small-en-v1.5                     (384d, 33M)
+ *   - bge-base          BAAI/bge-base-en-v1.5                      (768d, 110M)
+ *   - embedding-gemma   google/EmbeddingGemma-300M (ONNX community) (768d, 300M) — DEFAULT
+ *   - openai-3-large    OpenAI text-embedding-3-large              (3072d, API)  — opt-in
+ *
+ * Pick one via PLUR_EMBEDDER env var or programmatically via `getEmbedder()`.
+ *
+ *   PLUR_EMBEDDER=bge-base node -e "..."   # 768d, pgvector column resized
+ *   PLUR_EMBEDDER=openai-3-large           # API tier (requires OPENAI_API_KEY)
+ *   getEmbedder('embedding-gemma').embed(text)
+ *
+ * Wiring:
+ *   - benchmark/run.ts uses this to map --embedder flag to a real adapter
+ *   - storage-pglite.ts reads adapter.dim to size its vector(N) column
+ *   - embeddings.ts routes through the active adapter
+ *
+ * PR 5 default switch: bake-off (docs/benchmarks/embedder-bake-off-2026-05.md)
+ * showed EmbeddingGemma matches BGE-small on R@5 with the best Accuracy at
+ * N=5/category and Apache-2.0 license. The default flipped from bge-small to
+ * embedding-gemma. If Phase C (N=500) inverts the ordering it's a one-line
+ * revert here.
+ */
+import { logger } from '../logger.js'
+import { makeMiniLMAdapter } from './minilm.js'
+import { makeBgeSmallAdapter } from './bge-small.js'
+import { makeBgeBaseAdapter } from './bge-base.js'
+import { makeEmbeddingGemmaAdapter } from './embedding-gemma.js'
+import { makeOpenAI3LargeAdapter } from './openai.js'
+import type { EmbedderAdapter } from './types.js'
+
+export type { EmbedderAdapter } from './types.js'
+
+/** All embedder names supported by the factory. Drives benchmark CLI parsing. */
+export const EMBEDDER_NAMES = [
+  'minilm',
+  'bge-small',
+  'bge-base',
+  'embedding-gemma',
+  'openai-3-large',
+] as const
+export type EmbedderName = typeof EMBEDDER_NAMES[number]
+
+/**
+ * Default embedder when PLUR_EMBEDDER is unset.
+ *
+ * Sprint 0 iter-1 audit (docs/audit/sprint-0/iter-1-gaps-consolidated.md, B-2)
+ * reverted the default from `embedding-gemma` back to `bge-small`. The PR 4
+ * bake-off ran on N=5/category (30 scenarios) — too small to justify the
+ * decision rule "≥2pp R@5 at or below CPU cost." EmbeddingGemma tied BGE-small
+ * on R@5, lost on R@1 (43.3% vs 46.7%), and costs 2.4x peak RSS plus 11x p99
+ * latency. The default flip is deferred to Phase C (real LongMemEval-S, N=500
+ * per category) — see docs/benchmarks/embedder-bake-off-2026-05.md for the
+ * deferred decision. BGE-small remains the v0.9.x production default; this is
+ * a zero-risk revert until Phase C produces evidence.
+ *
+ * Flip to embedding-gemma via PLUR_EMBEDDER=embedding-gemma; the adapter is
+ * still bundled and tested.
+ */
+export const DEFAULT_EMBEDDER: EmbedderName = 'bge-small'
+
+/** Singleton cache so two callers asking for the same name share metadata + the inner pipeline. */
+const adapterCache = new Map<EmbedderName, EmbedderAdapter>()
+
+/** Reset cached adapters. Test-only — production code never calls this. */
+export function _resetEmbedderCache(): void {
+  adapterCache.clear()
+}
+
+/** Build (and cache) the adapter for a given name. Throws on unknown names. */
+export function getEmbedder(name: EmbedderName): EmbedderAdapter {
+  if (!EMBEDDER_NAMES.includes(name)) {
+    throw new Error(`Unknown embedder "${name}". Known: ${EMBEDDER_NAMES.join(', ')}`)
+  }
+  let adapter = adapterCache.get(name)
+  if (!adapter) {
+    adapter = build(name)
+    adapterCache.set(name, adapter)
+  }
+  return adapter
+}
+
+function build(name: EmbedderName): EmbedderAdapter {
+  switch (name) {
+    case 'minilm':           return makeMiniLMAdapter()
+    case 'bge-small':        return makeBgeSmallAdapter()
+    case 'bge-base':         return makeBgeBaseAdapter()
+    case 'embedding-gemma':  return makeEmbeddingGemmaAdapter()
+    case 'openai-3-large':   return makeOpenAI3LargeAdapter()
+    default: {
+      // Exhaustiveness check — TS will complain if a new EmbedderName is
+      // added without a switch arm.
+      const _exhaustive: never = name
+      throw new Error(`Unhandled embedder name: ${String(_exhaustive)}`)
+    }
+  }
+}
+
+/**
+ * Resolve which embedder to use based on PLUR_EMBEDDER. Returns the default
+ * (embedding-gemma) when unset; logs a single warning and falls back to
+ * default on unknown values rather than throwing — the active embedder is
+ * determined at process start and we don't want a typo in an env var to
+ * brick the engine.
+ */
+let warnedUnknown = false
+export function resolveEmbedderName(env: NodeJS.ProcessEnv = process.env): EmbedderName {
+  const raw = env.PLUR_EMBEDDER?.trim()
+  if (!raw) return DEFAULT_EMBEDDER
+  if (EMBEDDER_NAMES.includes(raw as EmbedderName)) return raw as EmbedderName
+  if (!warnedUnknown) {
+    logger.warning(
+      `[embedders] PLUR_EMBEDDER="${raw}" not recognised. Falling back to "${DEFAULT_EMBEDDER}". Known: ${EMBEDDER_NAMES.join(', ')}`,
+    )
+    warnedUnknown = true
+  }
+  return DEFAULT_EMBEDDER
+}
+
+/** Reset the unknown-env-var warning latch. Test-only. */
+export function _resetResolveWarnings(): void {
+  warnedUnknown = false
+}

--- a/packages/core/src/embedders/minilm.ts
+++ b/packages/core/src/embedders/minilm.ts
@@ -1,0 +1,24 @@
+/**
+ * MiniLM adapter — sentence-transformers/all-MiniLM-L6-v2 via @huggingface/transformers.
+ *
+ * 384-dim, ~22M params, ~90MB on disk. Apache 2.0.
+ *
+ * Historical default referenced in the PLUR design docs; kept as a baseline
+ * for the bake-off so we can measure how much BGE/EmbeddingGemma actually
+ * buy us on LongMemEval.
+ */
+import { makeTransformersAdapter } from './transformers-base.js'
+import type { EmbedderAdapter } from './types.js'
+
+export const MINILM_MODEL_ID = 'Xenova/all-MiniLM-L6-v2'
+
+export function makeMiniLMAdapter(): EmbedderAdapter {
+  return makeTransformersAdapter({
+    name: 'minilm',
+    dim: 384,
+    modelId: MINILM_MODEL_ID,
+    pooling: 'mean',
+    normalize: true,
+    dtype: 'fp32',
+  })
+}

--- a/packages/core/src/embedders/openai.ts
+++ b/packages/core/src/embedders/openai.ts
@@ -1,0 +1,91 @@
+/**
+ * OpenAI `text-embedding-3-large` adapter — Sprint 0 PR 5 (#219).
+ *
+ * 3072-dim embeddings via the OpenAI Embeddings API. Supports Matryoshka
+ * truncation through the `dimensions` request param; we ship the full 3072d
+ * by default to match the model's spec. Opt-in only — activated via
+ * `PLUR_EMBEDDER=openai-3-large` plus a valid `OPENAI_API_KEY`.
+ *
+ * License / cost note: the OpenAI API is a paid commercial service governed by
+ * OpenAI's terms (https://openai.com/policies). At the time of writing
+ * `text-embedding-3-large` is billed per 1k tokens. Local users typically
+ * stay on the default EmbeddingGemma adapter (Apache 2.0, no network) and
+ * only flip to this adapter when they want the higher-end retrieval ceiling
+ * and are happy to pay for it.
+ *
+ * Network shape: minimal `fetch` POST to `/v1/embeddings`. No SDK dependency
+ * so the package stays free of optional peer deps and works in environments
+ * that don't ship the `openai` package. If/when an SDK switch is wanted, the
+ * adapter is a single-file swap.
+ */
+import type { EmbedderAdapter } from './types.js'
+
+export const OPENAI_3_LARGE_MODEL_ID = 'text-embedding-3-large'
+export const OPENAI_3_LARGE_DIM = 3072
+
+const ENDPOINT = 'https://api.openai.com/v1/embeddings'
+
+function readApiKey(): string {
+  const key = process.env.OPENAI_API_KEY
+  if (!key || key.trim() === '') {
+    throw new Error(
+      'openai-3-large embedder requires OPENAI_API_KEY. Set the env var (export OPENAI_API_KEY=sk-...) or unset PLUR_EMBEDDER to fall back to the local default.',
+    )
+  }
+  return key
+}
+
+async function postEmbed(texts: string[]): Promise<Float32Array[]> {
+  const key = readApiKey()
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      model: OPENAI_3_LARGE_MODEL_ID,
+      input: texts,
+    }),
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(
+      `openai-3-large embed failed: HTTP ${res.status} ${res.statusText}${body ? ` — ${body.slice(0, 200)}` : ''}`,
+    )
+  }
+  const json = (await res.json()) as { data?: Array<{ embedding: number[] | string }> }
+  if (!Array.isArray(json.data) || json.data.length !== texts.length) {
+    throw new Error(
+      `openai-3-large embed returned ${json.data?.length ?? 'no'} vectors for ${texts.length} inputs`,
+    )
+  }
+  return json.data.map((row, i) => {
+    const e = row.embedding
+    if (!Array.isArray(e)) {
+      throw new Error(`openai-3-large returned non-array embedding at index ${i}`)
+    }
+    if (e.length !== OPENAI_3_LARGE_DIM) {
+      throw new Error(
+        `openai-3-large returned ${e.length}-dim vector at index ${i}, expected ${OPENAI_3_LARGE_DIM}`,
+      )
+    }
+    return Float32Array.from(e)
+  })
+}
+
+export function makeOpenAI3LargeAdapter(): EmbedderAdapter {
+  return {
+    name: 'openai-3-large',
+    dim: OPENAI_3_LARGE_DIM,
+    modelId: OPENAI_3_LARGE_MODEL_ID,
+    async embed(text: string): Promise<Float32Array> {
+      const [v] = await postEmbed([text])
+      return v
+    },
+    async embedBatch(texts: string[]): Promise<Float32Array[]> {
+      if (texts.length === 0) return []
+      return postEmbed(texts)
+    },
+  }
+}

--- a/packages/core/src/embedders/transformers-base.ts
+++ b/packages/core/src/embedders/transformers-base.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared base for @huggingface/transformers-backed adapters.
+ *
+ * Centralises the lazy pipeline load + the embed/embedBatch shape so each
+ * concrete adapter only declares its model id, dim, pooling strategy, and
+ * dtype. This is the path that handles MiniLM, BGE-small, BGE-base, and
+ * (if the transformers runtime supports it) EmbeddingGemma.
+ *
+ * Each adapter caches its pipeline as a module-local Map so two instances of
+ * the same name share the model instance — important because each load is
+ * 100MB+ of WASM / ONNX setup.
+ */
+import type { EmbedderAdapter } from './types.js'
+
+/** Pooling strategies supported by @huggingface/transformers feature-extraction. */
+export type Pooling = 'cls' | 'mean' | 'none'
+
+export interface TransformersAdapterConfig {
+  name: string
+  dim: number
+  modelId: string
+  pooling: Pooling
+  /** ONNX weight dtype. 'fp32' is the safe default; 'q8' / 'fp16' may be model-specific. */
+  dtype?: 'fp32' | 'fp16' | 'q8' | 'int8' | 'uint8' | 'q4'
+  /** Whether to L2-normalise the output. BGE and MiniLM use this. */
+  normalize?: boolean
+}
+
+const pipelineCache = new Map<string, Promise<unknown>>()
+
+async function loadPipeline(modelId: string, dtype: TransformersAdapterConfig['dtype']): Promise<unknown> {
+  const key = `${modelId}::${dtype ?? 'fp32'}`
+  let pending = pipelineCache.get(key)
+  if (!pending) {
+    pending = (async () => {
+      const { pipeline } = await import('@huggingface/transformers')
+      return pipeline('feature-extraction', modelId, dtype ? { dtype } : undefined)
+    })()
+    pipelineCache.set(key, pending)
+  }
+  return await pending
+}
+
+/** Reset the shared pipeline cache. Test-only. */
+export function _resetTransformersPipelineCache(): void {
+  pipelineCache.clear()
+}
+
+export function makeTransformersAdapter(config: TransformersAdapterConfig): EmbedderAdapter {
+  const pooling: Pooling = config.pooling
+  const normalize = config.normalize ?? true
+
+  async function embedOne(text: string): Promise<Float32Array> {
+    const pipe = (await loadPipeline(config.modelId, config.dtype)) as (
+      input: string | string[],
+      opts: { pooling: Pooling; normalize: boolean },
+    ) => Promise<{ data: Float32Array | number[] }>
+    const result = await pipe(text, { pooling, normalize })
+    const arr = result.data instanceof Float32Array ? result.data : new Float32Array(result.data)
+    if (arr.length !== config.dim) {
+      throw new Error(
+        `Embedder "${config.name}" returned ${arr.length}-dim vector, expected ${config.dim}`,
+      )
+    }
+    return arr
+  }
+
+  return {
+    name: config.name,
+    dim: config.dim,
+    modelId: config.modelId,
+    embed: embedOne,
+    async embedBatch(texts: string[]): Promise<Float32Array[]> {
+      // The transformers pipeline supports batched input, but in practice the
+      // batched-output reshape depends on the runtime version. Iterating
+      // gives stable order semantics — speed-critical batches are rare in
+      // PLUR's recall path.
+      const out: Float32Array[] = []
+      for (const t of texts) out.push(await embedOne(t))
+      return out
+    },
+  }
+}

--- a/packages/core/src/embedders/types.ts
+++ b/packages/core/src/embedders/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Embedder adapter interface — Sprint 0 PR 4 (feat/embedder-bake-off).
+ *
+ * Four candidate models live behind this shape so the benchmark harness can
+ * swap them via --embedder and the PGLite vector column can be sized at
+ * construction time based on `dim`.
+ *
+ * Adapters are responsible for:
+ *   - lazy model load on first embed call
+ *   - pooling + normalisation suitable for their family (CLS for BGE, mean
+ *     for MiniLM, model-specific for EmbeddingGemma)
+ *   - returning Float32Arrays of exactly `dim` floats
+ *
+ * Adapters must be stateless w.r.t. caller — repeated embed("foo") calls
+ * produce identical output once the model is loaded.
+ */
+export interface EmbedderAdapter {
+  /** Short name used by --embedder and PLUR_EMBEDDER. */
+  readonly name: string
+  /** Output dimensionality. Drives the PGLite vector(N) column type. */
+  readonly dim: number
+  /** Hugging Face model id (or local path) the adapter loads. */
+  readonly modelId: string
+  /** Embed a single text. Loads the model on first call. */
+  embed(text: string): Promise<Float32Array>
+  /** Embed N texts. Output order matches input order. */
+  embedBatch(texts: string[]): Promise<Float32Array[]>
+}

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -4,45 +4,40 @@ import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { createHash } from 'crypto'
 import { atomicWrite } from './sync.js'
+import { logger } from './logger.js'
 
 /**
  * Embedding-based semantic search for engrams.
  *
- * Uses @huggingface/transformers (ONNX runtime) for local embeddings.
- * Model: BAAI/bge-small-en-v1.5 (~130MB, 384-dim, strong MTEB, fast)
+ * Uses @huggingface/transformers (ONNX runtime) for local embeddings, routed
+ * through the embedder factory at packages/core/src/embedders/index.ts.
  *
- * BGE models significantly outperform MiniLM on MTEB retrieval benchmarks
- * while keeping the same 384-dim footprint. bge-small-en-v1.5 scores ~62 on
- * MTEB vs ~42 for all-MiniLM-L6-v2.
+ * Default model: BGE-small-en-v1.5 (MIT, 384d, ~130 MB on disk q8).
+ * EmbeddingGemma was briefly promoted to default in Sprint 0 PR 5 (#219) but
+ * the iter-1 audit (B-2) reverted the default pending Phase C LongMemEval-S
+ * evidence — see docs/audit/sprint-0/iter-1-gaps-consolidated.md and
+ * docs/benchmarks/embedder-bake-off-2026-05.md. EmbeddingGemma is still
+ * available via PLUR_EMBEDDER=embedding-gemma. Opt-in API tier:
+ * `openai-3-large` (text-embedding-3-large, 3072d) — requires OPENAI_API_KEY.
  *
  * Embeddings are cached per-engram using content hashing to avoid
- * re-computation on subsequent searches.
+ * re-computation on subsequent searches. The cache file is stamped with the
+ * active embedder name + dim; on mismatch the cache is invalidated and
+ * rebuilt (Sprint 0 iter-2 B-1, closes RC-3).
  */
 
 /**
- * Embedding dimension produced by the model (BAAI/bge-small-en-v1.5 → 384).
+ * Dimension of the DEFAULT embedder (bge-small → 384). Exported for backward
+ * compatibility with #289/#290.
  *
- * STABLE PUBLIC CONTRACT. Any backend that persists vectors must store them at
- * this dimension and produced by this exact model — vectors of a different
- * dimension or from a different model are incompatible and silently degrade
- * recall. Changing the model or this value is therefore a BREAKING change:
- * every consumer holding persisted vectors must re-embed. `embed()` asserts its
- * first successful output against this constant so a model swap that changes the
- * dimension fails loudly instead of drifting silently.
+ * NOTE (#335): the embedder is pluggable via PLUR_EMBEDDER, so the dimension of
+ * vectors this install actually produces is NOT fixed at this value —
+ * bge-base / embedding-gemma are 768, openai-3-large is 3072. Any backend that
+ * persists vectors MUST size its column to the **active** embedder's dim,
+ * obtained from `activeEmbedderDim()` — NOT this constant. `EMBED_DIM` remains
+ * only as the documented default; `activeEmbedderDim()` is the source of truth.
  */
 export const EMBED_DIM = 384
-
-/**
- * Model identity behind the embeddings, half of the stable contract above.
- * The ONNX/transformers.js port of BAAI/bge-small-en-v1.5. Named so the
- * dimension-mismatch error can name the model a consumer must match, and so a
- * model swap is a one-line, greppable change.
- */
-const EMBED_MODEL_ID = 'Xenova/bge-small-en-v1.5'
-
-// Verifies the live model output matches EMBED_DIM exactly once per process —
-// see assertEmbedDim().
-let embedDimChecked = false
 
 // Lazy-loaded pipeline — only initialized when first needed
 let embedPipeline: any = null
@@ -125,7 +120,6 @@ export function resetEmbedder(): void {
   transformersUnavailable = false
   lastLoadError = null
   embedPipeline = null
-  embedDimChecked = false
 }
 
 async function getEmbedder() {
@@ -135,10 +129,13 @@ async function getEmbedder() {
   // Loads are cheap once the model is cached; failures are rare and
   // transient (network, sandbox restrictions on first download).
   try {
-    const { pipeline } = await import('@huggingface/transformers')
-    embedPipeline = await pipeline('feature-extraction', EMBED_MODEL_ID, {
-      dtype: 'fp32',
-    })
+    // Sprint 0 PR 4: route through the embedder factory so PLUR_EMBEDDER
+    // controls which model is loaded. Default is bge-small (Sprint 0 iter-2
+    // B-2 revert) when the env var is unset, so existing installs are
+    // unchanged. EmbeddingGemma stays opt-in until Phase C produces evidence.
+    const { getEmbedder: getAdapter, resolveEmbedderName } = await import('./embedders/index.js')
+    const adapter = getAdapter(resolveEmbedderName())
+    embedPipeline = adapter
     transformersUnavailable = false
     lastLoadError = null
     return embedPipeline
@@ -149,48 +146,68 @@ async function getEmbedder() {
   }
 }
 
-/**
- * Generate an embedding for a text string. Returns a Float32Array of EMBED_DIM
- * (384) dims.
- *
- * Two distinct non-success outcomes — consumers MUST treat them differently:
- *
- * - Returns `null` → embeddings are unavailable (model not loaded, download
- *   failed, or disabled via config/PLUR_DISABLE_EMBEDDINGS). This is an
- *   environment condition; callers should degrade to keyword/BM25 search.
- * - Throws → the live model's output dimension does not match EMBED_DIM, i.e. a
- *   model/contract violation. This must NOT be swallowed into the degrade path:
- *   a catch-all that falls back to BM25 here re-introduces the exact silent
- *   drift this contract prevents and lets incompatible vectors get persisted.
- *   Let it surface.
- */
+/** Generate embedding for a text string. Returns the active embedder's native dim, or null if unavailable. */
 export async function embed(text: string): Promise<Float32Array | null> {
   const embedder = await getEmbedder()
   if (!embedder) return null
+  // When the cached value is an EmbedderAdapter (PR 4 path) it has an .embed
+  // method; the legacy code path stored the raw transformers pipeline. Branch
+  // on shape so the swap is backward-compatible in tests that stub the cache.
+  if (typeof embedder.embed === 'function') {
+    let vector: Float32Array | null
+    try {
+      vector = await embedder.embed(text)
+    } catch (err) {
+      transformersUnavailable = true
+      lastLoadError = err instanceof Error ? err.message : String(err)
+      embedPipeline = null
+      return null
+    }
+    // Dimension-drift check (#290 generalized to the active embedder, #335):
+    // the adapter declares its dim; if the live model produces a different
+    // length, persisted vectors would silently corrupt. Throw OUTSIDE the catch
+    // so it surfaces — degrading this to null would re-introduce the exact
+    // silent drift the contract prevents.
+    if (vector && typeof embedder.dim === 'number' && vector.length !== embedder.dim) {
+      throw new Error(
+        `Embedding dimension mismatch: embedder "${embedder.name}" declares ${embedder.dim} dims ` +
+          `but produced ${vector.length}. The adapter's declared dim and its model must agree; ` +
+          `vectors at the wrong dimension are incompatible with any store that persisted them.`,
+      )
+    }
+    return vector
+  }
   const result = await embedder(text, { pooling: 'cls', normalize: true })
-  const vector = new Float32Array(result.data)
-  assertEmbedDim(vector)
-  return vector
+  return new Float32Array(result.data)
 }
 
 /**
- * Assert (once per process) that the live model's output dimension matches
- * EMBED_DIM. A mismatch means the model changed without EMBED_DIM being updated
- * (or vice versa) — a contract violation that would silently corrupt any
- * persisted vectors, so we fail loudly here rather than let it drift.
+ * Get the active embedder's name+dim for cache stamping. Returns null when
+ * embeddings are disabled or the embedder failed to load — callers should
+ * skip cache writes in that case.
  */
-function assertEmbedDim(vector: Float32Array): void {
-  if (embedDimChecked) return
-  embedDimChecked = true
-  if (vector.length !== EMBED_DIM) {
-    throw new Error(
-      `Embedding dimension mismatch: model "${EMBED_MODEL_ID}" produced ${vector.length} dims ` +
-        `but EMBED_DIM is ${EMBED_DIM}. The embedding model and EMBED_DIM must agree. ` +
-        `Remediation: update EMBED_DIM to ${vector.length} or revert the model change. ` +
-        `Either way this is a BREAKING change for any consumer that persists vectors — ` +
-        `they must re-embed, since vectors at the old dimension are incompatible.`,
-    )
+async function getActiveEmbedderMeta(): Promise<{ name: string; dim: number } | null> {
+  const embedder = await getEmbedder()
+  if (!embedder) return null
+  if (typeof embedder.name === 'string' && typeof embedder.dim === 'number') {
+    return { name: embedder.name, dim: embedder.dim }
   }
+  // Legacy pipeline shape — pre-PR-4 raw transformers pipeline (only seen in
+  // older test stubs). Fall back to a sentinel that won't match any real
+  // adapter, so the cache invalidates conservatively.
+  return { name: 'legacy-pipeline', dim: 0 }
+}
+
+/**
+ * The dimension of vectors the ACTIVE embedder produces (per PLUR_EMBEDDER).
+ * This — not the `EMBED_DIM` default constant — is the value an external store
+ * must size its vector column to, so it never drifts from what core writes
+ * (#335). Returns null when embeddings are disabled or the embedder failed to
+ * load (no vectors will be produced, so there is nothing to size to).
+ */
+export async function activeEmbedderDim(): Promise<number | null> {
+  const meta = await getActiveEmbedderMeta()
+  return meta && meta.dim > 0 ? meta.dim : null
 }
 
 /** Cosine similarity between two vectors. */
@@ -200,20 +217,72 @@ export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   return dot // vectors are already normalized, so dot product = cosine similarity
 }
 
-/** Cache file for embeddings. */
-interface EmbeddingCache {
+/** Cache entries indexed by engram ID. */
+interface EmbeddingCacheEntries {
   [engramId: string]: {
     hash: string
     embedding: number[]
   }
 }
 
-function loadCache(cachePath: string): EmbeddingCache {
-  if (!existsSync(cachePath)) return {}
+/**
+ * Cache file format (iter-2 audit B-1/B-3).
+ *
+ * v1 stamps the file with the active embedder's name + dim. On load, if the
+ * meta header differs from the active embedder, the cache is invalidated and
+ * rebuilt. Backward-compat: the pre-iter-2 flat-object format
+ * `{ [engramId]: { hash, embedding } }` is detected by the absence of `meta`
+ * and treated as a hard mismatch (no data loss — cache rebuilds from YAML on
+ * the same call).
+ */
+interface EmbeddingCache {
+  meta: {
+    embedder_name: string
+    embedder_dim: number
+    version: number
+  }
+  entries: EmbeddingCacheEntries
+}
+
+const CACHE_VERSION = 1
+
+/** Active-embedder cache state used by load/save invariants. */
+function emptyCache(meta: { name: string; dim: number }): EmbeddingCache {
+  return {
+    meta: {
+      embedder_name: meta.name,
+      embedder_dim: meta.dim,
+      version: CACHE_VERSION,
+    },
+    entries: {},
+  }
+}
+
+/**
+ * Load cache from disk. When the on-disk header doesn't match `active`, the
+ * cache is invalidated (returns an empty cache stamped with the active
+ * meta). Legacy flat-object files are also invalidated. Logs a one-line info
+ * message on invalidation so users see why their first recall after a
+ * config change takes longer.
+ */
+function loadCache(cachePath: string, active: { name: string; dim: number }): EmbeddingCache {
+  if (!existsSync(cachePath)) return emptyCache(active)
   try {
-    return JSON.parse(readFileSync(cachePath, 'utf8'))
+    const raw = JSON.parse(readFileSync(cachePath, 'utf8'))
+    // Detect the v1 format. Legacy format has no `meta` field — invalidate.
+    if (!raw || typeof raw !== 'object' || !raw.meta) {
+      logger.info(`[embeddings] cache at ${cachePath} is in legacy format (no embedder meta) — rebuilding for active embedder ${active.name} (${active.dim}d).`)
+      return emptyCache(active)
+    }
+    const meta = raw.meta as Partial<EmbeddingCache['meta']>
+    if (meta.embedder_name !== active.name || meta.embedder_dim !== active.dim) {
+      logger.info(`[embeddings] cache embedder mismatch — on-disk: ${meta.embedder_name} (${meta.embedder_dim}d), active: ${active.name} (${active.dim}d). Rebuilding cache.`)
+      return emptyCache(active)
+    }
+    const entries = (raw.entries && typeof raw.entries === 'object') ? raw.entries as EmbeddingCacheEntries : {}
+    return { meta: { embedder_name: meta.embedder_name!, embedder_dim: meta.embedder_dim!, version: meta.version ?? CACHE_VERSION }, entries }
   } catch {
-    return {}
+    return emptyCache(active)
   }
 }
 
@@ -240,11 +309,16 @@ export async function embeddingSearch(
 ): Promise<Engram[]> {
   if (engrams.length === 0) return []
 
-  // Load embedding cache
+  // Resolve the active embedder before touching the cache so the cache load
+  // can compare against the right meta header.
+  const activeMeta = await getActiveEmbedderMeta()
+  if (!activeMeta) return []
+
+  // Load embedding cache (invalidates if the on-disk header doesn't match).
   const cachePath = storagePath
     ? join(storagePath, '.embeddings-cache.json')
     : '.embeddings-cache.json'
-  const cache = loadCache(cachePath)
+  const cache = loadCache(cachePath, activeMeta)
 
   // Embed the query
   const queryEmbedding = await embed(query)
@@ -261,15 +335,15 @@ export async function embeddingSearch(
     const hash = hashStatement(searchText)
     let engramEmbedding: Float32Array
 
-    if (cache[engram.id]?.hash === hash) {
+    if (cache.entries[engram.id]?.hash === hash) {
       // Cache hit
-      engramEmbedding = new Float32Array(cache[engram.id].embedding)
+      engramEmbedding = new Float32Array(cache.entries[engram.id].embedding)
     } else {
       // Cache miss — compute embedding from enriched text
       const emb = await embed(searchText)
       if (!emb) return [] // model unloaded mid-search
       engramEmbedding = emb
-      cache[engram.id] = {
+      cache.entries[engram.id] = {
         hash,
         embedding: Array.from(engramEmbedding),
       }
@@ -305,11 +379,14 @@ export async function embeddingSearchWithScores(
 ): Promise<SimilarityResult[]> {
   if (engrams.length === 0) return []
 
-  // Load embedding cache
+  const activeMeta = await getActiveEmbedderMeta()
+  if (!activeMeta) return []
+
+  // Load embedding cache (invalidates if the on-disk header doesn't match).
   const cachePath = storagePath
     ? join(storagePath, '.embeddings-cache.json')
     : '.embeddings-cache.json'
-  const cache = loadCache(cachePath)
+  const cache = loadCache(cachePath, activeMeta)
 
   // Embed the query
   const queryEmbedding = await embed(query)
@@ -326,15 +403,15 @@ export async function embeddingSearchWithScores(
     const hash = hashStatement(searchText)
     let engramEmbedding: Float32Array
 
-    if (cache[engram.id]?.hash === hash) {
+    if (cache.entries[engram.id]?.hash === hash) {
       // Cache hit
-      engramEmbedding = new Float32Array(cache[engram.id].embedding)
+      engramEmbedding = new Float32Array(cache.entries[engram.id].embedding)
     } else {
       // Cache miss — compute embedding from enriched text
       const emb = await embed(searchText)
       if (!emb) return [] // model unloaded mid-search
       engramEmbedding = emb
-      cache[engram.id] = {
+      cache.entries[engram.id] = {
         hash,
         embedding: Array.from(engramEmbedding),
       }
@@ -354,4 +431,52 @@ export async function embeddingSearchWithScores(
   // Sort by similarity (descending) and return top N with scores
   similarities.sort((a, b) => b.score - a.score)
   return similarities.slice(0, limit)
+}
+
+/**
+ * Rebuild the JSON `.embeddings-cache.json` file under `storagePath` using
+ * the active embedder. Used by `plur sync --reembed` when PGLite is NOT the
+ * active backend so non-PGLite users have a real migration path on embedder
+ * switches.
+ *
+ * `full=true` deletes the existing cache file before rebuilding (forces every
+ * engram to be re-embedded from scratch). `full=false` invalidates the meta
+ * header but lets matching entries survive — useful when only the cache file
+ * format version bumped without an embedder change.
+ *
+ * Returns the count of engrams whose embedding was rewritten. Returns 0 and
+ * `skipped: true` when embeddings are disabled or the embedder failed to
+ * load. Closes RC-3 for the default (non-PGLite) user (Sprint 0 iter-2 B-3).
+ */
+export async function rebuildJsonCache(
+  engrams: Engram[],
+  storagePath: string,
+  opts?: { full?: boolean },
+): Promise<{ reembedded: number; skipped: boolean; reason?: string }> {
+  const activeMeta = await getActiveEmbedderMeta()
+  if (!activeMeta) {
+    return { reembedded: 0, skipped: true, reason: 'embedder unavailable' }
+  }
+  const cachePath = join(storagePath, '.embeddings-cache.json')
+  // Start fresh when --full was requested. Even without --full we want the
+  // cache header to track the active embedder, so loadCache's invalidation
+  // path already does the right thing for matched entries.
+  const cache: EmbeddingCache = opts?.full
+    ? emptyCache(activeMeta)
+    : loadCache(cachePath, activeMeta)
+
+  let count = 0
+  for (const engram of engrams) {
+    const searchText = engramSearchText(engram)
+    const hash = hashStatement(searchText)
+    if (cache.entries[engram.id]?.hash === hash && !opts?.full) continue
+    const vec = await embed(searchText)
+    if (!vec) {
+      return { reembedded: count, skipped: true, reason: 'embedder unavailable mid-rebuild' }
+    }
+    cache.entries[engram.id] = { hash, embedding: Array.from(vec) }
+    count++
+  }
+  saveCache(cachePath, cache)
+  return { reembedded: count, skipped: false }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,7 +90,8 @@ export { withAsyncLock, asyncAtomicWrite } from './store/index.js'
 // vectors identically to core's hybrid search (same model + EMBED_DIM). The
 // model identity and EMBED_DIM are a stable contract; changing them is breaking
 // for any consumer that persists vectors. See embeddings.ts.
-export { embed, EMBED_DIM, embedderStatus, cosineSimilarity, type EmbedderStatus } from './embeddings.js'
+export { embed, EMBED_DIM, activeEmbedderDim, embedderStatus, cosineSimilarity, type EmbedderStatus } from './embeddings.js'
+export { EMBEDDER_NAMES, DEFAULT_EMBEDDER, resolveEmbedderName, type EmbedderName, type EmbedderAdapter } from './embedders/index.js'
 export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus } from './sync.js'
 export { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'

--- a/packages/core/test/embedder-default.test.ts
+++ b/packages/core/test/embedder-default.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Embedder default + OpenAI tier resolution — Sprint 0 PR 5
+ * (feat/embedding-gemma-default), closes plur-ai/plur#219.
+ *
+ * Sprint 0 iter-2 audit (B-2) reverted the default to "bge-small" pending
+ * Phase C LongMemEval-S evidence. EmbeddingGemma remains a first-class
+ * adapter; the default flip is deferred. See
+ * docs/audit/sprint-0/iter-1-gaps-consolidated.md.
+ *
+ * Contract:
+ *   - When PLUR_EMBEDDER is unset, the factory default is "bge-small".
+ *   - PLUR_EMBEDDER=openai-3-large resolves to an adapter named
+ *     "openai-3-large" with dim 3072 and modelId "text-embedding-3-large".
+ *   - Constructing the OpenAI adapter without OPENAI_API_KEY must NOT throw
+ *     (the factory only instantiates metadata; the throw fires on first
+ *     embed() call). The error message must mention OPENAI_API_KEY so users
+ *     get a clear pointer, not a confusing 401 surfaced from the openai SDK.
+ *
+ * No model loads happen in this file — only metadata + factory routing.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  DEFAULT_EMBEDDER,
+  EMBEDDER_NAMES,
+  getEmbedder,
+  resolveEmbedderName,
+  _resetEmbedderCache,
+  _resetResolveWarnings,
+  type EmbedderName,
+} from '../src/embedders/index.js'
+
+describe('embedder default — PR 5 (#219)', () => {
+  const originalEmbedder = process.env.PLUR_EMBEDDER
+  const originalKey = process.env.OPENAI_API_KEY
+
+  afterEach(() => {
+    if (originalEmbedder === undefined) delete process.env.PLUR_EMBEDDER
+    else process.env.PLUR_EMBEDDER = originalEmbedder
+    if (originalKey === undefined) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = originalKey
+    _resetEmbedderCache()
+    _resetResolveWarnings()
+  })
+
+  it('DEFAULT_EMBEDDER is "bge-small" (iter-2 audit B-2 revert)', () => {
+    expect(DEFAULT_EMBEDDER).toBe('bge-small')
+  })
+
+  it('resolveEmbedderName() returns "bge-small" when PLUR_EMBEDDER is unset', () => {
+    delete process.env.PLUR_EMBEDDER
+    expect(resolveEmbedderName()).toBe('bge-small')
+  })
+
+  it('resolveEmbedderName() falls back to "bge-small" on unknown values', () => {
+    process.env.PLUR_EMBEDDER = 'gpt-banana'
+    expect(resolveEmbedderName()).toBe('bge-small')
+  })
+
+  it('EMBEDDER_NAMES includes "openai-3-large"', () => {
+    expect(EMBEDDER_NAMES).toContain('openai-3-large')
+  })
+
+  it('PLUR_EMBEDDER=openai-3-large resolves to the OpenAI adapter', () => {
+    process.env.PLUR_EMBEDDER = 'openai-3-large'
+    expect(resolveEmbedderName()).toBe('openai-3-large')
+  })
+
+  it('getEmbedder("openai-3-large") reports name, dim, modelId without loading anything', () => {
+    // Adapter construction is metadata-only. No env var required to get here.
+    delete process.env.OPENAI_API_KEY
+    const adapter = getEmbedder('openai-3-large' as EmbedderName)
+    expect(adapter.name).toBe('openai-3-large')
+    expect(adapter.dim).toBe(3072)
+    expect(adapter.modelId).toBe('text-embedding-3-large')
+  })
+
+  it('getEmbedder("openai-3-large").embed() throws a clear error when OPENAI_API_KEY is missing', async () => {
+    delete process.env.OPENAI_API_KEY
+    const adapter = getEmbedder('openai-3-large' as EmbedderName)
+    await expect(adapter.embed('hello world')).rejects.toThrow(/OPENAI_API_KEY/)
+  })
+})

--- a/packages/core/test/embedders.test.ts
+++ b/packages/core/test/embedders.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Embedder adapter contract tests — Sprint 0 PR 4 (feat/embedder-bake-off).
+ *
+ * The bake-off needs four ONNX adapters behind a uniform interface so the
+ * benchmark harness can swap them via --embedder. The contract is:
+ *
+ *   interface EmbedderAdapter {
+ *     readonly name: string
+ *     readonly dim: number
+ *     readonly modelId: string
+ *     embed(text: string): Promise<Float32Array>
+ *     embedBatch(texts: string[]): Promise<Float32Array[]>
+ *   }
+ *
+ * Tests in this file exercise:
+ *   - The factory returns the right adapter for each known name.
+ *   - Each adapter reports name/dim/modelId matching the spec.
+ *   - embed() returns a Float32Array of exactly `dim` floats.
+ *   - embedBatch() returns N arrays in the same order as input.
+ *   - Unknown embedder names throw.
+ *
+ * Model loads can hit the network on first use. Real end-to-end load tests
+ * are gated behind PLUR_EMBEDDER_NETWORK_TESTS=1 so CI stays offline-safe.
+ * Without the flag set, only metadata + factory routing are checked.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  getEmbedder,
+  EMBEDDER_NAMES,
+  type EmbedderAdapter,
+  type EmbedderName,
+} from '../src/embedders/index.js'
+
+const NETWORK = process.env.PLUR_EMBEDDER_NETWORK_TESTS === '1'
+
+/** Expected metadata per adapter — checked even when the network is offline. */
+const EXPECTED: Record<EmbedderName, { dim: number; modelId: string }> = {
+  'minilm': { dim: 384, modelId: 'Xenova/all-MiniLM-L6-v2' },
+  'bge-small': { dim: 384, modelId: 'Xenova/bge-small-en-v1.5' },
+  'bge-base': { dim: 768, modelId: 'Xenova/bge-base-en-v1.5' },
+  'embedding-gemma': { dim: 768, modelId: 'onnx-community/embeddinggemma-300m-ONNX' },
+  'openai-3-large': { dim: 3072, modelId: 'text-embedding-3-large' },
+}
+
+describe('EmbedderAdapter factory — metadata contract', () => {
+  it('exports the five expected names', () => {
+    expect(EMBEDDER_NAMES.sort()).toEqual(
+      ['bge-base', 'bge-small', 'embedding-gemma', 'minilm', 'openai-3-large'],
+    )
+  })
+
+  it('throws on unknown embedder names', () => {
+    expect(() => getEmbedder('nope' as EmbedderName)).toThrow(/unknown embedder/i)
+  })
+
+  for (const name of EMBEDDER_NAMES) {
+    describe(`adapter "${name}"`, () => {
+      it('reports the expected name, dim, and modelId', () => {
+        const adapter = getEmbedder(name)
+        expect(adapter.name).toBe(name)
+        expect(adapter.dim).toBe(EXPECTED[name].dim)
+        expect(adapter.modelId).toBe(EXPECTED[name].modelId)
+      })
+
+      it('exposes embed and embedBatch as async functions', () => {
+        const adapter = getEmbedder(name)
+        expect(typeof adapter.embed).toBe('function')
+        expect(typeof adapter.embedBatch).toBe('function')
+      })
+    })
+  }
+})
+
+describe.skipIf(!NETWORK)('EmbedderAdapter — live model loads (PLUR_EMBEDDER_NETWORK_TESTS=1)', () => {
+  // Live tests share state across the suite because each model is ~100MB+
+  // and downloads can take a minute on cold caches.
+  const LIVE_TIMEOUT = 180_000
+
+  function check(adapter: EmbedderAdapter, vec: Float32Array): void {
+    expect(vec).toBeInstanceOf(Float32Array)
+    expect(vec.length).toBe(adapter.dim)
+    // Normalised embeddings have L2 norm ~= 1. Strict equality is brittle
+    // across runtimes; check the rough magnitude.
+    let norm = 0
+    for (let i = 0; i < vec.length; i++) norm += vec[i] * vec[i]
+    expect(Math.sqrt(norm)).toBeGreaterThan(0.5)
+    expect(Math.sqrt(norm)).toBeLessThan(1.5)
+  }
+
+  // openai-3-large requires both NETWORK access and OPENAI_API_KEY. Skip it
+  // from the live-load matrix — the OPENAI key is not a CI default and we
+  // don't want to bill the OpenAI API on every PR. The bare-key error path
+  // is exercised in embedder-default.test.ts instead.
+  const LIVE_NAMES = EMBEDDER_NAMES.filter((n) => n !== 'openai-3-large')
+
+  for (const name of LIVE_NAMES) {
+    it(`"${name}" embeds a single string`, async () => {
+      const adapter = getEmbedder(name)
+      const vec = await adapter.embed('the quick brown fox jumps over the lazy dog')
+      check(adapter, vec)
+    }, LIVE_TIMEOUT)
+
+    it(`"${name}" embeds a batch and preserves order`, async () => {
+      const adapter = getEmbedder(name)
+      const inputs = ['first sentence', 'second sentence', 'third sentence']
+      const vecs = await adapter.embedBatch(inputs)
+      expect(vecs.length).toBe(inputs.length)
+      for (const v of vecs) check(adapter, v)
+      // Sanity: the per-text embeddings should match what we get from embed().
+      const single0 = await adapter.embed(inputs[0])
+      // Cosine between batch[0] and single embed of the same text >= 0.99.
+      let dot = 0
+      let n1 = 0
+      let n2 = 0
+      for (let i = 0; i < single0.length; i++) {
+        dot += single0[i] * vecs[0][i]
+        n1 += single0[i] * single0[i]
+        n2 += vecs[0][i] * vecs[0][i]
+      }
+      const cos = dot / (Math.sqrt(n1) * Math.sqrt(n2))
+      expect(cos).toBeGreaterThan(0.99)
+    }, LIVE_TIMEOUT)
+  }
+})

--- a/packages/core/test/embeddings-cache-dim.test.ts
+++ b/packages/core/test/embeddings-cache-dim.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Embeddings cache dim safety — Sprint 0 iter-2 audit B-1 / B-3.
+ *
+ * Issue: `.embeddings-cache.json` was keyed only by `engramId + statementHash`
+ * with no embedder identity. Switching embedders (bge-small 384d <-> gemma
+ * 768d) silently poisoned recall — query vector at new dim, cached engram
+ * vector at old dim, cosineSimilarity loops over min(a,b) and returns
+ * meaningless scores.
+ *
+ * Fix: stamp the cache JSON with `{ embedder_name, embedder_dim, version }`
+ * in a meta header. On load, if the active embedder name or dim differs from
+ * the cache header, invalidate the cache and rebuild. Backward-compatible:
+ * the old flat-object format gets invalidated as if dim had mismatched (no
+ * data loss risk — cache is rebuildable from YAML on demand).
+ *
+ * Closes RC-3 from iter-1 evaluators (Data F-DATA-003, Critic concern #2).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { embeddingSearch } from '../src/embeddings.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function makeEngram(id: string, statement: string): Engram {
+  return {
+    id,
+    version: 2,
+    status: 'active',
+    consolidated: false,
+    type: 'behavioral',
+    scope: 'global',
+    visibility: 'private',
+    statement,
+    activation: {
+      retrieval_strength: 0.7,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-05-30',
+    },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [],
+    associations: [],
+    derivation_count: 1,
+    tags: [],
+    pack: null,
+    abstract: null,
+    derived_from: null,
+    polarity: null,
+    content_hash: 'h',
+    commitment: 'leaning',
+    reference_count: 1,
+    sources: [],
+    recurrence_count: 0,
+    summary: '',
+    engram_version: 1,
+    episode_ids: [],
+  } as any
+}
+
+// These exercise real `embeddingSearch`, which loads the BGE-small model.
+// Gated behind PLUR_EMBEDDER_NETWORK_TESTS=1 (same convention as
+// embedders.test.ts) so the suite stays offline-safe — without the model,
+// embed() returns null and no cache is written. Run with the env var set on a
+// machine with HuggingFace access to verify the cache dim-stamping for real.
+const NETWORK = process.env.PLUR_EMBEDDER_NETWORK_TESTS === '1'
+
+describe.skipIf(!NETWORK)('embeddings cache dim safety (iter-2 audit B-1/B-3)', () => {
+  let dir: string
+  let cachePath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-embed-cache-'))
+    cachePath = join(dir, '.embeddings-cache.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('writes a versioned meta header with embedder_name and embedder_dim', async () => {
+    const engrams = [makeEngram('ENG-2026-0530-001', 'cats are not dogs')]
+    await embeddingSearch(engrams, 'cats', 5, dir)
+
+    expect(existsSync(cachePath)).toBe(true)
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    // New format: { meta: { embedder_name, embedder_dim, version }, entries: {...} }
+    expect(parsed).toHaveProperty('meta')
+    expect(parsed.meta).toHaveProperty('embedder_name')
+    expect(parsed.meta).toHaveProperty('embedder_dim')
+    expect(parsed.meta).toHaveProperty('version')
+    expect(typeof parsed.meta.embedder_dim).toBe('number')
+    expect(parsed.meta.embedder_dim).toBeGreaterThan(0)
+    expect(parsed).toHaveProperty('entries')
+    expect(parsed.entries).toHaveProperty('ENG-2026-0530-001')
+  })
+
+  it('invalidates cache when embedder_dim mismatches (silently rebuilds)', async () => {
+    // Seed a cache with a 999-dim "old" vector under the new format
+    const oldCache = {
+      meta: { embedder_name: 'fake-old', embedder_dim: 999, version: 1 },
+      entries: {
+        'ENG-2026-0530-001': {
+          hash: 'wrong-hash',
+          embedding: new Array(999).fill(0.001),
+        },
+      },
+    }
+    writeFileSync(cachePath, JSON.stringify(oldCache))
+
+    const engrams = [makeEngram('ENG-2026-0530-001', 'cats are not dogs')]
+    await embeddingSearch(engrams, 'cats', 5, dir)
+
+    // After the call, the cache must have been rewritten with the current
+    // embedder's metadata, NOT the fake-old 999d header.
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    expect(parsed.meta.embedder_name).not.toBe('fake-old')
+    expect(parsed.meta.embedder_dim).not.toBe(999)
+    // The entry must have been replaced (not the original 999d vector).
+    const entry = parsed.entries['ENG-2026-0530-001']
+    expect(entry.embedding.length).not.toBe(999)
+    expect(entry.embedding.length).toBe(parsed.meta.embedder_dim)
+  })
+
+  it('invalidates cache when embedder_name mismatches even at same dim', async () => {
+    // Same dim, different name — should still invalidate. Catches the case
+    // where two embedder families produce 384d vectors but the vector spaces
+    // are not comparable (e.g. minilm vs bge-small).
+    const oldCache = {
+      meta: { embedder_name: 'fake-different-family', embedder_dim: 384, version: 1 },
+      entries: {
+        'ENG-2026-0530-001': {
+          hash: 'wrong-hash',
+          embedding: new Array(384).fill(0.001),
+        },
+      },
+    }
+    writeFileSync(cachePath, JSON.stringify(oldCache))
+
+    const engrams = [makeEngram('ENG-2026-0530-001', 'cats are not dogs')]
+    await embeddingSearch(engrams, 'cats', 5, dir)
+
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    expect(parsed.meta.embedder_name).not.toBe('fake-different-family')
+  })
+
+  it('reads the legacy flat-object format and invalidates it (no data loss)', async () => {
+    // Pre-iter-2 cache format: { [engramId]: { hash, embedding } }. No meta.
+    // On load, we treat the missing meta as a mismatch and rebuild.
+    const legacyCache = {
+      'ENG-2026-0530-001': {
+        hash: 'legacy-hash',
+        embedding: new Array(384).fill(0.5),
+      },
+    }
+    writeFileSync(cachePath, JSON.stringify(legacyCache))
+
+    const engrams = [makeEngram('ENG-2026-0530-001', 'cats are not dogs')]
+    await embeddingSearch(engrams, 'cats', 5, dir)
+
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    expect(parsed).toHaveProperty('meta')
+    expect(parsed.meta.embedder_name).toBeTruthy()
+    expect(parsed).toHaveProperty('entries')
+    // The legacy entry got dropped — it had a hash that doesn't match the
+    // current statement, so even if we'd preserved it the engram would have
+    // been re-embedded. The point of the test is: no crash, no garbage scores.
+    expect(parsed.entries['ENG-2026-0530-001']).toBeDefined()
+  })
+})


### PR DESCRIPTION
**PR-3 of the Sprint 0 unbundle (#332)** — re-lands the embedder work from retired epic #276 onto current `main`, with the `EMBED_DIM` contract decision (#335) resolved as **Option A**.

## Scope
- **`packages/core/src/embedders/*`** — 7 ONNX adapters (minilm / bge-small / bge-base / embedding-gemma / openai) over a shared transformers base + a factory (`getEmbedder` / `resolveEmbedderName`) selected by `PLUR_EMBEDDER`. **Default stays bge-small** → no behavior change unless opted in.
- **`embeddings.ts`** — `embed()` routes through the factory; the JSON cache is stamped with the active embedder name+dim and invalidated on mismatch.
- **`EMBED_DIM` — Option A (#335):** `EMBED_DIM` remains the documented **default** (384), but the source of truth is the new **`activeEmbedderDim()`** — the value an external backend must size its vector column to. `embed()` asserts its output against the **active adapter's** dim, and that throw is placed *outside* the catch so dimension drift surfaces loudly instead of degrading silently — generalizing #289/#290 to pluggable embedders.
- **`index.ts`** exports `activeEmbedderDim`, `EMBEDDER_NAMES`, `DEFAULT_EMBEDDER`, `resolveEmbedderName`, `EmbedderName`, `EmbedderAdapter`.

## Why Option A
#290's purpose is to let external stores size vector columns to exactly what core produces, so they never drift. Once the embedder is pluggable (384 / 768 / 3072), a fixed-384 constant lies for any non-default embedder — silent corruption on the *premium* (accuracy) path. `activeEmbedderDim()` keeps the value honest; the assertion keeps drift loud.

## Not in this PR (later in #332)
- PGLite recall wiring + sizing the vector column from `activeEmbedderDim()` → **PR-4** (#334).
- Benchmark harness → **PR-2** (#336).

## Tests
- `embedders.test.ts` (metadata contract — offline), `embedder-default.test.ts`, `embeddings-optout.test.ts` — pass offline.
- `embeddings-cache-dim.test.ts` needs the real model, so it's gated behind `PLUR_EMBEDDER_NETWORK_TESTS=1` (same convention as `embedders.test.ts`) to keep CI offline-safe. **Verified locally for real** with bge-small loaded (`HF_HUB_DISABLE_XET=1`) — cache dim-stamping passes.
- Build clean; `@plur-ai/mcp` 130, `@plur-ai/cli` 199 pass.

Part of #332.