### PR TITLE
feat(cli): plur inject default learning protocol — dead flag fix + tests

### DIFF
--- a/packages/cli/src/commands/inject.ts
+++ b/packages/cli/src/commands/inject.ts
@@ -1,40 +1,61 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
 
+// Note: the supersedes rule assumes the consumer has PLUR MCP tools available
+// (plur_learn). Consumers without MCP tooling can opt out via
+// --no-with-default-protocol.
+export const DEFAULT_PROTOCOL = `## Learning Protocol
+Each response must end with a 🧠 I learned block recording reusable insights, unless the response is [ACK] or pure tool output.
+---
+🧠 I learned:
+- <insight (min 10 chars)>
+- <insight>
+---
+Supersedes rule: if this 🧠 corrects a previous engram, call: plur_learn(statement="...", supersedes=["ENG-xxx"], source="<bot_name>")
+Skip the block only when truly nothing new was discovered.`
+
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
 
   let task = ''
   let budget = 2000
+  let withProtocol = true
 
   let i = 0
   while (i < args.length) {
     const arg = args[i]
     if (arg === '--budget' && i + 1 < args.length) { budget = parseInt(args[++i], 10); i++ }
+    else if (arg === '--no-with-default-protocol') { withProtocol = false; i++ }
     else if (!task) { task = arg; i++ }
     else { i++ }
   }
 
   if (!task) {
-    exit(1, 'Usage: plur inject <task> [--budget <n>]')
+    exit(1, 'Usage: plur inject <task> [--budget <n>] [--no-with-default-protocol]')
   }
 
   const result = flags.fast
     ? plur.inject(task, { budget })
     : await plur.injectHybrid(task, { budget })
 
+  // Append default learning protocol to directives (opt-out via --no-with-default-protocol)
+  let directives = result.directives || ''
+  if (withProtocol) {
+    directives = directives ? `${directives}\n\n${DEFAULT_PROTOCOL}` : DEFAULT_PROTOCOL
+  }
+
   if (shouldOutputJson(flags)) {
     outputJson({
-      directives: result.directives,
+      directives,
       constraints: result.constraints,
       consider: result.consider,
       count: result.count,
       tokens_used: result.tokens_used,
     })
   } else {
-    if (result.directives) {
+    if (directives) {
       outputText('## DIRECTIVES')
-      outputText(result.directives)
+      outputText(directives)
     }
     if (result.constraints) {
       outputText('## CONSTRAINTS')

--- a/packages/cli/test/inject.test.ts
+++ b/packages/cli/test/inject.test.ts
@@ -63,4 +63,32 @@ describe('plur inject', () => {
     }
     expect(threw).toBe(true)
   })
+
+  describe('default learning protocol', () => {
+    it('includes the default protocol in directives by default', () => {
+      const output = JSON.parse(run('inject "write unit tests"'))
+      expect(output.directives).toContain('## Learning Protocol')
+      expect(output.directives).toContain('🧠 I learned')
+    })
+
+    it('suppresses the protocol with --no-with-default-protocol', () => {
+      const output = JSON.parse(run('inject "write unit tests" --no-with-default-protocol'))
+      expect(output.directives).not.toContain('## Learning Protocol')
+    })
+
+    it('appends the protocol to existing directives instead of replacing them', () => {
+      // architectural → cognitive_level 'evaluate' → lands in the directives bucket
+      execSync(`node ${CLI} learn "the project deploys to the staging server via rsync" --type architectural --path ${dir} --json`, {
+        encoding: 'utf-8',
+        timeout: 10000,
+      })
+      const output = JSON.parse(run('inject "how do we deploy the project"'))
+      // Injected engram is still present...
+      expect(output.directives).toContain('deploys to the staging server')
+      // ...with the protocol appended after it
+      expect(output.directives).toContain('## Learning Protocol')
+      expect(output.directives.indexOf('deploys to the staging server'))
+        .toBeLessThan(output.directives.indexOf('## Learning Protocol'))
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Re-lands the default learning protocol feature from PR #227 (closed unmerged after branch drift) with both review items from #237 addressed.

## Changes

**1. Dead flags check fixed (option a from the issue)**

`flags['with-default-protocol']` was never in `GlobalFlags` and never parsed by `parseGlobalFlags` — the check evaluated to `true` only because `undefined !== false`. Replaced with an explicit `let withProtocol = true`; the `--no-with-default-protocol` opt-out is parsed in the command's own arg loop alongside `--budget`.

**2. Test coverage added** (`packages/cli/test/inject.test.ts`)

- `DEFAULT_PROTOCOL` text appears in directives by default
- `--no-with-default-protocol` suppresses it
- Protocol appends to (not replaces) existing directives when engrams are injected — uses `--type architectural` so the engram routes to the directives bucket (`architectural` → cognitive_level `evaluate` → directives)

**3. MCP assumption noted**

Added a comment on `DEFAULT_PROTOCOL` noting the supersedes rule assumes the consumer has PLUR MCP tools (`plur_learn`) available, per the issue's notes section.

## Testing

- `packages/cli/test/inject.test.ts`: 6/6 pass (3 new)
- Full CLI suite: 215 passed, 4 skipped. Three unrelated files (`hook-session-guard`, `recall`, `session-checkpoint`) timed out under parallel load and pass cleanly in isolation (15/15) — known load flake, untouched by this change.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1