### PR TITLE
feat(core): expose scope-routing match_threshold + weight_tag as config (#362 item i)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,7 +81,7 @@ export { parseDedupResponse, buildDedupPrompt, buildBatchDedupPrompt } from './d
 export { runMigrations, rollbackMigrations, getSchemaVersion, setSchemaVersion, ALL_MIGRATIONS, CURRENT_SCHEMA_VERSION, type Migration, type MigrationResult } from './migrations/index.js'
 export { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
 export { ScopeMetadataSchema, ScopeSensitivitySchema, SENSITIVITY_CATEGORIES, type ScopeMetadata, type ScopeSensitivity, type SensitivityCategory } from './schemas/scope-metadata.js'
-export { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
+export { rankScopes, SCOPE_MATCH_THRESHOLD, WEIGHT_TAG, type ScopeSignals, type ScopeCandidate, type RankScopesOptions } from './scope-routing.js'
 
 // Scope-family predicates live in the leaf module `scope-util.ts` to break a
 // module cycle: `inject.ts` (imported by index.ts) needs `isPersonalScope`, and
@@ -130,7 +130,7 @@ export type { Engram, PreviousVersionRef } from './schemas/engram.js'
 export type { Episode } from './schemas/episode.js'
 export type { PackManifest } from './schemas/pack.js'
 export type { PreviewResult, RegistryEntry, PrivacyScanResult, PrivacyIssue } from './packs.js'
-export type { PlurConfig, StoreEntry } from './schemas/config.js'
+export type { PlurConfig, StoreEntry, ScopeRoutingConfig } from './schemas/config.js'
 export type { ManifestSummary, PayloadDescriptor, Producer, Signer, CapsuleHeader, CapsulePreamble } from './schemas/capsule.js'
 export {
   CAPSULE_MAGIC,
@@ -1184,9 +1184,19 @@ export class Plur {
       const entry = (this.config.stores ?? []).find(s => s.scope === md.scope)
       return entry?.readonly !== true
     })
+    // Scope-routing tuning (#362): enterprise installs with many narrow,
+    // covers-rich scopes can raise `match_threshold` to cut false-positive
+    // routing, or adjust `weight_tag` to re-weight tag-only signals. Both default
+    // to the module constants in scope-routing.ts; WEIGHT_DOMAIN stays hardcoded —
+    // the lone-domain-clears-threshold invariant (THRESHOLD_SINGLE_DOMAIN) is
+    // load-bearing and must not be tunable.
+    const scopeRoutingCfg = this.config.scope_routing ?? {}
+    const matchThreshold = scopeRoutingCfg.match_threshold ?? SCOPE_MATCH_THRESHOLD
+    const weightTagOverride = scopeRoutingCfg.weight_tag
     const candidates = rankScopes(
       { statement, domain: context?.domain, tags: context?.tags },
       writableScopeMetadata,
+      weightTagOverride !== undefined ? { weightTag: weightTagOverride } : undefined,
     )
     const top = candidates[0]
     // PR-6 (#353) + reaudit finding 4: a FORWARD domain-prefix match — the scope's
@@ -1211,13 +1221,14 @@ export class Plur {
       return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
     }
     // No forward domain match: a reverse domain hit, tag-only, or keyword-only
-    // candidate stays gated by the threshold exactly as before — conservative by
-    // design. A LONE reverse-direction match squashes to 0.25 (WEIGHT_DOMAIN_REVERSE
-    // = 0.5 raw) and so does NOT clear the `>=` gate; it falls to the unscoped
-    // default unless additional tag/keyword evidence lifts the squashed score to
-    // >= SCOPE_MATCH_THRESHOLD. The deterministic bypass never forces a broad
-    // engram in.
-    if (top && top.confidence >= SCOPE_MATCH_THRESHOLD) {
+    // candidate stays gated by the threshold. A LONE reverse-direction match
+    // squashes to 0.25 (WEIGHT_DOMAIN_REVERSE = 0.5 raw) and so does NOT clear the
+    // `>=` gate at the default threshold (0.5); it falls to the unscoped default
+    // unless additional tag/keyword evidence lifts the squashed score to
+    // >= the threshold. The threshold is configurable (#362): a higher
+    // `match_threshold` makes routing more conservative, a lower one more
+    // permissive. The deterministic forward-domain bypass above is unaffected.
+    if (top && top.confidence >= matchThreshold) {
       return { scope: top.scope, routed: { scope: top.scope, confidence: top.confidence, reason: top.reason } }
     }
     return { scope: fallback, routed: null }

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -124,6 +124,25 @@ export const VectorConfigSchema = z.object({
 
 export type VectorConfigYaml = z.infer<typeof VectorConfigSchema>
 
+/**
+ * Scope-routing tuning — optional overrides for the deterministic ranker that
+ * auto-routes unscoped writes to a `covers`-matching scope (Stage 3b, #351/#362).
+ * Defaults match the module-level constants in scope-routing.ts.
+ *
+ * Enterprise installs with many narrow, covers-rich scopes may need to raise
+ * `match_threshold` to cut false-positive routing. Raising `weight_tag` boosts
+ * tag-only signals relative to keyword evidence. WEIGHT_DOMAIN (1.5) is NOT
+ * configurable: the lone-domain-clears-threshold invariant is load-bearing.
+ */
+export const ScopeRoutingConfigSchema = z.object({
+  /** Minimum confidence to auto-route an unscoped write. Default: 0.5. */
+  match_threshold: z.number().min(0).max(1).optional(),
+  /** Per-tag weight in the ranker. Default: 0.5. */
+  weight_tag: z.number().min(0).optional(),
+}).partial()
+
+export type ScopeRoutingConfig = z.infer<typeof ScopeRoutingConfigSchema>
+
 export const PlurConfigSchema = z.object({
   auto_learn: z.boolean().default(true),
   auto_capture: z.boolean().default(true),
@@ -195,6 +214,11 @@ export const PlurConfigSchema = z.object({
    * `unscoped_default`. Set false to disable auto-routing entirely.
    */
   auto_route_scope: z.boolean().default(true),
+  /**
+   * Scope-routing tuning — optional overrides for the deterministic ranker (#362).
+   * See {@link ScopeRoutingConfigSchema} for per-field semantics.
+   */
+  scope_routing: ScopeRoutingConfigSchema.default({}),
 }).partial()
 
 export type PlurConfig = z.infer<typeof PlurConfigSchema>

--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -61,7 +61,7 @@ export const SCOPE_MATCH_THRESHOLD = 0.5
  * WEIGHT_TAG/SATURATION shifts these boundaries — see the routing tests and
  * THRESHOLD_SINGLE_DOMAIN. */
 const WEIGHT_DOMAIN = 1.5
-const WEIGHT_TAG = 0.5
+export const WEIGHT_TAG = 0.5
 const WEIGHT_KEYWORD = 0.2
 
 /** Cap on the statement-keyword channel's total raw contribution (#395). Keyword
@@ -220,7 +220,9 @@ function scoreScope(
   signals: ScopeSignals,
   scope: string,
   covers: string[],
+  weightTagOverride?: number,
 ): { raw: number; reasons: string[]; domainMatch: boolean; coverContainsDomain: boolean; coverSpecificity: number } | null {
+  const effectiveWeightTag = weightTagOverride ?? WEIGHT_TAG
   const normalizedCovers = covers.map(c => ({ raw: c, norm: normalizeCover(c) })).filter(c => c.norm.length > 0)
   if (normalizedCovers.length === 0) return null
 
@@ -275,7 +277,7 @@ function scoreScope(
       c => c.norm === tag || isNamespacePrefix(c.norm, tag) || isNamespacePrefix(tag, c.norm),
     )
     if (hit) {
-      raw += WEIGHT_TAG
+      raw += effectiveWeightTag
       matchedTags.push(`tag ${tag} ~ covers ${hit.raw}`)
     }
   }
@@ -300,6 +302,12 @@ function scoreScope(
   return { raw, reasons, domainMatch, coverContainsDomain, coverSpecificity }
 }
 
+/** Options for {@link rankScopes} — all optional; defaults match the module constants. */
+export interface RankScopesOptions {
+  /** Override {@link WEIGHT_TAG} for this call. Default: 0.5. */
+  weightTag?: number
+}
+
 /**
  * Rank the supplied scopes by how well each is the home for an engram carrying
  * `signals`. Pure: same inputs → same output. Returns candidates sorted by
@@ -310,12 +318,13 @@ function scoreScope(
 export function rankScopes(
   signals: ScopeSignals,
   scopes: Array<Pick<ScopeMetadata, 'scope' | 'covers'>>,
+  options?: RankScopesOptions,
 ): ScopeCandidate[] {
   const candidates: ScopeCandidate[] = []
   for (const meta of scopes) {
     const covers = meta.covers ?? []
     if (covers.length === 0) continue
-    const scored = scoreScope(signals, meta.scope, covers)
+    const scored = scoreScope(signals, meta.scope, covers, options?.weightTag)
     if (!scored) continue
     candidates.push({
       scope: meta.scope,

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -447,6 +447,79 @@ describe('rankScopes — specificity tie-break (#399)', () => {
   })
 })
 
+describe('scope_routing config overrides — rankScopes() options (#362)', () => {
+  it('weightTag override: lower weight reduces tag-only confidence', () => {
+    // Default weight_tag=0.5: 3 tags → raw=1.5 → squash(1.5)=0.5000
+    // Override weight_tag=0.1: 3 tags → raw=0.3 → squash(0.3)=0.3/1.8≈0.1667
+    const defaultRanked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers', 'deploy', 'infra'] },
+      [{ scope: 'group:plur/infra', covers: ['servers', 'deploy', 'infra'] }],
+    )
+    const lowWeightRanked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers', 'deploy', 'infra'] },
+      [{ scope: 'group:plur/infra', covers: ['servers', 'deploy', 'infra'] }],
+      { weightTag: 0.1 },
+    )
+    expect(defaultRanked[0].confidence).toBe(0.5)
+    expect(lowWeightRanked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('weightTag override: higher weight boosts a single-tag match above threshold', () => {
+    // Default weight_tag=0.5: 1 tag → raw=0.5 → squash(0.5)=0.25 < threshold
+    // Override weight_tag=2.0: 1 tag → raw=2.0 → squash(2.0)=2.0/3.5≈0.571 >= threshold
+    const ranked = rankScopes(
+      { statement: 'no overlap zzz', tags: ['servers'] },
+      [{ scope: 'group:plur/infra', covers: ['servers'] }],
+      { weightTag: 2.0 },
+    )
+    expect(ranked).toHaveLength(1)
+    expect(ranked[0].confidence).toBeGreaterThanOrEqual(SCOPE_MATCH_THRESHOLD)
+  })
+
+  it('domain-prefix match is unaffected by weightTag override', () => {
+    // Domain hit uses WEIGHT_DOMAIN (hardcoded 1.5), not WEIGHT_TAG. Changing
+    // weightTag must not alter the domain match confidence.
+    const domainSignals = { statement: 'xyzzy nonoverlapping tokens', domain: 'plur.core.security' }
+    const scopes = [{ scope: 'group:plur/core', covers: ['plur.*'] }]
+    const defaultConf = rankScopes(domainSignals, scopes)[0].confidence
+    const overrideConf = rankScopes(domainSignals, scopes, { weightTag: 0.01 })[0].confidence
+    expect(defaultConf).toBe(overrideConf)
+  })
+})
+
+describe('scope_routing config — Plur integration (#362)', () => {
+  const dirs: string[] = []
+  const plurWithConfig = (stores: unknown[], scopeRouting: Record<string, unknown>) => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-sr-cfg-'))
+    dirs.push(dir)
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false, scope_routing: scopeRouting }, { noRefs: true }))
+    return new Plur({ path: dir })
+  }
+  afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }) })
+
+  it('match_threshold:0.7 — three-tag match (confidence=0.5) no longer auto-routes', () => {
+    // Default threshold 0.5: three tags route. Raised to 0.7: same three tags fall through.
+    const plur = plurWithConfig(
+      [{ path: '/tmp/infra.yaml', scope: 'group:plur/infra', covers: ['servers', 'deploy', 'infra'] }],
+      { match_threshold: 0.7 },
+    )
+    const ranked = plur.suggestScope({ statement: 'no overlap zzz', tags: ['servers', 'deploy', 'infra'] })
+    expect(ranked[0].confidence).toBe(0.5)
+    const e = plur.learn('no overlap zzz', { tags: ['servers', 'deploy', 'infra'] }) as { scope: string }
+    expect(e.scope).toBe('global')
+  })
+
+  it('weight_tag:0.3 — three-tag match drops below 0.5 and no longer auto-routes', () => {
+    // Default weight_tag=0.5: 3 tags → 0.5000 routes. Override 0.3: 3*0.3=0.9 → squash(0.9)=0.375 < 0.5.
+    const plur = plurWithConfig(
+      [{ path: '/tmp/infra.yaml', scope: 'group:plur/infra', covers: ['servers', 'deploy', 'infra'] }],
+      { weight_tag: 0.3 },
+    )
+    const e = plur.learn('no overlap zzz', { tags: ['servers', 'deploy', 'infra'] }) as { scope: string }
+    expect(e.scope).toBe('global')
+  })
+})
+
 describe('isSharedScope — public-prefix boundary (#403)', () => {
   it('classifies the public namespace as shared but NOT string-prefix siblings', () => {
     expect(isSharedScope('public')).toBe(true)


### PR DESCRIPTION
## Summary

Implements **item (i)** of the #362 v2 checklist: surface the deterministic scope-routing weights as config so enterprise installs can tune them without patching constants.

Current routing weights (`WEIGHT_TAG=0.5`, `SCOPE_MATCH_THRESHOLD=0.5`, `WEIGHT_DOMAIN=1.5`) are hardcoded in `scope-routing.ts`. Multi-scope installs with many narrow, `covers`-rich scopes accumulate more keyword/tag-overlap noise and may need to raise the threshold to cut false-positive auto-routing of unscoped writes.

## Changes

- **`schemas/config.ts`** — new optional `scope_routing` block on `PlurConfig`:
  - `scope_routing.match_threshold?: number` (default `0.5`)
  - `scope_routing.weight_tag?: number` (default `0.5`)
  - Validated with Zod (`match_threshold` ∈ [0,1], `weight_tag` ≥ 0). Exported as `ScopeRoutingConfig`.
- **`index.ts`** — `_resolveUnscopedScope` reads the config: the `>=` threshold gate now uses the configured `match_threshold`, and `weight_tag` is passed to `rankScopes` via the new `RankScopesOptions`.
- **`scope-routing.ts`** — `WEIGHT_TAG` and `RankScopesOptions` are now exported; `rankScopes`/`scoreScope` accept an optional `weightTag` override.

## Deliberately NOT configurable

`WEIGHT_DOMAIN` (1.5) stays hardcoded. The lone-domain-clears-threshold invariant — `THRESHOLD_SINGLE_DOMAIN === SCOPE_MATCH_THRESHOLD` (1.5 / (1.5+1.5) = 0.5) — is load-bearing and pinned by a unit test; making the domain weight tunable would silently re-break finding #11. The forward-domain deterministic bypass is likewise unaffected by either config knob.

## Tests

Added to `scope-routing.test.ts`:
- `weightTag` override lowers/raises tag-only confidence across the threshold (rankScopes level).
- domain-prefix match confidence is unchanged when `weightTag` is overridden.
- Plur integration via `config.yaml`: `match_threshold:0.7` makes a three-tag match (confidence 0.5) fall through to `global`; `weight_tag:0.3` drops a three-tag match below 0.5 so it no longer auto-routes.

Full `@plur-ai/core` suite green locally: **1559 passed / 28 skipped**.

Closes item (i) of #362.