### PR TITLE
fix(telemetry): unique tmp suffix for atomic writes

### DIFF
--- a/packages/claw/src/telemetry-counters.ts
+++ b/packages/claw/src/telemetry-counters.ts
@@ -81,16 +81,23 @@ function ensureParentDir(path: string): void {
   }
 }
 
+// Unique per call, not just per process (#188): pid-only tmp names collide
+// when two writes to the same path interleave in async contexts — the second
+// write clobbers the first tmp file before its rename.
+function tmpPath(path: string): string {
+  return `${path}.tmp.${process.pid}.${randomUUID()}`
+}
+
 function atomicWriteJson(path: string, data: unknown): void {
   ensureParentDir(path)
-  const tmp = `${path}.tmp.${process.pid}`
+  const tmp = tmpPath(path)
   writeFileSync(tmp, JSON.stringify(data), { encoding: 'utf8', mode: 0o600 })
   renameSync(tmp, path)
 }
 
 function atomicWriteString(path: string, data: string): void {
   ensureParentDir(path)
-  const tmp = `${path}.tmp.${process.pid}`
+  const tmp = tmpPath(path)
   writeFileSync(tmp, data, { encoding: 'utf8', mode: 0o600 })
   renameSync(tmp, path)
 }

--- a/packages/claw/test/telemetry-atomic-write.test.ts
+++ b/packages/claw/test/telemetry-atomic-write.test.ts
@@ -1,0 +1,81 @@
+// Atomic write tmp naming (#188): pid-only tmp suffixes collide when two
+// writes to the same path interleave in async contexts — the second write
+// clobbers the first process-local tmp file before its rename. Every atomic
+// write must use a unique tmp path.
+//
+// Lives in its own file because it partially mocks node:fs to observe tmp
+// paths; the main telemetry-counters suite uses the real filesystem.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const writtenPaths: string[] = []
+const renames: Array<{ from: string; to: string }> = []
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    writeFileSync: (path: any, data: any, opts: any) => {
+      writtenPaths.push(String(path))
+      return actual.writeFileSync(path, data, opts)
+    },
+    renameSync: (from: any, to: any) => {
+      renames.push({ from: String(from), to: String(to) })
+      return actual.renameSync(from, to)
+    },
+  }
+})
+
+import { recordEvent, resetCounters, type CountersOpts } from '../src/telemetry-counters.js'
+
+describe('atomic write tmp naming (#188)', () => {
+  let dir: string
+  let opts: CountersOpts
+
+  beforeEach(() => {
+    writtenPaths.length = 0
+    renames.length = 0
+    dir = mkdtempSync(join(tmpdir(), 'plur-claw-atomic-'))
+    opts = {
+      env: { PLUR_TELEMETRY: 'on' },
+      configPath: join(dir, 'telemetry.json'),
+      countersPath: join(dir, 'counters.json'),
+      installIdPath: join(dir, 'install-id'),
+      pendingDir: join(dir, 'pending'),
+      now: () => new Date('2026-05-02T18:00:00Z'),
+    }
+  })
+
+  it('never reuses a tmp path across writes to the same file', () => {
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+    resetCounters(opts)
+
+    const tmpPaths = writtenPaths.filter((p) => p.includes('.tmp.'))
+    // 3 counters.json writes + 1 install-id write
+    expect(tmpPaths.length).toBeGreaterThanOrEqual(4)
+    expect(new Set(tmpPaths).size).toBe(tmpPaths.length)
+  })
+
+  it('keeps the `<path>.tmp.` prefix convention for tmp files', () => {
+    recordEvent('learn', opts)
+
+    const counterTmps = writtenPaths.filter((p) => p.startsWith(`${join(dir, 'counters.json')}.tmp.`))
+    expect(counterTmps.length).toBe(1)
+    const installTmps = writtenPaths.filter((p) => p.startsWith(`${join(dir, 'install-id')}.tmp.`))
+    expect(installTmps.length).toBe(1)
+  })
+
+  it('renames each tmp file onto its final path', () => {
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+
+    for (const { from, to } of renames) {
+      expect(writtenPaths).toContain(from)
+      expect(from.startsWith(`${to}.tmp.`)).toBe(true)
+    }
+  })
+})

--- a/packages/core/src/telemetry-counters.ts
+++ b/packages/core/src/telemetry-counters.ts
@@ -81,16 +81,23 @@ function ensureParentDir(path: string): void {
   }
 }
 
+// Unique per call, not just per process (#188): pid-only tmp names collide
+// when two writes to the same path interleave in async contexts — the second
+// write clobbers the first tmp file before its rename.
+function tmpPath(path: string): string {
+  return `${path}.tmp.${process.pid}.${randomUUID()}`
+}
+
 function atomicWriteJson(path: string, data: unknown): void {
   ensureParentDir(path)
-  const tmp = `${path}.tmp.${process.pid}`
+  const tmp = tmpPath(path)
   writeFileSync(tmp, JSON.stringify(data), { encoding: 'utf8', mode: 0o600 })
   renameSync(tmp, path)
 }
 
 function atomicWriteString(path: string, data: string): void {
   ensureParentDir(path)
-  const tmp = `${path}.tmp.${process.pid}`
+  const tmp = tmpPath(path)
   writeFileSync(tmp, data, { encoding: 'utf8', mode: 0o600 })
   renameSync(tmp, path)
 }

