### PR TITLE
fix(sync): warn on private engrams + exclude scope:local from remote (#396)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ plur.capture('Fixed CrashLoopBackOff on bee-3-4 by increasing memory limits', {
 // Query timeline
 const incidents = plur.timeline({ agent: 'claude-code' })
 
-// Sync across machines
+// Sync across machines (use a private git remote — all engrams including private-visibility ones are pushed)
 plur.sync('git@github.com:you/plur-memory.git')
 ```
 
@@ -184,8 +184,16 @@ plur.sync('git@github.com:you/plur-memory.git')
 | `plur_capture` | Record an event — incident, resolution, session milestone |
 | `plur_timeline` | Query episode history by time, agent, or channel |
 | `plur_ingest` | Extract engrams from text automatically |
-| `plur_sync` | Sync across devices via git |
+| `plur_sync` | Sync across devices via git (remote receives all engrams — use a private repo) |
 | `plur_status` | Check system health and engram counts |
+
+### Syncing across devices
+
+`plur.sync(remote)` is git underneath: it commits your engram store and pushes it to the remote you give it. **The remote receives everything that is pushed — including `visibility: private` engrams.** Private visibility means "don't share this in a pack", not "don't mirror it to my own devices", so private engrams are intentionally synced so your memory follows you from machine to machine.
+
+Because the push contains private engrams, **always use a private git remote** (a private GitHub/GitLab repo, or your own server). PLUR surfaces a `warning` in the sync result reminding you of this whenever private engrams are present. Never point sync at a public repository.
+
+The one exception is **`scope: local` engrams**: these are machine-specific by design (paths, local ports, per-host quirks), so they are stripped from every commit and never reach the remote. They stay in your local working copy only — other devices won't see them, and they won't pollute a shared store.
 
 ## Benchmark details
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,7 +42,9 @@ const { directives, consider, tokens_used } = plur.inject('Write tests for the u
 // Rate what was useful — the system improves over time
 plur.feedback(results[0].id, 'positive')
 
-// Sync across machines via git
+// Sync across machines via git — use a PRIVATE remote: the push contains every
+// engram, including visibility:private ones. scope:local engrams are the exception —
+// they are machine-specific and stripped from every commit, so they never sync.
 plur.sync('git@github.com:you/plur-memory.git')
 ```
 

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'child_process'
-import { existsSync, writeFileSync, renameSync, mkdirSync, unlinkSync, statSync, readdirSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync, statSync, readdirSync } from 'fs'
 import { join, dirname, relative } from 'path'
+import * as yaml from 'js-yaml'
 
 export interface SyncStatus {
   initialized: boolean
@@ -16,6 +17,8 @@ export interface SyncResult {
   message: string
   remote: string | null
   files_changed: number
+  /** Present when syncing to a remote — all engrams (including private) are pushed to that remote. */
+  warning?: string
 }
 
 const GITIGNORE = `# PLUR — secrets (machine-local, NEVER synced)
@@ -184,21 +187,94 @@ function packStorePaths(root: string): string[] {
   return [...paths]
 }
 
+const YAML_DUMP_OPTS = { lineWidth: 120, noRefs: true, quotingType: '"' as const }
+
+interface EngramRecord { id?: string; scope?: string; visibility?: string; [k: string]: unknown }
+
+/**
+ * Read engrams.yaml and return the engram list, tolerating both the canonical
+ * `{ engrams: [...] }` shape and a bare top-level array. Returns null when the
+ * file is absent, unparseable, or not in a recognized engram shape.
+ */
+function readEngramList(root: string): { raw: unknown; list: EngramRecord[] } | null {
+  const path = join(root, 'engrams.yaml')
+  if (!existsSync(path)) return null
+  let raw: unknown
+  try {
+    raw = yaml.load(readFileSync(path, 'utf8'))
+  } catch {
+    return null
+  }
+  if (Array.isArray(raw)) return { raw, list: raw as EngramRecord[] }
+  if (raw && typeof raw === 'object' && Array.isArray((raw as any).engrams)) {
+    return { raw, list: (raw as any).engrams as EngramRecord[] }
+  }
+  return null
+}
+
+/**
+ * Warning shown when a remote is involved: the sync remote receives every engram
+ * that is pushed, including private-visibility ones. Counts private engrams that
+ * would actually be pushed (scope:local engrams are excluded from the remote).
+ * Returns undefined when nothing private would be pushed.
+ */
+function privateWarning(root: string): string | undefined {
+  const parsed = readEngramList(root)
+  if (!parsed) return undefined
+  const count = parsed.list.filter(
+    e => e?.scope !== 'local' && (e?.visibility ?? 'private') === 'private',
+  ).length
+  if (count === 0) return undefined
+  return `Note: sync remote receives all engrams including ${count} private-visibility one(s) — use a private git remote.`
+}
+
+/**
+ * Replace the *staged* engrams.yaml blob with one that omits scope:local engrams,
+ * using git plumbing (hash-object + update-index) so the working tree keeps the
+ * local engrams while the commit (and therefore the remote) never sees them.
+ *
+ * Must be called after staging. Re-serializes with the same YAML options PLUR
+ * uses everywhere, so the stripped blob is deterministic across runs — this is what
+ * prevents an infinite-dirty-state loop (issue #396): a sync whose only change is to
+ * a local engram produces the identical stripped blob and therefore no new commit.
+ */
+function stageLocalStripped(root: string): void {
+  const parsed = readEngramList(root)
+  if (!parsed) return
+  const { raw, list } = parsed
+  if (!list.some(e => e?.scope === 'local')) return
+  const filtered = list.filter(e => e?.scope !== 'local')
+  const out = Array.isArray(raw)
+    ? yaml.dump(filtered, YAML_DUMP_OPTS)
+    : yaml.dump({ ...(raw as object), engrams: filtered }, YAML_DUMP_OPTS)
+  const hash = execFileSync('git', ['hash-object', '-w', '--stdin'], {
+    cwd: root, input: out, encoding: 'utf8', timeout: 30_000,
+  }).trim()
+  git(['update-index', '--cacheinfo', `100644,${hash},engrams.yaml`], root)
+}
+
 function initRepo(root: string): void {
   git(['init'], root)
   atomicWrite(join(root, '.gitignore'), GITIGNORE)
   stageStoreFiles(root)
+  stageLocalStripped(root)
   git(['commit', '-m', 'Initial PLUR engram store'], root)
 }
 
 function commitChanges(root: string): number {
   const filesChanged = stageStoreFiles(root)
   if (filesChanged === 0) return 0
-  const diff = gitSafe(['diff', '--cached', '--stat', '--shortstat'], root)
+  stageLocalStripped(root)
+  // Count changes from the STAGED tree (after stripping) vs HEAD. When the only
+  // change is to a scope:local engram, the stripped blob is identical to HEAD, so
+  // nothing is staged and we must NOT commit — otherwise every sync would loop
+  // forever, since the working tree always differs from the stripped HEAD blob.
+  const diff = gitSafe(['diff', '--cached', '--shortstat'], root)
+  if (!diff || diff.length === 0) return 0
   const now = new Date().toISOString().slice(0, 19).replace('T', ' ')
   git(['commit', '-m', `plur sync ${now}`], root)
   // Parse "N files changed" from shortstat
-  const match = diff?.match(/(\d+) file/)
+  const match = diff.match(/(\d+) file/)
   return match ? parseInt(match[1], 10) : filesChanged
 }
 
@@ -240,7 +316,7 @@ export function sync(root: string, remote?: string): SyncResult {
       // Detect default branch name
       const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], root)
       git(['push', '-u', 'origin', branch], root)
-      return { action: 'initialized', message: `Initialized and pushed to ${remote}`, remote, files_changed: 0 }
+      return { action: 'initialized', message: `Initialized and pushed to ${remote}`, remote, files_changed: 0, warning: privateWarning(root) }
     }
     return {
       action: 'initialized',
@@ -257,7 +333,7 @@ export function sync(root: string, remote?: string): SyncResult {
     const filesChanged = commitChanges(root)
     const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], root)
     git(['push', '-u', 'origin', branch], root)
-    return { action: 'synced', message: `Remote added and pushed to ${remote}`, remote, files_changed: filesChanged }
+    return { action: 'synced', message: `Remote added and pushed to ${remote}`, remote, files_changed: filesChanged, warning: privateWarning(root) }
   }
 
   // State 2: Git repo, no remote
@@ -288,7 +364,7 @@ export function sync(root: string, remote?: string): SyncResult {
   }
 
   if (filesChanged === 0 && behind === 0 && aheadBefore === 0) {
-    return { action: 'up-to-date', message: 'Already in sync.', remote: existingRemote, files_changed: 0 }
+    return { action: 'up-to-date', message: 'Already in sync.', remote: existingRemote, files_changed: 0, warning: privateWarning(root) }
   }
 
   const parts: string[] = []
@@ -301,6 +377,7 @@ export function sync(root: string, remote?: string): SyncResult {
     message: `Synced. ${parts.join(', ')}.`,
     remote: existingRemote,
     files_changed: filesChanged,
+    warning: privateWarning(root),
   }
 }
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -292,4 +292,117 @@ describe('sync', () => {
       rmSync(dir2, { recursive: true, force: true })
     })
   })
+
+  describe('scope:local exclusion (issue #396)', () => {
+    let bareRemote: string
+
+    // Canonical engrams.yaml shape: { engrams: [...] }
+    const CANONICAL = [
+      'engrams:',
+      '  - id: ENG-001',
+      '    scope: "project:app"',
+      '    visibility: private',
+      '    statement: shared across my devices',
+      '  - id: ENG-002',
+      '    scope: local',
+      '    visibility: private',
+      '    statement: machine-specific note',
+      '',
+    ].join('\n')
+
+    beforeEach(() => {
+      writeFileSync(join(dir, 'engrams.yaml'), CANONICAL)
+      bareRemote = mkdtempSync(join(tmpdir(), 'plur-remote-'))
+      execSync('git init --bare', { cwd: bareRemote })
+    })
+
+    afterEach(() => {
+      rmSync(bareRemote, { recursive: true, force: true })
+    })
+
+    it('strips scope:local engrams from the committed (remote) engrams.yaml', () => {
+      sync(dir, bareRemote)
+      // The committed blob (== what the remote received) must not contain the local engram.
+      const committed = git('show HEAD:engrams.yaml', dir)
+      expect(committed).toContain('ENG-001')
+      expect(committed).not.toContain('ENG-002')
+      expect(committed).not.toContain('machine-specific note')
+    })
+
+    it('keeps scope:local engrams in the local working tree (no data loss)', () => {
+      sync(dir, bareRemote)
+      const onDisk = readFileSync(join(dir, 'engrams.yaml'), 'utf8')
+      expect(onDisk).toContain('ENG-002')
+      expect(onDisk).toContain('machine-specific note')
+    })
+
+    it('also strips local engrams committed during init (no remote)', () => {
+      sync(dir) // init only, no remote
+      const committed = git('show HEAD:engrams.yaml', dir)
+      expect(committed).toContain('ENG-001')
+      expect(committed).not.toContain('ENG-002')
+    })
+
+    it('does not create empty commits when only local engrams change (no infinite-dirty trap)', () => {
+      sync(dir, bareRemote)
+      const countAfterFirst = parseInt(git('rev-list --count HEAD', dir), 10)
+
+      // Mutate ONLY a local-scoped engram — this must not produce a new commit.
+      writeFileSync(
+        join(dir, 'engrams.yaml'),
+        CANONICAL.replace('machine-specific note', 'machine-specific note EDITED'),
+      )
+      const result = sync(dir)
+      expect(result.files_changed).toBe(0)
+      expect(result.action).toBe('up-to-date')
+
+      const countAfterSecond = parseInt(git('rev-list --count HEAD', dir), 10)
+      expect(countAfterSecond).toBe(countAfterFirst)
+    })
+
+    it('still commits when a non-local engram changes', () => {
+      sync(dir, bareRemote)
+      writeFileSync(
+        join(dir, 'engrams.yaml'),
+        CANONICAL.replace('shared across my devices', 'shared across my devices UPDATED'),
+      )
+      const result = sync(dir)
+      expect(result.files_changed).toBeGreaterThan(0)
+      const committed = git('show HEAD:engrams.yaml', dir)
+      expect(committed).toContain('UPDATED')
+      expect(committed).not.toContain('ENG-002')
+    })
+  })
+
+  describe('private-engram warning (issue #396)', () => {
+    let bareRemote: string
+
+    beforeEach(() => {
+      bareRemote = mkdtempSync(join(tmpdir(), 'plur-remote-'))
+      execSync('git init --bare', { cwd: bareRemote })
+    })
+
+    afterEach(() => {
+      rmSync(bareRemote, { recursive: true, force: true })
+    })
+
+    it('warns that the remote receives private engrams', () => {
+      writeFileSync(
+        join(dir, 'engrams.yaml'),
+        'engrams:\n  - id: ENG-001\n    scope: "project:app"\n    visibility: private\n    statement: secret\n',
+      )
+      const result = sync(dir, bareRemote)
+      expect(result.warning).toBeDefined()
+      expect(result.warning).toMatch(/private/i)
+    })
+
+    it('omits the warning when there are no private engrams', () => {
+      writeFileSync(
+        join(dir, 'engrams.yaml'),
+        'engrams:\n  - id: ENG-001\n    scope: "project:app"\n    visibility: public\n    statement: shareable\n',
+      )
+      const result = sync(dir, bareRemote)
+      expect(result.warning).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
## What

Implements the CTO decision on #396 (audit: *plur sync publishes ALL engrams regardless of scope/visibility*).

The decision:
- `visibility: private` **should** sync — it means "don't share in packs", not "don't mirror to my own devices".
- `scope: local` engrams **should** be excluded — they're machine-specific by design.

## Changes

**1. Private-engram warning (`packages/core/src/sync.ts`)**
`SyncResult.warning` is now populated (only when a remote is involved) whenever private-visibility engrams would be pushed. The count comes from a YAML parse of `engrams.yaml`. The MCP `plur_sync` tool already spreads `...result`, so the warning reaches the user with no MCP change. Engrams with no explicit `visibility` count as private (matching the schema default).

**2. `scope: local` exclusion via git plumbing**
After `git add -A`, the staged `engrams.yaml` blob is replaced with a copy that omits `scope: local` engrams:
- `git hash-object -w --stdin` writes the filtered blob to the object store
- `git update-index --cacheinfo 100644,<hash>,engrams.yaml` stages it

The **working tree is never touched**, so local engrams are preserved on disk (no data loss) while the commit — and therefore the remote — never sees them. Applied on both the init path and the steady-state commit path.

**Infinite-dirty-state trap avoided:** the filtered blob is re-serialized with PLUR's canonical YAML options, making it deterministic. `commitChanges` counts changes from the *staged* (post-strip) tree vs `HEAD`, so a sync whose only change is to a local engram stages nothing and creates no commit. (The working tree does still read as locally-modified vs HEAD by design — the alternative, `git checkout HEAD -- engrams.yaml`, would delete the user's local engrams.)

**3. Docs** — root + `packages/core` READMEs now state the remote receives everything, recommend a private remote, and document the `scope: local` exception.

## Tests

7 new tests in `packages/core/test/sync.test.ts`:
- local-scope engram stripped from committed/remote `engrams.yaml`
- local engram preserved in working tree (no data loss)
- stripping also applies on the init commit
- no empty commit when only a local engram changes (no infinite loop)
- non-local changes still commit
- private warning present / absent (public engrams)

`pnpm --filter @plur-ai/core build` clean; full core suite **576 passed, 10 skipped**. (The one unrelated pre-existing failure in `packages/mcp/test/pack-upgrade-helpers.test.ts` is a `process.exit` issue independent of this change.)

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)