### PR TITLE
Make the release notes findable by the release script + harden config writeback against bad data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.10.0 (2026-06-21)
+
 ### Leak guard: write-time demotion now covers `saveMetaEngrams` and remote-backed scopes (#368, #370)
 
 The sensitivity leak guard — which detects secrets/infra patterns in an engram and demotes a shared-scope write to `local`/`private` before it can reach a shared store — now runs on more write paths:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1113,19 +1113,23 @@ export class Plur {
     // also true for the REVERSE direction (engram domain BROADER than the cover,
     // `domain ⊃ cover`), and bypassing on that would over-route a broad/generic
     // engram (domain `plur`) into a NARROW shared scope (cover `plur.core`) it
-    // doesn't belong in. The reverse match still adds WEIGHT_DOMAIN to the squashed
-    // confidence below, so a lone reverse hit (conf 0.5) can still route via the
-    // `>=` threshold path — it just doesn't get the deterministic bypass.
-    // rankScopes prefers a domain-match candidate at the top on equal confidence,
-    // so `top` is the right scope to route to. Weights/threshold/squash UNCHANGED.
+    // doesn't belong in. The reverse match adds only the down-weighted
+    // WEIGHT_DOMAIN_REVERSE (0.5 raw, NOT the full WEIGHT_DOMAIN of 1.5), so a lone
+    // reverse hit squashes to 0.25 — BELOW SCOPE_MATCH_THRESHOLD (0.5) — and so
+    // does NOT route via the `>=` threshold path either (and never gets the
+    // deterministic bypass). rankScopes prefers a domain-match candidate at the top
+    // on equal confidence, so `top` is the right scope to route to. Weights/
+    // threshold/squash UNCHANGED.
     if (top && top.coverContainsDomain) {
       return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
     }
     // No forward domain match: a reverse domain hit, tag-only, or keyword-only
     // candidate stays gated by the threshold exactly as before — conservative by
-    // design. A lone reverse-direction match squashes to exactly 0.5 and so still
-    // clears the `>=` gate; a future weight tweak can de-calibrate it safely
-    // without the deterministic bypass forcing it in.
+    // design. A LONE reverse-direction match squashes to 0.25 (WEIGHT_DOMAIN_REVERSE
+    // = 0.5 raw) and so does NOT clear the `>=` gate; it falls to the unscoped
+    // default unless additional tag/keyword evidence lifts the squashed score to
+    // >= SCOPE_MATCH_THRESHOLD. The deterministic bypass never forces a broad
+    // engram in.
     if (top && top.confidence >= SCOPE_MATCH_THRESHOLD) {
       return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
     }
@@ -3419,10 +3423,19 @@ Generate an improved version of the procedure that prevents this failure. Return
    *  token-rotation paths. */
   private persistStores(stores: StoreEntry[]): void {
     let configData: Record<string, unknown> = {}
+    // Read the existing config to preserve other top-level keys (auto_learn,
+    // packs, embeddings, routing defaults, …). A TRANSIENT read failure on an
+    // EXISTING file (EACCES, a concurrent truncating writer, a momentary FS
+    // error) must NOT be swallowed: proceeding from `{}` would write a
+    // stores-only file and silently drop every other top-level setting. Only an
+    // ENOENT (the config genuinely doesn't exist yet) is safe to start from `{}`;
+    // any other error aborts the writeback so we never truncate a live config.
     try {
       const raw = fs.readFileSync(this.paths.config, 'utf8')
       if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
-    } catch {}
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+    }
     configData.stores = this.mergeStoresForWriteback(configData.stores, stores)
     fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
     this.config = loadConfig(this.paths.config)
@@ -3466,7 +3479,19 @@ Generate an improved version of the procedure that prevents this failure. Return
         if (!k) logger.warning(`[plur:persistStores] store entry for scope "${typed.scope}" has neither url nor path — writing typed entry as-is`)
         return typed
       }
