### PR TITLE
feat(core): suggestScope covers-ranker + surface scope metadata in discovery — Stage 3a

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ import { installPack, uninstallPack, listPacks, exportPack, scanPrivacy, compute
 import { sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncStatus } from './sync.js'
 import { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
 import type { ScopeMetadata, SensitivityCategory } from './schemas/scope-metadata.js'
+import { rankScopes, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
 import { appendHistory, readHistoryForEngram, generateEventId } from './history.js'
 import { computeContentHash } from './content-hash.js'
 import { decodeJwtExpiry } from './jwt.js'
@@ -75,6 +76,7 @@ export { parseDedupResponse, buildDedupPrompt, buildBatchDedupPrompt } from './d
 export { runMigrations, rollbackMigrations, getSchemaVersion, setSchemaVersion, ALL_MIGRATIONS, CURRENT_SCHEMA_VERSION, type Migration, type MigrationResult } from './migrations/index.js'
 export { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
 export { ScopeMetadataSchema, ScopeSensitivitySchema, SENSITIVITY_CATEGORIES, type ScopeMetadata, type ScopeSensitivity, type SensitivityCategory } from './schemas/scope-metadata.js'
+export { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
 
 /**
  * Scopes whose engrams are visible to people *other than* the author — the team
@@ -844,6 +846,40 @@ export class Plur {
       covers: entry.covers ?? [],
       ...(entry.sensitivity ? { sensitivity: entry.sensitivity } : {}),
     }
+  }
+
+  /**
+   * All registered scopes that declare self-describing metadata, materialized
+   * via {@link getScopeMetadata}. Deduplicated on scope (first declaration
+   * wins, matching getScopeMetadata's find-first semantics). Drives discovery
+   * surfacing and the {@link suggestScope} ranker. Additive — does not touch
+   * routing.
+   */
+  listScopeMetadata(): ScopeMetadata[] {
+    const seen = new Set<string>()
+    const out: ScopeMetadata[] = []
+    for (const s of this.config.stores ?? []) {
+      if (seen.has(s.scope)) continue
+      const md = this.getScopeMetadata(s.scope)
+      if (md) { out.push(md); seen.add(s.scope) }
+    }
+    return out
+  }
+
+  /**
+   * Suggest which registered scope(s) an engram belongs in, ranked by fit
+   * (#345/#346, Stage 3a). Deterministic — NO LLM, NO network. Scores the
+   * engram's signals (statement keywords, `domain` namespace, `tags`) against
+   * the `covers[]` each scope declares (see {@link rankScopes} for the weights).
+   *
+   * ADVISORY ONLY. This does NOT route or store anything — `learn()` /
+   * `learnRouted()` ignore it. The auto-route behavior flip is the gated Stage
+   * 3b PR; this method just answers "where would this fit?". Returns candidates
+   * sorted by confidence descending (empty array when nothing matches).
+   */
+  suggestScope(input: ScopeSignals): ScopeCandidate[] {
+    this.reloadConfigIfChanged()  // pick up out-of-process config edits (#307)
+    return rankScopes(input, this.listScopeMetadata())
   }
 
   /**

--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -1,0 +1,195 @@
+/**
+ * Deterministic scope-suggestion ranker (#345/#346, Stage 3a). Given an engram's
+ * signals (statement, domain, tags) and the registered scopes that declare a
+ * `covers[]` list, score how well each scope is the home for that engram and
+ * return a ranked candidate list.
+ *
+ * ADDITIVE ONLY. Nothing here changes where engrams are stored. `learn()` /
+ * `learnRouted()` do NOT call this — the auto-route behavior flip (and the
+ * un-scoped default global→local change) is the separate gated Stage 3b PR.
+ * This module is a pure, side-effect-free advisor: NO LLM, NO network, fully
+ * deterministic so the same inputs always produce the same ordering.
+ *
+ * Scoring is overlap between the engram's signals and each scope's `covers`
+ * tokens, across three weighted channels:
+ *
+ *   - domain-prefix (highest): the engram `domain` is a dotted namespace
+ *     (e.g. `plur.core.security`). A cover entry of `plur`, `plur.core`, or
+ *     `plur.*` matches it as a namespace prefix. This is the strongest signal
+ *     because domain is the most deliberate routing hint.
+ *   - tag (medium): any `tags[]` entry equal to, or a dotted-prefix of, a cover
+ *     token (or vice-versa).
+ *   - statement-keyword (low): tokenize the statement and count hits against the
+ *     cover tokens. Weakest because free text is noisy.
+ *
+ * Confidence is normalized into [0,1] by squashing the raw weighted score, so a
+ * single weak keyword hit reads as low-confidence and a domain-prefix match
+ * reads as high-confidence. Ties break deterministically on scope name.
+ */
+import type { ScopeMetadata } from './schemas/scope-metadata.js'
+
+/** Below this confidence a scope is not a confident home for an engram. Exported
+ * for Stage 3b to gate auto-routing on; NOT applied to ranking here — the ranker
+ * returns every scope that scores above zero and lets the caller decide. */
+export const SCOPE_MATCH_THRESHOLD = 0.5
+
+/** Per-channel weights. domain ≫ tag > keyword by design (see module doc). */
+const WEIGHT_DOMAIN = 1.0
+const WEIGHT_TAG = 0.5
+const WEIGHT_KEYWORD = 0.2
+
+/** Raw score at which confidence saturates to ~1.0. A single domain-prefix hit
+ * (WEIGHT_DOMAIN = 1.0) already lands near the top of the curve; stacking tag +
+ * keyword hits pushes it the rest of the way. */
+const SATURATION = 1.5
+
+/** Signals carried by an engram, used to score scope fit. */
+export interface ScopeSignals {
+  statement: string
+  domain?: string
+  tags?: string[]
+}
+
+/** One ranked scope candidate. */
+export interface ScopeCandidate {
+  scope: string
+  /** Normalized fit in [0,1], descending across the returned array. */
+  confidence: number
+  /** Human-readable matched signals, e.g. "domain plur.core.security ⊂ covers plur.*". */
+  reason: string
+}
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'are', 'but', 'not', 'you', 'all', 'any', 'can', 'had',
+  'her', 'was', 'one', 'our', 'out', 'use', 'with', 'this', 'that', 'from',
+  'have', 'has', 'his', 'its', 'who', 'how', 'why', 'what', 'when', 'where',
+  'will', 'into', 'than', 'then', 'them', 'they', 'your', 'about', 'which',
+])
+
+/** Lowercase, split on non-alphanumeric (keep dots so dotted tokens survive for
+ * the caller, but the keyword channel splits further), drop stopwords + tokens
+ * shorter than 3 chars. */
+function tokenizeStatement(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9.]+/)
+    .flatMap(t => t.split('.'))
+    .filter(t => t.length >= 3 && !STOPWORDS.has(t))
+}
+
+/** Normalize a cover token: lowercase, strip a trailing `.*` or `*` glob so
+ * `plur.*` and `plur` compare identically as a namespace prefix. */
+function normalizeCover(cover: string): string {
+  return cover.toLowerCase().replace(/\.?\*$/, '')
+}
+
+/** Does `value` sit under `prefix` as a dotted namespace? `plur.core.security`
+ * is under `plur` and `plur.core`; `plurple` is NOT under `plur` (segment
+ * boundary, not substring). Exact equality counts. */
+function isNamespacePrefix(prefix: string, value: string): boolean {
+  if (!prefix) return false
+  return value === prefix || value.startsWith(prefix + '.')
+}
+
+/** Squash a non-negative raw score into [0,1). Monotonic, saturating, so order
+ * is preserved and confidences stay comparable across scopes. */
+function squash(raw: number): number {
+  if (raw <= 0) return 0
+  return raw / (raw + SATURATION)
+}
+
+/**
+ * Score one scope against the engram signals. Returns the raw weighted score and
+ * the matched-signal reasons, or null when nothing overlaps.
+ */
+function scoreScope(
+  signals: ScopeSignals,
+  scope: string,
+  covers: string[],
+): { raw: number; reasons: string[] } | null {
+  const normalizedCovers = covers.map(c => ({ raw: c, norm: normalizeCover(c) })).filter(c => c.norm.length > 0)
+  if (normalizedCovers.length === 0) return null
+
+  let raw = 0
+  const reasons: string[] = []
+
+  // --- domain-prefix channel (highest weight) ---
+  const domain = signals.domain?.toLowerCase().trim()
+  if (domain) {
+    for (const cover of normalizedCovers) {
+      // Match either direction: the cover is a prefix of the domain
+      // (`plur.*` ⊃ `plur.core.security`), or the domain is a prefix of the
+      // cover (`plur` engram fits a `plur.core` scope, weaker but still a hit).
+      if (isNamespacePrefix(cover.norm, domain)) {
+        raw += WEIGHT_DOMAIN
+        reasons.push(`domain ${domain} ⊂ covers ${cover.raw}`)
+        break // one domain hit per scope — domain is single-valued
+      }
+      if (isNamespacePrefix(domain, cover.norm)) {
+        raw += WEIGHT_DOMAIN
+        reasons.push(`domain ${domain} ⊃ covers ${cover.raw}`)
+        break
+      }
+    }
+  }
+
+  // --- tag channel (medium weight) ---
+  const tags = (signals.tags ?? []).map(t => t.toLowerCase().trim()).filter(Boolean)
+  const matchedTags: string[] = []
+  for (const tag of tags) {
+    const hit = normalizedCovers.find(
+      c => c.norm === tag || isNamespacePrefix(c.norm, tag) || isNamespacePrefix(tag, c.norm),
+    )
+    if (hit) {
+      raw += WEIGHT_TAG
+      matchedTags.push(`tag ${tag} ~ covers ${hit.raw}`)
+    }
+  }
+  reasons.push(...matchedTags)
+
+  // --- statement-keyword channel (low weight) ---
+  const coverKeywords = new Set(normalizedCovers.flatMap(c => c.norm.split('.')).filter(t => t.length >= 3))
+  const statementTokens = new Set(tokenizeStatement(signals.statement))
+  const keywordHits: string[] = []
+  for (const token of statementTokens) {
+    if (coverKeywords.has(token)) {
+      raw += WEIGHT_KEYWORD
+      keywordHits.push(token)
+    }
+  }
+  if (keywordHits.length > 0) {
+    reasons.push(`keywords [${keywordHits.sort().join(', ')}] ∈ covers`)
+  }
+
+  if (raw <= 0) return null
+  return { raw, reasons }
+}
+
+/**
+ * Rank the supplied scopes by how well each is the home for an engram carrying
+ * `signals`. Pure: same inputs → same output. Returns candidates sorted by
+ * confidence descending, then by scope name ascending (deterministic tie-break).
+ * Scopes with no `covers` or no overlap are omitted; an empty array means no
+ * scope matched.
+ */
+export function rankScopes(
+  signals: ScopeSignals,
+  scopes: Array<Pick<ScopeMetadata, 'scope' | 'covers'>>,
+): ScopeCandidate[] {
+  const candidates: ScopeCandidate[] = []
+  for (const meta of scopes) {
+    const covers = meta.covers ?? []
+    if (covers.length === 0) continue
+    const scored = scoreScope(signals, meta.scope, covers)
+    if (!scored) continue
+    candidates.push({
+      scope: meta.scope,
+      confidence: Number(squash(scored.raw).toFixed(4)),
+      reason: scored.reasons.join('; '),
+    })
+  }
+  candidates.sort((a, b) =>
+    b.confidence - a.confidence || a.scope.localeCompare(b.scope),
+  )
+  return candidates
+}

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Deterministic scope-suggestion ranker (#345/#346, Stage 3a). Two surfaces:
+ *
+ *  1. rankScopes() — the pure helper. No Plur instance, no config, no I/O:
+ *     signals + scope metadata in, ranked candidates out. Proves the scoring
+ *     channels (domain-prefix ≫ tag > keyword), normalization into [0,1], and
+ *     the deterministic scope-name tie-break.
+ *
+ *  2. plur.suggestScope() — the Plur method, fed from config `stores` entries
+ *     that carry `covers`, mirroring scope-metadata.test.ts's plurWithStores
+ *     helper. Proves the method reads metadata the same way getScopeMetadata
+ *     does, and — crucially — that it is ADVISORY: it never routes or stores.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur, rankScopes, SCOPE_MATCH_THRESHOLD } from '../src/index.js'
+
+describe('rankScopes — pure ranker', () => {
+  const SCOPES = [
+    { scope: 'group:plur/core', covers: ['plur.*', 'engine', 'embeddings'] },
+    { scope: 'group:plur/infra', covers: ['infra', 'deployment', 'servers'] },
+    { scope: 'group:plur/docs', covers: ['documentation', 'guides'] },
+  ]
+
+  it('ranks a domain-prefix match at the top, above tag/keyword-only matches', () => {
+    const ranked = rankScopes(
+      { statement: 'the secret rotation policy', domain: 'plur.core.security', tags: ['servers'] },
+      SCOPES,
+    )
+    expect(ranked.length).toBeGreaterThanOrEqual(2)
+    // core wins on the domain-prefix hit (plur.core.security ⊂ plur.*)…
+    expect(ranked[0].scope).toBe('group:plur/core')
+    // …above infra, which only got a tag hit (servers).
+    expect(ranked[0].confidence).toBeGreaterThan(ranked[1].confidence)
+    expect(ranked.find(c => c.scope === 'group:plur/infra')).toBeDefined()
+    expect(ranked[0].reason).toContain('domain plur.core.security')
+    expect(ranked[0].reason).toContain('plur.*')
+  })
+
+  it('ranks a tag-only match below a domain match', () => {
+    const ranked = rankScopes(
+      { statement: 'no overlapping words here xyz', domain: 'plur.core.fts', tags: ['deployment'] },
+      SCOPES,
+    )
+    const core = ranked.find(c => c.scope === 'group:plur/core')!  // domain hit
+    const infra = ranked.find(c => c.scope === 'group:plur/infra')! // tag hit only
+    expect(core).toBeDefined()
+    expect(infra).toBeDefined()
+    expect(core.confidence).toBeGreaterThan(infra.confidence)
+  })
+
+  it('scores keyword-only matches lowest and still includes them', () => {
+    const ranked = rankScopes(
+      { statement: 'updating the deployment runbook for servers' },
+      SCOPES,
+    )
+    // Only infra's cover tokens (deployment, servers) appear in the statement.
+    expect(ranked.map(c => c.scope)).toContain('group:plur/infra')
+    const infra = ranked.find(c => c.scope === 'group:plur/infra')!
+    expect(infra.confidence).toBeGreaterThan(0)
+    // Keyword-only is weak — well under a domain-prefix match's confidence.
+    expect(infra.confidence).toBeLessThan(0.5)
+    expect(infra.reason).toContain('keywords')
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(rankScopes({ statement: 'completely unrelated content zzz' }, SCOPES)).toEqual([])
+    expect(rankScopes({ statement: 'anything', domain: 'other.namespace' }, SCOPES)).toEqual([])
+  })
+
+  it('omits scopes that declare no covers', () => {
+    const ranked = rankScopes(
+      { statement: 'engine internals', domain: 'plur.core' },
+      [
+        { scope: 'group:plur/core', covers: ['plur.*'] },
+        { scope: 'group:plur/empty', covers: [] },
+        { scope: 'group:plur/nocovers', covers: undefined as unknown as string[] },
+      ],
+    )
+    expect(ranked.map(c => c.scope)).toEqual(['group:plur/core'])
+  })
+
+  it('keeps every confidence in [0,1]', () => {
+    const ranked = rankScopes(
+      { statement: 'plur engine embeddings deployment servers infra', domain: 'plur.core.x', tags: ['infra', 'servers', 'deployment'] },
+      SCOPES,
+    )
+    expect(ranked.length).toBeGreaterThan(0)
+    for (const c of ranked) {
+      expect(c.confidence).toBeGreaterThan(0)
+      expect(c.confidence).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('breaks ties deterministically on scope name (ascending)', () => {
+    // Two scopes that match identically (same single tag hit) → equal score.
+    // Tie-break must order them by scope name, and be stable across input order.
+    const a = { scope: 'group:plur/aaa', covers: ['shared'] }
+    const b = { scope: 'group:plur/bbb', covers: ['shared'] }
+    const signals = { statement: 'irrelevant', tags: ['shared'] }
+    const forward = rankScopes(signals, [a, b])
+    const reversed = rankScopes(signals, [b, a])
+    expect(forward[0].confidence).toBe(forward[1].confidence) // genuinely tied
+    expect(forward.map(c => c.scope)).toEqual(['group:plur/aaa', 'group:plur/bbb'])
+    expect(reversed.map(c => c.scope)).toEqual(['group:plur/aaa', 'group:plur/bbb'])
+  })
+
+  it('treats a bare prefix and a trailing-".*" cover identically', () => {
+    const glob = rankScopes({ statement: 'x', domain: 'plur.core.security' }, [{ scope: 's', covers: ['plur.*'] }])
+    const bare = rankScopes({ statement: 'x', domain: 'plur.core.security' }, [{ scope: 's', covers: ['plur'] }])
+    expect(glob[0].confidence).toBe(bare[0].confidence)
+  })
+
+  it('does NOT match across a namespace segment boundary', () => {
+    // `plurple` must not match the `plur` namespace prefix (segment, not substring).
+    const ranked = rankScopes({ statement: 'x', domain: 'plurple.thing' }, [{ scope: 's', covers: ['plur'] }])
+    expect(ranked).toEqual([])
+  })
+
+  it('exports a routing threshold constant for Stage 3b (not applied here)', () => {
+    expect(SCOPE_MATCH_THRESHOLD).toBeGreaterThan(0)
+    expect(SCOPE_MATCH_THRESHOLD).toBeLessThan(1)
+  })
+})
+
+describe('plur.suggestScope — reads scope metadata from config stores', () => {
+  const dirs: string[] = []
+  /** Build a Plur whose config carries the given store entries (with covers). */
+  const plurWithStores = (stores: unknown[], extra: Record<string, unknown> = {}) => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-scope-route-'))
+    dirs.push(dir)
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false, ...extra }, { noRefs: true }))
+    return new Plur({ path: dir })
+  }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+  it('ranks registered scopes by fit', () => {
+    const plur = plurWithStores([
+      { path: '/tmp/core.yaml', scope: 'group:plur/core', description: 'Core engine', covers: ['plur.*', 'engine'] },
+      { path: '/tmp/infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers', 'deployment'] },
+    ])
+    const ranked = plur.suggestScope({ statement: 'embedding model init', domain: 'plur.core.embeddings' })
+    expect(ranked[0].scope).toBe('group:plur/core')
+    expect(ranked[0].confidence).toBeGreaterThan(0)
+  })
+
+  it('returns an empty array when no registered scope declares covers', () => {
+    const plur = plurWithStores([
+      { path: '/tmp/x.yaml', scope: 'group:plur/x', description: 'No covers declared' },
+    ])
+    expect(plur.suggestScope({ statement: 'anything at all', domain: 'plur.core' })).toEqual([])
+  })
+
+  it('returns an empty array with no stores configured', () => {
+    const plur = plurWithStores([])
+    expect(plur.suggestScope({ statement: 'whatever', tags: ['infra'] })).toEqual([])
+  })
+
+  it('is advisory: suggestScope does NOT route or store the engram', () => {
+    const plur = plurWithStores([
+      { path: '/tmp/infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers', 'deployment'] },
+    ])
+    // suggestScope points at the infra scope…
+    const ranked = plur.suggestScope({ statement: 'restart the deployment on the servers' })
+    expect(ranked[0].scope).toBe('group:plur/infra')
+    // …but a plain learn() with no scope still routes to the default (global),
+    // NOT to the suggested scope. The behavior flip is the gated Stage 3b PR.
+    const e = plur.learn('restart the deployment on the servers') as { scope: string }
+    expect(e.scope).toBe('global')
+  })
+
+  it('feeds tags through to the ranker', () => {
+    const plur = plurWithStores([
+      { path: '/tmp/infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers'] },
+    ])
+    const ranked = plur.suggestScope({ statement: 'no overlap words zzz', tags: ['servers'] })
+    expect(ranked.map(c => c.scope)).toContain('group:plur/infra')
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1155,7 +1155,20 @@ export function getToolDefinitions(): ToolDefinition[] {
         // caller must judge per-engram whether it belongs on the enterprise
         // store or stays local. Auto-setting all engrams to remote would
         // route personal/project-local knowledge to the team store.
-        const remote_scopes = plur.getWritableRemoteScopes()
+        //
+        // #345/#346 (Stage 3a): enrich each writable scope with its
+        // self-describing metadata (description + covers) so the AI caller can
+        // see what each scope is FOR when deciding routing. Additive — the
+        // existing { scope, url } shape is preserved; description/covers appear
+        // only when the scope declares them.
+        const remote_scopes = plur.getWritableRemoteScopes().map(s => {
+          const md = plur.getScopeMetadata(s.scope)
+          return {
+            ...s,
+            ...(md?.description ? { description: md.description } : {}),
+            ...(md?.covers && md.covers.length > 0 ? { covers: md.covers } : {}),
+          }
+        })
 
         // Project scope detection (#177) — read .plur.yaml from the MCP
         // server's cwd. Walking stops at .git boundary and refuses
@@ -1260,7 +1273,16 @@ export function getToolDefinitions(): ToolDefinition[] {
 
         // Append remote scope guidance to guide text (#229)
         if (remote_scopes.length > 0) {
-          const scopeList = remote_scopes.map(s => `"${s.scope}"`).join(', ')
+          // #345/#346: when a scope declares self-describing metadata, show what
+          // it's FOR (description + covers) inline so the agent can route by
+          // purpose, not just by name. Falls back to the bare "scope" name.
+          const scopeList = remote_scopes.map(s => {
+            const detail = [
+              s.description ? `— ${s.description}` : '',
+              s.covers && s.covers.length > 0 ? `(covers: ${s.covers.join(', ')})` : '',
+            ].filter(Boolean).join(' ')
+            return detail ? `"${s.scope}" ${detail}` : `"${s.scope}"`
+          }).join('; ')
           guide += default_scope
             ? `\n\nSession default scope is set to "${default_scope}". To route an engram to a remote ` +
               `enterprise store instead, pass scope explicitly to plur_learn (available remote scopes: ${scopeList}).`
@@ -1503,6 +1525,29 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           count: stores.length,
           ...(outboxCount > 0 ? { outbox_pending: outboxCount } : {}),
         }
+      },
+    },
+
+    {
+      name: 'plur_suggest_scope',
+      description: 'Suggest which registered scope(s) an engram belongs in, ranked by fit. Deterministic — no LLM, no network. Scores the statement keywords, optional domain (a dotted namespace like "plur.core.security"), and tags against the covers[] each scope declares. ADVISORY ONLY: this does not route or store anything; pass the chosen scope to plur_learn yourself. Returns candidates sorted by confidence (empty when nothing matches).',
+      annotations: { title: 'Suggest scope', readOnlyHint: true, idempotentHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          statement: { type: 'string', description: 'The engram statement to route' },
+          domain:    { type: 'string', description: 'Optional dotted namespace for the engram (e.g. "plur.core.security") — strongest routing signal' },
+          tags:      { type: 'array', items: { type: 'string' }, description: 'Optional tags on the engram' },
+        },
+        required: ['statement'],
+      },
+      handler: async (args, plur) => {
+        const candidates = plur.suggestScope({
+          statement: args.statement as string,
+          domain: args.domain as string | undefined,
+          tags: args.tags as string[] | undefined,
+        })
+        return { candidates, count: candidates.length }
       },
     },
 


