### PR TITLE
fix(core): config robustness — sensitivity .catch() + passthrough on StoreEntry & ScopeSensitivity (no data loss) — PR-3 (#353 audit)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs'
 import yaml from 'js-yaml'
 import { PlurConfigSchema, StoreEntrySchema, type PlurConfig } from './schemas/config.js'
+import { SENSITIVITY_CATEGORIES } from './schemas/scope-metadata.js'
 import { logger } from './logger.js'
 
 /**
@@ -48,10 +49,27 @@ export function loadConfig(configPath: string): PlurConfig {
     }
     raw.stores = validStores
   }
+  let parsed: PlurConfig
   try {
-    return PlurConfigSchema.parse(raw)
+    parsed = PlurConfigSchema.parse(raw)
   } catch (err) {
     logger.warning(`[plur:config] top-level config invalid at ${configPath}: ${(err as Error).message} — falling back to defaults`)
     return PlurConfigSchema.parse({})
   }
+  // PR-3 (#353) scope-naming pass. ScopeSensitivitySchema.forbid now preprocesses
+  // unknown categories away (non-fatal), but the field-level preprocess can't
+  // name the SCOPE it belongs to. Diff the raw `forbid` against the parsed one
+  // per entry and emit a scope-named warning so an operator can find the entry.
+  if (Array.isArray(raw.stores) && parsed.stores) {
+    for (let i = 0; i < parsed.stores.length; i++) {
+      const rawEntry = (raw.stores as unknown[])[i] as { sensitivity?: { forbid?: unknown } } | undefined
+      const rawForbid = rawEntry?.sensitivity?.forbid
+      if (!Array.isArray(rawForbid)) continue
+      const dropped = rawForbid.filter((c) => !(SENSITIVITY_CATEGORIES as readonly string[]).includes(c as string))
+      if (dropped.length) {
+        logger.warning(`[plur:config] scope=${parsed.stores[i].scope}: dropped unknown sensitivity categor${dropped.length > 1 ? 'ies' : 'y'} ${JSON.stringify(dropped)} from forbid (entry kept, url/token intact)`)
+      }
+    }
+  }
+  return parsed
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3201,10 +3201,63 @@ Generate an improved version of the procedure that prevents this failure. Return
       const raw = fs.readFileSync(this.paths.config, 'utf8')
       if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
     } catch {}
-    configData.stores = stores
+    configData.stores = this.mergeStoresForWriteback(configData.stores, stores)
     fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
     this.config = loadConfig(this.paths.config)
     this.configMtimeMs = this.statConfigMtime()
+  }
+
+  /**
+   * MERGE the typed `stores` array onto the RAW (freshly-read YAML) entries so a
+   * writeback never strips fields the typed schema doesn't know about (PR-3,
+   * #353 HIGH-17/18). `stores` is `StoreEntry[]` — the typed parse output —
+   * which (without this) would clobber `configData.stores` and lose:
+   *   - unknown/future TOP-LEVEL keys (recovered here; also kept by
+   *     StoreEntrySchema.passthrough so the typed value already carries them)
+   *   - unknown NESTED keys inside `sensitivity` (recovered by the explicit
+   *     one-level deep-merge below; a shallow spread would replace `sensitivity`
+   *     wholesale and lose them even with ScopeSensitivitySchema.passthrough)
+   * Parsed deltas (e.g. a corrected `forbid`) land ON TOP of the raw values.
+   */
+  private mergeStoresForWriteback(rawStores: unknown, stores: StoreEntry[]): StoreEntry[] {
+    if (!Array.isArray(rawStores)) return stores
+    // Key on url+scope (remote) or path+scope (local); never url alone — one
+    // enterprise URL hosts many scopes (addStore dedup identity is url+scope).
+    const keyOf = (e: { url?: unknown; path?: unknown; scope?: unknown }): string | null => {
+      const scope = typeof e?.scope === 'string' ? e.scope : ''
+      if (typeof e?.url === 'string') return `${e.url}\0${scope}`
+      if (typeof e?.path === 'string') return `${e.path}\0${scope}`
+      return null
+    }
+    const rawMap = new Map<string, Record<string, unknown>>()
+    for (const r of rawStores as unknown[]) {
+      const k = keyOf(r as Record<string, unknown>)
+      if (k) rawMap.set(k, r as Record<string, unknown>)
+    }
+    return stores.map((typed) => {
+      const k = keyOf(typed)
+      const raw = k ? rawMap.get(k) : undefined
+      if (!raw) {
+        // No raw match (genuinely new entry, e.g. an addStore append) — or an
+        // entry with neither url nor path (hand-edited; refine prevents at write
+        // time). Use the typed entry as-is rather than dropping it.
+        if (!k) logger.warning(`[plur:persistStores] store entry for scope "${typed.scope}" has neither url nor path — writing typed entry as-is`)
+        return typed
+      }
+      const rawSensitivity = (raw as { sensitivity?: Record<string, unknown> }).sensitivity
+      const merged: Record<string, unknown> = {
+        ...raw,
+        ...typed,
+        // One-level deep-merge of `sensitivity`: parsed deltas over raw nested
+        // unknowns. Without this explicit merge a shallow `...typed` would
+        // replace `sensitivity` wholesale and lose nested unknowns.
+        sensitivity: typed.sensitivity
+          ? { ...(rawSensitivity ?? {}), ...typed.sensitivity }
+          : rawSensitivity,
+      }
+      if (merged.sensitivity === undefined) delete merged.sensitivity
+      return merged as StoreEntry
+    })
   }
 
   addStore(

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -26,10 +26,18 @@ export const StoreEntrySchema = z.object({
     .describe('Topics/domains this scope is the home for (#345). Advisory; surfaced in discovery.'),
   sensitivity: ScopeSensitivitySchema.optional()
     .describe("Per-scope sensitivity policy (#345) consumed by the write-time leak guard. When present, overrides the default shared-scope demote-everything behavior for this scope."),
-}).refine(
-  (s) => Boolean(s.path) !== Boolean(s.url),
-  { message: 'StoreEntry requires exactly one of path or url' },
-)
+})
+  // PR-3 (#353): preserve unknown/future TOP-LEVEL store fields on a successful
+  // parse, so a config written by a NEWER PLUR (extra top-level keys) is not
+  // silently stripped when an OLDER PLUR re-parses and writes it back. The
+  // `.passthrough()` is placed BEFORE `.refine()` (refine yields a ZodEffects
+  // with no `.passthrough`); the path-xor-url predicate only touches known
+  // fields, so passthrough does not relax it.
+  .passthrough()
+  .refine(
+    (s) => Boolean(s.path) !== Boolean(s.url),
+    { message: 'StoreEntry requires exactly one of path or url' },
+  )
 
 export type StoreEntry = z.infer<typeof StoreEntrySchema>
 

