### PR TITLE
Tighten scope classification + routing (4 audit fixes)

### DIFF
--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -64,6 +64,15 @@ const WEIGHT_DOMAIN = 1.5
 const WEIGHT_TAG = 0.5
 const WEIGHT_KEYWORD = 0.2
 
+/** Cap on the statement-keyword channel's total raw contribution (#395). Keyword
+ * overlap is a weak, often-coincidental signal — statement words happening to match
+ * a cover's namespace tokens. On its OWN it must never clear the auto-route
+ * threshold and drop a generic engram into a shared team store (8 hits would
+ * otherwise reach 8*0.2 = 1.6 ⟹ squash ≈ 0.52 ≥ 0.5). The cap keeps keyword-only
+ * below the single-domain threshold (squash(1.0) = 0.4 < SCOPE_MATCH_THRESHOLD)
+ * while keywords still BOOST a real domain/tag match toward saturation. */
+const MAX_KEYWORD_RAW = 1.0
+
 /** Weight for a REVERSE-direction domain hit — the engram's `domain` is BROADER
  * than the cover (`domain ⊃ cover`, e.g. domain `plur` against cover `plur.core`).
  * The engram is NOT specific to the scope, so the reverse match is a weak signal:
@@ -150,6 +159,14 @@ export interface ScopeCandidate {
    * Weak signals (tag-only, keyword-only) also leave this `false`.
    */
   coverContainsDomain: boolean
