### PR TITLE
fix(core): revert unscoped default→global + read-side personal-scope visibility on all 3 paths — PR-1 (#353 audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
       - run: git config --global user.email "ci@plur.ai"
       - run: git config --global user.name "PLUR CI"
       - run: pnpm build
+      # D1-MODULE-CYCLE gate (#353): scope-family predicates were moved to the
+      # leaf module scope-util.ts so inject.ts can import isPersonalScope without
+      # forming an index → inject → index cycle. madge isn't a repo dep, so we use
+      # a tsc --noEmit gate: a reintroduced cycle (or any type error) fails here
+      # before the test step.
+      - name: Type-check core (module-cycle gate)
+        run: pnpm --filter @plur-ai/core exec tsc --noEmit
+      # D1-followup gate (#177): the KNOWN_ISSUES Stage 3b v2 tracking sentinel
+      # must be present and point at a GitHub issue. macOS grep lacks -P, so this
+      # is a portable Node check (mirrors release.sh).
+      - name: KNOWN_ISSUES Stage 3b v2 tracking sentinel
+        run: node -e "const s=require('fs').readFileSync('docs/KNOWN_ISSUES.md','utf8'); if(!/STAGE3B_V2_TRACKING:https:\/\/github\.com\//.test(s)){console.error('KNOWN_ISSUES sentinel missing'); process.exit(1)}"
       # Spec JSON Schemas are generated from the Zod source of truth (#315).
       # Regenerate and fail if the committed spec/*.json drifted.
       - name: Check spec schemas are in sync with Zod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Un-scoped write default reverted to `global` + read-side personal-scope visibility on all 3 paths (#353)
+
+The Stage 3b un-scoped WRITE default (`local`) is reverted to `global` (the historical default). The revert alone was insufficient: the read-side scope filters hardcoded a `global`-only personal pass-through and DROPPED other personal-family scopes (`local`, `user:*`, `agent:*`) under a project-scoped recall/inject. This PR fixes the read side on **all three read paths** — inject `scoreEngram`, the non-indexed recall filter, and the DEFAULT indexed SQLite path (`storage-indexed.ts`, via a new `personal` column) — using the authoritative predicate `isPersonalScope(scope) = !isSharedScope(scope)`, not a hardcoded `{local,global}` set.
+
+**Intended read-visibility surface change (not a leak):** Engrams at `scope=local` (including those written during the Stage 3b period) and any `scope=local` / `user:*` engrams now appear in project-scoped sessions after this fix, consistent with non-shared scopes being personal-family. Personal scopes never reach team shared stores; only an explicit shared scope (`group:`/`project:`/`space:`/`team:`/`org:`/`public`) does.
+
+**RECALL/INJECT asymmetry (intentional, kept):** an explicit `scope=global` RECALL returns ALL personal-family engrams, but an explicit `scope=global` INJECT returns ONLY global-scoped engrams (targeted global-namespace injection, encoded by `INJECT_GLOBAL_IS_TARGETED`). The `plur_recall` tool description and `plur_session_start` guidance note this.
+
+**Note:** Users with `unscoped_default: local` should be aware that cross-scope recurrence promotion currently ignores `unscoped_default` and promotes to `global` on the 2nd cross-scope hit (tracked as Stage 3b v2, see `docs/KNOWN_ISSUES.md`).
+
+**Cross-surface consistency:** the CLI `plur learn` now omits the scope key when `--scope` is absent (flowing through unscoped routing via `learnRouted`) and the OpenClaw `_learnIfNew` routes via `learnRouted` (so shared-scope auto-learns reach their remote store); both pass `undefined` rather than a hardcoded `global` for unscoped sessions. The MCP `scope_hint` now fires on any non-shared landing scope (`isSharedScope` swap).
+
+The module cycle that this required (inject.ts needing `isPersonalScope` from index.ts) is broken by moving the scope-family predicates to a new leaf module `scope-util.ts`; `@plur-ai/core` re-exports `isSharedScope`/`isPersonalScope` unchanged.
+
 ### Security hardening: pack install, remote-store, learnBatch (#306)
 
 Addresses the 2026-06-10 security audit of `@plur-ai/core`:

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,21 @@
+# Known Issues
+
+This file tracks known, accepted issues for the current release line, with
+machine-checkable sentinels that gate `release.sh` and CI.
+
+## Stage 3b v2 — un-scoped write default (#177)
+
+PR-1 (#353 audit) reverted the un-scoped WRITE default `local → global` and
+fixed the READ side so no personal-family scope is excluded by a project-scoped
+filter, on **all three read paths** (inject `scoreEngram`, the non-indexed
+recall filter, and the default indexed SQLite path via a `personal` column),
+using `isPersonalScope(scope) = !isSharedScope(scope)`.
+
+Reverting the write default to `global` restores the cross-project bleed that
+Stage 3b (#351) mitigated. Accepted for 0.10.0 because (a) the read-side
+invisibility was a correctness blocker, and (b) `.plur.yaml` project-scope
+config is the supported mitigation. The READ side is fully fixed; Stage 3b v2
+re-implements the WRITE default behavior with the family-aware read filter as a
+precondition.
+
+STAGE3B_V2_TRACKING:https://github.com/plur-ai/plur/issues/362

--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -119,13 +119,17 @@ export class PlurContextEngine implements ContextEngine {
         const learnings = extractLearnings([params.message])
         for (const candidate of learnings) {
           if (candidate.confidence >= 0.7) {
-            this._learnIfNew(key, candidate.statement, {
+            // Fire-and-forget: learnRouted may touch a remote for shared scopes;
+            // don't stall the ingest hook on it. Scope `|| undefined` (not
+            // `|| 'global'`) so an unscoped session reaches the core unscoped
+            // routing path (_guardSensitiveScope sees scope == null) (#353).
+            void this._learnIfNew(key, candidate.statement, {
               type: candidate.type,
-              scope: this.sessionScopes.get(params.sessionKey || '') || 'global',
+              scope: this.sessionScopes.get(params.sessionKey || '') || undefined,
               source: 'openclaw:ingest',
               rationale: 'user correction detected in real-time',
               tags: [candidate.type],
-            })
+            }).catch(err => console.error('[plur-claw] _learnIfNew error:', err))
           }
         }
       }
@@ -199,13 +203,13 @@ export class PlurContextEngine implements ContextEngine {
         const learnings = extractLearnings(messages)
         for (const candidate of learnings) {
           if (candidate.confidence >= 0.7) {
-            this._learnIfNew(key, candidate.statement, {
+            void this._learnIfNew(key, candidate.statement, {
               type: candidate.type,
-              scope: this.sessionScopes.get(params.sessionKey || '') || 'global',
+              scope: this.sessionScopes.get(params.sessionKey || '') || undefined,
               source: 'openclaw:compact',
               rationale: 'extracted during context compaction',
               tags: [candidate.type],
-            })
+            }).catch(err => console.error('[plur-claw] _learnIfNew error:', err))
           }
         }
       }
@@ -237,7 +241,9 @@ export class PlurContextEngine implements ContextEngine {
     try {
       const newMessages = params.messages.slice(params.prePromptMessageCount)
       const key = params.sessionKey || params.sessionId
-      const scope = this.sessionScopes.get(params.sessionKey || '') || 'global'
+      // `|| undefined` (not `|| 'global'`) so an unscoped session reaches core's
+      // unscoped routing path (_guardSensitiveScope sees scope == null) (#353).
+      const scope = this.sessionScopes.get(params.sessionKey || '') || undefined
 
       if (this.options.auto_learn && newMessages.length > 0) {
         // Primary: LLM self-reported learnings from 🧠 section in assistant response
@@ -245,13 +251,13 @@ export class PlurContextEngine implements ContextEngine {
         if (lastAssistant) {
           const selfReported = extractSelfReportedLearnings(lastAssistant)
           for (const statement of selfReported) {
-            this._learnIfNew(key, statement, {
+            void this._learnIfNew(key, statement, {
               type: 'behavioral',
               scope,
               source: 'openclaw:self-report',
               rationale: 'self-reported by agent via learning section',
               tags: ['self-report'],
-            })
+            }).catch(err => console.error('[plur-claw] _learnIfNew error:', err))
           }
         }
 
@@ -259,13 +265,13 @@ export class PlurContextEngine implements ContextEngine {
         const learnings = extractLearnings(newMessages)
         for (const candidate of learnings) {
           if (candidate.confidence >= 0.7) {
-            this._learnIfNew(key, candidate.statement, {
+            void this._learnIfNew(key, candidate.statement, {
               type: candidate.type,
               scope,
               source: 'openclaw:afterTurn',
               rationale: 'extracted from conversation via pattern matching',
               tags: [candidate.type],
-            })
+            }).catch(err => console.error('[plur-claw] _learnIfNew error:', err))
           }
         }
       }
@@ -332,8 +338,14 @@ export class PlurContextEngine implements ContextEngine {
     return this.sessionScopes.get(sessionKey)
   }
 
-  /** Learn a statement only if it hasn't been learned in this session already (prevents triple-learning). */
-  private _learnIfNew(sessionKey: string, statement: string, context: LearnContext): void {
+  /**
+   * Learn a statement only if it hasn't been learned in this session already
+   * (prevents triple-learning). Uses learnRouted (not learn) so a shared-scope
+   * engram is pushed to its remote store / outbox — learn() does no remote
+   * routing (#353, MED-4). Callers fire-and-forget this in async-friendly hooks;
+   * a slow remote does not stall the agent turn.
+   */
+  private async _learnIfNew(sessionKey: string, statement: string, context: LearnContext): Promise<void> {
     if (!this.sessionLearned.has(sessionKey)) {
       this.sessionLearned.set(sessionKey, new Set())
     }
@@ -341,7 +353,7 @@ export class PlurContextEngine implements ContextEngine {
     const key = statement.toLowerCase()
     if (seen.has(key)) return
     seen.add(key)
-    this.plur.learn(statement, context)
+    await this.plur.learnRouted(statement, context)
     maybeFlushAfter(recordEvent('learn'))
   }
 }

--- a/packages/claw/test/pr1-scope-routing.test.ts
+++ b/packages/claw/test/pr1-scope-routing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * PR-1 (#353) claw scope routing:
+ *  - _learnIfNew now calls learnRouted (not learn) so shared-scope engrams reach
+ *    their remote store / outbox (MED-4),
+ *  - an unscoped session passes scope `undefined` (NOT 'global') to core for each
+ *    of the three auto-learn paths (ingest, compact, afterTurn), so core's
+ *    unscoped routing path runs and the engram lands at the default (global).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { PlurContextEngine } from '../src/context-engine.js'
+
+// A correction-shaped message extractLearnings/isCorrection will pick up.
+const CORRECTION = (topic: string) =>
+  `No, always use snake_case for the ${topic} responses in this project`
+
+describe('PR-1 claw scope routing (#353)', () => {
+  let engine: PlurContextEngine
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-claw-pr1-'))
+    engine = new PlurContextEngine({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('_learnIfNew calls learnRouted (not learn) — spy', async () => {
+    const routedSpy = vi.spyOn(engine.plur, 'learnRouted')
+    const learnSpy = vi.spyOn(engine.plur, 'learn')
+    await engine.ingest({
+      sessionId: 's1', sessionKey: 'user:john',
+      message: { role: 'user', content: CORRECTION('ingest') },
+    })
+    await new Promise(r => setTimeout(r, 20)) // let the fire-and-forget settle
+    expect(routedSpy).toHaveBeenCalled()
+    // learn() may still be called internally by learnRouted's local path, but the
+    // claw engine itself must route through learnRouted, not call learn directly.
+    expect(routedSpy.mock.calls.length).toBeGreaterThan(0)
+    routedSpy.mockRestore()
+    learnSpy.mockRestore()
+  })
+
+  it('ingest path: unscoped session passes scope undefined → lands global', async () => {
+    const routedSpy = vi.spyOn(engine.plur, 'learnRouted')
+    await engine.ingest({
+      sessionId: 's1', sessionKey: 'user:john',
+      message: { role: 'user', content: CORRECTION('ingest-path') },
+    })
+    await new Promise(r => setTimeout(r, 20))
+    expect(routedSpy).toHaveBeenCalled()
+    // Every call from the unscoped session must pass scope undefined, never 'global'.
+    for (const call of routedSpy.mock.calls) {
+      expect((call[1] as { scope?: string })?.scope).toBeUndefined()
+    }
+    const e = (await routedSpy.mock.results[0].value) as { scope: string }
+    expect(e.scope).toBe('global')
+    routedSpy.mockRestore()
+  })
+
+  it('compact path: unscoped session passes scope undefined → lands global', async () => {
+    await engine.ingest({
+      sessionId: 's2', sessionKey: 'user:jane',
+      message: { role: 'user', content: CORRECTION('compact-path') },
+    })
+    const routedSpy = vi.spyOn(engine.plur, 'learnRouted')
+    await engine.compact({ sessionId: 's2', sessionKey: 'user:jane', sessionFile: '/tmp/x' })
+    await new Promise(r => setTimeout(r, 20))
+    for (const call of routedSpy.mock.calls) {
+      expect((call[1] as { scope?: string })?.scope).toBeUndefined()
+    }
+    routedSpy.mockRestore()
+  })
+
+  it('afterTurn path: unscoped session passes scope undefined → lands global', async () => {
+    const routedSpy = vi.spyOn(engine.plur, 'learnRouted')
+    await engine.afterTurn({
+      sessionId: 's3', sessionKey: 'user:kim', sessionFile: '/tmp/x',
+      messages: [
+        { role: 'system', content: 'sys' },
+        { role: 'user', content: CORRECTION('afterturn-path') },
+        { role: 'assistant', content: 'Understood.' },
+      ],
+      prePromptMessageCount: 1,
+    })
+    await new Promise(r => setTimeout(r, 20))
+    expect(routedSpy).toHaveBeenCalled()
+    for (const call of routedSpy.mock.calls) {
+      expect((call[1] as { scope?: string })?.scope).toBeUndefined()
+    }
+    const e = (await routedSpy.mock.results[0].value) as { scope: string }
+    expect(e.scope).toBe('global')
+    routedSpy.mockRestore()
+  })
+})

--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -5,7 +5,12 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
 
   let statement = ''
-  let scope = 'global'
+  // No hardcoded scope (#353): when --scope is absent the scope key is OMITTED
+  // from the LearnContext entirely so it flows through the unscoped-routing logic
+  // (_guardSensitiveScope → _resolveUnscopedScope → auto-route or unscoped_default,
+  // default global). Passing scope:'global' here would bypass that.
+  let scope: string | undefined = undefined
+  let scopeProvided = false
   let type: 'behavioral' | 'terminological' | 'procedural' | 'architectural' = 'behavioral'
   let domain: string | undefined
   let source: string | undefined
@@ -13,7 +18,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   let i = 0
   while (i < args.length) {
     const arg = args[i]
-    if (arg === '--scope' && i + 1 < args.length) { scope = args[++i]; i++ }
+    if (arg === '--scope' && i + 1 < args.length) { scope = args[++i]; scopeProvided = true; i++ }
     else if (arg === '--type' && i + 1 < args.length) { type = args[++i] as typeof type; i++ }
     else if (arg === '--domain' && i + 1 < args.length) { domain = args[++i]; i++ }
     else if (arg === '--source' && i + 1 < args.length) { source = args[++i]; i++ }
@@ -32,7 +37,50 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     exit(1, 'Usage: plur learn <statement> [--scope <scope>] [--type <type>] [--domain <domain>]')
   }
 
-  const engram = plur.learn(statement, { scope, type, domain, source })
+  // Build the context conditionally: when --scope is absent, OMIT the scope key
+  // (not scope:'global', not scope:undefined) — _guardSensitiveScope checks
+  // `context?.scope == null`, which is true for an absent key, reaching the
+  // unscoped routing path. When --scope is present it is honored as-is.
+  const ctx = { type, domain, source, ...(scopeProvided ? { scope } : {}) }
+
+  // ALWAYS use learnRouted (not learn): learn() stamps _demoted but does NOT do
+  // remote-outbox routing for shared scopes; only learnRouted() does — so an
+  // explicit `--scope group:engineering` on learn() would silently drop the
+  // remote push.
+  //
+  // learnRouted BLOCKS on the network for remote-scoped engrams (it awaits the
+  // POST to the remote store); the unscoped no-covers path falls to
+  // local/global (personal) and does NOT touch a remote, so it returns
+  // promptly. A 5s timeout guards against a dead/slow remote hanging the CLI.
+  let engram
+  // Hold the timer handle so it can be cleared on success — an un-cleared 5s
+  // setTimeout would keep Node's event loop alive and hang the CLI for 5s after
+  // learnRouted resolves (the unscoped/personal path returns immediately).
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+  try {
+    engram = await Promise.race([
+      plur.learnRouted(statement, ctx),
+      new Promise<never>((_, rej) => {
+        timeoutHandle = setTimeout(
+          () => rej(new Error('learnRouted timed out after 5s — remote store slow/unreachable; engram not confirmed remotely')),
+          5000,
+        )
+      }),
+    ])
+  } catch (err) {
+    if (timeoutHandle) clearTimeout(timeoutHandle)
+    const msg = err instanceof Error ? err.message : String(err)
+    // The local write may still have completed on the remote-failure outbox
+    // path; this only reports that the engram was NOT confirmed remotely.
+    if (shouldOutputJson(flags)) {
+      outputJson({ error: msg })
+      exit(1)
+    } else {
+      exit(1, `Error: ${msg}`)
+    }
+    return
+  }
+  if (timeoutHandle) clearTimeout(timeoutHandle)
 
   if (shouldOutputJson(flags)) {
     outputJson({

--- a/packages/cli/test/learn.test.ts
+++ b/packages/cli/test/learn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
@@ -22,6 +22,8 @@ describe('plur learn', () => {
     const output = JSON.parse(run('learn "test statement"'))
     expect(output.id).toMatch(/^ENG-/)
     expect(output.statement).toBe('test statement')
+    // PR-1 (#353): an un-scoped CLI learn omits the scope key so it flows through
+    // core's unscoped routing and lands at the default (global).
     expect(output.scope).toBe('global')
     expect(output.type).toBe('behavioral')
   })
@@ -49,5 +51,41 @@ describe('plur learn', () => {
 
   it('exits 1 with no statement and no stdin', () => {
     expect(() => run('learn')).toThrow()
+  })
+
+  // --- PR-1 (#353): scope routing via learnRouted, no hardcoded global ---
+
+  function writeCoversConfig(covers: string[]): void {
+    const coversYaml = covers.map(c => `      - "${c}"`).join('\n')
+    writeFileSync(join(dir, 'config.yaml'),
+      `index: false\n` +
+      `stores:\n` +
+      `  - path: ${join(dir, 'core.yaml')}\n` +
+      `    scope: "group:plur/core"\n` +
+      `    description: "Core"\n` +
+      `    covers:\n${coversYaml}\n`,
+    )
+  }
+
+  it('CLI covers-present: an un-scoped learn routes to a covers-matched scope', () => {
+    // CLI has no --tags flag, so reach the threshold with domain-prefix (1.0) +
+    // several cover-keyword hits in the statement (each 0.2): raw ≈ 1.8 → conf > 0.5.
+    writeCoversConfig(['plur.*', 'embeddings', 'index', 'engine', 'core'])
+    const output = JSON.parse(run('learn "the embeddings index for the core engine" --domain plur.core.embeddings'))
+    expect(output.scope).toBe('group:plur/core')
+  })
+
+  it('CLI no-covers: an un-scoped learn flows through unscoped routing and lands global', () => {
+    writeCoversConfig(['plur.*'])
+    // No covers match → falls to unscoped_default (global). Proves the scope key
+    // was OMITTED (a hardcoded scope:'global' would have skipped routing, but the
+    // landing scope is the same; the covers-present test above proves routing ran).
+    const output = JSON.parse(run('learn "an unrelated note about lunch preferences"'))
+    expect(output.scope).toBe('global')
+  })
+
+  it('CLI explicit: --scope is honored', () => {
+    const output = JSON.parse(run('learn "explicit scope statement" --scope project:foo'))
+    expect(output.scope).toBe('project:foo')
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ import { appendHistory, readHistoryForEngram, generateEventId } from './history.
 import { computeContentHash } from './content-hash.js'
 import { decodeJwtExpiry } from './jwt.js'
 import { RemoteStore } from './store/remote-store.js'
+import { isSharedScope, isPersonalScope } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { Episode } from './schemas/episode.js'
 import type { PackManifest } from './schemas/pack.js'
@@ -79,18 +80,12 @@ export { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.j
 export { ScopeMetadataSchema, ScopeSensitivitySchema, SENSITIVITY_CATEGORIES, type ScopeMetadata, type ScopeSensitivity, type SensitivityCategory } from './schemas/scope-metadata.js'
 export { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
 
-/**
- * Scopes whose engrams are visible to people *other than* the author — the team
- * store (`group:`), repo/project stores (`project:`), space stores (`space:`),
- * and org/public scopes. Personal scopes (`local`, `global`, `user:*`, `agent:*`)
- * are NOT shared: they live on the author's own machine or under their own remote
- * namespace. Used by the write-time leak guard to decide whether to scan + demote.
- */
-const SHARED_SCOPE_PREFIXES = ['group:', 'project:', 'space:', 'team:', 'org:', 'public'] as const
-
-export function isSharedScope(scope: string): boolean {
-  return SHARED_SCOPE_PREFIXES.some(p => scope.startsWith(p))
-}
+// Scope-family predicates live in the leaf module `scope-util.ts` to break a
+// module cycle: `inject.ts` (imported by index.ts) needs `isPersonalScope`, and
+// importing it from here would form index → inject → index. They are imported
+// above for internal use and re-exported here so the public `@plur-ai/core` API
+// (`isSharedScope`, `isPersonalScope`, `SHARED_SCOPE_PREFIXES`) is unchanged.
+export { isSharedScope, isPersonalScope, SHARED_SCOPE_PREFIXES } from './scope-util.js'
 export { detectPlurStorage, type PlurPaths } from './storage.js'
 export { IndexedStorage } from './storage-indexed.js'
 export { PGLiteAdapter, type PGLiteAdapterOptions } from './storage-pglite.js'
@@ -1000,7 +995,9 @@ export class Plur {
     statement: string,
     context?: LearnContext,
   ): { scope: string; routed: { scope: string; confidence: number; reason: string } | null } {
-    const fallback = this.config.unscoped_default ?? 'local'
+    // Match the schema default (config.ts `unscoped_default.default('global')`)
+    // so the two cannot drift; reverted local→global in 0.10.0 (#353).
+    const fallback = this.config.unscoped_default ?? 'global'
     if (this.config.auto_route_scope === false) {
       return { scope: fallback, routed: null }
     }
@@ -1029,7 +1026,10 @@ export class Plur {
       scope = resolved.scope
       routed = resolved.routed
     } else {
-      scope = context?.scope ?? this._sessionScope ?? 'global'
+      // Terminal fallback respects unscoped_default so a `unscoped_default:'local'`
+      // user with a null _sessionScope and no context scope is not silently forced
+      // to global (#353). No behavior change for the default-global user.
+      scope = context?.scope ?? this._sessionScope ?? (this.config.unscoped_default ?? 'global')
     }
     if (!isSharedScope(scope)) return { scope, context, demotion: null, routed }
     // Scan the FULL content the engram will carry — the statement AND the
@@ -1808,8 +1808,16 @@ export class Plur {
       }
       if (options?.scope) {
         const scope = options.scope
+        // Read-side scope filter (#353). Keep the `startsWith` arm so an explicit
+        // personal scope like `user:alice` still catches sub-scopes (e.g.
+        // `user:alice:notes`). `isPersonalScope` passes ALL personal-family
+        // scopes (local, global, user:*, agent:*), not just global — so a
+        // project-scope recall sees personal engrams. D1-ASYMMETRY: an explicit
+        // `global` recall therefore includes all personal-family engrams — wider
+        // than `global` inject, which is targeted to global-only (see inject.ts
+        // INJECT_GLOBAL_IS_TARGETED).
         engrams = engrams.filter(e =>
-          e.scope === 'global' || e.scope === scope || e.scope.startsWith(scope)
+          e.scope === scope || e.scope.startsWith(scope) || isPersonalScope(e.scope)
         )
       }
     }

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -5,6 +5,24 @@ import { decayedStrength, decayedCoAccessStrength, daysSince, confidenceDecay } 
 import { classifyPolarity } from './polarity.js'
 import { computeConfidence } from './confidence.js'
 import { freshTailBoost } from './fresh-tail.js'
+import { isPersonalScope } from './scope-util.js'
+
+/**
+ * D1-RECALL/INJECT-ASYMMETRY (#353). When an inject is given an EXPLICIT
+ * `scopeFilter === 'global'`, the first branch of scoreEngram returns ONLY
+ * `global`-scoped engrams — it is TARGETED global-namespace injection, NOT a
+ * personal-family catch-all. This is intentionally narrower than a PROJECT-scope
+ * filter, whose branch passes ALL personal-family scopes (`local`, `global`,
+ * `user:*`, `agent:*`).
+ *
+ * This is an asymmetry with RECALL: an explicit `scope=global` RECALL returns
+ * all personal-family engrams (because `isPersonalScope('global')` is true),
+ * whereas an explicit `scope=global` INJECT returns only `global`. The asymmetry
+ * is pre-existing for recall and DELIBERATELY kept for inject. A future change
+ * that "fixes" this (makes global inject a personal-family catch-all) MUST rename
+ * this constant so the intent is unmistakable. See the D1-ASYMMETRY tests.
+ */
+export const INJECT_GLOBAL_IS_TARGETED = true
 
 export interface InjectionContext {
   prompt: string
@@ -139,8 +157,17 @@ export function scoreEngram(
   // Scope filtering: if scope is specified, only include matching engrams
   if (scopeFilter) {
     if (scopeFilter === 'global') {
+      // INJECT_GLOBAL_IS_TARGETED: explicit scope=global inject returns ONLY
+      // global-scoped engrams — targeted global-namespace injection. The
+      // personal-family pass-through below applies to PROJECT-scope filters
+      // only; this branch predates D1 and is intentionally narrower than the
+      // project branch (see INJECT_GLOBAL_IS_TARGETED JSDoc + D1-ASYMMETRY tests).
+      void INJECT_GLOBAL_IS_TARGETED
       if (engram.scope !== 'global') return 0
-    } else if (!engram.scope.startsWith(scopeFilter) && engram.scope !== 'global') {
+    } else if (!engram.scope.startsWith(scopeFilter) && !isPersonalScope(engram.scope)) {
+      // Personal-family scopes (local, global, user:*, agent:*, anything not
+      // isSharedScope) always pass a project-scope filter; only SHARED scopes
+      // that don't match the filter are excluded (#353 read-side fix).
       return 0
     }
   }

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -108,14 +108,21 @@ export const PlurConfigSchema = z.object({
   registry_url: z.string().url().optional(),
   /**
    * Where a genuinely-unscoped write lands when nothing else decides its scope
-   * (Stage 3b, #351). Both `local` and `global` are PERSONAL, non-shared scopes
-   * — the enterprise "global" was renamed to `org` on 2026-05-11 — so this is an
-   * organizational default, NOT a leak-safety control. Defaults to `local` so
-   * unscoped writes stay in this machine's local store instead of the
-   * cross-project `global` namespace. Set to `global` to restore the historical
-   * pre-3b default.
+   * (Stage 3b, #351; reverted to `global` in 0.10.0, #353). Both `local` and
+   * `global` are PERSONAL, non-shared scopes — the enterprise "global" was
+   * renamed to `org` on 2026-05-11 — so this is an organizational default, NOT a
+   * leak-safety control (the sensitivity guard runs after this and still demotes
+   * an auto-routed SHARED scope carrying sensitive content).
+   *
+   * Defaults to `global` (the historical pre-3b default): the cross-project
+   * personal namespace, read-visible under any scoped recall/inject. With the
+   * 0.10.0 read-side fix, personal-family scopes — `local`, `global`, `user:*`,
+   * `agent:*` — are ALL visible under a project-scope recall/inject, so setting
+   * this to `local` keeps unscoped writes machine-local WITHOUT making them
+   * invisible to scoped sessions. `local` is a fully supported option, not a
+   * silent regression.
    */
-  unscoped_default: z.enum(['local', 'global']).default('local'),
+  unscoped_default: z.enum(['local', 'global']).default('global'),
   /**
    * When true (default), a genuinely-unscoped write (no explicit scope, no
    * session/`.plur.yaml` default) is run through the deterministic

--- a/packages/core/src/scope-util.ts
+++ b/packages/core/src/scope-util.ts
@@ -1,0 +1,41 @@
+/**
+ * Scope-family predicates — extracted to a leaf module to break a module cycle.
+ *
+ * `inject.ts` needs `isPersonalScope` for its read-side scope filter, but
+ * `index.ts` imports from `inject.ts`. If these predicates lived in `index.ts`,
+ * `inject.ts` importing them would create an `index.ts → inject.ts → index.ts`
+ * cycle. Keeping them here (a dependency-free leaf) lets `inject.ts`, `index.ts`,
+ * `storage-indexed.ts`, and `mcp/tools.ts` all import them without any cycle.
+ *
+ * `index.ts` re-exports `isSharedScope`/`isPersonalScope` so the public
+ * `@plur-ai/core` API surface is unchanged.
+ */
+
+/**
+ * Scopes whose engrams are visible to people *other than* the author — the team
+ * store (`group:`), repo/project stores (`project:`), space stores (`space:`),
+ * and org/public scopes. Personal scopes (`local`, `global`, `user:*`, `agent:*`)
+ * are NOT shared: they live on the author's own machine or under their own remote
+ * namespace. Used by the write-time leak guard to decide whether to scan + demote,
+ * and (via the negation below) by the read-side scope filters to decide which
+ * scopes always pass a project-scope recall/inject.
+ */
+export const SHARED_SCOPE_PREFIXES = ['group:', 'project:', 'space:', 'team:', 'org:', 'public'] as const
+
+export function isSharedScope(scope: string): boolean {
+  return SHARED_SCOPE_PREFIXES.some(p => scope.startsWith(p))
+}
+
+/**
+ * Personal-family scope test — the read-side authoritative predicate (#353).
+ *
+ * A scope is personal iff it is NOT a shared scope. This deliberately covers
+ * MORE than the historical hardcoded `{local, global}` set: `user:alice`,
+ * `agent:bot`, and any non-shared-prefixed scope are ALSO personal-family and
+ * must pass a project-scope recall/inject filter. Use this everywhere a read
+ * filter decides "always visible under any scoped recall" — never a hardcoded
+ * {local,global} set.
+ */
+export function isPersonalScope(scope: string): boolean {
+  return !isSharedScope(scope)
+}

--- a/packages/core/src/storage-indexed.ts
+++ b/packages/core/src/storage-indexed.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs'
 import { createRequire } from 'module'
 import { loadEngrams, storePrefix } from './engrams.js'
+import { isPersonalScope } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { StoreEntry } from './schemas/config.js'
 
@@ -45,7 +46,8 @@ export class IndexedStorage {
           scope TEXT NOT NULL,
           domain TEXT,
           last_accessed TEXT,
-          data TEXT NOT NULL
+          data TEXT NOT NULL,
+          personal INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_status ON engrams(status);
         CREATE INDEX IF NOT EXISTS idx_scope ON engrams(scope);
@@ -58,6 +60,23 @@ export class IndexedStorage {
         // Column already exists — expected on subsequent opens
       }
       this.db.exec('CREATE INDEX IF NOT EXISTS idx_source ON engrams(source)')
+      // Add `personal` column to pre-0.10.0 DBs (#353 read-side fix). The new
+      // DEFAULT 0 leaves existing rows wrong until repopulated, so a successful
+      // ADD COLUMN (i.e. an old DB that lacked it) triggers a one-time reindex
+      // that rewrites every row's `personal` flag from its scope. New DBs (column
+      // already present from CREATE TABLE) throw here and skip the reindex.
+      let addedPersonalColumn = false
+      try {
+        this.db.exec('ALTER TABLE engrams ADD COLUMN personal INTEGER NOT NULL DEFAULT 0')
+        addedPersonalColumn = true
+      } catch {
+        // Column already exists — expected on subsequent opens / fresh DBs.
+      }
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_personal ON engrams(personal)')
+      if (addedPersonalColumn) {
+        // One-time backfill: rebuild from YAML so every row gets `personal` set.
+        this.syncFromYaml()
+      }
     }
     return this.db
   }
@@ -86,7 +105,11 @@ export class IndexedStorage {
       params.push(filter.status)
     }
     if (filter.scope) {
-      conditions.push("(scope = 'global' OR scope = ? OR scope LIKE ? || '%')")
+      // Read-side scope filter (#353). `personal = 1` passes ALL personal-family
+      // scopes (local, global, user:*, agent:*) — set at index time from
+      // isPersonalScope — not just global, so a project-scope recall sees personal
+      // engrams. The two `scope` params (exact + LIKE prefix) are unchanged.
+      conditions.push("(personal = 1 OR scope = ? OR scope LIKE ? || '%')")
       params.push(filter.scope, filter.scope)
     }
     if (filter.domain) {
@@ -115,8 +138,8 @@ export class IndexedStorage {
   syncFromYaml(): void {
     const db = this.getDb()
     const upsert = db.prepare(`
-      INSERT OR REPLACE INTO engrams (id, status, scope, domain, last_accessed, data, source)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO engrams (id, status, scope, domain, last_accessed, data, source, personal)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `)
 
     const allSyncedIds = new Set<string>()
@@ -126,7 +149,9 @@ export class IndexedStorage {
       // Sync primary store
       const primaryEngrams = loadEngrams(this.engramsPath)
       for (const e of primaryEngrams) {
-        upsert.run(e.id, e.status, e.scope, e.domain ?? null, e.activation.last_accessed, JSON.stringify(e), 'primary')
+        // `personal` mirrors isPersonalScope of the stored scope so loadFiltered
+        // can pass personal-family scopes under any project-scope filter (#353).
+        upsert.run(e.id, e.status, e.scope, e.domain ?? null, e.activation.last_accessed, JSON.stringify(e), 'primary', isPersonalScope(e.scope) ? 1 : 0)
         allSyncedIds.add(e.id)
       }
 
@@ -145,8 +170,13 @@ export class IndexedStorage {
             continue
           }
           const nsId = e.id.replace(/^(ENG|ABS|META)-/, `$1-${prefix}-`)
+          // Cross-store narrowing (UNCHANGED, intentional): a global-scoped
+          // secondary-store engram is renamed to the store's scope on load (#353
+          // documents this as preserved behavior). `personal` reflects the FINAL
+          // written scope — a global engram renamed to a shared store scope is
+          // correctly indexed as non-personal.
           const scope = e.scope === 'global' ? store.scope : e.scope
-          upsert.run(nsId, e.status, scope, e.domain ?? null, e.activation.last_accessed, JSON.stringify({ ...e, id: nsId, scope }), store.path)
+          upsert.run(nsId, e.status, scope, e.domain ?? null, e.activation.last_accessed, JSON.stringify({ ...e, id: nsId, scope }), store.path, isPersonalScope(scope) ? 1 : 0)
           allSyncedIds.add(nsId)
         }
       }

--- a/packages/core/test/pr1-indexed-migration.test.ts
+++ b/packages/core/test/pr1-indexed-migration.test.ts
@@ -1,0 +1,61 @@
+/**
+ * PR-1 (#353) storage-indexed migration: a pre-0.10.0 engrams.db (no `personal`
+ * column) is migrated on open — ALTER TABLE ADD COLUMN personal, then a one-time
+ * reindex backfills the flag from each engram's scope — so a previously-invisible
+ * local engram becomes visible under a project-scope filter.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, unlinkSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { IndexedStorage } from '../src/storage-indexed.js'
+
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+let Database: any = null
+let hasSqlite = false
+try { Database = require('better-sqlite3'); hasSqlite = true } catch {}
+
+const dirs: string[] = []
+afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+describe.skipIf(!hasSqlite)('PR-1 indexed-storage personal-column migration (#353)', () => {
+  it('migrates a pre-0.10.0 DB and makes a local engram visible under a project filter', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-pr1-mig-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'engrams.db')
+    const yamlPath = join(dir, 'engrams.yaml')
+
+    // Seed schema-valid YAML via a real Plur (index:false so it writes only YAML).
+    writeFileSync(join(dir, 'config.yaml'), 'index: false\n')
+    const seed = new Plur({ path: dir })
+    const seeded = seed.learn('old local engram about widgets', { scope: 'local' })
+
+    // Build an OLD-schema engrams.db (no `personal` column) pointing at the YAML.
+    if (existsSync(dbPath)) unlinkSync(dbPath)
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
+    db.exec(`CREATE TABLE engrams (
+      id TEXT PRIMARY KEY, status TEXT NOT NULL, scope TEXT NOT NULL,
+      domain TEXT, last_accessed TEXT, data TEXT NOT NULL,
+      source TEXT NOT NULL DEFAULT 'primary');`)
+    db.prepare('INSERT INTO engrams (id,status,scope,domain,last_accessed,data,source) VALUES (?,?,?,?,?,?,?)')
+      .run(seeded.id, 'active', 'local', null, seeded.activation.last_accessed, JSON.stringify(seeded), 'primary')
+    db.close()
+
+    // Open via IndexedStorage — should ALTER TABLE ADD COLUMN personal + reindex.
+    const store = new IndexedStorage(yamlPath, dbPath, [])
+    const visible = store.loadFiltered({ status: 'active', scope: 'project:myapp' })
+    expect(visible.some(e => e.id === seeded.id)).toBe(true)
+
+    // Column now exists and the local engram's flag is 1.
+    store.close()
+    const db2 = new Database(dbPath)
+    const cols = db2.prepare('PRAGMA table_info(engrams)').all().map((c: any) => c.name)
+    expect(cols).toContain('personal')
+    const row = db2.prepare('SELECT personal FROM engrams WHERE id = ?').get(seeded.id) as any
+    expect(row.personal).toBe(1)
+    db2.close()
+  })
+})

--- a/packages/core/test/pr1-write-interactions.test.ts
+++ b/packages/core/test/pr1-write-interactions.test.ts
@@ -1,0 +1,89 @@
+/**
+ * PR-1 (#353) write-side interactions documented alongside the read-side fix:
+ *  - auto-route still fires on a confident covers match (revert didn't break it),
+ *  - RECURRENCE-INTERACTION: cross-scope recurrence still promotes a local engram
+ *    to global on the 2nd hit even under unscoped_default:'local' (index.ts:670
+ *    ignores unscoped_default — documented as v2 checklist item (ii)),
+ *  - SECONDARY-STORE rename: a global engram in a secondary store is renamed to
+ *    the store's scope on load (UNCHANGED, intentional cross-store narrowing).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur, SCOPE_MATCH_THRESHOLD } from '../src/index.js'
+
+const dirs: string[] = []
+function makeDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(d)
+  return d
+}
+afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+describe('PR-1 — auto-route still fires after the default revert (#353)', () => {
+  it('a confident covers match auto-routes an un-scoped write and stamps _routed', () => {
+    const dir = makeDir('plur-pr1-autoroute-')
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      index: false,
+      stores: [
+        { path: join(dir, 'core.yaml'), scope: 'group:plur/core', description: 'Core', covers: ['plur.*', 'embeddings', 'core'] },
+      ],
+    }, { noRefs: true }))
+    const plur = new Plur({ path: dir })
+    // domain-prefix hit (plur.core.embeddings ⊂ plur.*) + tag hit clears threshold
+    const e = plur.learn('the embeddings index for the core engine', {
+      domain: 'plur.core.embeddings',
+      tags: ['embeddings'],
+    }) as { scope: string; structured_data?: { _routed?: { scope: string; confidence: number } } }
+    expect(e.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.confidence).toBeGreaterThanOrEqual(SCOPE_MATCH_THRESHOLD)
+  })
+})
+
+describe('PR-1 — RECURRENCE-INTERACTION under unscoped_default:local (#353, v2 item ii)', () => {
+  it('a local engram promoted to global by _recordCrossScopeRecurrence on the 2nd cross-scope hit', () => {
+    const dir = makeDir('plur-pr1-recur-')
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ index: false, unscoped_default: 'local' }, { noRefs: true }))
+    const plur = new Plur({ path: dir })
+
+    // 1st learn, unscoped → lands local under unscoped_default:'local'
+    const first = plur.learn('recurrence-interaction probe statement') as { scope: string; id: string }
+    expect(first.scope).toBe('local')
+
+    // 1st cross-scope hit: recurrence=1, scope unchanged
+    plur.learn('recurrence-interaction probe statement', { scope: 'project:a' })
+    // 2nd cross-scope hit: recurrence=2 → promotion to global regardless of unscoped_default
+    const promoted = plur.learn('recurrence-interaction probe statement', { scope: 'project:b' }) as { scope: string; id: string }
+    expect(promoted.id).toBe(first.id)
+    // index.ts:670 hardcodes global on the 2nd cross-scope hit (ignores unscoped_default).
+    expect(promoted.scope).toBe('global')
+  })
+})
+
+describe('PR-1 — SECONDARY-STORE rename preserved (#353)', () => {
+  it('a global-scoped engram in a secondary store is renamed to the store scope on load', () => {
+    const primaryDir = makeDir('plur-pr1-sec-primary-')
+    const storeDir = makeDir('plur-pr1-sec-store-')
+
+    // Seed the secondary store directly with a global-scoped engram.
+    const seed = new Plur({ path: storeDir })
+    const seeded = seed.learn('secondary store global engram about widgets', { scope: 'global' })
+
+    writeFileSync(join(primaryDir, 'config.yaml'), yaml.dump({
+      index: false,
+      stores: [
+        { path: join(storeDir, 'engrams.yaml'), scope: 'group:plur/core' },
+      ],
+    }, { noRefs: true }))
+    const plur = new Plur({ path: primaryDir })
+
+    // Loaded through the secondary store, the global engram is narrowed to the
+    // store's scope (cross-store narrowing) — UNCHANGED behavior.
+    const loaded = plur.list().filter(e => (e as any)._originalId === seeded.id)
+    expect(loaded.length).toBe(1)
+    expect(loaded[0].scope).toBe('group:plur/core')
+  })
+})

--- a/packages/core/test/read-side-scope-visibility.test.ts
+++ b/packages/core/test/read-side-scope-visibility.test.ts
@@ -1,0 +1,174 @@
+/**
+ * PR-1 (#353) read-side scope visibility — ALL THREE read paths.
+ *
+ * The un-scoped WRITE default was reverted local→global, but the revert alone is
+ * insufficient: the read filters hardcoded a `global`-only personal pass-through
+ * and dropped other personal-family scopes (local, user:alice) under a
+ * project-scope filter. This file proves that EVERY personal-family scope is
+ * visible under a project-scope recall AND inject, on the DEFAULT indexed path
+ * (config.index: true → storage-indexed.ts loadFiltered), plus the two
+ * D1-RECALL/INJECT-ASYMMETRY behaviors.
+ *
+ * `recall` exercises the indexed SQL path (storage-indexed.ts:89). `inject`
+ * exercises inject.ts scoreEngram. The non-indexed recall filter (index.ts:1812)
+ * is exercised by the config.index:false sibling at the bottom.
+ *
+ * All tests use config.index:true (the production path) unless they explicitly
+ * test the non-indexed branch.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { isPersonalScope, isSharedScope } from '../src/scope-util.js'
+
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+let hasSqlite = false
+try { require('better-sqlite3'); hasSqlite = true } catch {}
+
+const PROJECT = 'project:myapp'
+// A statement and a recall query that share keywords so injection/recall surface it.
+const STMT = (who: string) => `the deployment pipeline uses snake_case naming for ${who}`
+const QUERY = 'deployment pipeline snake_case naming'
+
+function recallSeesId(plur: Plur, scope: string, id: string): boolean {
+  return plur.recall(QUERY, { scope }).some(e => e.id === id)
+}
+function injectSeesId(plur: Plur, scope: string, id: string): boolean {
+  const res = plur.inject(QUERY, { scope })
+  return res.injected_ids.includes(id)
+}
+
+describe.skipIf(!hasSqlite)('PR-1 read-side scope visibility (indexed path, #353)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-readside-'))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ index: true }, { noRefs: true }))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('predicate sanity: personal-family scopes are personal, shared are not', () => {
+    for (const s of ['local', 'global', 'user:alice', 'agent:bot', 'user:alice:notes']) {
+      expect(isPersonalScope(s)).toBe(true)
+      expect(isSharedScope(s)).toBe(false)
+    }
+    for (const s of ['group:x', 'project:y', 'space:z', 'team:t', 'org:o', 'public']) {
+      expect(isSharedScope(s)).toBe(true)
+      expect(isPersonalScope(s)).toBe(false)
+    }
+  })
+
+  // --- REGRESSION HIGH-7/8: global visible under project-scope ---
+  it('a global-scoped engram IS visible under project-scope recall AND inject', () => {
+    const e = plur.learn(STMT('global'), { scope: 'global' })
+    expect(recallSeesId(plur, PROJECT, e.id)).toBe(true)
+    expect(injectSeesId(plur, PROJECT, e.id)).toBe(true)
+  })
+
+  // --- REGRESSION local invisibility: was 0 before ---
+  it('a local-scoped engram IS visible under project-scope recall AND inject', () => {
+    const e = plur.learn(STMT('local'), { scope: 'local' })
+    expect(recallSeesId(plur, PROJECT, e.id)).toBe(true)
+    expect(injectSeesId(plur, PROJECT, e.id)).toBe(true)
+  })
+
+  // --- REGRESSION non-two-value personal: user:alice ---
+  it('a user:alice-scoped engram IS visible under project-scope recall AND inject', () => {
+    const e = plur.learn(STMT('useralice'), { scope: 'user:alice' })
+    expect(recallSeesId(plur, PROJECT, e.id)).toBe(true)
+    expect(injectSeesId(plur, PROJECT, e.id)).toBe(true)
+  })
+
+  // --- A genuinely-shared NON-matching scope is still excluded ---
+  it('a group:other shared engram is NOT visible under a different project-scope filter', () => {
+    const e = plur.learn(STMT('grpother'), { scope: 'group:other/team' })
+    expect(recallSeesId(plur, PROJECT, e.id)).toBe(false)
+    expect(injectSeesId(plur, PROJECT, e.id)).toBe(false)
+  })
+
+  // --- END-TO-END: no scope → lands global → visible in project session ---
+  it('end-to-end: unscoped learn lands global and appears in a project-scoped recall AND inject', () => {
+    const e = plur.learn(STMT('e2e')) // no scope → defaults to global
+    expect(e.scope).toBe('global')
+    expect(recallSeesId(plur, PROJECT, e.id)).toBe(true)
+    expect(injectSeesId(plur, PROJECT, e.id)).toBe(true)
+  })
+
+  // --- INDEXED-PATH explicit assertion: loadFiltered returns personal scopes ---
+  it('indexedStorage.loadFiltered (default) returns personal-family scopes under a project filter', () => {
+    const g = plur.learn(STMT('idxg'), { scope: 'global' })
+    const l = plur.learn(STMT('idxl'), { scope: 'local' })
+    const u = plur.learn(STMT('idxu'), { scope: 'user:alice' })
+    // list() → _filterEngrams → indexedStorage.loadFiltered when index:true
+    const visible = plur.list({ scope: PROJECT }).map(e => e.id)
+    expect(visible).toContain(g.id)
+    expect(visible).toContain(l.id)
+    expect(visible).toContain(u.id)
+  })
+
+  // --- D1-ASYMMETRY (2 tests) ---
+  it('D1-ASYMMETRY (a): explicit scope=global RECALL includes a local-scoped engram', () => {
+    const l = plur.learn(STMT('asymrecall'), { scope: 'local' })
+    expect(recallSeesId(plur, 'global', l.id)).toBe(true)
+  })
+
+  it('D1-ASYMMETRY (b): explicit scope=global INJECT does NOT include a local-scoped engram', () => {
+    const l = plur.learn(STMT('asyminject'), { scope: 'local' })
+    // global inject is targeted to the global namespace only (INJECT_GLOBAL_IS_TARGETED)
+    expect(injectSeesId(plur, 'global', l.id)).toBe(false)
+    // …while a global-scoped engram IS surfaced by the same global inject.
+    const g = plur.learn(STMT('asyminjectg'), { scope: 'global' })
+    expect(injectSeesId(plur, 'global', g.id)).toBe(true)
+  })
+
+  // --- DELIBERATE-LOCAL: unscoped_default:'local' still visible under project scope ---
+  it('DELIBERATE-LOCAL: with unscoped_default:local a local engram is still visible under project-scope recall/inject', () => {
+    const dir2 = mkdtempSync(join(tmpdir(), 'plur-readside-local-'))
+    writeFileSync(join(dir2, 'config.yaml'), yaml.dump({ index: true, unscoped_default: 'local' }, { noRefs: true }))
+    const p2 = new Plur({ path: dir2 })
+    try {
+      const e = p2.learn(STMT('delibloc')) // no scope → local under this config
+      expect(e.scope).toBe('local')
+      expect(recallSeesId(p2, PROJECT, e.id)).toBe(true)
+      expect(injectSeesId(p2, PROJECT, e.id)).toBe(true)
+    } finally {
+      rmSync(dir2, { recursive: true, force: true })
+    }
+  })
+})
+
+// --- Non-indexed read filter (index.ts:1812) ---
+describe('PR-1 read-side scope visibility (NON-indexed path, #353)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-readside-noidx-'))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ index: false }, { noRefs: true }))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('local, global, and user:alice are all visible under a project-scope recall (non-indexed)', () => {
+    const g = plur.learn(STMT('niG'), { scope: 'global' })
+    const l = plur.learn(STMT('niL'), { scope: 'local' })
+    const u = plur.learn(STMT('niU'), { scope: 'user:alice' })
+    const ids = plur.recall(QUERY, { scope: PROJECT }).map(e => e.id)
+    expect(ids).toContain(g.id)
+    expect(ids).toContain(l.id)
+    expect(ids).toContain(u.id)
+  })
+
+  it('explicit personal sub-scope (user:alice) still catches its sub-scopes via startsWith (non-indexed)', () => {
+    const sub = plur.learn(STMT('niSub'), { scope: 'user:alice:notes' })
+    // recalling with scope user:alice must include user:alice:notes (startsWith arm)
+    const ids = plur.recall(QUERY, { scope: 'user:alice' }).map(e => e.id)
+    expect(ids).toContain(sub.id)
+  })
+})

--- a/packages/core/test/route-unscoped.test.ts
+++ b/packages/core/test/route-unscoped.test.ts
@@ -54,7 +54,7 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
     expect(e.structured_data?._routed?.reason).toBeTruthy()
   })
 
-  it('falls to local (the default) when no covers match', () => {
+  it('falls to global (the default, reverted in 0.10.0 #353) when no covers match', () => {
     const plur = makePlur({
       stores: [
         { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.*', 'embeddings'] },
@@ -63,11 +63,11 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
     const e = plur.learn('completely unrelated note about lunch preferences') as {
       scope: string; structured_data?: { _routed?: unknown }
     }
-    expect(e.scope).toBe('local')
+    expect(e.scope).toBe('global')
     expect(e.structured_data?._routed).toBeUndefined()
   })
 
-  it('unscoped_default: "global" sends an unmatched write to global (back-compat)', () => {
+  it('unscoped_default: "global" sends an unmatched write to global (explicit; also the default)', () => {
     const plur = makePlur({
       unscoped_default: 'global',
       stores: [
@@ -78,6 +78,20 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
       scope: string; structured_data?: { _routed?: unknown }
     }
     expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('unscoped_default: "local" sends an unmatched write to local (opt-out of global)', () => {
+    const plur = makePlur({
+      unscoped_default: 'local',
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.*'] },
+      ],
+    })
+    const e = plur.learn('unrelated note that matches no covers') as {
+      scope: string; structured_data?: { _routed?: unknown }
+    }
+    expect(e.scope).toBe('local')
     expect(e.structured_data?._routed).toBeUndefined()
   })
 
@@ -112,7 +126,7 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
     expect(e.structured_data?._routed).toBeUndefined()
   })
 
-  it('auto_route_scope:false disables routing — unscoped falls straight to default', () => {
+  it('auto_route_scope:false disables routing — unscoped falls straight to default (global)', () => {
     const plur = makePlur({
       auto_route_scope: false,
       stores: [
@@ -123,7 +137,7 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
       domain: 'plur.core.embeddings',
       tags: ['embeddings'],
     }) as { scope: string; structured_data?: { _routed?: unknown } }
-    expect(e.scope).toBe('local')
+    expect(e.scope).toBe('global')
     expect(e.structured_data?._routed).toBeUndefined()
   })
 

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -168,11 +168,12 @@ describe('plur.suggestScope — reads scope metadata from config stores', () => 
     expect(ranked[0].scope).toBe('group:plur/infra')
     // …but its confidence is only a keyword match (deployment + servers), which
     // sits BELOW SCOPE_MATCH_THRESHOLD, so Stage 3b auto-routing does NOT fire —
-    // the unscoped write falls to unscoped_default ('local' by default). The
-    // confident (domain-prefix) auto-route path is covered in route-unscoped.test.ts.
+    // the unscoped write falls to unscoped_default ('global' by default, reverted
+    // in 0.10.0 #353). The confident (domain-prefix) auto-route path is covered
+    // in route-unscoped.test.ts.
     expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
     const e = plur.learn('restart the deployment on the servers') as { scope: string }
-    expect(e.scope).toBe('local')
+    expect(e.scope).toBe('global')
   })
 
   it('feeds tags through to the ranker', () => {

--- a/packages/core/test/session-scope.test.ts
+++ b/packages/core/test/session-scope.test.ts
@@ -123,20 +123,20 @@ describe('session scope (#229)', () => {
     expect(engram.scope).toBe('project:override')
   })
 
-  it('learn() falls back to unscoped_default (local) when no session scope set (Stage 3b, #351)', () => {
-    const plur = new Plur({ path: primaryDir })
-    const engram = plur.learn('local fallback test')
-    expect(engram.scope).toBe('local')
-  })
-
-  it('learn() falls back to global when unscoped_default is configured "global" (back-compat)', () => {
-    writeFileSync(
-      join(primaryDir, 'config.yaml'),
-      yaml.dump({ unscoped_default: 'global', index: false }, { noRefs: true }),
-    )
+  it('learn() falls back to unscoped_default (global, reverted 0.10.0 #353) when no session scope set', () => {
     const plur = new Plur({ path: primaryDir })
     const engram = plur.learn('global fallback test')
     expect(engram.scope).toBe('global')
+  })
+
+  it('learn() falls back to local when unscoped_default is configured "local"', () => {
+    writeFileSync(
+      join(primaryDir, 'config.yaml'),
+      yaml.dump({ unscoped_default: 'local', index: false }, { noRefs: true }),
+    )
+    const plur = new Plur({ path: primaryDir })
+    const engram = plur.learn('local fallback test')
+    expect(engram.scope).toBe('local')
   })
 
   // --- learnRouted() uses session scope for remote routing ---

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,7 +1,7 @@
 import { existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig } from '@plur-ai/core'
+import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope } from '@plur-ai/core'
 import type { LlmFunction, MetaField } from '@plur-ai/core'
 import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
@@ -177,14 +177,18 @@ export function getToolDefinitions(): ToolDefinition[] {
         // auto-routed, while a team store IS configured, team knowledge silently
         // never reaches the shared store. Surface that at the moment it happens —
         // non-fatal, informational, and only when there is a team store to route
-        // to (stays silent on personal installs). Stage 3b made un-scoped writes
-        // default to "local" (was "global") and auto-route on a confident covers
-        // match (stamping structured_data._routed); the hint must fire on either
-        // personal landing scope and stay silent when the write was auto-routed.
+        // to (stays silent on personal installs). Un-scoped writes default to
+        // "global" (the historical default, restored in 0.10.0, #353) and
+        // auto-route on a confident covers match (stamping structured_data._routed).
+        // The hint fires on ANY non-shared (personal-family) landing scope —
+        // "local", "global", "user:*", "agent:*" — and stays silent when the
+        // write was auto-routed or an explicit scope was passed.
         const explicitScope = typeof args.scope === 'string' && args.scope.length > 0
-        const PERSONAL_SCOPES = new Set(['local', 'global'])
         const scopeHint = (engramScope: string, wasRouted: boolean): { scope_hint?: string } => {
-          if (explicitScope || wasRouted || !PERSONAL_SCOPES.has(engramScope)) return {}
+          // isSharedScope swap (#353): fire on any non-shared landing scope, not
+          // just the hardcoded {local,global} set, so a user:alice personal scope
+          // also nudges when a team store is configured.
+          if (explicitScope || wasRouted || isSharedScope(engramScope)) return {}
           let remote: Array<{ scope: string }> = []
           try { remote = plur.getWritableRemoteScopes() } catch { return {} }
           if (remote.length === 0) return {}
@@ -236,7 +240,7 @@ export function getToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_recall',
-      description: 'Query engrams by BM25 keyword matching — use plur_recall_hybrid for semantic similarity',
+      description: 'Query engrams by BM25 keyword matching — use plur_recall_hybrid for semantic similarity. Note: a project-scope filter also returns personal-family engrams (local, global, user:*, agent:*); an explicit scope=global recall returns ALL personal-family engrams — wider than scope=global INJECT, which is targeted to the global namespace only.',
       annotations: { title: 'Recall (BM25)', readOnlyHint: true, idempotentHint: true },
       inputSchema: {
         type: 'object',
@@ -1279,8 +1283,12 @@ export function getToolDefinitions(): ToolDefinition[] {
           // (this is the #177 failure mode: agents that don't pass scope get
           // 'global', and global pollutes every future session).
           guide += `\n\n⚠️ No project scope detected. plur_learn calls without explicit scope will be tagged ` +
-            `"global" and will appear in EVERY project's future sessions. To avoid context bleed across ` +
-            `projects, create a .plur.yaml in this project's root with: scope: "project:<your-project-name>"`
+            `"global" and will appear in EVERY project's future sessions. Create a .plur.yaml NOW to prevent this: ` +
+            `scope: "project:<your-project-name>". (This is every project's PERSONAL recall context, NOT team ` +
+            `shared stores — use an explicit shared scope like project:/group: to reach a team store.) ` +
+            `Note: an explicit scope=global RECALL surfaces all your personal engrams, but scope=global INJECT is ` +
+            `targeted to the global namespace only — don't be surprised if a local engram a global recall finds is ` +
+            `absent from a global inject.`
         }
 
         // Append remote scope guidance to guide text (#229)

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -260,8 +260,11 @@ describe('Session & store tools', () => {
       const result = await callTool('plur_session_start', { task: 'work' }) as any
 
       expect(result.guide).toContain('No project scope detected')
-      expect(result.guide).toContain('context bleed')
+      // 0.10.0 (#353): the guidance is now IMPERATIVE — "Create a .plur.yaml NOW"
+      // — and clarifies the personal-recall vs team-store distinction.
+      expect(result.guide).toContain('Create a .plur.yaml NOW')
       expect(result.guide).toContain('.plur.yaml')
+      expect(result.guide).toContain('PERSONAL recall context')
     })
 
     it('guide includes confirmation when project scope is auto-detected', async () => {
@@ -273,6 +276,9 @@ describe('Session & store tools', () => {
       expect(result.guide).toContain('Auto-detected project scope')
       expect(result.guide).toContain('project:detected')
       expect(result.guide).toContain('.plur.yaml')
+      // The project-config branch references the EXISTING .plur.yaml but must NOT
+      // imperatively tell the user to CREATE one (that's the no-scope branch).
+      expect(result.guide).not.toContain('Create a .plur.yaml NOW')
     })
 
     it('cross-session: project A scope does not leak into project B', async () => {
@@ -290,10 +296,11 @@ describe('Session & store tools', () => {
         expect(plur.getSessionScope()).toBeNull()  // not "project:a"!
 
         const bEngram = plur.learn('B-side engram')
-        // Stage 3b: un-scoped writes default to "local" (was "global"). The
-        // property under test is "no cross-project leak" — "local" satisfies
-        // that even better than "global". The key assertion is NOT "project:a".
-        expect(bEngram.scope).toBe('local')  // not "project:a"
+        // 0.10.0 (#353): un-scoped writes default to "global" (reverted from the
+        // Stage 3b "local"). The property under test is "no cross-project leak"
+        // into project:a — "global" satisfies that (it is the personal namespace,
+        // not project A's scope). The key assertion is NOT "project:a".
+        expect(bEngram.scope).toBe('global')  // not "project:a"
       } finally {
         rmSync(projectB, { recursive: true, force: true })
       }

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -53,11 +53,28 @@ describe('MCP tools', () => {
 
     it('hints to use the team scope when scope is omitted and engram lands at a personal scope', async () => {
       const result = await callTool('plur_learn', { statement: 'We use trunk-based development' }) as any
-      // Stage 3b: un-scoped writes default to "local" (was "global"). The hint
-      // must still fire on a personal landing scope when a team store exists.
-      expect(result.scope).toBe('local')
+      // 0.10.0 (#353): un-scoped writes default to "global" (reverted). The hint
+      // must still fire on a personal landing scope (global is personal-family)
+      // when a team store exists — the scope_hint now keys off isSharedScope.
+      expect(result.scope).toBe('global')
       expect(result.scope_hint).toBeDefined()
       expect(result.scope_hint).toContain('group:acme/engineering')
+    })
+
+    it('hints on a user:* personal landing scope (proves isSharedScope swap, #353)', async () => {
+      // A user:alice scope is personal-family (not shared). Drive the engram to
+      // land there WITHOUT an explicit args.scope by setting a session default,
+      // so explicitScope is false and the hint must fire (the old hardcoded
+      // {local,global} set would have stayed silent on user:alice).
+      plur.setSessionScope('user:alice')
+      try {
+        const result = await callTool('plur_learn', { statement: 'team prefers tabs over spaces' }) as any
+        expect(result.scope).toBe('user:alice')
+        expect(result.scope_hint).toBeDefined()
+        expect(result.scope_hint).toContain('group:acme/engineering')
+      } finally {
+        plur.setSessionScope(null)
+      }
     })
 
     it('no hint when an explicit scope is passed', async () => {
@@ -75,9 +92,9 @@ describe('MCP tools', () => {
 
   it('plur_learn does NOT hint on a personal install (no team store configured)', async () => {
     const result = await callTool('plur_learn', { statement: 'Personal note' }) as any
-    // Stage 3b: un-scoped writes default to "local"; with no team store there is
-    // nowhere to route to, so the hint stays silent.
-    expect(result.scope).toBe('local')
+    // 0.10.0 (#353): un-scoped writes default to "global"; with no team store
+    // there is nowhere to route to, so the hint stays silent.
+    expect(result.scope).toBe('global')
     expect(result.scope_hint).toBeUndefined()
   })
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -253,6 +253,13 @@ echo "--- Step 2: Build ---"
 pnpm build 2>&1 | grep -E "success|error"
 echo ""
 
+# D1-followup gate (#177): the Stage 3b v2 tracking sentinel must be present and
+# point at a GitHub issue before any release. Portable Node check (macOS grep
+# lacks -P); mirrored in CI lint so it runs even when release.sh does not.
+node -e "const s=require('fs').readFileSync('docs/KNOWN_ISSUES.md','utf8'); if(!/STAGE3B_V2_TRACKING:https:\/\/github\.com\//.test(s)){console.error('KNOWN_ISSUES sentinel missing'); process.exit(1)}"
+echo "✓ KNOWN_ISSUES Stage 3b v2 tracking sentinel present"
+echo ""
+
 # --- 3. Test ---
 echo "--- Step 3: Test ---"
 TEST_OUTPUT=$(pnpm test 2>&1 || true)


### PR DESCRIPTION
PR-1 of the 0.10.0 evaluator-hardened fix plan. Reverts the un-scoped WRITE default `local → global` AND fixes every read-side scope filter so no personal-family scope is excluded by a project-scoped recall/inject. Resolves audit findings 3, 4, 5, 7, 8.

## Module-cycle break (mandatory precondition, done first)

`inject.ts` needs `isPersonalScope`, but `index.ts` imports from `inject.ts` — importing the predicate from `index.ts` would form an `index → inject → index` cycle. Resolution: new leaf module **`packages/core/src/scope-util.ts`** holds `SHARED_SCOPE_PREFIXES`, `isSharedScope`, and new `isPersonalScope(scope) = !isSharedScope(scope)`. `index.ts` re-exports `isSharedScope`/`isPersonalScope`/`SHARED_SCOPE_PREFIXES` (public API unchanged). Re-pointed imports: `inject.ts`, `index.ts`, `storage-indexed.ts` import from `scope-util.ts`; `mcp/tools.ts` imports `isSharedScope` from `@plur-ai/core`. `scope-util.ts` is a dependency-free leaf; `inject.ts` no longer imports `index.ts`. **CI gate:** `tsc --noEmit` on core added to the lint step (madge isn't a repo dep) — must be green before any filter edit.

## Read side — all three paths (`isPersonalScope`, not a hardcoded {local,global})

1. **`inject.ts` `scoreEngram`** — project-branch passes all personal-family scopes; the `scopeFilter === 'global'` branch is **kept targeted** (returns global only), encoded by the named constant `INJECT_GLOBAL_IS_TARGETED = true` with JSDoc (the documented RECALL/INJECT asymmetry).
2. **`index.ts` non-indexed recall filter** — `e.scope === scope || e.scope.startsWith(scope) || isPersonalScope(e.scope)` (keeps the `startsWith` arm so `user:alice` still catches `user:alice:notes`).
3. **`storage-indexed.ts` — the DEFAULT indexed SQLite path** (`config.index` defaults true → production path). New `personal INTEGER` column set at index time from `isPersonalScope(scope)` in both upsert sites; `loadFiltered` SQL changed from `scope = 'global'` to `personal = 1` (params unchanged). Pre-0.10.0 DBs migrate via guarded `ALTER TABLE ADD COLUMN personal` + a one-time reindex backfill.

## RECALL/INJECT asymmetry decision

An explicit `scope=global` RECALL returns ALL personal-family engrams; an explicit `scope=global` INJECT returns ONLY global (targeted global-namespace injection). Pre-existing for recall, intentionally kept for inject — `INJECT_GLOBAL_IS_TARGETED` JSDoc says a future "fix" must rename the constant. Noted in the `plur_recall` tool description and `plur_session_start` 'none' guidance. Two D1-ASYMMETRY tests lock it.

## Write default + consistency fixes

- `schemas/config.ts`: `unscoped_default` default `local → global` (enum + `auto_route_scope` kept); JSDoc rewritten. `_resolveUnscopedScope` and `_guardSensitiveScope` terminal fallbacks aligned to the schema default so they can't drift.
- CLI `learn.ts`: omits the scope key when `--scope` is absent (flows through unscoped routing); always uses `learnRouted` (so shared scopes reach the remote/outbox) with a 5s `Promise.race` timeout (cleared on success — an un-cleared timer would hang the CLI).
- claw `context-engine.ts`: `_learnIfNew` → `learnRouted` (async, fire-and-forget in hooks); the three scope fallbacks `|| 'global'` → `|| undefined`.
- MCP `tools.ts`: `scope_hint` fires on any non-shared landing scope via `isSharedScope` (deleted `PERSONAL_SCOPES`); session_start guidance made imperative ("Create a .plur.yaml NOW") + personal-recall-vs-team-store clarifier; `plur_recall` description notes the asymmetry.

## #177 tracking gate

Tracking issue **#362** ("Stage 3b v2: re-implement scoped unscoped-default with correct read-visibility…", v2 = WRITE-default only, READ side already fixed here). `docs/KNOWN_ISSUES.md` carries `STAGE3B_V2_TRACKING:<issue url>`; a portable Node sentinel check runs in **CI lint** and **release.sh**.

## Tests

New: read-side regression on all 3 paths (global/local/user:alice visible under project recall AND inject; indexed-path explicit `loadFiltered` assertion; end-to-end unscoped→global→visible), 2× D1-ASYMMETRY, DELIBERATE-LOCAL (`unscoped_default:local` still visible), recurrence-interaction (local→global on 2nd cross-scope hit under `unscoped_default:local`), secondary-store rename preserved, indexed-DB migration, CLI covers/no-covers/explicit, claw 3-path scope-undefined + `learnRouted` spy. Existing Stage-3b behavior tests updated to the reverted default.

Auto-route on a confident covers match still fires (test included); un-scoped → global confirmed end-to-end.

**Build/test:** full workspace green after rebuilding core dist — core 1090, mcp 133, claw 107, cli 202 (1555 total passing, 0 failing). `tsc --noEmit` clean on core (pre-existing unrelated tsc errors in mcp/claw/cli baseline are untouched; tsup build is the CI path). No circular import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)