### PR TITLE
Default new memories to private + scan merged tags before sharing

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1272,7 +1272,10 @@ export class Plur {
         consolidated: false,
         type,
         scope,
-        visibility: context?.visibility ?? (context?.domain ? 'public' : 'private'),
+        // #401: visibility defaults to 'private'. Having a `domain` (a topic
+        // classification most engrams carry) must NOT auto-publish an engram —
+        // public is opt-in, set it deliberately.
+        visibility: context?.visibility ?? 'private',
         statement,
         rationale: context?.rationale,
         source: context?.source,

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -64,7 +64,13 @@ function demoteIfSensitive(
   engram: any,
   newStatement: string,
 ): void {
-  const offending = deps.offendingHitsForScope(newStatement, engram.scope ?? 'global')
+  // Scan the post-mutation statement AND the engram's (merged) tags. A dedup
+  // UPDATE/MERGE unions `context.tags` into the engram before this runs, so a
+  // secret/infra value in a merged tag would otherwise ride to a shared store
+  // unguarded — the statement-only scan missed it (#409).
+  const tags = Array.isArray(engram.tags) ? engram.tags.filter((t: unknown) => typeof t === 'string') : []
+  const scanText = tags.length ? `${newStatement}\n${tags.join(' ')}` : newStatement
+  const offending = deps.offendingHitsForScope(scanText, engram.scope ?? 'global')
   if (offending.length === 0) return
   const patterns = [...new Set(offending.map(h => h.pattern))].join(', ')
   logger.warning(

--- a/packages/core/test/learn-async-scope.test.ts
+++ b/packages/core/test/learn-async-scope.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import { learnAsync } from '../src/learn-async.js'
 import type { LearnAsyncDeps } from '../src/learn-async.js'
+import { loadEngrams, saveEngrams } from '../src/engrams.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 /**
@@ -106,5 +110,55 @@ describe('learnAsync scope-aware LLM dedup (issue #359)', () => {
     // Without a requested scope the filter is skipped; global candidate is a valid target.
     expect(llm).toHaveBeenCalled()
     expect(result.decision).toBe('NOOP')
+  })
+})
+
+// #409: a dedup UPDATE/MERGE unions context.tags into the engram, but the demote
+// scan only looked at the statement — a secret in a merged TAG reached the shared
+// store unguarded. The demote now scans statement + tags.
+describe('learnAsync demote scans merged tags (#409)', () => {
+  let dir: string
+  let engramsPath: string
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }) })
+
+  function depsWithFile(candidates: Engram[]): LearnAsyncDeps {
+    dir = mkdtempSync(join(tmpdir(), 'plur-409-'))
+    engramsPath = join(dir, 'engrams.yaml')
+    saveEngrams(engramsPath, candidates)
+    return {
+      ...makeDeps(candidates),
+      engramsPath,
+      rootPath: dir,
+      // Flag any scan text containing the sentinel — placed ONLY in a tag below,
+      // so a hit proves the scan now includes the merged tags.
+      offendingHitsForScope: (text: string) =>
+        text.includes('LEAKTAG') ? ([{ pattern: 'fake_infra', match: 'LEAKTAG' }] as any) : [],
+    }
+  }
+
+  it('UPDATE demotes to local when a merged tag carries sensitive content', async () => {
+    const shared = { ...globalCandidate, id: 'ENG-2026-0101-409', scope: 'group:datafund/datafund', statement: 'clean shared note' } as unknown as Engram
+    const deps = depsWithFile([shared])
+    const llm = vi.fn().mockResolvedValue('DECISION: UPDATE\nTARGET: ENG-2026-0101-409\nREASON: same topic')
+
+    // Statement is clean; the sensitive sentinel rides ONLY in a tag.
+    const result = await learnAsync(deps, 'clean shared note refined', { scope: 'group:datafund/datafund', tags: ['LEAKTAG'], llm })
+
+    expect(result.decision).toBe('UPDATE')
+    const persisted = loadEngrams(engramsPath).find(e => e.id === 'ENG-2026-0101-409') as any
+    expect(persisted.scope).toBe('local')        // demoted — the merged tag was scanned
+    expect(persisted.visibility).toBe('private')
+  })
+
+  it('UPDATE does NOT demote when statement and tags are clean (no over-block)', async () => {
+    const shared = { ...globalCandidate, id: 'ENG-2026-0101-409b', scope: 'group:datafund/datafund', statement: 'clean shared note' } as unknown as Engram
+    const deps = depsWithFile([shared])
+    const llm = vi.fn().mockResolvedValue('DECISION: UPDATE\nTARGET: ENG-2026-0101-409b\nREASON: same topic')
+
+    const result = await learnAsync(deps, 'clean shared note refined', { scope: 'group:datafund/datafund', tags: ['ordinary-tag'], llm })
+
+    expect(result.decision).toBe('UPDATE')
+    const persisted = loadEngrams(engramsPath).find(e => e.id === 'ENG-2026-0101-409b') as any
+    expect(persisted.scope).toBe('group:datafund/datafund') // untouched
   })
 })

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -484,6 +484,15 @@ describe('Plur', () => {
     expect(engram.derived_from).toBeNull()
   })
 
+  it('#401 having a domain does NOT default visibility to public', () => {
+    // A domain is a topic classification most engrams carry; it must not
+    // auto-publish. Visibility stays private unless set deliberately.
+    const withDomain = plur.learn('Categorized note', { scope: 'global', domain: 'software.architecture' })
+    expect(withDomain.visibility).toBe('private')
+    const explicitPublic = plur.learn('Deliberately shared', { scope: 'global', domain: 'software.architecture', visibility: 'public' })
+    expect(explicitPublic.visibility).toBe('public')
+  })
+
   it('inject returns injected_ids array', () => {
     plur.learn('Always use blue-green deploy strategies', { scope: 'global' })
     plur.learn('Database for myapp is PostgreSQL', { scope: 'project:myapp' })


### PR DESCRIPTION
Batch **B2** (scan / guard coverage), part 1. Two fixes.

## 1. New memories default to private, not public — Closes #401

`visibility` defaulted to `public` whenever a memory had a `domain` (a topic classification that **nearly every** memory carries). So most memories were silently shareable-by-default. It now defaults to **private**; `public` is opt-in, set deliberately. Full suite stayed green with the flip — nothing legitimately relied on the old default.

## 2. Dedup demote now scans merged tags — Closes #409

A dedup **UPDATE/MERGE** unions `context.tags` into the target memory, but the pre-write leak re-check (`demoteIfSensitive`) scanned only the statement. A secret/infra value hidden in a merged **tag** rode to the shared store unguarded. The re-check now scans statement **+** the merged tags, matching the field coverage the first-write guard already has. New regression tests: a sensitive tag demotes to local/private; a clean tag does not (no over-block).

## Also resolved without code (closed as already-fixed / no exploitable path)
- **#393** (injection scan misses domain) — already closed by #389: the injection scan lives in pack export/install and #389 added `domain` to its field set. Local learns are self-authored; the remote-content variant was the skeptic-rejected finding.
- **#407** (cross-scope recurrence promotion skips the guard) — `_buildSourceEntry` carries only `{scope, session_id, stored_at}` metadata (no free text), recurrence doesn't alter the statement, and promotion is to the *safer* personal `global` scope. There's no new-content egress to guard, and naively re-running the guard would risk **false-demoting** legitimately-shared memories on recurrence. Closed with that rationale.

Full core suite: 1542 passed.