+  /**
+   * Segment depth of the `covers` entry that FORWARD-matched the domain (#399),
+   * e.g. cover `plur.core` → 2, `plur` → 1; 0 when there was no forward match.
+   * Used as a tie-break: between two scopes that both forward-match the same
+   * domain with equal confidence, the MORE specific cover (deeper) is the better
+   * home, so it wins over an alphabetical-name fallback.
+   */
+  coverSpecificity: number
 }
 
 const STOPWORDS = new Set([
@@ -199,13 +216,17 @@ function scoreScope(
   signals: ScopeSignals,
   scope: string,
   covers: string[],
-): { raw: number; reasons: string[]; domainMatch: boolean; coverContainsDomain: boolean } | null {
+): { raw: number; reasons: string[]; domainMatch: boolean; coverContainsDomain: boolean; coverSpecificity: number } | null {
   const normalizedCovers = covers.map(c => ({ raw: c, norm: normalizeCover(c) })).filter(c => c.norm.length > 0)
   if (normalizedCovers.length === 0) return null
 
   let raw = 0
   let domainMatch = false
   let coverContainsDomain = false
+  // Depth (segment count) of the cover that FORWARD-matched the domain (#399).
+  // A deeper cover is a more specific home; used to break ties between two scopes
+  // that both forward-match the same domain with equal confidence.
+  let coverSpecificity = 0
   const reasons: string[] = []
 
   // --- domain-prefix channel (highest weight) ---
@@ -221,6 +242,7 @@ function scoreScope(
         raw += WEIGHT_DOMAIN
         domainMatch = true
         coverContainsDomain = true
+        coverSpecificity = cover.norm.split('.').filter(Boolean).length
         reasons.push(`domain ${domain} ⊂ covers ${cover.raw}`)
         break // one domain hit per scope — domain is single-valued
       }
@@ -255,22 +277,23 @@ function scoreScope(
   }
   reasons.push(...matchedTags)
 
-  // --- statement-keyword channel (low weight) ---
+  // --- statement-keyword channel (low weight, capped #395) ---
   const coverKeywords = new Set(normalizedCovers.flatMap(c => c.norm.split('.')).filter(t => t.length >= 3))
   const statementTokens = new Set(tokenizeStatement(signals.statement))
   const keywordHits: string[] = []
   for (const token of statementTokens) {
-    if (coverKeywords.has(token)) {
-      raw += WEIGHT_KEYWORD
-      keywordHits.push(token)
-    }
+    if (coverKeywords.has(token)) keywordHits.push(token)
   }
   if (keywordHits.length > 0) {
+    // #395: cap the keyword contribution so keyword-only overlap can't reach the
+    // auto-route threshold — a generic engram must not land in a shared scope on
+    // word-coincidence alone. Keywords still boost a real domain/tag match.
+    raw += Math.min(keywordHits.length * WEIGHT_KEYWORD, MAX_KEYWORD_RAW)
     reasons.push(`keywords [${keywordHits.sort().join(', ')}] ∈ covers`)
   }
 
   if (raw <= 0) return null
-  return { raw, reasons, domainMatch, coverContainsDomain }
+  return { raw, reasons, domainMatch, coverContainsDomain, coverSpecificity }
 }
 
 /**
@@ -296,16 +319,21 @@ export function rankScopes(
       reason: scored.reasons.join('; '),
       domainMatch: scored.domainMatch,
       coverContainsDomain: scored.coverContainsDomain,
+      coverSpecificity: scored.coverSpecificity,
     })
   }
   // Sort by confidence desc; on equal confidence prefer a domain-prefix match
   // (so the deterministic-bypass caller picks the genuine domain candidate over
   // a coincidentally-equal weak-signal one — e.g. a lone domain hit and a
-  // three-tag hit both squash to exactly 0.5); finally break remaining ties on
-  // scope name ascending for full determinism.
+  // three-tag hit both squash to exactly 0.5); then, between two scopes that BOTH
+  // forward-match the same domain at equal confidence, prefer the MORE SPECIFIC
+  // cover (#399) — the narrower team that more precisely contains the topic, not
+  // whichever scope name sorts first; finally break remaining ties on scope name
+  // ascending for full determinism.
   candidates.sort((a, b) =>
     b.confidence - a.confidence ||
     (b.domainMatch ? 1 : 0) - (a.domainMatch ? 1 : 0) ||
+    b.coverSpecificity - a.coverSpecificity ||
     a.scope.localeCompare(b.scope),
   )
   return candidates

--- a/packages/core/src/scope-util.ts
+++ b/packages/core/src/scope-util.ts
@@ -23,7 +23,16 @@
 export const SHARED_SCOPE_PREFIXES = ['group:', 'project:', 'space:', 'team:', 'org:', 'public'] as const
 
 export function isSharedScope(scope: string): boolean {
-  return SHARED_SCOPE_PREFIXES.some(p => scope.startsWith(p))
+  // The `group:`/`project:`/… entries carry their `:` delimiter, so `startsWith`
+  // already requires a real boundary. `'public'` is the odd one out — a complete
+  // scope name / namespace root, not a bare prefix — so it must match exactly or
+  // on a real delimiter. A plain `startsWith('public')` misclassifies personal
+  // scopes like `public-roadmap` / `publicfoobar` as shared (#403).
+  return SHARED_SCOPE_PREFIXES.some(p =>
+    p === 'public'
+      ? scope === 'public' || scope.startsWith('public:') || scope.startsWith('public/')
+      : scope.startsWith(p),
+  )
 }
 
 /**

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -200,9 +200,19 @@ export class PGLiteAdapter implements StorageAdapter {
       params.push(filter.status)
     }
     if (filter.scope) {
-      // Segment-aware membership (#383): match only on a real delimiter (`:`/`/`)
-      // so a sibling string-prefix scope does not leak. Mirrors isScopeWithin.
-      conditions.push(`(scope = 'global' OR scope = $${i++} OR scope LIKE $${i++} || ':%' OR scope LIKE $${i++} || '/%')`)
+      // Read-side scope filter, two parts OR'd:
+      //  (1) personal-family pass-through — ALL non-shared scopes (local, global,
+      //      user:*, agent:*, …), not just 'global'. The old `scope = 'global'`
+      //      dropped local/user:/agent: under a project-scope recall (#402, the
+      //      pre-#353 behavior storage-indexed already fixed via its `personal`
+      //      column). This is the SQL form of isPersonalScope = NOT isSharedScope,
+      //      kept in sync with SHARED_SCOPE_PREFIXES in scope-util.ts.
+      //  (2) segment-aware membership (#383): the requested scope, exactly or a
+      //      descendant on a REAL delimiter (`:`/`/`) — never a sibling prefix.
+      conditions.push(
+        `((NOT (scope LIKE 'group:%' OR scope LIKE 'project:%' OR scope LIKE 'space:%' OR scope LIKE 'team:%' OR scope LIKE 'org:%' OR scope = 'public' OR scope LIKE 'public:%' OR scope LIKE 'public/%'))`
+        + ` OR scope = $${i++} OR scope LIKE $${i++} || ':%' OR scope LIKE $${i++} || '/%')`,
+      )
       params.push(filter.scope, filter.scope, filter.scope)
     }
     if (filter.domain) {

--- a/packages/core/test/pglite-adapter.test.ts
+++ b/packages/core/test/pglite-adapter.test.ts
@@ -184,6 +184,24 @@ describe('PGLiteAdapter — substrate', () => {
       await adapter.close()
     }, PGLITE_TIMEOUT)
 
+    it('#402 personal-family scopes (local, user:*) pass a project recall — not just global', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0530-101', 'project a', { scope: 'project:a' }),
+        mkEngram('ENG-2026-0530-102', 'project b', { scope: 'project:b' }),     // shared sibling → excluded
+        mkEngram('ENG-2026-0530-103', 'universal', { scope: 'global' }),
+        mkEngram('ENG-2026-0530-104', 'personal note', { scope: 'local' }),
+        mkEngram('ENG-2026-0530-105', 'my note', { scope: 'user:gregor' }),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const underA = await adapter.loadFiltered({ scope: 'project:a' })
+      const ids = underA.map(e => e.id).sort()
+      // project:a + EVERY personal-family scope (global, local, user:*); project:b stays out.
+      // Pre-#402 the hardcoded `scope = 'global'` dropped local + user:* here.
+      expect(ids).toEqual(['ENG-2026-0530-101', 'ENG-2026-0530-103', 'ENG-2026-0530-104', 'ENG-2026-0530-105'])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
     it('filters by domain prefix', async () => {
       seedYaml(yamlPath, [
         mkEngram('ENG-2026-0530-001', 'one', { domain: 'plur.architecture' }),

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
-import { Plur, rankScopes, SCOPE_MATCH_THRESHOLD } from '../src/index.js'
+import { Plur, rankScopes, SCOPE_MATCH_THRESHOLD, isSharedScope } from '../src/index.js'
 import { THRESHOLD_SINGLE_DOMAIN } from '../src/scope-routing.js'
 
 describe('rankScopes — pure ranker', () => {
@@ -393,5 +393,55 @@ describe('plur.suggestScope — reads scope metadata from config stores', () => 
     ])
     const ranked = plur.suggestScope({ statement: 'no overlap words zzz', tags: ['servers'] })
     expect(ranked.map(c => c.scope)).toContain('group:plur/infra')
+  })
+})
+
+describe('rankScopes — keyword-only cap (#395)', () => {
+  it('keyword-only overlap, however many tokens, does NOT clear the auto-route threshold', () => {
+    // A cover with many single-word namespaces; a statement that matches 9 of them
+    // but carries NO domain and NO tag — pure word-coincidence.
+    const scope = { scope: 'group:acme/eng', covers: ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel', 'india'] }
+    const ranked = rankScopes(
+      { statement: 'alpha bravo charlie delta echo foxtrot golf hotel india miscellaneous notes' },
+      [scope],
+    )
+    expect(ranked).toHaveLength(1)
+    // Without the cap, 9*0.2 = 1.8 ⟹ squash ≈ 0.545 ≥ 0.5 would auto-route. Capped, it stays below.
+    expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('keywords still boost a real domain match (the cap does not suppress them entirely)', () => {
+    const scope = { scope: 'group:acme/eng', covers: ['acme.eng', 'alpha', 'bravo', 'charlie'] }
+    const domainOnly = rankScopes({ statement: 'x', domain: 'acme.eng.api' }, [scope])[0]
+    const domainPlusKeywords = rankScopes({ statement: 'alpha bravo charlie', domain: 'acme.eng.api' }, [scope])[0]
+    expect(domainPlusKeywords.confidence).toBeGreaterThan(domainOnly.confidence)
+  })
+})
+
+describe('rankScopes — specificity tie-break (#399)', () => {
+  it('between two equal-confidence forward domain matches, the more specific cover wins (not the name)', () => {
+    // domain forward-matches BOTH covers; both score WEIGHT_DOMAIN ⟹ equal confidence.
+    // The deeper cover (plur.core, depth 2) is the better home than plur (depth 1),
+    // even though its scope name sorts LAST alphabetically.
+    const broad = { scope: 'group:aaa-broad', covers: ['plur'] }
+    const specific = { scope: 'group:zzz-specific', covers: ['plur.core'] }
+    const ranked = rankScopes({ statement: 'x', domain: 'plur.core.security' }, [broad, specific])
+    expect(ranked[0].confidence).toBe(ranked[1].confidence) // genuinely a tie on confidence
+    expect(ranked[0].scope).toBe('group:zzz-specific')      // specificity beats alphabetical
+  })
+})
+
+describe('isSharedScope — public-prefix boundary (#403)', () => {
+  it('classifies the public namespace as shared but NOT string-prefix siblings', () => {
+    expect(isSharedScope('public')).toBe(true)
+    expect(isSharedScope('public:roadmap')).toBe(true)
+    expect(isSharedScope('public/x')).toBe(true)
+    // personal scopes that merely start with the letters "public"
+    expect(isSharedScope('publicfoobar')).toBe(false)
+    expect(isSharedScope('public-roadmap')).toBe(false)
+    // sanity: the colon-delimited prefixes and personal scopes are unchanged
+    expect(isSharedScope('group:plur/eng')).toBe(true)
+    expect(isSharedScope('local')).toBe(false)
+    expect(isSharedScope('user:gregor')).toBe(false)
   })
 })


### PR DESCRIPTION
Batch **B3** (scope classification & routing) — four audit fixes, all independent of the in-flight PRs.

## #403 — "public"-prefixed scope names misclassified as shared
The shared-scope check matched the bare letters `public` with no delimiter, so a personal scope named `public-roadmap` or `publicfoobar` was treated as **shared** (and could be scanned/routed as team-visible). It now matches only the real public namespace: exactly `public`, or `public:` / `public/…`. The `group:`/`project:`/etc. prefixes already carry their `:` so they were never affected.

## #402 — pglite backend dropped personal scopes under a project recall
The alternate PGLite read filter hardcoded `scope = 'global'`, so other personal-family memories (`local`, `user:*`, `agent:*`) were invisible when recalling inside a project — the pre-#353 behavior the main (indexed) backend already fixed via its `personal` column. The pglite filter now uses the SQL equivalent of `isPersonalScope = NOT isSharedScope`, kept in sync with the corrected #403 predicate.

## #395 — keyword-only overlap could auto-file into a shared store
Word-overlap between a memory's statement and a team's `covers` list is a weak signal, but it was uncapped: ~8 matching words reached the auto-route threshold and filed a generic memory into a team's shared store with **no** domain or tag intent. The keyword channel is now capped below the single-domain threshold, so word-coincidence alone can't auto-route — while keywords still **boost** a real domain/tag match.

## #399 — domain-match ties broke alphabetically, not by specificity
When two scopes both forward-match a memory's domain at equal confidence (e.g. covers `plur` vs `plur.core` for domain `plur.core.security`), the tie went to whichever scope **name** sorted first. It now prefers the **more specific cover** (the team whose topic list more precisely contains the memory) before falling back to name order.

## Notes
- Full core suite: 1544 passed. New regression tests for all four (incl. boundary tests: keywords still boost a domain match; clean personal scopes still classify correctly).
- The pglite SQL shared-prefix list is inlined with a comment pointing at `SHARED_SCOPE_PREFIXES` to keep it in sync.
