### PR TITLE
fix(core): detector hardening — IPv6 + internal hosts + remove pii no-op — Stage 1.5b (#353)

### DIFF
--- a/packages/core/src/schemas/scope-metadata.ts
+++ b/packages/core/src/schemas/scope-metadata.ts
@@ -19,12 +19,18 @@ import { z } from 'zod'
  */
 
 /** Categories of sensitive content a scope can forbid or explicitly allow.
- *  These map to the detector families in secrets.ts:
+ *  These map 1:1 to the detector families in secrets.ts:
  *    - 'secrets' → detectSecrets() families (api keys, tokens, passwords, …)
- *    - 'infra'   → infra topology (public IPs, basic-auth URLs, host:port)
- *    - 'pii'     → personally identifying information (forward-looking; no
- *                   detector ships yet, but a scope may declare it now). */
-export const SENSITIVITY_CATEGORIES = ['secrets', 'infra', 'pii'] as const
+ *    - 'infra'   → infra topology (public IPv4/IPv6, basic-auth URLs,
+ *                   host:port, internal/infra hostnames)
+ *
+ *  PII detection is deliberately OUT OF SCOPE: no detector maps to a 'pii'
+ *  category, so a scope declaring `forbid: ['pii']` would silently protect
+ *  nothing (false protection). The category is therefore omitted entirely
+ *  rather than shipped as a no-op. It can be reintroduced — added back here AND
+ *  to sensitivityCategory()'s return type in secrets.ts — once a real,
+ *  low-false-positive PII detector exists. */
+export const SENSITIVITY_CATEGORIES = ['secrets', 'infra'] as const
 export type SensitivityCategory = (typeof SENSITIVITY_CATEGORIES)[number]
 
 export const ScopeSensitivitySchema = z.object({

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -97,12 +97,100 @@ function isPublicIpv4(ip: string): boolean {
   return !NON_PUBLIC_IPV4.test(ip)
 }
 
+// IPv6 — mirror isPublicIpv4's "public only" stance. We FLAG only a globally
+// routable address (global unicast, 2000::/3) and exclude everything that is
+// not internet-reachable: loopback (::1), link-local (fe80::/10), unique-local
+// /ULA (fc00::/7, treated as private like 10.x), and the documentation prefix
+// (2001:db8::/32). The candidate matcher is loose on purpose — `parseIpv6`
+// then VALIDATES structurally (correct hextet count, at most one `::`), so a
+// MAC address (00:11:22:33:44:55 — exactly six 2-hex groups, no `::`) or a
+// generic colon-string fails to parse and is never flagged. Integer- or
+// hex-encoded IPv4 (e.g. 2338339922) is deliberately NOT handled — too
+// false-positive-prone — and is an accepted risk.
+const IPV6_CANDIDATE = /\b(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}\b|\b(?:[0-9a-f]{1,4}:){1,7}:/gi
+
 /**
- * Scan text for secrets AND infrastructure-sensitive content (public IPs,
- * basic-auth URLs, host:port topology). Superset of `detectSecrets` — this is
- * the gate used before an engram is allowed into a public/shipped set, because
- * the visibility tag alone is not trustworthy (in the 2026-06 leak, several of
- * the worst engrams were mistagged `public`). Returns [] only when clean.
+ * Parse an IPv6 string into its 8 16-bit hextets, or return null if it is not
+ * a structurally valid IPv6 address. Strictly validates `::` (at most one) and
+ * the resulting hextet count (exactly 8), so non-IPv6 colon strings — MAC
+ * addresses, `time:like:strings`, etc. — are rejected. A trailing embedded
+ * IPv4 (e.g. `::ffff:192.0.2.1`) is intentionally NOT supported; such inputs
+ * return null (accepted false negative, keeps the parser simple and strict).
+ */
+function parseIpv6(addr: string): number[] | null {
+  if (addr.includes('.')) return null // no embedded-IPv4 form; keep it strict
+  const dbl = addr.indexOf('::')
+  if (dbl !== addr.lastIndexOf('::')) return null // more than one '::' is invalid
+
+  const parseGroups = (s: string): number[] | null => {
+    if (s === '') return []
+    const out: number[] = []
+    for (const g of s.split(':')) {
+      if (!/^[0-9a-f]{1,4}$/i.test(g)) return null
+      out.push(parseInt(g, 16))
+    }
+    return out
+  }
+
+  if (dbl === -1) {
+    const groups = parseGroups(addr)
+    if (groups === null || groups.length !== 8) return null
+    return groups
+  }
+  // One '::' — it expands to fill the missing hextets (at least one).
+  const head = parseGroups(addr.slice(0, dbl))
+  const tail = parseGroups(addr.slice(dbl + 2))
+  if (head === null || tail === null) return null
+  const fill = 8 - head.length - tail.length
+  if (fill < 1) return null // '::' must stand in for >=1 omitted hextet
+  return [...head, ...new Array(fill).fill(0), ...tail]
+}
+
+function isPublicIpv6(addr: string): boolean {
+  const h = parseIpv6(addr)
+  if (h === null) return false
+  const [h0] = h
+  // Loopback ::1  and unspecified ::  — not public.
+  if (h.every(x => x === 0)) return false
+  if (h.slice(0, 7).every(x => x === 0) && h[7] === 1) return false
+  // Link-local fe80::/10  — top 10 bits = 1111111010.
+  if ((h0 & 0xffc0) === 0xfe80) return false
+  // Unique-local / ULA fc00::/7 (fc00::–fdff::) — treat as private like 10.x.
+  if ((h0 & 0xfe00) === 0xfc00) return false
+  // Documentation prefix 2001:db8::/32.
+  if (h0 === 0x2001 && h[1] === 0x0db8) return false
+  // Global unicast 2000::/3 (top 3 bits = 001) — the only range we flag.
+  return (h0 & 0xe000) === 0x2000
+}
+
+// Targeted internal/infra hostname detection (portless variant — the ported
+// form is already caught by `fqdn_port`). CONSERVATIVE by design: only
+// high-signal forms, because a false match silently demotes a legitimate
+// engram. We flag a multi-label hostname that EITHER ends in an unambiguous
+// internal suffix label (.local/.internal/.corp/.lan/.intranet, or k8s
+// .svc / .svc.cluster.local) OR contains a `staging` label. We do NOT flag
+// standalone words (db/prod/redis alone) or ordinary public FQDNs
+// (example.com, api.github.com). The leading `[a-z0-9-]+\.` requires at least
+// two labels so a bare `internal` or `localhost` never trips it.
+const INTERNAL_HOST = new RegExp(
+  '\\b[a-z0-9-]+(?:\\.[a-z0-9-]+)*\\.' +
+    '(?:local|internal|corp|lan|intranet|svc)\\b' + // unambiguous internal suffix label
+    '|' +
+    '\\b[a-z0-9-]+(?:\\.[a-z0-9-]+)*\\.svc\\.cluster\\.local\\b' + // k8s fully-qualified
+    '|' +
+    '\\b[a-z0-9-]*staging[a-z0-9-]*(?:\\.[a-z0-9-]+)+\\b' + // hostname with a staging label
+    '|' +
+    '\\b[a-z0-9-]+(?:\\.[a-z0-9-]+)*\\.staging(?:\\.[a-z0-9-]+)+\\b', // ...or staging as inner label
+  'i',
+)
+
+/**
+ * Scan text for secrets AND infrastructure-sensitive content (public IPv4/IPv6,
+ * basic-auth URLs, host:port topology, internal/infra hostnames). Superset of
+ * `detectSecrets` — this is the gate used before an engram is allowed into a
+ * public/shipped set, because the visibility tag alone is not trustworthy (in
+ * the 2026-06 leak, several of the worst engrams were mistagged `public`).
+ * Returns [] only when clean.
  */
 export function detectSensitive(text: string): SecretMatch[] {
   if (typeof text !== 'string') {
@@ -119,6 +207,16 @@ export function detectSensitive(text: string): SecretMatch[] {
       break
     }
   }
+  for (const candidate of text.match(IPV6_CANDIDATE) ?? []) {
+    if (isPublicIpv6(candidate)) {
+      matches.push({ pattern: 'public_ipv6', match: candidate })
+      break
+    }
+  }
+  const internalHost = text.match(INTERNAL_HOST)
+  if (internalHost) {
+    matches.push({ pattern: 'internal_host', match: internalHost[0].slice(0, 30) })
+  }
   return matches
 }
 
@@ -128,12 +226,15 @@ export function detectSensitive(text: string): SecretMatch[] {
  * the broad families a scope forbids/allows — 'secrets' (credentials/tokens)
  * vs 'infra' (topology: IPs, internal hosts, host:port) — rather than the
  * fine-grained pattern names. The infra family is exactly the set introduced by
- * `detectSensitive` over `detectSecrets` (SENSITIVE_PATTERNS + public_ipv4);
- * everything else `detectSecrets` finds is a credential, i.e. 'secrets'.
+ * `detectSensitive` over `detectSecrets` (SENSITIVE_PATTERNS + public_ipv4 +
+ * public_ipv6 + internal_host); everything else `detectSecrets` finds is a
+ * credential, i.e. 'secrets'.
  */
 const INFRA_PATTERN_NAMES = new Set<string>([
   ...SENSITIVE_PATTERNS.map(p => p.name),
   'public_ipv4',
+  'public_ipv6',
+  'internal_host',
 ])
 
 export function sensitivityCategory(patternName: string): 'secrets' | 'infra' {

--- a/packages/core/test/scope-metadata.test.ts
+++ b/packages/core/test/scope-metadata.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
-import { Plur, ScopeMetadataSchema, sensitivityCategory } from '../src/index.js'
+import { Plur, ScopeMetadataSchema, SENSITIVITY_CATEGORIES, sensitivityCategory } from '../src/index.js'
 
 describe('ScopeMetadataSchema', () => {
   it('accepts a minimal valid record and applies defaults', () => {
@@ -30,6 +30,21 @@ describe('ScopeMetadataSchema', () => {
     expect(parsed.sensitivity).toBeUndefined() // optional, no default
     expect(parsed.injection_policy).toBeUndefined()
     expect(parsed.owner).toBeUndefined()
+  })
+
+  // Detector hardening — Stage 1.5b (#353). 'pii' was a no-op category: no
+  // detector maps to it, so `forbid: ['pii']` silently protected nothing. It
+  // was removed to kill the false protection; the enum must reject it now.
+  it('no longer accepts the removed "pii" category', () => {
+    expect(SENSITIVITY_CATEGORIES).toEqual(['secrets', 'infra'])
+    expect(SENSITIVITY_CATEGORIES as readonly string[]).not.toContain('pii')
+    expect(() =>
+      ScopeMetadataSchema.parse({
+        scope: 'group:plur/engineering',
+        description: 'has a pii forbid',
+        sensitivity: { forbid: ['pii'] },
+      }),
+    ).toThrow()
   })
 
   it('applies the sensitivity defaults (forbid secrets+infra, allow none)', () => {

--- a/packages/core/test/secrets.test.ts
+++ b/packages/core/test/secrets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { detectSecrets } from '../src/secrets.js'
+import { detectSecrets, detectSensitive, sensitivityCategory } from '../src/secrets.js'
 
 describe('detectSecrets', () => {
   it('detects AWS access keys', () => {
@@ -76,4 +76,119 @@ describe('detectSecrets', () => {
     expect(() => detectSecrets(42 as unknown as string))
       .toThrow(/expected string, got number/)
   })
+})
+
+// Detector hardening — Stage 1.5b (#353). These detectors GATE the publish
+// filter and trigger write-time scope-demotion, so the overriding constraint is
+// LOW FALSE POSITIVES: a false match silently demotes a legitimate engram on
+// every shared-scope write. The negative cases below are the load-bearing half.
+describe('detectSensitive — public IPv6 (infra)', () => {
+  const has = (text: string, pattern: string) =>
+    detectSensitive(text).some(m => m.pattern === pattern)
+
+  it('flags a globally-routable (global unicast 2000::/3) address', () => {
+    expect(has('dns is at 2001:4860:4860::8888', 'public_ipv6')).toBe(true)
+  })
+
+  it('classifies public_ipv6 as infra', () => {
+    expect(sensitivityCategory('public_ipv6')).toBe('infra')
+  })
+
+  it('does NOT flag loopback ::1', () => {
+    expect(has('bind to ::1 for local only', 'public_ipv6')).toBe(false)
+  })
+
+  it('does NOT flag link-local fe80::/10', () => {
+    expect(has('interface addr fe80::1', 'public_ipv6')).toBe(false)
+  })
+
+  it('does NOT flag unique-local / ULA fd00::/8', () => {
+    expect(has('ula prefix fd00::1', 'public_ipv6')).toBe(false)
+  })
+
+  it('does NOT flag the documentation prefix 2001:db8::/32', () => {
+    expect(has('example doc addr 2001:db8::1', 'public_ipv6')).toBe(false)
+  })
+
+  it('does NOT flag a MAC address (six 2-hex groups)', () => {
+    expect(has('mac 00:11:22:33:44:55', 'public_ipv6')).toBe(false)
+  })
+
+  it('does NOT flag a clock time', () => {
+    expect(has('meeting at 12:30:45 today', 'public_ipv6')).toBe(false)
+  })
+})
+
+describe('detectSensitive — internal hosts (infra)', () => {
+  const has = (text: string, pattern: string) =>
+    detectSensitive(text).some(m => m.pattern === pattern)
+
+  it('flags an .internal.corp suffix host', () => {
+    expect(has('connect to db.internal.corp', 'internal_host')).toBe(true)
+  })
+
+  it('flags a k8s .svc.cluster.local host', () => {
+    expect(has('svc.prod.svc.cluster.local is the target', 'internal_host')).toBe(true)
+  })
+
+  it('flags a bare .internal suffix host', () => {
+    expect(has('redis.internal handles the cache', 'internal_host')).toBe(true)
+  })
+
+  it('flags a hostname with a staging label', () => {
+    expect(has('the box is hub-staging.plur.ai', 'internal_host')).toBe(true)
+  })
+
+  it('flags staging as an inner label', () => {
+    expect(has('api.staging.example.com is pre-prod', 'internal_host')).toBe(true)
+  })
+
+  it('classifies internal_host as infra', () => {
+    expect(sensitivityCategory('internal_host')).toBe('infra')
+  })
+
+  it('does NOT flag ordinary public FQDNs', () => {
+    expect(has('see example.com for details', 'internal_host')).toBe(false)
+    expect(has('docs at https://google.com/path', 'internal_host')).toBe(false)
+    expect(has('the api.github.com endpoint', 'internal_host')).toBe(false)
+  })
+
+  it('does NOT flag an email address', () => {
+    expect(has('email user@example.com', 'internal_host')).toBe(false)
+  })
+
+  it('does NOT flag localhost or standalone infra words', () => {
+    expect(has('runs on localhost', 'internal_host')).toBe(false)
+    expect(has('check the db and redis on prod', 'internal_host')).toBe(false)
+  })
+
+  it('does NOT flag staging as a bare prose word', () => {
+    expect(has('the staging build failed', 'internal_host')).toBe(false)
+  })
+})
+
+describe('detectSensitive — false-positive safety (must stay clean)', () => {
+  // The single most important assertion set: none of these benign strings may
+  // produce ANY detectSensitive hit, or the leak guard demotes legitimate
+  // engrams on every shared-scope write.
+  const clean = [
+    '::1',
+    'fe80::1',
+    'fd00::1',
+    '2001:db8::1', // IPv6 documentation prefix
+    '00:11:22:33:44:55', // MAC address
+    '12:30:45', // clock time
+    '1.2.3', // semver
+    'example.com',
+    'https://google.com/path',
+    'api.github.com',
+    'user@example.com',
+    'localhost',
+    '550e8400-e29b-41d4-a716-446655440000', // UUID
+  ]
+  for (const text of clean) {
+    it(`stays clean: ${text}`, () => {
+      expect(detectSensitive(text)).toHaveLength(0)
+    })
+  }
 })


### PR DESCRIPTION
## Context

`detectSensitive` gates the publish filter and triggers write-time scope-demotion. A false match silently demotes a legitimate engram on every shared-scope write, so the **overriding constraint is LOW FALSE POSITIVES** — we prefer a missed host (false negative) over annoying the user (false positive).

## Three changes (all conservative)

### 1. Public IPv6 detection (infra)
New `isPublicIpv6(addr)` — a real validating parser (`parseIpv6`), not a loose regex. Classification rule, mirroring `isPublicIpv4`'s public-only stance:
- **FLAG**: global unicast `2000::/3` (e.g. `2001:4860:4860::8888`) — the only range emitted.
- **EXCLUDE**: loopback `::1`/unspecified `::`, link-local `fe80::/10`, unique-local/ULA `fc00::/7` (treated as private like 10.x), and documentation prefix `2001:db8::/32`.
- `parseIpv6` enforces at most one `::` and exactly 8 hextets, so **MAC addresses** (`00:11:22:33:44:55`) and generic colon-strings (`12:30:45`) fail to parse and are never flagged.
- Pattern `public_ipv6` → `INFRA_PATTERN_NAMES` → `sensitivityCategory('public_ipv6') === 'infra'`.

### 2. Targeted internal-host detection (infra)
`internal_host` flags only **high-signal** portless forms (the `:port` variant `hub-staging.plur.ai:443` was already caught by `fqdn_port`):
- multi-label hostnames ending in `.local` / `.internal` / `.corp` / `.lan` / `.intranet` / `.svc` (and k8s `.svc.cluster.local`);
- OR a multi-label hostname containing a `staging` label (`hub-staging.plur.ai`, `api.staging.example.com`). **Kept** the staging-label part — it tested low-FP with confidence.

Does **not** flag standalone words (`db`/`prod`/`redis`), ordinary public FQDNs (`example.com`, `api.github.com`), emails, or `localhost`. Pattern → `INFRA_PATTERN_NAMES` (infra).

### 3. Resolve the `pii` no-op (false protection)
No detector ever mapped to `'pii'`, so a scope `forbid: ['pii']` silently protected nothing. **Removed** `'pii'` from `SENSITIVITY_CATEGORIES` and the sensitivity `forbid`/`allow` enum. `sensitivityCategory`'s return type was already `'secrets'|'infra'`. A comment documents that PII detection is deliberately out of scope and the category can be reintroduced once a real low-FP PII detector exists. Removal rippled cleanly (nothing else referenced the literal `'pii'`).

## FP-safety stance + negative tests
The load-bearing half is the **13 false-positive-safety cases** that must stay clean (zero `detectSensitive` hits): `::1`, `fe80::1`, `fd00::1`, `2001:db8::1`, MAC `00:11:22:33:44:55`, time `12:30:45`, semver `1.2.3`, `example.com`, `https://google.com/path`, `api.github.com`, `user@example.com`, `localhost`, and a UUID. Plus targeted negatives in the IPv6 and internal-host suites. All pass.

## Deliberately skipped
- **Integer/hex-encoded IPv4** (e.g. `2338339922`) — too false-positive-prone; accepted risk, noted in code.

## Verification
- `tsc --noEmit` on core: clean (zero new errors vs baseline).
- Full core vitest suite: **1050 passed**, 28 skipped (sync/integration only). 32 new tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)