### PR TITLE
fix(core): leak guard covers remote-backed scopes (user:) — re-applied on post-audit main (supersedes #360)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -499,6 +499,22 @@ export class Plur {
     return null
   }
 
+  /**
+   * True when `scope` is backed by a REMOTE store — i.e. a `stores` entry with a
+   * `url` (data leaves this machine) whose scope exactly matches. The leak guard
+   * uses this alongside `isSharedScope`: a scope like `user:plur:gregor` is NOT
+   * `isSharedScope` (personal prefix) yet routes to plur.datafund.io, so sensitive
+   * content written there would cross the machine boundary unguarded.
+   *
+   * Pure CONFIG lookup — NO driver instantiation, NO network, NO side effects —
+   * because this runs on every learn(). It mirrors `_resolveRemoteStoreForScope`'s
+   * exact-scope-match rule (no prefix matching) so the guard and the router agree
+   * on which writes reach the remote.
+   */
+  private _isRemoteBackedScope(scope: string): boolean {
+    return (this.config.stores ?? []).some(s => !!s.url && s.scope === scope)
+  }
+
   /** Find which store owns an engram by ID. For namespaced IDs, strips prefix to find in store. */
   private _findEngramStore(id: string): { path: string; readonly: boolean; originalId: string } | null {
     // Check primary first (uses mtime cache)
@@ -879,12 +895,15 @@ export class Plur {
   }
 
   /**
-   * Write-time leak guard. If the target scope is one others can read
-   * (`isSharedScope`: group:/project:/space:/team:/org:/public) AND the statement
-   * trips `detectSensitive` (IPs, internal hosts, basic-auth, host:port, secrets),
-   * DEMOTE to a private local scope — the engram is kept but never written to a
-   * shared store — and warn. Personal scopes (local/global/user:/agent:) are
-   * exempt: infra notes legitimately live there. Called at the top of both
+   * Write-time leak guard. If the target scope can let data leave the machine —
+   * either SHARED (`isSharedScope`: group:/project:/space:/team:/org:/public, so
+   * others can read it) OR REMOTE-backed (`_isRemoteBackedScope`: routes to a
+   * remote store, e.g. a personal `user:` scope on plur.datafund.io) — AND the
+   * statement trips `detectSensitive` (IPs, internal hosts, basic-auth, host:port,
+   * secrets), DEMOTE to a private local scope — the engram is kept but never
+   * written to a shared/remote store — and warn. Purely-local scopes
+   * (`global`/`local`/local-file stores) are exempt: infra notes legitimately
+   * live there and never leave the machine. Called at the top of both
    * `learn()` and `learnRouted()`, so every client (CLI, MCP, hooks, OpenClaw,
    * Hermes) is covered, since they all route through one of those two.
    *
@@ -903,10 +922,13 @@ export class Plur {
    * `scope` forbids?". Returns the offending {@link SecretMatch} hits, or `[]`
    * when there are none.
    *
-   * Scope discipline: only SHARED scopes (`isSharedScope`) can leak, so for
-   * personal/local scopes (`local`/`global`/`user:`/`agent:`) this returns `[]`
-   * unconditionally — infra notes legitimately live in local storage, and the
-   * demotion target is local anyway, so a local write is always coherent.
+   * Scope discipline: data can leak when the scope is SHARED (`isSharedScope`,
+   * others can read it) OR REMOTE-backed (`_isRemoteBackedScope`, it routes off
+   * this machine — e.g. a `user:` scope on plur.datafund.io). For a scope that is
+   * neither — `global`/`local`/a local-file store — this returns `[]`
+   * unconditionally: infra notes legitimately live in local storage, the content
+   * never leaves the machine, and the demotion target is local anyway, so a local
+   * write is always coherent.
    *
    * Policy: scan `text` with `detectSensitive`, then keep only the hits the
    * scope's per-scope `sensitivity` policy forbids. With no scope metadata the
@@ -920,8 +942,11 @@ export class Plur {
    * so there is exactly one definition of "offending".
    */
   private _offendingHitsForScope(statement: string, scope: string): SecretMatch[] {
-    // Local/personal scopes never leak — demotion target is local anyway.
-    if (!isSharedScope(scope)) return []
+    // Guard runs when data can leave the machine: a SHARED scope (others read it)
+    // OR a REMOTE-backed scope (routes to a remote store). A scope that is neither
+    // — `global`/`local`/a local-file store — stays on this machine, so there is
+    // nothing to leak and the demotion target (local) is where it lives anyway.
+    if (!isSharedScope(scope) && !this._isRemoteBackedScope(scope)) return []
     const hits = detectSensitive(statement)
     if (hits.length === 0) return []
     const policy = this.getScopeMetadata(scope)?.sensitivity
@@ -1114,7 +1139,14 @@ export class Plur {
       // to global (#353). No behavior change for the default-global user.
       scope = context?.scope ?? this._sessionScope ?? (this.config.unscoped_default ?? 'global')
     }
-    if (!isSharedScope(scope)) return { scope, context, demotion: null, routed }
+    // Guard fires when the write can leave the machine: shared scope (others can
+    // read it) OR remote-backed scope (routes to a remote store, e.g. a personal
+    // `user:` scope on plur.datafund.io). Purely-local scopes (`global`/`local`/
+    // local-file stores) stay on this machine and are exempt — same gate as
+    // _offendingHitsForScope, kept in sync because this short-circuits before it.
+    if (!isSharedScope(scope) && !this._isRemoteBackedScope(scope)) {
+      return { scope, context, demotion: null, routed }
+    }
     // Scan the FULL content the engram will carry — the statement AND the
     // context fields (rationale, key_files, source, …), not just the statement.
     // Sensitive material hides in context too (#326 review, finding 1).

--- a/packages/core/test/guard-remote-scope.test.ts
+++ b/packages/core/test/guard-remote-scope.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Remote-backed (non-shared) leak guard.
+ *
+ * The write-time leak guard originally only fired for `isSharedScope`-prefixed
+ * scopes (group:/project:/space:/team:/org:/public). But a scope can be PERSONAL
+ * by prefix (`user:plur:gregor`) yet still be backed by a REMOTE store (a config
+ * entry with a `url` → data goes to plur.datafund.io). Such a write is NOT
+ * `isSharedScope`, so sensitive content used to bypass the guard and reach the
+ * remote unguarded. The real risk is "does the data leave the machine", i.e. the
+ * scope routes to a remote store.
+ *
+ * `_isRemoteBackedScope` closes that gap: the guard now fires for shared OR
+ * remote-backed scopes. These tests pin:
+ *   (a) sensitive write to a remote `user:` scope is DEMOTED to local, 0 appends.
+ *   (b) a CLEAN write to that same remote `user:` scope IS appended (not over-blocked).
+ *   (c) `global` (no store) + sensitive content stays personal (unchanged).
+ *   (d) a local-FILE store (path, no url) that is isSharedScope by prefix still
+ *       demotes on sensitive (unchanged existing behavior).
+ *   (e) per-scope `sensitivity.allow` policy is still honored on a remote scope.
+ *
+ * Harness mirrors guard-remote-boundary.test.ts: a vi.fn() over globalThis.fetch
+ * asserting on POST (append) calls.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+
+// A PERSONAL-prefix scope (NOT isSharedScope) that is nonetheless remote-backed.
+const REMOTE_USER_SCOPE = 'user:plur:gregor'
+const REMOTE_URL = 'https://plur.example.com/sse'
+// A real (public) droplet-shaped IPv4 — the exact shape that leaked in 2026-06.
+const PUBLIC_IP = '139.59.155.82'
+
+function writeStoresConfig(dir: string, stores: Array<Record<string, unknown>>) {
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    yaml.dump({ stores, index: false }, { lineWidth: 120, noRefs: true }),
+  )
+}
+
+/** A writable remote store for the personal `user:` scope. */
+function remoteUserStore(extra: Record<string, unknown> = {}) {
+  return [{
+    url: REMOTE_URL,
+    token: 'plur_sk_test',
+    scope: REMOTE_USER_SCOPE,
+    readonly: false,
+    ...extra,
+  }]
+}
+
+function readLocalEngrams(dir: string): any[] {
+  const path = join(dir, 'engrams.yaml')
+  if (!existsSync(path)) return []
+  const data = yaml.load(readFileSync(path, 'utf-8')) as { engrams?: unknown[] } | null
+  return (data?.engrams ?? []) as any[]
+}
+
+describe('remote-backed (non-shared) leak guard', () => {
+  let dir: string
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-guard-remote-scope-'))
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function postCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
+  }
+
+  /** Empty-list mock for the load() page-walk; POST append succeeds. */
+  function mockEmptyRemote() {
+    fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'POST') {
+        return { ok: true, status: 201, json: async () => ({ id: 'ENG-REMOTE-001' }), text: async () => '' } as Response
+      }
+      return { ok: true, status: 200, json: async () => ({ rows: [], total_count: 0 }), text: async () => '' } as Response
+    }) as any)
+  }
+
+  // (a) The new coverage: a public-IP statement learned to a REMOTE-backed but
+  // PERSONAL-prefix scope (`user:plur:gregor`) must be demoted to local and must
+  // NOT reach the remote (0 appends) — exactly the gap _isRemoteBackedScope fixes.
+  it('(a) sensitive write to a remote user: scope is demoted to local, never appended', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, remoteUserStore())
+    const plur = new Plur({ path: dir })
+
+    const engram = plur.learn(`my prod box is ${PUBLIC_IP}`, {
+      scope: REMOTE_USER_SCOPE,
+      type: 'behavioral',
+    }) as { scope: string; visibility: string }
+
+    // Demoted at the guard — stays on the machine.
+    expect(engram.scope).toBe('local')
+    expect(engram.visibility).toBe('private')
+
+    // Give any (erroneous) fire-and-forget push time to fire.
+    await new Promise(r => setTimeout(r, 50))
+
+    // The remote append spy saw ZERO engrams, and nothing queued for retry.
+    expect(postCalls().length).toBe(0)
+    expect(plur.outboxCount()).toBe(0)
+
+    // Kept locally (demoted), not lost.
+    const local = readLocalEngrams(dir)
+    expect(local.find(e => e.scope === 'local' && String(e.statement).includes(PUBLIC_IP))).toBeDefined()
+  })
+
+  // (b) A CLEAN write to the SAME remote user: scope is NOT demoted and DOES reach
+  // the remote — proves the guard is not over-blocking the personal remote scope.
+  it('(b) clean write to a remote user: scope is not demoted and reaches the remote', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, remoteUserStore())
+    const plur = new Plur({ path: dir })
+
+    const engram = plur.learn('I prefer concise commit messages', {
+      scope: REMOTE_USER_SCOPE,
+      type: 'preference',
+    }) as { scope: string }
+
+    // Not demoted — scope honored.
+    expect(engram.scope).toBe(REMOTE_USER_SCOPE)
+
+    // Let the fire-and-forget push settle.
+    await new Promise(r => setTimeout(r, 50))
+
+    // The clean engram WAS appended to the remote.
+    expect(postCalls().length).toBe(1)
+  })
+
+  // (c) `global` is a PERSONAL local scope with NO store backing — it must stay
+  // exempt. Sensitive content here is NOT demoted (global stays personal/local).
+  it('(c) sensitive write to global (no store) is not demoted', () => {
+    // No stores at all → global is neither shared nor remote-backed.
+    writeStoresConfig(dir, [])
+    const plur = new Plur({ path: dir })
+
+    const engram = plur.learn(`my home server is ${PUBLIC_IP}`, {
+      scope: 'global',
+      type: 'behavioral',
+    }) as { scope: string }
+
+    expect(engram.scope).toBe('global')
+  })
+
+  // (d) A local-FILE store (path, no url) at a shared-prefix scope still demotes
+  // on sensitive content — unchanged existing isSharedScope behavior. Confirms the
+  // change only ADDS remote-backed coverage, it does not alter shared-prefix paths.
+  it('(d) sensitive write to a local-file shared-prefix store still demotes', () => {
+    const filePath = join(dir, 'team-store.yaml')
+    writeStoresConfig(dir, [{
+      path: filePath,
+      scope: 'project:plur',   // isSharedScope by prefix, but LOCAL file (no url)
+      readonly: false,
+    }])
+    const plur = new Plur({ path: dir })
+
+    const engram = plur.learn(`the deploy target is ${PUBLIC_IP}`, {
+      scope: 'project:plur',
+      type: 'behavioral',
+    }) as { scope: string; visibility: string }
+
+    // Demoted exactly as before — shared prefix path unchanged.
+    expect(engram.scope).toBe('local')
+    expect(engram.visibility).toBe('private')
+  })
+
+  // (e) Per-scope policy is still honored on a remote-backed scope: when the
+  // scope's `sensitivity.allow` includes the matched category, the write is NOT
+  // demoted (it reaches the remote). Proves the new gate flows into the SAME
+  // per-scope policy as shared scopes.
+  it('(e) remote user: scope with sensitivity.allow:[infra] is not demoted on an infra hit', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, remoteUserStore({
+      description: 'my personal remote namespace',
+      sensitivity: { forbid: ['secrets'], allow: ['infra'] },
+    }))
+    const plur = new Plur({ path: dir })
+
+    const engram = plur.learn(`my prod box is ${PUBLIC_IP}`, {
+      scope: REMOTE_USER_SCOPE,
+      type: 'behavioral',
+    }) as { scope: string }
+
+    // The infra hit is explicitly allowed by this scope's policy → not demoted.
+    expect(engram.scope).toBe(REMOTE_USER_SCOPE)
+
+    await new Promise(r => setTimeout(r, 50))
+    // And it reached the remote.
+    expect(postCalls().length).toBe(1)
+  })
+})