--- a/packages/core/src/schemas/scope-metadata.ts
+++ b/packages/core/src/schemas/scope-metadata.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { logger } from '../logger.js'
 
 /**
  * Self-describing scope metadata (#345, Stage 2). A scope can declare what it is
@@ -34,11 +35,43 @@ export const SENSITIVITY_CATEGORIES = ['secrets', 'infra'] as const
 export type SensitivityCategory = (typeof SENSITIVITY_CATEGORIES)[number]
 
 export const ScopeSensitivitySchema = z.object({
-  forbid: z.array(z.enum(SENSITIVITY_CATEGORIES)).default(['secrets', 'infra'])
-    .describe('Sensitive categories that must NOT be written to this scope. A write that trips one of these is demoted to local/private. Default reproduces Stage 1: secrets + infra are forbidden on shared scopes.'),
+  /**
+   * Sensitive categories that must NOT be written to this scope (PR-3, #353
+   * HIGH-17/18). A bare `z.enum(...)` array used to be FATAL on an unknown
+   * category: a single hand-edited / forward-compat `forbid: ['pii']` failed the
+   * whole StoreEntry safeParse, so loadConfig dropped the entry — including its
+   * `url`/`token`. We now preprocess element-wise: unknown categories are
+   * dropped (named in a warning), valid ones survive, and only an empty result
+   * falls to the safe default. The whole StoreEntry NO LONGER fails on a bad
+   * category, so url/token always survive a malformed `sensitivity`.
+   *   `['secrets','pii']` → `['secrets']` (warn: pii)
+   *   `['pii']`           → `['secrets','infra']` (warn: pii)
+   *   scalar `'secrets'`  → `['secrets','infra']` (non-array → safe default, no Zod throw)
+   * The preprocess can't name the scope (it runs inside the field schema), so
+   * loadConfig adds a post-parse pass that diffs raw vs parsed `forbid` per entry
+   * and logs `scope=<s>` for the naming.
+   */
+  forbid: z.preprocess((val) => {
+    if (Array.isArray(val)) {
+      const bad = val.filter((c) => !SENSITIVITY_CATEGORIES.includes(c as SensitivityCategory))
+      if (bad.length) {
+        logger.warning(`[plur:config] dropping unknown sensitivity categor${bad.length > 1 ? 'ies' : 'y'} ${JSON.stringify(bad)} from a scope forbid list — keeping valid entries`)
+      }
+      const kept = val.filter((c) => SENSITIVITY_CATEGORIES.includes(c as SensitivityCategory))
+      return kept.length ? kept : ['secrets', 'infra']
+    }
+    return ['secrets', 'infra'] // non-array (e.g. hand-edited scalar) → safe default, NOT a re-thrown Zod error
+  }, z.array(z.enum(SENSITIVITY_CATEGORIES)).default(['secrets', 'infra']))
+    .describe('Sensitive categories that must NOT be written to this scope. A write that trips one of these is demoted to local/private. Default reproduces Stage 1: secrets + infra are forbidden on shared scopes. Unknown categories are dropped (not fatal) so a forward/hand-edited category never drops the whole store entry.'),
   allow: z.array(z.string()).default([])
     .describe('Detector pattern names or category names explicitly permitted on this scope, overriding `forbid`. A match whose categories are ALL allowed is not demoted (e.g. a scope that legitimately holds infra topology can allow "infra").'),