-      const rawSensitivity = (raw as { sensitivity?: Record<string, unknown> }).sensitivity
+      const rawSensitivityValue = (raw as { sensitivity?: unknown }).sensitivity
+      // The raw config is un-validated, un-salvaged on-disk YAML (persistStores
+      // reads it via yaml.load, NOT loadConfig), so `sensitivity` can be ANYTHING
+      // a hand-edit put there — including a truthy primitive (`sensitivity: 'oops'`,
+      // `5`, `true`). loadConfig dedups nothing over `stores`, so a duplicate entry
+      // on the same url+scope key can leave a primitive in rawMap (last-wins) while
+      // the typed entry carries a proper object. Only treat raw sensitivity as a
+      // mergeable object when it actually IS a plain object — otherwise the spreads
+      // and the `in` operator below corrupt the merge or throw a TypeError.
+      const rawSensitivity =
+        rawSensitivityValue && typeof rawSensitivityValue === 'object' && !Array.isArray(rawSensitivityValue)
+          ? (rawSensitivityValue as Record<string, unknown>)
+          : undefined
       // R2-D (#14): `forbid` is a KNOWN field whose value is NORMALIZED at read
       // time (loadConfig's preprocess rewrites a forward-compat `forbid:['pii']`
       // to the safe default). A shallow `...typed.sensitivity` would then write

