### PR TITLE
fix(core): saveMetaEngrams guard + context-field scan + demotion surfacing/tests — PR-5 (#353 audit)

### DIFF
--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -82,6 +82,13 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   }
   if (timeoutHandle) clearTimeout(timeoutHandle)
 
+  // LOW-10 (#353): surface a scope demotion instead of swallowing it silently.
+  // When learnRouted demotes a sensitive shared-scope write to local/private it
+  // stamps structured_data._demoted; mirror the MCP display contract (tools.ts)
+  // so the CLI user sees why the engram did not land at the requested scope.
+  const demoted = (engram as { structured_data?: { _demoted?: { from: string; to: string; patterns: string } } })
+    .structured_data?._demoted
+
   if (shouldOutputJson(flags)) {
     outputJson({
       id: engram.id,
@@ -89,9 +96,21 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       scope: engram.scope,
       type: engram.type,
       domain: engram.domain ?? null,
+      // Include the demotion only when it happened; include requested_scope ONLY
+      // when --scope was passed, to avoid a confusing requested_scope on an
+      // unscoped write that demoted from the resolved default.
+      ...(demoted
+        ? { demoted: { from: demoted.from, to: demoted.to, patterns: demoted.patterns }, ...(scopeProvided ? { requested_scope: demoted.from } : {}) }
+        : {}),
     })
   } else {
     outputText(`Learned: "${engram.statement}"`)
     outputText(`  ID: ${engram.id} | Scope: ${engram.scope} | Type: ${engram.type}${engram.domain ? ` | Domain: ${engram.domain}` : ''}`)
+    if (demoted) {
+      outputText(
+        `  Warning: Sensitive content (${demoted.patterns}) detected — stored at ` +
+        `${demoted.to}/private instead of ${demoted.from}; re-scope deliberately if false positive.`,
+      )
+    }
   }
 }

--- a/packages/cli/test/learn.test.ts
+++ b/packages/cli/test/learn.test.ts
@@ -88,4 +88,31 @@ describe('plur learn', () => {
     const output = JSON.parse(run('learn "explicit scope statement" --scope project:foo'))
     expect(output.scope).toBe('project:foo')
   })
