### PR TITLE
fix(core): close leak-guard bypasses in reportFailure/updateEngram/learnAsync — Stage 1.5a (#353)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ import { installPack, uninstallPack, listPacks, exportPack, scanPrivacy, compute
 // import { fetchRegistry, discoverPacks, verifyPackIntegrity, DEFAULT_REGISTRY_URL, type PackRegistry, type RegistryPack } from './registry.js'
 import { sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncStatus } from './sync.js'
 import { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
+import type { SecretMatch } from './secrets.js'
 import type { ScopeMetadata, SensitivityCategory } from './schemas/scope-metadata.js'
 import { appendHistory, readHistoryForEngram, generateEventId } from './history.js'
 import { computeContentHash } from './content-hash.js'
@@ -866,6 +867,78 @@ export class Plur {
    * `allow: []`) reproduces that demote-on-sensitive behavior, so adding metadata
    * is non-breaking.
    */
+  /**
+   * Single source of truth for "does this content carry sensitivity that scope
+   * `scope` forbids?". Returns the offending {@link SecretMatch} hits, or `[]`
+   * when there are none.
+   *
+   * Scope discipline: only SHARED scopes (`isSharedScope`) can leak, so for
+   * personal/local scopes (`local`/`global`/`user:`/`agent:`) this returns `[]`
+   * unconditionally — infra notes legitimately live in local storage, and the
+   * demotion target is local anyway, so a local write is always coherent.
+   *
+   * Policy: scan `text` with `detectSensitive`, then keep only the hits the
+   * scope's per-scope `sensitivity` policy forbids. With no scope metadata the
+   * default policy is `forbid:['secrets','infra'], allow:[]` — i.e. every hit is
+   * offending (the Stage 1 behavior). A hit is tolerated when its category is in
+   * `allow` (by category name OR by the specific detector pattern name) or when
+   * its category is not in `forbid`.
+   *
+   * Used by `_guardSensitiveScope` (the learn/learnRouted guard) AND by the
+   * mutation-path guards (learnAsync UPDATE/MERGE, reportFailure, updateEngram)
+   * so there is exactly one definition of "offending".
+   */
+  private _offendingHitsForScope(statement: string, scope: string): SecretMatch[] {
+    // Local/personal scopes never leak — demotion target is local anyway.
+    if (!isSharedScope(scope)) return []
+    const hits = detectSensitive(statement)
+    if (hits.length === 0) return []
+    const policy = this.getScopeMetadata(scope)?.sensitivity
+    const forbid = new Set<SensitivityCategory>(policy?.forbid ?? ['secrets', 'infra'])
+    const allow = new Set<string>(policy?.allow ?? [])
+    return hits.filter(h => {
+      const category = sensitivityCategory(h.pattern)
+      if (allow.has(category) || allow.has(h.pattern)) return false
+      return forbid.has(category)
+    })
+  }
+
+  /**
+   * Leak guard for the EXPLICIT-update mutation path (`updateEngram` /
+   * `updateEngramAsync`). Unlike learn/learnAsync, the caller hands us a fully
+   * formed engram and chose its scope deliberately, so the response differs by
+   * residence (#353):
+   *
+   * - REMOTE-resident (`isRemote: true`): there is no coherent demotion (we
+   *   can't silently re-scope an engram living on someone else's server), so a
+   *   forbidden hit THROWS — mirroring the hard `detectSecrets` guard. The
+   *   caller must re-scope locally or set `config.allow_secrets`.
+   * - LOCAL-resident: a forbidden hit DEMOTES in place (scope→'local',
+   *   visibility→'private') and warns. Returns the override the caller applies
+   *   before persisting; returns `null` when the statement is clean.
+   */
+  private _guardExplicitUpdate(
+    statement: string,
+    scope: string,
+    isRemote: boolean,
+  ): { scope: string; visibility: 'private' } | null {
+    const offending = this._offendingHitsForScope(statement, scope)
+    if (offending.length === 0) return null
+    const patterns = [...new Set(offending.map(h => h.pattern))].join(', ')
+    if (isRemote) {
+      throw new Error(
+        `Cannot update a shared/remote engram with sensitive content: ${patterns}. ` +
+        `Use a local scope or config.allow_secrets.`,
+      )
+    }
+    logger.warning(
+      `[plur] sensitive content (${patterns}) held back from shared scope "${scope}" — ` +
+      `demoted to local/private so it is not written to a shared store. ` +
+      `Re-scope deliberately if this is a false positive.`,
+    )
+    return { scope: 'local', visibility: 'private' }
+  }
+
   private _guardSensitiveScope(
     statement: string,
     context?: LearnContext,
@@ -876,21 +949,8 @@ export class Plur {
     // context fields (rationale, key_files, source, …), not just the statement.
     // Sensitive material hides in context too (#326 review, finding 1).
     const scanText = `${statement}\n${JSON.stringify(context ?? {})}`
-    const hits = detectSensitive(scanText)
-    if (hits.length === 0) return { scope, context, demotion: null }
-
-    // Per-scope policy: keep only the hits this scope actually forbids. With no
-    // metadata, `sensitivity` is undefined and the default policy forbids
-    // secrets+infra with nothing allowed — i.e. every hit is offending, exactly
-    // the Stage 1 behavior.
-    const policy = this.getScopeMetadata(scope)?.sensitivity
-    const forbid = new Set<SensitivityCategory>(policy?.forbid ?? ['secrets', 'infra'])
-    const allow = new Set<string>(policy?.allow ?? [])
-    const offending = hits.filter(h => {
-      const category = sensitivityCategory(h.pattern)
-      if (allow.has(category) || allow.has(h.pattern)) return false
-      return forbid.has(category)
-    })
+    // Single source of truth for the offending-hit policy (#353).
+    const offending = this._offendingHitsForScope(scanText, scope)
     if (offending.length === 0) return { scope, context, demotion: null }
 
     const patterns = [...new Set(offending.map(h => h.pattern))].join(', ')
@@ -1315,6 +1375,7 @@ export class Plur {
       recordLlmSuccess: () => this._recordLlmSuccess(),
       recordLlmFailure: () => this._recordLlmFailure(),
       syncIndex: () => this._syncIndex(),
+      offendingHitsForScope: (statement: string, scope: string) => this._offendingHitsForScope(statement, scope),
     }
   }
 
@@ -1987,7 +2048,10 @@ export class Plur {
       const engrams = loadEngrams(this.paths.engrams)
       const idx = engrams.findIndex(e => e.id === updated.id)
       if (idx === -1) return false
-      engrams[idx] = updated
+      // Leak guard (#353): local-resident → demote a sensitive update in place.
+      const demote = this._guardExplicitUpdate(updated.statement, updated.scope, false)
+      const toWrite = demote ? { ...updated, ...demote } : updated
+      engrams[idx] = toWrite
       this._writeEngrams(this.paths.engrams, engrams)
       this._syncIndex()
       return true
@@ -1998,6 +2062,9 @@ export class Plur {
     // strict ordering should use updateEngramAsync().
     for (const entry of (this.config.stores ?? [])) {
       if (!entry.url || entry.readonly === true) continue
+      // Leak guard (#353): remote-resident, explicit update → THROW on a
+      // forbidden hit (no coherent demotion for a remote engram).
+      this._guardExplicitUpdate(updated.statement, entry.scope, true)
       const serverId = this._stripRemotePrefix(updated.id, entry.scope)
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
       // PATCH a focused subset — full-engram PATCH would require strict
@@ -2025,15 +2092,21 @@ export class Plur {
       const engrams = loadEngrams(this.paths.engrams)
       const idx = engrams.findIndex(e => e.id === updated.id)
       if (idx === -1) return null
-      engrams[idx] = updated
+      // Leak guard (#353): local-resident → demote a sensitive update in place.
+      const demote = this._guardExplicitUpdate(updated.statement, updated.scope, false)
+      const toWrite = demote ? { ...updated, ...demote } : updated
+      engrams[idx] = toWrite
       this._writeEngrams(this.paths.engrams, engrams)
       this._syncIndex()
-      return updated
+      return toWrite
     })
     if (localResult) return localResult
 
     for (const entry of (this.config.stores ?? [])) {
       if (!entry.url || entry.readonly === true) continue
+      // Leak guard (#353): remote-resident, explicit update → THROW on a
+      // forbidden hit (no coherent demotion for a remote engram).
+      this._guardExplicitUpdate(updated.statement, entry.scope, true)
       const serverId = this._stripRemotePrefix(updated.id, entry.scope)
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
       const patched = await driver.patch(serverId, {
@@ -2673,7 +2746,7 @@ export class Plur {
     engramId: string,
     failureContext: string,
     llm?: LlmFunction,
-  ): Promise<{ engram: Engram; episode: Episode; evolved: boolean }> {
+  ): Promise<{ engram: Engram; episode: Episode; evolved: boolean; blocked?: boolean }> {
     const engram = this.getById(engramId)
     if (!engram) throw new Error(`Engram not found: ${engramId}`)
 
@@ -2735,6 +2808,20 @@ Generate an improved version of the procedure that prevents this failure. Return
             const oldVersion = raw.engram_version ?? 1
 
             raw.statement = improved.trim()
+            // Leak guard (#353): the LLM-improved statement can introduce
+            // sensitive content. This is a local write, so demotion is coherent:
+            // hold it back from the shared scope by demoting to local/private.
+            const localOffending = this._offendingHitsForScope(raw.statement, raw.scope ?? 'global')
+            if (localOffending.length > 0) {
+              const patterns = [...new Set(localOffending.map(h => h.pattern))].join(', ')
+              logger.warning(
+                `[plur] sensitive content (${patterns}) held back from shared scope "${raw.scope}" — ` +
+                `demoted to local/private so it is not written to a shared store. ` +
+                `Re-scope deliberately if this is a false positive.`,
+              )
+              raw.scope = 'local'
+              raw.visibility = 'private'
+            }
             raw.engram_version = oldVersion + 1
             raw.previous_version_ref = { event_id: eventId, changed_at: now }
             if (!raw.episode_ids) raw.episode_ids = []
@@ -2765,8 +2852,24 @@ Generate an improved version of the procedure that prevents this failure. Return
 
           // Remote routing (#86 reportFailure remainder): the engram lives
           // on a remote store. PATCH the new statement; history stays local.
+          let blockedRemote = false
           for (const entry of (this.config.stores ?? [])) {
             if (!entry.url || entry.readonly === true) continue
+            // Leak guard (#353): this is an AUTONOMOUS push to a shared/remote
+            // store — there is no coherent demotion (we can't silently re-scope
+            // someone else's remote engram). If the improved statement carries
+            // content this scope forbids, SKIP the push entirely and warn. Never
+            // throw: reportFailure is a background flow and must not crash.
+            const remoteOffending = this._offendingHitsForScope(improved.trim(), entry.scope)
+            if (remoteOffending.length > 0) {
+              const patterns = [...new Set(remoteOffending.map(h => h.pattern))].join(', ')
+              logger.warning(
+                `[plur] sensitive content (${patterns}) blocked from remote shared scope "${entry.scope}" — ` +
+                `procedure evolution NOT pushed. The remote engram is unchanged.`,
+              )
+              blockedRemote = true
+              continue
+            }
             const serverId = this._stripRemotePrefix(engramId, entry.scope)
             const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
             const patched = await driver.patch(serverId, { statement: improved.trim() })
@@ -2789,6 +2892,24 @@ Generate an improved version of the procedure that prevents this failure. Return
               evolved = true
               return { engram: patched, episode, evolved }
             }
+          }
+          // Leak guard (#353): every candidate remote was skipped because the
+          // improved statement was sensitive for its scope. The remote engram is
+          // intentionally left unchanged — report a not-evolved/blocked outcome
+          // (the failure episode is still linked below) instead of throwing.
+          if (blockedRemote) {
+            withLock(this.paths.engrams, () => {
+              const engrams = loadEngrams(this.paths.engrams)
+              const idx = engrams.findIndex(e => e.id === engramId)
+              if (idx !== -1) {
+                const raw = engrams[idx] as any
+                if (!raw.episode_ids) raw.episode_ids = []
+                raw.episode_ids.push(episode.id)
+                this._writeEngrams(this.paths.engrams, engrams)
+                this._syncIndex()
+              }
+            })
+            return { engram, episode, evolved: false, blocked: true }
           }
           // Neither local nor remote had it — defensive fallback (should not
           // happen since getById succeeded at top of function).

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -9,6 +9,7 @@ import { appendHistory } from './history.js'
 import { logger } from './logger.js'
 import { withLock } from './sync.js'
 import type { Engram } from './schemas/engram.js'
+import type { SecretMatch } from './secrets.js'
 import type { LearnContext, LearnAsyncContext, LearnAsyncResult, LearnBatchResult, DedupDecision, LlmFunction } from './types.js'
 
 export interface LearnAsyncDeps {
@@ -35,6 +36,38 @@ export interface LearnAsyncDeps {
   recordLlmFailure: () => void
   /** Sync index after write. */
   syncIndex: () => void
+  /**
+   * Leak guard predicate (#353). Returns the offending sensitivity hits when
+   * `statement` carries content the SHARED `scope` forbids, else `[]` (always
+   * `[]` for personal/local scopes). Single source of truth lives on the Plur
+   * class as `_offendingHitsForScope`; injected here so the UPDATE/MERGE paths
+   * can demote a mutated engram before it is written back to a shared store.
+   */
+  offendingHitsForScope: (statement: string, scope: string) => SecretMatch[]
+}
+
+/**
+ * Demote an engram in place when its (post-mutation) statement carries content
+ * the engram's shared scope forbids. Local write, so demotion is coherent:
+ * scope→'local', visibility→'private'. Warns naming the offending patterns,
+ * mirroring `_guardSensitiveScope`'s warning style. No-op (returns the engram
+ * unchanged) when there are no offending hits. (#353)
+ */
+function demoteIfSensitive(
+  deps: LearnAsyncDeps,
+  engram: any,
+  newStatement: string,
+): void {
+  const offending = deps.offendingHitsForScope(newStatement, engram.scope ?? 'global')
+  if (offending.length === 0) return
+  const patterns = [...new Set(offending.map(h => h.pattern))].join(', ')
+  logger.warning(
+    `[plur] sensitive content (${patterns}) held back from shared scope "${engram.scope}" — ` +
+    `demoted to local/private so it is not written to a shared store. ` +
+    `Re-scope deliberately if this is a false positive.`,
+  )
+  engram.scope = 'local'
+  engram.visibility = 'private'
 }
 
 /**
@@ -70,6 +103,9 @@ function executeDedupDecision(
             updated.version = (updated.version ?? 1) + 1
             updated.activation.last_accessed = new Date().toISOString().slice(0, 10)
             if (context?.tags) updated.tags = [...new Set([...updated.tags, ...context.tags])]
+            // Leak guard (#353): a dedup UPDATE can introduce sensitive content
+            // into an engram living at a shared scope. Demote before persisting.
+            demoteIfSensitive(deps, updated, updated.statement)
             engrams[idx] = updated
             saveEngrams(deps.engramsPath, engrams)
             deps.syncIndex()
@@ -101,6 +137,10 @@ function executeDedupDecision(
             merged.activation.last_accessed = new Date().toISOString().slice(0, 10)
             if (context?.tags) merged.tags = [...new Set([...merged.tags, ...context.tags])]
             if (0.7 > merged.activation.retrieval_strength) merged.activation.retrieval_strength = 0.7
+            // Leak guard (#353): a dedup MERGE concatenates the incoming
+            // statement, which can introduce sensitive content into an engram at
+            // a shared scope. Demote before persisting.
+            demoteIfSensitive(deps, merged, merged.statement)
             engrams[idx] = merged
             saveEngrams(deps.engramsPath, engrams)
             deps.syncIndex()

--- a/packages/core/test/guard-remote-boundary.test.ts
+++ b/packages/core/test/guard-remote-boundary.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Remote-boundary leak guard (#353 — Stage 1.5a).
+ *
+ * The write-time leak guard (`_guardSensitiveScope`) sat ONLY in
+ * learn()/learnRouted(). Three mutation paths reached a shared/remote store
+ * without it: reportFailure (LLM-evolved statement), updateEngram(Async)
+ * (caller-supplied statement), and learnAsync UPDATE/MERGE. These tests pin the
+ * Q2 invariant — sensitive content never crosses the remote boundary — across
+ * those paths, AND prove the guard does not over-block clean content.
+ *
+ * Harness mirrors remote-routing.test.ts / outbox.test.ts: a vi.fn() over
+ * globalThis.fetch, asserting on POST (append) and PATCH (mutate) calls.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import type { LlmFunction } from '../src/types.js'
+
+const REMOTE_SCOPE = 'group:plur/plur-ai/engineering'
+const REMOTE_URL = 'https://plur.example.com/sse'
+// A real (public) droplet-shaped IPv4 — the exact shape that leaked in 2026-06.
+const PUBLIC_IP = '139.59.155.82'
+
+function writeStoresConfig(dir: string, stores: Array<Record<string, unknown>>) {
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    yaml.dump({ stores, index: false }, { lineWidth: 120, noRefs: true }),
+  )
+}
+
+function storeConfig() {
+  return [{
+    url: REMOTE_URL,
+    token: 'plur_sk_test',
+    scope: REMOTE_SCOPE,
+    shared: true,
+    readonly: false,
+  }]
+}
+
+function readLocalEngrams(dir: string): any[] {
+  const path = join(dir, 'engrams.yaml')
+  if (!existsSync(path)) return []
+  const data = yaml.load(readFileSync(path, 'utf-8')) as { engrams?: unknown[] } | null
+  return (data?.engrams ?? []) as any[]
+}
+
+describe('remote-boundary leak guard (#353)', () => {
+  let dir: string
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-guard-remote-'))
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function postCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
+  }
+  function patchCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'PATCH')
+  }
+
+  /** Empty-list mock for the load() page-walk; POST append succeeds. */
+  function mockEmptyRemote() {
+    fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'POST') {
+        return { ok: true, status: 201, json: async () => ({ id: 'ENG-REMOTE-001' }), text: async () => '' } as Response
+      }
+      return { ok: true, status: 200, json: async () => ({ rows: [], total_count: 0 }), text: async () => '' } as Response
+    }) as any)
+  }
+
+  /**
+   * Mock a single procedural engram resident at the remote scope. The load()
+   * page-walk returns it so getById()/list() see it; any PATCH succeeds (so a
+   * test that asserts "no PATCH" is proving the GUARD skipped it, not that the
+   * server refused). `data` carries the engram contents per the DB-row shape.
+   */
+  function mockRemoteWithProcedure(serverId: string, statement: string) {
+    const row = {
+      id: serverId,
+      scope: REMOTE_SCOPE,
+      status: 'active',
+      data: { statement, type: 'procedural', scope: REMOTE_SCOPE, status: 'active', id: serverId },
+    }
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'PATCH') {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ engram: { ...row, data: { ...row.data } } }),
+          text: async () => '',
+        } as Response
+      }
+      // Single-engram GET /engrams/:id
+      if (method === 'GET' && typeof url === 'string' && /\/engrams\/[^?]+$/.test(url)) {
+        return { ok: true, status: 200, json: async () => row, text: async () => '' } as Response
+      }
+      // load() page-walk GET /engrams?scope=...
+      return { ok: true, status: 200, json: async () => ({ rows: [row], total_count: 1 }), text: async () => '' } as Response
+    }) as any)
+  }
+
+  /** Prime the lazy remote cache, then return the namespaced engram id list sees. */
+  async function primedRemoteId(plur: Plur, serverId: string): Promise<string> {
+    plur.list()                                   // triggers background load()
+    await new Promise(r => setTimeout(r, 50))     // let the load() settle
+    const found = plur.list().find(e => (e as any)._originalId === serverId || e.id.endsWith(serverId))
+    if (!found) throw new Error(`remote engram ${serverId} not in cache after prime`)
+    return found.id
+  }
+
+  // (a) Q2 invariant: a public-IP statement learned to a writable shared remote
+  // must NOT reach the remote (0 appends) and must NOT sit in the outbox — it is
+  // demoted to local instead.
+  it('(a) learn() of a public-IP statement to a shared remote is demoted, never appended', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, storeConfig())
+    const plur = new Plur({ path: dir })
+
+    const engram = plur.learn(`deploy target is ${PUBLIC_IP}`, {
+      scope: REMOTE_SCOPE,
+      type: 'behavioral',
+    }) as { scope: string; visibility: string }
+
+    // Demoted at the guard.
+    expect(engram.scope).toBe('local')
+    expect(engram.visibility).toBe('private')
+
+    // Give any (erroneous) fire-and-forget push time to fire.
+    await new Promise(r => setTimeout(r, 50))
+
+    // The remote append spy saw ZERO engrams, and nothing queued for retry.
+    expect(postCalls().length).toBe(0)
+    expect(plur.outboxCount()).toBe(0)
+
+    // It is kept locally (demoted), not lost.
+    const local = readLocalEngrams(dir)
+    expect(local.find(e => e.scope === 'local' && String(e.statement).includes(PUBLIC_IP))).toBeDefined()
+  })
+
+  // (b) reportFailure on a remote-resident procedural engram whose LLM-improved
+  // statement is sensitive: the remote PATCH must be skipped, result not-evolved
+  // and blocked.
+  it('(b) reportFailure with a sensitive improved statement does not PATCH the remote', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-001', 'Run the deploy script')
+    writeStoresConfig(dir, storeConfig())
+    const plur = new Plur({ path: dir })
+
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-001')
+
+    const sensitiveLlm: LlmFunction = async () =>
+      `Run the deploy script against ${PUBLIC_IP} after exporting the key`
+
+    const result = await plur.reportFailure(id, 'deploy kept failing', sensitiveLlm)
+
+    expect(patchCalls().length).toBe(0)        // never pushed
+    expect(result.evolved).toBe(false)         // not-evolved
+    expect(result.blocked).toBe(true)          // explicitly blocked
+  })
+
+  // (c) updateEngram / updateEngramAsync targeting a remote/shared engram with a
+  // sensitive statement: throws, and never PATCHes.
+  it('(c) updateEngramAsync with a sensitive statement on a remote engram throws, no PATCH', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-002', 'a clean procedure')
+    writeStoresConfig(dir, storeConfig())
+    const plur = new Plur({ path: dir })
+
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-002')
+    const found = plur.list().find(e => e.id === id)!
+    const sensitive = { ...found, statement: `connect to ${PUBLIC_IP}:8877 for the dashboard` } as any
+
+    await expect(plur.updateEngramAsync(sensitive)).rejects.toThrow(/sensitive content/i)
+    expect(patchCalls().length).toBe(0)
+  })
+
+  it('(c-sync) updateEngram with a sensitive statement on a remote engram throws, no PATCH', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-003', 'a clean procedure')
+    writeStoresConfig(dir, storeConfig())
+    const plur = new Plur({ path: dir })
+
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-003')
+    const found = plur.list().find(e => e.id === id)!
+    const sensitive = { ...found, statement: `the prod box is ${PUBLIC_IP}` } as any
+
+    expect(() => plur.updateEngram(sensitive)).toThrow(/sensitive content/i)
+    expect(patchCalls().length).toBe(0)
+  })
+
+  // (d) a CLEAN improved statement on the same remote path DOES reach the remote
+  // — proves the guard is not over-blocking.
+  it('(d) reportFailure with a CLEAN improved statement DOES PATCH the remote', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-004', 'Run the deploy script')
+    writeStoresConfig(dir, storeConfig())
+    const plur = new Plur({ path: dir })
+
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-004')
+
+    const cleanLlm: LlmFunction = async () =>
+      'Run the deploy script and verify the health check before declaring success'
+
+    const result = await plur.reportFailure(id, 'deploy kept failing', cleanLlm)
+
+    expect(patchCalls().length).toBe(1)        // pushed to remote
+    expect(result.evolved).toBe(true)
+    expect(result.blocked).toBeUndefined()
+  })
+
+  it('(d-update) updateEngramAsync with a CLEAN statement on a remote engram DOES PATCH', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-005', 'a clean procedure')
+    writeStoresConfig(dir, storeConfig())
+    const plur = new Plur({ path: dir })
+
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-005')
+    const found = plur.list().find(e => e.id === id)!
+    const clean = { ...found, statement: 'a slightly improved but still clean procedure' } as any
+
+    const patched = await plur.updateEngramAsync(clean)
+    expect(patched).not.toBeNull()
+    expect(patchCalls().length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

The write-time leak guard (`_guardSensitiveScope`) only sat in `learn()` / `learnRouted()`. Three engram-**mutation** paths reached a shared/remote store **without** the scope-demotion guard, re-opening the leak class for evolved/updated statements. This PR closes all three.

### Step 1 — single source of truth
Extracted `_offendingHitsForScope(statement: string, scope: string): SecretMatch[]` from `_guardSensitiveScope`:
- returns `[]` for non-shared / local scopes (local storage is fine — demotion target is local anyway),
- otherwise returns the `detectSensitive` hits the scope's per-scope `forbid`/`allow` policy forbids (via `getScopeMetadata(scope)?.sensitivity`, default `forbid:['secrets','infra']`; `allow` matches category name OR pattern name).

`_guardSensitiveScope` now delegates to this predicate, so **`learn()`/`learnRouted()` behavior is unchanged** (existing `scope-guard.test.ts` / `scope-metadata.test.ts` untouched and green).

### Step 2 — bypasses closed (residence-appropriate semantics)

| Bypass site | Resident | Behavior | Guarded write |
|---|---|---|---|
| `learnAsync` UPDATE & MERGE (`learn-async.ts`) | local | **demote** to `scope=local` / `visibility=private` + warn | before `saveEngrams` |
| `reportFailure` **local** branch | local | **demote** the evolved engram in place + warn | before `_writeEngrams` |
| `reportFailure` **remote** branch | remote (autonomous push) | **skip** `driver.patch` + warn, return not-evolved/**blocked** (`evolved=false`, `blocked=true`); never throws | before `driver.patch` |
| `updateEngram` / `updateEngramAsync` | remote/shared | **throw** `Cannot update a shared/remote engram with sensitive content: <patterns>. Use a local scope or config.allow_secrets.` | before `driver.patch` |
| `updateEngram` / `updateEngramAsync` | local | **demote** in place | before `_writeEngrams` |

### Step 3 — remote-boundary tests (`packages/core/test/guard-remote-boundary.test.ts`)
- **(a)** `learn()` of a public-IP statement (`139.59.155.82`) scoped to a writable shared remote → remote append spy received **0** engrams **and** `outboxCount() === 0` (demoted to local). Pins the Q2 invariant.
- **(b)** `reportFailure` producing a sensitive `improved` statement for a remote-resident engram → `driver.patch` **not called**, result `evolved=false` / `blocked=true`.
- **(c)** `updateEngram` and `updateEngramAsync` with a sensitive statement on a remote/shared engram → **throws** AND `driver.patch` not called.
- **(d)** clean statements on the same remote paths (`reportFailure` + `updateEngramAsync`) **do** reach the remote (exactly 1 PATCH) — proves the guard is not over-blocking.

## Verification
- `tsc -p packages/core/tsconfig.json --noEmit` — clean (exit 0, zero new errors).
- Full `@plur-ai/core` vitest suite — **1018 passed / 28 skipped**, 0 failed.
- `learn()` / `learnRouted()` behavior confirmed unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)