### PR DESCRIPTION
## The gap

The write-time leak guard only fired for `isSharedScope`-prefixed scopes (`group:`/`project:`/`space:`/`team:`/`org:`/`public`) — a pure PREFIX check, now living in `packages/core/src/scope-util.ts` after the PR-1..6 refactor. But a scope can be **personal by prefix** (`user:plur:gregor`) yet still be backed by a **REMOTE store** — a `stores` config entry with a `url:` whose data goes to `plur.datafund.io`. Such a write is NOT `isSharedScope`, so sensitive content (public IPs, internal hosts, secrets) written to it **bypassed the guard and reached the remote server unguarded**. The real risk is "does the data leave the machine", not "is the prefix shared".

## The predicate

A private, PURE config lookup (no driver instantiation, no network, no side effects — it runs on every `learn()`):

```ts
private _isRemoteBackedScope(scope: string): boolean {
  return (this.config.stores ?? []).some(s => !!s.url && s.scope === scope)
}
```

It mirrors `_resolveRemoteStoreForScope`'s exact-scope-match rule (no prefix matching) so the guard and the router agree on which writes reach the remote.

## All gates updated

There are exactly **TWO** early-return gates that short-circuit the demotion guard on `!isSharedScope(scope)` (verified by grepping `!isSharedScope` across `index.ts` on current `main` — these are the only two). Both now gate on shared **OR** remote-backed:

