### PR TITLE
fix(release+hermes+cli): targeted sed + npx-pin bump/check + CLI field passthrough + Hermes scope + CHANGELOG/SKILL sync — R2-B (reaudit 1,5,8,9,10,16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+### Leak guard: write-time demotion now covers `saveMetaEngrams` and remote-backed scopes (#368, #370)
+
+The sensitivity leak guard — which detects secrets/infra patterns in an engram and demotes a shared-scope write to `local`/`private` before it can reach a shared store — now runs on more write paths:
+
+- **`saveMetaEngrams` is guarded (#368).** Meta-engrams (abstractions, summaries) created on the save path now pass through the same `_guardSensitiveScope` check and context-field scan (`rationale`/`source`/`snippet`/`dual_coding`) as ordinary learns. A meta-engram carrying a secret in its statement *or* its context fields is demoted, and the demotion is **surfaced** to the caller (no longer silent) — the CLI/MCP display a "held back from shared scope" warning.
+- **Remote-backed personal scopes are covered (#370).** The guard now demotes sensitive content destined for any **remote-backed** scope, including `user:*` family scopes that resolve to a remote store — not just `group:`/`project:`/`space:` team scopes. Closes the gap where a remote-backed personal scope could receive un-demoted sensitive content.
+
+**Behavior change:** writes (including meta-engram saves) whose statement or context fields match a secret/infra pattern are demoted to `local`/`private` and the demotion is reported. Re-scope deliberately if a match is a false positive.
+
+### Routing recalibration: unscoped default = `global`, deterministic domain-prefix routing, readonly scopes excluded (#367, #369)
+
+The unscoped-write routing introduced for per-engram scoping is recalibrated:
+
+- **`WEIGHT_DOMAIN` raised 1.0 → 1.5 and readonly scopes excluded from auto-route (#367).** Domain-channel matches carry more weight when scoring candidate scopes, and read-only stores are no longer eligible auto-route destinations (a write can't land where it can't be written).
+- **Deterministic routing on a full domain-prefix match (#369).** When a genuinely-unscoped write's `domain` is at least as specific as a writable scope's declared `covers` namespace, it auto-routes to that scope deterministically (no edge-of-threshold flakiness). The default for a write with no matching cover remains `global`.
+
+**Behavior change:** an unscoped `plur learn` (no `--scope`) defaults to `global` and may **auto-route to a writable team scope** when its `domain` matches that scope's `covers`. This is the same path the CLI, MCP, OpenClaw, and Hermes (as of this release) all reach — Hermes no longer forces `--scope global` and so participates in auto-routing.
+
+### Detector quality: INTERNAL_HOST two-pass detection, `basic_auth` recategorized infra → secrets, 64 KB scan cap (#364)
+
+- INTERNAL_HOST detection is a two-pass match (candidate match + false-positive gate) so benign config-file names (`config.local`, `data-staging.csv`) don't suppress a real internal host elsewhere in the same text, and host-shaped tokens in ordinary prose are detected.
+- `basic_auth_url` is recategorized from `infra` to `secrets` (a HARD family) so a credential-bearing URL triggers write-time demotion under the default `allow_secrets:false` policy.
+- The sensitivity scan is capped at 64 KB of input per engram to bound worst-case scan cost on pathologically large content.
+
+**Behavior change:** more internal-host and credential-URL content is now detected and demoted; very large engram bodies are scanned up to a 64 KB cap.
+
+### Config robustness: stores writeback passthrough preserves `url`/`token` across version skew (#365)
+
+`persistStores` / `mergeStoresForWriteback` now pass unknown nested `sensitivity` fields through on writeback, so an older PLUR writing back a config authored by a newer PLUR no longer strips a store entry's forward-compat metadata — the store's `url`/`token` survive a load → persist round-trip even when the `sensitivity` block carries fields this version doesn't recognize.
+
+**Behavior change:** remote-store `url`/`token` are preserved across a config round-trip under version skew (previously a malformed/forward-compat `sensitivity` block could drop the entry).
+
 ### Un-scoped write default reverted to `global` + read-side personal-scope visibility on all 3 paths (#353)
 
 The Stage 3b un-scoped WRITE default (`local`) is reverted to `global` (the historical default). The revert alone was insufficient: the read-side scope filters hardcoded a `global`-only personal pass-through and DROPPED other personal-family scopes (`local`, `user:*`, `agent:*`) under a project-scoped recall/inject. This PR fixes the read side on **all three read paths** — inject `scoreEngram`, the non-indexed recall filter, and the DEFAULT indexed SQLite path (`storage-indexed.ts`, via a new `personal` column) — using the authoritative predicate `isPersonalScope(scope) = !isSharedScope(scope)`, not a hardcoded `{local,global}` set.

--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -14,6 +14,33 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   let type: 'behavioral' | 'terminological' | 'procedural' | 'architectural' = 'behavioral'
   let domain: string | undefined
   let source: string | undefined
+  // #8: Hermes' write path is the CLI bridge, and it SENDS these fields
+  // (bridge.py learn() → --tags/--rationale/--visibility/--knowledge-anchors/
+  // --dual-coding/--abstract/--derived-from). Before this, the parser only knew
+  // --scope/--type/--domain/--source and silently dropped the rest, so
+  // Hermes-built rationale/dual-coding/tags never reached the engram — and the
+  // PR-5 context-field leak scan had nothing to scan on the CLI/Hermes path.
+  // Parse them here and forward them in the LearnContext so the CLI surface
+  // matches the MCP/Plur-class field set.
+  let rationale: string | undefined
+  let tags: string[] | undefined
+  let visibility: 'private' | 'public' | 'template' | undefined
+  let abstract: string | undefined
+  let derivedFrom: string | undefined
+  let knowledgeAnchors: Array<{ path: string; relevance?: string; snippet?: string }> | undefined
+  let dualCoding: { example?: string; analogy?: string } | undefined
+
+  // Parse a value as JSON, exiting 1 with a clear message on malformed input
+  // (a bad --dual-coding/--knowledge-anchors should fail loudly, not silently
+  // drop the field as before).
+  const parseJsonFlag = <T>(flag: string, raw: string): T => {
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      exit(1, `Error: ${flag} expects valid JSON, got: ${raw}`)
+      throw new Error('unreachable') // exit() terminates; satisfies the type
+    }
+  }
 
   let i = 0
   while (i < args.length) {
@@ -22,6 +49,19 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     else if (arg === '--type' && i + 1 < args.length) { type = args[++i] as typeof type; i++ }
     else if (arg === '--domain' && i + 1 < args.length) { domain = args[++i]; i++ }
     else if (arg === '--source' && i + 1 < args.length) { source = args[++i]; i++ }
+    else if (arg === '--rationale' && i + 1 < args.length) { rationale = args[++i]; i++ }
+    else if (arg === '--tags' && i + 1 < args.length) {
+      tags = args[++i].split(',').map(t => t.trim()).filter(Boolean); i++
+    }
+    else if (arg === '--visibility' && i + 1 < args.length) { visibility = args[++i] as typeof visibility; i++ }
+    else if (arg === '--abstract' && i + 1 < args.length) { abstract = args[++i]; i++ }
+    else if (arg === '--derived-from' && i + 1 < args.length) { derivedFrom = args[++i]; i++ }
+    else if (arg === '--knowledge-anchors' && i + 1 < args.length) {
+      knowledgeAnchors = parseJsonFlag('--knowledge-anchors', args[++i]); i++
+    }
+    else if (arg === '--dual-coding' && i + 1 < args.length) {
+      dualCoding = parseJsonFlag('--dual-coding', args[++i]); i++
+    }
     else if (!statement) { statement = arg; i++ }
     else { i++ }
   }
@@ -34,14 +74,32 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   }
 
   if (!statement) {
-    exit(1, 'Usage: plur learn <statement> [--scope <scope>] [--type <type>] [--domain <domain>]')
+    exit(1, 'Usage: plur learn <statement> [--scope <scope>] [--type <type>] [--domain <domain>] ' +
+      '[--source <s>] [--rationale <r>] [--tags a,b,c] [--visibility private|public|template] ' +
+      '[--abstract <id>] [--derived-from <id>] [--knowledge-anchors <json>] [--dual-coding <json>]')
   }
 
   // Build the context conditionally: when --scope is absent, OMIT the scope key
   // (not scope:'global', not scope:undefined) — _guardSensitiveScope checks
   // `context?.scope == null`, which is true for an absent key, reaching the
   // unscoped routing path. When --scope is present it is honored as-is.
-  const ctx = { type, domain, source, ...(scopeProvided ? { scope } : {}) }
+  // Forward the parsed context fields. Only include a key when it was actually
+  // provided so an absent flag stays absent in the LearnContext (matches the
+  // scope-omission contract above and avoids planting undefined keys that the
+  // core defaults would otherwise resolve).
+  const ctx = {
+    type,
+    domain,
+    source,
+    ...(scopeProvided ? { scope } : {}),
+    ...(rationale !== undefined ? { rationale } : {}),
+    ...(tags !== undefined ? { tags } : {}),
+    ...(visibility !== undefined ? { visibility } : {}),
+    ...(abstract !== undefined ? { abstract } : {}),
+    ...(derivedFrom !== undefined ? { derived_from: derivedFrom } : {}),
+    ...(knowledgeAnchors !== undefined ? { knowledge_anchors: knowledgeAnchors } : {}),
+    ...(dualCoding !== undefined ? { dual_coding: dualCoding } : {}),
+  }
 
   // ALWAYS use learnRouted (not learn): learn() stamps _demoted but does NOT do
   // remote-outbox routing for shared scopes; only learnRouted() does — so an

--- a/packages/cli/test/learn.test.ts
+++ b/packages/cli/test/learn.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
+import { Plur } from '@plur-ai/core'
 
 const CLI = join(__dirname, '..', 'dist', 'index.js')
 
@@ -114,5 +115,84 @@ describe('plur learn', () => {
     expect(output.scope).toBe('group:plur/core')
     expect(output.demoted).toBeUndefined()
     expect(output.requested_scope).toBeUndefined()
+  })
+
+  // --- #8: CLI must accept and forward the context fields Hermes sends ---
+  // (was silently dropping --rationale/--tags/--visibility/--dual-coding/
+  //  --abstract/--knowledge-anchors/--derived-from). Each test writes via the
+  // CLI subprocess, then reads the persisted engram back through core's Plur
+  // class against the same --path and asserts the field landed on the engram.
+
+  /** Read the single engram persisted under `dir` back through core. */
+  function readEngram() {
+    const plur = new Plur({ path: dir })
+    const engrams = plur.list({})
+    expect(engrams.length).toBe(1)
+    return engrams[0]
+  }
+
+  it('#8: --rationale reaches the engram', () => {
+    run('learn "fly is the deploy host" --rationale "we standardized on fly.io"')
+    expect(readEngram().rationale).toBe('we standardized on fly.io')
+  })
+
+  it('#8: --tags reaches the engram (comma-split, trimmed)', () => {
+    run('learn "tagged note" --tags "deploy, ops ,infra"')
+    expect(readEngram().tags).toEqual(['deploy', 'ops', 'infra'])
+  })
+
+  it('#8: --visibility reaches the engram', () => {
+    run('learn "public note" --visibility public')
+    expect(readEngram().visibility).toBe('public')
+  })
+
+  it('#8: --abstract reaches the engram', () => {
+    run('learn "an instance note" --abstract "ABS-2026-0101-001"')
+    expect(readEngram().abstract).toBe('ABS-2026-0101-001')
+  })
+
+  it('#8: --derived-from reaches the engram', () => {
+    run('learn "a derived note" --derived-from "ENG-2026-0101-009"')
+    expect(readEngram().derived_from).toBe('ENG-2026-0101-009')
+  })
+
+  it('#8: --knowledge-anchors (JSON) reaches the engram', () => {
+    // relevance is a core enum (primary|supporting|example) — pass a valid one
+    // so the round-tripped engram survives schema validation.
+    run(`learn "anchored note" --knowledge-anchors '[{"path":"fly.toml","relevance":"primary"}]'`)
+    const anchors = readEngram().knowledge_anchors
+    expect(anchors).toHaveLength(1)
+    expect(anchors[0].path).toBe('fly.toml')
+    expect(anchors[0].relevance).toBe('primary')
+  })
+
+  it('#8: --dual-coding (JSON) reaches the engram', () => {
+    run(`learn "dual-coded note" --dual-coding '{"example":"fly deploy","analogy":"like git push"}'`)
+    const dc = readEngram().dual_coding
+    expect(dc?.example).toBe('fly deploy')
+    expect(dc?.analogy).toBe('like git push')
+  })
+
+  it('#8: all Hermes-sent fields reach the engram in one call', () => {
+    run(
+      `learn "kitchen sink note" --domain software.deployment --rationale "why" ` +
+      `--tags "a,b" --visibility public --abstract "ABS-2026-0101-002" ` +
+      `--derived-from "ENG-2026-0101-010" ` +
+      `--knowledge-anchors '[{"path":"p.ts"}]' ` +
+      `--dual-coding '{"example":"e","analogy":"a"}'`,
+    )
+    const e = readEngram()
+    expect(e.rationale).toBe('why')
+    expect(e.tags).toEqual(['a', 'b'])
+    expect(e.visibility).toBe('public')
+    expect(e.abstract).toBe('ABS-2026-0101-002')
+    expect(e.derived_from).toBe('ENG-2026-0101-010')
+    expect(e.knowledge_anchors[0].path).toBe('p.ts')
+    expect(e.dual_coding?.example).toBe('e')
+    expect(e.dual_coding?.analogy).toBe('a')
+  })
+
+  it('#8: malformed --dual-coding JSON exits 1 (loud, not silent drop)', () => {
+    expect(() => run(`learn "bad json note" --dual-coding 'not json'`)).toThrow()
   })
 })

--- a/packages/hermes/plur_hermes/bridge.py
+++ b/packages/hermes/plur_hermes/bridge.py
@@ -18,7 +18,14 @@ from typing import Any
 
 logger = logging.getLogger("plur_hermes.bridge")
 
-_NPX_CLI_VERSION = "0.9.12"
+# npx-fallback CLI pin. The bridge's write path shells out to `plur`; when no
+# local binary is found it falls back to `npx @plur-ai/cli@{_NPX_CLI_VERSION}`.
+# This MUST point at a CLI that carries the current scope-routing / leak-guard
+# fixes — a stale pin (e.g. a pre-0.10.0 CLI) would silently bypass write
+# demotion and unscoped auto-routing on the npx-fallback path. release.sh
+# rewrites this to the release version on every release (mirroring the pyproject
+# bump), and check_version_sync.py enforces pin >= the published @plur-ai/cli.
+_NPX_CLI_VERSION = "0.10.0"
 
 _DEFAULT_DEDUP_CACHE_SIZE = 256
 _DEFAULT_TIMEOUT = 30
@@ -290,7 +297,7 @@ class PlurBridge:
         except json.JSONDecodeError:
             raise PlurBridgeError(f"Invalid JSON from CLI: {result.stdout[:200]}")
 
-    def learn(self, statement: str, scope: str = "global", type: str = "behavioral",
+    def learn(self, statement: str, scope: str | None = None, type: str = "behavioral",
               domain: str | None = None, source: str | None = None,
               tags: list[str] | None = None, rationale: str | None = None,
               visibility: str | None = None,
@@ -310,7 +317,16 @@ class PlurBridge:
                 self._cache_put(needle, existing)
                 return {**existing, "deduplicated": True}
 
-        args = [statement, "--scope", scope, "--type", type]
+        # Scope is OMITTED when the caller didn't specify one (#9): passing no
+        # --scope lets the CLI omit the scope key entirely, so core's unscoped
+        # routing (_resolveUnscopedScope → auto-route or unscoped_default,
+        # default global) applies — same contract as the CLI/MCP/claw paths.
+        # Hard-coding --scope global here would bypass auto-route-to-team and
+        # opt Hermes out of the 0.10.0 routing behavior. An explicit scope is
+        # honored as-is.
+        args = [statement, "--type", type]
+        if scope is not None:
+            args.extend(["--scope", scope])
         if domain:
             args.extend(["--domain", domain])
         if source:

--- a/packages/hermes/scripts/check_version_sync.py
+++ b/packages/hermes/scripts/check_version_sync.py
@@ -5,22 +5,34 @@ Source of truth: pyproject.toml [project].version
 
 Checks:
   - plur_hermes/skills/plur-memory.SKILL.md  (YAML frontmatter `version:`)
-  - plur_hermes/__init__.py                  (importlib.metadata-derived; smoke check)
+  - plur_hermes/bridge.py                     (`_NPX_CLI_VERSION` npx-fallback pin)
 
-NPX CLI pin (`_NPX_CLI_VERSION` in bridge.py) is intentionally separate — it
-tracks the @plur-ai/cli release the bridge is qualified against, not the
-plur-hermes package version. We only verify it is set to a valid SemVer string.
+The npx pin (`_NPX_CLI_VERSION`) is the @plur-ai/cli version the bridge's
+npx-fallback write path runs. A stale pin silently runs a PRE-FIX CLI that
+bypasses the scope-routing / leak-guard fixes, so we no longer accept "any valid
+SemVer". The pin must be:
+
+  - a valid SemVer, AND
+  - >= the local pyproject version (the release version; release.sh bumps both
+    in lockstep, so during a release pin == pyproject), AND
+  - >= the published @plur-ai/cli@latest version when npm is reachable
+    (best-effort; a network/registry failure does NOT fail the check — the
+    pyproject floor above is the deterministic, offline-enforceable guarantee).
 
 Exits non-zero on any mismatch.
 """
 from __future__ import annotations
 
+import json
 import re
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+CLI_PACKAGE = "@plur-ai/cli"
 
 
 def _read_pyproject_version() -> str:
@@ -45,7 +57,51 @@ def _read_npx_pin() -> str:
     return m.group(1)
 
 
-SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+SEMVER = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def _version_tuple(v: str) -> tuple[int, int, int]:
+    """Parse the numeric MAJOR.MINOR.PATCH core of a SemVer for >= comparison.
+
+    Pre-release/build metadata is ignored for ordering — sufficient here since
+    we only ever compare release versions (no pre-release pins in practice).
+    """
+    m = SEMVER.match(v)
+    if not m:
+        raise ValueError(f"not a valid SemVer: {v!r}")
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def _published_cli_version() -> str | None:
+    """Best-effort: the @plur-ai/cli@latest version from the npm registry.
+
+    Returns None on any failure (no npm, offline, registry error) so the
+    deterministic offline pyproject-floor check remains the hard gate.
+    """
+    try:
+        out = subprocess.run(
+            ["npm", "view", CLI_PACKAGE, "version", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if out.returncode != 0:
+        return None
+    raw = (out.stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    # `npm view ... --json` returns a JSON string for a single match.
+    if isinstance(parsed, str):
+        return parsed
+    if isinstance(parsed, list) and parsed:
+        return str(parsed[-1])
+    return None
 
 
 def main() -> int:
@@ -56,8 +112,31 @@ def main() -> int:
     errors: list[str] = []
     if skill != canonical:
         errors.append(f"SKILL.md version {skill!r} != pyproject {canonical!r}")
+
     if not SEMVER.match(npx_pin):
         errors.append(f"_NPX_CLI_VERSION {npx_pin!r} is not valid SemVer")
+    else:
+        # Hard, offline gate: the npx pin must be >= the release (pyproject)
+        # version. release.sh bumps both in lockstep, so a forgotten pin bump
+        # trips here. This is what makes a stale pin impossible to ship.
+        if _version_tuple(npx_pin) < _version_tuple(canonical):
+            errors.append(
+                f"_NPX_CLI_VERSION {npx_pin!r} < pyproject/release {canonical!r} "
+                f"— the npx-fallback would run a pre-release CLI lacking this "
+                f"release's fixes; bump _NPX_CLI_VERSION in bridge.py"
+            )
+        else:
+            # Best-effort online gate: pin must also be >= the published CLI so
+            # the fallback never installs an OLDER CLI than what users already
+            # get from `npm install -g @plur-ai/cli`. Skipped silently offline.
+            published = _published_cli_version()
+            if published and SEMVER.match(published):
+                if _version_tuple(npx_pin) < _version_tuple(published):
+                    errors.append(
+                        f"_NPX_CLI_VERSION {npx_pin!r} < published {CLI_PACKAGE} "
+                        f"{published!r} — the npx-fallback would run an older CLI "
+                        f"than the one published to npm; bump _NPX_CLI_VERSION"
+                    )
 
     if errors:
         print("Version sync check FAILED:", file=sys.stderr)

--- a/packages/hermes/test/test_bridge.py
+++ b/packages/hermes/test/test_bridge.py
@@ -137,6 +137,70 @@ class TestPlurBridge:
             assert "agent:x" in call_args
             assert "--domain" in call_args
 
+    def test_learn_omits_scope_when_none(self):
+        """#9: with no scope, --scope is OMITTED so core's unscoped routing
+        (auto-route / unscoped_default) applies — the bridge no longer forces
+        --scope global and opts out of the 0.10.0 routing behavior."""
+        bridge = PlurBridge()
+        bridge._binary = "/usr/local/bin/plur"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"id": "ENG-001"})
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            bridge.learn("an unscoped fact")
+            call_args = mock_run.call_args[0][0]
+            assert "learn" in call_args
+            assert "--scope" not in call_args
+            assert "global" not in call_args
+
+    def test_learn_preserves_explicit_scope(self):
+        """#9: an explicitly passed scope is still honored as-is."""
+        bridge = PlurBridge()
+        bridge._binary = "/usr/local/bin/plur"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"id": "ENG-001"})
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            bridge.learn("a team fact", scope="group:plur/core")
+            call_args = mock_run.call_args[0][0]
+            assert "--scope" in call_args
+            assert "group:plur/core" in call_args
+
+    def test_learn_forwards_context_fields(self):
+        """#8: the bridge forwards every context flag the CLI now consumes
+        (rationale/tags/visibility/knowledge-anchors/dual-coding/abstract/
+        derived-from), so Hermes-built context is no longer dropped."""
+        bridge = PlurBridge()
+        bridge._binary = "/usr/local/bin/plur"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"id": "ENG-001"})
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            bridge.learn(
+                "rich fact",
+                rationale="why it matters",
+                tags=["a", "b"],
+                visibility="public",
+                knowledge_anchors=[{"path": "p.ts"}],
+                dual_coding={"example": "e", "analogy": "a"},
+                abstract="ABS-1",
+                derived_from="ENG-9",
+            )
+            call_args = mock_run.call_args[0][0]
+            for flag in (
+                "--rationale", "--tags", "--visibility",
+                "--knowledge-anchors", "--dual-coding",
+                "--abstract", "--derived-from",
+            ):
+                assert flag in call_args, f"{flag} missing from CLI args"
+            assert "a,b" in call_args  # tags comma-joined
+
     def test_inject_uses_fast_by_default(self):
         bridge = PlurBridge()
         bridge._binary = "/usr/local/bin/plur"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -204,8 +204,16 @@ echo "  ✓ packages/mcp/src/index.ts"
 sed -i '' "s/const VERSION = '.*'/const VERSION = '$VERSION'/" packages/cli/src/index.ts
 echo "  ✓ packages/cli/src/index.ts"
 