--- a/packages/core/test/telemetry-atomic-write.test.ts
+++ b/packages/core/test/telemetry-atomic-write.test.ts
@@ -1,0 +1,81 @@
+// Atomic write tmp naming (#188): pid-only tmp suffixes collide when two
+// writes to the same path interleave in async contexts — the second write
+// clobbers the first process-local tmp file before its rename. Every atomic
+// write must use a unique tmp path.
+//
+// Lives in its own file because it partially mocks node:fs to observe tmp
+// paths; the main telemetry-counters suite uses the real filesystem.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const writtenPaths: string[] = []
+const renames: Array<{ from: string; to: string }> = []
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    writeFileSync: (path: any, data: any, opts: any) => {
+      writtenPaths.push(String(path))
+      return actual.writeFileSync(path, data, opts)
+    },
+    renameSync: (from: any, to: any) => {
+      renames.push({ from: String(from), to: String(to) })
+      return actual.renameSync(from, to)
+    },
+  }
+})
+
+import { recordEvent, resetCounters, type CountersOpts } from '../src/telemetry-counters.js'
+
+describe('atomic write tmp naming (#188)', () => {
+  let dir: string
+  let opts: CountersOpts
+
+  beforeEach(() => {
+    writtenPaths.length = 0
+    renames.length = 0
+    dir = mkdtempSync(join(tmpdir(), 'plur-atomic-'))
+    opts = {
+      env: { PLUR_TELEMETRY: 'on' },
+      configPath: join(dir, 'telemetry.json'),
+      countersPath: join(dir, 'counters.json'),
+      installIdPath: join(dir, 'install-id'),
+      pendingDir: join(dir, 'pending'),
+      now: () => new Date('2026-05-02T18:00:00Z'),
+    }
+  })
+
+  it('never reuses a tmp path across writes to the same file', () => {
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+    resetCounters(opts)
+
+    const tmpPaths = writtenPaths.filter((p) => p.includes('.tmp.'))
+    // 3 counters.json writes + 1 install-id write
+    expect(tmpPaths.length).toBeGreaterThanOrEqual(4)
+    expect(new Set(tmpPaths).size).toBe(tmpPaths.length)
+  })
+
+  it('keeps the `<path>.tmp.` prefix convention for tmp files', () => {
+    recordEvent('learn', opts)
+
+    const counterTmps = writtenPaths.filter((p) => p.startsWith(`${join(dir, 'counters.json')}.tmp.`))
+    expect(counterTmps.length).toBe(1)
+    const installTmps = writtenPaths.filter((p) => p.startsWith(`${join(dir, 'install-id')}.tmp.`))
+    expect(installTmps.length).toBe(1)
+  })
+
+  it('renames each tmp file onto its final path', () => {
+    recordEvent('learn', opts)
+    recordEvent('recall', opts)
+
+    for (const { from, to } of renames) {
+      expect(writtenPaths).toContain(from)
+      expect(from.startsWith(`${to}.tmp.`)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`atomicWriteJson` / `atomicWriteString` named their tmp files `${path}.tmp.${process.pid}` — unique per process, but not per call. Two writes to the same path interleaving in an async context share one tmp file: the second `writeFileSync` clobbers the first before its `renameSync`, silently corrupting the losing write. Safe today because `recordEvent` is synchronous, but fragile the moment any call site goes async (the exact concern from the PR #173 review).

Fix: append `randomUUID()` to the tmp suffix so every atomic write gets its own tmp path. `randomUUID` was already imported in the module. Applied to both copies of the module — `packages/core/src/telemetry-counters.ts` and `packages/claw/src/telemetry-counters.ts`.

## Changes

| File | Purpose |
|------|---------|
| `packages/core/src/telemetry-counters.ts` | `tmpPath()` helper: `${path}.tmp.${pid}.${randomUUID()}` |
| `packages/claw/src/telemetry-counters.ts` | Same fix in claw's copy |
| `packages/core/test/telemetry-atomic-write.test.ts` | 3 tests: tmp path uniqueness across writes, `<path>.tmp.` prefix convention preserved, every rename source matches a written tmp path |
| `packages/claw/test/telemetry-atomic-write.test.ts` | Mirror of the core tests |

## Test plan

- [x] TDD: uniqueness test written first, fails on `main` (2 unique tmp paths for 4 writes), passes with fix
- [x] `@plur-ai/core` telemetry tests: 25 passed
- [x] `@plur-ai/claw` full suite: 110 passed
- [x] `@plur-ai/mcp` full suite: 137 passed
- [x] `@plur-ai/core` full suite

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1