### PR TITLE
fix(core): routing — domain match clears auto-route threshold + exclude readonly scopes from candidates — PR-4 (#353 audit)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1001,9 +1001,23 @@ export class Plur {
     if (this.config.auto_route_scope === false) {
       return { scope: fallback, routed: null }
     }
+    // MED-12 (#353, COSMETIC/REPORTING per D3): exclude readonly / non-writable
+    // scopes from the AUTO-ROUTE candidate set so a clean unscoped write is never
+    // LABELED as routed to a scope a write can't land on. This is not a
+    // write-safety fix — `_resolveRemoteStoreForScope` already `continue`s on
+    // readonly (line ~495), so a write to a readonly remote already falls to
+    // local; the only defect is that the ranker could RANK/LABEL a readonly scope
+    // as the target. `readonly` is one boolean on StoreEntry and applies to both
+    // path- and url-based stores, so this view covers both. `listScopeMetadata()`
+    // and `suggestScope()` are left UNCHANGED — advisory discovery still surfaces
+    // readonly scopes.
+    const writableScopeMetadata = this.listScopeMetadata().filter(md => {
+      const entry = (this.config.stores ?? []).find(s => s.scope === md.scope)
+      return entry?.readonly !== true
+    })
     const candidates = rankScopes(
       { statement, domain: context?.domain, tags: context?.tags },
-      this.listScopeMetadata(),
+      writableScopeMetadata,
     )
     const top = candidates[0]
     if (top && top.confidence >= SCOPE_MATCH_THRESHOLD) {

--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -30,18 +30,52 @@ import type { ScopeMetadata } from './schemas/scope-metadata.js'
 
 /** Below this confidence a scope is not a confident home for an engram. Exported
  * for Stage 3b to gate auto-routing on; NOT applied to ranking here — the ranker
- * returns every scope that scores above zero and lets the caller decide. */
+ * returns every scope that scores above zero and lets the caller decide. The
+ * auto-route gate in index.ts (`_resolveUnscopedScope`) is `>=`, so a confidence
+ * that lands EXACTLY on this value clears it — see THRESHOLD_SINGLE_DOMAIN. */
 export const SCOPE_MATCH_THRESHOLD = 0.5
 
-/** Per-channel weights. domain ≫ tag > keyword by design (see module doc). */
-const WEIGHT_DOMAIN = 1.0
+/** Per-channel weights. domain ≫ tag > keyword by design (see module doc).
+ *
+ * WEIGHT_DOMAIN is 1.5 (raised from 1.0 in 0.10.0, #353/finding-11) so that a
+ * LONE domain-prefix match — the strongest, most deliberate routing signal —
+ * clears SCOPE_MATCH_THRESHOLD on its own: squash(1.5) = 1.5/(1.5+1.5) = 0.5000,
+ * which the `>=` gate accepts (see THRESHOLD_SINGLE_DOMAIN). At the old 1.0,
+ * squash(1.0) = 1.0/2.5 = 0.40 < 0.5, so a domain-only match never auto-routed —
+ * the bug. domain-alone and three-tag-alone (3*0.5 = 1.5) now BOTH reach the
+ * threshold by design; the `>=` gate is deliberate (not `>`). Changing
+ * WEIGHT_TAG/SATURATION shifts these boundaries — see the routing tests and
+ * THRESHOLD_SINGLE_DOMAIN. */
+const WEIGHT_DOMAIN = 1.5
 const WEIGHT_TAG = 0.5
 const WEIGHT_KEYWORD = 0.2
 
 /** Raw score at which confidence saturates to ~1.0. A single domain-prefix hit
- * (WEIGHT_DOMAIN = 1.0) already lands near the top of the curve; stacking tag +
- * keyword hits pushes it the rest of the way. */
+ * (WEIGHT_DOMAIN = 1.5) lands EXACTLY on SCOPE_MATCH_THRESHOLD via squash; the
+ * `>=` gate then auto-routes it. This boundary is intentionally exact — any
+ * INCREASE to SATURATION or DECREASE to WEIGHT_DOMAIN breaks the lone-domain
+ * auto-route (e.g. SATURATION=2.0 → single-domain confidence 1.5/3.5 = 0.43 <
+ * 0.5; WEIGHT_DOMAIN=1.0 → 1.0/2.5 = 0.40 < 0.5). Stacking tag + keyword hits
+ * pushes a domain match the rest of the way up the curve. */
 const SATURATION = 1.5
+
+/**
+ * The confidence a LONE domain-prefix match produces, derived from the squash
+ * function squash(x) = x / (x + SATURATION) with x = WEIGHT_DOMAIN:
+ *
+ *     THRESHOLD_SINGLE_DOMAIN = WEIGHT_DOMAIN / (WEIGHT_DOMAIN + SATURATION)
+ *                             = 1.5 / (1.5 + 1.5)  =  1.5 / 3.0  =  0.5
+ *
+ * 0.5 is exactly representable in IEEE-754, and 1.5/3.0 evaluates to it exactly,
+ * so this equals {@link SCOPE_MATCH_THRESHOLD} and the `>=` auto-route gate
+ * accepts a lone-domain match. A unit test pins
+ * `THRESHOLD_SINGLE_DOMAIN === SCOPE_MATCH_THRESHOLD` so a future weight/
+ * saturation tweak that silently re-breaks finding #11 fails CI.
+ *
+ * VALID ONLY for squash(x) = x/(x+SATURATION); if the squash function changes,
+ * recompute this constant against the new function.
+ */
+export const THRESHOLD_SINGLE_DOMAIN = WEIGHT_DOMAIN / (WEIGHT_DOMAIN + SATURATION)
 
 /** Signals carried by an engram, used to score scope fit. */
 export interface ScopeSignals {

--- a/packages/core/test/route-unscoped.test.ts
+++ b/packages/core/test/route-unscoped.test.ts
@@ -10,9 +10,12 @@
  * SHARED scope carrying sensitive content is still demoted to local.
  *
  * Confidence note: SCOPE_MATCH_THRESHOLD is 0.5, and squash(raw)=raw/(raw+1.5),
- * so a confident auto-route needs raw weight >= 1.5 — a domain-prefix hit (1.0)
- * alone is NOT enough; it must be reinforced (e.g. + a tag hit at 0.5). The
- * "confident match" stores below stack domain + tag (+ keyword) to clear it.
+ * so a confident auto-route needs raw weight >= 1.5. As of 0.10.0 (#353,
+ * finding-11) WEIGHT_DOMAIN is 1.5, so a LONE domain-prefix hit clears it on its
+ * own: squash(1.5)=1.5/3.0=0.5, which the `>=` gate accepts. The lone-domain
+ * boundary is pinned in scope-routing.test.ts (THRESHOLD_SINGLE_DOMAIN) and in
+ * the "lone domain-prefix match auto-routes" case below; the stores here stack
+ * domain + tag (+ keyword) so they sit comfortably above the boundary.
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
@@ -139,6 +142,114 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
     }) as { scope: string; structured_data?: { _routed?: unknown } }
     expect(e.scope).toBe('global')
     expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('a LONE domain-prefix match auto-routes (confidence 0.50), stamps _routed (finding-11)', () => {
+    const plur = makePlur({
+      stores: [
+        // covers is a single namespace glob; the statement shares NO tokens with
+        // it, so the ONLY signal is the domain-prefix hit (plur.core.security ⊂
+        // plur.*) → raw = WEIGHT_DOMAIN = 1.5 → squash(1.5) = 0.50, which the `>=`
+        // gate accepts. Pre-0.10.0 (WEIGHT_DOMAIN=1.0) this squashed to 0.40 and
+        // the strongest, most deliberate signal never auto-routed — the bug.
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.*'] },
+      ],
+    })
+    const e = plur.learn('xyzzy nonoverlapping content tokens', {
+      domain: 'plur.core.security',
+    }) as { scope: string; structured_data?: { _routed?: { scope: string; confidence: number; reason: string } } }
+    expect(e.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed).toBeDefined()
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.confidence).toBe(0.5)
+    expect(e.structured_data?._routed?.confidence).toBeGreaterThanOrEqual(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('a LONE tag-only match does NOT auto-route (0.25 < 0.5) — falls to default', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers'] },
+      ],
+    })
+    // Single tag hit → raw = WEIGHT_TAG = 0.5 → squash(0.5) = 0.25 < threshold.
+    const e = plur.learn('no overlap words zzz', {
+      tags: ['servers'],
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('a LONE single-keyword match does NOT auto-route (0.118 < 0.5) — falls to default', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers'] },
+      ],
+    })
+    // One statement keyword overlaps a cover token → raw = WEIGHT_KEYWORD = 0.2.
+    const e = plur.learn('restart the servers now') as {
+      scope: string; structured_data?: { _routed?: unknown }
+    }
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('excludes a readonly URL-based store from auto-route targets (MED-12 — not labeled routed-to-readonly)', () => {
+    const plur = makePlur({
+      stores: [
+        // A readonly REMOTE store whose covers would confidently match. Because a
+        // write can never land here (_resolveRemoteStoreForScope continues on
+        // readonly), the ranker must not LABEL it as the auto-route target.
+        { url: 'https://ro.example.com', token: 't', readonly: true, scope: 'group:plur/core', description: 'Core (RO)', covers: ['plur.*', 'embeddings'] },
+      ],
+    })
+    const e = plur.learn('the embeddings index for the core engine', {
+      domain: 'plur.core.embeddings',
+      tags: ['embeddings'],
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    // Falls to the unscoped default (global), NOT routed to the readonly scope.
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('excludes a readonly PATH-based store from auto-route targets (MED-12)', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core-ro.yaml', readonly: true, scope: 'group:plur/core', description: 'Core (RO)', covers: ['plur.*', 'embeddings'] },
+      ],
+    })
+    const e = plur.learn('the embeddings index for the core engine', {
+      domain: 'plur.core.embeddings',
+      tags: ['embeddings'],
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('a WRITABLE store with the same covers still auto-routes (proves the filter is readonly-specific)', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core-rw.yaml', readonly: false, scope: 'group:plur/core', description: 'Core (RW)', covers: ['plur.*', 'embeddings'] },
+      ],
+    })
+    const e = plur.learn('the embeddings index for the core engine', {
+      domain: 'plur.core.embeddings',
+      tags: ['embeddings'],
+    }) as { scope: string; structured_data?: { _routed?: { scope: string } } }
+    expect(e.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/core')
+  })
+
+  it('suggestScope (advisory) STILL surfaces a readonly scope as a candidate (discovery unchanged)', () => {
+    const plur = makePlur({
+      stores: [
+        { url: 'https://ro.example.com', token: 't', readonly: true, scope: 'group:plur/core', description: 'Core (RO)', covers: ['plur.*', 'embeddings'] },
+      ],
+    })
+    // The readonly filter applies ONLY to the auto-route candidate set inside
+    // _resolveUnscopedScope. Advisory discovery (suggestScope/listScopeMetadata)
+    // must still show readonly scopes so a human can find them.
+    const ranked = plur.suggestScope({ statement: 'embeddings core', domain: 'plur.core.embeddings', tags: ['embeddings'] })
+    expect(ranked.map(c => c.scope)).toContain('group:plur/core')
   })
 
   it('auto-routed SHARED scope with sensitive content is still DEMOTED to local (3b + guard)', () => {

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -17,6 +17,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
 import { Plur, rankScopes, SCOPE_MATCH_THRESHOLD } from '../src/index.js'
+import { THRESHOLD_SINGLE_DOMAIN } from '../src/scope-routing.js'
 
 describe('rankScopes — pure ranker', () => {
   const SCOPES = [
@@ -123,6 +124,104 @@ describe('rankScopes — pure ranker', () => {
   it('exports a routing threshold constant for Stage 3b (not applied here)', () => {
     expect(SCOPE_MATCH_THRESHOLD).toBeGreaterThan(0)
     expect(SCOPE_MATCH_THRESHOLD).toBeLessThan(1)
+  })
+})
+
+describe('squash math — auto-route boundaries (#353 finding-11)', () => {
+  // squash(raw) = raw / (raw + SATURATION), SATURATION = 1.5.
+  // WEIGHT_DOMAIN = 1.5, WEIGHT_TAG = 0.5, WEIGHT_KEYWORD = 0.2.
+  // The auto-route gate (index.ts `_resolveUnscopedScope`) is `>=`, so a
+  // confidence landing EXACTLY on SCOPE_MATCH_THRESHOLD (0.5) clears it.
+
+  it('THRESHOLD_SINGLE_DOMAIN === SCOPE_MATCH_THRESHOLD (exact in IEEE-754)', () => {
+    // THRESHOLD_SINGLE_DOMAIN = WEIGHT_DOMAIN/(WEIGHT_DOMAIN+SATURATION)
+    //                         = 1.5/3.0 = 0.5 — exactly representable, so the
+    // derived constant equals the threshold by `===`, not by epsilon. If a future
+    // weight/saturation tweak shifts it off 0.5 this assertion fails CI, flagging
+    // a silent re-break of finding #11.
+    expect(THRESHOLD_SINGLE_DOMAIN).toBe(SCOPE_MATCH_THRESHOLD)
+    expect(THRESHOLD_SINGLE_DOMAIN).toBe(0.5)
+  })
+
+  it('a LONE domain-prefix match scores exactly 0.5 (clears the >= gate)', () => {
+    // Only a domain hit, no tag, no keyword overlap → raw = WEIGHT_DOMAIN = 1.5.
+    // squash(1.5) = 1.5/(1.5+1.5) = 0.5000.
+    const ranked = rankScopes(
+      { statement: 'xyzzy nonoverlapping tokens', domain: 'plur.core.security' },
+      [{ scope: 'group:plur/core', covers: ['plur.*'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBe(0.5)
+    expect(ranked[0].confidence).toBeGreaterThanOrEqual(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('a LONE weak keyword match stays well below threshold', () => {
+    // One keyword hit → raw = WEIGHT_KEYWORD = 0.2. squash(0.2)=0.2/1.7=0.1176.
+    const ranked = rankScopes(
+      { statement: 'embeddings' },
+      [{ scope: 'group:plur/core', covers: ['embeddings'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBeCloseTo(0.1176, 4)
+    expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('FIVE keyword-only hits still do NOT auto-route', () => {
+    // 5 keyword hits → raw = 5*0.2 = 1.0. squash(1.0)=1.0/2.5=0.40 < 0.5.
+    // Preserves "domain >> keyword": no pile of weak keywords out-routes one domain.
+    const ranked = rankScopes(
+      { statement: 'alpha beta gamma delta epsilon' },
+      [{ scope: 'group:plur/x', covers: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBeCloseTo(0.4, 4)
+    expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('ONE tag-only hit does NOT auto-route', () => {
+    // 1 tag hit → raw = WEIGHT_TAG = 0.5. squash(0.5)=0.5/2.0=0.25 < 0.5.
+    const ranked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers'] },
+      [{ scope: 'group:plur/infra', covers: ['servers'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBeCloseTo(0.25, 4)
+    expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('TWO matching tags do NOT auto-route (0.40 < 0.5)', () => {
+    // 2 tag hits → raw = 2*0.5 = 1.0. squash(1.0)=0.40 < 0.5.
+    const ranked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers', 'deploy'] },
+      [{ scope: 'group:plur/infra', covers: ['servers', 'deploy'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBeCloseTo(0.4, 4)
+    expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('THREE matching tags DO auto-route (0.50 — documented side effect)', () => {
+    // 3 tag hits → raw = 3*0.5 = 1.5. squash(1.5)=0.50 exactly clears `>=`.
+    // INTENT: three deliberate tag matches reaching threshold is acceptable and
+    // intended (mirrors lone-domain). See WEIGHT_TAG comment in scope-routing.ts.
+    const ranked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers', 'deploy', 'infra'] },
+      [{ scope: 'group:plur/infra', covers: ['servers', 'deploy', 'infra'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBe(0.5)
+    expect(ranked[0].confidence).toBeGreaterThanOrEqual(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('FOUR matching tags auto-route (forward-proof, 0.571 > 0.5)', () => {
+    // 4 tag hits → raw = 4*0.5 = 2.0. squash(2.0)=2.0/3.5=0.5714 > 0.5.
+    const ranked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers', 'deploy', 'infra', 'ops'] },
+      [{ scope: 'group:plur/infra', covers: ['servers', 'deploy', 'infra', 'ops'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBeCloseTo(0.5714, 4)
+    expect(ranked[0].confidence).toBeGreaterThan(SCOPE_MATCH_THRESHOLD)
   })
 })
 


### PR DESCRIPTION
PR-4 of the 0.10.0 evaluator-hardened fix plan (#353 audit): routing correctness. Resolves findings #11 and #12. Branches off post-PR-1/2/3 `main`.

## Finding #11 — a lone confident domain-prefix match must auto-route

`SCOPE_MATCH_THRESHOLD = 0.5`, the auto-route gate (`index.ts _resolveUnscopedScope`) is `>=`, and confidence is `squash(raw) = raw / (raw + SATURATION)` with `SATURATION = 1.5`. With the old `WEIGHT_DOMAIN = 1.0`:

```
squash(1.0) = 1.0 / (1.0 + 1.5) = 1.0 / 2.5 = 0.40  <  0.5   → never auto-routed
```

So the **strongest, most deliberate** routing signal (a domain-prefix match against a scope's `covers`) never cleared the bar. Fix: raise `WEIGHT_DOMAIN` 1.0 → 1.5 (SATURATION unchanged):

```
squash(1.5) = 1.5 / (1.5 + 1.5) = 1.5 / 3.0 = 0.5000  ≥  0.5   → auto-routes (>= gate)
```

`0.5` is exactly representable in IEEE-754 and `1.5/3.0` evaluates to it exactly, so the boundary is exact, not epsilon-fuzzy. To stop a future weight/saturation tweak from silently re-breaking this, a derived constant is exported and pinned:

```ts
export const THRESHOLD_SINGLE_DOMAIN = WEIGHT_DOMAIN / (WEIGHT_DOMAIN + SATURATION)  // 1.5/3.0 = 0.5
// test: expect(THRESHOLD_SINGLE_DOMAIN).toBe(SCOPE_MATCH_THRESHOLD)
```

**"domain >> keyword" preserved** (weak signals still don't over-route): one tag-only `squash(0.5)=0.25`; two tags `squash(1.0)=0.40`; five keyword-only hits `squash(1.0)=0.40` — all `< 0.5`. **Documented, intended side effect:** three tag hits `3*0.5=1.5` → `squash(1.5)=0.50` also reach the threshold (mirrors lone-domain); the `>=` gate is deliberate. Flagged in code comments and a CHANGELOG-worthy behavior note.

## Finding #12 — readonly scope labeling (COSMETIC per D3)

Per D3 reclassification this is **reporting-only, not a write hazard**: `_resolveRemoteStoreForScope` already `continue`s on `readonly === true`, so a write never lands on a readonly remote — it falls to local. The only defect is that the ranker could RANK/LABEL a readonly scope as the auto-route target.

Fix (minimal): inside `_resolveUnscopedScope`, filter `listScopeMetadata()` to drop entries whose `StoreEntry.readonly === true` before handing them to `rankScopes`. `readonly` is one boolean on `StoreEntry` and applies to both path- and url-based stores, so this covers both. `listScopeMetadata()` / `suggestScope()` are **left unchanged** — advisory discovery still surfaces readonly scopes.

## Tests

- `THRESHOLD_SINGLE_DOMAIN === SCOPE_MATCH_THRESHOLD` (exact IEEE-754).
- Lone domain-prefix match auto-routes (confidence `0.50`, `_routed` present).
- Lone tag-only (`0.25`) and lone single-keyword (`0.118`) do NOT auto-route — fall to `unscoped_default`.
- Five keyword-only hits (`0.40`) and two tags (`0.40`) stay below; three tags (`0.50`) and four tags (`0.571`) auto-route — boundaries pinned both ways.
- Readonly **URL-based** and **PATH-based** stores excluded from auto-route targets (write falls to global, not labeled routed-to-readonly); a **writable** store with identical covers still auto-routes (proves the filter is readonly-specific).
- `suggestScope` (advisory) STILL surfaces a readonly scope as a candidate.
- Re-derived squash math asserted inline so a future weight change can't silently re-break #11.

## Build / test

- `pnpm --filter @plur-ai/core build` succeeds.
- Full workspace green after dist rebuild: **1617 passed / 34 skipped / 0 failed** (core + mcp + claw + cli). Core alone: 1152 passed.
- `tsc --noEmit` clean on core (zero new vs baseline).

Files changed: `packages/core/src/scope-routing.ts`, `packages/core/src/index.ts`, `packages/core/test/scope-routing.test.ts`, `packages/core/test/route-unscoped.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)