### PR TITLE
Fix the server-address detector (stop a slowdown attack + a false alarm on code references) + add the attack-test suite

### DIFF
--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -114,7 +114,33 @@ const SENSITIVE_PATTERNS: { name: string; regex: RegExp }[] = [
       /(?:[a-z][a-z0-9+.-]{0,31}:\/\/[^/\s:@]{0,64}:[^/\s@]{1,128}@[a-z0-9.-]|[^/\s:@]{0,64}:[^/\s@]{1,128}@(?:[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,}|localhost|\d{1,3}(?:\.\d{1,3}){3}|[a-z0-9-]+:\d{2,5}))/i,
   },
   // FQDN:port — e.g. hub-staging.plur.ai:443, db.internal:5432 (infra topology)
-  { name: 'fqdn_port', regex: /\b(?:[a-z0-9-]+\.)+[a-z]{2,}:\d{2,5}\b/i },
+  //
+  // BOUNDED QUANTIFIERS (reaudit #3, ReDoS fix): the prior form
+  // `(?:[a-z0-9-]+\.)+[a-z]{2,}:\d{2,5}` had a `+`-over-`+` ambiguity — when the
+  // trailing `:port` failed to match, the engine explored every partition of a
+  // dotted run, giving catastrophic O(n^2) backtracking (~4s on a 64KB `a.a.a…`
+  // run at the scan cap; the 64KB cap does NOT help because 64KB IS the worst
+  // case). We rewrite the host as a single leading label followed by bounded
+  // `\.label` groups — every `.` is a hard anchor, so there is no cross-label
+  // backtracking — and bound each quantifier (label len {1,63}, up to 7 inner
+  // `.label` groups, TLD {2,24}, port {2,5}), mirroring the basic_auth_url fix.
+  // Now linear: the same 64KB inputs scan in <7ms.
+  //
+  // CODE-REF FP GATE (reaudit #3, FP fix): a code location of the form
+  // `file.ext:line` (inject.ts:49, app.py:100, scope-util.ts:12, main.rs:55,
+  // file.go:42, a.b.ts:10) previously matched as host:port — the extension looks
+  // like a TLD and the line number like a port — silently demoting shareable
+  // code-citing engrams out of shared scopes. We exclude a curated set of source/
+  // file extensions in the TLD position via a negative lookahead anchored to the
+  // `:port` boundary (`(?!(?:ts|py|rs|…):)`), so `file.ts:49` is NOT flagged while
+  // a real `host.tld:port` (db.internal:5432, hub.example.com:443,
+  // redis.prod.svc:6379) still is. The lookahead inherits the `i` flag, so
+  // `Main.RS:55` and `Config.YAML:33` are excluded too.
+  {
+    name: 'fqdn_port',
+    regex:
+      /\b[a-z0-9-]{1,63}(?:\.[a-z0-9-]{1,63}){0,7}\.(?!(?:ts|tsx|js|jsx|mjs|cjs|py|rs|go|rb|java|kt|c|cc|cpp|cxx|h|hpp|cs|php|swift|scala|clj|ex|exs|erl|hs|ml|md|mdx|json|jsonc|toml|ini|conf|cfg|lock|txt|csv|tsv|xml|html|htm|css|scss|sass|less|sh|bash|zsh|sql|vue|svelte|dart|lua|r|pl|pm|yaml|yml):)[a-z]{2,24}:\d{2,5}\b/i,
+  },
   // IPv4:port — e.g. 139.59.155.82:8877
   { name: 'ipv4_port', regex: /\b\d{1,3}(?:\.\d{1,3}){3}:\d{2,5}\b/ },
 ]
@@ -231,28 +257,44 @@ const INTERNAL_HOST = new RegExp(
   // INSIDE the group, so `match.groups.host` is always set on a match. The single
   // named group is preserved with the `g` flag (no duplicate-name compile error).
   //
-  // TRAILING-PUNCT FN FIX (reaudit #2): the prior trailing lookahead
+  // PUNCT FN FIX (reaudit #2, completed reaudit #3): the prior trailing lookahead
   // `(?=$|[\s:/?#)'"])` was far narrower than the original `\b` boundary — it
   // OMITTED `.` `,` `;` `]` `=` and backtick, so a real internal host at the end
   // of a sentence or before punctuation (`db.internal.`, `app.corp,`,
-  // `host=db.internal` reversed, `` `db.internal` ``) escaped the guard entirely.
-  // We add those terminators to BOTH the trailing lookahead and the leading
-  // delimiter. Internal dots are consumed by the host SHAPE (the greedy
-  // `(?:[a-z0-9-]+\.)+` prefers the longest host), so adding `.` to the lookahead
-  // does NOT truncate `db.internal.corp` — the engine still matches the full host
-  // and only consults the lookahead at the genuine trailing boundary.
-  "(?:^|[\\s/@'\"(`\\[])(?<host>" +
+  // `` `db.internal` ``) escaped the guard entirely. The trailing lookahead gained
+  // those terminators in reaudit #2. The LEADING delimiter, however, was left as
+  // `(?:^|[\s/@'"(`\[])` — missing `=` `,` `;` — so the env-var assignment form
+  // `host=db.internal` / `DATABASE_HOST=app.corp` and a comma-separated host list
+  // `a,db.internal` still escaped PASS-1 (the host FOLLOWS the `=`/`,`, and the
+  // engine never started a match). reaudit #3 adds `=` `,` `;` (and `.` `]` for
+  // symmetry with the trailing class) to the leading delimiter, so both sides now
+  // accept the same terminators and the assignment form is caught. The host SHAPE
+  // consumes internal dots greedily (it prefers the longest host), so `.` in the
+  // leading class only matches a separator BEFORE the host and does NOT truncate
+  // `db.internal.corp`.
+  //
+  // BOUNDED QUANTIFIERS (reaudit #3, ReDoS fix): the prior host alternatives used
+  // `(?:[a-z0-9-]+\.)+SUFFIX` — a `+`-over-`+` ambiguity identical to the old
+  // fqdn_port. On a long dotted run that never ends in an internal suffix
+  // (`ab.ab.ab…`, 64KB) the engine backtracked over every partition at every start
+  // position (~8s at the scan cap — a write/publish DoS, since matchInternalHost
+  // runs on every guarded write). We rewrite each alternative as a single leading
+  // label `[a-z0-9-]{1,63}` followed by bounded `(?:\.[a-z0-9-]{1,63}){0,N}` inner
+  // groups and a hard `\.` before the suffix — every `.` is an anchor, so there is
+  // no cross-label backtracking. Linear now: the same 64KB run scans in <8ms.
+  // Bounds (up to ~9 labels) cover every realistic internal hostname.
+  "(?:^|[\\s/@'\"(`\\[=,;.\\]])(?<host>" +
     // a. internal-suffix label (.local/.internal/.corp/.lan/.intranet)
-    '(?:[a-z0-9-]+\\.)+(?:local|internal|corp|lan|intranet)' +
+    '[a-z0-9-]{1,63}(?:\\.[a-z0-9-]{1,63}){0,7}\\.(?:local|internal|corp|lan|intranet)' +
     '|' +
     // b. k8s svc / svc.cluster.local
-    '(?:[a-z0-9-]+\\.)+svc(?:\\.cluster\\.local)?' +
+    '[a-z0-9-]{1,63}(?:\\.[a-z0-9-]{1,63}){0,7}\\.svc(?:\\.cluster\\.local)?' +
     '|' +
     // c. staging as a label fragment (hub-staging.plur.ai, staging-build.example.com)
-    '[a-z0-9-]*staging[a-z0-9-]*(?:\\.[a-z0-9-]+)+' +
+    '[a-z0-9-]{0,30}staging[a-z0-9-]{0,30}(?:\\.[a-z0-9-]{1,63}){1,8}' +
     '|' +
     // d. staging as an inner label (api.staging.example.com)
-    '(?:[a-z0-9-]+\\.)+staging(?:\\.[a-z0-9-]+)+' +
+    '[a-z0-9-]{1,63}(?:\\.[a-z0-9-]{1,63}){0,7}\\.staging(?:\\.[a-z0-9-]{1,63}){1,8}' +
     ")(?=$|[\\s:/?#)\\]'\"`,;.=])",
   'gi',
 )
