### PR TITLE
fix(sync): neutralize global gitignore — close silent engram data-loss bug (#329)

### DIFF
--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -86,8 +86,14 @@ export function getSyncStatus(root: string): SyncStatus {
   }
 }
 
+function neutralizeGlobalExcludes(root: string): void {
+  // Prevent the developer's global gitignore from silently excluding engram files.
+  git(['config', '--local', 'core.excludesFile', '/dev/null'], root)
+}
+
 function initRepo(root: string): void {
   git(['init'], root)
+  neutralizeGlobalExcludes(root)
   atomicWrite(join(root, '.gitignore'), GITIGNORE)
   git(['add', '-A'], root)
   git(['commit', '-m', 'Initial PLUR engram store'], root)
@@ -151,6 +157,9 @@ export function sync(root: string, remote?: string): SyncResult {
       files_changed: 0,
     }
   }
+
+  // Ensure existing repos are also immune to global gitignore (heal pre-fix installs)
+  neutralizeGlobalExcludes(root)
 
   // Add remote if provided and not yet set
   const existingRemote = getRemote(root)

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -11,8 +11,20 @@ function git(args: string, cwd: string): string {
 
 describe('sync', () => {
   let dir: string
+  let savedEnv: Record<string, string | undefined>
 
   beforeEach(() => {
+    // Neutralize global/system git config so developer gitignore rules can't
+    // silently drop engram files and so CI and local runs behave identically.
+    const keys = ['GIT_CONFIG_GLOBAL', 'GIT_CONFIG_SYSTEM', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL', 'GIT_COMMITTER_NAME', 'GIT_COMMITTER_EMAIL']
+    savedEnv = Object.fromEntries(keys.map(k => [k, process.env[k]]))
+    process.env.GIT_CONFIG_GLOBAL = '/dev/null'
+    process.env.GIT_CONFIG_SYSTEM = '/dev/null'
+    process.env.GIT_AUTHOR_NAME = 'PLUR Test'
+    process.env.GIT_AUTHOR_EMAIL = 'test@plur.ai'
+    process.env.GIT_COMMITTER_NAME = 'PLUR Test'
+    process.env.GIT_COMMITTER_EMAIL = 'test@plur.ai'
+
     dir = mkdtempSync(join(tmpdir(), 'plur-sync-'))
     // Create a minimal PLUR directory with an engrams file
     writeFileSync(join(dir, 'engrams.yaml'), '- id: ENG-001\n  statement: test\n')
@@ -20,6 +32,10 @@ describe('sync', () => {
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true })
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
   })
 
   describe('getSyncStatus', () => {


### PR DESCRIPTION
## Summary

- **Product fix** (`sync.ts`): call `git config --local core.excludesFile /dev/null` during `initRepo()` so the engram store is always committable regardless of a user's global gitignore. Also calls `neutralizeGlobalExcludes()` on every `sync()` invocation to heal pre-fix installs that already have a repo.
- **Test fix** (`sync.test.ts`): `beforeEach` now sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null` (and restores them in `afterEach`) so developer gitignore rules cannot cause the 6 `sync.test.ts` local failures or cascade intermittent flakes to other git-heavy tests.

Both changes are < 25 lines combined. Fixes the latent data-loss path where `plur sync` would silently stage nothing and appear to succeed.

Closes #329.

## Test plan
- [ ] `pnpm test --filter @plur-ai/core` passes locally (including on machines with `engrams.yaml` in `~/.gitignore_global`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)