### PR DESCRIPTION
## Stage 3a — routing ENGINE + discovery surfacing (ADDITIVE ONLY)

Builds on the Stage 2 self-describing scope metadata foundation (#345, merged via #346). This PR adds the deterministic routing **engine** and surfaces scope metadata in discovery. It does **NOT** change where engrams are stored.

> ⚠️ **No routing-behavior change.** `learn()` / `learnRouted()` default routing and the un-scoped-default behavior are untouched. The auto-route + un-scoped default `global`→`local` flip is the **separate gated follow-up, Stage 3b**. `suggestScope` here is purely advisory.

### 1. `suggestScope` ranker (`packages/core/src/scope-routing.ts`)

A pure, side-effect-free helper plus a Plur method.

- **`rankScopes(signals, scopes)`** — `signals: { statement; domain?; tags? }` → `{ scope; confidence; reason }[]`, sorted by confidence descending (empty when nothing matches). Deterministic — **NO LLM, NO network**.
- **`Plur.suggestScope(input)`** — advisory wrapper that feeds the registered scopes' metadata (resolved via `getScopeMetadata`) into `rankScopes`. Does not route or store anything.
- Also adds `Plur.listScopeMetadata()` — enumerates registered scopes that declare metadata.

**Scoring** — overlap between the engram's signals and each scope's `covers[]`, across three weighted channels:

| Channel | Weight | What matches |
|---|---|---|
| domain-prefix | **1.0** | engram `domain` (e.g. `plur.core.security`) is a dotted-namespace match for a cover `plur.*` / `plur` / `plur.core` (trailing `.*` and bare prefix treated identically; segment boundaries respected, so `plurple` does NOT match `plur`) |
| tag | 0.5 | any `tags[]` entry equals / is a dotted-prefix of a cover token (either direction) |
| statement-keyword | 0.2 | tokenized statement (lowercased, non-alnum split, stopwords + <3-char tokens dropped) hits a cover token |

Confidence is the raw weighted score squashed into `[0,1]` via `raw / (raw + 1.5)`, rounded to 4 dp. Ties break deterministically on scope name (ascending). `reason` carries the matched signals, e.g. `"domain plur.core.security ⊂ covers plur.*"`.

**`SCOPE_MATCH_THRESHOLD = 0.5`** is exported for Stage 3b to gate auto-routing on — it is **NOT** applied to ranking here (the ranker returns every scope scoring above zero).

### 2. Discovery surfacing (`packages/mcp/src/tools.ts`)

`plur_session_start` now enriches each writable remote scope with its `description` + `covers` (resolved via `getScopeMetadata`) and shows them inline in the guide text, so the agent can route by purpose, not just by name. Additive — the existing `{ scope, url }` shape on `remote_scopes` is preserved; `description`/`covers` appear only when declared. `plur_stores_list` already surfaced this (#346) — verified, left as-is.

### 3. MCP tool (optional, included)

New read-only `plur_suggest_scope` tool wrapping `suggestScope` — ~20 lines, no version-bump dance touched.

### 4. Tests (`packages/core/test/scope-routing.test.ts`)

15 tests, mirroring `scope-metadata.test.ts`'s `plurWithStores` helper: domain-prefix ranks top, tag-only ranks lower, keyword-only lowest, no-covers / no-match → `[]`, confidence in `[0,1]`, deterministic tie-break, namespace-segment boundary, glob vs bare prefix equivalence, and that `suggestScope` is **advisory** (a plain unscoped `learn()` still routes to `global`).

### Verification

- `tsc -p packages/core/tsconfig.json --noEmit` — clean (0 errors; the pre-existing `@electric-sql/pglite` optional-dep errors are environmental and resolve once the dep is present).
- Full core vitest suite — **1027 passed, 28 skipped, 0 failed**.

Refs #345, #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)