### PR TITLE
chore: add .claude-plugin / .openclaw-plugin discovery directories

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,25 @@
+# PLUR for Claude Code
+
+Give Claude Code persistent memory. Corrections, preferences, and conventions
+persist across sessions — stored as plain YAML on your disk, with zero-cost
+local search.
+
+## Install
+
+One command sets up storage, MCP config, and Claude Code hooks for automatic
+engram injection:
+
+```bash
+npx @plur-ai/mcp init
+```
+
+This creates `~/.plur/`, adds PLUR to your `.mcp.json`, and installs the hooks.
+PLUR is installed **globally** — one MCP server, one store, available in every
+project. You only run init once.
+
+## Verify
+
+Ask Claude: *"What's my PLUR status?"* — it should call `plur_status` and return
+your engram count and storage path.
+
+Full docs → [plur.ai](https://plur.ai) · [Engram spec](https://plur.ai/spec.html)

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "plur",
+  "version": "0.9.13",
+  "description": "Persistent, local-first shared memory for AI agents. Corrections, preferences, and conventions persist across sessions, tools, and machines — stored as plain YAML on your disk, with zero-cost local search.",
+  "author": {
+    "name": "PLUR",
+    "url": "https://plur.ai"
+  },
+  "homepage": "https://plur.ai",
+  "repository": "https://github.com/plur-ai/plur",
+  "license": "Apache-2.0",
+  "keywords": [
+    "memory",
+    "agent-memory",
+    "mcp",
+    "local-first",
+    "context-engine"
+  ]
+}

--- a/.openclaw-plugin/README.md
+++ b/.openclaw-plugin/README.md
@@ -1,0 +1,23 @@
+# PLUR for OpenClaw
+
+Shared memory across your OpenClaw agents. PLUR plugs into the OpenClaw
+ContextEngine — auto-injecting relevant memories on session start and
+auto-extracting learnings from conversations. Local-first, no cloud required.
+
+## Install
+
+```bash
+openclaw plugins install @plur-ai/claw
+openclaw config set plur.enabled true
+```
+
+That's it. PLUR works in the background from here — corrections accumulate
+automatically, no workflow changes needed.
+
+## Configuration
+
+The plugin exposes `path`, `auto_learn`, `auto_capture`, and `injection_budget`
+options. See the full manifest in
+[`packages/claw/openclaw.plugin.json`](../packages/claw/openclaw.plugin.json).
+
+Full docs → [plur.ai](https://plur.ai)

--- a/.openclaw-plugin/manifest.yaml
+++ b/.openclaw-plugin/manifest.yaml
@@ -1,0 +1,16 @@
+# OpenClaw plugin manifest for PLUR.
+# Canonical source: packages/claw/openclaw.plugin.json (shipped inside @plur-ai/claw).
+# This top-level copy is a discovery pointer — install the published package below.
+id: plur-claw
+name: PLUR Memory Engine
+description: >-
+  Persistent, learnable memory for OpenClaw agents. Local-first, no cloud
+  required. Auto-injects relevant memories on session start and auto-extracts
+  learnings from conversations.
+version: 0.9.17
+kind: memory
+package: "@plur-ai/claw"
+homepage: https://plur.ai
+repository: https://github.com/plur-ai/plur
+license: Apache-2.0
+enabledByDefault: true


### PR DESCRIPTION
Implements Tris's comms issue **#266** — plugin directories as an ecosystem/discoverability signal on the repo homepage file tree (mem0 shows `.claude-plugin/`, `.cursor-plugin/`, etc.).

## Changes
- **`.claude-plugin/`** — `plugin.json` (canonical Claude Code plugin metadata) + `README.md` with the `npx @plur-ai/mcp init` install flow.
- **`.openclaw-plugin/`** — `manifest.yaml` (discovery pointer derived from the real `packages/claw/openclaw.plugin.json`) + `README.md` with the `openclaw plugins install @plur-ai/claw` flow.

## Note on the manifest filename
The issue asked for `.claude-plugin/manifest.json`; I used **`plugin.json`**, which is Claude Code's documented manifest filename — a real, valid manifest beats a hollow signal file. Both manifests are syntactically validated in CI-friendly form (JSON + YAML parse clean).

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)