-}).describe('Per-scope sensitivity policy consumed by the write-time leak guard.')
+})
+  // PR-3 (#353): preserve unknown NESTED fields inside `sensitivity` on a
+  // successful parse, so a future sub-schema field survives the persistStores
+  // writeback (which merges parsed deltas onto the raw entry). Without this the
+  // typed parse would strip nested unknowns and the merge could never see them.
+  .passthrough()
+  .describe('Per-scope sensitivity policy consumed by the write-time leak guard.')
 
 export type ScopeSensitivity = z.infer<typeof ScopeSensitivitySchema>
 

--- a/packages/core/test/pr3-config-robustness.test.ts
+++ b/packages/core/test/pr3-config-robustness.test.ts
@@ -1,0 +1,230 @@
+/**
+ * PR-3 (#353 audit, HIGH-17/18) — config robustness / data-loss prevention.
+ *
+ * Two distinct losses are closed here:
+ *
+ *  (a) READ-DROP: a bad `forbid` category (a hand-edited / forward-compat
+ *      category like `pii`) used to fail StoreEntry safeParse, so loadConfig
+ *      dropped the WHOLE entry — including its `url`/`token`. The
+ *      ScopeSensitivitySchema.forbid preprocess now drops only the unknown
+ *      category and keeps the entry. (scope-metadata.ts)
+ *
+ *  (b) WRITEBACK-STRIP: persistStores wrote typed StoreEntry[] over the raw
+ *      YAML, stripping unknown/future fields — both TOP-LEVEL and NESTED inside
+ *      `sensitivity`. `.passthrough()` on BOTH StoreEntrySchema and
+ *      ScopeSensitivitySchema + a merge in persistStores (with an explicit
+ *      one-level `sensitivity` deep-merge) preserve them. (config.ts schema +
+ *      index.ts persistStores)
+ *
+ * NOTE (chain-of-custody): loadConfig already pushes the RAW entry on a
+ * successful per-entry safeParse, so top-level unknowns survive the READ path
+ * for entries that pass. The TOP-LEVEL round-trip test below is therefore
+ * driven through persistStores (via addStore token rotation) so it is
+ * NON-VACUOUS — it proves the WRITEBACK path, not merely the read path.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { loadConfig } from '../src/config.js'
+import { StoreEntrySchema } from '../src/schemas/config.js'
+
+describe('PR-3 config robustness — bad forbid category (read-drop fix)', () => {
+  const dirs: string[] = []
+  const mkdir = (): string => { const d = mkdtempSync(join(tmpdir(), 'plur-pr3-')); dirs.push(d); return d }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }); vi.restoreAllMocks() })
+
+  /** Write a config.yaml with the given raw stores array and return its path. */
+  const writeConfig = (dir: string, stores: unknown[]): string => {
+    const p = join(dir, 'config.yaml')
+    writeFileSync(p, yaml.dump({ index: false, stores }, { noRefs: true }))
+    return p
+  }
+
+  it('a bad forbid category does NOT drop the entry — url/token survive, forbid → safe default, scope named', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const p = writeConfig(dir, [
+      {
+        url: 'https://enterprise.example.com',
+        token: 'secret-token-123',
+        scope: 'group:eng',
+        shared: true,
+        // hand-edited / forward-compat category the schema doesn't know
+        sensitivity: { forbid: ['pii'] },
+      },
+    ])
+
+    const cfg = loadConfig(p)
+    // Entry preserved — NOT dropped.
+    expect(cfg.stores).toHaveLength(1)
+    const entry = cfg.stores![0]
+    expect(entry.url).toBe('https://enterprise.example.com')
+    expect(entry.token).toBe('secret-token-123')   // the data-loss target — intact
+    expect(entry.scope).toBe('group:eng')
+    // bad-only forbid falls to the safe default.
+    expect(entry.sensitivity?.forbid).toEqual(['secrets', 'infra'])
+
+    // One warning names the bad value `pii`; a second names the scope.
+    const msgs = warn.mock.calls.map(c => c.join(' '))
+    expect(msgs.some(m => /pii/.test(m) && /unknown sensitivity categor/.test(m))).toBe(true)
+    expect(msgs.some(m => /scope=group:eng/.test(m) && /pii/.test(m))).toBe(true)
+  })
+
+  it('partial-bad forbid keeps the VALID subset (not the whole-array default)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const p = writeConfig(dir, [
+      { path: '/tmp/eng.yaml', scope: 'group:eng', sensitivity: { forbid: ['secrets', 'pii'] } },
+    ])
+    const cfg = loadConfig(p)
+    expect(cfg.stores).toHaveLength(1)
+    expect(cfg.stores![0].sensitivity?.forbid).toEqual(['secrets']) // pii dropped, secrets kept
+  })
+
+  it('a scalar (non-array) forbid → safe default, no Zod throw, entry not dropped', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const p = writeConfig(dir, [
+      // hand-edited scalar instead of an array
+      { url: 'https://e.example.com', token: 't', scope: 'group:eng', sensitivity: { forbid: 'secrets' } },
+    ])
+    const cfg = loadConfig(p)
+    expect(cfg.stores).toHaveLength(1)
+    expect(cfg.stores![0].token).toBe('t')
+    expect(cfg.stores![0].sensitivity?.forbid).toEqual(['secrets', 'infra'])
+  })
+
+  it('StoreEntrySchema.passthrough + refine: an unknown field AND path-xor-url both hold', () => {
+    // refine still rejects a both-path-and-url entry…
+    expect(StoreEntrySchema.safeParse({ path: '/x', url: 'https://x.example.com', scope: 's' }).success).toBe(false)
+    // …but an unknown TOP-LEVEL field survives a valid (path-only) entry.
+    const ok = StoreEntrySchema.safeParse({ path: '/x', scope: 's', future_field: 'kept' })
+    expect(ok.success).toBe(true)
+    if (ok.success) expect((ok.data as Record<string, unknown>).future_field).toBe('kept')
+  })
+
+  // The NESTED writeback test below relies on the merge-against-raw AND on the
+  // sub-schema passthrough. Prove the sub-schema passthrough INDEPENDENTLY here
+  // so the round-trip test is non-vacuous even when read in isolation: the
+  // TYPED parse output of a store entry must itself carry a nested unknown
+  // inside `sensitivity` (this is what would be stripped without
+  // ScopeSensitivitySchema.passthrough).
+  it('ScopeSensitivitySchema.passthrough: the typed parse carries a NESTED unknown field', () => {
+    const ok = StoreEntrySchema.safeParse({
+      path: '/x', scope: 's', sensitivity: { forbid: ['secrets'], future_policy: { redact: true } },
+    })
+    expect(ok.success).toBe(true)
+    if (ok.success) {
+      const sens = (ok.data as { sensitivity?: Record<string, unknown> }).sensitivity!
+      expect(sens.forbid).toEqual(['secrets'])
+      expect(sens.future_policy).toEqual({ redact: true }) // nested unknown survives the TYPED parse
+    }
+  })
+})
+
+describe('PR-3 config robustness — version-skew writeback (no field stripping)', () => {
+  const dirs: string[] = []
+  const mkdir = (): string => { const d = mkdtempSync(join(tmpdir(), 'plur-pr3-skew-')); dirs.push(d); return d }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }); vi.restoreAllMocks() })
+
+  const readStores = (dir: string): Array<Record<string, unknown>> => {
+    const cfg = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as { stores?: Array<Record<string, unknown>> }
+    return cfg.stores ?? []
+  }
+
+  /**
+   * TOP-LEVEL version-skew (NON-VACUOUS): a store entry with an unknown future
+   * top-level field, driven through persistStores via addStore's token
+   * rotation, STILL has the field afterwards. This exercises the WRITEBACK path
+   * (typed stores → persistStores merge), not merely the read path.
+   */
+  it('preserves an unknown TOP-LEVEL field through a persistStores round-trip', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const URL = 'https://enterprise.example.com'
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      index: false,
+      stores: [
+        { url: URL, token: 'old-token', scope: 'group:eng', shared: true, readonly: false, future_field: 'preserve-me' },
+      ],
+    }, { noRefs: true }))
+
+    const plur = new Plur({ path: dir })
+    // Token rotation flows the entry through this.config.stores → persistStores.
+    const res = plur.addStore('', 'group:eng', { url: URL, token: 'new-token' })
+    expect(res.status).toBe('token_rotated')
+
+    const stores = readStores(dir)
+    expect(stores).toHaveLength(1)
+    expect(stores[0].token).toBe('new-token')         // parsed delta applied
+    expect(stores[0].url).toBe(URL)                   // preserved
+    expect(stores[0].future_field).toBe('preserve-me') // unknown top-level field survives writeback
+  })
+
+  /**
+   * NESTED version-skew: an unknown field INSIDE `sensitivity`, after the same
+   * round-trip, STILL has the nested field. This is the test the evaluator
+   * flagged would be vacuous unless ScopeSensitivitySchema ALSO has
+   * `.passthrough()` AND persistStores deep-merges `sensitivity` one level.
+   */
+  it('preserves an unknown NESTED field inside sensitivity through a persistStores round-trip', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const URL = 'https://enterprise.example.com'
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      index: false,
+      stores: [
+        {
+          url: URL, token: 'old-token', scope: 'group:eng', shared: true,
+          sensitivity: { forbid: ['secrets'], allow: [], future_policy: { redact: true } },
+        },
+      ],
+    }, { noRefs: true }))
+
+    const plur = new Plur({ path: dir })
+    const res = plur.addStore('', 'group:eng', { url: URL, token: 'new-token' })
+    expect(res.status).toBe('token_rotated')
+
+    const stores = readStores(dir)
+    expect(stores).toHaveLength(1)
+    const sensitivity = stores[0].sensitivity as Record<string, unknown>
+    expect(stores[0].token).toBe('new-token')
+    expect(sensitivity.forbid).toEqual(['secrets'])          // parsed value
+    expect(sensitivity.future_policy).toEqual({ redact: true }) // NESTED unknown survives writeback
+  })
+
+  /**
+   * MERGE-KEY correctness: two remote stores share the SAME url but DIFFERENT
+   * scopes. Rotating the token on one must leave the OTHER's token/url/unknowns
+   * unchanged — proving the merge keys on url+scope, not url alone.
+   */
+  it('rotating one of two same-url/different-scope stores leaves the other untouched (url+scope key)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const URL = 'https://enterprise.example.com'
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      index: false,
+      stores: [
+        { url: URL, token: 'eng-old', scope: 'group:eng', shared: true, eng_marker: 'E' },
+        { url: URL, token: 'comms-tok', scope: 'group:comms', shared: true, comms_marker: 'C' },
+      ],
+    }, { noRefs: true }))
+
+    const plur = new Plur({ path: dir })
+    const res = plur.addStore('', 'group:eng', { url: URL, token: 'eng-new' })
+    expect(res.status).toBe('token_rotated')
+
+    const stores = readStores(dir)
+    const byScope = Object.fromEntries(stores.map(s => [s.scope as string, s]))
+    // eng rotated.
+    expect(byScope['group:eng'].token).toBe('eng-new')
+    expect(byScope['group:eng'].eng_marker).toBe('E')
+    // comms entirely untouched — token, url, and its own unknown field intact.
+    expect(byScope['group:comms'].token).toBe('comms-tok')
+    expect(byScope['group:comms'].url).toBe(URL)
+    expect(byScope['group:comms'].comms_marker).toBe('C')
+  })
+})