-# mcp test version assertion
-sed -i '' "s/toBe('[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*')/toBe('$VERSION')/g" packages/mcp/test/server.test.ts
+# mcp test version assertion.
+# TARGETED: replace only the literal CURRENT version ($OLD_CORE), never a generic
+# X.Y.Z. The old generic pattern + /g rewrote EVERY toBe('a.b.c') in the file,
+# including the deliberate '99.0.0' staleness fixture (server.test.ts, the
+# 'plur_status includes update_available' test) — flipping it to $VERSION while
+# the mocked fetch still returns 99.0.0, so the assertion failed and the release
+# aborted at step 3. Anchoring to $OLD_CORE leaves 99.0.0 (and the 1.5.0/0.9.8
+# fixtures) untouched. Both real assertions hold the current version, so they
+# match $OLD_CORE and get bumped; the fixture does not.
+sed -i '' "s/toBe('${OLD_CORE}')/toBe('$VERSION')/g" packages/mcp/test/server.test.ts
 echo "  ✓ packages/mcp/test/server.test.ts"
 
 # Claw is on an independent version track — only bump if --claw was provided
@@ -245,6 +253,26 @@ fi
 # Hermes pyproject.toml
 sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" packages/hermes/pyproject.toml
 echo "  ✓ packages/hermes/pyproject.toml"