+
+  // --- LOW-10 (#353): surface a scope demotion instead of swallowing it ---
+
+  it('LOW-10 JSON: a demoted shared-scope write reports demoted{from,to,patterns}', () => {
+    // Explicit shared scope + a public IP → core demotes to local/private and
+    // stamps _demoted. The CLI must surface it (was silent before PR-5).
+    const output = JSON.parse(run('learn "deploy target is 139.59.155.82" --scope group:plur/core'))
+    expect(output.scope).toBe('local')
+    expect(output.demoted).toBeDefined()
+    expect(output.demoted.from).toBe('group:plur/core')
+    expect(output.demoted.to).toBe('local')
+    expect(output.demoted.patterns).toMatch(/public_ipv4/)
+    // requested_scope is present only because --scope was passed.
+    expect(output.requested_scope).toBe('group:plur/core')
+  })
+
+  // Note: text-mode output cannot be exercised through execSync (stdout is
+  // piped, so the CLI auto-selects JSON via shouldOutputJson). The text-mode
+  // warning mirrors the JSON `demoted` field and the MCP display contract; the
+  // JSON tests above/below pin the behavioral contract.
+
+  it('LOW-10 JSON: a clean write has no demoted field (no false warning)', () => {
+    const output = JSON.parse(run('learn "a perfectly clean note" --scope group:plur/core'))
+    expect(output.scope).toBe('group:plur/core')
+    expect(output.demoted).toBeUndefined()
+    expect(output.requested_scope).toBeUndefined()
+  })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -935,6 +935,39 @@ export class Plur {
   }
 
   /**
+   * Collect the context-ish fields of an engram (rationale, source, snippet,
+   * dual_coding, structured_data) into a plain object for the explicit-update
+   * leak scan (LOW-2, #353). Mirrors the field set a LearnContext carries into
+   * `_guardSensitiveScope`. Returns undefined when none are present so the scan
+   * text stays statement-only.
+   *
+   * PLUR-internal bookkeeping keys in `structured_data` (underscore-prefixed:
+   * `_outbox`, `_routed`, `_demoted`, …) are STRIPPED before scanning — they are
+   * system-generated, never user content, and legitimately carry the very host
+   * topology the infra detector flags (e.g. `_outbox.target_url` =
+   * `http://127.0.0.1:<port>`). Scanning them would falsely demote every
+   * remote-origin or auto-routed engram on update.
+   */
+  private _engramContextFields(engram: Engram): Record<string, unknown> | undefined {
+    const e = engram as Record<string, unknown>
+    const fields: Record<string, unknown> = {}
+    for (const k of ['rationale', 'source', 'snippet', 'dual_coding'] as const) {
+      if (e[k] != null) fields[k] = e[k]
+    }
+    const sd = e.structured_data
+    if (sd != null && typeof sd === 'object' && !Array.isArray(sd)) {
+      const userSd: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(sd as Record<string, unknown>)) {
+        if (!k.startsWith('_')) userSd[k] = v
+      }
+      if (Object.keys(userSd).length > 0) fields.structured_data = userSd
+    } else if (sd != null) {
+      fields.structured_data = sd
+    }
+    return Object.keys(fields).length > 0 ? fields : undefined
+  }
+
+  /**
    * Leak guard for the EXPLICIT-update mutation path (`updateEngram` /
    * `updateEngramAsync`). Unlike learn/learnAsync, the caller hands us a fully
    * formed engram and chose its scope deliberately, so the response differs by
@@ -947,13 +980,28 @@ export class Plur {
    * - LOCAL-resident: a forbidden hit DEMOTES in place (scope→'local',
    *   visibility→'private') and warns. Returns the override the caller applies
    *   before persisting; returns `null` when the statement is clean.
+   *
+   * LOW-2 (#353): scan the FULL content like `_guardSensitiveScope`, not just
+   * `statement`. Callers pass the engram's context-ish fields (rationale,
+   * source, snippet, dual_coding, structured_data) via `contextFields`; we
+   * serialize them onto the scan text so a credential hiding in a context field
+   * is caught. The 64KB byte-aware truncation (PR-2) is applied inside
+   * `detectSensitive` (reached via `_offendingHitsForScope`), so the scan is
+   * bounded here too.
    */
   private _guardExplicitUpdate(
     statement: string,
     scope: string,
     isRemote: boolean,
+    contextFields?: Record<string, unknown>,
   ): { scope: string; visibility: 'private' } | null {
-    const offending = this._offendingHitsForScope(statement, scope)
+    // Scan statement + context fields (mirrors _guardSensitiveScope scanText at
+    // index.ts:1052). Omit the context join entirely when there are no fields so
+    // the clean-statement scan is byte-identical to the old behavior.
+    const scanText = contextFields
+      ? `${statement}\n${JSON.stringify(contextFields)}`
+      : statement
+    const offending = this._offendingHitsForScope(scanText, scope)
     if (offending.length === 0) return null
     const patterns = [...new Set(offending.map(h => h.pattern))].join(', ')
     if (isRemote) {
@@ -2154,7 +2202,27 @@ export class Plur {
     this._feedbackPack(id, signal)
   }
 
-  /** Save extracted meta-engrams to the engram store. Skips IDs that already exist. */
+  /**
+   * Save extracted meta-engrams to the engram store. Skips IDs that already
+   * exist.
+   *
+   * LOW-1 (#353): this is the one public persist method that runs NO part of the
+   * scope-security stack (learn/learnRouted/learnAsync/updateEngram all guard;
+   * saveMetaEngrams did not). Run the same guard before persisting each meta:
+   *  - HARD `detectSecrets` check (mirrors learn/learnRouted) — a raw secret
+   *    (API key, token, …) in a meta at a shared scope THROWS unless
+   *    `config.allow_secrets`.
+   *  - SOFT `_offendingHitsForScope` demotion (mirrors the explicit-update /
+   *    learnAsync demotion paths) — infra-sensitive content (public IP, internal
+   *    host, …) at a shared scope is DEMOTED in place to local/private and
+   *    stamped with `_demoted{from,to,patterns}` rather than written at the
+   *    requested shared scope. Local write, so demotion is coherent.
+   *
+   * No-op for all known in-tree callers: in-tree metas use personal scopes
+   * (global/local), and `_offendingHitsForScope` returns [] for non-shared
+   * scopes (the index.ts personal fast-path). Defense-in-depth: activates only
+   * if a future caller passes a shared-scope meta.
+   */
   saveMetaEngrams(metas: Engram[]): { saved: number; skipped: number } {
     return withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)
@@ -2164,10 +2232,45 @@ export class Plur {
       for (const meta of metas) {
         if (existingIds.has(meta.id)) {
           skipped++
-        } else {
-          engrams.push(meta)
-          saved++
+          continue
         }
+        // LOW-1: guard each meta on the FULL content (statement + context
+        // fields) at its scope before persist. Do NOT call _guardExplicitUpdate
+        // (its warning text is the EXPLICIT-update path); inline the demotion
+        // shape here so the message is meta-specific.
+        const scope = meta.scope ?? 'global'
+        const contextFields = this._engramContextFields(meta)
+        const scanText = contextFields
+          ? `${meta.statement}\n${JSON.stringify(contextFields)}`
+          : meta.statement
+        // HARD secret check — mirror learn()/learnRouted.
+        if (!this.config.allow_secrets) {
+          const secrets = detectSecrets(scanText)
+          if (secrets.length > 0) {
+            throw new Error(
+              `Secret detected in meta-engram ${meta.id}: ${secrets[0].pattern}. ` +
+              `Use config.allow_secrets to override.`,
+            )
+          }
+        }
+        // SOFT infra demotion — mirror the explicit-update / learnAsync paths.
+        const hits = this._offendingHitsForScope(scanText, scope)
+        if (hits.length > 0) {
+          const patterns = [...new Set(hits.map(h => h.pattern))].join(', ')
+          logger.warning(
+            `[plur] sensitive content (${patterns}) held back from shared scope "${scope}" ` +
+            `in meta-engram ${meta.id} — demoted to local/private so it is not written to a ` +
+            `shared store. Re-scope deliberately if this is a false positive.`,
+          )
+          ;(meta as any).scope = 'local'
+          ;(meta as any).visibility = 'private'
+          ;(meta as any).structured_data = {
+            ...((meta as any).structured_data ?? {}),
+            _demoted: { from: scope, to: 'local', patterns },
+          }
+        }
+        engrams.push(meta)
+        saved++
       }
       if (saved > 0) {
         this._writeEngrams(this.paths.engrams, engrams)
@@ -2190,7 +2293,8 @@ export class Plur {
       const idx = engrams.findIndex(e => e.id === updated.id)
       if (idx === -1) return false
       // Leak guard (#353): local-resident → demote a sensitive update in place.
-      const demote = this._guardExplicitUpdate(updated.statement, updated.scope, false)
+      // LOW-2: scan context fields too, not just the statement.
+      const demote = this._guardExplicitUpdate(updated.statement, updated.scope, false, this._engramContextFields(updated))
       const toWrite = demote ? { ...updated, ...demote } : updated
       engrams[idx] = toWrite
       this._writeEngrams(this.paths.engrams, engrams)
@@ -2205,7 +2309,8 @@ export class Plur {
       if (!entry.url || entry.readonly === true) continue
       // Leak guard (#353): remote-resident, explicit update → THROW on a
       // forbidden hit (no coherent demotion for a remote engram).
-      this._guardExplicitUpdate(updated.statement, entry.scope, true)
+      // LOW-2: scan context fields too, not just the statement.
+      this._guardExplicitUpdate(updated.statement, entry.scope, true, this._engramContextFields(updated))
       const serverId = this._stripRemotePrefix(updated.id, entry.scope)
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
       // PATCH a focused subset — full-engram PATCH would require strict
@@ -2234,7 +2339,8 @@ export class Plur {
       const idx = engrams.findIndex(e => e.id === updated.id)
       if (idx === -1) return null
       // Leak guard (#353): local-resident → demote a sensitive update in place.
-      const demote = this._guardExplicitUpdate(updated.statement, updated.scope, false)
+      // LOW-2: scan context fields too, not just the statement.
+      const demote = this._guardExplicitUpdate(updated.statement, updated.scope, false, this._engramContextFields(updated))
       const toWrite = demote ? { ...updated, ...demote } : updated
       engrams[idx] = toWrite
       this._writeEngrams(this.paths.engrams, engrams)
@@ -2247,7 +2353,8 @@ export class Plur {
       if (!entry.url || entry.readonly === true) continue
       // Leak guard (#353): remote-resident, explicit update → THROW on a
       // forbidden hit (no coherent demotion for a remote engram).
-      this._guardExplicitUpdate(updated.statement, entry.scope, true)
+      // LOW-2: scan context fields too, not just the statement.
+      this._guardExplicitUpdate(updated.statement, entry.scope, true, this._engramContextFields(updated))
       const serverId = this._stripRemotePrefix(updated.id, entry.scope)
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
       const patched = await driver.patch(serverId, {

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -52,6 +52,12 @@ export interface LearnAsyncDeps {
  * scope→'local', visibility→'private'. Warns naming the offending patterns,
  * mirroring `_guardSensitiveScope`'s warning style. No-op (returns the engram
  * unchanged) when there are no offending hits. (#353)
+ *
+ * Stamps `structured_data._demoted = { from, to, patterns }` (LOW-9, #353)
+ * mirroring the sync learnRouted demotion (index.ts `guarded.demotion`) and the
+ * explicit-update / saveMetaEngrams demotion sites, so the MCP plur_learn
+ * response (tools.ts) and the CLI can surface that the requested shared scope
+ * was demoted. Captures `from` BEFORE the scope reassignment.
  */
 function demoteIfSensitive(
   deps: LearnAsyncDeps,
@@ -66,8 +72,13 @@ function demoteIfSensitive(
     `demoted to local/private so it is not written to a shared store. ` +
     `Re-scope deliberately if this is a false positive.`,
   )
+  const from = engram.scope ?? 'global'
   engram.scope = 'local'
   engram.visibility = 'private'
+  engram.structured_data = {
+    ...(engram.structured_data ?? {}),
+    _demoted: { from, to: 'local', patterns },
+  }
 }
 
 /**

--- a/packages/core/test/pr5-hardening.test.ts
+++ b/packages/core/test/pr5-hardening.test.ts
@@ -1,0 +1,195 @@
+/**
+ * PR-5 (#353 audit) — low-severity hardening + missing coverage.
+ *
+ * Covers four findings on the core side:
+ *  - LOW-1  saveMetaEngrams runs the leak guard before persist (HARD secret +
+ *           SOFT infra demotion) — previously the one public persist method with
+ *           NO scope-security stack.
+ *  - LOW-2  _guardExplicitUpdate scans context fields (rationale/source/…), not
+ *           just the statement.
+ *  - LOW-9  learnAsync UPDATE/MERGE demotion stamps `structured_data._demoted`.
+ *  - MED-20 learnAsync UPDATE/MERGE demotion is driven for REAL at a SHARED
+ *           scope (not short-circuited by a personal target).
+ *
+ * Every demotion test uses a SHARED-scope fixture so `_offendingHitsForScope`
+ * does NOT take the personal fast-path; a personal-scope boundary case proves
+ * the demotion is the guard firing, not a test accident.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { vi } from 'vitest'
+import { Plur } from '../src/index.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+// A real-shape public droplet IPv4 — the exact class that leaked in 2026-06.
+const PUBLIC_IP = '139.59.155.82'
+const SHARED_SCOPE = 'group:plur/engineering'
+
+const dirs: string[] = []
+function freshPlur(extraConfig: Record<string, unknown> = {}): Plur {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-pr5-'))
+  dirs.push(dir)
+  // index:false keeps the test on the YAML path; a path-based SHARED store makes
+  // the scope a real shared scope without standing up a remote.
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    yaml.dump({ stores: [{ scope: SHARED_SCOPE, shared: true, path: dir }], index: false, ...extraConfig }, { noRefs: true }),
+  )
+  return new Plur({ path: dir })
+}
+afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+/** Build a mock dedup LLM that always returns the given decision + target id. */
+function dedupLlm(decision: 'UPDATE' | 'MERGE', targetId: string) {
+  return vi.fn().mockResolvedValue(
+    `DECISION: ${decision}\nTARGET: ${targetId}\nCONFLICTS: none\nREASON: test-driven ${decision}`,
+  )
+}
+
+describe('MED-20 + LOW-9 — learnAsync UPDATE/MERGE demotion (real guard, shared scope)', () => {
+  it('UPDATE that introduces a public IP into a SHARED-scope engram demotes + stamps _demoted', async () => {
+    const plur = freshPlur({ dedup: { enabled: true, mode: 'llm' } })
+    // Seed a CLEAN engram at the shared scope (no demotion at creation).
+    const seed = plur.learn('the deploy runbook lives in the wiki', { scope: SHARED_SCOPE, type: 'procedural' }) as Engram
+    expect(seed.scope).toBe(SHARED_SCOPE)
+
+    const llm = dedupLlm('UPDATE', seed.id)
+    const result = await plur.learnAsync(`the deploy target is ${PUBLIC_IP}`, { llm })
+
+    expect(llm).toHaveBeenCalled()
+    expect(result.decision).toBe('UPDATE')
+    const e = result.engram as Engram & { visibility?: string; structured_data?: { _demoted?: { from: string; to: string; patterns: string } } }
+    // Real demotion: scope→local, visibility→private.
+    expect(e.scope).toBe('local')
+    expect(e.visibility).toBe('private')
+    // LOW-9 marker stamped, mirroring the sync demotion sites.
+    expect(e.structured_data?._demoted?.from).toBe(SHARED_SCOPE)
+    expect(e.structured_data?._demoted?.to).toBe('local')
+    expect(e.structured_data?._demoted?.patterns).toMatch(/public_ipv4/)
+  }, 30_000)
+
+  it('MERGE that introduces a public IP into a SHARED-scope engram demotes + stamps _demoted', async () => {
+    const plur = freshPlur({ dedup: { enabled: true, mode: 'llm' } })
+    const seed = plur.learn('the staging cluster is documented in the handbook', { scope: SHARED_SCOPE, type: 'procedural' }) as Engram
+
+    const llm = dedupLlm('MERGE', seed.id)
+    const result = await plur.learnAsync(`reachable at ${PUBLIC_IP}:8877`, { llm })
+
+    expect(result.decision).toBe('MERGE')
+    const e = result.engram as Engram & { visibility?: string; structured_data?: { _demoted?: { from: string; to: string; patterns: string } } }
+    expect(e.scope).toBe('local')
+    expect(e.visibility).toBe('private')
+    expect(e.structured_data?._demoted?.from).toBe(SHARED_SCOPE)
+    expect(e.structured_data?._demoted?.patterns).toMatch(/public_ipv4|ipv4_port/)
+  }, 30_000)
+
+  it('BOUNDARY: the SAME UPDATE into a PERSONAL (global) engram does NOT demote and does NOT stamp', async () => {
+    const plur = freshPlur({ dedup: { enabled: true, mode: 'llm' } })
+    // Personal scope — _offendingHitsForScope short-circuits (fast-path), so no demotion.
+    const seed = plur.learn('the deploy runbook lives in the wiki', { scope: 'global', type: 'procedural' }) as Engram
+    expect(seed.scope).toBe('global')
+
+    const llm = dedupLlm('UPDATE', seed.id)
+    const result = await plur.learnAsync(`the deploy target is ${PUBLIC_IP}`, { llm })
+
+    expect(result.decision).toBe('UPDATE')
+    const e = result.engram as Engram & { visibility?: string; structured_data?: { _demoted?: unknown } }
+    // Stays at its personal scope — proves the demotion above was the
+    // isSharedScope guard firing, not a test artifact.
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._demoted).toBeUndefined()
+  }, 30_000)
+})
+
+describe('LOW-2 — _guardExplicitUpdate scans context fields', () => {
+  it('demotes an explicit update when a public IP is ONLY in a context field (source) at a shared scope', () => {
+    const plur = freshPlur()
+    // Seed a clean engram at the shared scope.
+    const seed = plur.learn('the canonical pack format is SKILL.md', { scope: SHARED_SCOPE, type: 'architectural' }) as Engram
+    expect(seed.scope).toBe(SHARED_SCOPE)
+
+    // Explicit update: statement stays clean, but a sensitive IP hides in `source`.
+    const updated = { ...seed, source: `pulled from ${PUBLIC_IP}` } as Engram
+    const ok = plur.updateEngram(updated)
+    expect(ok).toBe(true)
+
+    const after = plur.list().find(e => e.id === seed.id) as (Engram & { visibility?: string }) | undefined
+    expect(after).toBeDefined()
+    // Demoted in place because the context field carried the credential.
+    expect(after!.scope).toBe('local')
+    expect(after!.visibility).toBe('private')
+  })
+
+  it('does NOT demote a clean explicit update (no over-blocking)', () => {
+    const plur = freshPlur()
+    const seed = plur.learn('the canonical pack format is SKILL.md', { scope: SHARED_SCOPE, type: 'architectural' }) as Engram
+    const updated = { ...seed, source: 'pulled from the team wiki', rationale: 'authoritative' } as Engram
+    plur.updateEngram(updated)
+    const after = plur.list().find(e => e.id === seed.id) as Engram | undefined
+    expect(after!.scope).toBe(SHARED_SCOPE)
+  })
+})
+
+describe('LOW-1 — saveMetaEngrams runs the leak guard before persist', () => {
+  let metaSeq = 0
+  /**
+   * Build a schema-valid meta-engram by deriving it from a real `learn()`
+   * engram on a throwaway Plur, then overriding fields. Hand-built engrams miss
+   * required fields (version/content_hash/…) and are silently dropped on reload.
+   */
+  function meta(overrides: Partial<Engram> & { statement: string; scope: string }): Engram {
+    const tmp = mkdtempSync(join(tmpdir(), 'plur-pr5-meta-'))
+    dirs.push(tmp)
+    writeFileSync(join(tmp, 'config.yaml'), yaml.dump({ stores: [], index: false }, { noRefs: true }))
+    const base = new (Plur as unknown as { new (o: { path: string }): Plur })({ path: tmp })
+      .learn('seed for meta shape', { scope: 'global' }) as Engram
+    metaSeq += 1
+    return {
+      ...base,
+      id: `ENG-2026-0620-9${String(metaSeq).padStart(2, '0')}`,
+      visibility: 'private',
+      ...overrides,
+    } as Engram
+  }
+
+  it('demotes a SHARED-scope meta with a public IP (statement) to local/private + stamps _demoted', () => {
+    const plur = freshPlur()
+    const m = meta({ statement: `infra note: prod box ${PUBLIC_IP}`, scope: SHARED_SCOPE })
+    const res = plur.saveMetaEngrams([m])
+    expect(res.saved).toBe(1)
+    const saved = plur.list().find(e => e.id === m.id) as (Engram & { visibility?: string; structured_data?: { _demoted?: { from: string; patterns: string } } }) | undefined
+    expect(saved).toBeDefined()
+    expect(saved!.scope).toBe('local')
+    expect(saved!.visibility).toBe('private')
+    expect(saved!.structured_data?._demoted?.from).toBe(SHARED_SCOPE)
+    expect(saved!.structured_data?._demoted?.patterns).toMatch(/public_ipv4/)
+  })
+
+  it('demotes a SHARED-scope meta whose sensitive content is in a CONTEXT field (source)', () => {
+    const plur = freshPlur()
+    const m = meta({ statement: 'a clean meta statement', source: `seen at ${PUBLIC_IP}`, scope: SHARED_SCOPE })
+    plur.saveMetaEngrams([m])
+    const saved = plur.list().find(e => e.id === m.id) as (Engram & { visibility?: string }) | undefined
+    expect(saved!.scope).toBe('local')
+    expect(saved!.visibility).toBe('private')
+  })
+
+  it('THROWS on a raw secret in a SHARED-scope meta (HARD detectSecrets check)', () => {
+    const plur = freshPlur()
+    const m = meta({ statement: 'the api key is sk-aaaabbbbccccddddeeeeffffgggg', scope: SHARED_SCOPE })
+    expect(() => plur.saveMetaEngrams([m])).toThrow(/secret detected/i)
+  })
+
+  it('leaves a clean PERSONAL-scope meta untouched (no-op for in-tree callers)', () => {
+    const plur = freshPlur()
+    const m = meta({ statement: 'a perfectly clean meta', scope: 'global' })
+    const res = plur.saveMetaEngrams([m])
+    expect(res.saved).toBe(1)
+    const saved = plur.list().find(e => e.id === m.id) as (Engram & { structured_data?: { _demoted?: unknown } }) | undefined
+    expect(saved!.scope).toBe('global')
+    expect(saved!.structured_data?._demoted).toBeUndefined()
+  })
+})

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '@plur-ai/core'
@@ -87,6 +87,74 @@ describe('MCP tools', () => {
     it('no hint when the explicit scope is global on purpose', async () => {
       const result = await callTool('plur_learn', { statement: 'TS enums are slow', scope: 'global' }) as any
       expect(result.scope_hint).toBeUndefined()
+    })
+  })
+
+  // LOW-22 (#353): the ONLY combo where wasRouted suppresses the hint — an
+  // un-scoped write that AUTO-ROUTES (Stage 3b) to a PERSONAL landing scope while
+  // a writable team store IS configured. Without the wasRouted-silence branch the
+  // hint would fire (personal landing + team store); with it, the routing decision
+  // already explained the scope, so the hint must stay silent.
+  describe('scope hint is suppressed after a Stage-3b auto-route to a personal scope (LOW-22)', () => {
+    let routedDir: string
+    let routedPlur: Plur
+    const routedCall = async (name: string, args: Record<string, unknown> = {}) => {
+      const tool = tools.find(t => t.name === name)!
+      return tool.handler(args, routedPlur)
+    }
+
+    beforeEach(() => {
+      routedDir = mkdtempSync(join(tmpdir(), 'plur-mcp-routed-'))
+      // Two stores:
+      //  (1) a writable LOCAL store at scope:"global" (PERSONAL family) whose
+      //      covers confidently match the statement → auto-route lands at global
+      //      and stamps _routed, so wasRouted=true.
+      //  (2) a writable REMOTE team store so getWritableRemoteScopes() is non-empty
+      //      — i.e. the hint WOULD fire if wasRouted were not honored.
+      const globalPath = join(routedDir, 'global.yaml')
+      writeFileSync(join(routedDir, 'config.yaml'),
+        `index: false\n` +
+        `stores:\n` +
+        `  - path: ${globalPath}\n` +
+        `    scope: global\n` +
+        `    description: Personal global\n` +
+        `    covers: ['plur.*', 'embeddings', 'core']\n` +
+        `  - url: https://plur.example.com\n` +
+        `    token: tok\n` +
+        `    scope: group:acme/engineering\n` +
+        `    shared: true\n` +
+        `    readonly: false\n`,
+      )
+      routedPlur = new Plur({ path: routedDir })
+    })
+    afterEach(() => { rmSync(routedDir, { recursive: true, force: true }) })
+
+    it('auto-routes to global, stamps routed, and SUPPRESSES the scope_hint', async () => {
+      // No scope passed; domain-prefix + tag + keyword hits clear the threshold.
+      const result = await routedCall('plur_learn', {
+        statement: 'the embeddings index for the core engine',
+        domain: 'plur.core.embeddings',
+        tags: ['embeddings'],
+      }) as any
+      // Landed at the personal (global) scope via auto-route...
+      expect(result.scope).toBe('global')
+      expect(result.routed).toBeDefined()
+      expect(result.routed.scope).toBe('global')
+      // ...and the hint is SILENT even though a team store is configured
+      // (wasRouted-silence — the only combo that suppresses).
+      expect(result.scope_hint).toBeUndefined()
+    })
+
+    it('control: the SAME personal landing WITHOUT a route DOES fire the hint', async () => {
+      // No covers match → no auto-route → wasRouted=false → hint fires (proves the
+      // suppression above is the wasRouted branch, not the team store being absent).
+      const result = await routedCall('plur_learn', {
+        statement: 'an unrelated note that matches no covers at all',
+      }) as any
+      expect(result.scope).toBe('global')
+      expect(result.routed).toBeUndefined()
+      expect(result.scope_hint).toBeDefined()
+      expect(result.scope_hint).toContain('group:acme/engineering')
     })
   })
 


### PR DESCRIPTION
PR-5 of the 0.10.0 evaluator-hardened fix plan — low-severity hardening + missing coverage (resolves audit findings 1, 2, 9, 10, 20, 22 from #353). Branched off post-PR-1..PR-4 main.

## Findings fixed
- **#1 (LOW) saveMetaEngrams guard** — the one public persist method that ran no part of the scope-security stack now guards each meta before persist: HARD `detectSecrets` check (throws on a raw secret at a shared scope unless `allow_secrets`) + SOFT `_offendingHitsForScope` demotion (shared-scope infra content → `local`/`private`, stamps `_demoted`). No-op for all in-tree personal-scope callers; defense-in-depth for a future shared-scope meta.
- **#2 (LOW) `_guardExplicitUpdate` context scan** — now scans `statement + JSON.stringify(context fields)` (rationale/source/snippet/dual_coding/structured_data) like `_guardSensitiveScope`, not just `statement`. A new `_engramContextFields` helper strips PLUR-internal underscore keys (`_outbox`/`_routed`/`_demoted`) so a remote-origin engram's loopback `target_url` is not falsely flagged. The 4 in-tree callers (updateEngram/updateEngramAsync, local + remote) pass the engram's context fields.
- **#9 learnAsync demotion marker** — `demoteIfSensitive` now stamps `structured_data._demoted = {from,to,patterns}` (captured before scope reassignment), mirroring the sync/explicit-update/saveMetaEngrams sites, surfaced via `LearnAsyncResult.engram`.
- **#10 CLI demotion warning** — `cli/learn.ts` reads `structured_data._demoted` and surfaces it (text warning + JSON `demoted{}` / `requested_scope`) instead of swallowing the demotion; mirrors the MCP display contract.

## New tests (drive real behavior, not vacuous)
- **#20** learnAsync UPDATE/MERGE demotion driven for REAL at a shared scope (`group:plur/engineering`) — asserts `scope→local`, `visibility→private`, and `_demoted{from,to,patterns}`. A personal-scope (`global`) BOUNDARY case asserts NO demotion + NO stamp, proving it's the `isSharedScope` guard firing, not a test accident.
- **#22** MCP `scope_hint` wasRouted-silence — a `scope:'global'` covers store + a writable team store auto-routes to `global` (`wasRouted=true`) and the hint is SUPPRESSED; a control with no covers match (`wasRouted=false`) DOES fire the hint — non-vacuous.
- Plus LOW-1 saveMetaEngrams demotion/secret/no-op cases and LOW-2 context-field demotion + clean-update cases and LOW-10 CLI JSON contract cases.

## Verification
- `pnpm --filter @plur-ai/core build` succeeds.
- Full workspace green after dist rebuild: **1630 passed / 34 skipped / 0 failed** (147 files), core+mcp+claw+cli.
- `tsc --noEmit` clean on core (zero errors). The mcp/cli tsc errors are pre-existing baseline in untouched files (`tools.ts:1804`, `init-remote.ts`, `tensions.ts`); none in any file this PR touches.
- No regex added or modified (the one-named-group-per-regex Node 20/22 constraint is not engaged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)