### PR TITLE
feat(core): deterministic routing on a full domain-prefix match (no edge-of-threshold) — PR-6

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1024,10 +1024,19 @@ export class Plur {
    * UNSCOPED case (Stage 3b, #351). Two non-explicit signals decide it:
    *
    *  - `config.auto_route_scope` (default true): run the deterministic
-   *    {@link suggestScope} ranker over the registered scopes' `covers[]`. If the
-   *    top candidate's confidence clears {@link SCOPE_MATCH_THRESHOLD}, route the
-   *    engram there and return the routing decision so it can be stamped.
-   *  - otherwise: fall to `config.unscoped_default` (default `local`).
+   *    {@link suggestScope} ranker over the registered scopes' `covers[]`.
+   *      - If the top writable candidate matched via a FULL domain-prefix
+   *        (`domainMatch`), route to it DETERMINISTICALLY — bypass the
+   *        squash/threshold. A full domain match is the strongest, most
+   *        deliberate routing signal; under the current weights a LONE domain
+   *        match squashes to EXACTLY {@link SCOPE_MATCH_THRESHOLD} (0.5) and
+   *        would route only via the edge-of-threshold `>=` gate (#353 PR-6).
+   *        The deterministic bypass removes that fragility with headroom and is
+   *        independent of the weight curve.
+   *      - Otherwise (tag-only / keyword-only — NO domain match): apply the
+   *        threshold to the squashed confidence exactly as before. Weak signals
+   *        stay gated — only a genuine domain-prefix match gets the bypass.
+   *  - otherwise (auto_route_scope false): fall to `config.unscoped_default`.
    *
    * INERT until scopes declare `covers` (Stage 5): with no `covers` the ranker
    * returns `[]` and every unscoped write falls to `unscoped_default`. Both
@@ -1068,6 +1077,18 @@ export class Plur {
       writableScopeMetadata,
     )
     const top = candidates[0]
+    // PR-6 (#353): a FULL domain-prefix match is the strongest, most deliberate
+    // routing signal. Route to it DETERMINISTICALLY — bypass the squash/threshold
+    // gate entirely — so a clean domain match routes with headroom instead of
+    // landing at exactly SCOPE_MATCH_THRESHOLD (0.5) and clearing only via the
+    // edge-of-threshold `>=`. rankScopes already prefers a domain-match candidate
+    // at the top on equal confidence, so `top` is the right scope to route to.
+    // The weights/threshold/squash are UNCHANGED — only the decision is bypassed.
+    if (top && top.domainMatch) {
+      return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
+    }
+    // No domain match: a tag-only or keyword-only candidate is a WEAK signal and
+    // stays gated by the threshold exactly as before — conservative by design.
     if (top && top.confidence >= SCOPE_MATCH_THRESHOLD) {
       return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
     }

--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -24,7 +24,16 @@
  *
  * Confidence is normalized into [0,1] by squashing the raw weighted score, so a
  * single weak keyword hit reads as low-confidence and a domain-prefix match
- * reads as high-confidence. Ties break deterministically on scope name.
+ * reads as high-confidence. Ties break deterministically: equal confidence
+ * prefers a domain-prefix match, then scope name ascending.
+ *
+ * Each candidate also carries `domainMatch` (see {@link ScopeCandidate}): a
+ * boolean exposing whether the match came through the domain-prefix channel.
+ * The write-path router (`_resolveUnscopedScope` in index.ts, #353 PR-6) routes
+ * a clean domain match DETERMINISTICALLY, bypassing the squash/threshold so it
+ * no longer has to land EXACTLY on SCOPE_MATCH_THRESHOLD; weak signals stay
+ * gated by the threshold. The weights/threshold/squash are unchanged — the
+ * deterministic bypass lives in the caller, not in this ranker.
  */
 import type { ScopeMetadata } from './schemas/scope-metadata.js'
 
@@ -91,6 +100,18 @@ export interface ScopeCandidate {
   confidence: number
   /** Human-readable matched signals, e.g. "domain plur.core.security ⊂ covers plur.*". */
   reason: string
+  /**
+   * True when this candidate matched via a FULL domain-prefix hit — the engram's
+   * `domain` is namespace-covered by (or namespace-covers) one of the scope's
+   * `covers` entries. This is the strongest, most deliberate routing signal.
+   *
+   * The caller (`_resolveUnscopedScope` in index.ts) uses this to route a clean
+   * domain match DETERMINISTICALLY, bypassing the squash/threshold edge — a lone
+   * domain match no longer has to land EXACTLY on SCOPE_MATCH_THRESHOLD to route.
+   * Weak signals (tag-only, keyword-only) leave this `false` and stay gated by
+   * the threshold. Additive: `confidence`/`reason` are unchanged.
+   */
+  domainMatch: boolean
 }
 
 const STOPWORDS = new Set([
@@ -140,11 +161,12 @@ function scoreScope(
   signals: ScopeSignals,
   scope: string,
   covers: string[],
-): { raw: number; reasons: string[] } | null {
+): { raw: number; reasons: string[]; domainMatch: boolean } | null {
   const normalizedCovers = covers.map(c => ({ raw: c, norm: normalizeCover(c) })).filter(c => c.norm.length > 0)
   if (normalizedCovers.length === 0) return null
 
   let raw = 0
+  let domainMatch = false
   const reasons: string[] = []
 
   // --- domain-prefix channel (highest weight) ---
@@ -156,11 +178,13 @@ function scoreScope(
       // cover (`plur` engram fits a `plur.core` scope, weaker but still a hit).
       if (isNamespacePrefix(cover.norm, domain)) {
         raw += WEIGHT_DOMAIN
+        domainMatch = true
         reasons.push(`domain ${domain} ⊂ covers ${cover.raw}`)
         break // one domain hit per scope — domain is single-valued
       }
       if (isNamespacePrefix(domain, cover.norm)) {
         raw += WEIGHT_DOMAIN
+        domainMatch = true
         reasons.push(`domain ${domain} ⊃ covers ${cover.raw}`)
         break
       }
@@ -196,7 +220,7 @@ function scoreScope(
   }
 
   if (raw <= 0) return null
-  return { raw, reasons }
+  return { raw, reasons, domainMatch }
 }
 
 /**
@@ -220,10 +244,18 @@ export function rankScopes(
       scope: meta.scope,
       confidence: Number(squash(scored.raw).toFixed(4)),
       reason: scored.reasons.join('; '),
+      domainMatch: scored.domainMatch,
     })
   }
+  // Sort by confidence desc; on equal confidence prefer a domain-prefix match
+  // (so the deterministic-bypass caller picks the genuine domain candidate over
+  // a coincidentally-equal weak-signal one — e.g. a lone domain hit and a
+  // three-tag hit both squash to exactly 0.5); finally break remaining ties on
+  // scope name ascending for full determinism.
   candidates.sort((a, b) =>
-    b.confidence - a.confidence || a.scope.localeCompare(b.scope),
+    b.confidence - a.confidence ||
+    (b.domainMatch ? 1 : 0) - (a.domainMatch ? 1 : 0) ||
+    a.scope.localeCompare(b.scope),
   )
   return candidates
 }

--- a/packages/core/test/route-unscoped.test.ts
+++ b/packages/core/test/route-unscoped.test.ts
@@ -17,12 +17,25 @@
  * the "lone domain-prefix match auto-routes" case below; the stores here stack
  * domain + tag (+ keyword) so they sit comfortably above the boundary.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
-import { Plur, SCOPE_MATCH_THRESHOLD } from '../src/index.js'
+
+// PR-6: wrap rankScopes so individual tests can inject a hand-built ranked list
+// (e.g. a sub-threshold domain candidate) to prove the deterministic bypass is
+// decoupled from SCOPE_MATCH_THRESHOLD. By DEFAULT it delegates to the real
+// implementation, so every other test in this file uses genuine ranking.
+const { rankScopes: realRankScopes } =
+  await vi.importActual<typeof import('../src/scope-routing.js')>('../src/scope-routing.js')
+const routeMock = vi.fn(realRankScopes)
+vi.mock('../src/scope-routing.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/scope-routing.js')>()
+  return { ...actual, rankScopes: (...args: Parameters<typeof actual.rankScopes>) => routeMock(...args) }
+})
+
+const { Plur, SCOPE_MATCH_THRESHOLD } = await import('../src/index.js')
 
 const dirs: string[] = []
 
@@ -34,7 +47,11 @@ function makePlur(config: Record<string, unknown>): Plur {
   return new Plur({ path: dir })
 }
 
-afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true })
+  routeMock.mockReset()
+  routeMock.mockImplementation(realRankScopes) // restore real ranking after any mockReturnValueOnce
+})
 
 describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
   it('routes an un-scoped write to a covers-matched scope (confident), stamps _routed', () => {
@@ -250,6 +267,167 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
     // must still show readonly scopes so a human can find them.
     const ranked = plur.suggestScope({ statement: 'embeddings core', domain: 'plur.core.embeddings', tags: ['embeddings'] })
     expect(ranked.map(c => c.scope)).toContain('group:plur/core')
+  })
+
+  // --- PR-6 (#353): a FULL domain-prefix match routes DETERMINISTICALLY,
+  // bypassing the squash/threshold edge. Weak signals (tag-only / keyword-only)
+  // stay gated by the threshold; readonly scopes stay excluded; weights/threshold
+  // are unchanged. ---
+
+  it('PR-6: a full domain-prefix match routes deterministically (via the bypass, not the >= edge)', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.*'] },
+      ],
+    })
+    // Domain-only hit, zero token overlap. Under the weight curve this squashes
+    // to EXACTLY 0.50 = SCOPE_MATCH_THRESHOLD — pre-PR-6 it routed only by landing
+    // on the `>=` edge. PR-6 routes it via the deterministic domainMatch bypass
+    // instead (taken BEFORE the threshold check), so the route no longer depends
+    // on the confidence sitting precisely on the threshold.
+    const e = plur.learn('xyzzy nonoverlapping content tokens', {
+      domain: 'plur.core.security',
+    }) as { scope: string; structured_data?: { _routed?: { scope: string; confidence: number; reason: string } } }
+    expect(e.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/core')
+    // The route is for a domain reason (proves it came through the domain channel,
+    // i.e. the deterministic branch, not a coincidental tag/keyword pile-up).
+    expect(e.structured_data?._routed?.reason).toContain('domain plur.core.security')
+  })
+
+  it('PR-6: the bypass is taken BEFORE the threshold gate — a sub-threshold domain candidate STILL routes', () => {
+    // Rigorously decouples the bypass from SCOPE_MATCH_THRESHOLD. We feed the
+    // private resolver a hand-built ranked list (via a mocked rankScopes) whose
+    // top candidate has `domainMatch:true` but a confidence WELL BELOW threshold
+    // (0.2). Threshold-only logic would refuse to route it; PR-6 routes it because
+    // the deterministic domain branch is taken first. A second list (same low
+    // confidence but `domainMatch:false`) must NOT route — proving the bypass is
+    // gated on domainMatch, not just on having a candidate.
+    const plur = makePlur({
+      stores: [{ path: '/tmp/r.yaml', scope: 'group:plur/core', covers: ['plur.*'], description: 'Core' }],
+    }) as unknown as {
+      _resolveUnscopedScope: (s: string, c?: { domain?: string }) => { scope: string; routed: { scope: string } | null }
+    }
+
+    // domainMatch:true, confidence 0.2 (< 0.5) → must route via the bypass.
+    routeMock.mockReturnValueOnce([
+      { scope: 'group:plur/core', confidence: 0.2, reason: 'domain x ⊂ covers plur.*', domainMatch: true },
+    ])
+    const routedLow = plur._resolveUnscopedScope('anything', { domain: 'plur.core.x' })
+    expect(routedLow.scope).toBe('group:plur/core')
+    expect(routedLow.routed?.scope).toBe('group:plur/core')
+
+    // domainMatch:false, same confidence 0.2 (< 0.5) → must NOT route (gated).
+    routeMock.mockReturnValueOnce([
+      { scope: 'group:plur/core', confidence: 0.2, reason: 'keywords [...]', domainMatch: false },
+    ])
+    const gatedLow = plur._resolveUnscopedScope('anything')
+    expect(gatedLow.scope).toBe('global')
+    expect(gatedLow.routed).toBeNull()
+  })
+
+  it('PR-6: a tag-only match (no domain) is STILL gated by threshold — two tags fall to default', () => {
+    const plur = makePlur({
+      stores: [
+        // Two cover tokens, hit by two tags → raw 1.0 → squash 0.40 < 0.5, and
+        // NO domain match. The bypass must not fire; the write stays gated.
+        { path: '/tmp/r-infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers', 'deploy'] },
+      ],
+    })
+    const e = plur.learn('no overlap words zzz', {
+      tags: ['servers', 'deploy'],
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('PR-6: a tag-only match that DOES clear threshold (three tags) still routes (threshold path intact)', () => {
+    const plur = makePlur({
+      stores: [
+        // Three tags → raw 1.5 → squash 0.50, NO domain. The threshold path (not
+        // the bypass) routes it — proves PR-6 left the weak-signal gate working.
+        { path: '/tmp/r-infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers', 'deploy', 'infra'] },
+      ],
+    })
+    const e = plur.learn('no overlap words zzz', {
+      tags: ['servers', 'deploy', 'infra'],
+    }) as { scope: string; structured_data?: { _routed?: { scope: string } } }
+    expect(e.scope).toBe('group:plur/infra')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/infra')
+  })
+
+  it('PR-6: a keyword-only match (no domain) is STILL gated by threshold — falls to default', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-infra.yaml', scope: 'group:plur/infra', description: 'Infra', covers: ['servers'] },
+      ],
+    })
+    const e = plur.learn('restart the servers now') as {
+      scope: string; structured_data?: { _routed?: unknown }
+    }
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('PR-6: a readonly scope with a domain match is STILL excluded (not chosen, falls to default)', () => {
+    const plur = makePlur({
+      stores: [
+        // Readonly store whose covers domain-match. PR-4's readonly exclusion runs
+        // BEFORE ranking, so the domain candidate never enters the set — the
+        // deterministic bypass has nothing to route to.
+        { url: 'https://ro.example.com', token: 't', readonly: true, scope: 'group:plur/core', description: 'Core (RO)', covers: ['plur.*'] },
+      ],
+    })
+    const e = plur.learn('zzz no overlap', {
+      domain: 'plur.core.security',
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('PR-6: multiple domain-match candidates → deterministic winner (domain-preferring, then scope-name)', () => {
+    const plur = makePlur({
+      stores: [
+        // Both scopes domain-match `plur.core.security` (plur.* and plur.core.*),
+        // both score 0.5. Tie-break is deterministic: both are domain matches, so
+        // it falls to scope name ascending → group:plur/a wins, every run.
+        { path: '/tmp/r-b.yaml', scope: 'group:plur/b', description: 'B', covers: ['plur.*'] },
+        { path: '/tmp/r-a.yaml', scope: 'group:plur/a', description: 'A', covers: ['plur.core.*'] },
+      ],
+    })
+    const e = plur.learn('zzz no overlap', {
+      domain: 'plur.core.security',
+    }) as { scope: string; structured_data?: { _routed?: { scope: string } } }
+    expect(e.scope).toBe('group:plur/a')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/a')
+  })
+
+  it('PR-6: explicit scope still bypasses auto-route entirely (domain match ignored)', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.*'] },
+      ],
+    })
+    const e = plur.learn('zzz no overlap', {
+      domain: 'plur.core.security',
+      scope: 'local',
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    expect(e.scope).toBe('local')
+    expect(e.structured_data?._routed).toBeUndefined()
+  })
+
+  it('PR-6: a session default still bypasses auto-route entirely (domain match ignored)', () => {
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.*'] },
+      ],
+    })
+    plur.setSessionScope('project:my-app')
+    const e = plur.learn('zzz no overlap', {
+      domain: 'plur.core.security',
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    expect(e.scope).toBe('project:my-app')
+    expect(e.structured_data?._routed).toBeUndefined()
   })
 
   it('auto-routed SHARED scope with sensitive content is still DEMOTED to local (3b + guard)', () => {

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -125,6 +125,65 @@ describe('rankScopes — pure ranker', () => {
     expect(SCOPE_MATCH_THRESHOLD).toBeGreaterThan(0)
     expect(SCOPE_MATCH_THRESHOLD).toBeLessThan(1)
   })
+
+  // --- PR-6 (#353): expose `domainMatch` on each candidate so the write-path
+  // router can route a FULL domain-prefix match deterministically. Additive —
+  // `confidence`/`reason` are unchanged; only the new boolean is asserted here.
+  it('flags `domainMatch:true` on a full domain-prefix candidate (cover ⊃ domain)', () => {
+    const ranked = rankScopes(
+      { statement: 'xyzzy nonoverlapping tokens', domain: 'plur.core.security' },
+      [{ scope: 'group:plur/core', covers: ['plur.*'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].domainMatch).toBe(true)
+  })
+
+  it('flags `domainMatch:true` in the reverse direction (domain ⊃ cover)', () => {
+    // domain `plur` is a prefix of cover `plur.core` — still a domain-channel hit.
+    const ranked = rankScopes(
+      { statement: 'zzz no overlap', domain: 'plur' },
+      [{ scope: 'group:plur/core', covers: ['plur.core'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].domainMatch).toBe(true)
+  })
+
+  it('leaves `domainMatch:false` on a tag-only candidate', () => {
+    const ranked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers', 'deploy', 'infra'] },
+      [{ scope: 'group:plur/infra', covers: ['servers', 'deploy', 'infra'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].domainMatch).toBe(false)
+  })
+
+  it('leaves `domainMatch:false` on a keyword-only candidate', () => {
+    const ranked = rankScopes(
+      { statement: 'updating the deployment runbook for servers' },
+      [{ scope: 'group:plur/infra', covers: ['deployment', 'servers'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].domainMatch).toBe(false)
+  })
+
+  it('on an EQUAL-confidence tie, ranks the domain-match candidate first', () => {
+    // A lone domain hit (group:zzz-core: domain ⊂ covers) and a three-tag hit
+    // (group:aaa-tags) BOTH squash to exactly 0.5. The domain candidate has the
+    // alphabetically-later scope name, so the old name-only tie-break would have
+    // put the tag candidate first; PR-6's domain-preferring tie-break must put
+    // the genuine domain match at the top so the deterministic router picks it.
+    const ranked = rankScopes(
+      { statement: 'no overlap zzz', domain: 'plur.core.x', tags: ['servers', 'deploy', 'infra'] },
+      [
+        { scope: 'group:aaa-tags', covers: ['servers', 'deploy', 'infra'] }, // 3 tags → 0.5
+        { scope: 'group:zzz-core', covers: ['plur.*'] },                     // domain → 0.5
+      ],
+    )
+    expect(ranked[0].confidence).toBe(ranked[1].confidence) // genuinely tied at 0.5
+    expect(ranked[0].scope).toBe('group:zzz-core')          // domain wins the tie
+    expect(ranked[0].domainMatch).toBe(true)
+    expect(ranked[1].domainMatch).toBe(false)
+  })
 })
 
 describe('squash math — auto-route boundaries (#353 finding-11)', () => {


### PR DESCRIPTION
## PR-6 — deterministic full-domain-prefix routing

PR-4 set `WEIGHT_DOMAIN=1.5` so a lone domain-prefix match against a scope's `covers` squashes to **exactly** `0.50 = SCOPE_MATCH_THRESHOLD` and routes only via the `>=` gate — edge-of-threshold. PR-6 makes a clean domain match route **deterministically**, with headroom, without perturbing the rest of the weight curve.

### The deterministic-domain rule
- `scope-routing.ts`: `ScopeCandidate` gains an additive `domainMatch: boolean`, set from the **existing** domain-prefix channel (both directions: cover ⊃ domain and domain ⊃ cover). `confidence`/`reason` are unchanged. The `rankScopes` tie-break now prefers a domain-match candidate on equal confidence (so a lone domain hit wins a 0.5 tie against a three-tag hit), then scope name ascending.
- `index.ts` `_resolveUnscopedScope` (the write-path routing decision): when the top **writable** candidate has `domainMatch`, route to it deterministically — **bypass the squash/threshold**. Otherwise apply `SCOPE_MATCH_THRESHOLD` to the squashed confidence exactly as today.

### What's preserved
- **Weak signals stay gated.** Tag-only and keyword-only matches (no domain match) are still threshold-gated: two tags / one keyword fall to the default; three tags still route via the unchanged threshold path. Only a genuine domain-prefix match gets the bypass.
- **PR-4 readonly exclusion.** A readonly scope with a domain match is filtered out before ranking, so the bypass has nothing to route to — the write falls to the default, never labeled routed-to-readonly.
- **Weights unchanged.** `WEIGHT_DOMAIN`/`WEIGHT_TAG`/`WEIGHT_KEYWORD`/`SATURATION`/`SCOPE_MATCH_THRESHOLD` are all untouched. The deterministic bypass lives in the caller, not the ranker.
- Explicit scope and session default still bypass auto-route entirely.

### Tests
- `scope-routing.test.ts`: `domainMatch` is `true` for both domain directions, `false` for tag/keyword-only; the tie-break ranks the domain candidate first on an equal-confidence (0.5 vs 0.5) tie.
- `route-unscoped.test.ts`: a full domain-prefix match routes deterministically (reason confirms it came through the domain channel); a **mocked sub-threshold (0.2) domain candidate** routes — proving the bypass is decoupled from the threshold — while a sub-threshold **non-domain** candidate does NOT (proving the gate still holds); two-tag and keyword-only matches stay gated; three tags still route via the threshold path; a readonly domain-match scope is excluded; multiple domain-match candidates resolve to a deterministic winner; explicit scope / session default still skip auto-route.

### Build / verification
- `pnpm --filter @plur-ai/core build` OK; full workspace green: **1644 passed, 34 skipped, 0 failed** after dist rebuild.
- `tsc --noEmit` clean on core (zero new vs baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)