@@ -321,10 +363,12 @@ function matchInternalHost(text: string): string | null {
 // Defense-in-depth length cap (#353). The publish loop scans whole serialized
 // engrams and `_guardSensitiveScope` scans statement + JSON.stringify(context),
 // so an unbounded input is an unbounded scan. We cap the SCAN INPUT at 64KB
-// (byte-aware). The "ReDoS" this once guarded against was empirically ~2.6ms
-// under V8 Irregexp (mandatory dot separators keep each alternative linear), so
-// this cap is cheap insurance, not a DoS fix. A leading credential is still
-// caught; callers must NOT assume full-input scanning.
+// (byte-aware). With every pattern now bounded (basic_auth_url reaudit #1,
+// fqdn_port reaudit #3 — both rewritten to linear-time forms with no `+`-over-`+`
+// ambiguity), a 64KB scan is empirically <7ms under V8 Irregexp, so this cap is
+// cheap insurance, not the DoS fix — the bounded quantifiers are. (Before the
+// fqdn_port bounding a 64KB dotted-label run took ~4s here.) A leading credential
+// is still caught; callers must NOT assume full-input scanning.
 const MAX_SCAN_BYTES = 65536
 
 function truncateToScanLimit(text: string): string {

--- a/packages/core/test/adversarial/detector-fuzz.test.ts
+++ b/packages/core/test/adversarial/detector-fuzz.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest'
+import { detectSensitive, detectSecrets, sensitivityCategory } from '../../src/secrets.js'
+
+/**
+ * ADVERSARIAL DETECTOR FUZZER — THIRD audit of the PLUR scope-security stack
+ * before the 0.10.0 release.
+ *
+ * Goal: prove the leak-guard detectors in `secrets.ts` have zero FALSE
+ * NEGATIVES on a large corpus of MUST-CATCH sensitive strings (the content that
+ * must NEVER reach a shared/remote scope un-demoted) and zero FALSE POSITIVES on
+ * a corpus of benign strings (legitimate engram content the guard must not
+ * silently demote). Also bounds worst-case timing on ReDoS-bait inputs.
+ *
+ * The corpora encode the round-2 fixes as durable regression assertions:
+ *  - internal-host two-pass scan-ALL-matches (a real host AFTER an FP-gated
+ *    config token must still be caught),
+ *  - trailing-punctuation terminators (. , ; ] = ` space EOL),
+ *  - scheme-less basic-auth tightened to real host shapes (benign prose
+ *    word:word@word no longer flagged),
+ *  - public IPv4/IPv6 (global-unicast only) vs private/doc/loopback,
+ *  - basic_auth categorised as 'secrets', infra topology as 'infra'.
+ *
+ * Per the audit charter the assertions are NOT weakened to make the suite pass.
+ * If the detector is wrong, the corresponding case FAILS and that failure is the
+ * finding.
+ */
+
+// ---------------------------------------------------------------------------
+// MUST-CATCH corpus: detectSensitive(input) MUST return >=1 match.
+// Each entry: [label, input].
+// ---------------------------------------------------------------------------
+const SENSITIVE: [string, string][] = []
+
+// --- Public IPv4, every surrounding-punctuation position ---
+const PUBLIC_IPV4 = ['139.59.155.82', '8.8.8.8', '1.1.1.1', '34.122.5.77', '52.0.0.1', '193.2.1.5']
+for (const ip of PUBLIC_IPV4) {
+  SENSITIVE.push([`ipv4 bare ${ip}`, `host ${ip} up`])
+  SENSITIVE.push([`ipv4 parens ${ip}`, `resolver (${ip}) ok`])
+  SENSITIVE.push([`ipv4 trailing period ${ip}`, `ping ${ip}.`])
+  SENSITIVE.push([`ipv4 trailing comma ${ip}`, `use ${ip}, then go`])
+  SENSITIVE.push([`ipv4 bracket ${ip}`, `nodes[${ip}]`])
+  SENSITIVE.push([`ipv4 EOL ${ip}`, `the droplet is ${ip}`])
+  SENSITIVE.push([`ipv4 backtick ${ip}`, `run \`${ip}\` now`])
+}
+
+// --- Public IPv6 (global-unicast 2000::/3), various forms ---
+const PUBLIC_IPV6 = [
+  '2606:4700:4700::1111',
+  '2001:4860:4860::8888',
+  '2a03:2880:f10c:83:face:b00c:0:25de',
+  '2400:cb00:2048:1::c629:d7a2',
+  '2620:0:ccc::2',
+  '2001:0db9:0000:0000:0000:0000:0000:0001', // db9 (NOT db8 doc) — public
+]
+for (const ip of PUBLIC_IPV6) {
+  SENSITIVE.push([`ipv6 bare ${ip}`, `addr ${ip} here`])
+  SENSITIVE.push([`ipv6 EOL ${ip}`, `the v6 endpoint is ${ip}`])
+}
+
+// --- Internal hosts at every position, before every terminator ---
+const INTERNAL_HOSTS = [
+  'db.internal',
+  'app.corp',
+  'cache.lan',
+  'gw.intranet',
+  'svc-a.local',
+  'dataset.internal',
+  'db.internal.corp',
+  'api.staging.example.com',
+  'hub-staging.plur.ai',
+  'staging-build.example.com',
+  'kafka.svc',
+  'redis.svc.cluster.local',
+]
+const TERMINATORS: [string, string][] = [
+  ['period', `${'%H%'}.`],
+  ['comma', `${'%H%'}, x`],
+  ['semicolon', `${'%H%'}; x`],
+  ['bracket', `[${'%H%'}]`],
+  ['backtick', `\`${'%H%'}\``],
+  ['space', `${'%H%'} x`],
+  ['EOL', `${'%H%'}`],
+  ['colon-path', `${'%H%'}:/x`],
+  ['slash', `${'%H%'}/x`],
+  ['question', `${'%H%'}?x`],
+]
+for (const host of INTERNAL_HOSTS) {
+  for (const [tlabel, tmpl] of TERMINATORS) {
+    SENSITIVE.push([`internal ${host} <${tlabel}>`, `connect to ${tmpl.replace('%H%', host)}`])
+  }
+}
+
+// --- Real host hidden AFTER a benign FP-gated token (scan-all-matches fix) ---
+SENSITIVE.push(['host after config.local', 'see config.local then ssh db.internal.corp'])
+SENSITIVE.push(['host after vite.config.local', 'edit vite.config.local and deploy api.staging.example.com'])
+SENSITIVE.push(['host after data-staging.csv', 'load data-staging.csv from db.internal'])
+SENSITIVE.push(['host after tsconfig.json', 'check tsconfig.json then hit app.corp'])
+SENSITIVE.push(['two FP tokens then host', 'config.local app.config.yml redis.svc.cluster.local'])
+
+// --- host:port topology ---
+SENSITIVE.push(['fqdn:port hub', 'endpoint hub-staging.plur.ai:443 live'])
+SENSITIVE.push(['fqdn:port db', 'db.internal:5432 conn'])
+SENSITIVE.push(['fqdn:port public', 'api.example.com:8080 svc'])
+SENSITIVE.push(['ipv4:port', '139.59.155.82:8877 svc'])
+SENSITIVE.push(['ipv4:port 2', '34.122.5.77:443 lb'])
+
+// --- basic-auth URLs: full / scheme-less / empty-username ---
+SENSITIVE.push(['basic-auth full https', 'url https://team:secret@hub-staging.plur.ai/x'])
+SENSITIVE.push(['basic-auth full http', 'http://admin:p4ssw0rd@example.com/path'])
+SENSITIVE.push(['basic-auth scheme-less host:port', 'creds user:pass@host:5432/db here'])
+SENSITIVE.push(['basic-auth scheme-less dotted', 'admin:hunter2@db.internal connect'])
+SENSITIVE.push(['basic-auth scheme-less domain', 'svc:tok3n@api.example.com call'])
+SENSITIVE.push(['basic-auth scheme-less ipv4', 'root:toor@10.0.0.5 ssh'])
+SENSITIVE.push(['basic-auth empty-username', 'https://:token1234abcd@host.example.com here'])
+SENSITIVE.push(['basic-auth localhost', 'user:secretpw@localhost dev'])
+
+// --- credentials (detectSecrets family) ---
+SENSITIVE.push(['bearer', 'Authorization: Bearer abcdefghij1234567890XYZ'])
+SENSITIVE.push(['jwt', 'token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0'])
+SENSITIVE.push(['aws akia', 'key AKIAIOSFODNN7EXAMPLE used'])
+SENSITIVE.push(['aws secret', 'aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY1'])
+SENSITIVE.push(['api_key assign', 'api_key=abcdef1234567890abcdef1234567890'])
+SENSITIVE.push(['secret_key assign', 'secret_key: 9f8e7d6c5b4a39281706f5e4d3c2b1a0ffff'])
+SENSITIVE.push(['password assign', 'password = hunter2secret'])
+SENSITIVE.push(['private key', '-----BEGIN RSA PRIVATE KEY-----'])
+SENSITIVE.push(['openai sk-', 'OPENAI_API_KEY=sk-1234567890abcdefghijklmn'])
+SENSITIVE.push(['connection string', 'Connect to postgres://user:pass@host:5432/db'])
+
+// ---------------------------------------------------------------------------
+// MUST-NOT-FLAG corpus: detectSensitive(input) MUST return [].
+// ---------------------------------------------------------------------------
+const BENIGN: [string, string][] = [
+  ['config.local alone', 'edit config.local file'],
+  ['vite.config.local', 'open vite.config.local'],
+  ['jest.config.local', 'see jest.config.local'],
+  ['tsconfig.local', 'tsconfig.local here'],
+  ['data-staging.csv', 'load data-staging.csv now'],
+  ['staging-build.yml', 'see staging-build.yml'],
+  ['app.config.yml', 'app.config.yml here'],
+  ['tsconfig.json', 'check tsconfig.json'],
+  ['next.config.local', 'next.config.local present'],
+  ['semver 1.2.3', 'version 1.2.3 released'],
+  ['semver 10.20.30', 'bump to 10.20.30 soon'],
+  ['time 5:30', 'meet at 5:30 today'],
+  ['time 12:30:45', 'at 12:30:45 exactly'],
+  ['ratio 3:1@scale', 'use 3:1@scale ratio'],
+  ['prose word:word@word', 'note name:value@scope here'],
+  ['prose meet:me@noon', 'remember meet:me@noon plan'],
+  ['email user@example.com', 'mail user@example.com please'],
+  ['email a.b@c.io', 'contact a.b@c.io now'],
+  ['example.com', 'visit example.com today'],
+  ['api.github.com', 'call api.github.com endpoint'],
+  ['docs.python.org', 'read docs.python.org guide'],
+  ['uuid', 'id 550e8400-e29b-41d4-a716-446655440000 set'],
+  ['uuid 2', 'run 123e4567-e89b-12d3-a456-426614174000 job'],
+  // Code refs file:line — MUST NOT FLAG (per audit charter).
+  ['code ref inject.ts:49', 'see inject.ts:49 for detail'],
+  ['code ref index.ts:1', 'index.ts:1 is the entry'],
+  ['code ref scope-util.ts:12', 'scope-util.ts:12 has it'],
+  ['code ref app.py:100', 'app.py:100 line throws'],
+  ['code ref file.go:42', 'file.go:42 panics'],
+  ['code ref main.rs:55', 'main.rs:55 owns it'],
+  ['code ref a.b.ts:10', 'a.b.ts:10 multi-dot'],
+  // Private / doc / loopback IPs — never public.
+  ['ipv4 private 10', 'lan 10.0.0.5 host'],
+  ['ipv4 private 192.168', 'router 192.168.1.1 here'],
+  ['ipv4 private 172.16', 'host 172.16.0.9 internal'],
+  ['ipv4 loopback', 'bind 127.0.0.1 only'],
+  ['ipv4 doc 203.0.113', 'doc 203.0.113.5 sample'],
+  ['ipv4 doc 192.0.2', 'rfc 192.0.2.1 example'],
+  ['ipv4 link-local', 'apipa 169.254.1.1 fallback'],
+  ['ipv6 loopback', 'local ::1 only'],
+  ['ipv6 unspecified', 'bind :: addr'],
+  ['ipv6 link-local', 'iface fe80::1 link'],
+  ['ipv6 ula fd00', 'fd00::1 private mesh'],
+  ['ipv6 doc db8', '2001:db8::1 example'],
+  ['mac address', 'mac 00:11:22:33:44:55 nic'],
+  // Standalone infra words — must NOT flag alone.
+  ['word prod', 'prod is down'],
+  ['word redis', 'redis cache warm'],
+  ['word staging (no host)', 'the staging env failed'],
+]
+
+describe('detector-fuzz: MUST-CATCH sensitive corpus (zero false negatives)', () => {
+  const falseNegatives: string[] = []
+  for (const [label, input] of SENSITIVE) {
+    it(`catches: ${label}`, () => {
+      const matches = detectSensitive(input)
+      if (matches.length === 0) falseNegatives.push(`${label} :: ${JSON.stringify(input)}`)
+      expect(matches.length, `FALSE NEGATIVE — leak escaped guard: ${label} :: ${JSON.stringify(input)}`).toBeGreaterThan(0)
+    })
+  }
+})
+
+describe('detector-fuzz: MUST-NOT-FLAG benign corpus (zero false positives)', () => {
+  for (const [label, input] of BENIGN) {
+    it(`ignores: ${label}`, () => {
+      const matches = detectSensitive(input)
+      expect(
+        matches,
+        `FALSE POSITIVE — benign content demoted: ${label} :: ${JSON.stringify(input)} -> ${JSON.stringify(matches.map(m => m.pattern))}`,
+      ).toEqual([])
+    })
+  }
+})
+
+describe('detector-fuzz: sensitivityCategory routing', () => {
+  it('basic_auth_url is a credential -> secrets', () => {
+    expect(sensitivityCategory('basic_auth_url')).toBe('secrets')
+  })
+  it('jwt/bearer are credentials -> secrets', () => {
+    expect(sensitivityCategory('jwt')).toBe('secrets')
+    expect(sensitivityCategory('bearer_token')).toBe('secrets')
+  })
+  it('IP / host topology -> infra', () => {
+    expect(sensitivityCategory('public_ipv4')).toBe('infra')
+    expect(sensitivityCategory('public_ipv6')).toBe('infra')
+    expect(sensitivityCategory('internal_host')).toBe('infra')
+    expect(sensitivityCategory('fqdn_port')).toBe('infra')
+    expect(sensitivityCategory('ipv4_port')).toBe('infra')
+  })
+})
+
+describe('detector-fuzz: ReDoS bait timing (64KB, must stay sub-second)', () => {
+  // The round-2 fix comment claims the detectors are linear on the 64KB-capped
+  // scan input ("~0.3ms on 64KB", "the 64KB cap is cheap insurance, not a DoS
+  // fix"). A second-plus runtime on a 64KB input means a stored prompt-injection
+  // / DoS vector: detectSensitive runs on serialized engrams at the publish gate
+  // AND inside _guardSensitiveScope, so a slow input stalls every guard call.
+  const N = 65536
+  const BAITS: [string, string][] = [
+    ['colon run (no @)', ':'.repeat(N)],
+    ['a: run', 'a:'.repeat(N / 2)],
+    ['userinfo word:word (no @)', 'word:word'.repeat(Math.floor(N / 9))],
+    ['ipv6-ish hex:colon', '1234:'.repeat(N / 5)],
+    ['dotted label run a.', 'a.'.repeat(N / 2)],
+    ['dotted label run ab.', 'ab.'.repeat(Math.floor(N / 3))],
+    ['scheme bait http://aaa', 'http://' + 'a'.repeat(N)],
+    ['at-run', 'a@'.repeat(N / 2)],
+  ]
+  const BUDGET_MS = 1000
+  for (const [label, input] of BAITS) {
+    it(`${label} scans in < ${BUDGET_MS}ms`, () => {
+      const t0 = performance.now()
+      detectSensitive(input)
+      const dt = performance.now() - t0
+      expect(dt, `ReDoS — 64KB '${label}' took ${dt.toFixed(0)}ms (budget ${BUDGET_MS}ms)`).toBeLessThan(BUDGET_MS)
+    })
+  }
+})
+
+describe('detector-fuzz: input-type guard', () => {
+  it('throws on non-string', () => {
+    // @ts-expect-error intentional misuse
+    expect(() => detectSensitive(123)).toThrow(TypeError)
+    // @ts-expect-error intentional misuse
+    expect(() => detectSecrets(null)).toThrow(TypeError)
+  })
+})

--- a/packages/core/test/adversarial/guard-fuzz.test.ts
+++ b/packages/core/test/adversarial/guard-fuzz.test.ts
@@ -1,0 +1,656 @@
+/**
+ * ADVERSARIAL LEAK-GUARD FUZZER — every write/update egress path (#353 round-3).
+ *
+ * THREAT MODEL: sensitive content (public IPv4/IPv6, host:port, basic-auth URLs,
+ * internal hosts, credentials) must NEVER reach a SHARED scope
+ * (group:/project:/space:/team:/org:/public) or a REMOTE-BACKED scope (a `user:`
+ * scope with a remote store entry) without being demoted to scope:local /
+ * visibility:private. `global` and `local` are personal and exempt.
+ *
+ * This file drives EVERY public write/update path that can reach a shared or
+ * remote-backed store, with adversarial sensitive payloads, against a Plur
+ * instance configured with:
+ *   - a SHARED LOCAL-FILE store (scope `project:plur`, path on disk) — exercises
+ *     the isSharedScope arm of the guard without a network, and
+ *   - a REMOTE-BACKED store (scope `user:plur:gregor`, a `url` → off-machine) with
+ *     a vi.fn() over globalThis.fetch as the append/PATCH SPY.
+ *
+ * For each path we assert BOTH halves of the invariant:
+ *   1. the persisted engram is demoted (scope==='local', visibility==='private'),
+ *      OR (for the explicit-remote-update path) the call THROWS; and
+ *   2. the remote append/PATCH spy received ZERO calls (nothing crossed the
+ *      machine boundary) and nothing sits in the outbox awaiting a retry push.
+ *
+ * Paths covered: learn, learnRouted, reportFailure, updateEngram,
+ * updateEngramAsync, saveMetaEngrams, learnAsync UPDATE, learnAsync MERGE, and
+ * flushOutbox (re-guard of a stale/poisoned queue entry).
+ *
+ * Harness mirrors guard-remote-boundary.test.ts / guard-remote-scope.test.ts /
+ * outbox.test.ts: a vi.fn() over globalThis.fetch, asserting on POST (append) and
+ * PATCH (mutate). A CLEAN counterpart on each path proves the guard does not
+ * over-block (else "demote everything" would pass vacuously).
+ *
+ * DURABLE: keep this file. A FAILURE here is a real leak finding, not a flaky
+ * test — do NOT weaken the assertions to make it green.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../../src/index.js'
+import { detectSensitive, sensitivityCategory } from '../../src/secrets.js'
+import type { LlmFunction, LearnContext } from '../../src/types.js'
+
+// ---- adversarial constants -------------------------------------------------
+
+// A real (public) droplet-shaped IPv4 — the exact shape that leaked in 2026-06.
+const PUBLIC_IP = '139.59.155.82'
+// Basic-auth URL with an internal staging host. Trips basic_auth_url (secrets)
+// AND internal_host (infra) — and notably is NOT caught by detectSecrets (the
+// HARD throw), so it must be stopped by the SOFT demotion path on every egress.
+const BASIC_AUTH_URL = 'https://t:p@hub-staging.plur.ai'
+
+// The adversarial payload corpus — each must trip detectSensitive.
+const SENSITIVE_CORPUS = [
+  `deploy target is ${PUBLIC_IP}`,
+  `login at ${BASIC_AUTH_URL}`,
+  `the prod box is ${PUBLIC_IP}:8877`,
+  `ssh into db.internal.corp then run the migration`,
+  `the staging api is api.staging.example.com`,
+] as const
+
+// Clean control corpus — must NOT trip detectSensitive, must NOT be demoted.
+const CLEAN_CORPUS = [
+  'I prefer concise commit messages',
+  'always run the test suite before shipping',
+  'the team retro is on Fridays',
+] as const
+
+// SHARED local-file store: isSharedScope by prefix, but a LOCAL file (no url) —
+// exercises the isSharedScope guard arm with no network involved.
+const SHARED_SCOPE = 'project:plur'
+// REMOTE-backed personal scope: NOT isSharedScope, but routes off-machine.
+const REMOTE_SCOPE = 'user:plur:gregor'
+const REMOTE_URL = 'https://plur.example.com/sse'
+
+// ---- harness ---------------------------------------------------------------
+
+function writeStoresConfig(dir: string, stores: Array<Record<string, unknown>>) {
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    yaml.dump({ stores, index: false }, { lineWidth: 120, noRefs: true }),
+  )
+}
+
+/** Both stores: a shared local-file store AND a remote-backed user: store. */
+function bothStores(dir: string) {
+  return [
+    { path: join(dir, 'team-store.yaml'), scope: SHARED_SCOPE, readonly: false },
+    { url: REMOTE_URL, token: 'plur_sk_test', scope: REMOTE_SCOPE, readonly: false },
+  ]
+}
+
+function readLocalEngrams(dir: string): any[] {
+  const path = join(dir, 'engrams.yaml')
+  if (!existsSync(path)) return []
+  const data = yaml.load(readFileSync(path, 'utf-8')) as { engrams?: unknown[] } | null
+  return (data?.engrams ?? []) as any[]
+}
+
+function writeLocalEngrams(dir: string, engrams: any[]) {
+  writeFileSync(join(dir, 'engrams.yaml'), yaml.dump({ engrams }, { lineWidth: 120, noRefs: true }))
+}
+
+function readSharedStore(dir: string): any[] {
+  const path = join(dir, 'team-store.yaml')
+  if (!existsSync(path)) return []
+  const data = yaml.load(readFileSync(path, 'utf-8')) as { engrams?: unknown[] } | null
+  return (data?.engrams ?? []) as any[]
+}
+
+describe('adversarial leak-guard fuzzer (#353 round-3)', () => {
+  let dir: string
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-guard-fuzz-'))
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function postCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'POST')
+  }
+  function patchCalls() {
+    return fetchMock.mock.calls.filter(([, init]) => (init as any)?.method === 'PATCH')
+  }
+  /** Any call that mutates the remote (append OR patch). */
+  function egressCalls() {
+    return fetchMock.mock.calls.filter(
+      ([, init]) => (init as any)?.method === 'POST' || (init as any)?.method === 'PATCH',
+    )
+  }
+
+  /** Empty-list mock for the load() page-walk; POST append + PATCH succeed. */
+  function mockEmptyRemote() {
+    fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'POST') {
+        return { ok: true, status: 201, json: async () => ({ id: 'ENG-REMOTE-001' }), text: async () => '' } as Response
+      }
+      if (method === 'PATCH') {
+        return { ok: true, status: 200, json: async () => ({ engram: {} }), text: async () => '' } as Response
+      }
+      return { ok: true, status: 200, json: async () => ({ rows: [], total_count: 0 }), text: async () => '' } as Response
+    }) as any)
+  }
+
+  /**
+   * Mock a single engram resident at the remote scope, so getById/list see it and
+   * any PATCH succeeds — so a "no PATCH" assertion proves the GUARD skipped it,
+   * not that the server refused.
+   */
+  function mockRemoteWithProcedure(serverId: string, statement: string) {
+    const row = {
+      id: serverId,
+      scope: REMOTE_SCOPE,
+      status: 'active',
+      data: { statement, type: 'procedural', scope: REMOTE_SCOPE, status: 'active', id: serverId },
+    }
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'PATCH') {
+        return { ok: true, status: 200, json: async () => ({ engram: { ...row, data: { ...row.data } } }), text: async () => '' } as Response
+      }
+      if (method === 'POST') {
+        return { ok: true, status: 201, json: async () => ({ id: serverId }), text: async () => '' } as Response
+      }
+      if (method === 'GET' && typeof url === 'string' && /\/engrams\/[^?]+$/.test(url)) {
+        return { ok: true, status: 200, json: async () => row, text: async () => '' } as Response
+      }
+      return { ok: true, status: 200, json: async () => ({ rows: [row], total_count: 1 }), text: async () => '' } as Response
+    }) as any)
+  }
+
+  async function primedRemoteId(plur: Plur, serverId: string): Promise<string> {
+    plur.list()
+    await new Promise(r => setTimeout(r, 50))
+    const found = plur.list().find(e => (e as any)._originalId === serverId || e.id.endsWith(serverId))
+    if (!found) throw new Error(`remote engram ${serverId} not in cache after prime`)
+    return found.id
+  }
+
+  // ==========================================================================
+  // CORPUS SANITY — every adversarial payload must actually be detected, and
+  // every clean control must NOT be. If this drifts, the rest is vacuous.
+  // ==========================================================================
+  it('corpus sanity: sensitive payloads trip detectSensitive; clean ones do not', () => {
+    for (const s of SENSITIVE_CORPUS) {
+      const hits = detectSensitive(s)
+      expect(hits.length, `sensitive payload should be detected: ${s}`).toBeGreaterThan(0)
+    }
+    for (const s of CLEAN_CORPUS) {
+      expect(detectSensitive(s), `clean payload must not trip: ${s}`).toEqual([])
+    }
+    // The basic-auth URL specifically belongs to the 'secrets' family AND carries
+    // an 'infra' internal_host — both families must be present so a custom
+    // forbid:['secrets'] OR forbid:['infra'] policy each catch it.
+    const cats = new Set(detectSensitive(BASIC_AUTH_URL).map(h => sensitivityCategory(h.pattern)))
+    expect(cats.has('secrets')).toBe(true)
+    expect(cats.has('infra')).toBe(true)
+  })
+
+  // ==========================================================================
+  // PATH 1 — learn() to the SHARED local-file scope and the REMOTE scope.
+  // ==========================================================================
+  it('learn() to a shared local-file scope demotes every sensitive payload, never written shared', () => {
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+
+    for (const payload of SENSITIVE_CORPUS) {
+      const e = plur.learn(payload, { scope: SHARED_SCOPE, type: 'behavioral' }) as any
+      expect(e.scope, `learn(shared) should demote: ${payload}`).toBe('local')
+      expect(e.visibility).toBe('private')
+    }
+    // Nothing landed in the shared store; only demoted-local engrams in primary.
+    expect(readSharedStore(dir).length).toBe(0)
+    const local = readLocalEngrams(dir)
+    expect(local.length).toBe(SENSITIVE_CORPUS.length)
+    expect(local.every(e => e.scope === 'local')).toBe(true)
+  })
+
+  it('learn() to a remote-backed scope demotes every sensitive payload, ZERO appends, empty outbox', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+
+    for (const payload of SENSITIVE_CORPUS) {
+      const e = plur.learn(payload, { scope: REMOTE_SCOPE, type: 'behavioral' }) as any
+      expect(e.scope, `learn(remote) should demote: ${payload}`).toBe('local')
+      expect(e.visibility).toBe('private')
+    }
+    await new Promise(r => setTimeout(r, 80)) // let any erroneous fire-and-forget settle
+    expect(postCalls().length, 'remote append spy must be ZERO').toBe(0)
+    expect(plur.outboxCount(), 'nothing queued for retry push').toBe(0)
+  })
+
+  it('learn() does NOT over-block clean content to the remote scope', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const e = plur.learn(CLEAN_CORPUS[0], { scope: REMOTE_SCOPE, type: 'preference' }) as any
+    expect(e.scope).toBe(REMOTE_SCOPE) // honored, not demoted
+    await new Promise(r => setTimeout(r, 80))
+    expect(postCalls().length, 'a clean engram SHOULD reach the remote').toBe(1)
+  })
+
+  // COMPOSITE (both round-2 fixes together): an UNSCOPED write that auto-routes
+  // (forward domain match) into a SHARED scope must then be demoted by the
+  // sensitivity guard — the guard runs AFTER _resolveUnscopedScope. Proves the
+  // auto-route fix did not open a back-door around the leak guard.
+  it('auto-route into a shared scope is still demoted when the content is sensitive', () => {
+    writeStoresConfig(dir, [
+      { path: join(dir, 'team-store.yaml'), scope: SHARED_SCOPE, readonly: false, covers: ['plur'] },
+      { url: REMOTE_URL, token: 'plur_sk_test', scope: REMOTE_SCOPE, readonly: false },
+    ])
+    const plur = new Plur({ path: dir })
+    // No explicit scope; domain forward-matches `covers:['plur']` → auto-route to
+    // project:plur, then the public IP must force a demotion.
+    const e = plur.learn(`deploy box is ${PUBLIC_IP}`, { domain: 'plur.infra', type: 'behavioral' }) as any
+    expect(e.scope, 'auto-routed shared scope must still demote').toBe('local')
+    expect(e.visibility).toBe('private')
+    expect(e.structured_data?._routed?.scope).toBe(SHARED_SCOPE) // it DID auto-route
+    expect(e.structured_data?._demoted?.from).toBe(SHARED_SCOPE) // and was then demoted
+    expect(readSharedStore(dir).length).toBe(0)
+  })
+
+  // ==========================================================================
+  // PATH 2 — learnRouted() (the remote-routing entry point).
+  // ==========================================================================
+  it('learnRouted() to a remote-backed scope demotes every sensitive payload, ZERO appends, empty outbox', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+
+    for (const payload of SENSITIVE_CORPUS) {
+      const e = (await plur.learnRouted(payload, { scope: REMOTE_SCOPE, type: 'behavioral' })) as any
+      expect(e.scope, `learnRouted(remote) should demote: ${payload}`).toBe('local')
+      expect(e.visibility).toBe('private')
+    }
+    await new Promise(r => setTimeout(r, 80))
+    expect(postCalls().length, 'remote append spy must be ZERO').toBe(0)
+    expect(plur.outboxCount(), 'nothing queued for retry push').toBe(0)
+  })
+
+  it('learnRouted() to a shared local-file scope demotes sensitive payloads', async () => {
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    for (const payload of SENSITIVE_CORPUS) {
+      const e = (await plur.learnRouted(payload, { scope: SHARED_SCOPE, type: 'behavioral' })) as any
+      expect(e.scope).toBe('local')
+      expect(e.visibility).toBe('private')
+    }
+    expect(readSharedStore(dir).length).toBe(0)
+  })
+
+  it('learnRouted() does NOT over-block clean content (it reaches the remote)', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const e = (await plur.learnRouted(CLEAN_CORPUS[1], { scope: REMOTE_SCOPE, type: 'behavioral' })) as any
+    expect(e.scope).toBe(REMOTE_SCOPE)
+    await new Promise(r => setTimeout(r, 80))
+    expect(postCalls().length).toBe(1)
+  })
+
+  // Sensitive material hiding in a CONTEXT FIELD (not the statement) must also be
+  // caught — _guardSensitiveScope scans statement + JSON.stringify(context).
+  it('learnRouted() catches sensitive content hidden in a context field', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const ctx: LearnContext = {
+      scope: REMOTE_SCOPE,
+      type: 'behavioral',
+      rationale: `because the box at ${PUBLIC_IP} keeps the index`,
+    }
+    const e = (await plur.learnRouted('a benign-looking statement', ctx)) as any
+    expect(e.scope, 'sensitive rationale must demote').toBe('local')
+    await new Promise(r => setTimeout(r, 80))
+    expect(postCalls().length).toBe(0)
+    expect(plur.outboxCount()).toBe(0)
+  })
+
+  // ==========================================================================
+  // PATH 3 — reportFailure() on a REMOTE-resident procedural engram whose
+  // LLM-improved statement is sensitive: remote PATCH skipped, blocked outcome.
+  // ==========================================================================
+  it('reportFailure() with a sensitive improved statement never PATCHes the remote', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-101', 'Run the deploy script')
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-101')
+
+    const sensitiveLlm: LlmFunction = async () => `Run the deploy against ${PUBLIC_IP} after exporting the key`
+    const result = await plur.reportFailure(id, 'deploy kept failing', sensitiveLlm)
+
+    expect(patchCalls().length, 'remote PATCH must be ZERO').toBe(0)
+    expect(result.evolved).toBe(false)
+    expect(result.blocked).toBe(true)
+  })
+
+  it('reportFailure() with a CLEAN improved statement DOES PATCH the remote (no over-block)', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-102', 'Run the deploy script')
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-102')
+
+    const cleanLlm: LlmFunction = async () => 'Run the deploy script and verify the health check before declaring success'
+    const result = await plur.reportFailure(id, 'deploy kept failing', cleanLlm)
+
+    expect(patchCalls().length).toBe(1)
+    expect(result.evolved).toBe(true)
+    expect(result.blocked).toBeUndefined()
+  })
+
+  // ==========================================================================
+  // PATH 4 — updateEngram / updateEngramAsync on a REMOTE-resident engram:
+  // a sensitive statement THROWS and never PATCHes.
+  // ==========================================================================
+  it('updateEngramAsync() with a sensitive statement on a remote engram throws, ZERO PATCH', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-103', 'a clean procedure')
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-103')
+    const found = plur.list().find(e => e.id === id)!
+
+    for (const payload of [`connect to ${PUBLIC_IP}:8877`, `login ${BASIC_AUTH_URL}`]) {
+      const sensitive = { ...found, statement: payload } as any
+      await expect(plur.updateEngramAsync(sensitive)).rejects.toThrow(/sensitive content/i)
+    }
+    expect(patchCalls().length, 'remote PATCH must be ZERO').toBe(0)
+  })
+
+  it('updateEngram() (sync) with a sensitive statement on a remote engram throws, ZERO PATCH', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-104', 'a clean procedure')
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-104')
+    const found = plur.list().find(e => e.id === id)!
+    const sensitive = { ...found, statement: `the prod box is ${PUBLIC_IP}` } as any
+
+    expect(() => plur.updateEngram(sensitive)).toThrow(/sensitive content/i)
+    expect(patchCalls().length).toBe(0)
+  })
+
+  // Sensitive content in a CONTEXT FIELD of an explicit remote update must also
+  // throw — _guardExplicitUpdate scans context fields, not just the statement.
+  it('updateEngramAsync() throws on sensitive content hidden in a context field', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-105', 'a clean procedure')
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-105')
+    const found = plur.list().find(e => e.id === id)!
+    const sensitive = { ...found, statement: 'still clean here', rationale: `because ${PUBLIC_IP} is the box` } as any
+
+    await expect(plur.updateEngramAsync(sensitive)).rejects.toThrow(/sensitive content/i)
+    expect(patchCalls().length).toBe(0)
+  })
+
+  it('updateEngramAsync() with a CLEAN statement on a remote engram DOES PATCH (no over-block)', async () => {
+    mockRemoteWithProcedure('ENG-2026-0601-106', 'a clean procedure')
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const id = await primedRemoteId(plur, 'ENG-2026-0601-106')
+    const found = plur.list().find(e => e.id === id)!
+    const clean = { ...found, statement: 'a slightly improved but still clean procedure' } as any
+
+    const patched = await plur.updateEngramAsync(clean)
+    expect(patched).not.toBeNull()
+    expect(patchCalls().length).toBe(1)
+  })
+
+  // A LOCAL-resident engram update with sensitive content DEMOTES in place (does
+  // not throw) and never reaches any shared store.
+  it('updateEngram() on a LOCAL engram demotes a sensitive statement in place', () => {
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    // Create a clean engram at the shared scope; it demotes-on-create, so seed a
+    // genuinely shared-scope LOCAL engram by writing directly, then update it.
+    const seeded = plur.learn('a clean team note', { scope: SHARED_SCOPE, type: 'behavioral' }) as any
+    // It was clean → it should have landed at the shared scope (in the shared file).
+    // Re-fetch its canonical id from whichever store holds it.
+    const all = plur.list()
+    const target = all.find(e => e.statement === 'a clean team note')!
+    const sensitive = { ...target, statement: `now mentions ${PUBLIC_IP}`, scope: SHARED_SCOPE } as any
+    const ok = plur.updateEngram(sensitive)
+    expect(ok).toBe(true)
+    const updated = plur.list().find(e => String(e.statement).includes(PUBLIC_IP))!
+    expect(updated.scope, 'local-resident sensitive update must demote').toBe('local')
+    expect((updated as any).visibility).toBe('private')
+    expect(readSharedStore(dir).find(e => String(e.statement).includes(PUBLIC_IP))).toBeUndefined()
+  })
+
+  // ==========================================================================
+  // PATH 5 — saveMetaEngrams(): the historically-unguarded persist path.
+  // ==========================================================================
+  it('saveMetaEngrams() demotes a shared-scope meta carrying infra-sensitive content', () => {
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+
+    const metas = SENSITIVE_CORPUS
+      // basic-auth URL would be caught by the HARD detectSecrets? No — it is NOT
+      // (verified in corpus sanity), so it goes through the SOFT demotion path
+      // like the rest. The IPv4:port and IP forms are also SOFT (infra).
+      .map((statement, i) => ({
+        id: `META-FUZZ-${i}`,
+        scope: SHARED_SCOPE,
+        statement,
+        type: 'behavioral',
+        status: 'active',
+        knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+      })) as any[]
+
+    const res = plur.saveMetaEngrams(metas)
+    expect(res.saved).toBe(metas.length)
+
+    const local = readLocalEngrams(dir)
+    for (const m of metas) {
+      const persisted = local.find(e => e.id === m.id)
+      expect(persisted, `meta ${m.id} persisted`).toBeDefined()
+      expect(persisted.scope, `meta ${m.id} demoted`).toBe('local')
+      expect(persisted.visibility).toBe('private')
+      expect(persisted.structured_data?._demoted?.to).toBe('local')
+    }
+    // None written at the shared scope.
+    expect(local.some(e => e.scope === SHARED_SCOPE)).toBe(false)
+    expect(readSharedStore(dir).length).toBe(0)
+  })
+
+  it('saveMetaEngrams() does NOT demote a clean shared-scope meta', () => {
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    const metas = [{
+      id: 'META-FUZZ-CLEAN',
+      scope: SHARED_SCOPE,
+      statement: CLEAN_CORPUS[2],
+      type: 'behavioral',
+      status: 'active',
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    }] as any[]
+    plur.saveMetaEngrams(metas)
+    const persisted = readLocalEngrams(dir).find(e => e.id === 'META-FUZZ-CLEAN')
+    expect(persisted.scope, 'clean meta keeps its scope').toBe(SHARED_SCOPE)
+  })
+
+  // ==========================================================================
+  // PATH 6 — learnAsync UPDATE: a clean engram is mutated to sensitive via the
+  // dedup UPDATE branch; it must demote, and never push to remote.
+  // ==========================================================================
+  it('learnAsync UPDATE: mutating a clean shared engram to sensitive demotes it, ZERO remote egress', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+
+    // Seed a clean engram at the shared LOCAL-FILE scope (no demotion on create).
+    plur.learn('the deployment runbook lives in the team wiki', { scope: SHARED_SCOPE, type: 'behavioral' })
+    const seededId = plur.list().find(e => e.statement.includes('deployment runbook'))!.id
+
+    // Force the dedup UPDATE decision: an LLM that always says UPDATE this target.
+    // parseDedupResponse expects `DECISION:`/`TARGET:` lines (NOT JSON).
+    const updateLlm: LlmFunction = async () => `DECISION: UPDATE\nTARGET: ${seededId}\nREASON: same runbook`
+    const res = await plur.learnAsync(`the deployment runbook now references ${PUBLIC_IP}`, {
+      scope: SHARED_SCOPE,
+      llm: updateLlm,
+    })
+
+    // The mutation must have been a real UPDATE (not an ADD) and demoted.
+    expect(res.decision).toBe('UPDATE')
+    expect(res.engram.scope, 'learnAsync UPDATE must demote').toBe('local')
+    expect((res.engram as any).visibility).toBe('private')
+    expect((res.engram as any).structured_data?._demoted?.to).toBe('local')
+
+    await new Promise(r => setTimeout(r, 80))
+    expect(egressCalls().length, 'no append/PATCH to remote').toBe(0)
+    expect(readSharedStore(dir).find(e => String(e.statement).includes(PUBLIC_IP))).toBeUndefined()
+  })
+
+  // ==========================================================================
+  // PATH 7 — learnAsync MERGE: concatenation introduces sensitive content.
+  // ==========================================================================
+  it('learnAsync MERGE: concatenating sensitive content into a clean shared engram demotes it', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+
+    plur.learn('the deployment notes summary for the release', { scope: SHARED_SCOPE, type: 'behavioral' })
+    const seededId = plur.list().find(e => e.statement.includes('deployment notes'))!.id
+
+    const mergeLlm: LlmFunction = async () => `DECISION: MERGE\nTARGET: ${seededId}\nREASON: complementary deployment notes`
+    const res = await plur.learnAsync(`the deployment target host is ${BASIC_AUTH_URL}`, {
+      scope: SHARED_SCOPE,
+      llm: mergeLlm,
+    })
+
+    expect(res.decision).toBe('MERGE')
+    expect(res.engram.scope, 'learnAsync MERGE must demote').toBe('local')
+    expect((res.engram as any).visibility).toBe('private')
+
+    await new Promise(r => setTimeout(r, 80))
+    expect(egressCalls().length).toBe(0)
+    expect(readSharedStore(dir).find(e => String(e.statement).includes('hub-staging'))).toBeUndefined()
+  })
+
+  it('learnAsync UPDATE: a CLEAN mutation does NOT demote (no over-block)', async () => {
+    writeStoresConfig(dir, bothStores(dir))
+    const plur = new Plur({ path: dir })
+    plur.learn('original clean note about the deployment wiki', { scope: SHARED_SCOPE, type: 'behavioral' })
+    const seededId = plur.list().find(e => e.statement.includes('original clean note'))!.id
+    const updateLlm: LlmFunction = async () => `DECISION: UPDATE\nTARGET: ${seededId}\nREASON: same note`
+    const res = await plur.learnAsync('a still-clean revised note about the deployment wiki', {
+      scope: SHARED_SCOPE,
+      llm: updateLlm,
+    })
+    expect(res.decision).toBe('UPDATE')
+    expect(res.engram.scope, 'clean UPDATE keeps the shared scope').toBe(SHARED_SCOPE)
+  })
+
+  // ==========================================================================
+  // PATH 8 — flushOutbox(): a STALE / POISONED queue entry carrying sensitive
+  // content (it bypassed the write-time guard, e.g. injected directly or queued
+  // before a policy tightened) must be RE-GUARDED at flush time and never pushed.
+  // ==========================================================================
+  it('flushOutbox() re-guards a poisoned _outbox entry: ZERO append, demoted in place', async () => {
+    mockEmptyRemote() // remote is UP — the re-guard must hold it back anyway
+    writeStoresConfig(dir, bothStores(dir))
+
+    // Inject an _outbox engram directly into the local store, carrying sensitive
+    // content targeting the REMOTE scope under the DEFAULT (forbid-all) policy.
+    // This simulates a stale/poisoned queue entry that never saw the write guard.
+    const poisoned = {
+      id: 'ENG-FUZZ-OUTBOX-1',
+      version: 2,
+      status: 'active',
+      type: 'behavioral',
+      scope: REMOTE_SCOPE,
+      visibility: 'public',
+      statement: `the prod jump box is ${PUBLIC_IP} reachable at ${BASIC_AUTH_URL}`,
+      activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 0, last_accessed: '2026-06-01' },
+      feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+      tags: [],
+      content_hash: 'deadbeef',
+      structured_data: {
+        _outbox: {
+          target_url: REMOTE_URL,
+          target_scope: REMOTE_SCOPE,
+          queued_at: new Date().toISOString(),
+          last_attempt: new Date().toISOString(),
+          attempt_count: 0,
+          last_error: '',
+        },
+      },
+    }
+    writeLocalEngrams(dir, [poisoned])
+
+    const plur = new Plur({ path: dir })
+    expect(plur.outboxCount()).toBe(1)
+
+    const result = await plur.flushOutbox()
+
+    // NOT flushed, counted as failed, never POSTed.
+    expect(result.flushed).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(postCalls().length, 'poisoned outbox entry must NEVER be appended').toBe(0)
+    expect(result.expired_warnings.some(w => /demoted to local\/private|now forbidden/.test(w))).toBe(true)
+
+    // Demoted in place: scope→local, _outbox dropped, _demoted stamped.
+    const found = readLocalEngrams(dir).find(e => e.id === 'ENG-FUZZ-OUTBOX-1')
+    expect(found.scope).toBe('local')
+    expect(found.visibility).toBe('private')
+    expect(found.structured_data?._outbox).toBeUndefined()
+    expect(found.structured_data?._demoted?.to).toBe('local')
+  })
+
+  it('flushOutbox() still pushes a CLEAN queued entry (no over-block)', async () => {
+    mockEmptyRemote()
+    writeStoresConfig(dir, bothStores(dir))
+    const clean = {
+      id: 'ENG-FUZZ-OUTBOX-2',
+      version: 2,
+      status: 'active',
+      type: 'behavioral',
+      scope: REMOTE_SCOPE,
+      visibility: 'public',
+      statement: 'a perfectly clean personal note',
+      activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 0, last_accessed: '2026-06-01' },
+      feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+      tags: [],
+      content_hash: 'cafef00d',
+      structured_data: {
+        _outbox: {
+          target_url: REMOTE_URL,
+          target_scope: REMOTE_SCOPE,
+          queued_at: new Date().toISOString(),
+          last_attempt: new Date().toISOString(),
+          attempt_count: 0,
+          last_error: '',
+        },
+      },
+    }
+    writeLocalEngrams(dir, [clean])
+    const plur = new Plur({ path: dir })
+    const result = await plur.flushOutbox()
+    expect(result.flushed).toBe(1)
+    expect(postCalls().length, 'a clean queued entry SHOULD be appended').toBe(1)
+  })
+})

