### PR TITLE
docs(examples): runnable getting-started scripts + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,6 @@ jobs:
             exit 1
           }
       - run: pnpm test
+      # Getting-started examples must stay runnable against the public API (#267).
+      - name: Run examples
+        run: pnpm --filter @plur-ai/examples run all

--- a/examples/01-basic-store-recall.ts
+++ b/examples/01-basic-store-recall.ts
@@ -1,0 +1,55 @@
+/**
+ * 01 — Basic store & recall
+ *
+ * Store a few engrams (corrections / conventions), then recall the most relevant
+ * one. Fully local and zero-cost: this uses BM25 keyword search — no model
+ * download, no API calls. (For semantic search, swap `recall` for the async
+ * `recallHybrid` — see the README.)
+ *
+ * Prerequisites: from the repo root, run `pnpm install && pnpm build` once
+ *   (examples import the built @plur-ai/core).
+ * Run: pnpm --filter @plur-ai/examples ex:basic
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur } from '@plur-ai/core'
+
+// Use a throwaway store so this example never touches your real ~/.plur
+const path = mkdtempSync(join(tmpdir(), 'plur-example-'))
+const plur = new Plur({ path })
+
+try {
+  // Teach the agent a few corrections / conventions
+  plur.learn('Use toMatchObject() for partial matching in Vitest — toEqual() is strict', {
+    type: 'behavioral',
+    domain: 'dev/testing',
+  })
+  plur.learn('Never force-push to main; open a PR instead', {
+    type: 'behavioral',
+    domain: 'dev/git',
+  })
+  plur.learn('House style: tabs for indentation, single quotes in TypeScript', {
+    type: 'terminological',
+    domain: 'dev/style',
+  })
+
+  // Recall the most relevant engrams for a query (BM25, sync, ~15ms)
+  const hits = plur.recall('vitest assertion matching', { limit: 3 })
+
+  console.log('Stored 3 engrams. Top matches for "vitest assertion matching":\n')
+  for (const e of hits) {
+    console.log(`  • ${e.statement}`)
+    console.log(`    (${e.id}, scope: ${e.scope})`)
+  }
+} finally {
+  rmSync(path, { recursive: true, force: true })
+}
+
+/* Expected output (engram IDs vary):
+ *
+ * Stored 3 engrams. Top matches for "vitest assertion matching":
+ *
+ *   • Use toMatchObject() for partial matching in Vitest — toEqual() is strict
+ *     (ENG-..., scope: global)
+ */

--- a/examples/02-mcp-integration.ts
+++ b/examples/02-mcp-integration.ts
@@ -1,0 +1,62 @@
+/**
+ * 02 — MCP integration
+ *
+ * How PLUR plugs into an MCP client (Claude Code, Cursor, Windsurf), and what the
+ * server's `plur_inject` tool actually does: select the engrams relevant to the
+ * current task within a token budget, formatted for the system prompt.
+ *
+ * In real use you don't call this yourself — `npx @plur-ai/mcp init` wires the
+ * server into your .mcp.json and the client invokes the tools automatically. This
+ * script prints that config and then runs the same core operation so you can see
+ * the output.
+ *
+ * Prerequisites: from the repo root, run `pnpm install && pnpm build` once.
+ * Run: pnpm --filter @plur-ai/examples ex:mcp
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur } from '@plur-ai/core'
+
+// The MCP config that `npx @plur-ai/mcp init` adds to your .mcp.json:
+const mcpConfig = {
+  mcpServers: {
+    plur: { command: 'npx', args: ['-y', '@plur-ai/mcp'] },
+  },
+}
+console.log('.mcp.json entry that `npx @plur-ai/mcp init` writes:\n')
+console.log(JSON.stringify(mcpConfig, null, 2) + '\n')
+
+const path = mkdtempSync(join(tmpdir(), 'plur-example-'))
+const plur = new Plur({ path })
+
+try {
+  plur.learn('Always run `pnpm build` before `pnpm test` — claw imports core dist', {
+    type: 'procedural',
+    domain: 'dev/build',
+  })
+  plur.learn('Deploy with blue-green; never in-place restart prod', {
+    type: 'architectural',
+    domain: 'ops/deploy',
+  })
+
+  // This is the operation the MCP server exposes as the `plur_inject` tool:
+  const result = plur.inject('How do I run the test suite safely?', { budget: 2000 })
+
+  console.log('Injected context for that task (what the agent receives):\n')
+  // inject() sorts engrams into three sections — print whichever are non-empty
+  for (const [label, text] of [
+    ['DIRECTIVES', result.directives],
+    ['CONSTRAINTS', result.constraints],
+    ['CONSIDER', result.consider],
+  ] as const) {
+    if (text.trim()) console.log(`${label}:\n${text}\n`)
+  }
+  console.log(`${result.count} engram(s), ~${result.tokens_used} tokens used`)
+} finally {
+  rmSync(path, { recursive: true, force: true })
+}
+
+/* Expected output: the .mcp.json block above, followed by the injected context
+ * (the `pnpm build before pnpm test` engram in one of the labelled sections),
+ * with an engram count and token estimate. */