--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -121,9 +121,11 @@ export interface ScopeCandidate {
    * True when this candidate matched via the domain-prefix channel — in EITHER
    * direction: the engram's `domain` is namespace-covered by one of the scope's
    * `covers` entries (`cover ⊃ domain`, forward), OR the engram's `domain` is
-   * BROADER than the cover (`domain ⊃ cover`, reverse). Both directions add the
-   * full WEIGHT_DOMAIN to the squashed `confidence`, so this flag exists for
-   * scoring/ordering (the domain-preferring tie-break) — NOT as the bypass key.
+   * BROADER than the cover (`domain ⊃ cover`, reverse). The two directions are
+   * NOT weighted equally: forward adds the full WEIGHT_DOMAIN (1.5) while reverse
+   * adds only WEIGHT_DOMAIN_REVERSE (= WEIGHT_TAG = 0.5), so a lone reverse hit
+   * squashes to 0.25 and does NOT auto-route. This flag exists for scoring/ordering
+   * (the domain-preferring tie-break) — NOT as the bypass key.
    *
    * Do NOT use `domainMatch` for the deterministic auto-route bypass: the reverse
    * direction would over-route a broad/generic engram into a NARROW shared scope
@@ -140,9 +142,11 @@ export interface ScopeCandidate {
    * The caller (`_resolveUnscopedScope` in index.ts) routes a clean FORWARD
    * domain match DETERMINISTICALLY, bypassing the squash/threshold edge. The
    * REVERSE direction (`domain ⊃ cover`, engram broader than the cover) leaves
-   * this `false`: it still contributes to `confidence` (so it can route via the
-   * normal `>=` threshold gate) but never gets the deterministic bypass, so a
-   * broad engram never deterministically lands in a narrow shared scope.
+   * this `false`: it contributes only the down-weighted WEIGHT_DOMAIN_REVERSE
+   * (0.5), so a LONE reverse hit squashes to 0.25 — below the `>=` threshold —
+   * and never gets the deterministic bypass either. A broad engram therefore
+   * never lands in a narrow shared scope on the reverse match alone; it can only
+   * route if additional tag/keyword evidence pushes the squashed score to >= 0.5.
    * Weak signals (tag-only, keyword-only) also leave this `false`.
    */
   coverContainsDomain: boolean

--- a/packages/core/test/pr3-config-robustness.test.ts
+++ b/packages/core/test/pr3-config-robustness.test.ts
@@ -23,7 +23,7 @@
  * NON-VACUOUS — it proves the WRITEBACK path, not merely the read path.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
@@ -314,5 +314,150 @@ describe('PR-3 config robustness — version-skew writeback (no field stripping)
     expect(byScope['group:comms'].token).toBe('comms-tok')
     expect(byScope['group:comms'].url).toBe(URL)
     expect(byScope['group:comms'].comms_marker).toBe('C')
+  })
+})
+
+/**
+ * R3 (final-audit MEDIUM): the R2-D forbid-restore added an `'forbid' in
+ * rawSensitivity` membership check WITHOUT a runtime object check. loadConfig
+ * does not dedup `stores`, so a hand-edited config with two entries on the SAME
+ * url+scope key — one with a proper sensitivity OBJECT, one with a malformed
+ * truthy PRIMITIVE (`sensitivity: 'oops'`) — survives loading. rawMap keeps the
+ * LAST raw dup (the primitive), and merging the object-typed entry then runs the
+ * `in` operator against a string and throws a TypeError that propagates out of
+ * addStore. The guard now type-checks rawSensitivity is a plain object first.
+ */
+describe('R3 config robustness — mergeStoresForWriteback primitive-sensitivity crash', () => {
+  const dirs: string[] = []
+  const mkdir = (): string => { const d = mkdtempSync(join(tmpdir(), 'plur-r3-prim-')); dirs.push(d); return d }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }); vi.restoreAllMocks() })
+
+  const readStores = (dir: string): Array<Record<string, unknown>> => {
+    const cfg = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as { stores?: Array<Record<string, unknown>> }
+    return cfg.stores ?? []
+  }
+
+  it('a duplicate-keyed entry with a primitive `sensitivity` round-trips without throwing (string)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const URL = 'https://enterprise.example.com'
+    // Two entries on the SAME url+scope: a proper object-sensitivity one, then a
+    // malformed scalar one (last-wins in rawMap). loadConfig coerces the scalar
+    // entry's `sensitivity` away but keeps BOTH entries (no dedup), so the typed
+    // array still carries an object-sensitivity entry whose raw match is a string.
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      index: false,
+      stores: [
+        { url: URL, token: 'old-token', scope: 'group:eng', shared: true, sensitivity: { forbid: ['secrets'] } },
+        { url: URL, token: 'old-token', scope: 'group:eng', shared: true, sensitivity: 'oops' },
+      ],
+    }, { noRefs: true }))
+
+    const plur = new Plur({ path: dir })
+    // Before the guard this threw: "Cannot use 'in' operator to search for 'forbid' in oops".
+    expect(() => plur.addStore('', 'group:eng', { url: URL, token: 'new-token' })).not.toThrow()
+    const stores = readStores(dir)
+    expect(stores.length).toBeGreaterThanOrEqual(1)
+    expect(stores.some(s => s.token === 'new-token')).toBe(true)
+  })
+
+  it.each([
+    ['number', 5],
+    ['boolean', true],
+  ])('a duplicate-keyed entry with a primitive `sensitivity` round-trips without throwing (%s)', (_label, prim) => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const URL = 'https://enterprise.example.com'
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      index: false,
+      stores: [
+        { url: URL, token: 'old-token', scope: 'group:eng', shared: true, sensitivity: { forbid: ['secrets'] } },
+        { url: URL, token: 'old-token', scope: 'group:eng', shared: true, sensitivity: prim },
+      ],
+    }, { noRefs: true }))
+
+    const plur = new Plur({ path: dir })
+    expect(() => plur.addStore('', 'group:eng', { url: URL, token: 'new-token' })).not.toThrow()
+  })
+})
+
+/**
+ * R3 (final-audit LOW): persistStores reads the existing config to PRESERVE
+ * other top-level keys (auto_learn, packs, embeddings, routing defaults, …). It
+ * used to swallow ANY read error and proceed from `{}`, so a TRANSIENT read
+ * failure on an EXISTING file caused the write to emit only `{ stores }` —
+ * silently nuking every other top-level setting. The read now re-throws on any
+ * error that is NOT ENOENT, aborting the writeback so a live config is never
+ * truncated. (ENOENT — a genuinely-absent config — still starts safely from {}.)
+ */
+describe('R3 config robustness — persistStores transient read failure does not nuke top-level keys', () => {
+  const dirs: string[] = []
+  const mkdir = (): string => { const d = mkdtempSync(join(tmpdir(), 'plur-r3-read-')); dirs.push(d); return d }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }); vi.restoreAllMocks() })
+
+  // Skip when running as root: chmod 000 doesn't block root reads, so the EACCES
+  // we rely on never fires (CI sometimes runs as root in containers).
+  const asRoot = typeof process.getuid === 'function' && process.getuid() === 0
+  const itNotRoot = asRoot ? it.skip : it
+  itNotRoot('aborts the write (does not discard auto_learn/embeddings/etc) when the config read fails transiently', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const URL = 'https://enterprise.example.com'
+    const cfgPath = join(dir, 'config.yaml')
+    // A config rich in non-store top-level keys — the data at risk.
+    const original = {
+      index: false,
+      auto_learn: true,
+      packs: ['team-core'],
+      embeddings: { model: 'bge-small' },
+      unscoped_default: 'local',
+      stores: [{ url: URL, token: 'old-token', scope: 'group:eng', shared: true }],
+    }
+    writeFileSync(cfgPath, yaml.dump(original, { noRefs: true }))
+
+    const plur = new Plur({ path: dir })
+
+    // Drive persistStores DIRECTLY so we isolate ONLY its read-then-merge step —
+    // addStore's own loadConfig calls swallow read errors and would obscure the
+    // guard under test. Simulate a TRANSIENT non-ENOENT read failure (EACCES — a
+    // permission glitch / a concurrent truncating writer) by making the EXISTING
+    // file unreadable. The file still EXISTS, so the guard must re-throw, not
+    // start from {}.
+    chmodSync(cfgPath, 0o000)
+    try {
+      // The writeback must ABORT (re-throw the non-ENOENT error) rather than
+      // silently truncate the config to a stores-only file.
+      expect(() => (plur as unknown as { persistStores(s: unknown[]): void }).persistStores([
+        { url: URL, token: 'new-token', scope: 'group:eng', shared: true },
+      ])).toThrow()
+    } finally {
+      chmodSync(cfgPath, 0o600)
+    }
+
+    // The on-disk config is INTACT — all the non-store top-level keys survive
+    // (the aborted write never overwrote the file with a stores-only document).
+    const after = yaml.load(readFileSync(cfgPath, 'utf8')) as Record<string, unknown>
+    expect(after.auto_learn).toBe(true)
+    expect(after.packs).toEqual(['team-core'])
+    expect(after.embeddings).toEqual({ model: 'bge-small' })
+    expect(after.unscoped_default).toBe('local')
+    expect(Array.isArray(after.stores)).toBe(true)
+    // and the token was NOT rotated — the write aborted before mutating anything.
+    expect((after.stores as Array<Record<string, unknown>>)[0].token).toBe('old-token')
+  })
+
+  it('ENOENT (config genuinely absent) still starts safely from {} and writes the stores', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dir = mkdir()
+    const URL = 'https://enterprise.example.com'
+    // No config.yaml on disk — a fresh install. persistStores must NOT throw on
+    // the ENOENT; it should write a brand-new config with just the stores.
+    const plur = new Plur({ path: dir })
+    expect(() => (plur as unknown as { persistStores(s: unknown[]): void }).persistStores([
+      { url: URL, token: 't', scope: 'group:eng', shared: true },
+    ])).not.toThrow()
+    const after = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as Record<string, unknown>
+    expect(Array.isArray(after.stores)).toBe(true)
+    expect((after.stores as Array<Record<string, unknown>>)[0].url).toBe(URL)
   })
 })


