### PR TITLE
feat(core): self-describing scope metadata foundation — Stage 2 (#345)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,8 @@ import { installPack, uninstallPack, listPacks, exportPack, scanPrivacy, compute
 // import { exportVault, type VaultExportOptions, type VaultExportResult } from './vault-export.js'
 // import { fetchRegistry, discoverPacks, verifyPackIntegrity, DEFAULT_REGISTRY_URL, type PackRegistry, type RegistryPack } from './registry.js'
 import { sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncStatus } from './sync.js'
-import { detectSecrets, detectSensitive } from './secrets.js'
+import { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
+import type { ScopeMetadata, SensitivityCategory } from './schemas/scope-metadata.js'
 import { appendHistory, readHistoryForEngram, generateEventId } from './history.js'
 import { computeContentHash } from './content-hash.js'
 import { decodeJwtExpiry } from './jwt.js'
@@ -72,7 +73,8 @@ export { applyBatchDecay, strengthToStatus, type BatchDecayResult, type DecayTra
 export { computeContentHash, normalizeStatement } from './content-hash.js'
 export { parseDedupResponse, buildDedupPrompt, buildBatchDedupPrompt } from './dedup.js'
 export { runMigrations, rollbackMigrations, getSchemaVersion, setSchemaVersion, ALL_MIGRATIONS, CURRENT_SCHEMA_VERSION, type Migration, type MigrationResult } from './migrations/index.js'
-export { detectSecrets, detectSensitive } from './secrets.js'
+export { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
+export { ScopeMetadataSchema, ScopeSensitivitySchema, SENSITIVITY_CATEGORIES, type ScopeMetadata, type ScopeSensitivity, type SensitivityCategory } from './schemas/scope-metadata.js'
 
 /**
  * Scopes whose engrams are visible to people *other than* the author — the team
@@ -181,6 +183,26 @@ export interface StatusResult {
  * (#292). `unregistered` is the actionable set: scopes the token is authorized
  * for but that aren't yet in local config.
  */
+/**
+ * One row of `listStores` / `listStoresAsync`. The primary local store plus
+ * each configured `stores` entry. `description`/`covers` are present only when
+ * the entry declares self-describing scope metadata (#345) — additive, so
+ * existing consumers that read only path/url/scope/.../engram_count are
+ * unaffected.
+ */
+export interface StoreSummary {
+  path?: string
+  url?: string
+  scope: string
+  shared: boolean
+  readonly: boolean
+  engram_count: number
+  /** Self-describing scope description (#345), when the entry declares it. */
+  description?: string
+  /** Topics/domains this scope covers (#345), when the entry declares it. */
+  covers?: string[]
+}
+
 export interface RemoteScopeDiscovery {
   url: string
   /** True when `/me` responded; false on network error, 401, etc. */
@@ -800,6 +822,31 @@ export class Plur {
    * Fast-path hash dedup returns existing on exact match.
    */
   /**
+   * Resolve self-describing metadata for a scope from the loaded config (#345).
+   * Metadata is carried on a `stores` entry: the first entry whose `scope`
+   * matches and that declares any metadata field (`description`/`covers`/
+   * `sensitivity`) is materialized into a {@link ScopeMetadata}. Returns
+   * `undefined` when the scope is unknown or declares no metadata — callers
+   * (notably the leak guard) treat that as "fall back to default behavior".
+   *
+   * This is the Stage 2 local resolver. The enterprise `/api/v1/scopes` source
+   * is a separate track; when it lands it can back this same accessor.
+   */
+  getScopeMetadata(scope: string): ScopeMetadata | undefined {
+    const entry = (this.config.stores ?? []).find(
+      s => s.scope === scope &&
+        (s.description !== undefined || s.covers !== undefined || s.sensitivity !== undefined),
+    )
+    if (!entry) return undefined
+    return {
+      scope,
+      description: entry.description ?? '',
+      covers: entry.covers ?? [],
+      ...(entry.sensitivity ? { sensitivity: entry.sensitivity } : {}),
+    }
+  }
+
+  /**
    * Write-time leak guard. If the target scope is one others can read
    * (`isSharedScope`: group:/project:/space:/team:/org:/public) AND the statement
    * trips `detectSensitive` (IPs, internal hosts, basic-auth, host:port, secrets),
@@ -808,6 +855,16 @@ export class Plur {
    * exempt: infra notes legitimately live there. Called at the top of both
    * `learn()` and `learnRouted()`, so every client (CLI, MCP, hooks, OpenClaw,
    * Hermes) is covered, since they all route through one of those two.
+   *
+   * Per-scope policy (#345): when the target scope declares `sensitivity`
+   * metadata, that policy decides demotion. A matched category is tolerated when
+   * it is in `sensitivity.allow` (by category name OR by the specific detector
+   * pattern name) OR not in `sensitivity.forbid`. Only categories that are both
+   * forbidden and not allowed trigger demotion. When the scope has NO metadata,
+   * this falls back EXACTLY to the Stage 1 behavior: any `detectSensitive` hit on
+   * a shared scope demotes. The default policy (`forbid: ['secrets','infra']`,
+   * `allow: []`) reproduces that demote-on-sensitive behavior, so adding metadata
+   * is non-breaking.
    */
   private _guardSensitiveScope(
     statement: string,
@@ -821,7 +878,22 @@ export class Plur {
     const scanText = `${statement}\n${JSON.stringify(context ?? {})}`
     const hits = detectSensitive(scanText)
     if (hits.length === 0) return { scope, context, demotion: null }
-    const patterns = [...new Set(hits.map(h => h.pattern))].join(', ')
+
+    // Per-scope policy: keep only the hits this scope actually forbids. With no
+    // metadata, `sensitivity` is undefined and the default policy forbids
+    // secrets+infra with nothing allowed — i.e. every hit is offending, exactly
+    // the Stage 1 behavior.
+    const policy = this.getScopeMetadata(scope)?.sensitivity
+    const forbid = new Set<SensitivityCategory>(policy?.forbid ?? ['secrets', 'infra'])
+    const allow = new Set<string>(policy?.allow ?? [])
+    const offending = hits.filter(h => {
+      const category = sensitivityCategory(h.pattern)
+      if (allow.has(category) || allow.has(h.pattern)) return false
+      return forbid.has(category)
+    })
+    if (offending.length === 0) return { scope, context, demotion: null }
+
+    const patterns = [...new Set(offending.map(h => h.pattern))].join(', ')
     logger.warning(
       `[plur] sensitive content (${patterns}) held back from shared scope "${scope}" — ` +
       `demoted to local/private so it is not written to a shared store. ` +
@@ -3050,9 +3122,7 @@ Generate an improved version of the procedure that prevents this failure. Return
 
   /** Build the primary-store summary row. Shared by listStores +
    * listStoresAsync to keep them in lockstep. */
-  private _primaryStoreRow(): {
-    path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
-  } {
+  private _primaryStoreRow(): StoreSummary {
     return {
       path: this.paths.engrams,
       scope: 'global',
@@ -3068,9 +3138,7 @@ Generate an improved version of the procedure that prevents this failure. Return
    * call after server start because the remote cache hasn't populated yet
    * (issue #184). Retained for callers that cannot await.
    */
-  listStores(): Array<{
-    path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
-  }> {
+  listStores(): Array<StoreSummary> {
     this.reloadConfigIfChanged()  // pick up out-of-process config edits (#307)
     const stores = this.config.stores ?? []
     const additional = stores.map(s => {
@@ -3087,6 +3155,9 @@ Generate an improved version of the procedure that prevents this failure. Return
         shared:   s.shared,
         readonly: s.readonly,
         engram_count: count,
+        // #345: surface self-describing metadata in discovery when present.
+        ...(s.description !== undefined ? { description: s.description } : {}),
+        ...(s.covers !== undefined ? { covers: s.covers } : {}),
       }
     })
     return [this._primaryStoreRow(), ...additional]
@@ -3100,9 +3171,7 @@ Generate an improved version of the procedure that prevents this failure. Return
    * Use for `plur_stores_list` and CLI diagnostics where freshness matters
    * more than latency.
    */
-  async listStoresAsync(): Promise<Array<{
-    path?: string; url?: string; scope: string; shared: boolean; readonly: boolean; engram_count: number
-  }>> {
+  async listStoresAsync(): Promise<Array<StoreSummary>> {
     this.reloadConfigIfChanged()  // pick up out-of-process config edits (#307)
     const stores = this.config.stores ?? []
     const REMOTE_LOAD_TIMEOUT_MS = 5000
@@ -3139,6 +3208,9 @@ Generate an improved version of the procedure that prevents this failure. Return
         shared:   s.shared,
         readonly: s.readonly,
         engram_count: count,
+        // #345: surface self-describing metadata in discovery when present.
+        ...(s.description !== undefined ? { description: s.description } : {}),
+        ...(s.covers !== undefined ? { covers: s.covers } : {}),
       }
     }))
     return [this._primaryStoreRow(), ...additional]

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -1,10 +1,17 @@
 import { z } from 'zod'
+import { ScopeSensitivitySchema } from './scope-metadata.js'
 
 /**
  * A store can be either:
  *   - filesystem (path) — historical default; YAML or SQLite
  *   - remote (url + token) — speaks to a PLUR Enterprise server over HTTP
  * Exactly one of path/url must be present.
+ *
+ * A store entry may also carry self-describing scope metadata (#345) —
+ * `description`, `covers`, `sensitivity` — so a registered scope declares
+ * locally what it is for and its sensitivity policy. All metadata fields are
+ * optional and non-breaking; absent metadata falls back to the default
+ * shared-scope leak-guard behavior.
  */
 export const StoreEntrySchema = z.object({
   path: z.string().optional(),
@@ -13,6 +20,12 @@ export const StoreEntrySchema = z.object({
   scope: z.string(),
   shared: z.boolean().default(false),
   readonly: z.boolean().default(false),
+  description: z.string().optional()
+    .describe('Human-readable explanation of what this scope is for (#345). Surfaced in store/scope discovery.'),
+  covers: z.array(z.string()).optional()
+    .describe('Topics/domains this scope is the home for (#345). Advisory; surfaced in discovery.'),
+  sensitivity: ScopeSensitivitySchema.optional()
+    .describe("Per-scope sensitivity policy (#345) consumed by the write-time leak guard. When present, overrides the default shared-scope demote-everything behavior for this scope."),
 }).refine(
   (s) => Boolean(s.path) !== Boolean(s.url),
   { message: 'StoreEntry requires exactly one of path or url' },

--- a/packages/core/src/schemas/scope-metadata.ts
+++ b/packages/core/src/schemas/scope-metadata.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+/**
+ * Self-describing scope metadata (#345, Stage 2). A scope can declare what it is
+ * for, what it covers, and — crucially — its own sensitivity policy, so the
+ * write-time leak guard can make a per-scope decision instead of the blanket
+ * "any shared scope rejects all sensitive content" rule from Stage 1.
+ *
+ * Metadata is OPTIONAL everywhere. A scope with no metadata falls back to the
+ * Stage 1 behavior exactly (isSharedScope + detectSensitive → demote). The
+ * `sensitivity` default (`forbid: ['secrets','infra']`) reproduces that behavior
+ * for a shared scope that declares metadata but no explicit policy, so adding
+ * metadata is non-breaking.
+ *
+ * In Stage 2 this metadata is carried locally on a config `stores` entry
+ * (packages/core/src/schemas/config.ts). The enterprise `scopes` table /
+ * `/api/v1/scopes` API / admin UI that would serve it centrally are a separate
+ * track and intentionally NOT built here.
+ */
+
+/** Categories of sensitive content a scope can forbid or explicitly allow.
+ *  These map to the detector families in secrets.ts:
+ *    - 'secrets' → detectSecrets() families (api keys, tokens, passwords, …)
+ *    - 'infra'   → infra topology (public IPs, basic-auth URLs, host:port)
+ *    - 'pii'     → personally identifying information (forward-looking; no
+ *                   detector ships yet, but a scope may declare it now). */
+export const SENSITIVITY_CATEGORIES = ['secrets', 'infra', 'pii'] as const
+export type SensitivityCategory = (typeof SENSITIVITY_CATEGORIES)[number]
+
+export const ScopeSensitivitySchema = z.object({
+  forbid: z.array(z.enum(SENSITIVITY_CATEGORIES)).default(['secrets', 'infra'])
+    .describe('Sensitive categories that must NOT be written to this scope. A write that trips one of these is demoted to local/private. Default reproduces Stage 1: secrets + infra are forbidden on shared scopes.'),
+  allow: z.array(z.string()).default([])
+    .describe('Detector pattern names or category names explicitly permitted on this scope, overriding `forbid`. A match whose categories are ALL allowed is not demoted (e.g. a scope that legitimately holds infra topology can allow "infra").'),
+}).describe('Per-scope sensitivity policy consumed by the write-time leak guard.')
+
+export type ScopeSensitivity = z.infer<typeof ScopeSensitivitySchema>
+
+export const ScopeMetadataSchema = z.object({
+  scope: z.string()
+    .describe('The scope this metadata describes (e.g. "group:plur/engineering", "project:plur").'),
+  description: z.string()
+    .describe('Human-readable explanation of what this scope is for. Surfaced in scope/store discovery.'),
+  covers: z.array(z.string()).default([])
+    .describe('Topics, domains, or areas this scope is the home for. Advisory; helps an agent pick the right scope and is surfaced in discovery.'),
+  sensitivity: ScopeSensitivitySchema.optional()
+    .describe('Per-scope sensitivity policy. When present, the leak guard uses it; when absent, the guard falls back to the default shared-scope behavior.'),
+  injection_policy: z.enum(['on_match', 'on_request', 'always']).optional()
+    .describe("When the loader may inject this scope's engrams. Mirrors pack injection_policy semantics."),
+  owner: z.string().optional()
+    .describe('Owner of the scope (person or team). Advisory.'),
+}).describe('Self-describing metadata for an engram scope (Open Engram Standard, scope layer).')
+
+export type ScopeMetadata = z.infer<typeof ScopeMetadataSchema>

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -121,3 +121,21 @@ export function detectSensitive(text: string): SecretMatch[] {
   }
   return matches
 }
+
+/**
+ * Sensitivity category a detector pattern belongs to. Lets per-scope policy
+ * (ScopeMetadata.sensitivity) reason about `detectSensitive` hits in terms of
+ * the broad families a scope forbids/allows — 'secrets' (credentials/tokens)
+ * vs 'infra' (topology: IPs, internal hosts, host:port) — rather than the
+ * fine-grained pattern names. The infra family is exactly the set introduced by
+ * `detectSensitive` over `detectSecrets` (SENSITIVE_PATTERNS + public_ipv4);
+ * everything else `detectSecrets` finds is a credential, i.e. 'secrets'.
+ */
+const INFRA_PATTERN_NAMES = new Set<string>([
+  ...SENSITIVE_PATTERNS.map(p => p.name),
+  'public_ipv4',
+])
+
+export function sensitivityCategory(patternName: string): 'secrets' | 'infra' {
+  return INFRA_PATTERN_NAMES.has(patternName) ? 'infra' : 'secrets'
+}

--- a/packages/core/test/scope-metadata.test.ts
+++ b/packages/core/test/scope-metadata.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Self-describing scope metadata (#345, Stage 2). Two surfaces:
+ *
+ *  1. ScopeMetadataSchema — Zod validation: required fields, defaults, and that
+ *     bad input is rejected. The schema is the contract a scope declares.
+ *
+ *  2. The metadata-driven leak guard: when the target scope carries a
+ *     `sensitivity` policy, that policy decides demotion; with no metadata the
+ *     guard falls back to Stage 1 behavior EXACTLY (any sensitive hit on a
+ *     shared scope demotes). Fixtures reuse the real 2026-06 leak shapes
+ *     (139.59.155.82, https://t:p@hub-staging.plur.ai) so the test proves the
+ *     policy gates the same content the blanket guard caught.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur, ScopeMetadataSchema, sensitivityCategory } from '../src/index.js'
+
+describe('ScopeMetadataSchema', () => {
+  it('accepts a minimal valid record and applies defaults', () => {
+    const parsed = ScopeMetadataSchema.parse({
+      scope: 'group:plur/engineering',
+      description: 'Engineering team shared knowledge',
+    })
+    expect(parsed.scope).toBe('group:plur/engineering')
+    expect(parsed.description).toBe('Engineering team shared knowledge')
+    expect(parsed.covers).toEqual([])          // default []
+    expect(parsed.sensitivity).toBeUndefined() // optional, no default
+    expect(parsed.injection_policy).toBeUndefined()
+    expect(parsed.owner).toBeUndefined()
+  })
+
+  it('applies the sensitivity defaults (forbid secrets+infra, allow none)', () => {
+    const parsed = ScopeMetadataSchema.parse({
+      scope: 'project:plur',
+      description: 'PLUR monorepo scope',
+      sensitivity: {},
+    })
+    expect(parsed.sensitivity?.forbid).toEqual(['secrets', 'infra'])
+    expect(parsed.sensitivity?.allow).toEqual([])
+  })
+
+  it('preserves an explicit allow/forbid policy and covers', () => {
+    const parsed = ScopeMetadataSchema.parse({
+      scope: 'group:plur/infra',
+      description: 'Infra topology lives here',
+      covers: ['deployment', 'servers'],
+      sensitivity: { forbid: ['secrets'], allow: ['infra'] },
+      injection_policy: 'on_match',
+      owner: 'gregor',
+    })
+    expect(parsed.covers).toEqual(['deployment', 'servers'])
+    expect(parsed.sensitivity?.forbid).toEqual(['secrets'])
+    expect(parsed.sensitivity?.allow).toEqual(['infra'])
+    expect(parsed.injection_policy).toBe('on_match')
+    expect(parsed.owner).toBe('gregor')
+  })
+
+  it('rejects missing required fields', () => {
+    expect(ScopeMetadataSchema.safeParse({ description: 'no scope' }).success).toBe(false)
+    expect(ScopeMetadataSchema.safeParse({ scope: 'group:x' }).success).toBe(false) // no description
+  })
+
+  it('rejects an unknown sensitivity category in forbid', () => {
+    const res = ScopeMetadataSchema.safeParse({
+      scope: 'group:x', description: 'd', sensitivity: { forbid: ['malware'] },
+    })
+    expect(res.success).toBe(false)
+  })
+
+  it('rejects an invalid injection_policy', () => {
+    const res = ScopeMetadataSchema.safeParse({
+      scope: 'group:x', description: 'd', injection_policy: 'sometimes',
+    })
+    expect(res.success).toBe(false)
+  })
+})
+
+describe('sensitivityCategory — pattern → family mapping', () => {
+  it('maps infra topology patterns to infra', () => {
+    for (const p of ['public_ipv4', 'basic_auth_url', 'fqdn_port', 'ipv4_port'])
+      expect(sensitivityCategory(p)).toBe('infra')
+  })
+  it('maps credential patterns to secrets', () => {
+    for (const p of ['aws_access_key', 'generic_api_key', 'jwt', 'private_key', 'bearer_token'])
+      expect(sensitivityCategory(p)).toBe('secrets')
+  })
+})
+
+describe('metadata-driven leak guard (#345)', () => {
+  const dirs: string[] = []
+  /** Build a Plur whose config carries the given store entries (with metadata). */
+  const plurWithStores = (stores: unknown[]) => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-scope-meta-'))
+    dirs.push(dir)
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false }, { noRefs: true }))
+    return new Plur({ path: dir })
+  }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+  it('getScopeMetadata resolves metadata declared on a store entry', () => {
+    const plur = plurWithStores([
+      { path: '/tmp/ignored.yaml', scope: 'group:plur/infra', description: 'Infra scope', covers: ['servers'], sensitivity: { allow: ['infra'] } },
+    ])
+    const md = plur.getScopeMetadata('group:plur/infra')
+    expect(md?.scope).toBe('group:plur/infra')
+    expect(md?.description).toBe('Infra scope')
+    expect(md?.covers).toEqual(['servers'])
+    expect(md?.sensitivity?.allow).toEqual(['infra'])
+  })
+
+  it('returns undefined for a scope with no metadata', () => {
+    const plur = plurWithStores([])
+    expect(plur.getScopeMetadata('group:plur/engineering')).toBeUndefined()
+  })
+
+  // (a) scope whose sensitivity.allow contains the matched category → NOT demoted.
+  it('does NOT demote when the matched category is allowed by the scope policy', () => {
+    const plur = plurWithStores([
+      { path: '/tmp/infra.yaml', scope: 'group:plur/infra', description: 'Infra topology home', sensitivity: { forbid: ['secrets'], allow: ['infra'] } },
+    ])
+    const e = plur.learn('deploy target is 139.59.155.82', { scope: 'group:plur/infra' }) as { scope: string; structured_data?: { _demoted?: unknown } }
+    expect(e.scope).toBe('group:plur/infra')           // kept at the shared scope
+    expect(e.structured_data?._demoted).toBeUndefined() // no demotion marker
+  })
+
+  it('still demotes a forbidden category even when another is allowed', () => {
+    const plur = plurWithStores([
+      // infra allowed, but secrets still forbidden → a bearer token must demote
+      { path: '/tmp/infra.yaml', scope: 'group:plur/infra', description: 'Infra home', sensitivity: { forbid: ['secrets', 'infra'], allow: ['infra'] } },
+    ])
+    const e = plur.learn('token is Bearer abcdefghijklmnopqrstuvwxyz0123456789', { scope: 'group:plur/infra' }) as { scope: string }
+    expect(e.scope).toBe('local')
+  })
+
+  // (b) scope with NO metadata + sensitive content on a shared scope → demoted (fallback unchanged).
+  it('falls back to Stage 1: no metadata + sensitive content on a shared scope demotes', () => {
+    const plur = plurWithStores([]) // no metadata anywhere
+    const e = plur.learn('login at https://t:p@hub-staging.plur.ai', { scope: 'project:plur' }) as { scope: string; visibility: string }
+    expect(e.scope).toBe('local')
+    expect(e.visibility).toBe('private')
+  })
+
+  // (c) scope with the DEFAULT forbid policy + infra content → demoted.
+  it('demotes under the default policy (forbid secrets+infra) with infra content', () => {
+    const plur = plurWithStores([
+      // declares metadata but an empty sensitivity → defaults apply (forbid secrets+infra)
+      { path: '/tmp/eng.yaml', scope: 'group:plur/engineering', description: 'Engineering scope', sensitivity: {} },
+    ])
+    const e = plur.learn('deploy target is 139.59.155.82', { scope: 'group:plur/engineering' }) as { scope: string; visibility: string }
+    expect(e.scope).toBe('local')
+    expect(e.visibility).toBe('private')
+  })
+
+  it('keeps clean content at a metadata-bearing shared scope', () => {
+    const plur = plurWithStores([
+      { path: '/tmp/eng.yaml', scope: 'group:plur/engineering', description: 'Engineering scope', sensitivity: {} },
+    ])
+    const e = plur.learn('SKILL.md is the canonical pack format', { scope: 'group:plur/engineering' }) as { scope: string }
+    expect(e.scope).toBe('group:plur/engineering')
+  })
+
+  it('surfaces description + covers in listStores when declared', async () => {
+    const plur = plurWithStores([
+      { path: '/tmp/eng.yaml', scope: 'group:plur/engineering', description: 'Eng knowledge', covers: ['ci', 'releases'] },
+    ])
+    const rows = await plur.listStoresAsync()
+    const eng = rows.find(r => r.scope === 'group:plur/engineering')
+    expect(eng?.description).toBe('Eng knowledge')
+    expect(eng?.covers).toEqual(['ci', 'releases'])
+  })
+})

--- a/packages/core/test/scope-metadata.test.ts
+++ b/packages/core/test/scope-metadata.test.ts
@@ -92,10 +92,10 @@ describe('sensitivityCategory — pattern → family mapping', () => {
 describe('metadata-driven leak guard (#345)', () => {
   const dirs: string[] = []
   /** Build a Plur whose config carries the given store entries (with metadata). */
-  const plurWithStores = (stores: unknown[]) => {
+  const plurWithStores = (stores: unknown[], extra: Record<string, unknown> = {}) => {
     const dir = mkdtempSync(join(tmpdir(), 'plur-scope-meta-'))
     dirs.push(dir)
-    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false }, { noRefs: true }))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false, ...extra }, { noRefs: true }))
     return new Plur({ path: dir })
   }
   afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
@@ -127,10 +127,13 @@ describe('metadata-driven leak guard (#345)', () => {
   })
 
   it('still demotes a forbidden category even when another is allowed', () => {
+    // allow_secrets:true bypasses the *hard* detectSecrets guard (which throws
+    // outright on credential patterns, before the scope logic runs) so we can
+    // exercise the *soft* per-scope policy: infra is allowed here, but secrets
+    // stays forbidden, so a bearer token must still demote off the shared scope.
     const plur = plurWithStores([
-      // infra allowed, but secrets still forbidden → a bearer token must demote
       { path: '/tmp/infra.yaml', scope: 'group:plur/infra', description: 'Infra home', sensitivity: { forbid: ['secrets', 'infra'], allow: ['infra'] } },
-    ])
+    ], { allow_secrets: true })
     const e = plur.learn('token is Bearer abcdefghijklmnopqrstuvwxyz0123456789', { scope: 'group:plur/infra' }) as { scope: string }
     expect(e.scope).toBe('local')
   })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1490,7 +1490,7 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
 
     {
       name: 'plur_stores_list',
-      description: 'List all configured engram stores with their scope, path, and engram count',
+      description: 'List all configured engram stores with their scope, path, and engram count. When a store declares self-describing scope metadata, its description and covers (topics the scope is the home for) are included so you can pick the right scope.',
       annotations: { title: 'List stores', readOnlyHint: true, idempotentHint: true },
       inputSchema: { type: 'object', properties: {} },
       handler: async (_args, plur) => {


### PR DESCRIPTION
## Stage 2 — client/core foundation for self-describing scopes (#345)

Scopes today are opaque strings. The Stage 1 leak guard (#326/#344) treats **every** shared scope identically: any `detectSensitive` hit demotes to local/private. Stage 2 lets a scope describe itself — what it is for, what it covers, and **its own sensitivity policy** — so the guard can make a per-scope decision instead of a blanket one.

This PR is the **client + core + config + mcp** foundation only. The enterprise `scopes` table, `/api/v1/scopes` API, and admin UI are a separate track and intentionally not built here.

### `ScopeMetadataSchema` (Zod)
New `packages/core/src/schemas/scope-metadata.ts`, modeled on the existing engram/pack schemas:

```
scope:            string (required)
description:      string (required)
covers:           string[] (default [])
sensitivity?:     { forbid: ('secrets'|'infra'|'pii')[]  (default ['secrets','infra'])
                    allow:  string[]                       (default []) }
injection_policy?: 'on_match' | 'on_request' | 'always'
owner?:           string
```

Exported as `ScopeMetadataSchema` + `type ScopeMetadata` (plus `ScopeSensitivitySchema`, `SENSITIVITY_CATEGORIES`) from the package index.

### Config-carried metadata
`StoreEntry` gains optional `description` / `covers` / `sensitivity`, so a registered scope declares its metadata locally in `~/.plur/config.yaml`. New accessor `Plur.getScopeMetadata(scope): ScopeMetadata | undefined` resolves metadata from the loaded config — returns `undefined` when the scope declares none. All fields optional → non-breaking.

### Guard wiring + non-breaking fallback
`_guardSensitiveScope` now consults per-scope `sensitivity`:

- A matched category is **tolerated** when it is in `sensitivity.allow` (by category name *or* the specific detector pattern name) **or** not in `sensitivity.forbid`.
- Only categories that are **forbidden and not allowed** trigger demotion.
- When the scope has **no metadata**, the guard falls back to Stage 1 **exactly** — any `detectSensitive` hit on a shared scope demotes.
- The default policy (`forbid: ['secrets','infra']`, `allow: []`) reproduces today's demote-on-sensitive behavior, so adding metadata can never *weaken* the guard unless a scope opts in via `allow`.

The `detectSensitive` scan and the `_demoted` marker are untouched. A new `sensitivityCategory(pattern)` helper in `secrets.ts` maps detector pattern names to the `secrets` / `infra` families the policy reasons about.

### Discovery (additive)
`listStores` / `listStoresAsync` (returning the new exported `StoreSummary` type) and the `plur_stores_list` MCP tool now include `description` / `covers` when a store declares them.

### Tests
`packages/core/test/scope-metadata.test.ts` — schema validation (defaults, required fields, bad input rejected) + the guard's metadata-driven path:
- (a) scope with `sensitivity.allow` containing the matched category → **not** demoted
- (b) scope with no metadata + sensitive content on a shared scope → demoted (Stage 1 fallback unchanged)
- (c) scope with the default `forbid` policy + infra content → demoted

Fixtures reuse the real leak shapes `139.59.155.82` and `https://t:p@hub-staging.plur.ai`.

### Verification
`pnpm -w exec tsc -p packages/core/tsconfig.json --noEmit` passes — the only remaining errors are the 3 pre-existing `@electric-sql/pglite` optional-dep errors present on `main`. Vitest is exercised in CI (local vitest binary is broken in this environment).

### Deferred
- Enterprise `scopes` table / `/api/v1/scopes` API / admin UI (separate track).
- **Not** wired into `gen:schemas` — that pipeline is scoped to the Open Engram Standard engram + pack-manifest JSON Schemas with CI drift tests; registering a third schema (new `spec/*.json` + drift-test update) is non-trivial, so it was deliberately left out per the "trivial registration only" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)