### PR TITLE
fix(secrets): raise scan window to 1 MiB, fail-closed past it (#386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Security: sensitivity scan window raised to 1 MiB and fail-closed past it (#386)
+
+`detectSensitive()` truncated its input to the first 64 KB before scanning, then silently passed the rest. The infra-topology detectors (`public_ipv4`, `public_ipv6`, `basic_auth_url`, `fqdn_port`, `ipv4_port`, `internal_host`) exist only in `detectSensitive`, so an engram whose first 64 KB was benign filler but which carried a public IP / basic-auth URL / internal host **after** byte 64 KB passed the write guard un-demoted and was written to a shared/remote store (and slipped past `filterPublishable`).
+
+- The scan window is raised from 64 KB to **1 MiB** — far above any realistic engram. The detector regexes are bounded/linear, so a single full-window pass is ~100 ms worst case, and total scan work is capped at 1 MiB regardless of input size (DoS-safe).
+- Input larger than the ceiling is now **fail-closed**: `detectSensitive` appends a synthetic `scan_truncated` hit so `_guardSensitiveScope` demotes the write and `filterPublishable` excludes the engram — the unscanned tail can no longer be assumed clean. The `scan_truncated` signal is always offending regardless of a scope's `sensitivity` policy.
+
+**Behavior change:** infra/secret content anywhere in the first 1 MiB is now detected and demoted; an engram larger than 1 MiB destined for a shared/remote scope is demoted to `local`/`private` (fail-closed) rather than silently passing.
+
 ## 0.10.0 (2026-06-21)
 
 ### Leak guard: write-time demotion now covers `saveMetaEngrams` and remote-backed scopes (#368, #370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 `detectSensitive()` truncated its input to the first 64 KB before scanning, then silently passed the rest. The infra-topology detectors (`public_ipv4`, `public_ipv6`, `basic_auth_url`, `fqdn_port`, `ipv4_port`, `internal_host`) exist only in `detectSensitive`, so an engram whose first 64 KB was benign filler but which carried a public IP / basic-auth URL / internal host **after** byte 64 KB passed the write guard un-demoted and was written to a shared/remote store (and slipped past `filterPublishable`).
 
-- The scan window is raised from 64 KB to **1 MiB** — far above any realistic engram. The detector regexes are bounded/linear, so a single full-window pass is ~100 ms worst case, and total scan work is capped at 1 MiB regardless of input size (DoS-safe).
+- The scan window is raised from 64 KB to **1 MiB** — far above any realistic engram. The detector regexes are bounded/linear; a benign full-window pass is ~7ms/64KB but adversarial regex-dense input measured ~300–420 ms for a full 1 MiB pass (#386 review). Total scan work is capped at 1 MiB regardless of input size (bounded, linear — a per-write CPU cost on >64KB engrams, not a DoS).
 - Input larger than the ceiling is now **fail-closed**: `detectSensitive` appends a synthetic `scan_truncated` hit so `_guardSensitiveScope` demotes the write and `filterPublishable` excludes the engram — the unscanned tail can no longer be assumed clean. The `scan_truncated` signal is always offending regardless of a scope's `sensitivity` policy.
+- **Packs export inherits this** (via #389): `scanPrivacy` now routes through `detectSensitive` + `truncateToScanLimit`, so the raised window, the infra-family detectors, and the `scan_truncated` fail-closed all apply to `exportPack`/`installPack` too — the "...and packs" half of #386, delivered by the #389 packs-scan change rather than here.
 
 **Behavior change:** infra/secret content anywhere in the first 1 MiB is now detected and demoted; an engram larger than 1 MiB destined for a shared/remote scope is demoted to `local`/`private` (fail-closed) rather than silently passing.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ import { installPack, uninstallPack, listPacks, exportPack, scanPrivacy, compute
 // import { exportVault, type VaultExportOptions, type VaultExportResult } from './vault-export.js'
 // import { fetchRegistry, discoverPacks, verifyPackIntegrity, DEFAULT_REGISTRY_URL, type PackRegistry, type RegistryPack } from './registry.js'
 import { sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncStatus } from './sync.js'
-import { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
+import { detectSecrets, detectSensitive, sensitivityCategory, SCAN_TRUNCATED } from './secrets.js'
 import type { SecretMatch } from './secrets.js'
 import type { ScopeMetadata, SensitivityCategory } from './schemas/scope-metadata.js'
 import { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
@@ -956,6 +956,9 @@ export class Plur {
     const forbid = new Set<SensitivityCategory>(policy?.forbid ?? ['secrets', 'infra'])
     const allow = new Set<string>(policy?.allow ?? [])
     return hits.filter(h => {
+      // Fail-closed (#386): a truncated-scan signal is always offending — the
+      // unscanned tail can't be certified clean, and no scope policy may allow it.
+      if (h.pattern === SCAN_TRUNCATED) return true
       const category = sensitivityCategory(h.pattern)
       if (allow.has(category) || allow.has(h.pattern)) return false
       return forbid.has(category)

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -360,24 +360,25 @@ function matchInternalHost(text: string): string | null {
   return null
 }
 
-// Defense-in-depth length cap (#353). The publish loop scans whole serialized
+// Scan-input ceiling (#353, #386). The publish loop scans whole serialized
 // engrams and `_guardSensitiveScope` scans statement + JSON.stringify(context),
-// so an unbounded input is an unbounded scan. We cap the SCAN INPUT at 64KB
-// (byte-aware). With every pattern now bounded (basic_auth_url reaudit #1,
-// fqdn_port reaudit #3 — both rewritten to linear-time forms with no `+`-over-`+`
-// ambiguity), a 64KB scan is empirically <7ms under V8 Irregexp, so this cap is
-// cheap insurance, not the DoS fix — the bounded quantifiers are. (Before the
-// fqdn_port bounding a 64KB dotted-label run took ~4s here.) A leading credential
-// is still caught; callers must NOT assume full-input scanning.
-const MAX_SCAN_BYTES = 65536
+// so an unbounded input is an unbounded scan. Every pattern is now bounded
+// (basic_auth_url reaudit #1, fqdn_port reaudit #3 — both rewritten to linear-time
+// forms with no `+`-over-`+` ambiguity), so a single linear pass is ~7ms/64KB
+// under V8 Irregexp; a full 1 MiB pass is ~100ms worst case. We therefore scan a
+// generous 1 MiB window — far above any realistic engram — instead of the old
+// 64KB cap, which left infra-family content past byte 64KB UN-scanned and
+// silently passed to shared/remote stores (the #386 blind spot).
+//
+// Beyond the ceiling we do NOT silently truncate-and-pass: `detectSensitive`
+// emits a synthetic `scan_truncated` hit so the write guard demotes and
+// `filterPublishable` excludes — fail-closed, since the unscanned tail can't be
+// certified clean. Realistic engrams never approach 1 MiB, so this never falsely
+// demotes ordinary content.
+const MAX_SCAN_BYTES = 1024 * 1024
 
-function truncateToScanLimit(text: string): string {
-  // Buffer.byteLength avoids materializing a Buffer for the common (small) case.
-  if (Buffer.byteLength(text, 'utf8') <= MAX_SCAN_BYTES) return text
-  // Replace-mode decode (default) — a multi-byte char split at the boundary
-  // becomes U+FFFD; no exception, no silent corruption, always valid UTF-8.
-  return Buffer.from(text, 'utf8').subarray(0, MAX_SCAN_BYTES).toString('utf8')
-}
+/** Synthetic detector name emitted when input exceeded MAX_SCAN_BYTES (#386). */
+export const SCAN_TRUNCATED = 'scan_truncated'
 
 /**
  * Scan text for secrets AND infrastructure-sensitive content (public IPv4/IPv6,
@@ -397,7 +398,16 @@ export function detectSensitive(text: string): SecretMatch[] {
   if (typeof text !== 'string') {
     throw new TypeError(`detectSensitive: expected string, got ${typeof text}`)
   }
-  text = truncateToScanLimit(text)
+  // Byte-aware: cap the scanned region at MAX_SCAN_BYTES and remember whether the
+  // input was longer (so the tail goes UN-scanned). Buffer.byteLength avoids
+  // materializing a Buffer for the common (small) case.
+  const totalBytes = Buffer.byteLength(text, 'utf8')
+  const truncated = totalBytes > MAX_SCAN_BYTES
+  if (truncated) {
+    // Replace-mode decode (default) — a multi-byte char split at the boundary
+    // becomes U+FFFD; no exception, no silent corruption, always valid UTF-8.
+    text = Buffer.from(text, 'utf8').subarray(0, MAX_SCAN_BYTES).toString('utf8')
+  }
   const matches = detectSecrets(text)
   for (const { name, regex } of SENSITIVE_PATTERNS) {
     const m = text.match(regex)
@@ -418,6 +428,12 @@ export function detectSensitive(text: string): SecretMatch[] {
   const internalHost = matchInternalHost(text)
   if (internalHost) {
     matches.push({ pattern: 'internal_host', match: internalHost.slice(0, 30) })
+  }
+  if (truncated) {
+    // Fail-closed (#386): the region past MAX_SCAN_BYTES was not scanned, so we
+    // cannot certify it clean. Signal it so the write guard demotes and
+    // filterPublishable excludes — a sensitive payload can't hide in the tail.
+    matches.push({ pattern: SCAN_TRUNCATED, match: `${totalBytes} bytes (> ${MAX_SCAN_BYTES}B scan limit)` })
   }
   return matches
 }

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -364,8 +364,10 @@ function matchInternalHost(text: string): string | null {
 // engrams and `_guardSensitiveScope` scans statement + JSON.stringify(context),
 // so an unbounded input is an unbounded scan. Every pattern is now bounded
 // (basic_auth_url reaudit #1, fqdn_port reaudit #3 — both rewritten to linear-time
-// forms with no `+`-over-`+` ambiguity), so a single linear pass is ~7ms/64KB
-// under V8 Irregexp; a full 1 MiB pass is ~100ms worst case. We therefore scan a
+// forms with no `+`-over-`+` ambiguity). Benign filler is ~7ms/64KB under V8
+// Irregexp, but adversarial regex-dense input is ~4x that: a full 1 MiB pass
+// measured ~300-420ms worst case (#386 review). Still bounded and linear — this
+// is a per-write CPU cost on >64KB engrams, not a DoS. We therefore scan a
 // generous 1 MiB window — far above any realistic engram — instead of the old
 // 64KB cap, which left infra-family content past byte 64KB UN-scanned and
 // silently passed to shared/remote stores (the #386 blind spot).

--- a/packages/core/test/secrets.test.ts
+++ b/packages/core/test/secrets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { detectSecrets, detectSensitive, sensitivityCategory } from '../src/secrets.js'
+import { detectSecrets, detectSensitive, sensitivityCategory, SCAN_TRUNCATED } from '../src/secrets.js'
 
 describe('detectSecrets', () => {
   it('detects AWS access keys', () => {
@@ -409,30 +409,43 @@ describe('detectSensitive — basic_auth_url (#353)', () => {
   })
 })
 
-// PR-2 (#353) — length cap (defense-in-depth, byte-aware). detectSensitive scans
-// at most the first 64KB; the bound is asserted structurally (NOT by wall-clock).
-describe('detectSensitive — 64KB scan-input length cap (#353)', () => {
-  const CAP = 65536
+// #386 — scan-input ceiling raised 64KB → 1 MiB, and FAIL-CLOSED past it.
+// Previously detectSensitive truncated to 64KB and silently passed the tail, so
+// infra-family content past byte 64KB leaked to shared/remote stores. Now the
+// window is 1 MiB (far above any realistic engram) and anything larger emits a
+// `scan_truncated` signal so the guard demotes / publish excludes. Total scan
+// work is bounded at 1 MiB regardless of input size. Asserted structurally.
+describe('detectSensitive — 1 MiB scan ceiling, fail-closed (#386)', () => {
+  const CAP = 1024 * 1024
 
-  it('still detects a secret within the first 64KB of a 200KB input', () => {
+  it('detects a secret within the scanned window', () => {
     const head = 'AKIAIOSFODNN7EXAMPLE is the key. '
     const big = head + 'x'.repeat(200 * 1024)
+    expect(detectSensitive(big).some(m => m.pattern === 'aws_access_key')).toBe(true)
+  })
+
+  it('#386 detects infra content past the OLD 64KB cap (now inside the 1 MiB window)', () => {
+    const filler = 'x'.repeat(70 * 1024) // past 64KB, well under 1 MiB
+    expect(detectSensitive(`${filler} 139.59.155.82`).some(m => m.pattern === 'public_ipv4')).toBe(true)
+    expect(detectSensitive(`${filler} https://t:p@hub-staging.plur.ai`).some(m => m.pattern === 'basic_auth_url')).toBe(true)
+  })
+
+  it('#386 fail-closed: an input larger than the ceiling reports scan_truncated even when the scanned prefix is clean', () => {
+    const big = 'x'.repeat(CAP + 1024) // benign filler, but > ceiling
+    expect(detectSensitive(big).some(m => m.pattern === SCAN_TRUNCATED)).toBe(true)
+  })
+
+  it('a secret ENTIRELY past the ceiling is not directly detected, but the input is flagged truncated', () => {
+    const big = 'x'.repeat(CAP) + ' AKIAIOSFODNN7EXAMPLE'
     const matches = detectSensitive(big)
-    expect(matches.some(m => m.pattern === 'aws_access_key')).toBe(true)
+    expect(matches.some(m => m.pattern === 'aws_access_key')).toBe(false) // past the window
+    expect(matches.some(m => m.pattern === SCAN_TRUNCATED)).toBe(true)     // but fail-closed
   })
 
-  it('does NOT detect a secret that lands ENTIRELY past the 64KB cap (proves the bound, no wall-clock)', () => {
-    const padding = 'x'.repeat(CAP)
-    const big = padding + ' AKIAIOSFODNN7EXAMPLE'
-    expect(detectSensitive(big).some(m => m.pattern === 'aws_access_key')).toBe(false)
-  })
-
-  it('truncation produces valid UTF-8 even when the cap splits a multibyte char', () => {
-    // 'é' is 2 bytes; fill exactly to the cap boundary minus 1 so the cap splits it.
-    const big = 'a'.repeat(CAP - 1) + 'é' + 'b'.repeat(1024)
-    // Must not throw and must be a no-op detection-wise (clean prose).
+  it('truncation at the ceiling produces valid UTF-8 even when it splits a multibyte char (no throw)', () => {
+    const big = 'a'.repeat(CAP - 1) + 'é' + 'b'.repeat(1024) // 'é' is 2 bytes, split at the cap
     expect(() => detectSensitive(big)).not.toThrow()
-    expect(detectSensitive(big)).toHaveLength(0)
+    expect(detectSensitive(big).some(m => m.pattern === SCAN_TRUNCATED)).toBe(true)
   })
 })
 
@@ -468,5 +481,40 @@ describe('context-field credential demotion at shared scope (#353 #21)', () => {
       .structured_data?._demoted
     expect(demoted).toBeDefined()
     expect(demoted?.patterns).toContain('basic_auth_url')
+  })
+})
+
+// #386 end-to-end: infra content PAST the old 64KB cap must now be demoted on a
+// shared-scope write and excluded from a publishable set. Before the ceiling was
+// raised it was silently passed — the exact 2026-06-leak class.
+describe('infra content past 64KB is demoted / excluded (#386)', () => {
+  const FILLER = 'x'.repeat(70 * 1024) // past the old 64KB cap, inside the 1 MiB window
+
+  it('demotes a shared-scope learn whose infra payload sits past byte 64KB', async () => {
+    const { Plur } = await import('../src/index.js')
+    const { mkdtempSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+
+    const dir = mkdtempSync(join(tmpdir(), 'plur-386-'))
+    const sharedPath = mkdtempSync(join(tmpdir(), 'plur-386-shared-'))
+    const plur = new Plur({ path: dir, stores: [{ scope: 'group:eng', shared: true, path: sharedPath }] })
+
+    const engram = plur.learn(`benign runbook ${FILLER} deploy droplet 139.59.155.82`, { scope: 'group:eng' })
+    expect(engram.scope).toBe('local')
+    expect((engram as { visibility?: string }).visibility).toBe('private')
+  })
+
+  it('filterPublishable excludes a public engram with infra past byte 64KB', async () => {
+    const { filterPublishable } = await import('../src/publish.js')
+    const { EngramSchema } = await import('../src/schemas/engram.js')
+    const e = EngramSchema.parse({
+      id: 'ENG-2026-0101-386',
+      statement: `notes ${FILLER} https://t:p@hub-staging.plur.ai`,
+      type: 'behavioral', scope: 'global', status: 'active', visibility: 'public',
+    })
+    const { publishable, rejected } = filterPublishable([e])
+    expect(publishable).toHaveLength(0)
+    expect(rejected).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## What & why

Fixes #386 from the #377 scope-security audit (High, confidentiality).

`detectSensitive()` truncated its input to the first 64 KB before scanning, then silently passed the rest. The infra-topology detectors (`public_ipv4`, `public_ipv6`, `basic_auth_url`, `fqdn_port`, `ipv4_port`, `internal_host`) exist **only** in `detectSensitive` (not in the non-truncating `detectSecrets`). So an engram whose first 64 KB is benign filler but which carries a public IP / basic-auth URL / internal host **after** byte 64 KB:
- passed `_offendingHitsForScope` (`[]` on the truncated benign prefix),
- was **not demoted**, written to a SHARED scope and POSTed to the REMOTE store,
- and slipped past `filterPublishable` (same truncation) — the exact 2026-06 leak class.

## Fix

- **Window raised 64 KB → 1 MiB.** The detector regexes were already rewritten to bounded/linear forms (the codebase comment notes the 64 KB cap is "cheap insurance, not the DoS fix — the bounded quantifiers are"). A single full-window pass is ~100 ms worst case, and total scan work is **capped at 1 MiB regardless of input size**, so this stays DoS-safe. 1 MiB is far above any realistic engram, so ordinary content is now fully scanned.
- **Fail-closed past the ceiling.** Input larger than 1 MiB now appends a synthetic `scan_truncated` hit (exported as `SCAN_TRUNCATED`) so `_guardSensitiveScope` demotes the write and `filterPublishable` excludes the engram — the unscanned tail can no longer be assumed clean. The signal is **always offending regardless of a scope's `sensitivity` policy** (a policy can't `allow` it).

## Tests (`secrets.test.ts`)

- infra content (`public_ipv4`, `basic_auth_url`) past the old 64 KB cap is now detected
- a >1 MiB benign input reports `scan_truncated`; a secret entirely past the ceiling is flagged truncated (fail-closed) rather than silently passing
- truncation at the 1 MiB boundary produces valid UTF-8 (no throw) even when it splits a multibyte char
- **end-to-end:** a >64 KB engram with infra past byte 64 KB is **demoted** on a shared-scope `learn` and **excluded** by `filterPublishable`
- the existing 64 KB ReDoS-timing fuzz test still passes (linearity holds)

Full workspace suite green (2000 passed, 34 skipped).

Part of #377. Closes #386.
