### PR TITLE
fix(core): deterministic domain routing only on cover⊃domain (stop over-routing broad engrams into narrow scopes) — R2-C (reaudit 4)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1102,18 +1102,30 @@ export class Plur {
       writableScopeMetadata,
     )
     const top = candidates[0]
-    // PR-6 (#353): a FULL domain-prefix match is the strongest, most deliberate
-    // routing signal. Route to it DETERMINISTICALLY — bypass the squash/threshold
-    // gate entirely — so a clean domain match routes with headroom instead of
-    // landing at exactly SCOPE_MATCH_THRESHOLD (0.5) and clearing only via the
-    // edge-of-threshold `>=`. rankScopes already prefers a domain-match candidate
-    // at the top on equal confidence, so `top` is the right scope to route to.
-    // The weights/threshold/squash are UNCHANGED — only the decision is bypassed.
-    if (top && top.domainMatch) {
+    // PR-6 (#353) + reaudit finding 4: a FORWARD domain-prefix match — the scope's
+    // declared coverage CONTAINS the engram's topic (`cover ⊃ domain` or equal) —
+    // is the strongest, most deliberate routing signal. Route to it
+    // DETERMINISTICALLY — bypass the squash/threshold gate entirely — so a clean
+    // domain match routes with headroom instead of landing at exactly
+    // SCOPE_MATCH_THRESHOLD (0.5) and clearing only via the edge-of-threshold `>=`.
+    //
+    // Key the bypass on `coverContainsDomain`, NOT `domainMatch`: `domainMatch` is
+    // also true for the REVERSE direction (engram domain BROADER than the cover,
+    // `domain ⊃ cover`), and bypassing on that would over-route a broad/generic
+    // engram (domain `plur`) into a NARROW shared scope (cover `plur.core`) it
+    // doesn't belong in. The reverse match still adds WEIGHT_DOMAIN to the squashed
+    // confidence below, so a lone reverse hit (conf 0.5) can still route via the
+    // `>=` threshold path — it just doesn't get the deterministic bypass.
+    // rankScopes prefers a domain-match candidate at the top on equal confidence,
+    // so `top` is the right scope to route to. Weights/threshold/squash UNCHANGED.
+    if (top && top.coverContainsDomain) {
       return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
     }
-    // No domain match: a tag-only or keyword-only candidate is a WEAK signal and
-    // stays gated by the threshold exactly as before — conservative by design.
+    // No forward domain match: a reverse domain hit, tag-only, or keyword-only
+    // candidate stays gated by the threshold exactly as before — conservative by
+    // design. A lone reverse-direction match squashes to exactly 0.5 and so still
+    // clears the `>=` gate; a future weight tweak can de-calibrate it safely
+    // without the deterministic bypass forcing it in.
     if (top && top.confidence >= SCOPE_MATCH_THRESHOLD) {
       return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
     }

--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -27,12 +27,17 @@
  * reads as high-confidence. Ties break deterministically: equal confidence
  * prefers a domain-prefix match, then scope name ascending.
  *
- * Each candidate also carries `domainMatch` (see {@link ScopeCandidate}): a
- * boolean exposing whether the match came through the domain-prefix channel.
- * The write-path router (`_resolveUnscopedScope` in index.ts, #353 PR-6) routes
- * a clean domain match DETERMINISTICALLY, bypassing the squash/threshold so it
- * no longer has to land EXACTLY on SCOPE_MATCH_THRESHOLD; weak signals stay
- * gated by the threshold. The weights/threshold/squash are unchanged — the
+ * Each candidate carries two domain-channel booleans (see {@link ScopeCandidate}):
+ * `domainMatch` (true for EITHER prefix direction — used for scoring/ordering)
+ * and `coverContainsDomain` (true ONLY when the cover is a prefix of, or equals,
+ * the engram domain — the FORWARD direction). The write-path router
+ * (`_resolveUnscopedScope` in index.ts, #353 PR-6) routes a clean FORWARD domain
+ * match DETERMINISTICALLY, bypassing the squash/threshold so it no longer has to
+ * land EXACTLY on SCOPE_MATCH_THRESHOLD. The REVERSE direction (engram broader
+ * than the cover) and weak signals (tag-only, keyword-only) stay gated by the
+ * threshold — keying the bypass on `coverContainsDomain` rather than `domainMatch`
+ * stops a broad/generic engram from over-routing into a narrow shared scope
+ * (reaudit finding 4). The weights/threshold/squash are unchanged — the
  * deterministic bypass lives in the caller, not in this ranker.
  */
 import type { ScopeMetadata } from './schemas/scope-metadata.js'
@@ -58,6 +63,18 @@ export const SCOPE_MATCH_THRESHOLD = 0.5
 const WEIGHT_DOMAIN = 1.5
 const WEIGHT_TAG = 0.5
 const WEIGHT_KEYWORD = 0.2
+
+/** Weight for a REVERSE-direction domain hit — the engram's `domain` is BROADER
+ * than the cover (`domain ⊃ cover`, e.g. domain `plur` against cover `plur.core`).
+ * The engram is NOT specific to the scope, so the reverse match is a weak signal:
+ * it contributes WEIGHT_DOMAIN_REVERSE (NOT the full WEIGHT_DOMAIN) to the score
+ * and never sets `coverContainsDomain`. A LONE reverse hit therefore squashes to
+ * squash(0.5)=0.5/2.0=0.25 < SCOPE_MATCH_THRESHOLD, so a broad/generic engram
+ * does NOT land in a narrow shared scope on the reverse match alone (reaudit
+ * finding 4) — it must accumulate additional tag/keyword evidence to clear the
+ * threshold. The FORWARD direction is unchanged at full WEIGHT_DOMAIN, so
+ * THRESHOLD_SINGLE_DOMAIN and every forward routing test are untouched. */
+const WEIGHT_DOMAIN_REVERSE = WEIGHT_TAG
 
 /** Raw score at which confidence saturates to ~1.0. A single domain-prefix hit
  * (WEIGHT_DOMAIN = 1.5) lands EXACTLY on SCOPE_MATCH_THRESHOLD via squash; the
@@ -101,17 +118,34 @@ export interface ScopeCandidate {
   /** Human-readable matched signals, e.g. "domain plur.core.security ⊂ covers plur.*". */
   reason: string
   /**
-   * True when this candidate matched via a FULL domain-prefix hit — the engram's
-   * `domain` is namespace-covered by (or namespace-covers) one of the scope's
-   * `covers` entries. This is the strongest, most deliberate routing signal.
+   * True when this candidate matched via the domain-prefix channel — in EITHER
+   * direction: the engram's `domain` is namespace-covered by one of the scope's
+   * `covers` entries (`cover ⊃ domain`, forward), OR the engram's `domain` is
+   * BROADER than the cover (`domain ⊃ cover`, reverse). Both directions add the
+   * full WEIGHT_DOMAIN to the squashed `confidence`, so this flag exists for
+   * scoring/ordering (the domain-preferring tie-break) — NOT as the bypass key.
    *
-   * The caller (`_resolveUnscopedScope` in index.ts) uses this to route a clean
-   * domain match DETERMINISTICALLY, bypassing the squash/threshold edge — a lone
-   * domain match no longer has to land EXACTLY on SCOPE_MATCH_THRESHOLD to route.
-   * Weak signals (tag-only, keyword-only) leave this `false` and stay gated by
-   * the threshold. Additive: `confidence`/`reason` are unchanged.
+   * Do NOT use `domainMatch` for the deterministic auto-route bypass: the reverse
+   * direction would over-route a broad/generic engram into a NARROW shared scope
+   * (reaudit finding 4). Key the bypass on {@link coverContainsDomain} instead.
    */
   domainMatch: boolean
+  /**
+   * True ONLY for the FORWARD direction of the domain match — the scope's
+   * declared coverage CONTAINS the engram's topic: a `covers` entry is a
+   * namespace-prefix of, or equals, the engram's `domain` (`cover ⊃ domain` or
+   * `cover === domain`). The engram is at least as specific as the scope, so it
+   * genuinely belongs there.
+   *
+   * The caller (`_resolveUnscopedScope` in index.ts) routes a clean FORWARD
+   * domain match DETERMINISTICALLY, bypassing the squash/threshold edge. The
+   * REVERSE direction (`domain ⊃ cover`, engram broader than the cover) leaves
+   * this `false`: it still contributes to `confidence` (so it can route via the
+   * normal `>=` threshold gate) but never gets the deterministic bypass, so a
+   * broad engram never deterministically lands in a narrow shared scope.
+   * Weak signals (tag-only, keyword-only) also leave this `false`.
+   */
+  coverContainsDomain: boolean
 }
 
 const STOPWORDS = new Set([
@@ -161,29 +195,41 @@ function scoreScope(
   signals: ScopeSignals,
   scope: string,
   covers: string[],
-): { raw: number; reasons: string[]; domainMatch: boolean } | null {
+): { raw: number; reasons: string[]; domainMatch: boolean; coverContainsDomain: boolean } | null {
   const normalizedCovers = covers.map(c => ({ raw: c, norm: normalizeCover(c) })).filter(c => c.norm.length > 0)
   if (normalizedCovers.length === 0) return null
 
   let raw = 0
   let domainMatch = false
+  let coverContainsDomain = false
   const reasons: string[] = []
 
   // --- domain-prefix channel (highest weight) ---
   const domain = signals.domain?.toLowerCase().trim()
   if (domain) {
     for (const cover of normalizedCovers) {
-      // Match either direction: the cover is a prefix of the domain
-      // (`plur.*` ⊃ `plur.core.security`), or the domain is a prefix of the
-      // cover (`plur` engram fits a `plur.core` scope, weaker but still a hit).
+      // FORWARD: the cover is a prefix of (or equals) the domain
+      // (`plur.*` ⊃ `plur.core.security`). The scope's declared coverage CONTAINS
+      // the engram's topic, so the engram genuinely belongs here. Only this
+      // direction sets `coverContainsDomain` — the signal the deterministic
+      // auto-route bypass keys on (reaudit finding 4).
       if (isNamespacePrefix(cover.norm, domain)) {
         raw += WEIGHT_DOMAIN
         domainMatch = true
+        coverContainsDomain = true
         reasons.push(`domain ${domain} ⊂ covers ${cover.raw}`)
         break // one domain hit per scope — domain is single-valued
       }
+      // REVERSE: the domain is a STRICT prefix of the cover (`plur` engram, scope
+      // covering `plur.core`). The engram is BROADER than the scope. Still a
+      // domain-channel hit for scoring, but DOWN-WEIGHTED (WEIGHT_DOMAIN_REVERSE,
+      // not the full WEIGHT_DOMAIN) and it must NOT get the deterministic bypass —
+      // `coverContainsDomain` stays false. So a lone reverse hit squashes below the
+      // threshold and a broad/generic engram never lands in a narrow shared scope
+      // (reaudit finding 4); it can still route only if additional tag/keyword
+      // evidence pushes its squashed score to `>= SCOPE_MATCH_THRESHOLD` as normal.
       if (isNamespacePrefix(domain, cover.norm)) {
-        raw += WEIGHT_DOMAIN
+        raw += WEIGHT_DOMAIN_REVERSE
         domainMatch = true
         reasons.push(`domain ${domain} ⊃ covers ${cover.raw}`)
         break
@@ -220,7 +266,7 @@ function scoreScope(
   }
 
   if (raw <= 0) return null
-  return { raw, reasons, domainMatch }
+  return { raw, reasons, domainMatch, coverContainsDomain }
 }
 
 /**
@@ -245,6 +291,7 @@ export function rankScopes(
       confidence: Number(squash(scored.raw).toFixed(4)),
       reason: scored.reasons.join('; '),
       domainMatch: scored.domainMatch,
+      coverContainsDomain: scored.coverContainsDomain,
     })
   }
   // Sort by confidence desc; on equal confidence prefer a domain-prefix match

--- a/packages/core/test/route-unscoped.test.ts
+++ b/packages/core/test/route-unscoped.test.ts
@@ -295,31 +295,43 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
     expect(e.structured_data?._routed?.reason).toContain('domain plur.core.security')
   })
 
-  it('PR-6: the bypass is taken BEFORE the threshold gate — a sub-threshold domain candidate STILL routes', () => {
+  it('R2-C: the bypass is taken BEFORE the threshold gate — a sub-threshold FORWARD (coverContainsDomain) candidate STILL routes', () => {
     // Rigorously decouples the bypass from SCOPE_MATCH_THRESHOLD. We feed the
     // private resolver a hand-built ranked list (via a mocked rankScopes) whose
-    // top candidate has `domainMatch:true` but a confidence WELL BELOW threshold
-    // (0.2). Threshold-only logic would refuse to route it; PR-6 routes it because
-    // the deterministic domain branch is taken first. A second list (same low
-    // confidence but `domainMatch:false`) must NOT route — proving the bypass is
-    // gated on domainMatch, not just on having a candidate.
+    // top candidate has `coverContainsDomain:true` (FORWARD: cover ⊃ domain) but a
+    // confidence WELL BELOW threshold (0.2). Threshold-only logic would refuse to
+    // route it; the deterministic forward-domain branch is taken first so it
+    // routes. Subsequent lists prove the bypass is gated on `coverContainsDomain`
+    // — NOT on `domainMatch` (which is also true for the reverse direction) and
+    // NOT just on having a candidate (reaudit finding 4, R2-C).
     const plur = makePlur({
       stores: [{ path: '/tmp/r.yaml', scope: 'group:plur/core', covers: ['plur.*'], description: 'Core' }],
     }) as unknown as {
       _resolveUnscopedScope: (s: string, c?: { domain?: string }) => { scope: string; routed: { scope: string } | null }
     }
 
-    // domainMatch:true, confidence 0.2 (< 0.5) → must route via the bypass.
+    // FORWARD: coverContainsDomain:true, confidence 0.2 (< 0.5) → routes via bypass.
     routeMock.mockReturnValueOnce([
-      { scope: 'group:plur/core', confidence: 0.2, reason: 'domain x ⊂ covers plur.*', domainMatch: true },
+      { scope: 'group:plur/core', confidence: 0.2, reason: 'domain x ⊂ covers plur.*', domainMatch: true, coverContainsDomain: true },
     ])
     const routedLow = plur._resolveUnscopedScope('anything', { domain: 'plur.core.x' })
     expect(routedLow.scope).toBe('group:plur/core')
     expect(routedLow.routed?.scope).toBe('group:plur/core')
 
-    // domainMatch:false, same confidence 0.2 (< 0.5) → must NOT route (gated).
+    // REVERSE: domainMatch:true BUT coverContainsDomain:false, confidence 0.2
+    // (< 0.5) → must NOT route (the over-route case: broad engram, narrow scope).
+    // Keying on domainMatch (the old bug) would have routed this; keying on
+    // coverContainsDomain correctly gates it.
     routeMock.mockReturnValueOnce([
-      { scope: 'group:plur/core', confidence: 0.2, reason: 'keywords [...]', domainMatch: false },
+      { scope: 'group:plur/core', confidence: 0.2, reason: 'domain plur ⊃ covers plur.core', domainMatch: true, coverContainsDomain: false },
+    ])
+    const reverseLow = plur._resolveUnscopedScope('anything', { domain: 'plur' })
+    expect(reverseLow.scope).toBe('global')
+    expect(reverseLow.routed).toBeNull()
+
+    // WEAK: neither flag set, same low confidence 0.2 (< 0.5) → must NOT route.
+    routeMock.mockReturnValueOnce([
+      { scope: 'group:plur/core', confidence: 0.2, reason: 'keywords [...]', domainMatch: false, coverContainsDomain: false },
     ])
     const gatedLow = plur._resolveUnscopedScope('anything')
     expect(gatedLow.scope).toBe('global')
@@ -400,6 +412,88 @@ describe('Stage 3b — auto-route un-scoped writes (#351)', () => {
     }) as { scope: string; structured_data?: { _routed?: { scope: string } } }
     expect(e.scope).toBe('group:plur/a')
     expect(e.structured_data?._routed?.scope).toBe('group:plur/a')
+  })
+
+  it('R2-C: a FORWARD domain match (cover ⊃ domain) STILL routes deterministically (unchanged)', () => {
+    // The intended case, end-to-end via REAL ranking: a specific engram (domain
+    // `plur.core.security`) into a broad cover (`plur` / `plur.*`). Cover contains
+    // the engram's topic → coverContainsDomain → deterministic bypass routes it.
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur'] },
+      ],
+    })
+    const e = plur.learn('zzz no overlap tokens', {
+      domain: 'plur.core.security',
+    }) as { scope: string; structured_data?: { _routed?: { scope: string; reason: string } } }
+    expect(e.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.reason).toContain('domain plur.core.security ⊂ covers plur')
+  })
+
+  it('R2-C: an EXACT domain==cover match STILL routes deterministically', () => {
+    // Equality is the forward direction at the boundary (cover === domain) →
+    // coverContainsDomain → deterministic bypass.
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.core'] },
+      ],
+    })
+    const e = plur.learn('zzz no overlap tokens', {
+      domain: 'plur.core',
+    }) as { scope: string; structured_data?: { _routed?: { scope: string } } }
+    expect(e.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/core')
+  })
+
+  it('R2-C OVER-ROUTE REGRESSION: a BROAD engram (domain ⊃ cover) does NOT deterministically route into a narrow shared scope', () => {
+    // The exact over-route scenario from reaudit finding 4: a genuinely-unscoped
+    // write whose context.domain is a generic top-level namespace (`plur`) against
+    // a NARROW shared sub-scope (cover `plur.core`). This is the REVERSE direction
+    // — the engram is BROADER than the scope, so it does NOT belong in the narrow
+    // scope. Under the old bug (bypass keyed on domainMatch, reverse at full
+    // WEIGHT_DOMAIN → conf 0.5) it deterministically landed in group:plur/core.
+    // Now: reverse is down-weighted (WEIGHT_DOMAIN_REVERSE → squash(0.5)=0.25 < 0.5)
+    // and never sets coverContainsDomain, so it falls to unscoped_default (global).
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.core'] },
+      ],
+    })
+    const e = plur.learn('a broad personal preference about plur in general zzz', {
+      domain: 'plur',
+    }) as { scope: string; structured_data?: { _routed?: unknown } }
+    // Falls to the default — NOT into the narrow shared scope.
+    expect(e.scope).toBe('global')
+    expect(e.structured_data?._routed).toBeUndefined()
+    // Sanity: the advisory ranker still SURFACES the scope (reverse hit scores > 0)
+    // — only the deterministic auto-route is withheld. Confidence stays below
+    // threshold so even the `>=` path doesn't fire on the lone reverse match.
+    const ranked = plur.suggestScope({ statement: 'zzz', domain: 'plur' })
+    const core = ranked.find(c => c.scope === 'group:plur/core')!
+    expect(core).toBeDefined()
+    expect(core.domainMatch).toBe(true)            // it IS a domain-channel hit…
+    expect(core.coverContainsDomain).toBe(false)   // …but the REVERSE direction…
+    expect(core.confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD) // …and sub-threshold.
+  })
+
+  it('R2-C: a reverse match that DOES clear threshold (reverse + tags) still routes via the >= path', () => {
+    // The reverse direction still CONTRIBUTES to the score: a broad-domain engram
+    // that ALSO carries enough tag evidence clears the threshold and routes via the
+    // normal `>=` gate (not the deterministic bypass). Proves the reverse signal is
+    // down-weighted, not discarded. reverse(0.5) + 3 tags(1.5) = raw 2.0 →
+    // squash(2.0)=0.5714 >= 0.5.
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/r-core.yaml', scope: 'group:plur/core', description: 'Core', covers: ['plur.core', 'alpha', 'beta', 'gamma'] },
+      ],
+    })
+    const e = plur.learn('zzz no overlap', {
+      domain: 'plur',
+      tags: ['alpha', 'beta', 'gamma'],
+    }) as { scope: string; structured_data?: { _routed?: { scope: string } } }
+    expect(e.scope).toBe('group:plur/core')
+    expect(e.structured_data?._routed?.scope).toBe('group:plur/core')
   })
 
   it('PR-6: explicit scope still bypasses auto-route entirely (domain match ignored)', () => {

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -148,6 +148,59 @@ describe('rankScopes — pure ranker', () => {
     expect(ranked[0].domainMatch).toBe(true)
   })
 
+  // --- R2-C (reaudit finding 4): `coverContainsDomain` distinguishes the two
+  // domain-prefix directions. Only the FORWARD direction (cover ⊃ domain or
+  // cover === domain) sets it; the caller keys the deterministic auto-route
+  // bypass on it so a broad engram never lands in a narrow shared scope. ---
+  it('R2-C: FORWARD direction (cover ⊃ domain) sets coverContainsDomain:true', () => {
+    const ranked = rankScopes(
+      { statement: 'xyzzy nonoverlapping tokens', domain: 'plur.core.security' },
+      [{ scope: 'group:plur/core', covers: ['plur.*'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].domainMatch).toBe(true)
+    expect(ranked[0].coverContainsDomain).toBe(true)
+  })
+
+  it('R2-C: EXACT match (cover === domain) sets coverContainsDomain:true', () => {
+    const ranked = rankScopes(
+      { statement: 'zzz no overlap', domain: 'plur.core' },
+      [{ scope: 'group:plur/core', covers: ['plur.core'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].coverContainsDomain).toBe(true)
+  })
+
+  it('R2-C: REVERSE direction (domain ⊃ cover) leaves coverContainsDomain:false and is down-weighted below threshold', () => {
+    // domain `plur` is BROADER than cover `plur.core`. domainMatch is true (for
+    // scoring/ordering) but coverContainsDomain is false (no deterministic bypass),
+    // and the lone reverse hit squashes to squash(WEIGHT_DOMAIN_REVERSE=0.5)=0.25,
+    // BELOW SCOPE_MATCH_THRESHOLD — so a broad engram does not even clear the `>=`
+    // gate on the reverse match alone.
+    const ranked = rankScopes(
+      { statement: 'zzz no overlap', domain: 'plur' },
+      [{ scope: 'group:plur/core', covers: ['plur.core'] }],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].domainMatch).toBe(true)
+    expect(ranked[0].coverContainsDomain).toBe(false)
+    expect(ranked[0].confidence).toBeCloseTo(0.25, 4)
+    expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('R2-C: tag-only and keyword-only candidates leave coverContainsDomain:false', () => {
+    const tagOnly = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers'] },
+      [{ scope: 'group:plur/infra', covers: ['servers'] }],
+    )
+    expect(tagOnly[0].coverContainsDomain).toBe(false)
+    const kwOnly = rankScopes(
+      { statement: 'updating the deployment runbook for servers' },
+      [{ scope: 'group:plur/infra', covers: ['deployment', 'servers'] }],
+    )
+    expect(kwOnly[0].coverContainsDomain).toBe(false)
+  })
+
   it('leaves `domainMatch:false` on a tag-only candidate', () => {
     const ranked = rankScopes(
       { statement: 'no overlap zzz', tags: ['servers', 'deploy', 'infra'] },


### PR DESCRIPTION
## R2-C — deterministic domain routing over-route (reaudit finding 4)

### The bug (bidirectional match)
`scoreScope` in `scope-routing.ts` matched the domain channel **bidirectionally** and set `domainMatch=true` for BOTH directions:
- **forward** — `cover ⊃ domain` (the scope's coverage is a namespace-prefix of, or equals, the engram's domain → the engram genuinely belongs in this scope), and
- **reverse** — `domain ⊃ cover` (the engram's domain is *broader* than the cover → the engram is more general than the scope).

PR-6's deterministic bypass in `_resolveUnscopedScope` (`if (top.domainMatch) return routed`) then routed on `domainMatch` **alone**, bypassing the squash/threshold gate **with no regard for direction**. So a broad/generic engram (domain `plur`, which defaults to `visibility: public`) deterministically auto-routed into the alphabetically-first **narrow** shared sub-scope declaring a cover under that namespace (cover `plur.core`) — silently over-routing cross-cutting personal/public knowledge into a shared/remote tier it doesn't belong in.

### The fix (cover⊃domain only)
- **`scope-routing.ts`**: added a precise `coverContainsDomain` boolean to `ScopeCandidate`, set **only** for the forward direction (`cover ⊃ domain` or `cover === domain`). `domainMatch` is kept (true for either direction) but is now used **only for scoring/ordering** (the domain-preferring tie-break), never as the bypass key.
- The **reverse** direction is **down-weighted** (new `WEIGHT_DOMAIN_REVERSE = WEIGHT_TAG`) so a lone reverse hit squashes to `0.25 < SCOPE_MATCH_THRESHOLD` and falls to the default rather than landing in a narrow scope. It still **contributes to the score**, so a reverse hit plus enough tag/keyword evidence can route via the normal `>=` gate. The forward direction stays at full `WEIGHT_DOMAIN` — `THRESHOLD_SINGLE_DOMAIN` and every forward routing test are untouched. (The existing `WEIGHT_DOMAIN`/`WEIGHT_TAG`/`WEIGHT_KEYWORD`/`SATURATION`/`SCOPE_MATCH_THRESHOLD` constants are unchanged.)
- **`index.ts` `_resolveUnscopedScope`**: the deterministic branch now keys on `coverContainsDomain`, not `domainMatch`.

### What's preserved
- The weak-signal `>=` threshold gating (tag-only / keyword-only stay gated).
- PR-4's readonly-scope exclusion (a readonly scope with a domain match is still excluded before ranking).
- The reverse direction still **scores** and can route via the normal threshold path when it accumulates enough evidence — it just never gets the deterministic bypass.
- `THRESHOLD_SINGLE_DOMAIN === SCOPE_MATCH_THRESHOLD` invariant and the lone-forward-domain `0.5` boundary.

### Tests
- **over-route regression** (the new key test): a broad engram (domain `plur`) against a narrow cover `plur.core` → falls to `unscoped_default` (global), **NOT** into `group:plur/core`.
- forward (`cover ⊃ domain`) and exact (`cover == domain`) → still route deterministically (unchanged).
- reverse + 3 tags → still routes via the `>=` path (proves reverse is down-weighted, not discarded).
- readonly scope with a domain match → still excluded.
- tag-only / keyword-only → still threshold-gated.
- ranker-level tests pin `coverContainsDomain` across all four directions.

### Verification
- `pnpm --filter @plur-ai/core build` OK.
- Full workspace: **148 files / 1657 tests passed**, 34 skipped, 0 failed (after dist rebuild).
- `tsc --noEmit` clean on core (0 errors, == baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