--- a/packages/core/test/adversarial/routing-fuzz.test.ts
+++ b/packages/core/test/adversarial/routing-fuzz.test.ts
@@ -1,0 +1,338 @@
+/**
+ * ADVERSARIAL ROUTING FUZZER (0.10.0 third / final scope-security audit).
+ *
+ * Exercises the two routing surfaces that decide where a genuinely-UNSCOPED
+ * engram lands, across a large generated corpus of (engram-domain × scope-covers)
+ * combinations plus tag-only / keyword-only / readonly variants:
+ *
+ *   1. rankScopes()           — the pure deterministic ranker (scope-routing.ts).
+ *                               Asserts the directionality flags it stamps —
+ *                               `coverContainsDomain` (FORWARD only) and
+ *                               `domainMatch` (either direction) — are computed
+ *                               correctly for every pair. These flags are the
+ *                               KEY the write-path bypass relies on (reaudit
+ *                               finding 4): a wrong flag is a latent over-route.
+ *
+ *   2. _resolveUnscopedScope() — the actual write-path decision (index.ts). For
+ *                               every corpus case it asserts the resolved scope
+ *                               against an INDEPENDENT oracle derived from the
+ *                               documented contract, and — adversarially — the
+ *                               two security-critical invariants directly:
+ *                                 • NO OVER-ROUTE: a reverse-only (domain ⊃ cover,
+ *                                   "engram broader than the narrow scope") or a
+ *                                   weak (tag-/keyword-only sub-threshold) signal
+ *                                   must NOT land in a shared scope — it falls to
+ *                                   the unscoped default.
+ *                                 • NO UNDER-ROUTE: a clean FORWARD domain match
+ *                                   (cover ⊃ domain or cover === domain) to a
+ *                                   WRITABLE scope must route there.
+ *                                 • Readonly scopes are excluded from auto-route.
+ *
+ * The oracle is built from the spec text, NOT by calling the production ranker,
+ * so a bug in rankScopes that flips a flag is caught by surface (1), and a bug in
+ * _resolveUnscopedScope that mis-applies the flags/threshold is caught by the
+ * scope mismatch in surface (2). The two cross-check each other.
+ *
+ * DURABLE — keep this file. A failure here is a real finding.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur, rankScopes, SCOPE_MATCH_THRESHOLD } from '../../src/index.js'
+import { isSharedScope } from '../../src/scope-util.js'
+
+// ---------------------------------------------------------------------------
+// Independent oracle helpers — derived from the SPEC, not the implementation.
+// ---------------------------------------------------------------------------
+
+/** Normalize a cover token the way the ranker does: lowercase, strip trailing
+ * glob. Re-implemented here so the oracle does not import the private helper. */
+function normCover(cover: string): string {
+  return cover.toLowerCase().replace(/\.?\*$/, '')
+}
+
+/** `value` sits under `prefix` as a dotted namespace (equality counts). */
+function isNsPrefix(prefix: string, value: string): boolean {
+  if (!prefix) return false
+  return value === prefix || value.startsWith(prefix + '.')
+}
+
+type DomainDir = 'forward' | 'reverse' | 'none'
+
+/**
+ * Independently classify the domain channel for a (domain, covers) pair:
+ *   forward — some cover ⊃ domain or cover === domain  (engram belongs in scope)
+ *   reverse — domain ⊃ some cover (strictly)           (engram broader than scope)
+ *   none    — no namespace relation
+ * Forward takes precedence (the ranker breaks on the first forward hit), so if
+ * ANY cover is forward we report forward.
+ */
+function classifyDomain(domain: string | undefined, covers: string[]): DomainDir {
+  const d = domain?.toLowerCase().trim()
+  if (!d) return 'none'
+  const norms = covers.map(normCover).filter(c => c.length > 0)
+  if (norms.some(c => isNsPrefix(c, d))) return 'forward'   // cover ⊃ domain
+  if (norms.some(c => isNsPrefix(d, c))) return 'reverse'   // domain ⊃ cover
+  return 'none'
+}
+
+// ---------------------------------------------------------------------------
+// Plur construction (mirrors route-unscoped.test.ts makePlur).
+// ---------------------------------------------------------------------------
+const dirs: string[] = []
+function makePlur(config: Record<string, unknown>): Plur {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-routing-fuzz-'))
+  dirs.push(dir)
+  writeFileSync(join(dir, 'config.yaml'), yaml.dump({ index: false, ...config }, { noRefs: true }))
+  return new Plur({ path: dir })
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true })
+})
+
+type Resolver = {
+  _resolveUnscopedScope: (
+    s: string,
+    c?: { domain?: string; tags?: string[] },
+  ) => { scope: string; routed: { scope: string; confidence: number; reason: string } | null }
+}
+
+// ---------------------------------------------------------------------------
+// Corpus generation.
+// ---------------------------------------------------------------------------
+
+const SHARED_SCOPE = 'group:plur/core' // a SHARED, writable scope
+const FALLBACK = 'global'              // schema default unscoped_default
+
+/** Domains spanning broad → specific, plus adversarial near-misses. */
+const DOMAINS = [
+  'plur',
+  'plur.core',
+  'plur.core.security',
+  'plur.core.security.tokens',
+  'plurple',            // segment-boundary near-miss: NOT under 'plur'
+  'plur2',              // near-miss
+  'other.namespace',    // unrelated
+  'PLUR.Core',          // case variation → forward against plur.core
+  ' plur.core ',        // whitespace variation
+  undefined,            // no domain
+] as const
+
+/** Cover sets spanning glob/exact/narrow/broad/empty/unrelated. */
+const COVER_SETS: string[][] = [
+  ['plur.*'],
+  ['plur'],
+  ['plur.core'],
+  ['plur.core.*'],
+  ['plur.core.security'],
+  ['plur.core.security.tokens'],
+  ['plur.core.security.tokens.deep'], // narrower than every domain → reverse for specific domains
+  ['servers'],                         // unrelated to plur domains
+  ['plurple'],                         // near-miss token
+  [],                                  // no covers → omitted entirely
+]
+
+// ---------------------------------------------------------------------------
+// SURFACE 1 — pure ranker directionality. Exhaustive over DOMAINS × COVER_SETS.
+// ---------------------------------------------------------------------------
+describe('routing-fuzz — rankScopes directionality flags (forward/reverse classification)', () => {
+  const wrong: string[] = []
+  let cases = 0
+
+  it('coverContainsDomain is set IFF the domain match is FORWARD; domainMatch covers either direction', () => {
+    for (const domain of DOMAINS) {
+      for (const covers of COVER_SETS) {
+        cases++
+        const ranked = rankScopes(
+          { statement: 'xyzzy nonoverlapping unique tokens qwertz', domain, tags: [] },
+          [{ scope: SHARED_SCOPE, covers }],
+        )
+        const cand = ranked.find(c => c.scope === SHARED_SCOPE)
+        const dir = classifyDomain(domain, covers)
+
+        if (dir === 'forward') {
+          if (!cand) { wrong.push(`FORWARD but no candidate: domain=${String(domain)} covers=${JSON.stringify(covers)}`); continue }
+          if (!cand.coverContainsDomain)
+            wrong.push(`FORWARD but coverContainsDomain=false: domain=${String(domain)} covers=${JSON.stringify(covers)} reason="${cand.reason}"`)
+          if (!cand.domainMatch)
+            wrong.push(`FORWARD but domainMatch=false: domain=${String(domain)} covers=${JSON.stringify(covers)}`)
+        } else if (dir === 'reverse') {
+          if (!cand) { wrong.push(`REVERSE but no candidate: domain=${String(domain)} covers=${JSON.stringify(covers)}`); continue }
+          // Reverse: domainMatch true, coverContainsDomain MUST be false (the
+          // over-route guard). A true here is a latent over-route bug.
+          if (cand.coverContainsDomain)
+            wrong.push(`REVERSE but coverContainsDomain=TRUE (over-route risk): domain=${String(domain)} covers=${JSON.stringify(covers)} reason="${cand.reason}"`)
+          if (!cand.domainMatch)
+            wrong.push(`REVERSE but domainMatch=false: domain=${String(domain)} covers=${JSON.stringify(covers)}`)
+          // A lone reverse hit must squash strictly below threshold (down-weighted).
+          if (cand.confidence >= SCOPE_MATCH_THRESHOLD)
+            wrong.push(`REVERSE lone hit confidence>=threshold (${cand.confidence}): domain=${String(domain)} covers=${JSON.stringify(covers)}`)
+        } else {
+          // No domain relation: if a candidate exists at all it must NOT claim a
+          // domain match in either flag (it could exist via tag/keyword, but here
+          // tags=[] and the statement shares no tokens, so usually no candidate).
+          if (cand?.coverContainsDomain)
+            wrong.push(`NONE but coverContainsDomain=true: domain=${String(domain)} covers=${JSON.stringify(covers)} reason="${cand.reason}"`)
+          if (cand?.domainMatch)
+            wrong.push(`NONE but domainMatch=true: domain=${String(domain)} covers=${JSON.stringify(covers)} reason="${cand.reason}"`)
+        }
+      }
+    }
+    expect(cases).toBeGreaterThan(80)
+    expect(wrong, `directionality mismatches:\n${wrong.join('\n')}`).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SURFACE 2 — write-path decision via _resolveUnscopedScope.
+//
+// Oracle decision rule (from index.ts contract):
+//   if auto_route_scope === false        → FALLBACK
+//   drop readonly scopes from candidates
+//   forward domain match (writable)      → that scope          (deterministic bypass)
+//   else top.confidence >= threshold     → that scope          (>= gate)
+//   else                                 → FALLBACK
+//
+// We test single-scope configs so "top" is unambiguous, and assert the resolved
+// scope against the oracle PLUS the two adversarial security invariants.
+// ---------------------------------------------------------------------------
+describe('routing-fuzz — _resolveUnscopedScope no-over-route / no-under-route', () => {
+  // Each scenario fixes a scope (writable or readonly) and varies the engram
+  // signals. The statement is token-disjoint from covers so the ONLY signals are
+  // the domain channel and explicit tags — keeping the oracle tractable.
+  const STMT = 'xyzzy nonoverlapping unique tokens qwertz' // shares no cover tokens
+
+  type Case = {
+    label: string
+    covers: string[]
+    readonly: boolean
+    domain?: string
+    tags?: string[]
+    /** Expected resolved scope per the independent oracle. */
+    expect: string
+  }
+
+  const SCOPE = SHARED_SCOPE
+  const cases: Case[] = []
+
+  // (a) Domain × cover matrix on a WRITABLE shared scope, no tags.
+  for (const domain of DOMAINS) {
+    for (const covers of COVER_SETS) {
+      const dir = classifyDomain(domain, covers)
+      // Oracle: forward → route to scope; reverse/none with a lone signal → fallback
+      // (reverse squashes to 0.25 < 0.5; none has no candidate). Empty covers →
+      // scope omitted entirely → fallback.
+      const exp = dir === 'forward' && covers.length > 0 ? SCOPE : FALLBACK
+      cases.push({
+        label: `writable domain=${String(domain)} covers=${JSON.stringify(covers)} (${dir})`,
+        covers,
+        readonly: false,
+        domain,
+        expect: exp,
+      })
+    }
+  }
+
+  // (b) Readonly scope: a FORWARD domain match must STILL fall to fallback
+  // (readonly excluded from auto-route candidates).
+  for (const covers of [['plur.*'], ['plur.core'], ['plur']]) {
+    cases.push({
+      label: `readonly forward covers=${JSON.stringify(covers)}`,
+      covers,
+      readonly: true,
+      domain: 'plur.core.security',
+      expect: FALLBACK,
+    })
+  }
+
+  // (c) Tag-only matches: 1 tag (0.25), 2 tags (0.40) → fallback; 3 tags (0.50) → route.
+  cases.push({ label: 'tag-only x1 (0.25 < thr)', covers: ['a'], readonly: false, tags: ['a'], expect: FALLBACK })
+  cases.push({ label: 'tag-only x2 (0.40 < thr)', covers: ['a', 'b'], readonly: false, tags: ['a', 'b'], expect: FALLBACK })
+  cases.push({ label: 'tag-only x3 (0.50 >= thr)', covers: ['a', 'b', 'c'], readonly: false, tags: ['a', 'b', 'c'], expect: SCOPE })
+
+  // (d) Reverse domain + tags: reverse(0.5)+3 tags(1.5)=2.0 → squash 0.571 → routes
+  // via the >= gate (reverse contributes, is not discarded).
+  cases.push({
+    label: 'reverse domain + 3 tags clears threshold',
+    covers: ['plur.core', 'alpha', 'beta', 'gamma'],
+    readonly: false,
+    domain: 'plur',
+    tags: ['alpha', 'beta', 'gamma'],
+    expect: SCOPE,
+  })
+
+  // (e) Reverse domain alone (the canonical over-route scenario) → fallback.
+  cases.push({
+    label: 'reverse domain alone (over-route scenario) → fallback',
+    covers: ['plur.core'],
+    readonly: false,
+    domain: 'plur',
+    expect: FALLBACK,
+  })
+
+  const failures: string[] = []
+  const overRoutes: string[] = []
+  const underRoutes: string[] = []
+
+  it('resolves every case per the independent oracle, with no over-route into the shared scope and no under-route of a forward match', () => {
+    for (const c of cases) {
+      const store: Record<string, unknown> = c.readonly
+        ? { url: 'https://ro.example.com', token: 't', readonly: true, scope: SCOPE, description: 'S', covers: c.covers }
+        : { path: '/tmp/fuzz.yaml', scope: SCOPE, description: 'S', covers: c.covers }
+      const plur = makePlur({ stores: [store] }) as unknown as Resolver
+      const res = plur._resolveUnscopedScope(c.domain ? STMT : STMT, { domain: c.domain, tags: c.tags })
+
+      if (res.scope !== c.expect)
+        failures.push(`${c.label}: oracle=${c.expect} got=${res.scope} routed=${JSON.stringify(res.routed)}`)
+
+      // SECURITY INVARIANT 1 — NO OVER-ROUTE. The shared scope is reached only
+      // when the oracle says so. Any reverse-only or sub-threshold signal landing
+      // in the shared scope is an over-route leak.
+      if (res.scope === SCOPE && c.expect !== SCOPE)
+        overRoutes.push(`${c.label}: landed in SHARED ${SCOPE} (oracle=${c.expect})`)
+
+      // SECURITY INVARIANT 2 — NO UNDER-ROUTE of a clean forward match to a
+      // writable scope (a forward case that fell to fallback).
+      if (c.expect === SCOPE && res.scope !== SCOPE)
+        underRoutes.push(`${c.label}: forward/threshold match did NOT route (got ${res.scope})`)
+
+      // The shared scope is in fact shared (sanity on the predicate the guard uses).
+      expect(isSharedScope(SCOPE)).toBe(true)
+    }
+
+    expect(overRoutes, `OVER-ROUTE (leak) cases:\n${overRoutes.join('\n')}`).toEqual([])
+    expect(underRoutes, `UNDER-ROUTE cases:\n${underRoutes.join('\n')}`).toEqual([])
+    expect(failures, `oracle mismatches:\n${failures.join('\n')}`).toEqual([])
+  })
+
+  it('auto_route_scope:false never routes regardless of a perfect forward domain match', () => {
+    const bad: string[] = []
+    for (const covers of [['plur.*'], ['plur'], ['plur.core']]) {
+      const plur = makePlur({
+        auto_route_scope: false,
+        stores: [{ path: '/tmp/fuzz.yaml', scope: SCOPE, description: 'S', covers }],
+      }) as unknown as Resolver
+      const res = plur._resolveUnscopedScope(STMT, { domain: 'plur.core.security' })
+      if (res.scope !== FALLBACK || res.routed !== null)
+        bad.push(`covers=${JSON.stringify(covers)} → scope=${res.scope} routed=${JSON.stringify(res.routed)}`)
+    }
+    expect(bad, `auto_route_scope:false leaked a route:\n${bad.join('\n')}`).toEqual([])
+  })
+
+  it('multi-candidate forward ties resolve deterministically and stay within a forward scope', () => {
+    // Two shared scopes that both forward-match the domain. Winner must be one of
+    // them (never fallback — that would be an under-route) and deterministic.
+    const plur = makePlur({
+      stores: [
+        { path: '/tmp/b.yaml', scope: 'group:plur/b', description: 'B', covers: ['plur.*'] },
+        { path: '/tmp/a.yaml', scope: 'group:plur/a', description: 'A', covers: ['plur.core.*'] },
+      ],
+    }) as unknown as Resolver
+    const r1 = plur._resolveUnscopedScope(STMT, { domain: 'plur.core.security' })
+    const r2 = plur._resolveUnscopedScope(STMT, { domain: 'plur.core.security' })
+    expect(r1.scope).toBe(r2.scope)                  // deterministic
+    expect(['group:plur/a', 'group:plur/b']).toContain(r1.scope) // forward, not fallback
+  })
+})


### PR DESCRIPTION
The final 0.10.0 security audit ran three attack-test (fuzzer) files against the leak-guard that decides whether an engram is safe to share. They found two real problems in the part that recognizes server addresses, plus one gap where a real internal host could slip through. This PR fixes all three and keeps the fuzzers as permanent tests.

## What each fix does

**1. Stop a slowdown attack on the host:port detector (was HIGH).**
The detector that recognizes things like `db.internal:5432` could be tricked into doing an enormous amount of backtracking work. A single long dotted token with no port (e.g. 64KB of `a.a.a.a...`) made the scanner grind for about **4 seconds** — and because this scan runs on every save/publish, an attacker could stall the whole write path. We rewrote the pattern so each dot is a hard anchor with bounded repetition (no ambiguous nesting). It now runs in **~25ms** on the same 64KB input — fully linear time. Real host:port addresses (`db.internal:5432`, `hub.example.com:443`, `redis.prod.svc:6379`) are still recognized.

**2. Stop the false alarm on code references (was MEDIUM).**
A code citation like `inject.ts:49`, `app.py:100`, or `main.rs:55` looked exactly like a server `host.tld:port` to the detector — `ts` looked like a domain suffix and `49` looked like a port — so a perfectly shareable engram that merely pointed at a line of code got silently demoted to private. We now exclude a curated list of source/file extensions (ts, tsx, js, py, rs, go, rb, java, json, yaml, md, …) in the suffix position. So `file.ts:49` is left alone, while `db.internal:5432` is still flagged.

**3. Close the internal-host assignment gap (was LOW) + fix an inaccurate comment.**
A previous round added `=`, `,`, `;` to the *end* boundary of the internal-host detector but not the *start* boundary, even though the comment claimed both. As a result the common env-var shape `host=db.internal`, `DATABASE_HOST=app.corp`, and comma-separated host lists were never flagged. We added those characters (plus `.` and `]` for symmetry) to the leading boundary and corrected the comment to match reality.

While fixing #3 the fuzzer's `ab.ab.ab…` bait also exposed that the **internal-host detector had the same slowdown bug** (~8s on a 64KB run). We bounded its host patterns the same way; it's now linear too.

## Timing, before → after (64KB worst-case input, full detector path)

| Input | Before | After |
|-------|--------|-------|
| `a.a.a…` (no port) | ~4000 ms | ~25 ms |
| `ab.ab…` (no port) | ~3500–8000 ms | ~28 ms |

## The attack-test suite is now permanent

The three fuzzer files (`detector-fuzz`, `guard-fuzz`, `routing-fuzz` — 287 adversarial cases total) are committed under `packages/core/test/adversarial/` so they run in CI on every change. They assert zero false negatives (no leak escapes), zero false positives (no shareable content wrongly demoted), the ReDoS timing budget, zero remote egress of sensitive content across every write path, and correct routing directionality.

## Verification
- All 3 fuzzers pass (287/287).
- Full `@plur-ai/core` suite: 1508 passing.
- Full workspace (core + mcp + claw, dist rebuilt first): 1986 passing.
- `tsc --noEmit` on core: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)