### PR TITLE
Harden remote-store trust + honest store-registration reporting (5 audit fixes)

### DIFF
--- a/packages/cli/src/commands/stores.ts
+++ b/packages/cli/src/commands/stores.ts
@@ -15,10 +15,25 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const readonly = args.includes('--readonly')
     const result = plur.addStore(path, scope, { shared, readonly })
 
+    // #406: a local store is keyed by its PATH, so adding a NEW scope to an
+    // already-registered path is a no-op for that scope (the existing entry's
+    // scope wins). Don't report a plain success — say the requested scope was
+    // not added.
+    const scopeDropped = result.status === 'already_registered' && result.scope !== scope
+
     if (shouldOutputJson(flags)) {
-      // result.scope is the EXISTING entry's scope on already_registered —
-      // local stores have path-only identity, so it may differ from the request.
-      outputJson({ success: true, status: result.status, path, scope: result.scope })
+      outputJson({
+        success: !scopeDropped,
+        status: result.status,
+        path,
+        scope: result.scope,
+        ...(scopeDropped ? { requested_scope: scope } : {}),
+      })
+    } else if (scopeDropped) {
+      outputText(
+        `This path is already registered under scope "${result.scope}". A local store is keyed by its path, ` +
+        `so the requested scope "${scope}" was NOT added. Use a separate store file for a different scope.`,
+      )
     } else {
       const verb = {
         already_registered: 'Already registered',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -474,9 +474,17 @@ export class Plur {
 
   /** Get or create a RemoteStore driver for a store config entry. */
   private _getRemoteDriver(entry: { url: string; token?: string; scope: string }): RemoteStore {
-    const key = `${entry.url}::${entry.scope}`
+    // #394: include the token in the cache key so a ROTATED token produces a FRESH
+    // driver instead of one still holding the old (now-401) token + its stale cache.
+    // On rotation, drop any prior driver for the same url::scope so the old token
+    // can't keep serving and the map doesn't grow unbounded across rotations.
+    const baseKey = `${entry.url}::${entry.scope}`
+    const key = `${baseKey}::${entry.token ?? ''}`
     let driver = this._remoteStores.get(key)
     if (!driver) {
+      for (const k of this._remoteStores.keys()) {
+        if (k !== key && k.startsWith(baseKey + '::')) this._remoteStores.delete(k)
+      }
       driver = new RemoteStore(entry.url, entry.token ?? '', entry.scope)
       this._remoteStores.set(key, driver)
     }
@@ -4004,9 +4012,18 @@ Generate an improved version of the procedure that prevents this failure. Return
           )
           continue
         }
-        const { status } = this.addStore('', scope, { url: d.url, token })
-        if (status === 'added') added.push(scope)
-        else already.push(scope)
+        try {
+          const { status } = this.addStore('', scope, { url: d.url, token })
+          if (status === 'added') added.push(scope)
+          else already.push(scope)
+        } catch (err) {
+          // #397: a single bad/conflicting scope (e.g. one already bound to a
+          // DIFFERENT endpoint → addStore throws) must NOT abort the whole batch
+          // and leave a partial registration. Record it as skipped and continue
+          // with the remaining authorized scopes.
+          skipped.push(scope)
+          logger.warning(`[plur] could not auto-register scope "${scope}" from ${d.url}: ${err instanceof Error ? err.message : String(err)}`)
+        }
       }
       return { url: d.url, ok: true, added, already_registered: already, skipped }
     })

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -76,8 +76,13 @@ export class RemoteStore implements EngramStore {
     const candidate = { ...d, id: raw.id, scope: raw.scope, status: raw.status }
     const parsed = RemoteRowSchema.safeParse(candidate)
     if (!parsed.success) {
-      const why = parsed.error.issues.map(i => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ')
-      logger.warning(`[plur:remote-store] ${this.url} returned a malformed engram (id=${String(raw.id)}) — dropped: ${why}`)
+      // #408: do NOT echo server-controlled VALUES into the log. Zod messages can
+      // embed the received value, and a crafted id could carry newlines/control
+      // chars to forge log lines (log injection) or leak data. Log only the field
+      // PATHS + failure CODES, plus a sanitized, bounded id.
+      const why = parsed.error.issues.map(i => `${i.path.join('.') || '(root)'}: ${i.code}`).join('; ')
+      const safeId = String(raw.id ?? '').replace(/[^\w:./-]/g, '?').slice(0, 64)
+      logger.warning(`[plur:remote-store] ${this.url} returned a malformed engram (id="${safeId}") — dropped: ${why}`)
       return null
     }
     return parsed.data as unknown as Engram
@@ -203,15 +208,21 @@ export class RemoteStore implements EngramStore {
       const text = await r.text().catch(() => '')
       throw new Error(`Remote store append failed: ${r.status} ${text}`)
     }
-    const data = await r.json().catch(() => ({})) as { id?: string }
-    if (!data.id) {
-      throw new Error(`Remote store append succeeded but server returned no id`)
+    const data = await r.json().catch(() => ({})) as { id?: unknown }
+    // #404: validate the server-assigned id's SHAPE, not just truthiness. It
+    // becomes this engram's id (cached, rendered, used as a key), so a non-string,
+    // empty, over-long, or control-char-bearing id from a buggy/hostile endpoint
+    // must be rejected rather than trusted.
+    const id = data.id
+    if (typeof id !== 'string' || id.length === 0 || id.length > 128 || !/^[\w:./-]+$/.test(id)) {
+      const shown = typeof id === 'string' ? `"${id.slice(0, 64).replace(/[^\w:./-]/g, '?')}"` : typeof id
+      throw new Error(`Remote store append: server returned an invalid id (${shown})`)
     }
     // Optimistic cache insert (issue #89): the POST succeeded so the server
     // has the engram. Insert with the server-assigned id so the very next
     // recall sees it without waiting for a background refresh. If the server
     // transformed other fields, the next refresh corrects them.
-    const stored = { ...(engram as any), id: data.id } as Engram
+    const stored = { ...(engram as any), id } as Engram
     if (this.cache) {
       this.cache.engrams.push(stored)
     } else {
@@ -220,7 +231,7 @@ export class RemoteStore implements EngramStore {
       // from the server instead of treating the partial view as fresh.
       this.cache = { ts: 0, engrams: [stored] }
     }
-    return { id: data.id }
+    return { id }
   }
 
   /**

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -68,6 +68,9 @@ export class StubServer {
   private me: { username: string; org_id: string; role: string; scopes: string[] } = {
     username: 'testuser', org_id: 'test-org', role: 'developer', scopes: ['group:test'],
   }
+  /** When set, POST /engrams returns this as the assigned id instead of a valid
+   *  one — to simulate a buggy/hostile server (e.g. for the #404 id-shape test). */
+  badAppendId: unknown = null
 
   constructor(private readonly validToken: string) {}
 
@@ -128,6 +131,7 @@ export class StubServer {
   reset(): void {
     this.engrams.clear()
     this.idCounter = 0
+    this.badAppendId = null
   }
 
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
@@ -163,7 +167,10 @@ export class StubServer {
           updated_at: now,
         }
         this.engrams.set(id, engram)
-        this.json(res, 201, { id, scope: engram.scope, status: engram.status, data: engram.data })
+        // Normally the server returns the real assigned id; badAppendId lets a
+        // test make it return a malformed one (#404).
+        const returnedId = this.badAppendId !== null ? this.badAppendId : id
+        this.json(res, 201, { id: returnedId, scope: engram.scope, status: engram.status, data: engram.data })
       })
       return
     }

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -68,6 +68,21 @@ describe('RemoteStore against stub server', () => {
     expect((all[0] as any).statement).toBe('hello world')
   })
 
+  it('#404 rejects a malformed server-assigned id on append (does not trust it)', async () => {
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
+    // A buggy/hostile server returns an id carrying a newline + forged log line.
+    server.badAppendId = 'ENG-EVIL\n[plur] forged admin line'
+    await expect(
+      store.append({ id: 'tmp', scope: 'group:test', status: 'active', statement: 'x' } as any),
+    ).rejects.toThrow(/invalid id/)
+
+    // A non-string id is rejected too (object instead of a string).
+    server.badAppendId = { not: 'a string' }
+    await expect(
+      store.append({ id: 'tmp', scope: 'group:test', status: 'active', statement: 'y' } as any),
+    ).rejects.toThrow(/invalid id/)
+  })
+
   it('getById returns engram or null', async () => {
     const store = new RemoteStore(baseUrl, TOKEN, 'group:test')
     await store.append({ id: 'tmp', scope: 'group:test', status: 'active', statement: 'findable' } as any)

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1515,18 +1515,28 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
         // the caller is never told a scope was added when it already existed
         // (#291). A second scope on an already-registered remote URL now
         // genuinely persists, so success:true here is honest.
-        const result = plur.addStore(path ?? '', args.scope as string, {
+        const requestedScope = args.scope as string
+        const result = plur.addStore(path ?? '', requestedScope, {
           shared:   args.shared   as boolean | undefined,
           readonly: args.readonly as boolean | undefined,
           url, token,
         })
+        // #406: a local store is identified by its PATH, so registering a NEW
+        // scope on an already-registered path is a no-op for that scope — the
+        // existing entry's scope wins and the requested scope is dropped. Reporting
+        // success:true there is misleading; surface the drop honestly.
+        const scopeDropped = result.status === 'already_registered' && result.scope !== requestedScope
         return {
-          success: true,
+          success: !scopeDropped,
           status: result.status,
           ...(path ? { path } : { url }),
           // On already_registered this is the EXISTING entry's scope — for
           // local stores (path-only identity) it may differ from the request.
           scope: result.scope,
+          ...(scopeDropped ? {
+            requested_scope: requestedScope,
+            note: `This path is already registered under scope "${result.scope}". A local store is keyed by its path, so the requested scope "${requestedScope}" was NOT added. Use a separate store file for a different scope, or remove the existing entry first.`,
+          } : {}),
           kind: url ? 'remote' : 'filesystem',
         }
       },

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -251,4 +251,30 @@ describe('MCP tools', () => {
       expect(engineering).toHaveLength(1)
     })
   })
+
+  describe('plur_stores_add honest reporting for a re-registered local path (#406)', () => {
+    it('reports success:false and the dropped requested scope when a local path already exists', async () => {
+      const storePath = join(dir, 'extra', 'engrams.yaml')
+      const first = await callTool('plur_stores_add', { path: storePath, scope: 'space:original' }) as any
+      expect(first.success).toBe(true)
+      expect(first.status).toBe('added')
+
+      // Same path, NEW scope: a local store is path-keyed, so the scope is dropped.
+      const second = await callTool('plur_stores_add', { path: storePath, scope: 'space:other' }) as any
+      expect(second.success).toBe(false)               // not a silent success
+      expect(second.status).toBe('already_registered')
+      expect(second.scope).toBe('space:original')      // the existing scope wins
+      expect(second.requested_scope).toBe('space:other')
+      expect(second.note).toMatch(/was NOT added/)
+    })
+
+    it('still reports success when the same path + same scope is a true no-op', async () => {
+      const storePath = join(dir, 'extra2', 'engrams.yaml')
+      await callTool('plur_stores_add', { path: storePath, scope: 'space:same' })
+      const again = await callTool('plur_stores_add', { path: storePath, scope: 'space:same' }) as any
+      expect(again.success).toBe(true)                 // idempotent no-op, not a drop
+      expect(again.status).toBe('already_registered')
+      expect(again.requested_scope).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
Batch **B4** (remote-store trust & robustness) — five audit fixes across core + the MCP tool + the CLI.

## #394 — rotated token kept failing until restart
The driver that talks to a remote store was cached by `url::scope` and never refreshed when you rotate its token, so writes 401'd until the process restarted. The cache now keys on the token too — a rotated token gets a fresh driver immediately, and the stale driver for that url+scope is dropped (so it can't keep serving and the map doesn't grow across rotations).

## #397 — one bad scope aborted the whole "register all my scopes" batch
`registerDiscoveredScopes` looped over your authorized scopes with no error isolation, so one conflicting/bad scope threw and aborted the rest — leaving a partial registration. Each scope is now handled in its own try/catch: the bad one is recorded and skipped, the rest proceed.

## #404 — server-assigned id was trusted on truthiness alone
After a remote write, the id the server returns becomes the memory's id (cached, rendered, used as a key). It was only checked for truthiness, so a malformed/hostile id (an object, an over-long string, control chars) was trusted. It's now validated for shape: a non-empty string, bounded length, safe charset.

## #408 — malformed-row warning echoed server-controlled values
When a bad row from a server is dropped, the warning included the Zod messages (which embed received values) and the raw id — a hostile server could forge log lines or leak data. The log now carries only the field names + failure kind + a sanitized, bounded id.

## #406 — "stores add" reported success while dropping a scope
A local store is keyed by its **path**, so adding a *second* scope to an already-registered path is a no-op for that scope — but the MCP tool and CLI reported plain success. Both now report that the requested scope was **not** added (and name the existing scope), while a true same-path/same-scope no-op still reports success.

## Tests
- Full workspace suite green (2020 passed). New regression tests: a malformed/non-string append id is rejected (#404, via a stub-server "bad id" mode); the MCP tool reports `success:false` + `requested_scope` on a dropped local-path scope and still succeeds on a true no-op (#406).
- #394/#397/#408 are localized, reviewed changes covered by the passing suite (their internals — a private driver cache, discovery mocking, log assertions — aren't cleanly unit-testable without heavier plumbing).