### PR DESCRIPTION
Final-audit cleanup of three release-blocking / robustness items found in the 0.10.0 audit. This is scoped to the CHANGELOG, the config writeback, and some stale comments — it does not touch the secrets/detector code (that ReDoS work is a separate PR).

## What this fixes

- **The 0.10.0 release notes were invisible to the release script.** The notes were written under a `## Unreleased` heading, but `scripts/release.sh` pulls the release section by matching a heading that starts with the version number (`## 0.10.0`). So cutting 0.10.0 found nothing and either aborted or shipped a generic "see CHANGELOG" note. Renamed the heading to `## 0.10.0 (2026-06-21)` (the same `## <version> (date)` format every previous release uses) and added a fresh empty `## Unreleased` above it for future entries. Verified the release script's extraction now returns the full 0.10.0 section.

- **A hand-edited config could crash store registration.** When two store entries share the same URL + scope and one of them has a malformed `sensitivity` value that's a plain string/number/boolean instead of an object, the writeback used `'forbid' in <value>`, which throws on a non-object and took down the add-store / token-rotation flow. It now checks the value is actually an object first, and drops a malformed primitive instead of merging it.

- **A transient config-read glitch could wipe unrelated settings.** When persisting stores, the code reads the existing config to keep all the other top-level settings (auto-learn, packs, embeddings, routing defaults, …). It used to swallow any read error and carry on with an empty object — so a momentary permission error or a concurrent writer would cause it to overwrite the file with only the stores list, silently dropping everything else. It now re-throws on any read error that isn't "file does not exist", so a live config is never truncated; a genuinely-absent config still starts cleanly.

- **Stale comments fixed (no behavior change).** Several comments described an old version of the reverse-domain routing weight, claiming a lone reverse-domain match still routes. The shipped code down-weights it so it does not. Updated the comments in `_resolveUnscopedScope` and the routing doc comments to match the actual scoring, so a future maintainer doesn't "fix" the code back to the wrong behavior.

## Tests
- 5 new tests covering both config guards: malformed-primitive `sensitivity` round-trips without throwing (string / number / boolean), a transient read failure aborts the write and preserves all top-level keys, and an absent config still writes cleanly.
- Full workspace: 1704 passed, 34 skipped, 0 failed. `tsc --noEmit` clean on core. All packages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)