### PR TITLE
Keep packs free of personal data + stop the agent keystore from being synced

### DIFF
--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -608,12 +608,13 @@ export function exportPack(
   // Privacy scan — filter out problematic engrams
   const allPrivacy = scanPrivacy(engrams)
 
-  // Remove private and secret-containing engrams from export
-  const blockedIds = new Set(
-    allPrivacy.issues
-      .filter(i => i.type === 'secret' || i.type === 'private_visibility')
-      .map(i => i.engram_id)
-  )
+  // A pack is a SHARED artifact, so exclude EVERY engram scanPrivacy flagged —
+  // not only secrets and private-tagged ones, but also PII (personal paths,
+  // emails, private IPs) and prompt-injection (#398). scanPrivacy only flags
+  // content that has no place in a shared pack, so ANY issue is disqualifying.
+  // The full scan is still returned in `privacy`, so the caller sees exactly
+  // which engrams were held back and why.
+  const blockedIds = new Set(allPrivacy.issues.map(i => i.engram_id))
   const safeEngrams = engrams.filter(e => !blockedIds.has(e.id))
 
   // Derive match_terms from engram tags and domains

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -21,6 +21,7 @@ export interface SyncResult {
 const GITIGNORE = `# PLUR — secrets (machine-local, NEVER synced)
 config.yaml
 secrets.yaml
+agent-keystore.json
 *.token
 
 # PLUR — derived/cache files (regenerated automatically)
@@ -42,11 +43,13 @@ const SYNC_PATHS = ['engrams.yaml', 'episodes.yaml', 'candidates.yaml', 'packs',
 
 /**
  * Secret-bearing files that must never be tracked. Untracked on every sync, so a
- * repo created by a vulnerable pre-0.10.0 client that already committed config.yaml
- * stops carrying it forward. (Rotating the exposed token and purging git history
- * remain manual, operational steps — code can only stop the bleeding.)
+ * repo created by a vulnerable pre-0.10.0 client that already committed one stops
+ * carrying it forward. Includes `agent-keystore.json` (an encrypted agent key —
+ * exposed the same way as config.yaml in the 2026-06 incident; #392). (Rotating
+ * an exposed token/key and purging git history remain manual, operational steps —
+ * code can only stop the bleeding.)
  */
-const SECRET_PATHS = ['config.yaml', 'secrets.yaml'] as const
+const SECRET_PATHS = ['config.yaml', 'secrets.yaml', 'agent-keystore.json'] as const
 
 /**
  * Secret-bearing filenames that must never be staged even from WITHIN a pack

--- a/packages/core/test/packs.test.ts
+++ b/packages/core/test/packs.test.ts
@@ -518,6 +518,36 @@ describe('pack management', () => {
     ).toBe(0)
   })
 
+  // #398: a SHARED pack must not carry PII either. exportPack previously excluded
+  // only secrets + private-tagged engrams; personal paths, emails, and private IPs
+  // rode along. Now ANY scanPrivacy issue is disqualifying for export.
+  it('#398 export excludes engrams with PII (personal path / private IP / email)', () => {
+    const personalPath = EngramSchema.parse({
+      id: 'ENG-2026-0101-398a', statement: 'notes live in /Users/gregor/secrets/plan.md',
+      type: 'behavioral', scope: 'global', status: 'active', visibility: 'public',
+    })
+    const privateIp = EngramSchema.parse({
+      id: 'ENG-2026-0101-398b', statement: 'the box is on the LAN', summary: 'reachable at 192.168.1.50',
+      type: 'behavioral', scope: 'global', status: 'active', visibility: 'public',
+    })
+    const email = EngramSchema.parse({
+      id: 'ENG-2026-0101-398c', statement: 'ping the owner', source: 'gregor.private@example.com',
+      type: 'behavioral', scope: 'global', status: 'active', visibility: 'public',
+    })
+    expect(exportPack([personalPath], join(dir, 'exp-pp'), { name: 'exp-pp', version: '1.0.0' }).engram_count).toBe(0)
+    expect(exportPack([privateIp], join(dir, 'exp-ip'), { name: 'exp-ip', version: '1.0.0' }).engram_count).toBe(0)
+    expect(exportPack([email], join(dir, 'exp-em'), { name: 'exp-em', version: '1.0.0' }).engram_count).toBe(0)
+  })
+
+  // BOUNDARY: a clean public engram must still export — the PII gate must not over-block.
+  it('#398 export still includes a clean public engram', () => {
+    const clean = EngramSchema.parse({
+      id: 'ENG-2026-0101-398ok', statement: 'prefer composition over inheritance',
+      type: 'behavioral', scope: 'global', status: 'active', visibility: 'public',
+    })
+    expect(exportPack([clean], join(dir, 'exp-clean'), { name: 'exp-clean', version: '1.0.0' }).engram_count).toBe(1)
+  })
+
   it('install allows injection text when allowInjection override is set', () => {
     const packDir = join(dir, 'injection-pack-ok')
     mkdirSync(packDir)

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -88,6 +88,7 @@ describe('sync', () => {
       // Secrets must be ignored so they never ride along into a synced repo (#380).
       expect(gitignore).toContain('config.yaml')
       expect(gitignore).toContain('secrets.yaml')
+      expect(gitignore).toContain('agent-keystore.json')
     })
 
     it('commits all existing files', () => {
@@ -129,6 +130,19 @@ describe('sync', () => {
       writeFileSync(join(dir, 'engrams.yaml'), '- id: ENG-002\n  statement: new\n')
       sync(dir)
       expect(git('ls-files', dir).split('\n')).not.toContain('config.yaml')
+    })
+
+    it('untracks an agent-keystore.json committed by a vulnerable client on the next sync (#392)', () => {
+      // The 2026-06 incident exposed agent-keystore.json (an encrypted agent key)
+      // the same way as config.yaml — committed to the store repo and pushed.
+      git('init', dir)
+      writeFileSync(join(dir, 'agent-keystore.json'), '{"address":"x.eth","crypto":{"ciphertext":"deadbeef"}}')
+      git('add -A -f', dir)
+      git('commit -m "legacy commit with keystore"', dir)
+      expect(git('ls-files', dir).split('\n')).toContain('agent-keystore.json')
+      writeFileSync(join(dir, 'engrams.yaml'), '- id: ENG-003\n  statement: new\n')
+      sync(dir)
+      expect(git('ls-files', dir).split('\n')).not.toContain('agent-keystore.json')
     })
 
     it('does not commit machine-local derived files (engrams.db, store.pglite/)', () => {


### PR DESCRIPTION
Second slice of audit batch **B1** (distribution hygiene), now that #387/#389 are on `main`. Two fixes.

## 1. Keep personal data out of exported packs — Closes #398

A knowledge pack is a **shared artifact**. The export privacy scan already detected personal data — home-folder paths, email addresses, private-range IPs — and prompt-injection text, but `exportPack` only actually held back **secrets** and engrams the user had explicitly tagged **private**. Everything else (PII, injection) still shipped in the pack.

Now **any** engram the scan flags — for any reason — is excluded from the export. The full scan is still returned in the result, so the caller sees exactly which engrams were held back and why. The PII detectors are tight (only real home dirs, RFC-bounded emails, private-range IPs `10/172.16-31/192.168`), so clean content exports normally — verified by a boundary test.

## 2. Stop the agent keystore from being synced — Closes #392

`agent-keystore.json` (an encrypted agent key) was exposed in the June incident the **same way** `config.yaml` was — committed to the local store's git repo and pushed. #387 added self-healing for `config.yaml`/`secrets.yaml` but not the keystore. This adds it to both the store `.gitignore` and the self-heal untrack list, so it's never tracked and gets untracked on the next sync if a prior client already committed it.

(As before: rotating an exposed key and purging history remain manual operational steps — code only stops the bleeding. The exposed token in this install is already scheduled for rotation.)

## Notes
- Full core suite green (1539 passed); new regression tests for both (PII-excluded + clean-still-exports for #398; keystore-untracked + gitignore for #392).
- This completes **B1** except #396, which is **re-scoped** per the architecture (`plur sync` is private backup, enterprise stores are permissioned via the org's GitLab/GitHub) — it's a remote-target guard, not a per-engram sync filter, tracked separately. Next up: **B2**.
