### PR TITLE
fix(sync): neutralize global gitignore so engram files are always staged

### DIFF
--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -88,6 +88,9 @@ export function getSyncStatus(root: string): SyncStatus {
 
 function initRepo(root: string): void {
   git(['init'], root)
+  // Neutralize any global/system gitignore so engram files (engrams.yaml, episodes.yaml)
+  // are always stageable regardless of the user's personal excludes file.
+  git(['config', '--local', 'core.excludesFile', '/dev/null'], root)
   atomicWrite(join(root, '.gitignore'), GITIGNORE)
   git(['add', '-A'], root)
   git(['commit', '-m', 'Initial PLUR engram store'], root)

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { execSync } from 'child_process'
 import { join } from 'path'
@@ -11,6 +11,31 @@ function git(args: string, cwd: string): string {
 
 describe('sync', () => {
   let dir: string
+  let tmpConfigDir: string
+  let origGitConfigGlobal: string | undefined
+  let origGitConfigSystem: string | undefined
+
+  beforeAll(() => {
+    origGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL
+    origGitConfigSystem = process.env.GIT_CONFIG_SYSTEM
+    // Isolate all git operations from the developer's global/system config.
+    // Without this, a global gitignore containing engrams.yaml/episodes.yaml
+    // silently drops those files from git add -A, causing 6 test failures and
+    // the same latent data-loss bug in plur sync itself (see issue #329).
+    tmpConfigDir = mkdtempSync(join(tmpdir(), 'plur-gitconfig-'))
+    const configFile = join(tmpConfigDir, 'gitconfig')
+    writeFileSync(configFile, '[user]\n  name = PLUR Test\n  email = test@plur.ai\n')
+    process.env.GIT_CONFIG_GLOBAL = configFile
+    process.env.GIT_CONFIG_SYSTEM = '/dev/null'
+  })
+
+  afterAll(() => {
+    if (origGitConfigGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL
+    else process.env.GIT_CONFIG_GLOBAL = origGitConfigGlobal
+    if (origGitConfigSystem === undefined) delete process.env.GIT_CONFIG_SYSTEM
+    else process.env.GIT_CONFIG_SYSTEM = origGitConfigSystem
+    rmSync(tmpConfigDir, { recursive: true, force: true })
+  })
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'plur-sync-'))


### PR DESCRIPTION
## Summary

Fixes the P1 data-loss bug reported in #329.

- **`sync.ts`**: After `git init`, immediately run `git config --local core.excludesFile /dev/null` so the engram store repo is insulated from any global/system excludes file. Engrams.yaml and episodes.yaml are always stageable, regardless of what the user has in their `~/.gitignore_global`.
- **`sync.test.ts`**: Wrap the suite in `beforeAll`/`afterAll` that redirect `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to isolated throwaway paths. Tests now pass regardless of a developer's global gitignore — the same 6 tests that failed locally now run clean.

## Test plan

- [ ] Run `pnpm test -- packages/core/test/sync.test.ts` on a machine with `engrams.yaml` / `episodes.yaml` in its global gitignore — all 12 sync tests should pass
- [ ] Confirm `git config --local core.excludesFile` is set to `/dev/null` in a newly initialized PLUR store

Closes #329