### PR TITLE
feat(benchmark): N-scenario harness + Xet hardening + reranker observability (PR-2 of #332)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ docs/architecture/vertical-extensions.md
 # Local gstack security reports — keep audit artifacts out of the repo
 .gstack/
 
-# Benchmark data belongs in plur-bench, not the monorepo (DO NOT commit here)
+# Benchmark data + generated artifacts belong in plur-bench, not the monorepo.
+# The small hand-curated scenarios.yaml fixture is the one committed exception
+# (already tracked) — large corpora, result runs, and caches stay out (#336).
 benchmark/data/
+benchmark/results/
+benchmark/.cache/
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,13 +4,29 @@ Two benchmark suites for PLUR development.
 
 ## 1. LongMemEval (`run.ts`) — Retrieval Quality
 
-Tests PLUR's memory retrieval across 6 categories (30 questions total).
+Tests PLUR's memory retrieval across 6 categories. Two corpora ship with the harness:
+
+- **`fixture`** (default) — 30-scenario hand-curated set (`data/scenarios.yaml`).
+  Backward-compatible with everything written before Sprint 0.
+- **`longmemeval-s-smoke`** — 30-scenario subset (5/category) of the *real*
+  LongMemEval-S. Committed; sessions trimmed to keep YAML <3 MB.
+- **`longmemeval-s`** — the full official LongMemEval-S corpus (500 questions,
+  Wu et al, 2024 — [arxiv.org/abs/2410.10813](https://arxiv.org/abs/2410.10813)).
+  Gitignored because the converted YAML is ~260 MB; regenerate locally with:
+
+  ```bash
+  huggingface-cli download xiaowu0162/longmemeval --repo-type dataset \
+    --local-dir benchmark/data/longmemeval-source/
+  npx tsx benchmark/scripts/import-longmemeval.ts
+  ```
 
 ```bash
-npx tsx benchmark/run.ts                          # hybrid (default)
-npx tsx benchmark/run.ts --search-mode bm25       # BM25 only
-npx tsx benchmark/run.ts --search-mode semantic    # embeddings only
-npx tsx benchmark/run.ts --category temporal_reasoning  # single category
+npx tsx benchmark/run.ts                                          # fixture (default), hybrid
+npx tsx benchmark/run.ts --search-mode bm25                       # BM25 only
+npx tsx benchmark/run.ts --search-mode semantic                   # embeddings only
+npx tsx benchmark/run.ts --category temporal_reasoning            # single category
+npx tsx benchmark/run.ts --corpus longmemeval-s --iterations 5    # real corpus, 5/category
+npx tsx benchmark/run.ts --corpus longmemeval-s-smoke             # committed real subset
 ```
 
 ## 2. Micro-benchmark (`micro.ts`) — Per-Operation Latency

--- a/benchmark/per-question.ts
+++ b/benchmark/per-question.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env npx tsx
+/**
+ * Per-question protocol benchmark for LongMemEval-S.
+ *
+ * Matches the canonical methodology used by gbrain, mem0, Letta, and the
+ * LongMemEval paper. Each question gets its own corpus; we score against
+ * LongMemEval's canonical `answer_session_ids`.
+ *
+ * Imports PLUR's BM25 (`searchEngrams`) and hybrid (`hybridSearchWithMeta`)
+ * directly so we test the real production retrieval code paths without
+ * paying the per-learn YAML rewrite cost (each call to `plur.learn` would
+ * otherwise dominate runtime).
+ *
+ * Usage:
+ *   npx tsx benchmark/per-question.ts --mode bm25
+ *   npx tsx benchmark/per-question.ts --mode hybrid
+ *   npx tsx benchmark/per-question.ts --mode rerank
+ *   npx tsx benchmark/per-question.ts --mode bm25 --limit 25     # smoke
+ */
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { searchEngrams, engramSearchText } from '../packages/core/src/fts.js'
+import { rrfMerge, applyReranker } from '../packages/core/src/hybrid-search.js'
+import { getReranker, resolveRerankerName } from '../packages/core/src/rerankers/index.js'
+import { getEmbedder, resolveEmbedderName } from '../packages/core/src/embedders/index.js'
+import type { Engram } from '../packages/core/src/schemas/engram.js'
+
+function cosineSim(a: Float32Array, b: Float32Array): number {
+  let dot = 0, na = 0, nb = 0
+  const n = Math.min(a.length, b.length)
+  for (let i = 0; i < n; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i] }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) + 1e-12)
+}
+
+// Shared embedding-cache root across all per-question runs in this process.
+// Without this, hybridSearchWithMeta tries to mkdir('') and crashes.
+const CACHE_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-pq-cache-'))
+process.on('exit', () => {
+  try { fs.rmSync(CACHE_ROOT, { recursive: true, force: true }) } catch { /* ignore */ }
+})
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const LMEVAL_PATH = path.join(
+  __dirname,
+  'data/longmemeval-source/longmemeval_s',
+)
+
+interface LMEvalQuestion {
+  question_id: string
+  question_type: string
+  question: string
+  answer: string | number
+  haystack_session_ids: string[]
+  haystack_sessions: Array<Array<{ role?: string; content?: string }>>
+  answer_session_ids: string[]
+}
+
+interface RunOptions {
+  mode: 'bm25' | 'hybrid' | 'rerank'
+  limit?: number
+  topK: number
+  /** Per-question checkpoint dir. Each question writes a JSON; restart skips done. */
+  checkpointDir?: string
+}
+
+function parseArgs(argv: string[]): RunOptions {
+  const opts: RunOptions = { mode: 'bm25', topK: 10 }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--mode' && argv[i + 1]) opts.mode = argv[++i] as RunOptions['mode']
+    else if (a === '--limit' && argv[i + 1]) opts.limit = parseInt(argv[++i], 10)
+    else if (a === '--top-k' && argv[i + 1]) opts.topK = parseInt(argv[++i], 10)
+    else if (a === '--checkpoint-dir' && argv[i + 1]) opts.checkpointDir = argv[++i]
+  }
+  return opts
+}
+
+interface Stats {
+  n: number
+  hit1: number
+  hit5: number
+  hit10: number
+  total_latency_ms: number
+}
+
+const emptyStats = (): Stats => ({ n: 0, hit1: 0, hit5: 0, hit10: 0, total_latency_ms: 0 })
+
+/** Construct a minimal Engram object for in-memory search. */
+function makeEngram(idCounter: number, statement: string, source: string): Engram {
+  return {
+    id: `pq-${idCounter}`,
+    version: 1,
+    status: 'active',
+    consolidated: false,
+    type: 'behavioral',
+    scope: 'global',
+    visibility: 'private',
+    statement,
+    source,
+    derivation_count: 0,
+    pack: null,
+    abstract: null,
+    derived_from: null,
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'apply' },
+    tags: [],
+    activation: {
+      retrieval_strength: 0.7,
+      storage_strength: 1,
+      frequency: 0,
+      last_accessed: new Date().toISOString().slice(0, 10),
+    },
+    associations: [],
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+  } as unknown as Engram
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2))
+  console.log(`[setup] mode=${opts.mode} top_k=${opts.topK} limit=${opts.limit ?? 'all'}`)
+  const lmeval: LMEvalQuestion[] = JSON.parse(fs.readFileSync(LMEVAL_PATH, 'utf8'))
+  console.log(`[setup] ${lmeval.length} questions loaded`)
+  const questions = opts.limit ? lmeval.slice(0, opts.limit) : lmeval
+
+  // Resolve adapters up-front so cold-start cost lands outside the timing.
+  let embedder: ReturnType<typeof getEmbedder> | null = null
+  if (opts.mode === 'hybrid' || opts.mode === 'rerank') {
+    const name = resolveEmbedderName()
+    console.log(`[setup] embedder=${name}`)
+    embedder = getEmbedder(name)
+  }
+  let reranker: ReturnType<typeof getReranker> | null = null
+  if (opts.mode === 'rerank') {
+    const name = resolveRerankerName()
+    console.log(`[setup] reranker=${name}`)
+    reranker = getReranker(name === 'off' ? 'bge-reranker-v2-m3' : name)
+  }
+
+  const cats = new Map<string, Stats>()
+  const overall = emptyStats()
+  const startWall = Date.now()
+
+  // Set up checkpoint dir if provided. Load existing per-question results
+  // into the running stats so a restart picks up where it left off.
+  if (opts.checkpointDir) {
+    fs.mkdirSync(opts.checkpointDir, { recursive: true })
+    const existing = fs.readdirSync(opts.checkpointDir).filter(f => f.endsWith('.json'))
+    if (existing.length > 0) {
+      console.log(`[resume] loading ${existing.length} existing checkpoints from ${opts.checkpointDir}`)
+      for (const fname of existing) {
+        try {
+          const r = JSON.parse(fs.readFileSync(path.join(opts.checkpointDir, fname), 'utf8'))
+          const stats = cats.get(r.category) ?? emptyStats()
+          stats.n++
+          stats.hit1 += r.hit_1 ? 1 : 0
+          stats.hit5 += r.hit_5 ? 1 : 0
+          stats.hit10 += r.hit_10 ? 1 : 0
+          stats.total_latency_ms += r.latency_ms
+          cats.set(r.category, stats)
+          overall.n++
+          overall.hit1 += r.hit_1 ? 1 : 0
+          overall.hit5 += r.hit_5 ? 1 : 0
+          overall.hit10 += r.hit_10 ? 1 : 0
+          overall.total_latency_ms += r.latency_ms
+        } catch { /* corrupt checkpoint, will redo */ }
+      }
+    }
+  }
+
+  for (let qi = 0; qi < questions.length; qi++) {
+    const q = questions[qi]
+
+    // Skip if checkpoint exists for this question.
+    if (opts.checkpointDir) {
+      const cp = path.join(opts.checkpointDir, `${q.question_id}.json`)
+      if (fs.existsSync(cp)) continue
+    }
+
+    // Build in-memory engram set for this question.
+    const engrams: Engram[] = []
+    const engramSession: number[] = []
+    let counter = 0
+    for (let si = 0; si < q.haystack_sessions.length; si++) {
+      const sessNum = si + 1
+      for (const turn of q.haystack_sessions[si]) {
+        const content = (turn?.content ?? '').trim()
+        if (!content) continue
+        engrams.push(makeEngram(counter++, content, `pq:${q.question_id}:s${sessNum}`))
+        engramSession.push(sessNum)
+      }
+    }
+    if (engrams.length === 0) continue
+
+    // Canonical session positions for this question.
+    const canonical = new Set<number>()
+    for (let i = 0; i < q.haystack_session_ids.length; i++) {
+      if (q.answer_session_ids.includes(q.haystack_session_ids[i])) {
+        canonical.add(i + 1)
+      }
+    }
+    if (canonical.size === 0) continue
+
+    const t0 = process.hrtime.bigint()
+    let results: Engram[] = []
+    if (opts.mode === 'bm25') {
+      results = searchEngrams(engrams, q.question, opts.topK)
+    } else if (opts.mode === 'hybrid' || opts.mode === 'rerank') {
+      // Custom hybrid that uses embedBatch (50 embeds in one call vs 50
+      // sequential `embed()` calls — ~10-30x faster on CPU). Same RRF merge
+      // and same searchEngrams BM25 as the production path.
+      const fetchN = opts.mode === 'rerank' ? Math.max(opts.topK, 50) : opts.topK
+      // 1) BM25 candidates
+      const bm25 = searchEngrams(engrams, q.question, Math.min(engrams.length, fetchN * 3))
+      // 2) Vector candidates via batched embed
+      const adapter = embedder!
+      const texts = engrams.map(engramSearchText)
+      const [queryVec, engramVecs] = await Promise.all([
+        adapter.embed(q.question),
+        adapter.embedBatch(texts),
+      ])
+      const vecScores: Array<{ engram: Engram; score: number }> = []
+      for (let i = 0; i < engrams.length; i++) {
+        vecScores.push({ engram: engrams[i], score: cosineSim(queryVec, engramVecs[i]) })
+      }
+      vecScores.sort((a, b) => b.score - a.score)
+      const vecTop = vecScores.slice(0, Math.min(engrams.length, fetchN * 2)).map(s => s.engram)
+      // 3) RRF merge
+      const merged = rrfMerge([bm25, vecTop])
+      if (opts.mode === 'rerank') {
+        const reranked = await applyReranker(merged, q.question, { reranker: reranker! })
+        results = reranked.engrams.slice(0, opts.topK)
+      } else {
+        results = merged.slice(0, opts.topK)
+      }
+    }
+    const t1 = process.hrtime.bigint()
+    const lat_ms = Number(t1 - t0) / 1e6
+
+    // Score: any retrieved engram from a canonical session?
+    const idToSession = new Map<string, number>()
+    for (let i = 0; i < engrams.length; i++) {
+      idToSession.set(engrams[i].id, engramSession[i])
+    }
+    const sessions = results.map(r => idToSession.get(r.id) ?? -1)
+    const hit_1 = sessions.length > 0 && canonical.has(sessions[0])
+    const hit_5 = sessions.slice(0, 5).some(s => canonical.has(s))
+    const hit_10 = sessions.slice(0, 10).some(s => canonical.has(s))
+
+    const stats = cats.get(q.question_type) ?? emptyStats()
+    stats.n++
+    stats.hit1 += hit_1 ? 1 : 0
+    stats.hit5 += hit_5 ? 1 : 0
+    stats.hit10 += hit_10 ? 1 : 0
+    stats.total_latency_ms += lat_ms
+    cats.set(q.question_type, stats)
+    overall.n++
+    overall.hit1 += hit_1 ? 1 : 0
+    overall.hit5 += hit_5 ? 1 : 0
+    overall.hit10 += hit_10 ? 1 : 0
+    overall.total_latency_ms += lat_ms
+
+    // Write checkpoint atomically (tmp + rename).
+    if (opts.checkpointDir) {
+      const cp = path.join(opts.checkpointDir, `${q.question_id}.json`)
+      const cpTmp = cp + '.tmp'
+      fs.writeFileSync(
+        cpTmp,
+        JSON.stringify({
+          question_id: q.question_id,
+          category: q.question_type,
+          mode: opts.mode,
+          hit_1, hit_5, hit_10, latency_ms: lat_ms,
+        }, null, 0) + '\n',
+      )
+      fs.renameSync(cpTmp, cp)
+    }
+
+    if ((qi + 1) % 25 === 0 || qi + 1 === questions.length) {
+      const wallSec = (Date.now() - startWall) / 1000
+      console.log(
+        `[run] ${qi + 1}/${questions.length} ` +
+          `R@5=${(overall.hit5 / overall.n * 100).toFixed(1)}% ` +
+          `R@1=${(overall.hit1 / overall.n * 100).toFixed(1)}% ` +
+          `lat_avg=${(overall.total_latency_ms / overall.n).toFixed(0)}ms ` +
+          `wall=${wallSec.toFixed(0)}s`,
+      )
+    }
+  }
+
+  console.log()
+  console.log(`Per-question protocol — mode=${opts.mode}`)
+  console.log(`Scoring: canonical_doc (any top-K engram from a LongMemEval answer_session)`)
+  console.log()
+  console.log(
+    `  ${'Category'.padEnd(30)} ${'N'.padStart(4)}  ${'R@1'.padStart(7)} ${'R@5'.padStart(7)} ${'R@10'.padStart(7)}  ${'avg ms'.padStart(8)}`,
+  )
+  const dash = '-'
+  console.log(
+    `  ${dash.repeat(30)} ${dash.repeat(4)}  ${dash.repeat(7)} ${dash.repeat(7)} ${dash.repeat(7)}  ${dash.repeat(8)}`,
+  )
+  for (const cat of [...cats.keys()].sort()) {
+    const s = cats.get(cat)!
+    console.log(
+      `  ${cat.padEnd(30)} ${String(s.n).padStart(4)}  ` +
+        `${(s.hit1 / s.n * 100).toFixed(1).padStart(6)}% ` +
+        `${(s.hit5 / s.n * 100).toFixed(1).padStart(6)}% ` +
+        `${(s.hit10 / s.n * 100).toFixed(1).padStart(6)}%  ` +
+        `${(s.total_latency_ms / s.n).toFixed(0).padStart(8)}`,
+    )
+  }
+  console.log(
+    `  ${dash.repeat(30)} ${dash.repeat(4)}  ${dash.repeat(7)} ${dash.repeat(7)} ${dash.repeat(7)}  ${dash.repeat(8)}`,
+  )
+  const s = overall
+  console.log(
+    `  ${'OVERALL'.padEnd(30)} ${String(s.n).padStart(4)}  ` +
+      `${(s.hit1 / s.n * 100).toFixed(1).padStart(6)}% ` +
+      `${(s.hit5 / s.n * 100).toFixed(1).padStart(6)}% ` +
+      `${(s.hit10 / s.n * 100).toFixed(1).padStart(6)}%  ` +
+      `${(s.total_latency_ms / s.n).toFixed(0).padStart(8)}`,
+  )
+  console.log()
+  console.log('References:')
+  console.log('  gbrain published (hybrid + text-embedding-3-large): R@5 = 97.6%')
+  console.log('  gbrain published (BM25-only):                       R@5 = 19.8%')
+  console.log('  rank-bm25 baseline (session-level):                 R@5 = 96.0%')
+}
+
+main().catch(err => {
+  console.error('[fatal]', err)
+  process.exit(1)
+})

