### PR TITLE
chore: add server.json for the official MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,47 @@
+name: Publish to MCP Registry
+
+# Publishes server.json to the official MCP Registry (registry.modelcontextprotocol.io)
+# on every GitHub Release. Auth is GitHub OIDC — no secrets, no local install needed.
+# The registry listing propagates to directories that ingest it (PulseMCP, mcp.so, …).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write          # required for GitHub OIDC auth to the registry
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync server.json version to the release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          python3 - "$VERSION" <<'PY'
+          import json, re, sys
+          raw = sys.argv[1] if len(sys.argv) > 1 else ""
+          d = json.load(open("server.json"))
+          v = raw if re.match(r"^\d+\.\d+\.\d+", raw or "") else d["version"]
+          d["version"] = v
+          for p in d.get("packages", []):
+              p["version"] = v
+          json.dump(d, open("server.json", "w"), indent=2)
+          print("server.json version ->", v)
+          PY
+
+      - name: Install mcp-publisher
+        run: |
+          url=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest \
+            | grep -o '"browser_download_url": *"[^"]*linux_amd64.tar.gz"' | head -1 | cut -d'"' -f4)
+          echo "Downloading $url"
+          curl -L "$url" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Login (GitHub OIDC) and publish
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
+  "name": "io.github.plur-ai/plur",
+  "description": "Open, local-first engram memory for AI agents — read, correct, and delete what your agent remembers, shared across MCP tools (Claude Code, Cursor, Windsurf).",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/plur-ai/plur",
+    "source": "github"
+  },
+  "version": "0.10.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@plur-ai/mcp",
+      "version": "0.10.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
   "name": "io.github.plur-ai/plur",
-  "description": "Open, local-first engram memory for AI agents — read, correct, and delete what your agent remembers, shared across MCP tools (Claude Code, Cursor, Windsurf).",
+  "description": "Engram memory exchange for AI agents — persistent, shareable memory across Claude Code, Cursor, Windsurf, and Hermes. Read, correct, and delete what your agent learns.",
   "status": "active",
   "repository": {
     "url": "https://github.com/plur-ai/plur",


### PR DESCRIPTION
## What

Adds `server.json` — the **official MCP Registry** manifest for PLUR (`io.github.plur-ai/plur`, npm `@plur-ai/mcp` v0.10.0, stdio transport).

## Why

Publishing to the official registry (`registry.modelcontextprotocol.io`) is the **propagating** move: directories that ingest from it — PulseMCP, mcp.so, and others — pick PLUR up from one source instead of per-site forms. (Glama is already listed separately.)

## To publish (maintainer step — needs interactive GitHub auth)

After merge, from the repo root:

```bash
# install the publisher CLI (brew, or the release binary)
brew install mcp-publisher          # or download from modelcontextprotocol/registry releases

mcp-publisher login github          # verifies the io.github.plur-ai namespace via GitHub
mcp-publisher publish               # publishes server.json to the registry
```

Tip: run `mcp-publisher init` once to validate `server.json` against the current schema before publishing, and consider wiring `mcp-publisher publish` into the release workflow so the registry stays in sync on each version bump.

## Notes

- Version pinned to **0.10.0** (current `@plur-ai/mcp`); bump on each release.
- The `io.github.plur-ai/*` namespace is auto-verifiable because the org owns the GitHub account — no DNS step needed.
