### PR TITLE
Close the gaps our pre-Črt audit found (2 HIGH + tags parity + routing + lows)

### DIFF
--- a/packages/cli/src/commands/stores.ts
+++ b/packages/cli/src/commands/stores.ts
@@ -72,7 +72,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       registered.forEach(r => {
         if (!r.ok) { outputText(`${r.url}: register failed — ${r.error}`); return }
         outputText(`${r.url}: added ${r.added.length} scope(s)${r.added.length ? ` (${r.added.join(', ')})` : ''}`)
-        if (r.skipped.length) outputText(`  skipped ${r.skipped.length} non-shared scope(s) (not auto-registered): ${r.skipped.join(', ')}`)
+        // `skipped` now has two causes (a personal-family scope refused by the
+        // #382 guard, OR a scope whose addStore threw — e.g. an endpoint conflict
+        // from #397), so the label stays neutral rather than asserting one cause.
+        if (r.skipped.length) outputText(`  skipped ${r.skipped.length} scope(s) (not auto-registered): ${r.skipped.join(', ')}`)
       })
     } else {
       const total = discoveries.reduce((n, d) => n + d.unregistered.length, 0)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -979,16 +979,17 @@ export class Plur {
 
   /**
    * Collect the context-ish fields of an engram (rationale, source, snippet,
-   * dual_coding, domain, structured_data) into a plain object for the
-   * explicit-update / meta / outbox-reguard leak scan (LOW-2, #353). Mirrors the
-   * field set a LearnContext carries into `_guardSensitiveScope` — which scans
-   * `JSON.stringify(context)`, and `context.domain` is part of LearnContext, so
-   * `domain` must be reconstructed here too or the reconstruct-from-engram guards
-   * (update/meta/outbox) scan a strictly smaller surface than learn-time. `domain`
-   * IS sent to the remote API, so a host:port / basic-auth value placed there would
-   * otherwise reach a shared/remote store unguarded on the outbox flush (#405).
-   * Classification domains (`software.architecture`, `plur.memory-model`) produce
-   * no detector hits, so scanning `domain` adds no false-positive demotions.
+   * dual_coding, domain, tags, knowledge_anchors, structured_data) into a plain
+   * object for the explicit-update / meta / outbox-reguard leak scan (LOW-2, #353).
+   * Must mirror the field set a LearnContext carries into `_guardSensitiveScope` —
+   * which scans `JSON.stringify(context)`. LearnContext carries `domain`, `tags`,
+   * and `knowledge_anchors`, so all three must be reconstructed here too, or the
+   * reconstruct-from-engram guards (update / meta / outbox-reguard) scan a strictly
+   * SMALLER surface than learn-time and than the learnAsync demote (which scans
+   * tags, #409) — letting a host:port / basic-auth value placed in a `tag` (or an
+   * anchor snippet/path, or `domain`) ride to a git-synced shared scope unguarded
+   * (pre-Crt audit, #405/#409 parity). Classification domains and ordinary tags
+   * produce no detector hits, so scanning them adds no false-positive demotions.
    * Returns undefined when none are present so the scan text stays statement-only.
    *
    * PLUR-internal bookkeeping keys in `structured_data` (underscore-prefixed:
@@ -1001,7 +1002,7 @@ export class Plur {
   private _engramContextFields(engram: Engram): Record<string, unknown> | undefined {
     const e = engram as Record<string, unknown>
     const fields: Record<string, unknown> = {}
-    for (const k of ['rationale', 'source', 'snippet', 'dual_coding', 'domain'] as const) {
+    for (const k of ['rationale', 'source', 'snippet', 'dual_coding', 'domain', 'tags', 'knowledge_anchors'] as const) {
       if (e[k] != null) fields[k] = e[k]
     }
     const sd = e.structured_data
@@ -1612,7 +1613,12 @@ export class Plur {
       consolidated: false,
       type,
       scope,
-      visibility: context?.visibility ?? (context?.domain ? 'public' : 'private'),
+      // #401: default visibility to 'private' here too. This is the learnRouted
+      // constructor — the PRIMARY production write path (plur_learn / CLI both go
+      // through learnRouted), where `visibility` is never supplied and `domain`
+      // usually is. The old `domain ? 'public'` default silently shipped real
+      // learns as public. Mirrors the learn() constructor's #401 fix above.
+      visibility: context?.visibility ?? 'private',
       statement,
       rationale: context?.rationale,
       source: context?.source,

--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -66,12 +66,16 @@ const WEIGHT_KEYWORD = 0.2
 
 /** Cap on the statement-keyword channel's total raw contribution (#395). Keyword
  * overlap is a weak, often-coincidental signal — statement words happening to match
- * a cover's namespace tokens. On its OWN it must never clear the auto-route
- * threshold and drop a generic engram into a shared team store (8 hits would
- * otherwise reach 8*0.2 = 1.6 ⟹ squash ≈ 0.52 ≥ 0.5). The cap keeps keyword-only
- * below the single-domain threshold (squash(1.0) = 0.4 < SCOPE_MATCH_THRESHOLD)
- * while keywords still BOOST a real domain/tag match toward saturation. */
-const MAX_KEYWORD_RAW = 1.0
+ * a cover's namespace tokens. It must never, on its own OR combined with a single
+ * coincidental tag, clear the auto-route threshold and drop a generic engram into a
+ * shared team store. Sizing: a lone tag hit is WEIGHT_TAG (0.5); to keep
+ * keyword + 1 tag under the single-domain threshold raw (1.5 ⟹ squash 0.5) the cap
+ * must be < 1.0. At 0.8: keyword-only squash(0.8)=0.348, keyword+1-tag
+ * squash(1.3)=0.464 — both below 0.5; keyword+2-tags (1.8 ⟹ 0.545) routes, but two
+ * matching tags is deliberate intent, not coincidence. Keywords still BOOST a real
+ * domain/tag match toward saturation. (Pre-Crt audit: at 1.0 keyword+1-tag hit
+ * exactly 0.5 and auto-routed — the cap was one weak signal too high.) */
+const MAX_KEYWORD_RAW = 0.8
 
 /** Weight for a REVERSE-direction domain hit — the engram's `domain` is BROADER
  * than the cover (`domain ⊃ cover`, e.g. domain `plur` against cover `plur.core`).

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -398,11 +398,13 @@ export function truncateToScanLimit(text: string): string {
  * the 2026-06 leak, several of the worst engrams were mistagged `public`).
  * Returns [] only when clean.
  *
- * Scans at most the first 64KB of input. Inputs over the cap are truncated (a
- * leading credential is still caught); callers must NOT assume full-input
- * scanning. The cap is applied here, so all three call sites — `detectSensitive`
- * itself, the publish loop (publish.ts), and `_guardSensitiveScope`'s scanText
- * (index.ts) — inherit the bound.
+ * Scans at most the first MAX_SCAN_BYTES (1 MiB) of input. Input OVER the cap is
+ * NOT silently truncated-and-passed: a synthetic `scan_truncated` hit is emitted
+ * so the unscanned tail is treated as offending (fail-closed, #386). The cap is
+ * applied here, so the real call sites — the write guard (`_guardSensitiveScope`
+ * / `_offendingHitsForScope` in index.ts) and the pack privacy scan (`scanPrivacy`
+ * in packs.ts) — inherit the bound. (The former engram-publish filter `publish.ts`
+ * was removed in #400; it is no longer a consumer.)
  */
 export function detectSensitive(text: string): SecretMatch[] {
   if (typeof text !== 'string') {

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -55,13 +55,16 @@ const SECRET_PATHS = ['config.yaml', 'secrets.yaml', 'agent-keystore.json'] as c
  * Secret-bearing filenames that must never be staged even from WITHIN a pack
  * directory. `packs` is force-added (`-f`), so `.gitignore` can't stop them —
  * these exclude-pathspecs do. Packs are installed from external/untrusted
- * sources, so a `packs/<name>/config.yaml` / `secrets.yaml` / `*.token` is a real
- * ride-along path that the root-level SECRET_PATHS untrack does not cover. (#387 review)
+ * sources, so a `packs/<name>/config.yaml` / `secrets.yaml` / `*.token` /
+ * `agent-keystore.json` is a real ride-along path that the root-level SECRET_PATHS
+ * untrack does not cover. (#387 review; keystore added pre-Crt audit — #392 had
+ * given the keystore only root protection, leaving the nested-pack vector open.)
  */
 const PACK_SECRET_EXCLUDES = [
   ':(exclude)packs/**/config.yaml',
   ':(exclude)packs/**/secrets.yaml',
   ':(exclude)packs/**/*.token',
+  ':(exclude)packs/**/agent-keystore.json',
 ] as const
 
 function git(args: string[], cwd: string): string {

--- a/packages/core/test/pglite-adapter.test.ts
+++ b/packages/core/test/pglite-adapter.test.ts
@@ -21,6 +21,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
 import { PGLiteAdapter } from '../src/storage-pglite.js'
+import { isSharedScope, isPersonalScope } from '../src/index.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 function mkEngram(id: string, statement: string, opts: Partial<Engram> = {}): Engram {
@@ -199,6 +200,30 @@ describe('PGLiteAdapter — substrate', () => {
       // project:a + EVERY personal-family scope (global, local, user:*); project:b stays out.
       // Pre-#402 the hardcoded `scope = 'global'` dropped local + user:* here.
       expect(ids).toEqual(['ENG-2026-0530-101', 'ENG-2026-0530-103', 'ENG-2026-0530-104', 'ENG-2026-0530-105'])
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('drift guard: pglite scope classification matches isSharedScope for every prefix + boundary (#402/#403)', async () => {
+      // The pglite filter re-encodes SHARED_SCOPE_PREFIXES as raw SQL. This pins it
+      // to the canonical isSharedScope: if a new prefix is added to the list but not
+      // the SQL, this fails. Oracle: a scope is visible under `project:probe` iff it
+      // is personal-family OR within the probe namespace on a real delimiter.
+      const probe = 'project:probe'
+      const within = (s: string) => s === probe || s.startsWith(probe + ':') || s.startsWith(probe + '/')
+      const battery = [
+        probe, 'project:probe/sub', 'project:probeextra',      // exact / descendant / sibling-prefix
+        'global', 'local', 'user:gregor', 'agent:bot',          // personal-family
+        'group:other', 'team:x', 'space:y', 'org:z',            // other shared
+        'public', 'public:roadmap', 'publicfoobar', 'public-roadmap', // #403 public edge cases
+      ]
+      seedYaml(yamlPath, battery.map((s, i) => mkEngram(`ENG-2026-0531-${String(i).padStart(3, '0')}`, s, { scope: s })))
+      const adapter = new PGLiteAdapter(yamlPath, dbPath)
+      await adapter.reindex()
+      const visible = new Set((await adapter.loadFiltered({ scope: probe })).map(e => (e as { scope: string }).scope))
+      for (const s of battery) {
+        const expected = isPersonalScope(s) || within(s)
+        expect(visible.has(s), `${s} (shared=${isSharedScope(s)}) expected visible=${expected}`).toBe(expected)
+      }
       await adapter.close()
     }, PGLITE_TIMEOUT)
 

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -493,6 +493,15 @@ describe('Plur', () => {
     expect(explicitPublic.visibility).toBe('public')
   })
 
+  it('#401 learnRouted (the production write path) also defaults visibility to private with a domain', async () => {
+    // _buildEngramShape is the constructor learnRouted uses — the path plur_learn
+    // and the CLI actually hit. The pre-Crt audit found it still defaulted public.
+    const routed = await plur.learnRouted('Team deploy note', { scope: 'global', domain: 'software.deploy' })
+    expect(routed.visibility).toBe('private')
+    const explicit = await plur.learnRouted('Deliberately shared', { scope: 'global', domain: 'software.deploy', visibility: 'public' })
+    expect(explicit.visibility).toBe('public')
+  })
+
   it('inject returns injected_ids array', () => {
     plur.learn('Always use blue-green deploy strategies', { scope: 'global' })
     plur.learn('Database for myapp is PostgreSQL', { scope: 'project:myapp' })

--- a/packages/core/test/pr5-hardening.test.ts
+++ b/packages/core/test/pr5-hardening.test.ts
@@ -230,6 +230,18 @@ describe('LOW-1 — saveMetaEngrams runs the leak guard before persist', () => {
     expect(saved!.visibility).toBe('private')
   })
 
+  it('demotes a SHARED-scope meta whose sensitive content is in a TAG (pre-Crt audit — tags parity with #409)', () => {
+    // Statement clean; the infra host:port rides ONLY in a tag. _engramContextFields
+    // previously omitted `tags`, so saveMetaEngrams scanned a smaller surface than
+    // learn-time and the tag reached the shared (git-synced) scope unguarded.
+    const plur = freshPlur()
+    const m = meta({ statement: 'a clean meta statement', tags: ['db.internal:5432'], scope: SHARED_SCOPE })
+    plur.saveMetaEngrams([m])
+    const saved = plur.list().find(e => e.id === m.id) as (Engram & { visibility?: string }) | undefined
+    expect(saved!.scope).toBe('local')
+    expect(saved!.visibility).toBe('private')
+  })
+
   it('THROWS on a raw secret in a SHARED-scope meta (HARD detectSecrets check)', () => {
     const plur = freshPlur()
     const m = meta({ statement: 'the api key is sk-aaaabbbbccccddddeeeeffffgggg', scope: SHARED_SCOPE })

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -279,14 +279,16 @@ describe('squash math — auto-route boundaries (#353 finding-11)', () => {
   })
 
   it('FIVE keyword-only hits still do NOT auto-route', () => {
-    // 5 keyword hits → raw = 5*0.2 = 1.0. squash(1.0)=1.0/2.5=0.40 < 0.5.
-    // Preserves "domain >> keyword": no pile of weak keywords out-routes one domain.
+    // 5 keyword hits → raw = 5*0.2 = 1.0, capped at MAX_KEYWORD_RAW (lowered to 0.8
+    // pre-Crt audit so keyword + 1 coincidental tag can't tip over). squash(0.8) =
+    // 0.8/2.3 ≈ 0.348 < 0.5. Preserves "domain >> keyword": no pile of weak
+    // keywords out-routes one domain.
     const ranked = rankScopes(
       { statement: 'alpha beta gamma delta epsilon' },
       [{ scope: 'group:plur/x', covers: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'] }],
     )
     expect(ranked).toHaveLength(1)
-    expect(ranked[0].confidence).toBeCloseTo(0.4, 4)
+    expect(ranked[0].confidence).toBeCloseTo(0.3478, 3)
     expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
   })
 
@@ -415,6 +417,20 @@ describe('rankScopes — keyword-only cap (#395)', () => {
     const domainOnly = rankScopes({ statement: 'x', domain: 'acme.eng.api' }, [scope])[0]
     const domainPlusKeywords = rankScopes({ statement: 'alpha bravo charlie', domain: 'acme.eng.api' }, [scope])[0]
     expect(domainPlusKeywords.confidence).toBeGreaterThan(domainOnly.confidence)
+  })
+
+  it('keyword-coincidence + ONE coincidental tag still does NOT clear the threshold (pre-Crt audit)', () => {
+    // The original cap (1.0) let keyword(1.0)+1 tag(0.5)=1.5 squash to exactly 0.5
+    // and auto-route a generic, no-domain engram into a shared scope. The lowered
+    // cap keeps keyword + 1 tag below the gate.
+    const scope = { scope: 'group:acme/eng', covers: ['acme.platform.core.security.auth.tokens', 'alpha'] }
+    const ranked = rankScopes(
+      { statement: 'platform core security auth tokens notes', tags: ['alpha'] }, // tag 'alpha' coincidentally matches a cover
+      [scope],
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].domainMatch).toBe(false)               // genuinely no domain intent
+    expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD) // must not auto-route
   })
 })
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -174,11 +174,15 @@ describe('sync', () => {
       writeFileSync(join(packDir, 'config.yaml'), configWithToken)
       writeFileSync(join(packDir, 'secrets.yaml'), `token: ${TOKEN}\n`)
       writeFileSync(join(packDir, 'creds.token'), TOKEN)
+      // pre-Crt audit: the keystore had only ROOT protection; a copy nested in a
+      // pack rode into the pushed repo because it wasn't in PACK_SECRET_EXCLUDES.
+      writeFileSync(join(packDir, 'agent-keystore.json'), `{"crypto":{"ciphertext":"${TOKEN}"}}`)
       sync(dir)
       const tracked = git('ls-files', dir).split('\n')
       expect(tracked).not.toContain('packs/evil-pack/config.yaml')
       expect(tracked).not.toContain('packs/evil-pack/secrets.yaml')
       expect(tracked).not.toContain('packs/evil-pack/creds.token')
+      expect(tracked).not.toContain('packs/evil-pack/agent-keystore.json')
       // the pack's non-secret content still rides along
       expect(tracked).toContain('packs/evil-pack/SKILL.md')
       // and no committed blob carries the token


### PR DESCRIPTION
Before handing 0.10.0 to Črt, we ran our **own** adversarial audit of the merged fixes (6 dimension auditors → 3 skeptics per finding → synthesis). It returned **HOLD** and caught 9 real gaps — including two HIGH regressions in the work just merged. This PR closes all of them, with the regression tests that were missing (the suite was falsely green because tests only hit the simple paths).

## HIGH
- **Private-by-default only half-applied (#401).** #412 fixed the visibility default on the simple `learn()` constructor but missed `_buildEngramShape` — the constructor used by `learnRouted`, which is the path `plur_learn` and the CLI **actually** take. Since `visibility` is never passed there and `domain` usually is, real learns still defaulted **public**. Now both constructors default private. New `learnRouted` test.
- **Keystore protected at root but not in packs (#392).** `agent-keystore.json` was added to the root untrack/gitignore but **not** `PACK_SECRET_EXCLUDES`. `packs/` is force-added, so a keystore nested in an untrusted pack still got staged + pushed. Added the pack-exclude + a nested-keystore test.

## MEDIUM
- **Reconstruct-from-memory guards skipped tags.** `_engramContextFields` (used by the meta / update / outbox re-check guards) omitted `tags` (and anchor text), so it scanned a smaller surface than both the first-write guard and the #409 learnAsync fix — a sensitive value in a tag on a shared, git-backed scope rode out unguarded. Added `tags` + `knowledge_anchors`; new sensitive-tag-in-meta demote test.
- **Keyword-route cap one signal too high.** The #395 cap (1.0) let keyword-coincidence + **one** coincidental tag reach exactly the threshold and auto-file a generic memory into a shared store. Lowered to 0.8 so keyword + 1 tag stays under; a real domain match or two matching tags still routes. New keyword+1-tag no-route test.

## LOW
- pglite scope filter re-encodes the shared-prefix list in raw SQL — added a **drift-guard test** pinning it to the canonical `isSharedScope` (so a future prefix can't silently diverge).
- Fixed a stale `secrets.ts` comment that named the removed `publish.ts` and said "64KB" (real limit is 1 MiB, fail-closed).
- Neutralized a CLI label that called endpoint-conflict skips "non-shared scope(s)" (a `group:` conflict is shared).

Full workspace suite (2032) + the 287 adversarial cases green. After this lands, `main` is — by our own audit — ready to hand to Črt.