- **`_offendingHitsForScope`** (`packages/core/src/index.ts:946`) — single source of truth for "does this content carry sensitivity this scope forbids", reached by every mutation path.
- **`_guardSensitiveScope`** own gate (`packages/core/src/index.ts:1142`) — the learn/learnRouted guard; short-circuits before `_offendingHitsForScope`, so it must carry the same gate or the leak stays open on the learn path.

Both became:
```ts
if (!isSharedScope(scope) && !this._isRemoteBackedScope(scope)) ...
```

## What's unchanged

- `global` and `local` (no store backing → neither shared nor remote-backed) stay **UNguarded** — infra notes legitimately live there and never leave the machine; `global` does NOT start demoting.
- A local-file `project:` store (a `path` store, no `url`) stays guarded via its `isSharedScope` prefix — existing behavior, untouched.
- Only **NEW** coverage = remote-backed non-shared scopes (`user:`).

## Tests

New `packages/core/test/guard-remote-scope.test.ts` (mirrors the original #360 design, harness mirrors `guard-remote-boundary.test.ts` — a `vi.fn()` over `globalThis.fetch` asserting on POST appends):

- **(a)** sensitive write (public IP) to a remote-backed `user:` scope → demoted to `local`, remote append spy = 0, outbox = 0, kept locally.
- **(b)** clean write to the same remote `user:` scope → not demoted, reaches the remote (1 append) — proves no over-blocking.
- **(c)** `global` (no store) + sensitive → NOT demoted (unchanged).
- **(d)** local-file shared-prefix store → still demotes on sensitive (unchanged `isSharedScope` path).
- **(e)** per-scope `sensitivity.allow:['infra']` on the remote scope honored → not demoted, reaches remote.

## Verification

- `pnpm --filter @plur-ai/core build` ✅
- Full workspace after dist rebuild: **1649 passed, 34 skipped (148 files)** ✅
- `tsc --noEmit` on core: clean (zero new vs baseline) ✅

Supersedes #360 (stale after the PR-1..6 `index.ts` refactor that moved `isSharedScope` to `scope-util.ts`). No code logic differs from #360 — same predicate, same two gates, same tests — only the gate line numbers moved due to the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)