--- a/packages/core/test/scope-metadata.test.ts
+++ b/packages/core/test/scope-metadata.test.ts
@@ -32,19 +32,28 @@ describe('ScopeMetadataSchema', () => {
     expect(parsed.owner).toBeUndefined()
   })
 
-  // Detector hardening — Stage 1.5b (#353). 'pii' was a no-op category: no
-  // detector maps to it, so `forbid: ['pii']` silently protected nothing. It
-  // was removed to kill the false protection; the enum must reject it now.
-  it('no longer accepts the removed "pii" category', () => {
+  // Detector hardening — Stage 1.5b (#353): 'pii' is not a real category (no
+  // detector maps to it). PR-3 (#353 HIGH-17/18) changes the FAILURE MODE from
+  // fatal to non-fatal: an unknown category in `forbid` is now DROPPED (so it
+  // can never drop the whole store entry incl. url/token), keeping the valid
+  // subset or falling to the safe default — it no longer throws.
+  it('drops the removed "pii" category instead of throwing (PR-3 non-fatal)', () => {
     expect(SENSITIVITY_CATEGORIES).toEqual(['secrets', 'infra'])
     expect(SENSITIVITY_CATEGORIES as readonly string[]).not.toContain('pii')
-    expect(() =>
-      ScopeMetadataSchema.parse({
-        scope: 'group:plur/engineering',
-        description: 'has a pii forbid',
-        sensitivity: { forbid: ['pii'] },
-      }),
-    ).toThrow()
+    // pii alone → falls to the safe default, no throw.
+    const onlyBad = ScopeMetadataSchema.parse({
+      scope: 'group:plur/engineering',
+      description: 'has a pii forbid',
+      sensitivity: { forbid: ['pii'] },
+    })
+    expect(onlyBad.sensitivity?.forbid).toEqual(['secrets', 'infra'])
+    // valid + bad → keep only the valid subset.
+    const mixed = ScopeMetadataSchema.parse({
+      scope: 'group:plur/engineering',
+      description: 'has a mixed forbid',
+      sensitivity: { forbid: ['secrets', 'pii'] },
+    })
+    expect(mixed.sensitivity?.forbid).toEqual(['secrets'])
   })
 
   it('applies the sensitivity defaults (forbid secrets+infra, allow none)', () => {
@@ -78,11 +87,12 @@ describe('ScopeMetadataSchema', () => {
     expect(ScopeMetadataSchema.safeParse({ scope: 'group:x' }).success).toBe(false) // no description
   })
 
-  it('rejects an unknown sensitivity category in forbid', () => {
+  it('drops an unknown sensitivity category in forbid (PR-3: non-fatal, falls to default)', () => {
     const res = ScopeMetadataSchema.safeParse({
       scope: 'group:x', description: 'd', sensitivity: { forbid: ['malware'] },
     })
-    expect(res.success).toBe(false)
+    expect(res.success).toBe(true)
+    if (res.success) expect(res.data.sensitivity?.forbid).toEqual(['secrets', 'infra'])
   })
 
   it('rejects an invalid injection_policy', () => {


### PR DESCRIPTION
PR-3 of the #353 evaluator-hardened fix plan (HIGH-17/18 — config robustness / data-loss prevention). Per the D3 recalibration, `loadConfig` already safeParses each store entry on read and pushes the RAW entry on success, so the whole-file wipe was already fixed. This PR closes the two remaining losses.

## (a) Read-drop: a bad `forbid` category no longer drops the entry

A hand-edited / forward-compat sensitivity category (e.g. `pii`, which the schema comment says may be reintroduced) used to fail `StoreEntrySchema.safeParse`, so `loadConfig` dropped the **whole** store entry — including its `url` and `token`.

`ScopeSensitivitySchema.forbid` now uses a `z.preprocess` that filters unknown categories **element-wise**: it warns per unknown (naming the value), keeps the valid subset, and falls to the safe default `['secrets','infra']` only when the filtered result is empty. A non-array (hand-edited scalar) returns the safe default rather than re-throwing a Zod error. Net:
- `['secrets','pii']` → `['secrets']` (warn: pii)
- `['pii']` → `['secrets','infra']` (warn: pii)
- scalar `secrets` → `['secrets','infra']` (no throw)

The whole `StoreEntry` parse no longer fails on a bad category, so **`url`/`token` always survive** a malformed `sensitivity`. Because the field-level preprocess can't name the owning scope, `loadConfig` adds a post-parse pass that diffs raw vs parsed `forbid` per entry and logs `scope=<s>`.

## (b) Writeback: preserve unknown fields at BOTH levels (top-level + nested)

`persistStores` wrote typed `StoreEntry[]` over the raw YAML, stripping unknown/future fields — both top-level and nested inside `sensitivity`. Two-level fix:

- **`.passthrough()` on `StoreEntrySchema`** — unknown/future **top-level** store keys survive a successful parse (placed before `.refine()`; the path-xor-url predicate only touches known fields, so passthrough does not relax it).
- **`.passthrough()` on `ScopeSensitivitySchema`** — unknown **nested** keys inside `sensitivity` survive the typed parse.
- **`persistStores` now MERGES** the typed array onto the freshly-read raw entries (keyed `url+scope` for remote / `path+scope` for local — never `url` alone, matching addStore's dedup identity) with an explicit **one-level `sensitivity` deep-merge**, so parsed deltas land on top of raw nested unknowns. A shallow assign would replace `sensitivity` wholesale and lose nested unknowns even with passthrough — the explicit deep-merge is required.

## Tests

- **Bad `forbid:['pii']`** → entry preserved (`url`/`token` intact), `forbid` corrected to the safe default `['secrets','infra']`, entry NOT dropped; one warning names `pii`, a second names the scope.
- **Partial-bad `['secrets','pii']`** → `['secrets']` (valid subset kept, not the whole-array default).
- **Scalar `forbid: secrets`** → `['secrets','infra']`, no Zod throw, entry not dropped.
- **Version-skew TOP-LEVEL (non-vacuous)** → unknown top-level field, driven through `persistStores` via addStore's token rotation, still present after the round-trip; `url`/`token` preserved.
- **Version-skew NESTED** → unknown field inside `sensitivity` still present after the same round-trip. An independent schema-level assertion proves `ScopeSensitivitySchema.passthrough` is load-bearing (verified: that assertion fails when the passthrough is removed).
- **Merge-key correctness** → two remote stores sharing the same url but different scopes; rotating one leaves the other's token/url/unknowns untouched.
- **passthrough + refine** → unknown top-level field and path-xor-url both hold.

Full workspace green after a core dist rebuild: core 1137, mcp 133, claw 107, cli 202 (1602 total, 34 skipped). `tsc --noEmit` clean on core (zero new vs baseline). Two existing scope-metadata tests that asserted the old fatal `forbid` behavior were updated to assert the new non-fatal salvage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)