+
+# Hermes SKILL.md frontmatter version (#16) — kept in lockstep with pyproject so
+# check_version_sync.py stays green and the published wheel doesn't advertise a
+# stale SKILL version. Without this the bundled plur-memory.SKILL.md keeps its
+# previous version on every release.
+sed -i '' "s/^version: .*/version: $VERSION/" packages/hermes/plur_hermes/skills/plur-memory.SKILL.md
+echo "  ✓ packages/hermes/plur_hermes/skills/plur-memory.SKILL.md"
+
+# Hermes npx-fallback CLI pin (#1) — the npx-fallback write path runs
+# @plur-ai/cli@$_NPX_CLI_VERSION; if it lags the release it runs a PRE-FIX CLI
+# that bypasses every scope/leak-guard fix. Bump it to $VERSION so the fallback
+# installs the current CLI. check_version_sync.py enforces pin >= published cli.
+sed -i '' "s/^_NPX_CLI_VERSION = \".*\"/_NPX_CLI_VERSION = \"$VERSION\"/" packages/hermes/plur_hermes/bridge.py
+echo "  ✓ packages/hermes/plur_hermes/bridge.py (_NPX_CLI_VERSION)"
+
+# Verify hermes version-sync invariant immediately after the bumps so a missed
+# bump aborts the release here (before commit/tag/publish) rather than shipping
+# an internally-inconsistent wheel.
+python3 packages/hermes/scripts/check_version_sync.py
+echo "  ✓ hermes version-sync check passed"
 
 echo ""
 


