### PR TITLE
fix(core): scope-aware LLM dedup + personal-scope ceiling in cross-scope recurrence

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -662,7 +662,10 @@ export class Plur {
       ;(e as any).sources = [...((e as any).sources ?? []), source]
 
       if (newRecurrence >= 2) {
-        if (e.scope !== 'global') e.scope = 'global'
+        // Only promote SHARED scopes (project:*, space:*, etc.) to global —
+        // personal-family scopes (local, user:*) stay within their family.
+        // See issue #362 item (ii): personal-scope ceiling for cross-scope recurrence.
+        if (isSharedScope(e.scope)) e.scope = 'global'
         if (e.commitment !== 'locked') {
           // Forward-only ladder: exploring → leaning → decided → locked.
           e.commitment = e.commitment === 'exploring'

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -197,6 +197,12 @@ export async function learnAsync(
     candidates = deps.recall(statement, { limit: 5 })
   }
   candidates = candidates.filter(c => c.status === 'active')
+  // Mirror hashDedup scope-awareness (issue #359): only dedup against same-scope engrams.
+  // Without this, a global engram silently absorbs an explicitly-scoped write — the requested
+  // scope is dropped and the team store never receives the engram.
+  if (context?.scope) {
+    candidates = candidates.filter(c => c.scope === context.scope)
+  }
 
   if (candidates.length === 0) {
     return { engram: deps.learn(statement, context), decision: 'ADD' }

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -86,11 +86,14 @@ export function getSyncStatus(root: string): SyncStatus {
   }
 }
 
+function neutraliseGlobalExcludes(root: string): void {
+  // Prevent a developer's global gitignore from silently dropping engram files
+  gitSafe(['config', 'core.excludesFile', '/dev/null'], root)
+}
+
 function initRepo(root: string): void {
   git(['init'], root)
-  // Neutralize any global/system gitignore so engram files (engrams.yaml, episodes.yaml)
-  // are always stageable regardless of the user's personal excludes file.
-  git(['config', '--local', 'core.excludesFile', '/dev/null'], root)
+  neutraliseGlobalExcludes(root)
   atomicWrite(join(root, '.gitignore'), GITIGNORE)
   git(['add', '-A'], root)
   git(['commit', '-m', 'Initial PLUR engram store'], root)
@@ -154,6 +157,9 @@ export function sync(root: string, remote?: string): SyncResult {
       files_changed: 0,
     }
   }
+
+  // Ensure global excludes are neutralised for this store (idempotent; migrates existing repos)
+  neutraliseGlobalExcludes(root)
 
   // Add remote if provided and not yet set
   const existingRemote = getRemote(root)

--- a/packages/core/test/cross-scope-recurrence.test.ts
+++ b/packages/core/test/cross-scope-recurrence.test.ts
@@ -265,6 +265,23 @@ describe('cross-scope recurrence (#176)', () => {
       const second = plur.learn('always use   semicolons', { scope: 'project:b' })
       expect(second.recurrence_count).toBe(1)
     })
+
+    it('personal-scope engrams (local) are NOT promoted to global on cross-scope recurrence (#362 item ii)', () => {
+      // A local engram recurring across scopes should stay in the personal family.
+      // Only shared scopes (project:*, space:*, etc.) get promoted to global.
+      const first = plur.learn('personal rule', { scope: 'local' })
+      expect(first.scope).toBe('local')
+
+      plur.learn('personal rule', { scope: 'project:a' })  // 1st cross-scope, recurrence=1
+      const third = plur.learn('personal rule', { scope: 'project:b' })  // 2nd cross-scope
+
+      // recurrence_count increments as normal
+      expect(third.recurrence_count).toBe(2)
+      // Commitment escalates (that behavior is unchanged)
+      expect(third.commitment).toBe('decided')
+      // But scope stays local — personal-family ceiling prevents global promotion
+      expect(third.scope).toBe('local')
+    })
   })
 
   describe('persistence + observability', () => {

--- a/packages/core/test/learn-async-scope.test.ts
+++ b/packages/core/test/learn-async-scope.test.ts
@@ -54,6 +54,7 @@ function makeDeps(candidates: Engram[]): LearnAsyncDeps {
     recordLlmSuccess: () => {},
     recordLlmFailure: () => {},
     syncIndex: () => {},
+    offendingHitsForScope: () => [],
   }
 }
 
@@ -77,7 +78,7 @@ describe('learnAsync scope-aware LLM dedup (issue #359)', () => {
 
   it('still deduplicates same-scope candidates', async () => {
     const sameScope = { ...globalCandidate, id: 'ENG-2026-0101-002', scope: 'group:datafund/datafund' }
-    const llm = vi.fn().mockResolvedValue('NOOP')
+    const llm = vi.fn().mockResolvedValue('DECISION: NOOP\nTARGET: ENG-2026-0101-002\nREASON: identical content')
     const deps = makeDeps([sameScope as unknown as Engram])
 
     const result = await learnAsync(
@@ -93,7 +94,7 @@ describe('learnAsync scope-aware LLM dedup (issue #359)', () => {
   })
 
   it('does not filter candidates when no scope is requested', async () => {
-    const llm = vi.fn().mockResolvedValue('NOOP')
+    const llm = vi.fn().mockResolvedValue('DECISION: NOOP\nTARGET: ENG-2026-0101-001\nREASON: identical content')
     const deps = makeDeps([globalCandidate])
 
     const result = await learnAsync(

--- a/packages/core/test/learn-async-scope.test.ts
+++ b/packages/core/test/learn-async-scope.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest'
+import { learnAsync } from '../src/learn-async.js'
+import type { LearnAsyncDeps } from '../src/learn-async.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/**
+ * Issue #359: LLM-dedup candidates were not scope-filtered, so a global engram
+ * could absorb an explicitly-scoped write via NOOP/UPDATE/MERGE, silently dropping
+ * the requested scope and leaving the team store empty.
+ *
+ * Fix: filter LLM-dedup candidates to context.scope before the LLM sees them,
+ * mirroring the scope-awareness already present in hashDedup.
+ */
+
+const globalCandidate: Engram = {
+  id: 'ENG-2026-0101-001',
+  statement: 'PLUR positions Datafund as the data economy infrastructure layer',
+  type: 'behavioral',
+  domain: 'test',
+  status: 'active',
+  scope: 'global',
+  version: 2,
+  consolidated: false,
+  visibility: 'private',
+  tags: [],
+  activation: { retrieval_strength: 0.8, storage_strength: 1.0, frequency: 3, last_accessed: '2026-06-01' },
+  associations: [],
+  knowledge_anchors: [],
+  feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+  pack: null,
+  abstract: null,
+  derived_from: null,
+  derivation_count: 1,
+  reference_count: 1,
+  recurrence_count: 0,
+  sources: [],
+  engram_version: 1,
+  episode_ids: [],
+  polarity: null,
+} as unknown as Engram
+
+function makeDeps(candidates: Engram[]): LearnAsyncDeps {
+  return {
+    hashDedup: () => null,
+    recallHybrid: async () => candidates,
+    recall: () => candidates,
+    learn: (statement: string, context?: any) =>
+      ({ id: 'ENG-2026-0619-001', statement, scope: context?.scope ?? 'global' } as unknown as Engram),
+    getById: (id: string) => candidates.find(c => c.id === id) ?? null,
+    engramsPath: '/tmp/plur-test-engrams.yaml',
+    rootPath: '/tmp/plur-test',
+    dedupConfig: { enabled: true, mode: 'llm' },
+    isLlmAvailable: () => true,
+    recordLlmSuccess: () => {},
+    recordLlmFailure: () => {},
+    syncIndex: () => {},
+  }
+}
+
+describe('learnAsync scope-aware LLM dedup (issue #359)', () => {
+  it('does not dedup an explicitly-scoped write against a global engram', async () => {
+    const llm = vi.fn().mockResolvedValue('NOOP')
+    const deps = makeDeps([globalCandidate])
+
+    const result = await learnAsync(
+      deps,
+      'PLUR positions Datafund as the data economy backbone',
+      { scope: 'group:datafund/datafund', llm },
+    )
+
+    // The global candidate must be filtered out before the LLM is called.
+    expect(llm).not.toHaveBeenCalled()
+    // With no candidates, learnAsync falls through to ADD at the requested scope.
+    expect(result.decision).toBe('ADD')
+    expect(result.engram.scope).toBe('group:datafund/datafund')
+  })
+
+  it('still deduplicates same-scope candidates', async () => {
+    const sameScope = { ...globalCandidate, id: 'ENG-2026-0101-002', scope: 'group:datafund/datafund' }
+    const llm = vi.fn().mockResolvedValue('NOOP')
+    const deps = makeDeps([sameScope as unknown as Engram])
+
+    const result = await learnAsync(
+      deps,
+      'PLUR positions Datafund as the data economy backbone',
+      { scope: 'group:datafund/datafund', llm },
+    )
+
+    // Same-scope candidate passes the filter; LLM is consulted.
+    expect(llm).toHaveBeenCalled()
+    expect(result.decision).toBe('NOOP')
+    expect(result.existing_id).toBe('ENG-2026-0101-002')
+  })
+
+  it('does not filter candidates when no scope is requested', async () => {
+    const llm = vi.fn().mockResolvedValue('NOOP')
+    const deps = makeDeps([globalCandidate])
+
+    const result = await learnAsync(
+      deps,
+      'PLUR positions Datafund as the data economy backbone',
+      { llm },
+    )
+
+    // Without a requested scope the filter is skipped; global candidate is a valid target.
+    expect(llm).toHaveBeenCalled()
+    expect(result.decision).toBe('NOOP')
+  })
+})

--- a/packages/core/test/pr1-write-interactions.test.ts
+++ b/packages/core/test/pr1-write-interactions.test.ts
@@ -1,9 +1,9 @@
 /**
  * PR-1 (#353) write-side interactions documented alongside the read-side fix:
  *  - auto-route still fires on a confident covers match (revert didn't break it),
- *  - RECURRENCE-INTERACTION: cross-scope recurrence still promotes a local engram
- *    to global on the 2nd hit even under unscoped_default:'local' (index.ts:670
- *    ignores unscoped_default — documented as v2 checklist item (ii)),
+ *  - RECURRENCE-INTERACTION: personal-scope (local) engrams are NOT promoted to
+ *    global by cross-scope recurrence — fixed in #362/#366 (personal-scope ceiling).
+ *    Only shared-family scopes (project:*, space:*, group:*, org:*, public) escalate.
  *  - SECONDARY-STORE rename: a global engram in a secondary store is renamed to
  *    the store's scope on load (UNCHANGED, intentional cross-store narrowing).
  */
@@ -43,8 +43,8 @@ describe('PR-1 — auto-route still fires after the default revert (#353)', () =
   })
 })
 
-describe('PR-1 — RECURRENCE-INTERACTION under unscoped_default:local (#353, v2 item ii)', () => {
-  it('a local engram promoted to global by _recordCrossScopeRecurrence on the 2nd cross-scope hit', () => {
+describe('PR-1 — RECURRENCE-INTERACTION under unscoped_default:local (#353, v2 item ii — fixed #362/#366)', () => {
+  it('a local engram stays local on cross-scope recurrence (personal-scope ceiling)', () => {
     const dir = makeDir('plur-pr1-recur-')
     writeFileSync(join(dir, 'config.yaml'), yaml.dump({ index: false, unscoped_default: 'local' }, { noRefs: true }))
     const plur = new Plur({ path: dir })
@@ -55,11 +55,11 @@ describe('PR-1 — RECURRENCE-INTERACTION under unscoped_default:local (#353, v2
 
     // 1st cross-scope hit: recurrence=1, scope unchanged
     plur.learn('recurrence-interaction probe statement', { scope: 'project:a' })
-    // 2nd cross-scope hit: recurrence=2 → promotion to global regardless of unscoped_default
-    const promoted = plur.learn('recurrence-interaction probe statement', { scope: 'project:b' }) as { scope: string; id: string }
-    expect(promoted.id).toBe(first.id)
-    // index.ts:670 hardcodes global on the 2nd cross-scope hit (ignores unscoped_default).
-    expect(promoted.scope).toBe('global')
+    // 2nd cross-scope hit: recurrence=2, but personal-scope ceiling prevents global promotion
+    const after = plur.learn('recurrence-interaction probe statement', { scope: 'project:b' }) as { scope: string; id: string }
+    expect(after.id).toBe(first.id)
+    // Personal-family scopes stay within their family — local does NOT escalate to global.
+    expect(after.scope).toBe('local')
   })
 })
 


### PR DESCRIPTION
## Summary

Two write-correctness bugs that silently drop engrams or misplace them in the wrong scope.

### Bug 1 — LLM dedup absorbs scoped writes into global (#359)

**Root cause:** `learnAsync` passes all recall candidates to the LLM dedup stage without scope-filtering. A global engram with a similar statement could return `NOOP`/`UPDATE`/`MERGE`, silently dropping the requested scope — the team-scoped write never reaches the team store.

**Fix:** Filter LLM dedup candidates to `context.scope` before the LLM sees them, mirroring the scope-awareness already present in `hashDedup`. When no scope is requested, candidates are unfiltered (backward-compatible).

### Bug 2 — Personal-scope engrams promoted to global on cross-scope recurrence (#362 item ii)

**Root cause:** The cross-scope recurrence promotion (`recurrence_count >= 2 → scope = 'global'`) fired for ALL scopes, including personal-family scopes (`local`, `user:*`). A personal rule recurring across projects would escape to `global` and be visible everywhere.

**Fix:** Only shared scopes (`isSharedScope` — `project:*`, `space:*`, `group:*`, `org:*`, `public`) get promoted to `global`. Personal-family scopes stay within their family.

### Bonus — neutraliseGlobalExcludes in sync() (#361 follow-up)

Extracts the gitignore-neutralisation into a reusable function and calls it in `sync()` as well as `initRepo()`. Existing repos created before the #361 fix now get the neutralisation applied on their next sync (idempotent).

## Tests

- `learn-async-scope.test.ts` (new, 109 lines) — 3 cases:
  - Cross-scope write NOT absorbed by global engram (LLM not called, ADD at requested scope)
  - Same-scope dedup still works (LLM called, NOOP)
  - No scope = no filter (backward-compatible)
- `cross-scope-recurrence.test.ts` +17 lines — personal-scope (local) is NOT promoted to global

## Issues closed

Closes #359. Partial #362 (item ii only — item i is tracked separately in the Stage 3b v2 issue).