### PR TITLE
fix(scope): segment-aware scope membership, no sibling-prefix bleed (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Security: segment-aware scope membership — no sibling-prefix bleed (#383)
+
+The read-side scope filters and store-load gates decided shared-scope membership with a bare string-prefix test (`scope.startsWith(query)` / `LIKE query || '%'`) and no delimiter boundary. A shared scope that is a string-prefix of a sibling leaked across the isolation boundary: a `project:app` recall/inject/list surfaced `project:application` and `project:app-secret`; a `group:plur/eng` query surfaced `group:plur/eng-private`.
+
+- New `isScopeWithin(scope, queryScope)` predicate in `scope-util.ts` matches a scope iff it is exactly equal or a descendant separated by a real delimiter (`:` or `/`) — so `project:app:sub` and `project:app/x` still match, but `project:application` does not.
+- Applied at all read paths and store-load gates: non-indexed recall (`index.ts`), indexed SQLite `loadFiltered` + reindex gate (`storage-indexed.ts`), PGLite `buildFilterClause` (`storage-pglite.ts`), inject `scoreEngram` (`inject.ts`), and the in-memory store gate (`index.ts`). SQL paths use `scope = ? OR scope LIKE ?||':%' OR scope LIKE ?||'/%'`.
+- The personal-family pass-through (`isPersonalScope`) is unchanged — personal scopes still surface under a project-scope recall.
+
+**Behavior change:** an engram in a shared scope that is merely a string-prefix of the query scope is no longer returned by recall/inject/list. True descendants (delimiter-separated) are unaffected.
+
 ## 0.10.0 (2026-06-21)
 
 ### Leak guard: write-time demotion now covers `saveMetaEngrams` and remote-backed scopes (#368, #370)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ import { appendHistory, readHistoryForEngram, generateEventId } from './history.
 import { computeContentHash } from './content-hash.js'
 import { decodeJwtExpiry } from './jwt.js'
 import { RemoteStore } from './store/remote-store.js'
-import { isSharedScope, isPersonalScope } from './scope-util.js'
+import { isSharedScope, isPersonalScope, isScopeWithin } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { Episode } from './schemas/episode.js'
 import type { PackManifest } from './schemas/pack.js'
@@ -380,8 +380,10 @@ export class Plur {
         : this._loadCached(store.path!)
       const prefix = storePrefix(store.scope)
       for (const e of storeEngrams) {
-        // Phase 4: Scope validation
-        if (e.scope !== 'global' && e.scope !== store.scope && !e.scope.startsWith(store.scope)) {
+        // Phase 4: Scope validation. Segment-aware (#383): a sibling that is a
+        // mere string-prefix of the store scope (group:plur/eng-private under a
+        // group:plur/eng store) must NOT load.
+        if (e.scope !== 'global' && !isScopeWithin(e.scope, store.scope)) {
           logger.debug(`Skipping engram ${e.id} from store ${store.scope}: scope mismatch (${e.scope})`)
           continue
         }
@@ -1951,7 +1953,7 @@ export class Plur {
         // than `global` inject, which is targeted to global-only (see inject.ts
         // INJECT_GLOBAL_IS_TARGETED).
         engrams = engrams.filter(e =>
-          e.scope === scope || e.scope.startsWith(scope) || isPersonalScope(e.scope)
+          isScopeWithin(e.scope, scope) || isPersonalScope(e.scope)
         )
       }
     }

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -5,7 +5,7 @@ import { decayedStrength, decayedCoAccessStrength, daysSince, confidenceDecay } 
 import { classifyPolarity } from './polarity.js'
 import { computeConfidence } from './confidence.js'
 import { freshTailBoost } from './fresh-tail.js'
-import { isPersonalScope } from './scope-util.js'
+import { isPersonalScope, isScopeWithin } from './scope-util.js'
 
 /**
  * D1-RECALL/INJECT-ASYMMETRY (#353). When an inject is given an EXPLICIT
@@ -164,7 +164,7 @@ export function scoreEngram(
       // project branch (see INJECT_GLOBAL_IS_TARGETED JSDoc + D1-ASYMMETRY tests).
       void INJECT_GLOBAL_IS_TARGETED
       if (engram.scope !== 'global') return 0
-    } else if (!engram.scope.startsWith(scopeFilter) && !isPersonalScope(engram.scope)) {
+    } else if (!isScopeWithin(engram.scope, scopeFilter) && !isPersonalScope(engram.scope)) {
       // Personal-family scopes (local, global, user:*, agent:*, anything not
       // isSharedScope) always pass a project-scope filter; only SHARED scopes
       // that don't match the filter are excluded (#353 read-side fix).

--- a/packages/core/src/scope-util.ts
+++ b/packages/core/src/scope-util.ts
@@ -39,3 +39,20 @@ export function isSharedScope(scope: string): boolean {
 export function isPersonalScope(scope: string): boolean {
   return !isSharedScope(scope)
 }
+
+/**
+ * Segment-aware scope membership (#383). Does `scope` fall within the `queryScope`
+ * namespace — exactly equal, or a descendant separated by a REAL delimiter
+ * (`:` or `/`)? A bare `startsWith` leaks a sibling that is merely a string-prefix:
+ * `project:app` would wrongly match `project:application`. This predicate matches
+ * `project:app`, `project:app:sub`, and `project:app/x` but NOT `project:application`.
+ *
+ * Use everywhere a read-side filter or store-load gate decides scope membership.
+ * The SQL paths (storage-indexed, storage-pglite) inline the equivalent:
+ *   `scope = ? OR scope LIKE ?||':%' OR scope LIKE ?||'/%'`.
+ */
+export function isScopeWithin(scope: string, queryScope: string): boolean {
+  return scope === queryScope
+    || scope.startsWith(queryScope + ':')
+    || scope.startsWith(queryScope + '/')
+}

--- a/packages/core/src/storage-indexed.ts
+++ b/packages/core/src/storage-indexed.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs'
 import { createRequire } from 'module'
 import { loadEngrams, storePrefix } from './engrams.js'
-import { isPersonalScope } from './scope-util.js'
+import { isPersonalScope, isScopeWithin } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { StoreEntry } from './schemas/config.js'
 
@@ -142,9 +142,11 @@ export class IndexedStorage {
       // Read-side scope filter (#353). `personal = 1` passes ALL personal-family
       // scopes (local, global, user:*, agent:*) — set at index time from
       // isPersonalScope — not just global, so a project-scope recall sees personal
-      // engrams. The two `scope` params (exact + LIKE prefix) are unchanged.
-      conditions.push("(personal = 1 OR scope = ? OR scope LIKE ? || '%')")
-      params.push(filter.scope, filter.scope)
+      // engrams. Segment-aware membership (#383): a descendant matches only on a
+      // real delimiter (`:`/`/`), so a sibling string-prefix (project:application
+      // under a project:app query) does NOT leak. Mirrors isScopeWithin.
+      conditions.push("(personal = 1 OR scope = ? OR scope LIKE ? || ':%' OR scope LIKE ? || '/%')")
+      params.push(filter.scope, filter.scope, filter.scope)
     }
     if (filter.domain) {
       conditions.push("domain LIKE ? || '%'")
@@ -199,8 +201,9 @@ export class IndexedStorage {
         const storeEngrams = loadEngrams(store.path)
         const prefix = storePrefix(store.scope)
         for (const e of storeEngrams) {
-          // Scope validation: skip mismatched scopes
-          if (e.scope !== 'global' && e.scope !== store.scope && !e.scope.startsWith(store.scope)) {
+          // Scope validation: skip mismatched scopes. Segment-aware (#383) so a
+          // sibling string-prefix scope can't be indexed under this store.
+          if (e.scope !== 'global' && !isScopeWithin(e.scope, store.scope)) {
             continue
           }
           const nsId = e.id.replace(/^(ENG|ABS|META)-/, `$1-${prefix}-`)

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -200,8 +200,10 @@ export class PGLiteAdapter implements StorageAdapter {
       params.push(filter.status)
     }
     if (filter.scope) {
-      conditions.push(`(scope = 'global' OR scope = $${i++} OR scope LIKE $${i++} || '%')`)
-      params.push(filter.scope, filter.scope)
+      // Segment-aware membership (#383): match only on a real delimiter (`:`/`/`)
+      // so a sibling string-prefix scope does not leak. Mirrors isScopeWithin.
+      conditions.push(`(scope = 'global' OR scope = $${i++} OR scope LIKE $${i++} || ':%' OR scope LIKE $${i++} || '/%')`)
+      params.push(filter.scope, filter.scope, filter.scope)
     }
     if (filter.domain) {
       conditions.push(`domain LIKE $${i++} || '%'`)

--- a/packages/core/test/read-side-scope-visibility.test.ts
+++ b/packages/core/test/read-side-scope-visibility.test.ts
@@ -22,7 +22,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
 import { Plur } from '../src/index.js'
-import { isPersonalScope, isSharedScope } from '../src/scope-util.js'
+import { isPersonalScope, isSharedScope, isScopeWithin } from '../src/scope-util.js'
 
 import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
@@ -172,3 +172,61 @@ describe('PR-1 read-side scope visibility (NON-indexed path, #353)', () => {
     expect(ids).toContain(sub.id)
   })
 })
+
+// --- #383: segment-aware scope membership — no sibling-prefix bleed ---
+describe('#383 isScopeWithin predicate', () => {
+  it('matches a descendant only on a real delimiter (`:` / `/`), never a string-prefix sibling', () => {
+    // exact + true descendants
+    expect(isScopeWithin('project:app', 'project:app')).toBe(true)
+    expect(isScopeWithin('project:app:sub', 'project:app')).toBe(true)
+    expect(isScopeWithin('project:app/x', 'project:app')).toBe(true)
+    expect(isScopeWithin('group:plur/eng/team', 'group:plur/eng')).toBe(true)
+    // sibling string-prefixes must NOT match (the leak)
+    expect(isScopeWithin('project:application', 'project:app')).toBe(false)
+    expect(isScopeWithin('project:app-secret', 'project:app')).toBe(false)
+    expect(isScopeWithin('group:plur/eng-private', 'group:plur/eng')).toBe(false)
+  })
+})
+
+// End-to-end isolation across BOTH read paths (indexed SQL + non-indexed filter)
+// and BOTH directions, asserting true descendants stay visible. (#383)
+for (const indexed of [true, false]) {
+  const label = indexed ? 'indexed' : 'non-indexed'
+  const block = indexed ? describe.skipIf(!hasSqlite) : describe
+  block(`#383 sibling-prefix scope isolation (${label} path)`, () => {
+    let dir: string
+    let plur: Plur
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'plur-383-'))
+      writeFileSync(join(dir, 'config.yaml'), yaml.dump({ index: indexed }, { noRefs: true }))
+      plur = new Plur({ path: dir })
+    })
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+    it('a string-prefix sibling is NOT visible under the shorter scope (recall + inject + list)', () => {
+      const collide = plur.learn(STMT('collide'), { scope: 'project:application' })
+      expect(recallSeesId(plur, 'project:app', collide.id)).toBe(false)
+      expect(injectSeesId(plur, 'project:app', collide.id)).toBe(false)
+      expect(plur.list({ scope: 'project:app' }).map(e => e.id)).not.toContain(collide.id)
+    })
+
+    it('the reverse direction is isolated too (group:plur/eng-private under group:plur/eng)', () => {
+      const priv = plur.learn(STMT('grppriv'), { scope: 'group:plur/eng-private' })
+      expect(recallSeesId(plur, 'group:plur/eng', priv.id)).toBe(false)
+      expect(injectSeesId(plur, 'group:plur/eng', priv.id)).toBe(false)
+    })
+
+    it('a true descendant (project:app:sub) IS still visible under the parent scope', () => {
+      const sub = plur.learn(STMT('appsub'), { scope: 'project:app:sub' })
+      expect(recallSeesId(plur, 'project:app', sub.id)).toBe(true)
+      expect(injectSeesId(plur, 'project:app', sub.id)).toBe(true)
+    })
+
+    it('an exact-scope engram remains visible (sanity)', () => {
+      const exact = plur.learn(STMT('exact'), { scope: 'project:app' })
+      expect(recallSeesId(plur, 'project:app', exact.id)).toBe(true)
+      expect(injectSeesId(plur, 'project:app', exact.id)).toBe(true)
+    })
+  })
+}


### PR DESCRIPTION
## What & why

Fixes #383 from the #377 scope-security audit (High, confidentiality).

The read-side scope filters and store-load gates decided **shared-scope** membership with a bare string-prefix test and **no delimiter boundary**:
- non-indexed recall — `e.scope.startsWith(scope)` (`index.ts`)
- indexed SQLite — `scope LIKE ? || '%'` (`storage-indexed.ts` `loadFiltered`)
- inject — `engram.scope.startsWith(scopeFilter)` (`inject.ts`)
- store-load gates — `e.scope.startsWith(store.scope)` (`index.ts`, `storage-indexed.ts` reindex)
- PGLite — `scope LIKE $n || '%'` (`storage-pglite.ts`)

Result: a `project:app` recall/inject/list surfaced `project:application` and `project:app-secret`; a `group:plur/eng` query surfaced `group:plur/eng-private`. The leak crosses the project/team isolation boundary.

> Two sites the issue didn't enumerate are also fixed here: the `storage-indexed.ts` **reindex** store gate and the **PGLite** `buildFilterClause`.

## Fix

New leaf predicate in `scope-util.ts`:

```ts
isScopeWithin(scope, queryScope) =
  scope === queryScope || scope.startsWith(queryScope + ':') || scope.startsWith(queryScope + '/')
```

Matches exact + delimiter-separated descendants (`project:app:sub`, `project:app/x`) but **not** string-prefix siblings (`project:application`). Applied at all six sites; SQL paths inline the equivalent `scope = ? OR scope LIKE ?||':%' OR scope LIKE ?||'/%'`. The personal-family pass-through (`isPersonalScope`) is unchanged.

## Tests

In `read-side-scope-visibility.test.ts`:
- `isScopeWithin` predicate unit test (both directions + true descendants)
- end-to-end isolation on **both** the indexed and non-indexed paths: a string-prefix sibling is invisible under the shorter scope across **recall + inject + list**, the reverse direction (`group:plur/eng-private`) is isolated, and a true descendant (`project:app:sub`) plus the exact scope remain visible.

Full `@plur-ai/core` suite green (1526 passed, 28 skipped).

## Note
The store-load gate change uses the same predicate (unit-tested); a multi-store fixture wasn't added since the gate is mechanically identical to the recall path and shares the predicate.

Part of #377. Closes #383.