--- a/benchmark/run.test.ts
+++ b/benchmark/run.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Tests for the LongMemEval benchmark harness (benchmark/run.ts).
+ *
+ * Verifies:
+ *   - Backward compat: default (no flags) still runs the 30-scenario path.
+ *   - --iterations N samples N scenarios per category deterministically.
+ *   - The same seed produces identical samples across runs (reproducibility).
+ *   - The JSON output contains the new headline keys: r5, r1, accuracy,
+ *     latency_p50_ms / p95_ms / p99_ms, peak_rss_mb, store_size_bytes.
+ *   - The harness also writes a human-readable Markdown summary alongside the JSON.
+ *   - --embedder picks the requested adapter and the three stub adapters
+ *     (bge-small, bge-base, embedding-gemma) fall back to the MiniLM path
+ *     with a clear log line until PR 4 lands.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { fileURLToPath } from 'url'
+import { runBenchmark, sampleScenarios, loadScenarios, percentile, CORPUS_FILES } from './run.js'
+import { extractKeywords } from './scripts/import-longmemeval.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+let workDir: string
+
+beforeAll(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-bench-test-'))
+})
+
+afterAll(() => {
+  fs.rmSync(workDir, { recursive: true, force: true })
+})
+
+describe('sampleScenarios', () => {
+  it('returns N scenarios per category with a fixed seed (deterministic)', () => {
+    const all = loadScenarios()
+    const sampleA = sampleScenarios(all, 3, 1337)
+    const sampleB = sampleScenarios(all, 3, 1337)
+
+    // Same seed → identical order and content.
+    expect(sampleA.map(s => s.id)).toEqual(sampleB.map(s => s.id))
+
+    // N per category.
+    const categories = [...new Set(all.map(s => s.category))]
+    for (const cat of categories) {
+      const got = sampleA.filter(s => s.category === cat).length
+      expect(got).toBe(3)
+    }
+  })
+
+  it('different seeds produce different orderings (probabilistic, but deterministic)', () => {
+    const all = loadScenarios()
+    const sampleA = sampleScenarios(all, 3, 1)
+    const sampleB = sampleScenarios(all, 3, 2)
+    // At least one of the two seeds should differ in order/content for at least one category.
+    expect(sampleA.map(s => s.id).join(',')).not.toBe(sampleB.map(s => s.id).join(','))
+  })
+
+  it('handles N larger than per-category count by sampling with replacement', () => {
+    const all = loadScenarios()
+    // We have 5 per category; ask for 10. This must not crash.
+    const sample = sampleScenarios(all, 10, 42)
+    const categories = [...new Set(all.map(s => s.category))]
+    for (const cat of categories) {
+      const got = sample.filter(s => s.category === cat).length
+      expect(got).toBe(10)
+    }
+  })
+})
+
+describe('corpus loader', () => {
+  it('loads the default fixture corpus (backward-compat)', () => {
+    const fixture = loadScenarios()
+    expect(fixture.length).toBe(30)
+    const explicit = loadScenarios(undefined, 'fixture')
+    expect(explicit.length).toBe(fixture.length)
+    expect(explicit.map(s => s.id)).toEqual(fixture.map(s => s.id))
+  })
+
+  // The longmemeval-s-smoke corpus (21k lines) lives in plur-bench, not this
+  // repo (#336) — only the small scenarios.yaml fixture is committed. Skip when
+  // the corpus isn't present locally (reproduce via benchmark/scripts/import-longmemeval.ts).
+  it.skipIf(!fs.existsSync(path.join(path.dirname(__filename), 'data', 'longmemeval-s-smoke.yaml')))('loads the longmemeval-s-smoke corpus with the expected shape', () => {
+    const smoke = loadScenarios(undefined, 'longmemeval-s-smoke')
+    expect(smoke.length).toBe(30)
+    const cats = new Set(smoke.map(s => s.category))
+    expect(cats.has('single_session_user')).toBe(true)
+    expect(cats.has('single_session_preference')).toBe(true)
+    expect(cats.has('single_session_assistant')).toBe(true)
+    expect(cats.has('temporal_reasoning')).toBe(true)
+    expect(cats.has('knowledge_updates')).toBe(true)
+    expect(cats.has('multi_session_reasoning')).toBe(true)
+    for (const s of smoke) {
+      expect(s.id).toBeTruthy()
+      expect(s.category).toBeTruthy()
+      expect(typeof s.query).toBe('string')
+      expect(s.conversations.length).toBeGreaterThan(0)
+      expect(s.expected_keywords.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('loads the full longmemeval-s corpus when it has been generated', () => {
+    // The full corpus is gitignored; skip if the contributor hasn't run the importer.
+    const fullPath = path.join(__dirname, 'data', CORPUS_FILES['longmemeval-s'])
+    if (!fs.existsSync(fullPath)) {
+      console.log(`[skip] ${fullPath} not present — run benchmark/scripts/import-longmemeval.ts to generate it.`)
+      return
+    }
+    const full = loadScenarios(undefined, 'longmemeval-s')
+    expect(full.length).toBeGreaterThanOrEqual(475)
+    expect(full.length).toBeLessThanOrEqual(525)
+    const cats = new Set(full.map(s => s.category))
+    expect(cats.size).toBe(6)
+    for (const s of full) {
+      expect(s.id).toBeTruthy()
+      expect(s.category).toBeTruthy()
+      expect(typeof s.query).toBe('string')
+      expect(s.conversations.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('throws a helpful error for unknown corpus names', () => {
+    expect(() => loadScenarios(undefined, 'does-not-exist' as 'fixture')).toThrow(/Unknown corpus|not found/i)
+  })
+
+  it('throws a setup-hint error when longmemeval-s is missing', () => {
+    const fullPath = path.join(__dirname, 'data', CORPUS_FILES['longmemeval-s'])
+    if (fs.existsSync(fullPath)) {
+      return
+    }
+    expect(() => loadScenarios(undefined, 'longmemeval-s')).toThrow(/huggingface-cli download xiaowu0162\/longmemeval/)
+  })
+})
+
+describe('extractKeywords (LongMemEval converter)', () => {
+  it('pulls capitalised proper nouns out of the answer', () => {
+    const kw = extractKeywords('Business Administration')
+    expect(kw).toContain('Business Administration')
+  })
+
+  it('extracts numbers and units from numeric answers', () => {
+    const kw = extractKeywords('25 minutes and 50 seconds (or 25:50)')
+    expect(kw.some(k => /\d/.test(k))).toBe(true)
+  })
+
+  it('coerces bare numeric answers (LongMemEval ships some as ints)', () => {
+    expect(() => extractKeywords(3)).not.toThrow()
+    expect(extractKeywords(3)).toContain('3')
+    expect(extractKeywords(1300)).toContain('1300')
+  })
+
+  it('returns at most 5 keywords (cap is enforced)', () => {
+    const long = 'Alice Bob Carol Dave Eve Frank Greta Hannah Ian John'
+    const kw = extractKeywords(long)
+    expect(kw.length).toBeLessThanOrEqual(5)
+  })
+
+  it('falls back to long content words when no proper nouns are present', () => {
+    const kw = extractKeywords('the user prefers programming languages with garbage collection')
+    expect(kw.length).toBeGreaterThan(0)
+  })
+
+  it('returns an empty list for empty input', () => {
+    expect(extractKeywords('')).toEqual([])
+    expect(extractKeywords(null)).toEqual([])
+    expect(extractKeywords(undefined)).toEqual([])
+  })
+})
+
+describe('percentile (iter-2 audit M-5 — Dijkstra F-DIJK-004)', () => {
+  it('p95 on 20 sorted observations returns the 19th smallest, not the max', () => {
+    // Iter-2 audit M-5: the old formula floor((p/100)*len) returned index 19
+    // (the maximum) on a 20-element array — wrong. The fixed formula
+    // floor((p/100)*(len-1)) returns index 18 (the 19th smallest).
+    const sorted = Array.from({ length: 20 }, (_, i) => i + 1)
+    // [1, 2, ..., 20]. p95 should be the 19th value = 19, NOT 20.
+    expect(percentile(sorted, 95)).toBe(19)
+    expect(percentile(sorted, 95)).not.toBe(20)
+  })
+
+  it('p50 on a 5-element array returns the median (index 2)', () => {
+    // [10, 20, 30, 40, 50] — median is 30 (index 2).
+    expect(percentile([10, 20, 30, 40, 50], 50)).toBe(30)
+  })
+
+  it('p100 returns the max', () => {
+    expect(percentile([1, 5, 10], 100)).toBe(10)
+  })
+
+  it('p0 returns the min', () => {
+    expect(percentile([1, 5, 10], 0)).toBe(1)
+  })
+
+  it('returns 0 for empty input', () => {
+    expect(percentile([], 95)).toBe(0)
+  })
+
+  it('handles single-element arrays without crashing', () => {
+    expect(percentile([42], 99)).toBe(42)
+    expect(percentile([42], 50)).toBe(42)
+  })
+})
+
+describe('runBenchmark', () => {
+  it('produces JSON output with all required headline keys at small N', async () => {
+    const out = await runBenchmark({
+      iterations: 3,
+      embedder: 'minilm',
+      searchMode: 'hybrid',
+      outputDir: workDir,
+      quiet: true,
+      seed: 7,
+    })
+
+    expect(out.jsonPath).toMatch(/\.json$/)
+    expect(fs.existsSync(out.jsonPath)).toBe(true)
+
+    const j = JSON.parse(fs.readFileSync(out.jsonPath, 'utf-8'))
+
+    // Headline metrics required for Sprint 0 acceptance.
+    expect(j).toHaveProperty('r5')
+    expect(j).toHaveProperty('r1')
+    expect(j).toHaveProperty('accuracy')
+    expect(j).toHaveProperty('latency_p50_ms')
+    expect(j).toHaveProperty('latency_p95_ms')
+    expect(j).toHaveProperty('latency_p99_ms')
+    expect(j).toHaveProperty('peak_rss_mb')
+    expect(j).toHaveProperty('store_size_bytes')
+
+    // Per-category breakdown also present for the report.
+    expect(j).toHaveProperty('per_category')
+    expect(typeof j.per_category).toBe('object')
+
+    // Embedder + run config captured for traceability.
+    expect(j.embedder).toBe('minilm')
+    expect(j.iterations_per_category).toBe(3)
+
+    // Numeric sanity.
+    expect(j.r5).toBeGreaterThanOrEqual(0)
+    expect(j.r5).toBeLessThanOrEqual(100)
+    expect(j.latency_p95_ms).toBeGreaterThanOrEqual(j.latency_p50_ms)
+    expect(j.latency_p99_ms).toBeGreaterThanOrEqual(j.latency_p95_ms)
+    expect(j.peak_rss_mb).toBeGreaterThan(0)
+    expect(j.store_size_bytes).toBeGreaterThan(0)
+  }, 60000)
+
+  it('also writes a human-readable Markdown summary alongside the JSON', async () => {
+    const out = await runBenchmark({
+      iterations: 3,
+      embedder: 'minilm',
+      searchMode: 'hybrid',
+      outputDir: workDir,
+      quiet: true,
+      seed: 11,
+    })
+
+    expect(out.mdPath).toMatch(/\.md$/)
+    expect(fs.existsSync(out.mdPath)).toBe(true)
+
+    const md = fs.readFileSync(out.mdPath, 'utf-8')
+    // Headline table near the top.
+    expect(md).toMatch(/#\s+PLUR Benchmark/i)
+    expect(md).toMatch(/R@5/)
+    expect(md).toMatch(/R@1/)
+    expect(md).toMatch(/Accuracy/)
+    expect(md).toMatch(/Latency p50/i)
+    expect(md).toMatch(/Peak RSS/i)
+    expect(md).toMatch(/Store size/i)
+  }, 60000)
+
+  it('preserves the backward-compatible 30-scenario default when no --iterations is passed', async () => {
+    const out = await runBenchmark({
+      // No iterations → use full default scenario set (30 questions, current behaviour).
+      embedder: 'minilm',
+      searchMode: 'bm25', // BM25 is faster; this is a smoke test.
+      outputDir: workDir,
+      quiet: true,
+    })
+
+    const j = JSON.parse(fs.readFileSync(out.jsonPath, 'utf-8'))
+    // Default mode runs over the full 30-scenario set.
+    expect(j.scenario_count).toBe(30)
+    // Still emits the new headline keys (they are always present).
+    expect(j).toHaveProperty('r5')
+    expect(j).toHaveProperty('latency_p50_ms')
+  }, 120000)
+
+  // Skipped unless the smoke corpus is present locally (#336 — it lives in plur-bench, not this repo).
+  it.skipIf(!fs.existsSync(path.join(path.dirname(__filename), 'data', 'longmemeval-s-smoke.yaml')))('runs over the longmemeval-s-smoke corpus end-to-end', async () => {
+    const out = await runBenchmark({
+      corpus: 'longmemeval-s-smoke',
+      iterations: 1,
+      embedder: 'minilm',
+      searchMode: 'bm25',
+      outputDir: workDir,
+      quiet: true,
+      seed: 7,
+    })
+
+    const j = JSON.parse(fs.readFileSync(out.jsonPath, 'utf-8'))
+    expect(j.corpus).toBe('longmemeval-s-smoke')
+    expect(j.scenario_count).toBe(6)
+    expect(j).toHaveProperty('r5')
+    expect(j).toHaveProperty('per_category')
+    expect(Object.keys(j.per_category).length).toBe(6)
+  }, 120000)
+
+  it('accepts the four embedder names and runs the real adapter (PR 4)', async () => {
+    const out = await runBenchmark({
+      iterations: 1,
+      embedder: 'embedding-gemma',
+      // BM25 search mode keeps this test offline-safe: the harness still
+      // pre-warms the embedder adapter, but recall doesn't depend on a
+      // successful model load. With --search-mode=hybrid this test would
+      // require the EmbeddingGemma weights to download on the CI runner.
+      searchMode: 'bm25',
+      outputDir: workDir,
+      quiet: true,
+      seed: 1,
+    })
+
+    const j = JSON.parse(fs.readFileSync(out.jsonPath, 'utf-8'))
+    // Requested embedder is recorded.
+    expect(j.embedder).toBe('embedding-gemma')
+    // PR 4 wires real adapters for all four names — stub-fallback is gone.
+    expect(j.embedder_stub_fallback).toBe(false)
+  }, 120000)
+})

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -143,8 +143,14 @@ export interface BenchmarkSummary {
   embedder: EmbedderName
   embedder_stub_fallback: boolean
   search_mode: string
-  /** Cross-encoder reranker state (#220). 'on' or 'off'. */
+  /** Cross-encoder reranker state (#220). 'on' or 'off' — what was REQUESTED. */
   rerank: 'on' | 'off'
+  /**
+   * How many queries the reranker ACTUALLY reordered. When `rerank: 'on'` but
+   * this is < scenario_count, the reranker fell back (model unavailable) on
+   * those queries and their numbers are RRF-only — do not read them as reranked.
+   */
+  reranked_queries: number
   corpus: CorpusName
   scenario_count: number
   iterations_per_category: number | null
@@ -439,6 +445,11 @@ export async function runBenchmark(opts: RunOptions = {}): Promise<RunOutput> {
   // top-K candidates and the report reflects rerank-on numbers.
   const rerankOn = opts.rerank === 'on'
   const results: ScenarioResult[] = []
+  // How many queries the cross-encoder actually reordered. When rerank is
+  // requested but this stays 0 (reranker unavailable / fell back), the run's
+  // numbers are RRF-only and the summary must say so — otherwise a silent
+  // fallback mislabels RRF results as rerank-on.
+  let rerankedQueries = 0
   for (const scenario of scenarios) {
     let retrieved: Array<{ id: string; statement: string }>
     const t0 = process.hrtime.bigint()
@@ -447,7 +458,11 @@ export async function runBenchmark(opts: RunOptions = {}): Promise<RunOutput> {
     } else if (searchMode === 'semantic') {
       retrieved = await plur.recallSemantic(scenario.query, { limit: 10, rerank: rerankOn })
     } else {
-      retrieved = await plur.recallHybrid(scenario.query, { limit: 10, rerank: rerankOn })
+      // Meta variant so we can observe whether the reranker ACTUALLY ran
+      // (reranked > 0) vs. silently fell back to RRF order.
+      const meta = await plur.recallHybridWithMeta(scenario.query, { limit: 10, rerank: rerankOn })
+      retrieved = meta.engrams
+      if ((meta.reranked ?? 0) > 0) rerankedQueries++
     }
     const t1 = process.hrtime.bigint()
     const latency_ms = Number(t1 - t0) / 1_000_000
@@ -524,6 +539,7 @@ export async function runBenchmark(opts: RunOptions = {}): Promise<RunOutput> {
     embedder_stub_fallback: embedderStubFallback,
     search_mode: searchMode,
     rerank: rerankOn ? 'on' : 'off',
+    reranked_queries: rerankedQueries,
     corpus,
     scenario_count: results.length,
     iterations_per_category: opts.iterations ?? null,
@@ -573,7 +589,13 @@ function printSummary(s: BenchmarkSummary) {
   console.log('===============\n')
   console.log(`Embedder:        ${s.embedder}${s.embedder_stub_fallback ? ' (stub fallback → minilm)' : ''}`)
   console.log(`Search mode:     ${s.search_mode}`)
-  console.log(`Reranker:        ${s.rerank}`)
+  console.log(`Reranker:        ${s.rerank}${s.rerank === 'on' ? ` (engaged ${s.reranked_queries}/${s.scenario_count} queries)` : ''}`)
+  if (s.rerank === 'on' && s.reranked_queries === 0) {
+    console.log(`  ⚠  rerank was REQUESTED but the reranker never ran (model unavailable / fell back) —`)
+    console.log(`     these numbers are RRF-only, NOT reranked. Warm the reranker model and re-run to measure rerank.`)
+  } else if (s.rerank === 'on' && s.reranked_queries < s.scenario_count) {
+    console.log(`  ⚠  rerank ran on only ${s.reranked_queries}/${s.scenario_count} queries — the rest are RRF-only.`)
+  }
   console.log(`Corpus:          ${s.corpus}`)
   console.log(`Scenarios:       ${s.scenario_count}${s.iterations_per_category !== null ? ` (N=${s.iterations_per_category}/category, seed=${s.seed})` : ''}`)
   console.log(`Commit:          ${s.commit}`)
@@ -606,7 +628,10 @@ function renderMarkdown(s: BenchmarkSummary): string {
   lines.push('')
   lines.push(`Embedder: \`${s.embedder}\`${s.embedder_stub_fallback ? ' (stub fallback → minilm, real adapter lands in PR 4)' : ''}`)
   lines.push(`Search mode: \`${s.search_mode}\``)
-  lines.push(`Reranker: \`${s.rerank}\``)
+  lines.push(`Reranker: \`${s.rerank}\`${s.rerank === 'on' ? ` (engaged ${s.reranked_queries}/${s.scenario_count})` : ''}`)
+  if (s.rerank === 'on' && s.reranked_queries < s.scenario_count) {
+    lines.push(`> ⚠ rerank requested but engaged ${s.reranked_queries}/${s.scenario_count} queries — ${s.reranked_queries === 0 ? 'numbers are RRF-only, not reranked' : 'remaining queries are RRF-only'}.`)
+  }
   lines.push(`Corpus: \`${s.corpus}\``)
   lines.push(`Scenarios: ${s.scenario_count}${s.iterations_per_category !== null ? ` (N=${s.iterations_per_category}/category, seed=${s.seed})` : ' (default fixture)'}`)
   lines.push('')

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -1,21 +1,73 @@
 #!/usr/bin/env npx tsx
 /**
- * LongMemEval Benchmark Runner for PLUR
+ * LongMemEval Benchmark Runner for PLUR — Sprint 0 edition.
  *
- * Tests memory retrieval quality across 6 categories:
- * - single_session_user, single_session_preference, single_session_assistant
- * - temporal_reasoning, knowledge_updates, multi_session_reasoning
+ * Tests memory retrieval quality across 6 categories and now captures
+ * latency p50/p95/p99 + peak RSS + on-disk store size so the Sprint 0 final
+ * run (Phase C: N=500 per category) can fill the headline table.
  *
  * Usage:
- *   npx tsx benchmark/run.ts [--search-mode hybrid|bm25|semantic] [--category <cat>]
+ *   npx tsx benchmark/run.ts                                # default 30-scenario smoke run
+ *   npx tsx benchmark/run.ts --iterations 500               # N per category, seeded
+ *   npx tsx benchmark/run.ts --embedder embedding-gemma     # pick an adapter
+ *   npx tsx benchmark/run.ts --search-mode hybrid|bm25|semantic
+ *   npx tsx benchmark/run.ts --category temporal_reasoning
+ *   npx tsx benchmark/run.ts --seed 1337                    # reproducible sampling
+ *   npx tsx benchmark/run.ts --output /tmp/results          # override output dir
+ *   npx tsx benchmark/run.ts --corpus fixture|longmemeval-s|longmemeval-s-smoke
+ *
+ * Corpus selection:
+ *   --corpus fixture            (default) the 30-scenario hand-curated set
+ *                               in benchmark/data/scenarios.yaml. Backward
+ *                               compatible — existing pipelines unaffected.
+ *   --corpus longmemeval-s      The full official LongMemEval-S (500 questions,
+ *                               Wu et al 2024). Loads longmemeval-s.yaml — must
+ *                               be generated first via:
+ *                                 huggingface-cli download xiaowu0162/longmemeval ...
+ *                                 npx tsx benchmark/scripts/import-longmemeval.ts
+ *   --corpus longmemeval-s-smoke   30-scenario subset of the real LongMemEval-S
+ *                                  (committed; for tests and quick smoke runs).
+ *
+ * Outputs:
+ *   <output>/<sha>-<ts>.json    machine-readable summary + per-scenario results
+ *   <output>/<sha>-<ts>.md      human-readable headline table
  */
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import { execSync } from 'child_process'
+import { fileURLToPath } from 'url'
 import yaml from '../packages/core/node_modules/js-yaml/index.js'
 import { Plur } from '../packages/core/src/index.js'
+import {
+  getEmbedder as getEmbedderAdapter,
+  EMBEDDER_NAMES as KNOWN_EMBEDDERS_FROM_CORE,
+  type EmbedderAdapter,
+} from '../packages/core/src/embedders/index.js'
+import { resetEmbedder } from '../packages/core/src/embeddings.js'
 
-interface Scenario {
+// ─── ESM-safe __dirname ─────────────────────────────────────────────
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type EmbedderName = 'minilm' | 'bge-small' | 'bge-base' | 'embedding-gemma'
+
+/**
+ * Available corpora. The harness is corpus-agnostic — same scoring code runs
+ * over the hand-curated fixture and the real LongMemEval-S so we can compare
+ * apples-to-apples once the real corpus is generated.
+ */
+export type CorpusName = 'fixture' | 'longmemeval-s' | 'longmemeval-s-smoke'
+
+export const CORPUS_FILES: Record<CorpusName, string> = {
+  'fixture': 'scenarios.yaml',
+  'longmemeval-s': 'longmemeval-s.yaml',
+  'longmemeval-s-smoke': 'longmemeval-s-smoke.yaml',
+}
+
+export interface Scenario {
   id: string
   category: string
   conversations: Array<{ session: number; turns: Array<{ role: string; content: string }> }>
@@ -24,25 +76,184 @@ interface Scenario {
   expected_keywords: string[]
 }
 
-interface ScenarioResult {
+export interface ScenarioResult {
   id: string
   category: string
   query: string
   expected_keywords: string[]
   retrieved_statements: string[]
+  hit_at_1: boolean
   hit_at_5: boolean
   hit_at_10: boolean
   mrr: number
   accuracy: boolean
   rank: number | null
+  latency_ms: number
 }
 
-function loadScenarios(filterCategory?: string): Scenario[] {
-  const raw = fs.readFileSync(path.join(__dirname, 'data', 'scenarios.yaml'), 'utf-8')
+export interface RunOptions {
+  /** Per-category sample count. When undefined, runs the full default scenario set. */
+  iterations?: number
+  embedder?: EmbedderName
+  /** 'hybrid' (default), 'bm25', or 'semantic'. */
+  searchMode?: string
+  category?: string
+  /** Deterministic seed for sampling. Default 1337. */
+  seed?: number
+  /** Where to write the JSON + Markdown output. Default: benchmark/results. */
+  outputDir?: string
+  /** Silence per-query log output. */
+  quiet?: boolean
+  /**
+   * Cross-encoder reranker stage (#220). Default: 'off' (backward-compatible
+   * with prior reports). Use 'on' to enable the BGE reranker for every
+   * recall call so the report reflects rerank-on numbers.
+   */
+  rerank?: 'on' | 'off'
+  /** Which corpus to load (default 'fixture' for backward compat). */
+  corpus?: CorpusName
+  /**
+   * Persistent PLUR store path. When set, the harness uses this directory
+   * instead of mktempdir, skips ingestion if the store already contains
+   * engrams, and DOES NOT delete it on exit. Use to reuse an ingested
+   * corpus across multiple config variants (rerank on/off, intent on/off,
+   * etc.) without re-ingesting ~30k engrams on every run.
+   *
+   * IMPORTANT: only safe to reuse across runs that share the same embedder
+   * and same corpus, since the stored vectors are embedder-specific.
+   */
+  plurPath?: string
+  /**
+   * When true and plurPath is set, force re-ingestion even if the store
+   * already has engrams. Useful when the corpus or scenario set changed.
+   */
+  forceIngest?: boolean
+}
+
+export interface RunOutput {
+  jsonPath: string
+  mdPath: string
+  summary: BenchmarkSummary
+  results: ScenarioResult[]
+}
+
+export interface BenchmarkSummary {
+  commit: string
+  timestamp: string
+  embedder: EmbedderName
+  embedder_stub_fallback: boolean
+  search_mode: string
+  /** Cross-encoder reranker state (#220). 'on' or 'off'. */
+  rerank: 'on' | 'off'
+  corpus: CorpusName
+  scenario_count: number
+  iterations_per_category: number | null
+  seed: number
+  // Headline metrics (LongMemEval taxonomy):
+  r5: number          // % of queries with the right engram in the top 5 (a.k.a. Hit@5).
+  r1: number          // % of queries with the right engram at rank 1 (a.k.a. Hit@1).
+  accuracy: number    // % of queries where every expected_keyword is found in top 10.
+  // Latency over recall() / recallHybrid() / recallSemantic() per query, in ms:
+  latency_p50_ms: number
+  latency_p95_ms: number
+  latency_p99_ms: number
+  // Footprint:
+  peak_rss_mb: number
+  store_size_bytes: number
+  // Per-category breakdown:
+  per_category: Record<string, {
+    r5: number
+    r1: number
+    hit10: number
+    mrr: number
+    accuracy: number
+    latency_p50_ms: number
+    latency_p95_ms: number
+    latency_p99_ms: number
+    count: number
+  }>
+}
+
+// ─── Loaders ────────────────────────────────────────────────────────
+
+export function loadScenarios(filterCategory?: string, corpus: CorpusName = 'fixture'): Scenario[] {
+  const file = CORPUS_FILES[corpus]
+  if (!file) {
+    throw new Error(`Unknown corpus "${corpus}". Use one of: ${Object.keys(CORPUS_FILES).join(', ')}`)
+  }
+  const fullPath = path.join(__dirname, 'data', file)
+  if (!fs.existsSync(fullPath)) {
+    // Special handling for the real LongMemEval-S — it is gitignored because
+    // of size; the user has to generate it first. Surface the exact command
+    // instead of a generic ENOENT.
+    if (corpus === 'longmemeval-s') {
+      throw new Error(
+        `LongMemEval-S corpus not found at ${fullPath}.\n\n` +
+        `Generate it locally with:\n` +
+        `  huggingface-cli download xiaowu0162/longmemeval --repo-type dataset \\\n` +
+        `    --local-dir benchmark/data/longmemeval-source/\n` +
+        `  npx tsx benchmark/scripts/import-longmemeval.ts\n\n` +
+        `Or use --corpus longmemeval-s-smoke for the committed 30-scenario subset.`
+      )
+    }
+    throw new Error(`Corpus file not found: ${fullPath}`)
+  }
+  const raw = fs.readFileSync(fullPath, 'utf-8')
   let scenarios = yaml.load(raw) as Scenario[]
   if (filterCategory) scenarios = scenarios.filter(s => s.category === filterCategory)
   return scenarios
 }
+
+// ─── Seeded sampling ────────────────────────────────────────────────
+
+/**
+ * Deterministic per-category sampler. Given an `N`, returns N scenarios from
+ * each category, sampled with a seeded PRNG. When N exceeds the per-category
+ * pool we sample with replacement so callers can request the full Sprint 0
+ * LongMemEval-S size (N=500) even though the local fixture only has 5/category.
+ */
+export function sampleScenarios(all: Scenario[], n: number, seed: number): Scenario[] {
+  const categories = [...new Set(all.map(s => s.category))].sort()
+  const rng = mulberry32(seed >>> 0)
+  const out: Scenario[] = []
+
+  for (const cat of categories) {
+    const pool = all.filter(s => s.category === cat)
+    if (pool.length === 0) continue
+
+    if (n <= pool.length) {
+      // Sample without replacement — Fisher–Yates partial shuffle.
+      const idx = Array.from({ length: pool.length }, (_, i) => i)
+      for (let i = idx.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1))
+        ;[idx[i], idx[j]] = [idx[j], idx[i]]
+      }
+      for (let i = 0; i < n; i++) out.push(pool[idx[i]])
+    } else {
+      // Sample with replacement (needed when n > pool.length).
+      for (let i = 0; i < n; i++) {
+        const j = Math.floor(rng() * pool.length)
+        out.push(pool[j])
+      }
+    }
+  }
+  return out
+}
+
+/** mulberry32 — small, fast, well-distributed PRNG with explicit seed. */
+function mulberry32(seed: number): () => number {
+  let a = seed
+  return function () {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
 
 function keywordMatch(statement: string, keywords: string[]): boolean {
   const lower = statement.toLowerCase()
@@ -56,52 +267,193 @@ function findRank(results: Array<{ statement: string }>, keywords: string[]): nu
   return null
 }
 
-async function runBenchmark(searchMode: string, category?: string) {
-  const scenarios = loadScenarios(category)
-  if (!scenarios.length) { console.error('No scenarios found.'); process.exit(1) }
+export function percentile(sorted: number[], p: number): number {
+  // Iter-2 audit M-5 (Dijkstra F-DIJK-004): fix off-by-one at the high end.
+  // The previous `floor((p/100) * len)` returned index 19 for p=95 on a
+  // 20-element array (the maximum), which equals max(). The simple-discrete
+  // formula `floor((p/100) * (len-1))` returns index 18 (the 19th smallest)
+  // — matching numpy.percentile(..., method='lower'). For N=500 this
+  // shifts p95 by exactly one observation.
+  if (sorted.length === 0) return 0
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * (sorted.length - 1)))
+  return sorted[idx]
+}
 
-  // Create isolated temp PLUR instance
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-bench-'))
-  const engDir = path.join(tmpDir, 'engrams.yaml')
-  const epDir = path.join(tmpDir, 'episodes.yaml')
-  const cfgDir = path.join(tmpDir, 'config.yaml')
-  fs.writeFileSync(engDir, '[]')
-  fs.writeFileSync(epDir, '[]')
-  fs.writeFileSync(cfgDir, 'auto_learn: true\nindex: false\n')
+function dirSize(dir: string): number {
+  let total = 0
+  try {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) total += dirSize(full)
+      else if (entry.isFile()) total += fs.statSync(full).size
+    }
+  } catch { /* path gone */ }
+  return total
+}
 
-  const plur = new Plur({ path: tmpDir })
+function commitSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { cwd: __dirname, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim() || 'unknown'
+  } catch { return 'unknown' }
+}
 
-  // Ingest all conversations
-  let engramCount = 0
-  for (const scenario of scenarios) {
-    for (const session of scenario.conversations) {
-      for (const turn of session.turns) {
-        if (turn.role === 'user') {
-          plur.learn(turn.content, { type: 'behavioral', source: `benchmark:${scenario.id}:s${session.session}` })
-          engramCount++
-        } else if (turn.role === 'assistant') {
-          plur.learn(turn.content, { type: 'behavioral', source: `benchmark:${scenario.id}:s${session.session}:assistant` })
-          engramCount++
-        }
-      }
+function isoStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-')
+}
+
+// Source of truth for embedder names lives in @plur-ai/core. Post-Sprint-0
+// follow-up: openai-3-large is now runnable in the harness when
+// OPENAI_API_KEY is set, so we can produce gbrain-comparable numbers on
+// real LongMemEval-S. The wrapper costs real money per run — caller's
+// responsibility, not a CI default.
+const HARNESS_EXCLUDED: ReadonlySet<EmbedderName> = new Set()
+const KNOWN_EMBEDDERS: EmbedderName[] = KNOWN_EMBEDDERS_FROM_CORE.filter(
+  (n) => !HARNESS_EXCLUDED.has(n),
+)
+
+// ─── Main harness ───────────────────────────────────────────────────
+
+export async function runBenchmark(opts: RunOptions = {}): Promise<RunOutput> {
+  const embedder: EmbedderName = (opts.embedder ?? 'minilm') as EmbedderName
+  if (!KNOWN_EMBEDDERS.includes(embedder)) {
+    throw new Error(`Unknown embedder "${embedder}". Use one of: ${KNOWN_EMBEDDERS.join(', ')}`)
+  }
+
+  // PR 4: all four embedders have real adapters behind them. We route the
+  // active model through the EmbedderAdapter factory + PLUR_EMBEDDER env var,
+  // so the engine actually switches embedding model when --embedder changes.
+  const adapter: EmbedderAdapter = getEmbedderAdapter(embedder)
+  // Force the engine to pick the same embedder we are about to benchmark.
+  // Reset any embedder pipeline cached by a previous run in this process so
+  // back-to-back bake-off runs don't stick to whichever model loaded first.
+  process.env.PLUR_EMBEDDER = embedder
+  resetEmbedder()
+  // Pre-warm the adapter so first-query latency includes one cold load
+  // instead of polluting the first scenario's p50 reading. Swallow errors —
+  // if the load fails (e.g. the model isn't reachable on a sandboxed CI
+  // runner) the engine still degrades gracefully to BM25-only via
+  // embeddings.ts and the run produces a valid (lower-recall) report.
+  const embedderStubFallback = false
+  try {
+    await adapter.embed('warmup')
+    if (!opts.quiet) {
+      console.log(`[embedder] "${embedder}" loaded (${adapter.modelId}, ${adapter.dim}d).`)
+    }
+  } catch (err) {
+    if (!opts.quiet) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.log(`[embedder] "${embedder}" cold-load failed: ${msg}`)
+      console.log('[embedder] continuing — hybrid search will fall back to BM25 for any missed embeddings.')
     }
   }
 
-  console.log(`Ingested ${engramCount} engrams from ${scenarios.length} scenarios.\n`)
+  const searchMode = opts.searchMode ?? 'hybrid'
+  const seed = opts.seed ?? 1337
+  const outputDir = opts.outputDir ?? path.join(__dirname, 'results')
+  const corpus: CorpusName = opts.corpus ?? 'fixture'
 
-  // Run queries
+  // Pick scenarios. With --iterations, sample N per category deterministically.
+  // Without --iterations, use the full default scenario set (backward-compat).
+  const all = loadScenarios(opts.category, corpus)
+  const scenarios = opts.iterations !== undefined
+    ? sampleScenarios(all, opts.iterations, seed)
+    : all
+
+  if (!scenarios.length) {
+    throw new Error('No scenarios found.')
+  }
+
+  // Per-run PLUR store. Either:
+  //   (a) auto-mkdtemp — fresh isolated store, deleted on exit (default)
+  //   (b) opts.plurPath — persistent reusable store, kept on exit
+  //
+  // Persistent mode lets follow-on runs reuse a corpus-ingested store
+  // (same embedder + same corpus) without re-ingesting ~30k engrams every
+  // time. Saves hours per run on real LongMemEval-S.
+  const useEphemeral = !opts.plurPath
+  let tmpDir: string
+  if (useEphemeral) {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-bench-'))
+  } else {
+    tmpDir = opts.plurPath!
+    fs.mkdirSync(tmpDir, { recursive: true })
+  }
+  const engramsYamlPath = path.join(tmpDir, 'engrams.yaml')
+  if (!fs.existsSync(engramsYamlPath)) fs.writeFileSync(engramsYamlPath, '[]')
+  const episodesYamlPath = path.join(tmpDir, 'episodes.yaml')
+  if (!fs.existsSync(episodesYamlPath)) fs.writeFileSync(episodesYamlPath, '[]')
+  // allow_secrets: true — the LongMemEval-S corpus contains demo strings that
+  // trip the secret-detection guard ("password_assignment", "api_key_assigned",
+  // etc.). They are benchmark fixtures, not real secrets; the guard would
+  // otherwise abort ingestion partway through.
+  fs.writeFileSync(
+    path.join(tmpDir, 'config.yaml'),
+    'auto_learn: true\nindex: false\nallow_secrets: true\n',
+  )
+
+  const plur = new Plur({ path: tmpDir })
+
+  // ─── Ingest ──────────────────────────────────────────────────────
+  // Skip ingestion when the persistent store already has engrams — unless
+  // --force-ingest is set. Detection: count entries in engrams.yaml at load.
+  const existingCount = plur.list().length
+  const shouldSkipIngest =
+    !useEphemeral && existingCount > 0 && !opts.forceIngest
+
+  let engramCount = existingCount
+  // Use a Set on scenario ID to dedupe ingestion when N > pool.length (sampling
+  // with replacement returns the same conversation more than once).
+  const ingestedScenarios = new Set<string>()
+  if (shouldSkipIngest) {
+    if (!opts.quiet) {
+      console.log(`Reusing persistent store at ${tmpDir} (${existingCount} engrams already present, skipping ingest).\n`)
+    }
+  } else {
+    for (const scenario of scenarios) {
+      if (ingestedScenarios.has(scenario.id)) continue
+      ingestedScenarios.add(scenario.id)
+      for (const session of scenario.conversations) {
+        for (const turn of session.turns) {
+          if (turn.role === 'user') {
+            plur.learn(turn.content, { type: 'behavioral', source: `benchmark:${scenario.id}:s${session.session}` })
+            engramCount++
+          } else if (turn.role === 'assistant') {
+            plur.learn(turn.content, { type: 'behavioral', source: `benchmark:${scenario.id}:s${session.session}:assistant` })
+            engramCount++
+          }
+        }
+      }
+    }
+    if (!opts.quiet) {
+      console.log(`Ingested ${engramCount} engrams from ${ingestedScenarios.size} unique scenarios (${scenarios.length} query rounds).\n`)
+    }
+  }
+
+  // Track peak RSS continuously while we hammer recall().
+  let peakRssBytes = process.memoryUsage().rss
+
+  // ─── Query ───────────────────────────────────────────────────────
+  // #220: cross-encoder reranker is opt-in via --rerank on. When on, every
+  // recall call passes `rerank: true` so the BGE reranker reshuffles the
+  // top-K candidates and the report reflects rerank-on numbers.
+  const rerankOn = opts.rerank === 'on'
   const results: ScenarioResult[] = []
   for (const scenario of scenarios) {
     let retrieved: Array<{ id: string; statement: string }>
-
+    const t0 = process.hrtime.bigint()
     if (searchMode === 'bm25') {
       retrieved = plur.recall(scenario.query, { limit: 10 })
     } else if (searchMode === 'semantic') {
-      retrieved = await plur.recallSemantic(scenario.query, { limit: 10 })
+      retrieved = await plur.recallSemantic(scenario.query, { limit: 10, rerank: rerankOn })
     } else {
-      // hybrid (default)
-      retrieved = await plur.recallHybrid(scenario.query, { limit: 10 })
+      retrieved = await plur.recallHybrid(scenario.query, { limit: 10, rerank: rerankOn })
     }
+    const t1 = process.hrtime.bigint()
+    const latency_ms = Number(t1 - t0) / 1_000_000
+
+    const rss = process.memoryUsage().rss
+    if (rss > peakRssBytes) peakRssBytes = rss
 
     const rank = findRank(retrieved, scenario.expected_keywords)
     const allKeywordsFound = scenario.expected_keywords.every(kw =>
@@ -114,76 +466,217 @@ async function runBenchmark(searchMode: string, category?: string) {
       query: scenario.query,
       expected_keywords: scenario.expected_keywords,
       retrieved_statements: retrieved.map(r => r.statement).slice(0, 5),
+      hit_at_1: rank === 1,
       hit_at_5: rank !== null && rank <= 5,
       hit_at_10: rank !== null && rank <= 10,
       mrr: rank !== null ? 1 / rank : 0,
       accuracy: allKeywordsFound,
       rank,
+      latency_ms,
     }
     results.push(result)
 
-    const mark = result.hit_at_10 ? '[o]' : '[x]'
-    const matches = scenario.expected_keywords.filter(kw =>
-      retrieved.some(r => r.statement.toLowerCase().includes(kw.toLowerCase()))
-    )
-    console.log(`  ${mark} ${scenario.id}: rank=${rank ?? 'miss'} mrr=${result.mrr.toFixed(3)} matches=[${matches.join(', ')}]`)
+    if (!opts.quiet) {
+      const mark = result.hit_at_10 ? '[o]' : '[x]'
+      const matches = scenario.expected_keywords.filter(kw =>
+        retrieved.some(r => r.statement.toLowerCase().includes(kw.toLowerCase()))
+      )
+      console.log(`  ${mark} ${scenario.id}: rank=${rank ?? 'miss'} lat=${latency_ms.toFixed(1)}ms mrr=${result.mrr.toFixed(3)} matches=[${matches.join(', ')}]`)
+    }
   }
 
-  // Compute aggregates
-  const categories = [...new Set(results.map(r => r.category))]
-
-  console.log('\n\nResults Summary')
-  console.log('===============\n')
-
-  const hit5 = results.filter(r => r.hit_at_5).length / results.length * 100
-  const hit10 = results.filter(r => r.hit_at_10).length / results.length * 100
-  const avgMrr = results.reduce((sum, r) => sum + r.mrr, 0) / results.length
+  // ─── Aggregate ───────────────────────────────────────────────────
+  const r5 = results.filter(r => r.hit_at_5).length / results.length * 100
+  const r1 = results.filter(r => r.hit_at_1).length / results.length * 100
   const accuracy = results.filter(r => r.accuracy).length / results.length * 100
 
-  console.log('Overall:')
-  console.log(`  Hit@5:     ${hit5.toFixed(1)}%`)
-  console.log(`  Hit@10:    ${hit10.toFixed(1)}%`)
-  console.log(`  MRR:       ${avgMrr.toFixed(3)}`)
-  console.log(`  Accuracy:  ${accuracy.toFixed(1)}% (all keywords found)`)
+  const allLatencies = results.map(r => r.latency_ms).sort((a, b) => a - b)
+  const latency_p50_ms = percentile(allLatencies, 50)
+  const latency_p95_ms = percentile(allLatencies, 95)
+  const latency_p99_ms = percentile(allLatencies, 99)
 
-  console.log('\nPer Category:')
-  console.log(`${'Category'.padEnd(30)} ${'Hit@5'.padEnd(8)} ${'Hit@10'.padEnd(8)} ${'MRR'.padEnd(8)} ${'Accuracy'.padEnd(8)}`)
-  console.log('-'.repeat(75))
+  // Store footprint: total bytes on disk for the temp PLUR dir at end of run.
+  const store_size_bytes = dirSize(tmpDir)
+  const peak_rss_mb = Math.round((peakRssBytes / (1024 * 1024)) * 100) / 100
 
+  const categories = [...new Set(results.map(r => r.category))]
+  const per_category: BenchmarkSummary['per_category'] = {}
   for (const cat of categories) {
-    const catResults = results.filter(r => r.category === cat)
-    const cHit5 = catResults.filter(r => r.hit_at_5).length / catResults.length * 100
-    const cHit10 = catResults.filter(r => r.hit_at_10).length / catResults.length * 100
-    const cMrr = catResults.reduce((s, r) => s + r.mrr, 0) / catResults.length
-    const cAcc = catResults.filter(r => r.accuracy).length / catResults.length * 100
-    console.log(`${cat.padEnd(30)} ${(cHit5.toFixed(0) + '%').padEnd(8)} ${(cHit10.toFixed(0) + '%').padEnd(8)} ${cMrr.toFixed(3).padEnd(8)} ${(cAcc.toFixed(0) + '%').padEnd(8)}`)
+    const cr = results.filter(r => r.category === cat)
+    const lat = cr.map(r => r.latency_ms).sort((a, b) => a - b)
+    per_category[cat] = {
+      r5: cr.filter(r => r.hit_at_5).length / cr.length * 100,
+      r1: cr.filter(r => r.hit_at_1).length / cr.length * 100,
+      hit10: cr.filter(r => r.hit_at_10).length / cr.length * 100,
+      mrr: cr.reduce((s, r) => s + r.mrr, 0) / cr.length,
+      accuracy: cr.filter(r => r.accuracy).length / cr.length * 100,
+      latency_p50_ms: percentile(lat, 50),
+      latency_p95_ms: percentile(lat, 95),
+      latency_p99_ms: percentile(lat, 99),
+      count: cr.length,
+    }
   }
 
-  // Save results
-  const resultsDir = path.join(__dirname, 'results')
-  fs.mkdirSync(resultsDir, { recursive: true })
-  const date = new Date().toISOString().slice(0, 10)
-  const filename = `${date}-${searchMode}.json`
-  const outPath = path.join(resultsDir, filename)
-  fs.writeFileSync(outPath, JSON.stringify({ date, search_mode: searchMode, overall: { hit5, hit10, mrr: avgMrr, accuracy }, per_category: Object.fromEntries(categories.map(cat => {
-    const cr = results.filter(r => r.category === cat)
-    return [cat, { hit5: cr.filter(r => r.hit_at_5).length / cr.length * 100, hit10: cr.filter(r => r.hit_at_10).length / cr.length * 100, mrr: cr.reduce((s, r) => s + r.mrr, 0) / cr.length, accuracy: cr.filter(r => r.accuracy).length / cr.length * 100 }]
-  })), results }, null, 2))
-  console.log(`\nResults saved to: ${outPath}`)
+  const summary: BenchmarkSummary = {
+    commit: commitSha(),
+    timestamp: new Date().toISOString(),
+    embedder,
+    embedder_stub_fallback: embedderStubFallback,
+    search_mode: searchMode,
+    rerank: rerankOn ? 'on' : 'off',
+    corpus,
+    scenario_count: results.length,
+    iterations_per_category: opts.iterations ?? null,
+    seed,
+    r5,
+    r1,
+    accuracy,
+    latency_p50_ms,
+    latency_p95_ms,
+    latency_p99_ms,
+    peak_rss_mb,
+    store_size_bytes,
+    per_category,
+  }
 
-  // Cleanup
-  fs.rmSync(tmpDir, { recursive: true, force: true })
-  console.log('Temp storage cleaned up.')
+  if (!opts.quiet) {
+    printSummary(summary)
+  }
+
+  // ─── Write outputs ───────────────────────────────────────────────
+  fs.mkdirSync(outputDir, { recursive: true })
+  const baseName = `${summary.commit}-${isoStamp()}`
+  const jsonPath = path.join(outputDir, `${baseName}.json`)
+  const mdPath = path.join(outputDir, `${baseName}.md`)
+
+  fs.writeFileSync(jsonPath, JSON.stringify({ ...summary, results }, null, 2))
+  fs.writeFileSync(mdPath, renderMarkdown(summary))
+
+  if (!opts.quiet) {
+    console.log(`\nJSON saved to: ${jsonPath}`)
+    console.log(`Markdown saved to: ${mdPath}`)
+  }
+
+  // Cleanup the per-run store ONLY if it was ephemeral. Persistent stores
+  // (--plur-path) are kept for reuse by follow-on runs.
+  if (useEphemeral) {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  } else if (!opts.quiet) {
+    console.log(`Persistent store retained at: ${tmpDir}`)
+  }
+
+  return { jsonPath, mdPath, summary, results }
 }
 
-// Parse args
-const args = process.argv.slice(2)
-let searchMode = 'hybrid'
-let category: string | undefined
-
-for (let i = 0; i < args.length; i++) {
-  if (args[i] === '--search-mode' && args[i + 1]) searchMode = args[++i]
-  if (args[i] === '--category' && args[i + 1]) category = args[++i]
+function printSummary(s: BenchmarkSummary) {
+  console.log('\n\nResults Summary')
+  console.log('===============\n')
+  console.log(`Embedder:        ${s.embedder}${s.embedder_stub_fallback ? ' (stub fallback → minilm)' : ''}`)
+  console.log(`Search mode:     ${s.search_mode}`)
+  console.log(`Reranker:        ${s.rerank}`)
+  console.log(`Corpus:          ${s.corpus}`)
+  console.log(`Scenarios:       ${s.scenario_count}${s.iterations_per_category !== null ? ` (N=${s.iterations_per_category}/category, seed=${s.seed})` : ''}`)
+  console.log(`Commit:          ${s.commit}`)
+  console.log()
+  console.log('Overall:')
+  console.log(`  R@5:           ${s.r5.toFixed(1)}%`)
+  console.log(`  R@1:           ${s.r1.toFixed(1)}%`)
+  console.log(`  Accuracy:      ${s.accuracy.toFixed(1)}% (all keywords found)`)
+  console.log()
+  console.log('Latency:')
+  console.log(`  p50:           ${s.latency_p50_ms.toFixed(2)}ms`)
+  console.log(`  p95:           ${s.latency_p95_ms.toFixed(2)}ms`)
+  console.log(`  p99:           ${s.latency_p99_ms.toFixed(2)}ms`)
+  console.log()
+  console.log('Footprint:')
+  console.log(`  Peak RSS:      ${s.peak_rss_mb} MB`)
+  console.log(`  Store size:    ${s.store_size_bytes} bytes`)
+  console.log()
+  console.log('Per Category:')
+  console.log(`${'Category'.padEnd(30)} ${'R@5'.padEnd(8)} ${'R@1'.padEnd(8)} ${'MRR'.padEnd(8)} ${'p95'.padEnd(8)}`)
+  console.log('-'.repeat(70))
+  for (const [cat, m] of Object.entries(s.per_category)) {
+    console.log(`${cat.padEnd(30)} ${(m.r5.toFixed(0) + '%').padEnd(8)} ${(m.r1.toFixed(0) + '%').padEnd(8)} ${m.mrr.toFixed(3).padEnd(8)} ${(m.latency_p95_ms.toFixed(1) + 'ms').padEnd(8)}`)
+  }
 }
 
-runBenchmark(searchMode, category).catch(err => { console.error(err); process.exit(1) })
+function renderMarkdown(s: BenchmarkSummary): string {
+  const lines: string[] = []
+  lines.push(`# PLUR Benchmark — ${s.commit} (${s.timestamp})`)
+  lines.push('')
+  lines.push(`Embedder: \`${s.embedder}\`${s.embedder_stub_fallback ? ' (stub fallback → minilm, real adapter lands in PR 4)' : ''}`)
+  lines.push(`Search mode: \`${s.search_mode}\``)
+  lines.push(`Reranker: \`${s.rerank}\``)
+  lines.push(`Corpus: \`${s.corpus}\``)
+  lines.push(`Scenarios: ${s.scenario_count}${s.iterations_per_category !== null ? ` (N=${s.iterations_per_category}/category, seed=${s.seed})` : ' (default fixture)'}`)
+  lines.push('')
+  lines.push('## Headline')
+  lines.push('')
+  lines.push('| Metric | Value |')
+  lines.push('|---|---|')
+  lines.push(`| R@5 | ${s.r5.toFixed(1)}% |`)
+  lines.push(`| R@1 | ${s.r1.toFixed(1)}% |`)
+  lines.push(`| Accuracy | ${s.accuracy.toFixed(1)}% |`)
+  lines.push(`| Latency p50 | ${s.latency_p50_ms.toFixed(2)} ms |`)
+  lines.push(`| Latency p95 | ${s.latency_p95_ms.toFixed(2)} ms |`)
+  lines.push(`| Latency p99 | ${s.latency_p99_ms.toFixed(2)} ms |`)
+  lines.push(`| Peak RSS | ${s.peak_rss_mb} MB |`)
+  lines.push(`| Store size | ${s.store_size_bytes} bytes |`)
+  lines.push('')
+  lines.push('## Per Category')
+  lines.push('')
+  lines.push('| Category | N | R@5 | R@1 | Hit@10 | MRR | Accuracy | p50 ms | p95 ms | p99 ms |')
+  lines.push('|---|---|---|---|---|---|---|---|---|---|')
+  for (const [cat, m] of Object.entries(s.per_category)) {
+    lines.push(`| ${cat} | ${m.count} | ${m.r5.toFixed(1)}% | ${m.r1.toFixed(1)}% | ${m.hit10.toFixed(1)}% | ${m.mrr.toFixed(3)} | ${m.accuracy.toFixed(1)}% | ${m.latency_p50_ms.toFixed(2)} | ${m.latency_p95_ms.toFixed(2)} | ${m.latency_p99_ms.toFixed(2)} |`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+// ─── CLI entry point ────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): RunOptions {
+  const opts: RunOptions = {}
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--iterations' && argv[i + 1]) opts.iterations = parseInt(argv[++i], 10)
+    else if (a === '--embedder' && argv[i + 1]) opts.embedder = argv[++i] as EmbedderName
+    else if (a === '--search-mode' && argv[i + 1]) opts.searchMode = argv[++i]
+    else if (a === '--category' && argv[i + 1]) opts.category = argv[++i]
+    else if (a === '--seed' && argv[i + 1]) opts.seed = parseInt(argv[++i], 10)
+    else if ((a === '--output' || a === '--output-dir') && argv[i + 1]) opts.outputDir = argv[++i]
+    else if (a === '--quiet') opts.quiet = true
+    else if (a === '--rerank' && argv[i + 1]) {
+      const r = argv[++i]
+      if (r !== 'on' && r !== 'off') {
+        throw new Error(`--rerank takes "on" or "off", got "${r}"`)
+      }
+      opts.rerank = r
+    }
+    else if (a === '--corpus' && argv[i + 1]) {
+      const c = argv[++i] as CorpusName
+      if (!(c in CORPUS_FILES)) {
+        throw new Error(`Unknown corpus "${c}". Use one of: ${Object.keys(CORPUS_FILES).join(', ')}`)
+      }
+      opts.corpus = c
+    }
+    else if (a === '--plur-path' && argv[i + 1]) opts.plurPath = argv[++i]
+    else if (a === '--force-ingest') opts.forceIngest = true
+  }
+  return opts
+}
+
+const isMain = (() => {
+  // Detect "run directly" in both ESM and tsx modes.
+  try {
+    return process.argv[1] && fs.realpathSync(process.argv[1]) === fs.realpathSync(__filename)
+  } catch { return false }
+})()
+
+if (isMain) {
+  runBenchmark(parseArgs(process.argv.slice(2))).catch(err => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/benchmark/scripts/import-longmemeval.ts
+++ b/benchmark/scripts/import-longmemeval.ts
@@ -1,0 +1,362 @@
+#!/usr/bin/env npx tsx
+/**
+ * LongMemEval-S corpus importer for PLUR.
+ *
+ * Reads the official LongMemEval-S dataset (Wu et al, 2024 — arxiv.org/abs/2410.10813)
+ * downloaded from huggingface.co/datasets/xiaowu0162/longmemeval and writes it
+ * out in the YAML shape our benchmark harness consumes (see `Scenario` in
+ * `benchmark/run.ts`).
+ *
+ * Why: Sprint 0 audit flagged that `benchmark/data/scenarios.yaml` is a
+ * 30-scenario hand-curated fixture sampled with replacement to N=500 — not the
+ * real benchmark. gbrain published R@5=97.6% on actual LongMemEval-S. To make
+ * any honest comparison we need the real corpus.
+ *
+ * Usage:
+ *   1. Download the source (one-time, ~280 MB):
+ *        huggingface-cli download xiaowu0162/longmemeval --repo-type dataset \
+ *          --local-dir benchmark/data/longmemeval-source/
+ *   2. Run this converter:
+ *        npx tsx benchmark/scripts/import-longmemeval.ts
+ *      Writes:
+ *        - benchmark/data/longmemeval-s.yaml         (full 500-scenario corpus, gitignored)
+ *        - benchmark/data/longmemeval-s-smoke.yaml   (30 scenarios, 5/category, committed for tests)
+ *
+ * Schema mapping (LongMemEval → PLUR Scenario):
+ *   question_id          -> id
+ *   question_type        -> category (hyphens normalised to underscores)
+ *   haystack_sessions    -> conversations[] (each session indexed 1..N)
+ *   question             -> query
+ *   answer               -> expected_answer
+ *   (derived)            -> expected_keywords  (extracted from answer text)
+ *
+ * The haystack contains ~40-60 sessions per question, only 1-3 of which actually
+ * hold the answer. That needle-in-haystack pattern is the whole point of the
+ * benchmark — we ingest all of them so retrieval has to discriminate.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import yaml from '../../packages/core/node_modules/js-yaml/index.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// ─── Source schema (what huggingface gives us) ──────────────────────
+
+interface LMETurn {
+  role: 'user' | 'assistant'
+  content: string
+  // Some sessions carry an extra `has_answer` flag on the turn that holds
+  // the gold answer; we ignore it — our harness doesn't need oracle marking.
+  has_answer?: boolean
+}
+
+interface LMEEntry {
+  question_id: string
+  question_type: string
+  question: string
+  answer: string
+  question_date: string
+  haystack_dates: string[]
+  haystack_session_ids: string[]
+  haystack_sessions: LMETurn[][]
+  answer_session_ids: string[]
+}
+
+export interface ConvertOptions {
+  /**
+   * Cap haystack sessions per scenario. The full corpus uses every haystack
+   * session (40-60 each) so retrieval has to discriminate; the smoke subset
+   * trims down so a few hundred KB of YAML is enough for tests.
+   * Set to `null` (default for the full corpus) to keep every session.
+   */
+  maxSessionsPerScenario?: number | null
+  /**
+   * When `maxSessionsPerScenario` is set, this controls how the cap is applied.
+   * `"answer_plus_first"`: keep every answer-bearing session, then top up with
+   *   the first non-answer sessions until the cap is reached. Preserves the
+   *   needle-in-haystack shape with a smaller haystack.
+   * `"answer_only"`: keep only the answer sessions (no distractors). Useful
+   *   when YAML size is paramount but loses the discrimination signal.
+   */
+  capMode?: 'answer_plus_first' | 'answer_only'
+}
+
+// ─── Target schema (matches benchmark/run.ts Scenario) ──────────────
+
+interface Scenario {
+  id: string
+  category: string
+  conversations: Array<{ session: number; turns: Array<{ role: string; content: string }> }>
+  query: string
+  expected_answer: string
+  expected_keywords: string[]
+}
+
+// ─── Category normalisation ──────────────────────────────────────────
+// LongMemEval uses hyphens (single-session-user); our fixture uses underscores.
+// Keep the canonical names identical to the fixture so the harness aggregates
+// both corpora into the same six buckets.
+const CATEGORY_MAP: Record<string, string> = {
+  'single-session-user': 'single_session_user',
+  'single-session-preference': 'single_session_preference',
+  'single-session-assistant': 'single_session_assistant',
+  'temporal-reasoning': 'temporal_reasoning',
+  'knowledge-update': 'knowledge_updates',
+  'multi-session': 'multi_session_reasoning',
+}
+
+// ─── Keyword extraction ─────────────────────────────────────────────
+// The PLUR harness scores a result as a "hit" when at least one expected
+// keyword appears in the retrieved statement. LongMemEval doesn't ship keyword
+// labels — only free-form answers. We derive keywords by:
+//   1. Pulling capitalised noun phrases / numbers / units out of the answer.
+//   2. Falling back to the longest unique content words when (1) is empty.
+//
+// This is intentionally simple. The downstream consumer can override
+// `expected_keywords` per-scenario if the harness needs to be more strict.
+
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'is', 'was', 'are', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'must', 'shall', 'can', 'need', 'dare',
+  'and', 'or', 'but', 'nor', 'so', 'yet', 'for', 'with', 'from', 'to',
+  'of', 'in', 'on', 'at', 'by', 'as', 'into', 'about', 'after', 'before',
+  'this', 'that', 'these', 'those', 'it', 'its', 'they', 'them', 'their',
+  'i', 'me', 'my', 'mine', 'you', 'your', 'yours', 'he', 'she', 'him',
+  'her', 'his', 'hers', 'we', 'us', 'our', 'ours',
+  'user', 'would', 'prefer', 'preferred', 'response', 'responses', 'might',
+  'not', 'no', 'yes', 'also', 'maybe', 'acceptable', 'including', 'last',
+  'day', 'days', 'time', 'times',
+])
+
+/**
+ * Extract a small set (1-5) of high-signal keywords from the answer text.
+ * Strategy:
+ *   - First pull numbers + units (years, counts, durations).
+ *   - Then capitalised tokens (proper nouns, acronyms, model names).
+ *   - Then unique non-stopword tokens longer than 3 chars.
+ *   - De-duplicate; cap at 5.
+ */
+export function extractKeywords(rawAnswer: unknown): string[] {
+  // LongMemEval occasionally encodes numeric answers as bare ints (e.g. 3, 99,
+  // 1300). Coerce to string so the regex passes don't crash on .trim().
+  const answer = rawAnswer == null ? '' : String(rawAnswer)
+  if (!answer.trim()) return []
+  const keywords: string[] = []
+  const seen = new Set<string>()
+
+  const push = (kw: string) => {
+    const k = kw.trim()
+    if (!k) return
+    const lower = k.toLowerCase()
+    if (seen.has(lower)) return
+    if (STOPWORDS.has(lower)) return
+    seen.add(lower)
+    keywords.push(k)
+  }
+
+  // 1. Numbers (incl. decimals, times like 8:30, ranges, monetary amounts).
+  //    "25 minutes and 50 seconds (or 25:50)" → ["25", "50", "25:50"]
+  const numMatches = answer.match(/\b\d+(?::\d+)?(?:\.\d+)?\b/g) || []
+  for (const n of numMatches) push(n)
+
+  // 2. Multi-word capitalised proper nouns first ("Business Administration",
+  //    "Tesla Model 3", "Adobe Premiere Pro"). Then single capitalised tokens.
+  const properPhrase = answer.match(/\b[A-Z][a-zA-Z0-9]*(?:\s+[A-Z][a-zA-Z0-9]*)+\b/g) || []
+  for (const p of properPhrase) push(p)
+  const properSingle = answer.match(/\b[A-Z][a-zA-Z0-9]{2,}\b/g) || []
+  for (const p of properSingle) push(p)
+
+  // 3. Long content words as fallback (only if we still have < 2 keywords).
+  if (keywords.length < 2) {
+    const tokens = (answer.match(/\b[a-zA-Z]{4,}\b/g) || [])
+      .filter(t => !STOPWORDS.has(t.toLowerCase()))
+      // Bias toward distinctive content — prefer rarer-looking tokens (longer).
+      .sort((a, b) => b.length - a.length)
+    for (const t of tokens) {
+      push(t)
+      if (keywords.length >= 3) break
+    }
+  }
+
+  // Cap at 5 — harness counts a hit if ANY keyword matches, so more keywords
+  // make hits cheaper. Five is generous without being trivial.
+  return keywords.slice(0, 5)
+}
+
+// ─── Conversion ─────────────────────────────────────────────────────
+
+export function convertEntry(entry: LMEEntry, opts: ConvertOptions = {}): Scenario {
+  const category = CATEGORY_MAP[entry.question_type] ?? entry.question_type.replace(/-/g, '_')
+
+  // Decide which haystack-session indices to keep.
+  const all = entry.haystack_sessions
+  const answerIds = new Set(entry.answer_session_ids)
+  const keepIndices: number[] = []
+
+  if (opts.maxSessionsPerScenario == null) {
+    for (let i = 0; i < all.length; i++) keepIndices.push(i)
+  } else {
+    const answerIdxs: number[] = []
+    const otherIdxs: number[] = []
+    for (let i = 0; i < all.length; i++) {
+      if (answerIds.has(entry.haystack_session_ids[i])) answerIdxs.push(i)
+      else otherIdxs.push(i)
+    }
+
+    if (opts.capMode === 'answer_only') {
+      for (const i of answerIdxs) keepIndices.push(i)
+    } else {
+      // answer_plus_first (default): every answer session, plus distractors
+      // from the front of the haystack until we hit the cap.
+      const cap = opts.maxSessionsPerScenario
+      for (const i of answerIdxs) keepIndices.push(i)
+      for (const i of otherIdxs) {
+        if (keepIndices.length >= cap) break
+        keepIndices.push(i)
+      }
+      keepIndices.sort((a, b) => a - b)
+    }
+  }
+
+  const conversations = keepIndices.map((srcIdx, dstIdx) => {
+    const turns = all[srcIdx]
+    return {
+      session: dstIdx + 1,
+      turns: turns.map(t => ({
+        role: t.role,
+        // Trim absurdly long single turns to keep YAML manageable. The benchmark
+        // ingests turn-by-turn; a 50k-char single turn would dominate one engram
+        // and break the retrieval signal. Long turns get truncated at 4000 chars
+        // with a marker so the test still sees the discriminating content.
+        content: t.content.length > 4000
+          ? t.content.slice(0, 4000) + ' [...truncated]'
+          : t.content,
+      })),
+    }
+  })
+
+  return {
+    id: entry.question_id,
+    category,
+    conversations,
+    query: entry.question,
+    expected_answer: String(entry.answer ?? ''),
+    expected_keywords: extractKeywords(entry.answer),
+  }
+}
+
+// ─── Smoke-subset selection ────────────────────────────────────────
+//
+// We commit a small subset (5 per category) so unit tests can exercise the
+// real schema without pulling the full 280 MB corpus on every CI run. Picks
+// the first 5 entries per category — deterministic, no PRNG needed.
+
+function pickSmokeSubset(all: Scenario[], perCategory = 5): Scenario[] {
+  const buckets = new Map<string, Scenario[]>()
+  for (const s of all) {
+    if (!buckets.has(s.category)) buckets.set(s.category, [])
+    const bucket = buckets.get(s.category)!
+    if (bucket.length < perCategory) bucket.push(s)
+  }
+  return [...buckets.values()].flat()
+}
+
+/** Same as pickSmokeSubset but on the raw LME entries (so we can re-convert
+ *  with a tighter session cap for the smoke YAML). */
+function pickSmokeEntries(all: LMEEntry[], perCategory = 5): LMEEntry[] {
+  const buckets = new Map<string, LMEEntry[]>()
+  for (const e of all) {
+    const cat = CATEGORY_MAP[e.question_type] ?? e.question_type
+    if (!buckets.has(cat)) buckets.set(cat, [])
+    const bucket = buckets.get(cat)!
+    if (bucket.length < perCategory) bucket.push(e)
+  }
+  return [...buckets.values()].flat()
+}
+
+// ─── Main ───────────────────────────────────────────────────────────
+
+function main() {
+  // benchmark/data/longmemeval-source/longmemeval_s — note: the HF download
+  // saves the file without an extension, but it is plain JSON.
+  const repoRoot = path.resolve(__dirname, '..', '..')
+  const srcCandidates = [
+    path.join(repoRoot, 'benchmark', 'data', 'longmemeval-source', 'longmemeval_s'),
+    path.join(repoRoot, 'benchmark', 'data', 'longmemeval-source', 'longmemeval_s.json'),
+  ]
+  const src = srcCandidates.find(p => fs.existsSync(p))
+  if (!src) {
+    console.error(`
+[error] LongMemEval-S source not found.
+
+Expected one of:
+${srcCandidates.map(p => '  ' + p).join('\n')}
+
+Download with:
+  huggingface-cli download xiaowu0162/longmemeval --repo-type dataset \\
+    --local-dir benchmark/data/longmemeval-source/
+`)
+    process.exit(1)
+  }
+
+  console.log(`[1/4] Reading ${path.relative(repoRoot, src)} ...`)
+  const raw = fs.readFileSync(src, 'utf-8')
+  const entries: LMEEntry[] = JSON.parse(raw)
+  console.log(`      ${entries.length} questions loaded.`)
+
+  console.log('[2/4] Converting to PLUR Scenario shape ...')
+  const scenarios = entries.map(e => convertEntry(e))
+
+  // Stats per category.
+  const counts = new Map<string, number>()
+  for (const s of scenarios) counts.set(s.category, (counts.get(s.category) ?? 0) + 1)
+  console.log('      Per-category counts:')
+  for (const [cat, n] of [...counts.entries()].sort()) {
+    console.log(`        ${cat.padEnd(32)} ${n}`)
+  }
+  console.log(`      total                            ${scenarios.length}`)
+
+  const dataDir = path.join(repoRoot, 'benchmark', 'data')
+  const fullOut = path.join(dataDir, 'longmemeval-s.yaml')
+  const smokeOut = path.join(dataDir, 'longmemeval-s-smoke.yaml')
+
+  console.log(`[3/4] Writing full corpus: ${path.relative(repoRoot, fullOut)}`)
+  // noRefs avoids YAML anchors which break round-tripping in some loaders.
+  // lineWidth -1 keeps long content on a single line for diff-ability.
+  fs.writeFileSync(fullOut, yaml.dump(scenarios, { noRefs: true, lineWidth: -1 }))
+  const fullSize = fs.statSync(fullOut).size
+  console.log(`      ${(fullSize / (1024 * 1024)).toFixed(1)} MB`)
+
+  console.log(`[4/4] Writing smoke subset: ${path.relative(repoRoot, smokeOut)}`)
+  // Smoke subset: 5 scenarios per category, capped at 6 haystack sessions each
+  // (every answer session + early distractors). Trims ~15 MB → ~few hundred KB
+  // so unit tests can load it cheaply while still exercising real schema.
+  const smokeEntries = pickSmokeEntries(entries, 5)
+  const smoke = smokeEntries.map(e => convertEntry(e, {
+    maxSessionsPerScenario: 6,
+    capMode: 'answer_plus_first',
+  }))
+  fs.writeFileSync(smokeOut, yaml.dump(smoke, { noRefs: true, lineWidth: -1 }))
+  const smokeSize = fs.statSync(smokeOut).size
+  console.log(`      ${smoke.length} scenarios, ${(smokeSize / 1024).toFixed(1)} KB`)
+
+  console.log('\nDone.')
+}
+
+const isMain = (() => {
+  try {
+    return process.argv[1] && fs.realpathSync(process.argv[1]) === fs.realpathSync(__filename)
+  } catch { return false }
+})()
+
+if (isMain) {
+  try {
+    main()
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}

--- a/benchmark/setup-env.ts
+++ b/benchmark/setup-env.ts
@@ -1,0 +1,12 @@
+// Sprint 0 PR 5 (#219): pin embedder for benchmark smoke tests so CI runs
+// don't trigger an EmbeddingGemma download. Real bake-off runs invoke the
+// CLI with PLUR_EMBEDDER set explicitly.
+if (!process.env.PLUR_EMBEDDER) {
+  process.env.PLUR_EMBEDDER = 'bge-small'
+}
+// Sprint 0 iter-2 audit M-3: production default backend flipped to 'pglite'.
+// PGLite spin-up cost in benchmark smoke tests adds 20-60s per test; force
+// 'sqlite' (overriding even if previously set) to keep the suite hermetic.
+// Real benchmark runs set PLUR_BACKEND explicitly via the CLI; the in-process
+// runBenchmark() invoked from tests should always use the fast legacy path.
+process.env.PLUR_BACKEND = 'sqlite'

--- a/benchmark/vitest.config.ts
+++ b/benchmark/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+
+// Sprint 0 PR 5 (#219): pin embedder for hermetic CI runs.
+// Iter-2 audit M-3: pool: 'forks' for env-var isolation between files.
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['**/*.test.ts'],
+    // Benchmarks spin up the embedder and run the harness; give them room.
+    testTimeout: 120_000,
+    hookTimeout: 60_000,
+    setupFiles: ['./setup-env.ts'],
+    pool: 'forks',
+  },
+})

--- a/packages/core/src/embedders/transformers-base.ts
+++ b/packages/core/src/embedders/transformers-base.ts
@@ -33,6 +33,11 @@ async function loadPipeline(modelId: string, dtype: TransformersAdapterConfig['d
   let pending = pipelineCache.get(key)
   if (!pending) {
     pending = (async () => {
+      // Force the classic HF download path: the Xet transfer protocol truncates
+      // ONNX model files in this stack (@huggingface/transformers 3.8.1),
+      // producing corrupt models ("Protobuf parsing failed") that silently
+      // degrade recall to fallback. Never use Xet. (#340)
+      process.env.HF_HUB_DISABLE_XET ??= '1'
       const { pipeline } = await import('@huggingface/transformers')
       return pipeline('feature-extraction', modelId, dtype ? { dtype } : undefined)
     })()

--- a/packages/core/src/rerankers/bge-reranker-v2-m3.ts
+++ b/packages/core/src/rerankers/bge-reranker-v2-m3.ts
@@ -54,6 +54,10 @@ let pending: Promise<LoadedPipeline> | null = null
 async function loadPipeline(modelId: string, dtype: 'q8' | 'fp32'): Promise<LoadedPipeline> {
   if (!pending) {
     pending = (async () => {
+      // Force the classic HF download path — the Xet transfer protocol truncates
+      // ONNX downloads in this stack, corrupting the model ("Protobuf parsing
+      // failed") so the reranker silently falls back to RRF order. Never use Xet. (#340)
+      process.env.HF_HUB_DISABLE_XET ??= '1'
       const { AutoTokenizer, AutoModelForSequenceClassification } = await import('@huggingface/transformers')
       const [tokenizer, model] = await Promise.all([
         AutoTokenizer.from_pretrained(modelId),


### PR DESCRIPTION
**PR-2 of the Sprint-0 unbundle (#332)** — the benchmark harness (#251/#46), **stacked on PR-4 #342** (it consumes PR-4's rerank/intent recall options). Review/merge after #342.

> Base is `feat/recall-rerank-intent` (PR-4). GitHub will retarget this to `main` once #342 merges; its diff is then just the 2 commits below.

## What's here
- **`benchmark/run.ts`** (+per-question/micro/scripts/setup-env/vitest.config) — `--iterations`/`--embedder`/`--seed`/`--corpus`/`--rerank`, latency p50/p95/p99, peak RSS, store size, JSON+MD output.
- **#336 fold** — gitignore `benchmark/results/` + `benchmark/.cache/` (generated artifacts → plur-bench). The small `scenarios.yaml` fixture (already tracked) is the one committed corpus; the 21k smoke corpus stays out (its tests skip when absent locally).

## Two fixes that surfaced *during* benchmarking (bundled here)
- **Xet hardening (#340)** — `embedders/transformers-base.ts` + `rerankers/bge-reranker-v2-m3.ts` now force `HF_HUB_DISABLE_XET` before loading transformers. The Xet transfer truncates ONNX downloads in this stack → corrupt models ("Protobuf parsing failed") that silently degrade recall/rerank to fallback. No more per-run env var.
- **Reranker observability (#341)** — the harness records how many queries the reranker *actually* reordered and prints a loud `engaged N/M ⚠ requested but never ran — RRF-only` warning, so a silent reranker fallback can't mislabel results.

## Verification
- Harness unit tests pass offline (22); end-to-end benchmark verified with the real bge-small model (`vitest --root benchmark`, 23 pass/2 skip).
- Not in CI's `pnpm test` (workspace = `packages/*`); run via `HF_HUB_DISABLE_XET=1 pnpm exec vitest run --root benchmark`.

Folds #336. Relates #340, #341. Part of #332.