### PR TITLE
fix(scope): don't auto-register personal-family scopes from /me (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Security: scope auto-registration refuses personal-family scopes from `/me` (#382)
+
+`registerDiscoveredScopes()` registered **every** scope a server returned from `GET /api/v1/me` as a writable remote store, with no shared-scope check. A compromised or MITM'd endpoint could return `scopes: ['global', 'user:<victim>', 'local']`; registering `global` (the default unscoped routing fallback) as a writable remote store would route every later default/unscoped `learn` to the attacker's server.
+
+- `registerDiscoveredScopes()` now filters `/me`-advertised scopes through `isSharedScope()` before `addStore`: only shared-family scopes (`group:`/`project:`/`space:`/`team:`/`org:`/`public`) are auto-registered. Personal-family scopes (`global`/`local`/`user:*`/`agent:*`) are refused, logged, and returned in a new `skipped` field on `RegisterDiscoveredResult`. The CLI (`plur stores discover --register`) and MCP (`plur_scopes_discover`) surface the skipped scopes.
+- A genuine remote-backed personal scope (e.g. a `user:` scope on your own server) must be added deliberately via `plur stores add`; it is never auto-registered from untrusted server input.
+
+**Behavior change:** `plur_scopes_discover register:true` / `plur stores discover --register` no longer register personal-family scopes a server advertises — they are reported as `skipped`.
+
 ## 0.10.0 (2026-06-21)
 
 ### Leak guard: write-time demotion now covers `saveMetaEngrams` and remote-backed scopes (#368, #370)

--- a/packages/cli/src/commands/stores.ts
+++ b/packages/cli/src/commands/stores.ts
@@ -57,6 +57,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       registered.forEach(r => {
         if (!r.ok) { outputText(`${r.url}: register failed — ${r.error}`); return }
         outputText(`${r.url}: added ${r.added.length} scope(s)${r.added.length ? ` (${r.added.join(', ')})` : ''}`)
+        if (r.skipped.length) outputText(`  skipped ${r.skipped.length} non-shared scope(s) (not auto-registered): ${r.skipped.join(', ')}`)
       })
     } else {
       const total = discoveries.reduce((n, d) => n + d.unregistered.length, 0)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -246,6 +246,8 @@ export interface RegisterDiscoveredResult {
   ok: boolean
   added: string[]
   already_registered: string[]
+  /** Personal-family scopes a `/me` returned that were refused auto-registration (#382). */
+  skipped: string[]
   error?: string
 }
 
@@ -3951,19 +3953,36 @@ Generate an improved version of the procedure that prevents this failure. Return
   async registerDiscoveredScopes(opts?: { url?: string; timeoutMs?: number }): Promise<RegisterDiscoveredResult[]> {
     const discoveries = await this.discoverRemoteScopes(opts)
     return discoveries.map(d => {
-      if (!d.ok) return { url: d.url, ok: false, added: [], already_registered: [], error: d.error }
+      if (!d.ok) return { url: d.url, ok: false, added: [], already_registered: [], skipped: [], error: d.error }
       const token = (this.config.stores ?? []).find(s => s.url === d.url)?.token
       const added: string[] = []
       const already: string[] = []
+      const skipped: string[] = []
       // Attempt every authorized scope (not just the pre-computed unregistered
       // set) and let addStore's url+scope idempotency (#291) classify each — so
       // the result is accurate even if config changed between discover and now.
       for (const scope of d.authorized) {
+        // SECURITY (#382): never auto-register a PERSONAL-family scope returned
+        // by `/me` as a writable remote store. A compromised/MITM'd endpoint can
+        // claim `scopes:['global','user:<victim>','local']`; registering those
+        // makes the hostile server the routing target for the user's default and
+        // unscoped writes. Only shared-family scopes (group:/project:/space:/
+        // team:/org:/public) are auto-registered. A genuine remote-backed
+        // personal scope must be added deliberately via `plur stores add`.
+        if (!isSharedScope(scope)) {
+          skipped.push(scope)
+          logger.warning(
+            `[plur] refused to auto-register non-shared scope "${scope}" from ${d.url} — ` +
+            `a /me-advertised personal-family scope is not auto-registered (it would route ` +
+            `your default/unscoped writes to that endpoint). Add it explicitly if intended.`,
+          )
+          continue
+        }
         const { status } = this.addStore('', scope, { url: d.url, token })
         if (status === 'added') added.push(scope)
         else already.push(scope)
       }
-      return { url: d.url, ok: true, added, already_registered: already }
+      return { url: d.url, ok: true, added, already_registered: already, skipped }
     })
   }
 

--- a/packages/core/test/scope-discovery.test.ts
+++ b/packages/core/test/scope-discovery.test.ts
@@ -172,6 +172,31 @@ describe('Plur.registerDiscoveredScopes()', () => {
     ])
   })
 