### PR DESCRIPTION
R2-B second-round 0.10.0 fixes — release tooling + Hermes/CLI write-path (core `index.ts`/`secrets.ts` untouched; isolated from R2-A).

- **#5 release.sh sed (BLOCKER):** version-bump sed targets only the literal current version (`$OLD_CORE`) instead of a generic `X.Y.Z` + `/g`, so it no longer rewrites the `99.0.0` staleness fixture (`server.test.ts:355`) that aborted the release; `--dry-run` for 0.10.0 confirms the fixture survives and tests don't abort.
- **#1 Hermes npx pin (BLOCKER):** release.sh now rewrites `_NPX_CLI_VERSION` to `$VERSION`; `check_version_sync.py` tightened to require the pin be valid SemVer AND `>=` pyproject/release (hard, offline) AND `>=` published `@plur-ai/cli` (best-effort, online); pin set to the `0.10.0` floor today so it no longer points at pre-fix `0.9.12`.
- **#8 CLI `learn`:** parses and forwards `--rationale/--tags/--visibility/--abstract/--derived-from/--knowledge-anchors/--dual-coding` into the LearnContext (Hermes sends these; they were silently dropped). New tests read each field back off the persisted engram.
- **#9 Hermes scope:** `learn()` defaults `scope=None` and omits `--scope` when unspecified, so unscoped writes reach core's unscoped routing/auto-route (matching CLI/MCP/claw); explicit scope preserved. New bridge tests.
- **#10 CHANGELOG:** Unreleased entries added for #364/#365/#367/#368/#369/#370 — leak guard (saveMetaEngrams + remote-backed scopes), routing recalibration (unscoped default global + deterministic domain routing + readonly exclusion), detector FP/FN fixes, stores writeback robustness.
- **#16 SKILL.md sync:** release.sh bumps `plur-memory.SKILL.md` frontmatter alongside pyproject and runs `check_version_sync.py` in step 1, so the wheel is no longer internally inconsistent.

**Tests:** full workspace green (1658 passed / 34 skipped); CLI learn suite 213 passed; Hermes pytest 132 passed; core `tsc --noEmit` clean (0 errors); cli tsc unchanged (37 pre-existing, 0 new). `release.sh 0.10.0 --dry-run` bumps all locations, version-sync passes, fixture untouched, no abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)