### PR TITLE
fix(core): patch() no longer returns null on a 2xx whose echoed row fails validation

### DIFF
--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -326,12 +326,28 @@ export class RemoteStore implements EngramStore {
       const text = await r.text().catch(() => '')
       throw new Error(`Remote patch failed: ${r.status} ${text}`)
     }
+    // #327: the server confirmed the write (2xx). Capture the pre-write row
+    // from the cache BEFORE invalidating so the fallback below can merge it.
+    const prev = this.cache?.engrams.find(e => e.id === id) ?? null
     this.cache = null
     // Server returns {engram: {id, scope, status, data: {...}, ...}}; reshape
     // to top-level Engram (same as load() does for rows[]).
     const body = await r.json().catch(() => null) as { engram?: { id: string; scope: string; status: string; data?: any } } | null
-    if (!body?.engram) return null
-    return this.reshape(body.engram)
+    const reshaped = body?.engram ? this.reshape(body.engram) : null
+    if (reshaped) return reshaped
+    // #327: 2xx but the echoed row was missing or failed validation. Returning
+    // null here would be indistinguishable from the 404 above — callers would
+    // misreport a successful write as not-found, or retry it. Return the
+    // optimistically-merged engram (pre-write cached row + the acknowledged
+    // updates); the next load() observes the server's authoritative state.
+    // Only defined update values are applied, mirroring what JSON.stringify
+    // actually sent to the server. Same #408 id sanitization as reshape().
+    const safeId = id.replace(/[^\w:./-]/g, '?').slice(0, 64)
+    logger.warning(`[plur:remote-store] ${this.url} PATCH ${safeId} succeeded but the echoed row was unusable — returning optimistic merge`)
+    const merged: Record<string, unknown> = prev ? { ...(prev as unknown as Record<string, unknown>) } : {}
+    for (const [k, v] of Object.entries(updates)) if (v !== undefined) merged[k] = v
+    merged.id = id
+    return merged as unknown as Engram
   }
 
   async close(): Promise<void> {

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -71,6 +71,10 @@ export class StubServer {
   /** When set, POST /engrams returns this as the assigned id instead of a valid
    *  one — to simulate a buggy/hostile server (e.g. for the #404 id-shape test). */
   badAppendId: unknown = null
+  /** When set, PATCH /engrams/:id still applies the update server-side but
+   *  echoes this value as the {engram: ...} body — to simulate a server whose
+   *  echoed row fails RemoteRowSchema validation (#327). */
+  badPatchEcho: unknown = null
 
   constructor(private readonly validToken: string) {}
 
@@ -132,6 +136,7 @@ export class StubServer {
     this.engrams.clear()
     this.idCounter = 0
     this.badAppendId = null
+    this.badPatchEcho = null
   }
 
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
@@ -222,6 +227,12 @@ export class StubServer {
           data[k] = v
         }
         engram.updated_at = new Date().toISOString()
+        // #327: optionally echo a malformed row AFTER applying the write, to
+        // simulate "PATCH succeeded but the response fails validation".
+        if (this.badPatchEcho !== null) {
+          this.json(res, 200, { engram: this.badPatchEcho })
+          return
+        }
         // Server returns the patched engram in {engram: ...} envelope so the
         // client can observe the post-write authoritative state.
         this.json(res, 200, { engram: { id: engram.id, scope: engram.scope, status: engram.status, data } })

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -162,6 +162,64 @@ describe('RemoteStore against stub server', () => {
     expect(all[1].id).toMatch(/^ENG-SRV-/)
   })
 
+  // #327: a 2xx PATCH whose echoed row fails RemoteRowSchema must NOT return
+  // null — that's indistinguishable from the 404 "not found" return, so a
+  // successful write would be misreported as a failure (or retried).
+  describe('patch() — 2xx with malformed echoed row (#327)', () => {
+    it('returns the optimistically-merged engram when the echo fails validation (warm cache)', async () => {
+      const store = new RemoteStore(baseUrl, TOKEN, 'group:test')
+      server.seedEngram({
+        id: 'ENG-SRV-327', scope: 'group:test', status: 'active',
+        data: { statement: 'patch me', type: 'behavioral' },
+      })
+      await store.load() // warm the cache with the pre-write row
+
+      server.badPatchEcho = { id: 42, garbage: true } // fails RemoteRowSchema
+      const result = await store.patch('ENG-SRV-327', { pinned: true } as any)
+
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe('ENG-SRV-327')
+      expect((result as any).pinned).toBe(true)
+      expect((result as any).statement).toBe('patch me') // merged from cached pre-write row
+      // The write really did land server-side.
+      expect((server.getEngram('ENG-SRV-327')?.data as any)?.pinned).toBe(true)
+    })
+
+    it('returns an id+updates view when the echo fails and there is no cached row (cold cache)', async () => {
+      const store = new RemoteStore(baseUrl, TOKEN, 'group:test')
+      server.seedEngram({
+        id: 'ENG-SRV-328', scope: 'group:test', status: 'active',
+        data: { statement: 'cold cache', type: 'behavioral' },
+      })
+
+      server.badPatchEcho = { nope: 'not an engram' }
+      const result = await store.patch('ENG-SRV-328', { statement: 'rewritten' } as any)
+
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe('ENG-SRV-328')
+      expect((result as any).statement).toBe('rewritten')
+      expect((server.getEngram('ENG-SRV-328')?.data as any)?.statement).toBe('rewritten')
+    })
+
+    it('a genuine 404 still returns null', async () => {
+      const store = new RemoteStore(baseUrl, TOKEN, 'group:test')
+      const result = await store.patch('ENG-SRV-MISSING', { pinned: true } as any)
+      expect(result).toBeNull()
+    })
+
+    it('a valid echo still returns the reshaped server row (no behavior change)', async () => {
+      const store = new RemoteStore(baseUrl, TOKEN, 'group:test')
+      server.seedEngram({
+        id: 'ENG-SRV-329', scope: 'group:test', status: 'active',
+        data: { statement: 'valid echo', type: 'behavioral' },
+      })
+      const result = await store.patch('ENG-SRV-329', { pinned: true } as any)
+      expect(result).not.toBeNull()
+      expect((result as any).statement).toBe('valid echo')
+      expect((result as any).pinned).toBe(true)
+    })
+  })
+
   // Finding #3 (audit 2026-06-10): server responses were written to the engram
   // pool with `as unknown as Engram` — no validation. A compromised server could
   // inject type-confused / malformed engrams. load() must drop malformed rows.


### PR DESCRIPTION
Closes #327.

## What

`RemoteStore.patch()` returned `null` when a PATCH succeeded on the server (2xx) but the echoed row failed `RemoteRowSchema` validation — the same value it returns for a genuine 404. Callers (`setPinnedAsync`, `updateEngramAsync`, `reportFailure` remote routing) conflate that with "not found" and misreport a successful write as a failure, or fall through to the next store.

## How

- `patch()` captures the pre-write row from the TTL cache **before** invalidating it.
- On a 2xx whose body is missing or fails reshape, it returns the **optimistically-merged** engram (cached pre-write row + the acknowledged updates, defined values only — mirroring what `JSON.stringify` actually sent), plus a sanitized warning log (#408 pattern). The next `load()` observes the server's authoritative state.
- Genuine 404 → still `null`. Valid echo → still the reshaped server row (no behavior change).
- Stub server gains a `badPatchEcho` knob (mirrors `badAppendId`) to simulate the malformed-echo case; cleared on `reset()`.

## Acceptance criteria (from #327)

- [x] A 2xx PATCH whose response row fails `RemoteRowSchema` does **not** return `null` as if not-found
- [x] A genuine 404 still returns `null`
- [x] Test covering the 2xx-but-malformed-response case (extends `test/helpers/stub-server.ts`)

## Testing

- `remote-integration.test.ts`: 30/30 (4 new: warm-cache merge, cold-cache fallback, 404, valid-echo regression)
- Core dist rebuilt, then full workspace: core 1564 passed (1 unrelated timing flake — `packs.test.ts` ReDoS guard — passes in isolation; PGLite timeouts from the first run likewise isolation-green), mcp 137/137, claw 107/107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1