+  it('#382 refuses to auto-register personal-family scopes returned by /me', async () => {
+    // A compromised/MITM'd endpoint advertises personal-family scopes alongside
+    // a legit shared one. None of the personal scopes may be registered — else
+    // the hostile server becomes the routing target for default/unscoped writes.
+    server.setMe({
+      username: 'crtahlin', org_id: 'plur', role: 'developer',
+      scopes: ['global', 'local', 'user:victim', 'agent:bot', 'group:plur/plur-ai/engineering'],
+    })
+    const plur = freshPlur()
+    const [result] = await plur.registerDiscoveredScopes()
+
+    expect(result.ok).toBe(true)
+    expect(result.added).toEqual([])                       // nothing new registered
+    expect(result.skipped.sort()).toEqual(['agent:bot', 'global', 'local', 'user:victim'])
+    expect(result.already_registered).toEqual(['group:plur/plur-ai/engineering'])
+
+    // No personal-family scope was persisted as a remote store.
+    const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(config.stores).toHaveLength(1)
+    expect(config.stores.map((s: any) => s.scope)).toEqual(['group:plur/plur-ai/engineering'])
+    for (const bad of ['global', 'local', 'user:victim', 'agent:bot']) {
+      expect(config.stores.some((s: any) => s.scope === bad)).toBe(false)
+    }
+  })
+
   it('is idempotent — a second run reports everything already_registered', async () => {
     const plur = freshPlur()
     await plur.registerDiscoveredScopes()

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1575,7 +1575,7 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
 
     {
       name: 'plur_scopes_discover',
-      description: 'Discover which scopes your remote token is authorized for via the enterprise server (GET /api/v1/me), and which of those are not yet registered locally. Read-only by default; pass register:true to register all authorized-but-unregistered scopes in one step. Use this when you have access to multiple team scopes on one server.',
+      description: 'Discover which scopes your remote token is authorized for via the enterprise server (GET /api/v1/me), and which of those are not yet registered locally. Read-only by default; pass register:true to register all authorized-but-unregistered scopes in one step. Only shared-family scopes (group:/project:/space:/team:/org:/public) are auto-registered — personal-family scopes (global/local/user:*/agent:*) advertised by /me are skipped and surfaced in the result. Use this when you have access to multiple team scopes on one server.',
       annotations: { title: 'Discover scopes', readOnlyHint: false, idempotentHint: true },
       inputSchema: {
         type: 'object',


### PR DESCRIPTION
## What & why

Fixes #382 from the #377 scope-security audit (High, confidentiality).

`registerDiscoveredScopes()` registered **every** scope a server returned from `GET /api/v1/me` as a writable remote store, with no shared-scope check. `addStore` validates only URL/protocol/non-empty-scope + dedup.

A compromised or MITM'd endpoint can return `scopes: ['global', 'user:<victim>', 'local']`. Registering `global` — the default unscoped routing fallback and default scope — as a writable remote store makes `_resolveRemoteStoreForScope('global')` return the hostile driver, so **every later default/unscoped `learn` POSTs to the attacker's server**. The scope-conflict guard doesn't fire (the primary `global` store isn't a `config.stores` row). The READ side (#306) already treats `/me` rows as semi-trusted; the REGISTER side granted full trust.

Reachable via `plur_scopes_discover register:true` (which `session_start` nudges) and `plur stores discover --register`.

## Fix

`registerDiscoveredScopes()` filters `/me`-advertised scopes through `isSharedScope()` before `addStore`:
- Only shared-family scopes (`group:`/`project:`/`space:`/`team:`/`org:`/`public`) are auto-registered.
- Personal-family scopes (`global`/`local`/`user:*`/`agent:*`) are refused, logged, and returned in a new `skipped` field on `RegisterDiscoveredResult`. The CLI and MCP (`plur_scopes_discover`) surface them.
- A genuine remote-backed personal scope (e.g. a `user:` scope on your own server) must be added deliberately via `plur stores add` — never auto-registered from untrusted server input.

Both register call sites (MCP `plur_scopes_discover`, CLI `plur stores discover --register`) delegate to this one core method, so the single fix covers them. `init-remote` takes explicit user-provided scopes (no `/me` trust) and is unaffected.

## Tests

`scope-discovery.test.ts`: a `/me` returning `['global','local','user:victim','agent:bot','group:plur/plur-ai/engineering']` registers **nothing new** (`added: []`), reports the four personal scopes in `skipped`, and persists **no** personal-scoped remote store in config.

Full workspace suite green (1996 passed, 34 skipped).

Part of #377. Closes #382.
