### PR TITLE
fix(core): scope guard — scan full content + surface demotion (follow-up to #326)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -812,18 +812,26 @@ export class Plur {
   private _guardSensitiveScope(
     statement: string,
     context?: LearnContext,
-  ): { scope: string; context: LearnContext | undefined } {
+  ): { scope: string; context: LearnContext | undefined; demotion: { from: string; to: string; patterns: string } | null } {
     const scope = context?.scope ?? this._sessionScope ?? 'global'
-    if (!isSharedScope(scope)) return { scope, context }
-    const hits = detectSensitive(statement)
-    if (hits.length === 0) return { scope, context }
+    if (!isSharedScope(scope)) return { scope, context, demotion: null }
+    // Scan the FULL content the engram will carry — the statement AND the
+    // context fields (rationale, key_files, source, …), not just the statement.
+    // Sensitive material hides in context too (#326 review, finding 1).
+    const scanText = `${statement}\n${JSON.stringify(context ?? {})}`
+    const hits = detectSensitive(scanText)
+    if (hits.length === 0) return { scope, context, demotion: null }
     const patterns = [...new Set(hits.map(h => h.pattern))].join(', ')
     logger.warning(
       `[plur] sensitive content (${patterns}) held back from shared scope "${scope}" — ` +
       `demoted to local/private so it is not written to a shared store. ` +
       `Re-scope deliberately if this is a false positive.`,
     )
-    return { scope: 'local', context: { ...context, scope: 'local', visibility: 'private' } }
+    return {
+      scope: 'local',
+      context: { ...context, scope: 'local', visibility: 'private' },
+      demotion: { from: scope, to: 'local', patterns },
+    }
   }
 
   learn(statement: string, context?: LearnContext): Engram {
@@ -930,6 +938,16 @@ export class Plur {
           conflicts: conflictIds,
         } : undefined,
         pinned: context?.pinned === true ? true : undefined,
+      }
+
+      // Stamp the demotion marker (#326 review, finding 2) so the plur_learn MCP
+      // response can tell the agent its engram was held back from the shared scope
+      // it asked for. Set only on a direct learn() whose own guard demoted.
+      if (guarded.demotion) {
+        ;(engram as any).structured_data = {
+          ...((engram as any).structured_data ?? {}),
+          _demoted: guarded.demotion,
+        }
       }
 
       // Multi-store routing (issue #26 outbox pattern): if the engram's
@@ -1053,8 +1071,17 @@ export class Plur {
     context = guarded.context
     const remoteDriver = this._resolveRemoteStoreForScope(scope)
     if (!remoteDriver) {
-      // Local route — sync learn() owns dedup, build, write, history.
-      return this.learn(statement, context)
+      // Local route — sync learn() owns dedup, build, write, history. learn()'s
+      // own guard sees the already-demoted (local) context and no-ops, so the
+      // demotion marker is stamped here for the learnRouted-demoted case (#326).
+      const engram = this.learn(statement, context)
+      if (guarded.demotion) {
+        ;(engram as any).structured_data = {
+          ...((engram as any).structured_data ?? {}),
+          _demoted: guarded.demotion,
+        }
+      }
+      return engram
     }
     // Remote route — dedup against the merged local+cached-remote view,
     // then POST and merge the server-assigned ID into the local engram

--- a/packages/core/test/scope-guard.test.ts
+++ b/packages/core/test/scope-guard.test.ts
@@ -54,4 +54,17 @@ describe('write-time sensitivity demotion (learn)', () => {
     const e = freshPlur().learn('my droplet is 139.59.155.82', { scope: 'local' }) as { scope: string }
     expect(e.scope).toBe('local')
   })
+
+  it('scans CONTEXT fields too — sensitive content outside the statement still demotes (finding 1)', () => {
+    const e = freshPlur().learn('a totally clean statement', { scope: 'group:plur/engineering', source: 'pulled from 139.59.155.82' } as never) as { scope: string; visibility: string }
+    expect(e.scope).toBe('local')
+    expect(e.visibility).toBe('private')
+  })
+
+  it('stamps a demotion marker the agent can see (finding 2)', () => {
+    const e = freshPlur().learn('deploy at 139.59.155.82', { scope: 'group:plur/engineering' }) as { structured_data?: { _demoted?: { from: string; to: string; patterns: string } } }
+    expect(e.structured_data?._demoted?.from).toBe('group:plur/engineering')
+    expect(e.structured_data?._demoted?.to).toBe('local')
+    expect(e.structured_data?._demoted?.patterns).toMatch(/public_ipv4/)
+  })
 })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -190,6 +190,7 @@ export function getToolDefinitions(): ToolDefinition[] {
         try {
           const engram = await plur.learnRouted(statement, context)
           const isOutbox = !!(engram as any).structured_data?._outbox
+          const demoted = (engram as any).structured_data?._demoted as { from: string; to: string; patterns: string } | undefined
           mcpCanary.signal('learn_activity')
           // Opt-in, content-free engagement counter (default-off; no statement text).
           recordTelemetry('learn')
@@ -200,6 +201,7 @@ export function getToolDefinitions(): ToolDefinition[] {
             decision: 'ADD',
             ...scopeHint(engram.scope),
             ...(isOutbox ? { outbox: true, warning: 'Remote write failed; engram queued locally for retry on next session start or plur_sync.' } : {}),
+            ...(demoted ? { demoted: true, requested_scope: demoted.from, warning: `Sensitive content (${demoted.patterns}) detected — stored at "${demoted.to}"/private instead of the requested shared scope "${demoted.from}". If this is a false positive, re-scope deliberately.` } : {}),
           }
         } catch (err) {
 // learnRouted now saves to outbox on remote failure, so this


### PR DESCRIPTION
Follow-up to **#326**, which merged at the write-time-demotion commit *before* these two review findings landed. Closes them against current main:

- **Finding 1 — full-content scan.** The guard scanned only the `statement`; it now scans `statement + serialized context`, so infra-sensitive material in a context field (`rationale`, `key_files`, `source`, …) is caught and demoted too — not just content in the statement.
- **Finding 2 — agent-visible demotion signal.** Demotion now stamps `structured_data._demoted = {from, to, patterns}` on the engram, and the `plur_learn` MCP handler surfaces `demoted: true` + `requested_scope` + a warning — so the agent knows its write was held back from the shared scope it requested, instead of only a server-side log.

Finding 3 (false-positive over-demotion / `allow_sensitive` override) is intentionally left for later, per review.

Two new `scope-guard.test.ts` cases cover both (context-field detection; the `_demoted` marker). `tsc --noEmit` clean.