### PR TITLE
feat(spec): wire ScopeMetadataSchema into gen:schemas drift gate (#345)

### DIFF
--- a/packages/core/scripts/gen-spec-schemas.ts
+++ b/packages/core/scripts/gen-spec-schemas.ts
@@ -30,6 +30,7 @@ import { fileURLToPath } from 'url'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import { EngramSchema } from '../src/schemas/engram.js'
 import { PackManifestSchema } from '../src/schemas/pack.js'
+import { ScopeMetadataSchema } from '../src/schemas/scope-metadata.js'
 
 const DRAFT = 'https://json-schema.org/draft/2020-12/schema'
 
@@ -38,6 +39,7 @@ const HERE = path.dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..')
 export const ENGRAM_SCHEMA_PATH = path.join(REPO_ROOT, 'spec', 'engram.schema.json')
 export const PACK_SCHEMA_PATH = path.join(REPO_ROOT, 'spec', 'pack-manifest.schema.json')
+export const SCOPE_METADATA_SCHEMA_PATH = path.join(REPO_ROOT, 'spec', 'scope-metadata.schema.json')
 
 type JsonObject = Record<string, unknown>
 
@@ -99,6 +101,18 @@ export function buildPackManifestSchema(): JsonObject {
   })
 }
 
+export function buildScopeMetadataSchema(): JsonObject {
+  return generate(ScopeMetadataSchema, {
+    $id: 'https://plur.ai/spec/v1/scope-metadata.schema.json',
+    title: 'ScopeMetadata',
+    description:
+      'Self-describing metadata for an engram scope (Open Engram Standard, Stage 2, #345). ' +
+      'Generated from the Zod ScopeMetadataSchema in @plur-ai/core (packages/core/src/schemas/scope-metadata.ts) ' +
+      'by packages/core/scripts/gen-spec-schemas.ts — do not edit by hand. ' +
+      'A scope with no metadata falls back to Stage 1 behavior (isSharedScope + detectSensitive).',
+  })
+}
+
 /** Canonical serialization: 2-space indent, trailing newline. */
 export function serialize(schema: JsonObject): string {
   return JSON.stringify(schema, null, 2) + '\n'
@@ -107,7 +121,12 @@ export function serialize(schema: JsonObject): string {
 function main(): void {
   fs.writeFileSync(ENGRAM_SCHEMA_PATH, serialize(buildEngramSchema()))
   fs.writeFileSync(PACK_SCHEMA_PATH, serialize(buildPackManifestSchema()))
-  console.log(`Wrote ${path.relative(REPO_ROOT, ENGRAM_SCHEMA_PATH)} and ${path.relative(REPO_ROOT, PACK_SCHEMA_PATH)}`)
+  fs.writeFileSync(SCOPE_METADATA_SCHEMA_PATH, serialize(buildScopeMetadataSchema()))
+  console.log(
+    `Wrote ${path.relative(REPO_ROOT, ENGRAM_SCHEMA_PATH)}, ` +
+    `${path.relative(REPO_ROOT, PACK_SCHEMA_PATH)}, and ` +
+    `${path.relative(REPO_ROOT, SCOPE_METADATA_SCHEMA_PATH)}`,
+  )
 }
 
 // Only write when run as a CLI, not when imported by the drift test.

--- a/packages/core/test/spec-schema-drift.test.ts
+++ b/packages/core/test/spec-schema-drift.test.ts
@@ -3,9 +3,11 @@ import { readFileSync } from 'fs'
 import {
   buildEngramSchema,
   buildPackManifestSchema,
+  buildScopeMetadataSchema,
   serialize,
   ENGRAM_SCHEMA_PATH,
   PACK_SCHEMA_PATH,
+  SCOPE_METADATA_SCHEMA_PATH,
 } from '../scripts/gen-spec-schemas.js'
 
 /**
@@ -27,6 +29,11 @@ describe('spec JSON Schema drift (#315)', () => {
   it('spec/pack-manifest.schema.json matches the generated output', () => {
     const committed = readFileSync(PACK_SCHEMA_PATH, 'utf8')
     expect(serialize(buildPackManifestSchema())).toBe(committed)
+  })
+
+  it('spec/scope-metadata.schema.json matches the generated output', () => {
+    const committed = readFileSync(SCOPE_METADATA_SCHEMA_PATH, 'utf8')
+    expect(serialize(buildScopeMetadataSchema())).toBe(committed)
   })
 
   it('generation is deterministic (no runtime-dependent values leak in)', () => {

--- a/spec/scope-metadata.schema.json
+++ b/spec/scope-metadata.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://plur.ai/spec/v1/scope-metadata.schema.json",
+  "title": "ScopeMetadata",
+  "description": "Self-describing metadata for an engram scope (Open Engram Standard, scope layer).",
+  "type": "object",
+  "properties": {
+    "scope": {
+      "type": "string",
+      "description": "The scope this metadata describes (e.g. \"group:plur/engineering\", \"project:plur\")."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable explanation of what this scope is for. Surfaced in scope/store discovery."
+    },
+    "covers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "Topics, domains, or areas this scope is the home for. Advisory; helps an agent pick the right scope and is surfaced in discovery."
+    },
+    "sensitivity": {
+      "type": "object",
+      "properties": {
+        "forbid": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "secrets",
+              "infra"
+            ]
+          },
+          "default": [
+            "secrets",
+            "infra"
+          ],
+          "description": "Sensitive categories that must NOT be written to this scope. A write that trips one of these is demoted to local/private. Default reproduces Stage 1: secrets + infra are forbidden on shared scopes. Unknown categories are dropped (not fatal) so a forward/hand-edited category never drops the whole store entry."
+        },
+        "allow": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Detector pattern names or category names explicitly permitted on this scope, overriding `forbid`. A match whose categories are ALL allowed is not demoted (e.g. a scope that legitimately holds infra topology can allow \"infra\"). A non-array shape coerces to [] (not fatal) so it never drops the whole store entry."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Per-scope sensitivity policy. When present, the leak guard uses it; when absent, the guard falls back to the default shared-scope behavior."
+    },
+    "injection_policy": {
+      "type": "string",
+      "enum": [
+        "on_match",
+        "on_request",
+        "always"
+      ],
+      "description": "When the loader may inject this scope's engrams. Mirrors pack injection_policy semantics."
+    },
+    "owner": {
+      "type": "string",
+      "description": "Owner of the scope (person or team). Advisory."
+    }
+  },
+  "required": [
+    "scope",
+    "description"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Stage 2 Deliverable 1 (partial): adds `spec/scope-metadata.schema.json` to the Open Engram Standard and wires `ScopeMetadataSchema` into the spec-drift gate so it can never silently diverge from the Zod source.

**The Zod schema** (`packages/core/src/schemas/scope-metadata.ts`) was already on `main` — this PR closes the spec-file gap.

### Changes

- `gen-spec-schemas.ts`: import `ScopeMetadataSchema`, export `SCOPE_METADATA_SCHEMA_PATH`, add `buildScopeMetadataSchema()`, write `scope-metadata.schema.json` in `main()`
- `spec-schema-drift.test.ts`: add drift assertion for `scope-metadata.schema.json`
- `spec/scope-metadata.schema.json`: generated from Zod (3 files changed, 100 insertions)

### Why this matters

Without a spec file, the `ScopeMetadataSchema` is invisible to external tooling (schema validators, docs generators, API clients). Without a drift test, a future field addition to the Zod schema would silently go missing from the spec. This PR closes both gaps with the same pattern used for `engram.schema.json` and `pack-manifest.schema.json`.

### What this does NOT include (separate tracks in #345)

- Server `scopes` table / `GET /PUT /api/v1/scopes` (enterprise)
- Admin UI
- Wiring `sensitivity` into the demotion guard
- Discovery surfacing (`plur_scopes_discover` / `plur stores list`)

These are intentionally deferred — the spec file is the stable contract they all depend on.

## Test plan

- [ ] `pnpm test` passes (drift test + 1045 existing tests)
- [ ] `pnpm --filter @plur-ai/core gen:schemas && git diff --exit-code spec/` exits 0 (CI gate)
- [ ] `spec/scope-metadata.schema.json` matches Zod schema: `required: [scope, description]`, `additionalProperties: true`, all optional fields present

Closes part of #345 (Stage 2 — spec file + drift gate).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)