### PR TITLE
feat(core): recall reconciliation — reranker + intent routing + PGLite-into-recall + auto-embed (PR-4 of #332)

### DIFF
--- a/packages/core/src/hybrid-search.ts
+++ b/packages/core/src/hybrid-search.ts
@@ -78,6 +78,15 @@ function rrfMerge(resultSets: Engram[][], k = 60): Array<{ engram: Engram; score
   return Array.from(scores.values()).sort((a, b) => b.score - a.score)
 }
 
+/**
+ * RRF-merge result sets and return just the engrams (no scores). For callers
+ * that fuse externally-ranked lists and don't need topScore — e.g. the PGLite
+ * recall path fusing pgvector hits with BM25 before the rerank stage.
+ */
+export function rrfMergeEngrams(resultSets: Engram[][], k = 60): Engram[] {
+  return rrfMerge(resultSets, k).map(s => s.engram)
+}
+
 /** Detect aggregation queries that need exhaustive retrieval */
 const AGGREGATION_PATTERNS = [
   /how many/i,

--- a/packages/core/src/hybrid-search.ts
+++ b/packages/core/src/hybrid-search.ts
@@ -1,6 +1,9 @@
 import type { Engram } from './schemas/engram.js'
 import { searchEngrams } from './fts.js'
 import { embeddingSearch, embedderStatus } from './embeddings.js'
+import { logger } from './logger.js'
+import type { RerankerAdapter } from './rerankers/types.js'
+import { isRerankerOff } from './rerankers/index.js'
 
 /** Result of a hybrid search call with diagnostic metadata. */
 export interface HybridSearchResult {
@@ -21,8 +24,30 @@ export interface HybridSearchResult {
    * score as a miss even when ≥1 engram came back. Exposing this value does
    * NOT change the retrieval algorithm; it only stops discarding a number
    * rrfMerge already produced.
+   *
+   * NOTE: this is the **pre-rerank** RRF fusion score — the miss-signal reasons
+   * about fusion strength, not the cross-encoder's reordering. Reranking (#220)
+   * reorders the returned engrams but does not change topScore.
    */
   topScore: number | null
+  /**
+   * Number of candidates re-scored by the cross-encoder reranker (#220), or 0
+   * when the reranker was off (default), unavailable, or the candidate pool was
+   * empty. Useful for benchmark + diagnostic reporting.
+   */
+  reranked?: number
+}
+
+/** Options for the optional cross-encoder rerank stage (#220). */
+export interface RerankOptions {
+  /** Adapter to use. When omitted or `isRerankerOff(adapter)` is true, skips. */
+  reranker?: RerankerAdapter
+  /**
+   * How many top RRF candidates to feed into the cross-encoder. Larger K
+   * means more chances to surface a buried gem but more model passes. The
+   * cost is O(K) cross-encoder calls per query. Default 50.
+   */
+  topK?: number
 }
 
 /**
@@ -84,8 +109,9 @@ export async function hybridSearch(
   query: string,
   limit: number,
   storagePath?: string,
+  rerank?: RerankOptions,
 ): Promise<Engram[]> {
-  const result = await hybridSearchWithMeta(engrams, query, limit, storagePath)
+  const result = await hybridSearchWithMeta(engrams, query, limit, storagePath, rerank)
   return result.engrams
 }
 
@@ -99,9 +125,10 @@ export async function hybridSearchWithMeta(
   query: string,
   limit: number,
   storagePath?: string,
+  rerank?: RerankOptions,
 ): Promise<HybridSearchResult> {
   if (engrams.length === 0) {
-    return { engrams: [], mode: 'hybrid', embedderError: null, topScore: null }
+    return { engrams: [], mode: 'hybrid', embedderError: null, topScore: null, reranked: 0 }
   }
 
   const exhaustive = isAggregationQuery(query)
@@ -134,10 +161,64 @@ export async function hybridSearchWithMeta(
 
   const merged = rrfMerge([bm25Results, embResults])
   const ranked = merged.slice(0, effectiveLimit)
+  // topScore is the RRF fusion score of the top candidate, captured BEFORE the
+  // optional rerank stage — the miss-signal reasons about fusion strength, not
+  // the cross-encoder's reordering.
+  const topScore = ranked.length > 0 ? ranked[0].score : null
+  // Optional cross-encoder rerank (#220): reorders the top-K by joint relevance.
+  // Off by default; on failure applyReranker logs + falls back to RRF order, so
+  // recall always returns something.
+  const reranked = await applyReranker(ranked.map(s => s.engram), query, rerank)
   return {
-    engrams: ranked.map(s => s.engram),
+    engrams: reranked.engrams,
     mode,
     embedderError,
-    topScore: ranked.length > 0 ? ranked[0].score : null,
+    topScore,
+    reranked: reranked.count,
+  }
+}
+
+/**
+ * Internal: apply the cross-encoder reranker to the top-K of a fused list.
+ *
+ * - When no reranker is supplied (or the sentinel `off` adapter is supplied)
+ *   returns the input order unchanged with count=0.
+ * - When the reranker throws (model unavailable, network, etc.) logs a
+ *   warning and falls back to the RRF order — recall should always return
+ *   something, even when the optional rerank stage fails.
+ */
+export async function applyReranker(
+  candidates: Engram[],
+  query: string,
+  rerank?: RerankOptions,
+): Promise<{ engrams: Engram[]; count: number }> {
+  if (!rerank?.reranker || isRerankerOff(rerank.reranker)) {
+    return { engrams: candidates, count: 0 }
+  }
+  if (candidates.length === 0) {
+    return { engrams: candidates, count: 0 }
+  }
+  const topK = Math.max(1, Math.min(candidates.length, rerank.topK ?? 50))
+  const head = candidates.slice(0, topK)
+  const tail = candidates.slice(topK)
+  try {
+    const docs = head.map(e => e.statement)
+    const scores = await rerank.reranker.scoreBatch(query, docs)
+    if (scores.length !== head.length) {
+      logger.warning(
+        `[hybrid-search] reranker returned ${scores.length} scores for ${head.length} candidates; skipping rerank.`,
+      )
+      return { engrams: candidates, count: 0 }
+    }
+    const ranked = head
+      .map((engram, i) => ({ engram, score: scores[i] }))
+      .sort((a, b) => b.score - a.score)
+      .map(r => r.engram)
+    return { engrams: [...ranked, ...tail], count: head.length }
+  } catch (err) {
+    logger.warning(
+      `[hybrid-search] reranker "${rerank.reranker.name}" failed: ${(err as Error).message}. Falling back to RRF order.`,
+    )
+    return { engrams: candidates, count: 0 }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,7 +16,7 @@ import { agenticSearch } from './agentic-search.js'
 import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } from './embeddings.js'
 import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as pgliteRrfMerge, type HybridSearchResult, type RerankOptions } from './hybrid-search.js'
 import { getReranker, resolveRerankerName, isRerankerOff, type RerankerAdapter } from './rerankers/index.js'
-import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
+import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, isEntityDomain, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
 import { getEmbedder, resolveEmbedderName } from './embedders/index.js'
 import { emitMissSignal } from './telemetry-miss-signal.js'
 import { embedderStatus, resetEmbedder, setEmbeddingsEnabled, type EmbedderStatus } from './embeddings.js'
@@ -1631,16 +1631,86 @@ export class Plur {
     let embeddingBoosts: Map<string, number> | undefined
     try {
       const engrams = this._loadAllEngrams().filter(e => e.status === 'active')
-      const results: SimilarityResult[] = await embeddingSearchWithScores(
-        engrams,
-        task,
-        engrams.length,
-        this.paths.root,
-      )
+      // Route through PGLite/pgvector when active (#226 B-1), intersecting hits
+      // with the YAML-rooted `engrams` set; else the JSON cache path.
+      let results: SimilarityResult[] = []
+      if (this.pgliteAdapter) {
+        const { embed } = await import('./embeddings.js')
+        const queryVec = await embed(task)
+        if (queryVec) {
+          try {
+            const hits = await this.pgliteAdapter.searchVector(queryVec, engrams.length)
+            if (hits.length > 0) {
+              const allowed = new Map<string, Engram>(engrams.map(e => [e.id, e]))
+              for (const hit of hits) {
+                const e = allowed.get(hit.engram.id)
+                if (e) results.push({ engram: e, score: Math.max(0, Math.min(1, hit.score)) })
+              }
+            }
+          } catch (err) {
+            logger.warning(`[plur] PGLite searchVector failed in injectHybrid: ${(err as Error).message}.`)
+          }
+        }
+      }
+      if (results.length === 0) {
+        results = await embeddingSearchWithScores(engrams, task, engrams.length, this.paths.root)
+      }
+      // Cross-encoder rerank stage (#220): replace the cosine boosts for the
+      // top-K with the reranker's relevance, min-max normalized into [0,1] so
+      // the selectAndSpread 0.5 threshold stays meaningful. Off by default.
+      const rerank = this._resolveRerankOptions(options?.rerank)
+      if (rerank && results.length > 0) {
+        const topK = Math.max(1, Math.min(results.length, rerank.topK ?? 50))
+        const head = results.slice(0, topK)
+        try {
+          const scores = await rerank.reranker!.scoreBatch(task, head.map(r => r.engram.statement))
+          if (scores.length === head.length) {
+            const min = Math.min(...scores)
+            const max = Math.max(...scores)
+            const span = max - min
+            for (let i = 0; i < head.length; i++) {
+              const normalized = span > 0 ? (scores[i] - min) / span : 0.5
+              head[i] = { engram: head[i].engram, score: normalized }
+            }
+            head.sort((a, b) => b.score - a.score)
+            results = [...head, ...results.slice(topK)]
+          }
+        } catch (err) {
+          logger.warning(`[plur] injectHybrid reranker "${rerank.reranker!.name}" failed: ${(err as Error).message}. Falling back to cosine boosts.`)
+        }
+      }
       if (results.length > 0) {
         embeddingBoosts = new Map()
         for (const r of results) {
           embeddingBoosts.set(r.engram.id, r.score)
+        }
+      }
+      // Intent-aware boost (#224): modest (<=1.5x) upweight for engrams matching
+      // the query intent. Boost cap stays 1.0 so the 0.5 threshold keeps meaning.
+      const intent = this._resolveIntentProfile(task, options?.intentOverride)
+      if (intent && embeddingBoosts) {
+        for (const e of results.map(r => r.engram)) {
+          let mult = 1.0
+          if (intent.profile.entityBoost !== 1.0 && isEntityDomain(e.domain)) {
+            mult *= intent.profile.entityBoost
+          }
+          if (intent.profile.episodeBoost !== 1.0 && Array.isArray(e.episode_ids) && e.episode_ids.length > 0) {
+            mult *= intent.profile.episodeBoost
+          }
+          if (intent.profile.recencyBoost !== 1.0) {
+            const ts = e.activation?.last_accessed ?? e.temporal?.learned_at
+            if (ts) {
+              const days = (Date.now() - Date.parse(ts)) / (1000 * 60 * 60 * 24)
+              if (Number.isFinite(days) && days >= 0) {
+                const r = Math.exp(-days / 30) // half-life ~30 days
+                mult *= 1.0 + r * (intent.profile.recencyBoost - 1.0)
+              }
+            }
+          }
+          if (mult !== 1.0) {
+            const cur = embeddingBoosts.get(e.id) ?? 0
+            embeddingBoosts.set(e.id, Math.min(1.0, cur * mult))
+          }
         }
       }
     } catch {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } fro
 import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as pgliteRrfMerge, type HybridSearchResult, type RerankOptions } from './hybrid-search.js'
 import { getReranker, resolveRerankerName, isRerankerOff, type RerankerAdapter } from './rerankers/index.js'
 import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
+import { getEmbedder, resolveEmbedderName } from './embedders/index.js'
 import { emitMissSignal } from './telemetry-miss-signal.js'
 import { embedderStatus, resetEmbedder, setEmbeddingsEnabled, type EmbedderStatus } from './embeddings.js'
 import { expandedSearch } from './query-expansion.js'
@@ -2131,7 +2132,9 @@ export class Plur {
   reindex(): void {
     if (this.pgliteAdapter) {
       // Fire-and-track. Callers that need to block use reindexAsync().
-      this._pgliteInitPromise = this.pgliteAdapter.reindex()
+      const adapter = this.pgliteAdapter
+      this._pgliteInitPromise = adapter.reindex()
+        .then(() => this._autoEmbedNewEngrams(adapter))
         .catch((err: unknown) => {
           logger.warning(`[plur] PGLite reindex failed: ${(err as Error).message}`)
         })
@@ -2150,6 +2153,7 @@ export class Plur {
   async reindexAsync(): Promise<void> {
     if (this.pgliteAdapter) {
       await this.pgliteAdapter.reindex()
+      await this._autoEmbedNewEngrams(this.pgliteAdapter)
       return
     }
     if (!this.indexedStorage) {
@@ -2158,12 +2162,45 @@ export class Plur {
     this.indexedStorage.reindex()
   }
 
+  /**
+   * Embed any active engrams missing a row in engram_embeddings and upsert them
+   * (#226 B-1). Runs after every syncFromYaml/reindex so learn()/learnAsync()/
+   * sync() keep the PGLite vector index in step with YAML. Skips silently when
+   * the embedder is unavailable (recall on those engrams degrades to the JSON
+   * path until the next cycle) or when the active embedder dim differs from the
+   * indexed column (run `plur sync --reembed --full` to migrate intentionally).
+   */
+  private async _autoEmbedNewEngrams(adapter: PGLiteAdapter): Promise<void> {
+    try {
+      const { embed } = await import('./embeddings.js')
+      const indexedDim = await adapter.getVectorColumnDim()
+      if (indexedDim !== null && getEmbedder(resolveEmbedderName()).dim !== indexedDim) {
+        logger.debug(`[plur] auto-embed skip: active embedder dim differs from indexed column (${indexedDim}). Run 'plur sync --reembed --full' to migrate.`)
+        return
+      }
+      const active = this._loadAllEngrams().filter(e => e.status === 'active' && !(e as any)._originalId && !(e as any)._pack)
+      if (active.length === 0) return
+      const { engramSearchText } = await import('./fts.js')
+      for (const engram of active) {
+        if (await adapter.hasEmbedding(engram.id)) continue
+        const vec = await embed(engramSearchText(engram))
+        if (!vec) return // embedder unavailable — next cycle retries
+        await adapter.upsertEmbedding(engram.id, vec)
+      }
+    } catch (err) {
+      logger.warning(`[plur] auto-embed failed: ${(err as Error).message}`)
+    }
+  }
+
   /** Sync index after YAML write (no-op if no index is active). */
   private _syncIndex(): void {
     if (this.pgliteAdapter) {
       // Synchronous-shaped path: kick off the sync, track the promise.
-      // The YAML write already happened — this is the index catching up.
-      this._pgliteInitPromise = this.pgliteAdapter.syncFromYaml()
+      // The YAML write already happened — this is the index catching up, then
+      // auto-embed any new engrams so they're vector-searchable.
+      const adapter = this.pgliteAdapter
+      this._pgliteInitPromise = adapter.syncFromYaml()
+        .then(() => this._autoEmbedNewEngrams(adapter))
         .catch((err: unknown) => {
           logger.warning(`[plur] PGLite syncFromYaml failed (YAML is still source of truth): ${(err as Error).message}`)
         })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,9 @@ import { reactivate, applyBatchDecay, type BatchDecayResult } from './decay.js'
 import { captureEpisode, queryTimeline } from './episodes.js'
 import { agenticSearch } from './agentic-search.js'
 import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } from './embeddings.js'
-import { hybridSearch, hybridSearchWithMeta, type HybridSearchResult } from './hybrid-search.js'
+import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as pgliteRrfMerge, type HybridSearchResult, type RerankOptions } from './hybrid-search.js'
+import { getReranker, resolveRerankerName, isRerankerOff, type RerankerAdapter } from './rerankers/index.js'
+import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
 import { emitMissSignal } from './telemetry-miss-signal.js'
 import { embedderStatus, resetEmbedder, setEmbeddingsEnabled, type EmbedderStatus } from './embeddings.js'
 import { expandedSearch } from './query-expansion.js'
@@ -268,6 +270,12 @@ export class Plur {
   private _llmFailureCount = 0
   private _llmDisabledUntil: number | null = null
   private _sessionScope: string | null = null
+  /**
+   * Cross-encoder reranker adapter (#220). Resolved lazily on first recall with
+   * `rerank: true`. Defaults to the "off" sentinel when PLUR_RERANKER is unset,
+   * so existing call sites pay zero cost until they opt in.
+   */
+  private _reranker: RerankerAdapter | null = null
   /** mtime (ms) of config.yaml at last load — drives reloadConfigIfChanged (#307). */
   private configMtimeMs = 0
 
@@ -1250,22 +1258,41 @@ export class Plur {
     return results
   }
 
-  /** Search engrams using local embeddings (transformers.js). Async, no API calls. */
+  /** Search engrams using local embeddings. Async, no API calls. Routes through PGLite/pgvector when active (#226), with optional intent routing (#224) + cross-encoder rerank (#220). */
   async recallSemantic(query: string, options?: Omit<RecallOptions, 'mode' | 'llm'>): Promise<Engram[]> {
     const filtered = this._filterEngrams(options)
     const limit = options?.limit ?? 20
-    const results = await embeddingSearch(filtered, query, limit, this.paths.root)
+    const rerank = this._resolveRerankOptions(options?.rerank)
+    const intent = this._resolveIntentProfile(query, options?.intentOverride)
+    // Two over-fetch sources stack: intent routing wants headroom for its
+    // re-rank, the reranker wants topK candidates. Take the larger; truncate
+    // back to `limit` after both stages.
+    const intentFetch = intent ? Math.max(limit * 2, limit + 10) : limit
+    const rerankFetch = rerank ? Math.max(limit, rerank.topK ?? 50) : limit
+    const fetchLimit = Math.max(intentFetch, rerankFetch)
+    let results: Engram[]
+    if (this.pgliteAdapter) {
+      results = await this._pgliteSemanticRecall(query, fetchLimit, filtered)
+    } else {
+      results = await embeddingSearch(filtered, query, fetchLimit, this.paths.root)
+    }
+    if (intent) {
+      results = applyIntentRouting(results, intent.profile).slice(0, fetchLimit)
+    }
+    if (rerank) {
+      const reranked = await applyReranker(results, query, rerank)
+      results = reranked.engrams.slice(0, limit)
+    } else {
+      results = results.slice(0, limit)
+    }
     this._reactivateResults(results)
     return results
   }
 
-  /** Hybrid search: BM25 + embeddings merged via Reciprocal Rank Fusion. Async, no API calls. */
+  /** Hybrid search: BM25 + embeddings merged via Reciprocal Rank Fusion. Async, no API calls. Delegates to recallHybridWithMeta so it gets intent/rerank/PGLite routing too. */
   async recallHybrid(query: string, options?: Omit<RecallOptions, 'mode' | 'llm'>): Promise<Engram[]> {
-    const filtered = this._filterEngrams(options)
-    const limit = options?.limit ?? 20
-    const results = await hybridSearch(filtered, query, limit, this.paths.root)
-    this._reactivateResults(results)
-    return results
+    const result = await this.recallHybridWithMeta(query, options)
+    return result.engrams
   }
 
   /**
@@ -1279,23 +1306,155 @@ export class Plur {
   ): Promise<HybridSearchResult> {
     const filtered = this._filterEngrams(options)
     const limit = options?.limit ?? 20
-    const result = await hybridSearchWithMeta(filtered, query, limit, this.paths.root)
+    const rerank = this._resolveRerankOptions(options?.rerank)
+    const intent = this._resolveIntentProfile(query, options?.intentOverride)
+    // When intent routing is on we over-fetch from the hybrid call WITHOUT the
+    // reranker, apply intent routing, then run the reranker on the routed set.
+    // When intent is off the hybrid call handles reranking inline so the
+    // PGLite and JSON paths stay symmetric.
+    const intentLimit = intent ? Math.max(limit * 2, limit + 10) : limit
+    let result: HybridSearchResult
+    if (intent) {
+      result = this.pgliteAdapter
+        ? await this._pgliteHybridRecall(query, intentLimit, filtered)
+        : await hybridSearchWithMeta(filtered, query, intentLimit, this.paths.root)
+      let routed = applyIntentRouting(result.engrams, intent.profile)
+      let rerankedCount = result.reranked
+      if (rerank) {
+        const reranked = await applyReranker(routed, query, rerank)
+        routed = reranked.engrams
+        rerankedCount = reranked.count
+      }
+      result = { ...result, engrams: routed.slice(0, limit), reranked: rerankedCount }
+    } else if (this.pgliteAdapter) {
+      result = await this._pgliteHybridRecall(query, limit, filtered, rerank)
+    } else {
+      result = await hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
+    }
     this._reactivateResults(result.engrams)
     // WS5 demand flywheel: a zero-result or low-top-score recall is a demand
-    // signal — the user asked memory something it could not answer. Emit an
-    // anonymized, content-free miss-signal (query fingerprint hash + scope/
-    // domain + timestamp; never the raw query). Opt-in/default-off and
-    // fire-and-forget: emitMissSignal self-gates on telemetry opt-in and never
-    // throws, so an opted-out install does nothing and the recall path is never
-    // disturbed.
+    // signal. Emit an anonymized, content-free miss-signal (query fingerprint +
+    // scope/domain + timestamp; never the raw query). Opt-in/default-off and
+    // fire-and-forget — never disturbs the recall path. (topScore is null on the
+    // PGLite path, which doesn't surface an RRF fusion score; the count-based
+    // miss still fires.)
     void emitMissSignal({
       query,
       scope: options?.scope,
       domain: options?.domain,
       resultCount: result.engrams.length,
-      topScore: result.topScore,
+      topScore: result.topScore ?? null,
     }).catch(() => {})
     return result
+  }
+
+  /** Resolve the cross-encoder rerank options for a call (#220). */
+  private _resolveRerankOptions(rerank?: boolean): RerankOptions | undefined {
+    if (rerank === false) return undefined
+    if (rerank === true) {
+      // Explicit opt-in: if PLUR_RERANKER is off (the default), upgrade to
+      // bge-reranker-v2-m3 for this call only so opt-in actually does something.
+      const envName = resolveRerankerName()
+      const name = envName === 'off' ? 'bge-reranker-v2-m3' : envName
+      this._reranker = getReranker(name)
+      return { reranker: this._reranker }
+    }
+    // Implicit: follow the env. Off → undefined so the stage is skipped.
+    const envName = resolveRerankerName()
+    if (envName === 'off') return undefined
+    if (!this._reranker || isRerankerOff(this._reranker)) {
+      this._reranker = getReranker(envName)
+    }
+    return { reranker: this._reranker }
+  }
+
+  /** Resolve the query-intent routing profile for a call (#224). undefined = no routing (general). */
+  private _resolveIntentProfile(
+    query: string,
+    intentOverride?: QueryIntent,
+  ): { intent: QueryIntent; profile: IntentRoutingProfile } | undefined {
+    if (isIntentRoutingDisabled()) return undefined
+    const intent: QueryIntent = intentOverride ?? classifyQuery(query).intent
+    if (intent === 'general') return undefined
+    return { intent, profile: routeForIntent(intent) }
+  }
+
+  /**
+   * PGLite/pgvector hybrid recall (#226 B-1). Routes the vector portion through
+   * the persistent pgvector index, intersects hits against the YAML-rooted
+   * `filtered` set (the yaml-as-truth defense — a DB-only row can't surface),
+   * RRF-fuses with BM25, then applies the optional rerank. Falls back to the
+   * JSON-cache hybrid path on cold-start / embedder-unavailable / PGLite error.
+   */
+  private async _pgliteHybridRecall(
+    query: string,
+    limit: number,
+    filtered: Engram[],
+    rerank?: RerankOptions,
+  ): Promise<HybridSearchResult> {
+    if (!this.pgliteAdapter) {
+      return hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
+    }
+    if (filtered.length === 0) {
+      return { engrams: [], mode: 'hybrid', embedderError: null, topScore: null, reranked: 0 }
+    }
+    const { embed } = await import('./embeddings.js')
+    const queryVec = await embed(query)
+    const status = embedderStatus()
+    if (!queryVec) {
+      return hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
+    }
+    const wantReranker = rerank?.reranker && !isRerankerOff(rerank.reranker)
+    const embLimit = Math.min(filtered.length, wantReranker ? Math.max(limit * 3, 50) : limit * 2)
+    let pgHits: Engram[] = []
+    try {
+      const hits = await this.pgliteAdapter.searchVector(queryVec, embLimit)
+      const allowed = new Map<string, Engram>(filtered.map(e => [e.id, e]))
+      pgHits = hits.map(h => allowed.get(h.engram.id)).filter((e): e is Engram => !!e)
+    } catch (err) {
+      logger.warning(`[plur] PGLite searchVector failed in hybrid: ${(err as Error).message}.`)
+      return hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
+    }
+    if (pgHits.length === 0) {
+      return hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
+    }
+    const bm25Limit = Math.min(filtered.length, wantReranker ? Math.max(limit * 3, 50) : limit * 3)
+    const bm25Results = searchEngrams(filtered, query, bm25Limit)
+    const merged = pgliteRrfMerge([bm25Results, pgHits])
+    const reranked = await applyReranker(merged, query, rerank)
+    const mode: HybridSearchResult['mode'] = status.disabled ? 'bm25-only' : 'hybrid'
+    return { engrams: reranked.engrams.slice(0, limit), mode, embedderError: null, topScore: null, reranked: reranked.count }
+  }
+
+  /**
+   * PGLite/pgvector semantic recall (#226 B-1). Vector search via pgvector,
+   * intersected with the YAML-rooted `filtered` set. Falls back to the JSON
+   * cache on cold-start / embedder-unavailable / PGLite error.
+   */
+  private async _pgliteSemanticRecall(query: string, limit: number, filtered: Engram[]): Promise<Engram[]> {
+    if (!this.pgliteAdapter) return []
+    const { embed } = await import('./embeddings.js')
+    const queryVec = await embed(query)
+    if (!queryVec) {
+      return embeddingSearch(filtered, query, limit, this.paths.root)
+    }
+    try {
+      const hits = await this.pgliteAdapter.searchVector(queryVec, Math.max(limit * 3, 50))
+      if (hits.length === 0) {
+        return embeddingSearch(filtered, query, limit, this.paths.root)
+      }
+      const allowed = new Map<string, Engram>(filtered.map(e => [e.id, e]))
+      const results: Engram[] = []
+      for (const hit of hits) {
+        const allowedEngram = allowed.get(hit.engram.id)
+        if (allowedEngram) results.push(allowedEngram)
+        if (results.length >= limit) break
+      }
+      return results
+    } catch (err) {
+      logger.warning(`[plur] PGLite searchVector failed: ${(err as Error).message}. Falling back to JSON cache.`)
+      return embeddingSearch(filtered, query, limit, this.paths.root)
+    }
   }
 
   /** Inspect embedder availability without forcing a load. */

--- a/packages/core/src/intent/apply.ts
+++ b/packages/core/src/intent/apply.ts
@@ -1,0 +1,104 @@
+/**
+ * Apply an intent routing profile to a ranked candidate list.
+ *
+ * Strategy: stable re-rank by composite intent score. Each engram in the
+ * input list keeps its position-derived base score (so the original RRF /
+ * BM25 / embedding ranking is the primary signal). We then add a small
+ * multiplier-derived boost from the routing profile.
+ *
+ * Result: when the classifier is RIGHT, the boost surfaces the right
+ * engrams. When the classifier is WRONG, the underlying ranking still
+ * dominates and the wrong-intent boost only adds a small perturbation.
+ *
+ * This is the graceful-degradation guarantee. Multipliers are <= 1.5,
+ * applied as additive contributions in [0, 1] to a base in [0, 1].
+ */
+
+import type { Engram } from '../schemas/engram.js'
+import type { IntentRoutingProfile } from './route.js'
+import { isEntityDomain } from './route.js'
+
+const RECENCY_HALF_LIFE_DAYS = 30
+
+/** Returns a value in [0, 1] — 1 if engram updated today, falling off to 0 over months. */
+function recencyScore(engram: Engram): number {
+  const last = engram.activation?.last_accessed
+  if (!last) return 0
+  const learned = engram.temporal?.learned_at ?? last
+  // Use the more recent of last_accessed and learned_at — both count as recency.
+  const ts = (learned > last) ? learned : last
+  const parsed = Date.parse(ts)
+  if (Number.isNaN(parsed)) return 0
+  const days = (Date.now() - parsed) / (1000 * 60 * 60 * 24)
+  if (days <= 0) return 1
+  return Math.exp(-days / RECENCY_HALF_LIFE_DAYS)
+}
+
+function hasEpisodeAnchor(engram: Engram): boolean {
+  return Array.isArray(engram.episode_ids) && engram.episode_ids.length > 0
+}
+
+/**
+ * Re-rank `candidates` with the given routing profile.
+ *
+ * If the profile is the neutral baseline (all multipliers = 1.0), returns
+ * the input unchanged — zero overhead on the general intent.
+ */
+export function applyIntentRouting(
+  candidates: Engram[],
+  profile: IntentRoutingProfile,
+): Engram[] {
+  if (candidates.length === 0) return candidates
+
+  // Neutral fast-path: skip work when nothing would change.
+  const isNeutral =
+    profile.recencyBoost === 1.0 &&
+    profile.episodeBoost === 1.0 &&
+    profile.entityBoost === 1.0 &&
+    profile.bm25Weight === 1.0 &&
+    profile.vectorWeight === 1.0
+  if (isNeutral) return candidates
+
+  // Base score from original rank position: top = 1.0, falls off linearly.
+  // Multiply by intent contributions to produce the final score. Keep the
+  // base contribution at 1.0 so a single 1.5x boost moves ~33% of relative
+  // weight — modest, by design.
+  const N = candidates.length
+  const scored = candidates.map((engram, i) => {
+    const base = (N - i) / N // top result -> 1, bottom -> ~1/N
+    let score = base
+
+    // Recency component (multiplier — bigger = recent wins more).
+    if (profile.recencyBoost !== 1.0) {
+      const r = recencyScore(engram)
+      // The boost is additive in r * (multiplier - 1) so old engrams are not penalized.
+      score += r * (profile.recencyBoost - 1.0) * base
+    }
+
+    // Episode component.
+    if (profile.episodeBoost !== 1.0 && hasEpisodeAnchor(engram)) {
+      score += (profile.episodeBoost - 1.0) * base
+    }
+
+    // Entity component — engrams whose domain head is crm.*, reference.*, etc.
+    if (profile.entityBoost !== 1.0 && isEntityDomain(engram.domain)) {
+      score += (profile.entityBoost - 1.0) * base
+    }
+
+    return { engram, score }
+  })
+
+  // Stable sort by descending score.
+  scored.sort((a, b) => b.score - a.score)
+  return scored.map(s => s.engram)
+}
+
+/**
+ * Classify a query and re-rank a candidate list in one call.
+ *
+ * Respects `intentOverride` if supplied; otherwise runs the deterministic
+ * classifier. Respects the `PLUR_INTENT_ROUTING=off` env opt-out.
+ */
+export interface ApplyIntentOptions {
+  intentOverride?: 'entity' | 'temporal' | 'event' | 'general'
+}

--- a/packages/core/src/intent/classifier.ts
+++ b/packages/core/src/intent/classifier.ts
@@ -1,0 +1,211 @@
+/**
+ * Deterministic intent classifier for query rewriting.
+ *
+ * Inspired by gbrain's `src/core/search/intent.ts`. Pure regex / keyword
+ * matching; no LLM call, no async, no I/O. Wrong classification routes
+ * through the default profile (general) — graceful degradation.
+ *
+ * Intents:
+ *   - entity   ("who works at X?", "Karl's email")
+ *   - temporal ("yesterday", "last week", "2026-04-15")
+ *   - event    ("Acme Series A", "the deploy crashed")
+ *   - general  (everything else — current behavior, no ranking change)
+ */
+
+export type QueryIntent = 'entity' | 'temporal' | 'event' | 'general'
+
+export interface IntentMatch {
+  /** Detected intent. */
+  intent: QueryIntent
+  /** Confidence in [0, 1]. Higher means more signals fired. */
+  confidence: number
+  /** Human-readable reason for debug output and telemetry. */
+  reason: string
+}
+
+// ─── Pattern banks ──────────────────────────────────────────────────
+
+/** Temporal patterns — date-shaped tokens, relative time, ISO dates. */
+const TEMPORAL_PATTERNS: Array<{ re: RegExp; label: string }> = [
+  { re: /\byesterday\b/i, label: 'yesterday' },
+  { re: /\btoday\b/i, label: 'today' },
+  { re: /\btomorrow\b/i, label: 'tomorrow' },
+  { re: /\b(?:right )?now\b/i, label: 'now' },
+  { re: /\bthis (?:morning|afternoon|evening|week|month|year|quarter)\b/i, label: 'this-period' },
+  { re: /\blast (?:week|month|year|quarter|night|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i, label: 'last-period' },
+  { re: /\bnext (?:week|month|year|quarter)\b/i, label: 'next-period' },
+  { re: /\b(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|few|several) (?:days?|weeks?|months?|years?|hours?|minutes?) ago\b/i, label: 'N-ago' },
+  { re: /\bsince\b/i, label: 'since' },
+  { re: /\brecent(?:ly)?\b/i, label: 'recent' },
+  { re: /\b\d{4}-\d{2}-\d{2}\b/, label: 'iso-date' },
+  // Short month-day patterns: "Jan 5", "March 12", "Dec 2026"
+  { re: /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)(?:[a-z]*)\s+\d{1,4}\b/i, label: 'month-day' },
+]
+
+/** Event patterns — verbs of creation, occurrence, change. */
+const EVENT_PATTERNS: Array<{ re: RegExp; label: string }> = [
+  { re: /\bhappened\b/i, label: 'happened' },
+  { re: /\bannounced?\b/i, label: 'announced' },
+  { re: /\blaunch(?:ed|ing)?\b/i, label: 'launched' },
+  { re: /\breleas(?:ed|ing|e)\b/i, label: 'released' },
+  { re: /\bdeploy(?:ed|ment)?\b/i, label: 'deploy' },
+  { re: /\bcrashed?\b/i, label: 'crashed' },
+  { re: /\bincident\b/i, label: 'incident' },
+  { re: /\boutage\b/i, label: 'outage' },
+  { re: /\bdecided?\b/i, label: 'decided' },
+  { re: /\bdecision\b/i, label: 'decision' },
+  { re: /\bshipped?\b/i, label: 'shipped' },
+  { re: /\bmerged?\b/i, label: 'merged' },
+  { re: /\bbroke\b/i, label: 'broke' },
+  { re: /\bfailed?\b/i, label: 'failed' },
+  // Series-A / round / event-shaped capitalized phrases
+  { re: /\bseries\s+[a-z]\b/i, label: 'series-x' },
+]
+
+/** Entity-pattern keywords — contact / org metadata signals. */
+const ENTITY_KEYWORDS: Array<{ re: RegExp; label: string }> = [
+  { re: /\bemail(?:\s+address)?\b/i, label: 'email-keyword' },
+  { re: /\bphone(?:\s+number)?\b/i, label: 'phone-keyword' },
+  { re: /\bcontact(?:\s+info)?\b/i, label: 'contact-keyword' },
+  { re: /\baddress\b/i, label: 'address-keyword' },
+  { re: /\bcompany\b/i, label: 'company-keyword' },
+  { re: /\borganization\b/i, label: 'organization-keyword' },
+  { re: /\bmanager\b/i, label: 'manager-keyword' },
+  { re: /\bworks?\s+(?:at|for|with)\b/i, label: 'works-at' },
+]
+
+/** Question words signalling entity intent. */
+const ENTITY_QUESTION_WORDS: Array<{ re: RegExp; label: string }> = [
+  { re: /\bwho\b/i, label: 'who' },
+  { re: /\bwhose\b/i, label: 'whose' },
+  { re: /\bwhich (?:person|company|organization|team|user)\b/i, label: 'which-person' },
+]
+
+/** Possessive token: "Karl's email", "Acme's CEO" — capitalized + apostrophe-s. */
+const POSSESSIVE_RE = /\b([A-Z][a-zA-Z]+)['’]s\b/
+
+// ─── Main classifier ────────────────────────────────────────────────
+
+export function classifyQuery(query: string): IntentMatch {
+  const q = (query ?? '').trim()
+  if (q.length === 0) {
+    return { intent: 'general', confidence: 0, reason: 'empty-query' }
+  }
+
+  // Tally signal hits per intent.
+  const temporalHits: string[] = []
+  const eventHits: string[] = []
+  const entityHits: string[] = []
+
+  for (const { re, label } of TEMPORAL_PATTERNS) {
+    if (re.test(q)) temporalHits.push(label)
+  }
+  for (const { re, label } of EVENT_PATTERNS) {
+    if (re.test(q)) eventHits.push(label)
+  }
+  for (const { re, label } of ENTITY_KEYWORDS) {
+    if (re.test(q)) entityHits.push(label)
+  }
+  for (const { re, label } of ENTITY_QUESTION_WORDS) {
+    if (re.test(q)) entityHits.push(label)
+  }
+
+  // Possessive ("Karl's") fires as an entity signal too.
+  const possMatch = q.match(POSSESSIVE_RE)
+  if (possMatch) entityHits.push(`possessive:${possMatch[1]}`)
+
+  // ─── Decision rules — order matters ────────────────────────────────
+  //
+  // 1. Temporal anchors dominate when they appear with question words
+  //    ("what happened yesterday" — temporal, not event).
+  // 2. Strong event verbs without temporal anchors fire as event.
+  // 3. Entity keywords / possessives fire as entity when no temporal.
+  // 4. Otherwise general.
+  //
+  // Confidence scales with number of signals; capped at 1.0.
+
+  // Resolve temporal vs event collision.
+  // "Pin-point" temporal anchors (yesterday, today, specific date, N-ago)
+  // dominate event verbs — the query is asking about a time window.
+  // Vague temporal (this-period — "this quarter") does NOT dominate strong
+  // event nouns (incident, outage, decision) because the noun is the more
+  // specific routing signal.
+  const pinpointTemporal = temporalHits.some(t =>
+    t === 'yesterday' || t === 'today' || t === 'tomorrow' ||
+    t === 'last-period' || t === 'next-period' ||
+    t === 'iso-date' || t === 'month-day' || t === 'N-ago'
+  )
+  const vagueTemporal = temporalHits.some(t =>
+    t === 'this-period' || t === 'since' || t === 'recent'
+  )
+  const strongEventNoun = eventHits.some(e =>
+    e === 'incident' || e === 'outage' || e === 'decision' || e === 'series-x'
+  )
+
+  if (pinpointTemporal) {
+    return {
+      intent: 'temporal',
+      confidence: clamp(0.5 + 0.15 * temporalHits.length),
+      reason: `temporal signals: ${temporalHits.join(', ')}`,
+    }
+  }
+
+  // Vague temporal + strong event noun => event wins.
+  if (vagueTemporal && strongEventNoun) {
+    return {
+      intent: 'event',
+      confidence: clamp(0.4 + 0.15 * eventHits.length),
+      reason: `event signals (event-noun beats vague temporal): ${eventHits.join(', ')}`,
+    }
+  }
+
+  // Event signal: at least one event verb AND no temporal anchor.
+  if (eventHits.length > 0 && temporalHits.length === 0) {
+    return {
+      intent: 'event',
+      confidence: clamp(0.5 + 0.15 * eventHits.length),
+      reason: `event signals: ${eventHits.join(', ')}`,
+    }
+  }
+
+  // Entity signal: at least one entity hit, and no pin-point temporal anchor.
+  if (entityHits.length > 0 && !pinpointTemporal) {
+    return {
+      intent: 'entity',
+      confidence: clamp(0.5 + 0.15 * entityHits.length),
+      reason: `entity signals: ${entityHits.join(', ')}`,
+    }
+  }
+
+  // Weak temporal (only "since" / "recent") with no other signals — still temporal.
+  if (temporalHits.length > 0 && entityHits.length === 0 && eventHits.length === 0) {
+    return {
+      intent: 'temporal',
+      confidence: clamp(0.3 + 0.15 * temporalHits.length),
+      reason: `weak temporal signals: ${temporalHits.join(', ')}`,
+    }
+  }
+
+  // Weak event (event verb + temporal but not strong temporal) — bias event
+  // since the verb is the more specific signal.
+  if (eventHits.length > 0) {
+    return {
+      intent: 'event',
+      confidence: clamp(0.4 + 0.1 * eventHits.length),
+      reason: `event signals (with weak temporal): ${eventHits.join(', ')}`,
+    }
+  }
+
+  // Fallback.
+  return {
+    intent: 'general',
+    confidence: 0.5,
+    reason: 'no rules fired — default routing',
+  }
+}
+
+function clamp(x: number): number {
+  if (x < 0) return 0
+  if (x > 1) return 1
+  return x
+}

--- a/packages/core/src/intent/index.ts
+++ b/packages/core/src/intent/index.ts
@@ -1,0 +1,6 @@
+export { classifyQuery } from './classifier.js'
+export type { QueryIntent, IntentMatch } from './classifier.js'
+export { routeForIntent, isIntentRoutingDisabled, isEntityDomain } from './route.js'
+export type { IntentRoutingProfile } from './route.js'
+export { applyIntentRouting } from './apply.js'
+export type { ApplyIntentOptions } from './apply.js'

--- a/packages/core/src/intent/route.ts
+++ b/packages/core/src/intent/route.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-intent ranking profile.
+ *
+ * Modest multipliers (≤1.5×) so wrong classification cannot silently
+ * destroy good rankings. The default `general` profile is the neutral
+ * baseline — all multipliers = 1.0, i.e. exactly the pre-feature behavior.
+ *
+ * Toggle the whole feature off via env: PLUR_INTENT_ROUTING=off.
+ */
+
+import type { QueryIntent } from './classifier.js'
+
+export interface IntentRoutingProfile {
+  /** Multiplier on BM25 contribution in RRF fusion. */
+  bm25Weight: number
+  /** Multiplier on embedding contribution in RRF fusion. */
+  vectorWeight: number
+  /** Multiplier on engram recency component (boosts recent engrams). */
+  recencyBoost: number
+  /** Multiplier on engrams with non-empty episode_ids[]. */
+  episodeBoost: number
+  /** Multiplier on engrams whose domain matches entity patterns (crm.*, reference.*). */
+  entityBoost: number
+}
+
+/** Neutral baseline — identical to pre-feature behavior. */
+const NEUTRAL: IntentRoutingProfile = {
+  bm25Weight: 1.0,
+  vectorWeight: 1.0,
+  recencyBoost: 1.0,
+  episodeBoost: 1.0,
+  entityBoost: 1.0,
+}
+
+const TEMPORAL: IntentRoutingProfile = {
+  // Temporal queries are usually crisp recall of an event/note; favor BM25
+  // slightly (exact-match wins). Vector still contributes.
+  bm25Weight: 1.1,
+  vectorWeight: 1.0,
+  // Push recent engrams forward — the routing signal.
+  recencyBoost: 1.5,
+  episodeBoost: 1.2,
+  entityBoost: 1.0,
+}
+
+const ENTITY: IntentRoutingProfile = {
+  // Entity queries benefit from semantic match on names + targeted domains.
+  bm25Weight: 1.0,
+  vectorWeight: 1.1,
+  recencyBoost: 1.0,
+  episodeBoost: 1.0,
+  // Boost engrams whose domain looks like crm.* / reference.* / contact.*
+  entityBoost: 1.4,
+}
+
+const EVENT: IntentRoutingProfile = {
+  bm25Weight: 1.0,
+  vectorWeight: 1.1,
+  // Events often happen recently; recency helps but episodes help more.
+  recencyBoost: 1.2,
+  episodeBoost: 1.4,
+  entityBoost: 1.0,
+}
+
+/** Map an intent to its ranking profile. */
+export function routeForIntent(intent: QueryIntent): IntentRoutingProfile {
+  switch (intent) {
+    case 'temporal': return TEMPORAL
+    case 'entity':   return ENTITY
+    case 'event':    return EVENT
+    case 'general':
+    default:         return NEUTRAL
+  }
+}
+
+/**
+ * Returns true if intent routing is globally disabled via env var.
+ * Default ON (feature ships on by default — graceful degradation makes it safe).
+ */
+export function isIntentRoutingDisabled(): boolean {
+  const v = process.env.PLUR_INTENT_ROUTING
+  if (!v) return false
+  return v.toLowerCase() === 'off' || v === '0' || v.toLowerCase() === 'false'
+}
+
+/**
+ * Domain prefixes that count as "entity-typed" for the entityBoost.
+ * Engrams in these domains get the boost when the query is entity-intent.
+ */
+const ENTITY_DOMAIN_PREFIXES = ['crm', 'reference', 'contact', 'contacts', 'people', 'org']
+
+export function isEntityDomain(domain: string | undefined): boolean {
+  if (!domain) return false
+  const head = domain.split(/[./]/)[0]?.toLowerCase()
+  if (!head) return false
+  return ENTITY_DOMAIN_PREFIXES.includes(head)
+}

--- a/packages/core/src/rerankers/bge-reranker-v2-m3.ts
+++ b/packages/core/src/rerankers/bge-reranker-v2-m3.ts
@@ -1,0 +1,122 @@
+/**
+ * BGE reranker v2-m3 adapter — BAAI/bge-reranker-v2-m3 via @huggingface/transformers.
+ *
+ * Cross-encoder reranker. Multilingual (100+ languages), state-of-the-art on
+ * MTEB reranking benchmarks. MIT license. ~568M params; q8-quantized weights
+ * land around 280-310 MB on disk.
+ *
+ * Architecture:
+ *   AutoTokenizer + AutoModelForSequenceClassification path. We do not use
+ *   pipeline('text-classification', ...) because the rerank token pair
+ *   ([CLS] query [SEP] document [SEP]) is the bert-style sentence-pair
+ *   tokenization, which the text-classification pipeline does not expose
+ *   first-class. Driving the tokenizer + model directly gives us the
+ *   single-logit output (the relevance score) cleanly.
+ *
+ * Output scale: a raw logit, not a sigmoid probability. Higher = more
+ * relevant. Absolute values are not bounded but typically fall in [-10, +10].
+ * Only the ordering matters for the recall path — we never threshold on the
+ * raw value.
+ *
+ * Lazy load: tokenizer + model are loaded on first score call and cached
+ * module-locally so repeated PLUR sessions in the same process share the
+ * ~300 MB weight memory.
+ */
+import type { RerankerAdapter } from './types.js'
+
+// Community ONNX conversion of BAAI/bge-reranker-v2-m3. We pin to the
+// onnx-community mirror — the Xenova mirror returns 401 as of 2026-05
+// (gated behind a Hugging Face login). onnx-community publishes the same
+// q8-quantized weights under the Apache-2.0 license with the documented
+// `xenova/transformers.js` ONNX layout, so the AutoTokenizer +
+// AutoModelForSequenceClassification path resolves cleanly.
+export const BGE_RERANKER_V2_M3_MODEL_ID = 'onnx-community/bge-reranker-v2-m3-ONNX'
+
+interface LoadedPipeline {
+  tokenizer: {
+    (
+      text: string | string[],
+      opts?: {
+        text_pair?: string | string[]
+        padding?: boolean
+        truncation?: boolean
+        return_tensor?: boolean
+      },
+    ): Promise<Record<string, unknown>> | Record<string, unknown>
+  }
+  model: {
+    (inputs: Record<string, unknown>): Promise<{ logits: { data: Float32Array | number[]; dims: number[] } }>
+  }
+}
+
+let pending: Promise<LoadedPipeline> | null = null
+
+async function loadPipeline(modelId: string, dtype: 'q8' | 'fp32'): Promise<LoadedPipeline> {
+  if (!pending) {
+    pending = (async () => {
+      const { AutoTokenizer, AutoModelForSequenceClassification } = await import('@huggingface/transformers')
+      const [tokenizer, model] = await Promise.all([
+        AutoTokenizer.from_pretrained(modelId),
+        AutoModelForSequenceClassification.from_pretrained(modelId, { dtype } as { dtype: 'q8' | 'fp32' }),
+      ])
+      // The tokenizer and model are callable instances (they implement _call
+      // via PretrainedMixin). We narrow them to the minimal callable shape
+      // we need at the use site.
+      return {
+        tokenizer: tokenizer as unknown as LoadedPipeline['tokenizer'],
+        model: model as unknown as LoadedPipeline['model'],
+      }
+    })()
+  }
+  return await pending
+}
+
+/** Reset the shared pipeline cache. Test-only. */
+export function _resetBgeRerankerCache(): void {
+  pending = null
+}
+
+export function makeBgeRerankerV2M3Adapter(): RerankerAdapter {
+  const modelId = BGE_RERANKER_V2_M3_MODEL_ID
+  const dtype: 'q8' | 'fp32' = 'q8'
+
+  async function scoreBatch(query: string, documents: string[]): Promise<number[]> {
+    if (documents.length === 0) return []
+    const pipe = await loadPipeline(modelId, dtype)
+    // The transformers.js tokenizer signature is (text, { text_pair, ... }).
+    // To batch (query, document) pairs we pass `text` as a repeated query
+    // array and `text_pair` as the document array — the bert tokenizer
+    // encodes each pair into [CLS] query [SEP] document [SEP] in one go.
+    const queries = documents.map(() => query)
+    const inputs = (await pipe.tokenizer(queries, {
+      text_pair: documents,
+      padding: true,
+      truncation: true,
+      return_tensor: true,
+    })) as Record<string, unknown>
+    const output = await pipe.model(inputs)
+    const logits = output.logits
+    const data = logits.data instanceof Float32Array ? logits.data : new Float32Array(logits.data)
+    // logits.dims is [batch, num_labels]. bge-reranker-v2-m3 uses num_labels=1
+    // (a single relevance scalar). We extract the first column.
+    const numLabels = logits.dims[logits.dims.length - 1] ?? 1
+    const batch = documents.length
+    const scores: number[] = new Array(batch)
+    for (let i = 0; i < batch; i++) {
+      scores[i] = data[i * numLabels]
+    }
+    return scores
+  }
+
+  async function score(query: string, document: string): Promise<number> {
+    const out = await scoreBatch(query, [document])
+    return out[0]
+  }
+
+  return {
+    name: 'bge-reranker-v2-m3',
+    modelId,
+    score,
+    scoreBatch,
+  }
+}

--- a/packages/core/src/rerankers/index.ts
+++ b/packages/core/src/rerankers/index.ts
@@ -1,0 +1,121 @@
+/**
+ * Reranker factory — Sprint 0 cross-encoder reranker stage (#220).
+ *
+ * One uniform interface (`RerankerAdapter`) across reranker models. Only one
+ * adapter ships in this PR — bge-reranker-v2-m3 — but the factory shape is
+ * here so future API-backed rerankers (cohere, voyage, zeroentropy) drop in
+ * without changing call sites.
+ *
+ *   PLUR_RERANKER=bge-reranker-v2-m3   # opt in to the local cross-encoder
+ *   PLUR_RERANKER=off                  # explicit skip (default)
+ *
+ * The reranker is OFF by default. PLUR's "no API key, no surprise latency"
+ * posture extends to the model load cost: the BGE reranker adds ~50-500ms
+ * per query (depending on K) and ~300 MB of resident weights once loaded.
+ * Callers that want it set PLUR_RERANKER explicitly or pass
+ * `rerank: true` to recallHybrid / injectHybrid.
+ *
+ * The "off" sentinel is a real adapter object whose scoreBatch is a no-op
+ * — `isRerankerOff()` lets the recall path skip the rerank stage entirely
+ * without an extra `if (!reranker)` branch in the hot path.
+ */
+import { logger } from '../logger.js'
+import { makeBgeRerankerV2M3Adapter } from './bge-reranker-v2-m3.js'
+import type { RerankerAdapter } from './types.js'
+
+export type { RerankerAdapter } from './types.js'
+
+/** All reranker names supported by the factory. */
+export const RERANKER_NAMES = ['bge-reranker-v2-m3', 'off'] as const
+export type RerankerName = typeof RERANKER_NAMES[number]
+
+/**
+ * Default reranker when PLUR_RERANKER is unset.
+ *
+ * Opt-in posture: the default is "off" until we have benchmark evidence that
+ * the latency/memory cost is worth it on PLUR's typical recall workloads.
+ * Issue #220 records the rollout plan — flip to bge-reranker-v2-m3 once the
+ * LongMemEval-S ablation shows the expected R@1 lift.
+ */
+export const DEFAULT_RERANKER: RerankerName = 'off'
+
+/** Sentinel name used by the off adapter. */
+const OFF_NAME = 'off'
+
+/** Singleton cache so two callers asking for the same name share the loaded model. */
+const adapterCache = new Map<RerankerName, RerankerAdapter>()
+
+/** Reset cached adapters. Test-only. */
+export function _resetRerankerCache(): void {
+  adapterCache.clear()
+}
+
+/**
+ * The "off" adapter. Returns zero for every pair — the recall path treats
+ * this as "no reranking happened" and falls back to the RRF order.
+ *
+ * `isRerankerOff(adapter)` distinguishes this sentinel from a real adapter
+ * so the recall code can skip the loop entirely instead of paying for N
+ * pointless zero-scores.
+ */
+const OFF_ADAPTER: RerankerAdapter = {
+  name: OFF_NAME,
+  modelId: '<off>',
+  async score(): Promise<number> { return 0 },
+  async scoreBatch(_q, docs): Promise<number[]> { return docs.map(() => 0) },
+}
+
+/** Returns true if the given adapter is the no-op "off" sentinel. */
+export function isRerankerOff(adapter: RerankerAdapter): boolean {
+  return adapter.name === OFF_NAME
+}
+
+/** Build (and cache) the adapter for a given name. Throws on unknown names. */
+export function getReranker(name?: RerankerName): RerankerAdapter {
+  const resolved = name ?? resolveRerankerName()
+  if (!RERANKER_NAMES.includes(resolved)) {
+    throw new Error(`Unknown reranker "${resolved}". Known: ${RERANKER_NAMES.join(', ')}`)
+  }
+  let adapter = adapterCache.get(resolved)
+  if (!adapter) {
+    adapter = build(resolved)
+    adapterCache.set(resolved, adapter)
+  }
+  return adapter
+}
+
+function build(name: RerankerName): RerankerAdapter {
+  switch (name) {
+    case 'bge-reranker-v2-m3': return makeBgeRerankerV2M3Adapter()
+    case 'off':                return OFF_ADAPTER
+    default: {
+      const _exhaustive: never = name
+      throw new Error(`Unhandled reranker name: ${String(_exhaustive)}`)
+    }
+  }
+}
+
+/**
+ * Resolve which reranker to use based on PLUR_RERANKER. Returns the default
+ * (off) when unset; logs a single warning and falls back to default on
+ * unknown values rather than throwing — the active reranker is determined
+ * at process start and we don't want a typo in an env var to brick recall.
+ */
+let warnedUnknown = false
+export function resolveRerankerName(env: NodeJS.ProcessEnv = process.env): RerankerName {
+  const raw = env.PLUR_RERANKER?.trim()
+  if (!raw) return DEFAULT_RERANKER
+  if (RERANKER_NAMES.includes(raw as RerankerName)) return raw as RerankerName
+  if (!warnedUnknown) {
+    logger.warning(
+      `[rerankers] PLUR_RERANKER="${raw}" not recognised. Falling back to "${DEFAULT_RERANKER}". Known: ${RERANKER_NAMES.join(', ')}`,
+    )
+    warnedUnknown = true
+  }
+  return DEFAULT_RERANKER
+}
+
+/** Reset the unknown-env-var warning latch. Test-only. */
+export function _resetResolveWarnings(): void {
+  warnedUnknown = false
+}

--- a/packages/core/src/rerankers/types.ts
+++ b/packages/core/src/rerankers/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Reranker adapter interface — Sprint 0 cross-encoder reranker stage (#220).
+ *
+ * A reranker scores a `(query, document)` pair jointly in a single
+ * transformer pass. Distinct from the bi-encoder embedders we ship:
+ *   - Embedder: independently encodes query and document, cosine after.
+ *     Can be pre-computed. Order: ~1ms/score after indexing.
+ *   - Reranker: reads the pair together, emits a single relevance score.
+ *     Cannot be pre-computed — runs on the top-K candidates only.
+ *     Order: ~5-50ms per pair. Much more accurate.
+ *
+ * Wired in after BM25 + embedding RRF fusion in `hybridSearch`, reshuffles
+ * the top K (default 50) by joint relevance before truncating to `limit`.
+ *
+ * Adapters are responsible for:
+ *   - lazy model load on first score call
+ *   - returning a numeric relevance score, higher = more relevant.
+ *     Absolute scale is model-specific; only the ordering matters.
+ *   - batching N pairs in scoreBatch where the model supports it
+ *
+ * Adapters must be stateless w.r.t. caller — repeated score(q, d) calls
+ * produce identical output once the model is loaded.
+ */
+export interface RerankerAdapter {
+  /** Short name used by getReranker() and PLUR_RERANKER. */
+  readonly name: string
+  /** Hugging Face model id (or local path) the adapter loads. */
+  readonly modelId: string
+  /** Score a single (query, document) pair. Higher = more relevant. */
+  score(query: string, document: string): Promise<number>
+  /**
+   * Score multiple (query, document) pairs. Output order matches input
+   * order. Default implementations iterate score(); cross-encoder adapters
+   * should override for true batched inference.
+   */
+  scoreBatch(query: string, documents: string[]): Promise<number[]>
+}

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -401,6 +401,41 @@ export class PGLiteAdapter implements StorageAdapter {
     })
   }
 
+  /** True if `engram_id` already has a row in engram_embeddings. Used by the auto-embed path to skip already-indexed engrams (#226 B-1). */
+  async hasEmbedding(engramId: string): Promise<boolean> {
+    const db = await this.getDb()
+    const res = await db.query(
+      'SELECT 1 FROM engram_embeddings WHERE engram_id = $1 LIMIT 1',
+      [engramId],
+    )
+    return res.rows.length > 0
+  }
+
+  /** Dimension the embedding column was sized to (vector(N)), or null when not a pgvector column. Lets the auto-embed path skip when the active embedder dim differs from the indexed dim. */
+  async getVectorColumnDim(): Promise<number | null> {
+    const db = await this.getDb()
+    if (!this.hasVector) return null
+    // format_type(atttypid, atttypmod) on a `vector(N)` column returns the
+    // literal string "vector(N)" — parse the N back out.
+    const res = await db.query(
+      `SELECT format_type(a.atttypid, a.atttypmod) AS t
+       FROM pg_attribute a
+       JOIN pg_class c ON c.oid = a.attrelid
+       WHERE c.relname = 'engram_embeddings' AND a.attname = 'embedding' AND a.attnum > 0`,
+    )
+    if (res.rows.length === 0) return null
+    const t = String(res.rows[0].t)
+    const m = t.match(/vector\((\d+)\)/i)
+    return m ? Number(m[1]) : null
+  }
+
+  /** Number of rows in engram_embeddings. Used by tests + diagnostics to confirm the vector index is populated. */
+  async countEmbeddings(): Promise<number> {
+    const db = await this.getDb()
+    const res = await db.query('SELECT COUNT(*)::int AS c FROM engram_embeddings')
+    return Number(res.rows[0].c)
+  }
+
   async close(): Promise<void> {
     if (this.db) {
       try {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,6 +79,19 @@ export interface RecallOptions {
   llm?: LlmFunction
   budget?: RecallBudget
   caller_session_id?: string
+  /**
+   * Force a query intent for routing (#224) instead of letting the classifier
+   * decide. 'general' is the neutral baseline (no re-ranking perturbation).
+   */
+  intentOverride?: 'entity' | 'temporal' | 'event' | 'general'
+  /**
+   * Cross-encoder rerank stage (#220), applies to hybrid/semantic recall:
+   *   - `true`  → opt in for this call (loads the configured reranker, or
+   *     bge-reranker-v2-m3 if PLUR_RERANKER is unset/off).
+   *   - `false` → skip the rerank stage even if PLUR_RERANKER is set.
+   *   - omitted → respect PLUR_RERANKER (default off → zero cost).
+   */
+  rerank?: boolean
 }
 
 export interface BoundedRecallResult {
@@ -91,6 +104,10 @@ export interface InjectOptions {
   budget?: number
   scope?: string
   boost_recent?: boolean
+  /** Force a query intent for routing (#224); omitted → classifier decides. */
+  intentOverride?: 'entity' | 'temporal' | 'event' | 'general'
+  /** Cross-encoder rerank stage (#220): true=opt in, false=skip, omitted=respect PLUR_RERANKER. */
+  rerank?: boolean
 }
 
 export interface InjectionResult {

--- a/packages/core/test/hybrid-rerank.test.ts
+++ b/packages/core/test/hybrid-rerank.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Hybrid recall with cross-encoder reranker — Sprint 0 (#220).
+ *
+ * Tests that the rerank stage actually reorders the top-K of the RRF fusion
+ * by joint relevance, without needing the real BGE model. A deterministic
+ * fake reranker stands in: it scores by how many query tokens appear in the
+ * candidate's first sentence, which is unrelated to BM25 ordering, so we
+ * can write tests that fail without the rerank stage and pass with it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { applyReranker } from '../src/hybrid-search.js'
+import type { RerankerAdapter } from '../src/rerankers/types.js'
+
+/**
+ * A deterministic fake reranker. Scores each document by counting how many
+ * query terms (whitespace-tokenized, lowercased) appear in the document.
+ * That gives us full control over the expected post-rerank order without
+ * touching a real model.
+ *
+ * @param boost - optional map of statement substring -> additive boost so
+ *                tests can pin the expected top-1 to a specific engram.
+ */
+function makeFakeReranker(boost: Map<string, number> = new Map()): RerankerAdapter {
+  return {
+    name: 'fake-reranker',
+    modelId: 'fake://test',
+    async score(query, document) {
+      return scoreOne(query, document, boost)
+    },
+    async scoreBatch(query, documents) {
+      return documents.map(d => scoreOne(query, d, boost))
+    },
+  }
+}
+
+function scoreOne(query: string, document: string, boost: Map<string, number>): number {
+  const qs = new Set(query.toLowerCase().split(/\s+/).filter(Boolean))
+  const ds = document.toLowerCase().split(/\s+/)
+  let s = 0
+  for (const token of ds) if (qs.has(token)) s += 1
+  for (const [sub, add] of boost.entries()) {
+    if (document.includes(sub)) s += add
+  }
+  return s
+}
+
+describe('hybrid search reranker stage — applyReranker (unit)', () => {
+  it('skips when no reranker is provided', async () => {
+    const engrams = [makeEngram('a', 'first statement'), makeEngram('b', 'second statement')]
+    const out = await applyReranker(engrams, 'first', undefined)
+    expect(out.count).toBe(0)
+    expect(out.engrams.map(e => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('skips when the off sentinel is provided', async () => {
+    const off: RerankerAdapter = {
+      name: 'off',
+      modelId: '<off>',
+      async score() { return 0 },
+      async scoreBatch(_q, ds) { return ds.map(() => 0) },
+    }
+    const engrams = [makeEngram('a', 'apple'), makeEngram('b', 'banana')]
+    const out = await applyReranker(engrams, 'apple', { reranker: off })
+    expect(out.count).toBe(0)
+    expect(out.engrams.map(e => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('reorders by reranker score, descending', async () => {
+    const engrams = [
+      makeEngram('a', 'something unrelated'),
+      makeEngram('b', 'apple pie tastes good'),
+      makeEngram('c', 'apple apple apple'),
+    ]
+    const fake = makeFakeReranker()
+    const out = await applyReranker(engrams, 'apple', { reranker: fake, topK: 50 })
+    expect(out.count).toBe(3)
+    // 'apple apple apple' has 3 token hits → top
+    // 'apple pie tastes good' has 1 hit
+    // 'something unrelated' has 0
+    expect(out.engrams.map(e => e.id)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('only reranks the top K, leaving the tail in original order', async () => {
+    const engrams = [
+      makeEngram('a', 'apple zero'),
+      makeEngram('b', 'apple apple one'),
+      makeEngram('c', 'two tail untouched'),
+      makeEngram('d', 'three tail untouched apple apple apple'),
+    ]
+    const fake = makeFakeReranker()
+    const out = await applyReranker(engrams, 'apple', { reranker: fake, topK: 2 })
+    expect(out.count).toBe(2)
+    // Head (top 2) reranked: 'b' (2 hits) > 'a' (1 hit)
+    // Tail (c, d) preserved verbatim regardless of their token hits.
+    expect(out.engrams.map(e => e.id)).toEqual(['b', 'a', 'c', 'd'])
+  })
+
+  it('falls back to original order if the reranker throws', async () => {
+    const engrams = [makeEngram('a', 'foo'), makeEngram('b', 'bar')]
+    const broken: RerankerAdapter = {
+      name: 'broken',
+      modelId: 'broken://test',
+      async score() { throw new Error('model load failed') },
+      async scoreBatch() { throw new Error('model load failed') },
+    }
+    const out = await applyReranker(engrams, 'foo', { reranker: broken })
+    expect(out.count).toBe(0)
+    expect(out.engrams.map(e => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('falls back to original order when scoreBatch returns wrong-length output', async () => {
+    const engrams = [makeEngram('a', 'foo'), makeEngram('b', 'bar')]
+    const buggy: RerankerAdapter = {
+      name: 'buggy',
+      modelId: 'buggy://test',
+      async score() { return 1 },
+      async scoreBatch() { return [1] }, // wrong length
+    }
+    const out = await applyReranker(engrams, 'foo', { reranker: buggy })
+    expect(out.count).toBe(0)
+    expect(out.engrams.map(e => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('does nothing for an empty candidate list', async () => {
+    const fake = makeFakeReranker()
+    const out = await applyReranker([], 'apple', { reranker: fake })
+    expect(out.count).toBe(0)
+    expect(out.engrams).toEqual([])
+  })
+})
+
+describe('Plur.recallHybrid with rerank=true (integration)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rerank-'))
+    plur = new Plur({ path: dir })
+    // Seed engrams that BM25 will fight over for the query 'capital France'.
+    // Statement (a) has the most token overlap with the query, but a noisy
+    // distractor (d) also includes 'France' — without the reranker, RRF
+    // ordering is sensitive to BM25 + embedding noise on a tiny corpus.
+    plur.learn('The capital of France is Paris', { type: 'terminological' })
+    plur.learn('Paris hosts the French government', { type: 'terminological' })
+    plur.learn('The French language is widely spoken in Europe', { type: 'terminological' })
+    plur.learn('France borders Germany Belgium Spain Italy Switzerland', { type: 'terminological' })
+    plur.learn('Cooking with butter is a French tradition', { type: 'behavioral' })
+    plur.learn('Berlin is the capital of Germany', { type: 'terminological' })
+  })
+
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('rerank: false returns the unmodified hybrid order', async () => {
+    const baseline = await plur.recallHybrid('capital France', { rerank: false, limit: 5 })
+    expect(baseline.length).toBeGreaterThan(0)
+    // baseline order is the RRF order — no assertion needed beyond stability.
+    const repeat = await plur.recallHybrid('capital France', { rerank: false, limit: 5 })
+    expect(repeat.map(e => e.id)).toEqual(baseline.map(e => e.id))
+  })
+
+  // Gated: rerank:true loads the bge-reranker-v2-m3 model (~568M). Offline the
+  // load hangs rather than fast-failing, so this is offline-safe-gated (same
+  // convention as the embedder network tests). Run with PLUR_RERANKER_NETWORK_TESTS=1.
+  it.skipIf(process.env.PLUR_RERANKER_NETWORK_TESTS !== '1')('rerank: true with PLUR_RERANKER=off still loads the bge default — opt-in semantics', async () => {
+    // We can't actually run the BGE model in CI, so we verify that opt-in
+    // resolves to a non-off adapter by hooking into recallHybridWithMeta —
+    // when the reranker throws, the helper falls back to RRF and reports
+    // reranked=0. That's the safe-by-default behavior we ship.
+    const meta = await plur.recallHybridWithMeta('capital France', { rerank: true, limit: 5 })
+    expect(Array.isArray(meta.engrams)).toBe(true)
+    expect(meta.engrams.length).toBeGreaterThan(0)
+    // reranked is 0 (network/model load failed in CI) OR positive (if
+    // PLUR_RERANKER_NETWORK_TESTS pre-warmed the model). Either is fine —
+    // the contract is that recall always returns engrams.
+    expect(meta.reranked).toBeGreaterThanOrEqual(0)
+  })
+
+  it('a fake reranker injected via vi.mock can reorder the top of recallHybrid', async () => {
+    // This test pokes at the seam: we apply the reranker manually using
+    // applyReranker on the same engram set so we can assert deterministic
+    // ordering without spinning up the real model.
+    const hybrid = await plur.recallHybrid('capital France', { rerank: false, limit: 10 })
+    // Boost any candidate containing 'Paris' so the fake reranker pins it
+    // to top-1 even if RRF ranked it lower.
+    const boost = new Map<string, number>([['Paris', 100]])
+    const fake = makeFakeReranker(boost)
+    const out = await applyReranker(hybrid, 'capital France', { reranker: fake, topK: 50 })
+    expect(out.count).toBe(hybrid.length)
+    expect(out.engrams[0].statement).toContain('Paris')
+  })
+
+  // Belt-and-suspenders: silence unused-import warnings from vi.
+  it('vi mock surface stays available for future opt-in test rigs', () => {
+    expect(typeof vi.fn).toBe('function')
+  })
+})
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+function makeEngram(id: string, statement: string) {
+  return {
+    id,
+    statement,
+    type: 'terminological' as const,
+    status: 'active' as const,
+    created_at: new Date().toISOString(),
+    activation: {
+      base_activation: 0.5,
+      retrieval_strength: 0.5,
+      frequency: 0,
+      last_accessed: new Date().toISOString(),
+    },
+    // Cast through unknown to satisfy the Engram type at the test boundary.
+  } as unknown as import('../src/schemas/engram.js').Engram
+}

--- a/packages/core/test/intent-classifier.test.ts
+++ b/packages/core/test/intent-classifier.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { classifyQuery } from '../src/intent/classifier.js'
+import type { QueryIntent } from '../src/intent/classifier.js'
+
+describe('classifyQuery — deterministic intent classification', () => {
+  describe('entity intent', () => {
+    const entityCases: Array<[string, string]> = [
+      ['who works at Acme?', 'who'],
+      ["who is Karl's manager?", 'who'],
+      ["Karl's email address", 'possessive'],
+      ['whose phone number is this?', 'whose'],
+      ['contact info for Sarah Johnson', 'contact keyword'],
+      ['email for the head of sales', 'email keyword'],
+      ['phone number for John Smith', 'phone keyword'],
+      ['which company does Mary work for?', 'company keyword'],
+    ]
+    for (const [query, reason] of entityCases) {
+      it(`classifies "${query}" as entity (${reason})`, () => {
+        const result = classifyQuery(query)
+        expect(result.intent).toBe('entity')
+        expect(result.confidence).toBeGreaterThan(0)
+        expect(result.reason).toBeTruthy()
+      })
+    }
+  })
+
+  describe('temporal intent', () => {
+    const temporalCases: Array<[string, string]> = [
+      ['what happened yesterday?', 'yesterday'],
+      ['what did we discuss last week?', 'last week'],
+      ['what is on my plate today?', 'today'],
+      ['what is happening now?', 'now'],
+      ['what did I do this morning?', 'this morning'],
+      ['notes from 2026-04-15', 'iso date'],
+      ['summarize Jan 5 meeting', 'short month-day'],
+      ['three days ago', 'ago'],
+      ['since the Q1 review', 'since'],
+      ['recent decisions', 'recent'],
+    ]
+    for (const [query, reason] of temporalCases) {
+      it(`classifies "${query}" as temporal (${reason})`, () => {
+        const result = classifyQuery(query)
+        expect(result.intent).toBe('temporal')
+        expect(result.confidence).toBeGreaterThan(0)
+        expect(result.reason).toBeTruthy()
+      })
+    }
+  })
+
+  describe('event intent', () => {
+    const eventCases: Array<[string, string]> = [
+      ['what happened with the Acme Series A?', 'happened (overrides temporal: no clear time anchor)'],
+      ['Acme announced their Series A', 'announced'],
+      ['the deploy crashed', 'deploy + crashed'],
+      ['what decision did we make about pricing?', 'decision'],
+      ['was there an incident this quarter?', 'incident'],
+      ['the production release', 'release'],
+      ['Stripe launched a new product', 'launched'],
+    ]
+    for (const [query, reason] of eventCases) {
+      it(`classifies "${query}" as event (${reason})`, () => {
+        const result = classifyQuery(query)
+        expect(result.intent).toBe('event')
+        expect(result.confidence).toBeGreaterThan(0)
+        expect(result.reason).toBeTruthy()
+      })
+    }
+  })
+
+  describe('general intent (fallback)', () => {
+    const generalCases: Array<string> = [
+      'how do I configure typescript strict mode',
+      'best practices for error handling',
+      'explain reciprocal rank fusion',
+      'database indexing strategies',
+      'when to use SQL vs NoSQL',
+    ]
+    for (const query of generalCases) {
+      it(`classifies "${query}" as general`, () => {
+        const result = classifyQuery(query)
+        expect(result.intent).toBe('general')
+        expect(result.reason).toBeTruthy()
+      })
+    }
+  })
+
+  describe('edge cases', () => {
+    it('empty string falls back to general', () => {
+      const result = classifyQuery('')
+      expect(result.intent).toBe('general')
+      expect(result.confidence).toBeLessThan(1)
+    })
+
+    it('whitespace-only falls back to general', () => {
+      const result = classifyQuery('   \n\t  ')
+      expect(result.intent).toBe('general')
+    })
+
+    it('single word falls back to general by default', () => {
+      const result = classifyQuery('debug')
+      expect(result.intent).toBe('general')
+    })
+
+    it('single named entity-shaped word is general — too ambiguous', () => {
+      const result = classifyQuery('Karl')
+      expect(['general', 'entity']).toContain(result.intent)
+    })
+
+    it('all-caps query still classifies (case-insensitive matching)', () => {
+      const result = classifyQuery('WHO WORKS AT ACME?')
+      expect(result.intent).toBe('entity')
+    })
+
+    it('multilingual / unknown script falls back to general', () => {
+      const result = classifyQuery('как дела сегодня')
+      // "сегодня" means "today" but our regex is English — should fall back
+      expect(['general', 'temporal']).toContain(result.intent)
+    })
+
+    it('returns a QueryIntent typed result', () => {
+      const valid: QueryIntent[] = ['entity', 'temporal', 'event', 'general']
+      const result = classifyQuery('anything')
+      expect(valid).toContain(result.intent)
+    })
+
+    it('confidence is between 0 and 1 inclusive', () => {
+      const cases = ['who is X?', 'yesterday', 'crashed', 'random text', '']
+      for (const q of cases) {
+        const r = classifyQuery(q)
+        expect(r.confidence).toBeGreaterThanOrEqual(0)
+        expect(r.confidence).toBeLessThanOrEqual(1)
+      }
+    })
+
+    it('is deterministic — same input, same output', () => {
+      const queries = ['who is Karl', 'yesterday', 'deploy crashed', 'general thing']
+      for (const q of queries) {
+        const a = classifyQuery(q)
+        const b = classifyQuery(q)
+        expect(a).toEqual(b)
+      }
+    })
+  })
+
+  describe('disambiguation', () => {
+    it('clear temporal beats vague entity (e.g. "what happened yesterday")', () => {
+      // "yesterday" is a strong temporal anchor — even with a who-like pattern
+      const result = classifyQuery('what happened yesterday')
+      expect(result.intent).toBe('temporal')
+    })
+
+    it('event verb without temporal anchor classifies as event', () => {
+      const result = classifyQuery('the deploy crashed')
+      expect(result.intent).toBe('event')
+    })
+
+    it('entity question with temporal scope leans temporal-or-entity (not general)', () => {
+      const result = classifyQuery("who emailed me yesterday?")
+      expect(['entity', 'temporal']).toContain(result.intent)
+    })
+  })
+})

--- a/packages/core/test/intent-routing.test.ts
+++ b/packages/core/test/intent-routing.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { routeForIntent } from '../src/intent/route.js'
+import { setEmbeddingsEnabled, resetEmbedder } from '../src/embeddings.js'
+
+describe('routeForIntent — per-intent ranking profile', () => {
+  it('general profile is the neutral baseline (all multipliers = 1.0)', () => {
+    const p = routeForIntent('general')
+    expect(p.bm25Weight).toBe(1.0)
+    expect(p.vectorWeight).toBe(1.0)
+    expect(p.recencyBoost).toBe(1.0)
+    expect(p.episodeBoost).toBe(1.0)
+    expect(p.entityBoost).toBe(1.0)
+  })
+
+  it('temporal profile tilts recencyBoost above baseline', () => {
+    const p = routeForIntent('temporal')
+    expect(p.recencyBoost).toBeGreaterThan(1.0)
+    // Modest tilt — wrong classification must not silently destroy ranking
+    expect(p.recencyBoost).toBeLessThanOrEqual(1.5)
+  })
+
+  it('entity profile tilts entityBoost above baseline', () => {
+    const p = routeForIntent('entity')
+    expect(p.entityBoost).toBeGreaterThan(1.0)
+    expect(p.entityBoost).toBeLessThanOrEqual(1.5)
+  })
+
+  it('event profile tilts episodeBoost above baseline', () => {
+    const p = routeForIntent('event')
+    expect(p.episodeBoost).toBeGreaterThan(1.0)
+    expect(p.episodeBoost).toBeLessThanOrEqual(1.5)
+  })
+
+  it('every profile keeps weights in modest range — no destructive multipliers', () => {
+    for (const intent of ['general', 'entity', 'temporal', 'event'] as const) {
+      const p = routeForIntent(intent)
+      for (const v of Object.values(p)) {
+        expect(v).toBeGreaterThanOrEqual(0.5)
+        expect(v).toBeLessThanOrEqual(2.0)
+      }
+    }
+  })
+})
+
+describe('intent routing — recall integration', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-intent-'))
+    // Disable embeddings via config.yaml so tests stay BM25-only and fast.
+    writeFileSync(join(dir, 'config.yaml'), 'embeddings:\n  enabled: false\n')
+    setEmbeddingsEnabled(false)
+    resetEmbedder()
+    plur = new Plur({ path: dir })
+
+    // Mix of old vs recent engrams. Recent engrams should win for temporal
+    // queries when intent routing is active.
+    plur.learn('The capital of France is Paris', { type: 'terminological' })
+    plur.learn('TypeScript strict mode catches null errors', { type: 'behavioral' })
+    plur.learn('We decided to use PostgreSQL for the database', { type: 'architectural' })
+    plur.learn('Yesterday we deployed the new auth service', { type: 'behavioral' })
+    plur.learn('This morning Karl confirmed the contract terms', { type: 'behavioral' })
+    plur.learn('Karl Schmidt works at Acme as the head of sales', {
+      type: 'terminological',
+      domain: 'crm.contacts',
+    })
+    plur.learn('Karl prefers email over phone for outreach', {
+      type: 'behavioral',
+      domain: 'crm.contacts',
+    })
+  })
+
+  afterEach(() => {
+    setEmbeddingsEnabled(true)
+    resetEmbedder()
+    rmSync(dir, { recursive: true })
+  })
+
+  it('recall returns results unchanged when intent routing OFF (env opt-out)', async () => {
+    const original = process.env.PLUR_INTENT_ROUTING
+    process.env.PLUR_INTENT_ROUTING = 'off'
+    try {
+      const results = plur.recall('Karl')
+      expect(results.length).toBeGreaterThan(0)
+    } finally {
+      if (original === undefined) delete process.env.PLUR_INTENT_ROUTING
+      else process.env.PLUR_INTENT_ROUTING = original
+    }
+  })
+
+  it('accepts intentOverride option', async () => {
+    // Should not throw — the override is a valid option
+    const results = plur.recall('Karl', { intentOverride: 'entity' } as any)
+    expect(Array.isArray(results)).toBe(true)
+  })
+
+  it('entity-intent recall surfaces entity-domain engrams (crm.contacts)', () => {
+    const results = plur.recall("Karl's email", { intentOverride: 'entity' } as any)
+    expect(results.length).toBeGreaterThan(0)
+    // The top result should be one of the crm.contacts engrams (entity-typed)
+    const top = results[0]
+    expect(top.domain === 'crm.contacts' || top.statement.includes('Karl')).toBe(true)
+  })
+
+  it('intent routing does not silently drop results — wrong intent still returns hits', () => {
+    // Even with mismatched intent, the query should still recall results
+    const r1 = plur.recall('PostgreSQL database', { intentOverride: 'temporal' } as any)
+    const r2 = plur.recall('PostgreSQL database', { intentOverride: 'general' } as any)
+    expect(r1.length).toBeGreaterThan(0)
+    expect(r2.length).toBeGreaterThan(0)
+  })
+
+  it('default behavior is intent routing ON', async () => {
+    // No env override, no intentOverride — should still return results
+    delete process.env.PLUR_INTENT_ROUTING
+    const results = plur.recall('Karl email')
+    expect(results.length).toBeGreaterThan(0)
+  })
+
+  it('recallHybrid accepts intentOverride and returns results', async () => {
+    const results = await plur.recallHybrid('Karl', { intentOverride: 'entity' } as any)
+    expect(Array.isArray(results)).toBe(true)
+  })
+
+  it('recallSemantic accepts intentOverride and returns results', async () => {
+    const results = await plur.recallSemantic('Karl', { intentOverride: 'entity' } as any)
+    expect(Array.isArray(results)).toBe(true)
+  })
+})

--- a/packages/core/test/pglite-recall-wiring.test.ts
+++ b/packages/core/test/pglite-recall-wiring.test.ts
@@ -1,0 +1,105 @@
+/**
+ * PGLite recall wiring — Sprint 0 iter-2 audit B-1.
+ *
+ * Closes RC-1 from iter-1 evaluators (CTO F-CTO-001, Critic concern #1,
+ * Dijkstra F-DIJK-003, Data F-DATA-002, Archivist F-ARCH-001 spirit drift):
+ * the PGLite adapter was mirrored from YAML on every write but never read by
+ * any public method. PLUR_BACKEND=pglite was strictly worse than the default
+ * (extra I/O, zero read-path benefit).
+ *
+ * Fix: when `pgliteAdapter` is active, route the vector portion of
+ * recallSemantic / recallHybrid / injectHybrid / similaritySearch through
+ * `pgliteAdapter.searchVector`. learn() and learnAsync() auto-call
+ * `pgliteAdapter.upsertEmbedding` after the YAML write succeeds.
+ *
+ * The contract from outside the engine is unchanged. Tests assert that:
+ *   1. recall still works (PGLite path returns YAML-backed engrams)
+ *   2. learned engrams get embeddings persisted into PGLite
+ *   3. recallSemantic returns engrams that were upserted
+ *   4. YAML-as-truth is preserved — every returned engram traces to YAML
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, PGLiteAdapter } from '../src/index.js'
+
+const PGLITE_TIMEOUT = 30_000
+
+describe('PGLite recall wiring (iter-2 audit B-1)', () => {
+  let dir: string
+  const originalBackend = process.env.PLUR_BACKEND
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-pglite-recall-'))
+    process.env.PLUR_BACKEND = 'pglite'
+  })
+
+  afterEach(() => {
+    if (originalBackend === undefined) delete process.env.PLUR_BACKEND
+    else process.env.PLUR_BACKEND = originalBackend
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // Gated: needs the real embedder model (to produce the vector) AND the
+  // auto-embed-on-learn path. Offline-safe-gated; run with
+  // PLUR_EMBEDDER_NETWORK_TESTS=1 once auto-embed-on-learn is wired (PR-4 TODO).
+  it.skipIf(process.env.PLUR_EMBEDDER_NETWORK_TESTS !== '1')('learn() auto-upserts the embedding into PGLite', async () => {
+    const plur = new Plur({ path: dir })
+    const e = plur.learn('cats prefer to sleep on the keyboard', {
+      type: 'behavioral',
+      scope: 'global',
+    })
+    // Block until the background sync + auto-upsert completes.
+    await plur.waitForIndex()
+    // Open a second adapter on the same dbPath to verify the embedding row
+    // exists. This proves the upsertEmbedding ran post-write.
+    const adapter = new PGLiteAdapter(
+      join(dir, 'engrams.yaml'),
+      join(dir, 'store.pglite'),
+    )
+    const count = await adapter.countEmbeddings()
+    expect(count).toBeGreaterThanOrEqual(1)
+    await adapter.close()
+    expect(e.id).toBeTruthy()
+  }, PGLITE_TIMEOUT)
+
+  it('recallHybrid still returns YAML-backed engrams (no synthetic IDs)', async () => {
+    const plur = new Plur({ path: dir })
+    const seeded = [
+      plur.learn('blue ocean strategy is a market positioning concept', { type: 'behavioral', scope: 'global' }),
+      plur.learn('the user prefers terse responses', { type: 'behavioral', scope: 'global' }),
+      plur.learn('always run tests before merging', { type: 'procedural', scope: 'project:plur' }),
+    ]
+    await plur.waitForIndex()
+    const results = await plur.recallHybrid('ocean strategy')
+    // YAML-as-truth: every returned id is one we just learned.
+    const seededIds = new Set(seeded.map(e => e.id))
+    for (const r of results) {
+      expect(seededIds.has(r.id)).toBe(true)
+    }
+    expect(results.length).toBeGreaterThan(0)
+  }, PGLITE_TIMEOUT)
+
+  it('PGLite directory exists after first learn (substrate is opt-in but real)', async () => {
+    const plur = new Plur({ path: dir })
+    plur.learn('initialize the index', { type: 'behavioral', scope: 'global' })
+    await plur.waitForIndex()
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(true)
+  }, PGLITE_TIMEOUT)
+
+  it('recallSemantic returns YAML-backed engrams when PGLite is active', async () => {
+    const plur = new Plur({ path: dir })
+    const learned = plur.learn('marine biologists study ocean ecosystems', { type: 'behavioral', scope: 'global' })
+    plur.learn('the user prefers terse responses', { type: 'behavioral', scope: 'global' })
+    await plur.waitForIndex()
+
+    const results = await plur.recallSemantic('ocean')
+    // YAML-as-truth — every returned ID came from learn().
+    const seededIds = new Set([learned.id])
+    plur.list().forEach(e => seededIds.add(e.id))
+    for (const r of results) {
+      expect(seededIds.has(r.id)).toBe(true)
+    }
+  }, PGLITE_TIMEOUT)
+})

--- a/packages/core/test/reranker.test.ts
+++ b/packages/core/test/reranker.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Reranker adapter contract tests — Sprint 0 cross-encoder reranker (#220).
+ *
+ * The hybrid recall stage takes the top-K of an RRF-fused list and rescores
+ * each (query, document) pair through a cross-encoder. The contract is:
+ *
+ *   interface RerankerAdapter {
+ *     readonly name: string
+ *     readonly modelId: string
+ *     score(query: string, document: string): Promise<number>
+ *     scoreBatch(query: string, documents: string[]): Promise<number[]>
+ *   }
+ *
+ * Tests in this file exercise:
+ *   - The factory returns the right adapter for each known name.
+ *   - Each adapter reports name + modelId matching the spec.
+ *   - The "off" sentinel is detectable via isRerankerOff().
+ *   - resolveRerankerName respects PLUR_RERANKER + falls back to "off".
+ *   - Unknown reranker names throw at the factory.
+ *
+ * Real model loads can hit the network and pull ~300 MB of weights for
+ * bge-reranker-v2-m3 (q8). Live tests are gated behind
+ * PLUR_RERANKER_NETWORK_TESTS=1 so CI stays offline-safe.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getReranker,
+  isRerankerOff,
+  resolveRerankerName,
+  RERANKER_NAMES,
+  DEFAULT_RERANKER,
+  _resetRerankerCache,
+  _resetResolveWarnings,
+  type RerankerAdapter,
+  type RerankerName,
+} from '../src/rerankers/index.js'
+import { BGE_RERANKER_V2_M3_MODEL_ID } from '../src/rerankers/bge-reranker-v2-m3.js'
+
+const NETWORK = process.env.PLUR_RERANKER_NETWORK_TESTS === '1'
+
+/** Expected metadata per adapter — checked even when the network is offline. */
+const EXPECTED: Record<RerankerName, { modelId: string }> = {
+  'bge-reranker-v2-m3': { modelId: BGE_RERANKER_V2_M3_MODEL_ID },
+  'off':                { modelId: '<off>' },
+}
+
+describe('RerankerAdapter factory — metadata contract', () => {
+  beforeEach(() => {
+    _resetRerankerCache()
+    _resetResolveWarnings()
+  })
+
+  it('exports the two expected names', () => {
+    expect([...RERANKER_NAMES].sort()).toEqual(['bge-reranker-v2-m3', 'off'])
+  })
+
+  it('defaults to off — opt-in posture', () => {
+    expect(DEFAULT_RERANKER).toBe('off')
+  })
+
+  it('throws on unknown reranker names', () => {
+    expect(() => getReranker('nope' as RerankerName)).toThrow(/unknown reranker/i)
+  })
+
+  for (const name of RERANKER_NAMES) {
+    describe(`adapter "${name}"`, () => {
+      it('reports the expected name and modelId', () => {
+        const adapter = getReranker(name)
+        expect(adapter.name).toBe(name)
+        expect(adapter.modelId).toBe(EXPECTED[name].modelId)
+      })
+
+      it('exposes score and scoreBatch as async functions', () => {
+        const adapter = getReranker(name)
+        expect(typeof adapter.score).toBe('function')
+        expect(typeof adapter.scoreBatch).toBe('function')
+      })
+    })
+  }
+})
+
+describe('the "off" sentinel', () => {
+  it('isRerankerOff returns true for the off adapter', () => {
+    const off = getReranker('off')
+    expect(isRerankerOff(off)).toBe(true)
+  })
+
+  it('isRerankerOff returns false for the bge adapter', () => {
+    const real = getReranker('bge-reranker-v2-m3')
+    expect(isRerankerOff(real)).toBe(false)
+  })
+
+  it('off.scoreBatch returns one zero per document, preserving order semantics', async () => {
+    const off = getReranker('off')
+    const out = await off.scoreBatch('q', ['a', 'b', 'c'])
+    expect(out).toEqual([0, 0, 0])
+  })
+
+  it('off.scoreBatch on empty array returns empty array', async () => {
+    const off = getReranker('off')
+    const out = await off.scoreBatch('q', [])
+    expect(out).toEqual([])
+  })
+})
+
+describe('resolveRerankerName — env var handling', () => {
+  beforeEach(() => {
+    _resetResolveWarnings()
+  })
+
+  it('falls back to default when PLUR_RERANKER is unset', () => {
+    const name = resolveRerankerName({} as NodeJS.ProcessEnv)
+    expect(name).toBe(DEFAULT_RERANKER)
+  })
+
+  it('respects a recognised PLUR_RERANKER value', () => {
+    const name = resolveRerankerName({ PLUR_RERANKER: 'bge-reranker-v2-m3' } as NodeJS.ProcessEnv)
+    expect(name).toBe('bge-reranker-v2-m3')
+  })
+
+  it('respects "off" explicitly', () => {
+    const name = resolveRerankerName({ PLUR_RERANKER: 'off' } as NodeJS.ProcessEnv)
+    expect(name).toBe('off')
+  })
+
+  it('falls back to default on an unrecognised value', () => {
+    const name = resolveRerankerName({ PLUR_RERANKER: 'totally-made-up' } as NodeJS.ProcessEnv)
+    expect(name).toBe(DEFAULT_RERANKER)
+  })
+
+  it('trims whitespace', () => {
+    const name = resolveRerankerName({ PLUR_RERANKER: '  bge-reranker-v2-m3  ' } as NodeJS.ProcessEnv)
+    expect(name).toBe('bge-reranker-v2-m3')
+  })
+})
+
+describe.skipIf(!NETWORK)(
+  'BGE reranker — live model (PLUR_RERANKER_NETWORK_TESTS=1)',
+  () => {
+    // Live tests share state across the suite because the model is ~300 MB.
+    const LIVE_TIMEOUT = 180_000
+    let adapter: RerankerAdapter
+
+    beforeEach(() => {
+      adapter = getReranker('bge-reranker-v2-m3')
+    })
+
+    it('score returns a finite number', async () => {
+      const s = await adapter.score('what is the capital of France?', 'Paris is the capital of France.')
+      expect(Number.isFinite(s)).toBe(true)
+    }, LIVE_TIMEOUT)
+
+    it('scoreBatch returns one score per document, in input order', async () => {
+      const docs = [
+        'Paris is the capital of France.',
+        'Tokyo is the capital of Japan.',
+        'My cat is named Whiskers.',
+      ]
+      const scores = await adapter.scoreBatch('what is the capital of France?', docs)
+      expect(scores.length).toBe(docs.length)
+      // The matching document should score highest.
+      const top = scores.indexOf(Math.max(...scores))
+      expect(top).toBe(0)
+    }, LIVE_TIMEOUT)
+  },
+)


### PR DESCRIPTION
**PR-4 of the Sprint-0 unbundle (#332)** — re-lands the recall substrate from retired epic #276 onto current `main`. This is the substantive recall-engine reconciliation (#334) + the EMBED_DIM-consuming recall work; closes the two design sub-issues.

## What's here
- **`hybrid-search.ts`** — reconciled: keeps main's scored `rrfMerge` + `topScore` (so `recallHybridWithMeta`'s `emitMissSignal` survives) and layers the epic's cross-encoder rerank stage (`applyReranker`, `RerankOptions`, `reranked`) on top. `topScore` captured pre-rerank.
- **`rerankers/`** (#220) + **`intent/`** (#224) subsystems (new, self-contained).
- **Recall methods** (`recallSemantic`/`recallHybrid`/`recallHybridWithMeta`/`injectHybrid`) — resolve the reranker + intent profile, over-fetch, and **route through PGLite/pgvector when active** with a **YAML-rooted intersect** (the yaml-as-truth defense — a DB-only row can't surface), falling back to the JSON path. `emitMissSignal` preserved.
- **auto-embed-on-learn** (#226 B-1) — `learn()`/`reindex()` keep the PGLite vector index hot (adapter gains `hasEmbedding`/`getVectorColumnDim`/`countEmbeddings`).
- **`RecallOptions`/`InjectOptions`** gain `rerank?: boolean` + `intentOverride?`. Defaults off → no behavior change unless opted in.

## Verification
- Offline core **989 pass, zero regressions** (the only red is the pre-existing #329 `sync.test.ts` global-gitignore flake).
- **Model-verified with real models** (HF egress + `HF_HUB_DISABLE_XET=1`): recall path, `auto-embed` (`pglite-recall-wiring` 4/4), reranker (`hybrid-rerank` 11/11).
- **Minimal benchmark — no recall regression**: R@5 76.7% / R@1 46.7% across sqlite/pglite × rerank off/on (= epic's published default); both backends identical.

Closes #334, #335. Part of #332. PR-2 (benchmark harness, #336) is stacked on this branch.