--- a/examples/03-scope-filtering.ts
+++ b/examples/03-scope-filtering.ts
@@ -1,0 +1,56 @@
+/**
+ * 03 — Scope filtering (multi-project)
+ *
+ * One store, many projects. Scope isolates project knowledge while `global` facts
+ * are always included. This is how PLUR keeps one machine's memory from leaking
+ * project A's conventions into project B.
+ *
+ * Prerequisites: from the repo root, run `pnpm install && pnpm build` once.
+ * Run: pnpm --filter @plur-ai/examples ex:scope
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur } from '@plur-ai/core'
+
+const path = mkdtempSync(join(tmpdir(), 'plur-example-'))
+const plur = new Plur({ path })
+
+try {
+  // A global fact — applies in every project
+  plur.learn('Prefer explicit over implicit; avoid clever one-liners', {
+    type: 'behavioral',
+    scope: 'global',
+    domain: 'dev/style',
+  })
+  // Project A convention
+  plur.learn('api-service uses REST, not GraphQL', {
+    type: 'architectural',
+    scope: 'project:api-service',
+    domain: 'dev/arch',
+  })
+  // Project B convention
+  plur.learn('web-app uses GraphQL via Apollo', {
+    type: 'architectural',
+    scope: 'project:web-app',
+    domain: 'dev/arch',
+  })
+
+  // Recall scoped to project A: sees project A + global, never project B
+  console.log('Recall in scope project:api-service:')
+  for (const e of plur.recall('which API style do we use', { scope: 'project:api-service', limit: 10 })) {
+    console.log(`  • [${e.scope}] ${e.statement}`)
+  }
+
+  console.log('\nRecall in scope project:web-app:')
+  for (const e of plur.recall('which API style do we use', { scope: 'project:web-app', limit: 10 })) {
+    console.log(`  • [${e.scope}] ${e.statement}`)
+  }
+} finally {
+  rmSync(path, { recursive: true, force: true })
+}
+
+/* Expected: the project:api-service recall shows the REST engram plus the global
+ * style engram, but never the web-app GraphQL engram — and vice-versa. Global
+ * knowledge rides along with every scoped recall; sibling project scopes stay
+ * isolated. */

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,39 @@
+# PLUR examples
+
+Runnable, copy-pasteable getting-started scripts for [`@plur-ai/core`](../packages/core).
+Each is self-contained, writes to a throwaway temp store (never your real
+`~/.plur`), and prints what it does.
+
+## Prerequisites
+
+From the repo root, once:
+
+```bash
+pnpm install
+pnpm build      # examples import the built @plur-ai/core
+```
+
+## Run
+
+```bash
+pnpm --filter @plur-ai/examples ex:basic   # 01 — store & recall
+pnpm --filter @plur-ai/examples ex:mcp     # 02 — MCP integration / inject
+pnpm --filter @plur-ai/examples ex:scope   # 03 — multi-project scope filtering
+pnpm --filter @plur-ai/examples all        # run all three
+```
+
+## What each shows
+
+| File | What it demonstrates |
+|------|----------------------|
+| [`01-basic-store-recall.ts`](01-basic-store-recall.ts) | Store engrams, recall the most relevant (BM25, sync, zero-cost) |
+| [`02-mcp-integration.ts`](02-mcp-integration.ts) | The `.mcp.json` config `npx @plur-ai/mcp init` writes, and the `plur_inject` operation an MCP client calls for you |
+| [`03-scope-filtering.ts`](03-scope-filtering.ts) | One store, many projects — scope isolation with global facts always included |
+
+## Notes
+
+- The examples use the **synchronous, BM25** API (`recall`, `inject`) so they run
+  instantly with no model download. For semantic search, swap in the async
+  `recallHybrid` / `injectHybrid` — same arguments, plus local BGE embeddings.
+- These run in CI on every PR (`.github/workflows/ci.yml`) so they can't silently
+  rot against API changes.

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@plur-ai/examples",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Runnable getting-started examples for @plur-ai/core",
+  "scripts": {
+    "ex:basic": "tsx 01-basic-store-recall.ts",
+    "ex:mcp": "tsx 02-mcp-integration.ts",
+    "ex:scope": "tsx 03-scope-filtering.ts",
+    "all": "pnpm ex:basic && pnpm ex:mcp && pnpm ex:scope"
+  },
+  "dependencies": {
+    "@plur-ai/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.22.4"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,16 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  examples:
+    dependencies:
+      '@plur-ai/core':
+        specifier: workspace:*
+        version: link:../packages/core
+    devDependencies:
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+
   packages/claw:
     dependencies:
       '@plur-ai/core':
@@ -688,89 +698,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -867,30 +893,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
     resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
@@ -964,30 +995,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -1046,66 +1082,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - packages/*
+  - examples
 
 autoInstallPeers: true


### PR DESCRIPTION
Implements Tris's comms issue **#267** — a runnable `examples/` directory so developers have copy-paste working code to try PLUR.

## What
New `examples/` workspace package with three self-contained scripts using the public `@plur-ai/core` API:

| Script | Shows |
|--------|-------|
| `01-basic-store-recall.ts` | Store engrams → recall most relevant (BM25, sync, zero-cost) |
| `02-mcp-integration.ts` | The `.mcp.json` that `npx @plur-ai/mcp init` writes, plus the `plur_inject` operation an MCP client calls for you |
| `03-scope-filtering.ts` | One store, many projects — scope isolation with global facts always included |

Each writes to a **throwaway temp store** (never the user's `~/.plur`), prints its output, and documents expected results. `examples/README.md` has prerequisites + run commands.

## Stays runnable
A new **`Run examples`** step in `.github/workflows/ci.yml` runs all three on every PR, so they can't silently rot against API changes (an explicit acceptance criterion).

## Design choices
- Examples use the **synchronous BM25 path** (`recall`/`inject`) so CI stays fast and avoids triggering the ~1GB embedding-model download — deliberate given the repo's known flaky-embedder issues (#311, #340). READMEs point to the async `recallHybrid`/`injectHybrid` for semantic search.
- `examples/` added to `pnpm-workspace.yaml`; lockfile updated. `pnpm install --frozen-lockfile` verified green on pnpm 9.15.9 (the version CI's `action-setup@v4 version: 9` resolves to).
- All three verified running locally before commit.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)