### PR TITLE
test(cli): session-guard follow-ups from #285 review

### DIFF
--- a/packages/cli/test/hook-session-guard.test.ts
+++ b/packages/cli/test/hook-session-guard.test.ts
@@ -66,6 +66,12 @@ describe('hook-session-guard', () => {
     // deferred-tool retry spiral on the exempt session_start call.
     const first = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
     expect(first.stdout).toContain('deny')
+    // Lock the anti-batching deny-reason guidance against regressions (#328):
+    // load the deferred tool via ToolSearch as its own step, don't batch,
+    // don't repeat, and the nudge fires only once.
+    expect(first.stdout).toContain('ToolSearch')
+    expect(first.stdout).toContain('Do not batch')
+    expect(first.stdout).toContain('This reminder fires only once')
 
     // Second call falls through with the fallback warning.
     const fallback = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
@@ -78,4 +84,46 @@ describe('hook-session-guard', () => {
       expect(result.stdout).not.toContain('deny')
     }
   })
+
+  it('memory injection is independent of the session-start sentinel (#328)', () => {
+    // The fail-open guard relies on hook-inject (UserPromptSubmit) injecting
+    // memory regardless of the guard sentinel: even if plur_session_start
+    // never runs, the session still gets engrams. hook-inject keys its own
+    // marker on ppid under $TMPDIR/plur-sessions/ and never reads the
+    // guard's plur-session-{session_id} sentinel.
+    mkdirSync(join(home, 'tmp'), { recursive: true })
+    const env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      TMPDIR: join(home, 'tmp'),
+      PLUR_PATH: join(home, '.plur'),
+      // Degrade injectHybrid to BM25 — no model load in tests
+      PLUR_DISABLE_EMBEDDINGS: '1',
+    }
+
+    // Seed an engram in the store — no session ever started.
+    spawnSync('node', [CLI, 'learn', 'the project deploys to the staging server via rsync', '--json'], {
+      encoding: 'utf-8',
+      timeout: 15000,
+      env,
+      cwd: home,
+    })
+
+    // No guard sentinel exists for any session.
+    expect(existsSync(join(home, 'tmp', 'plur-session-never-started'))).toBe(false)
+
+    // hook-inject still starts a session and injects the engram.
+    const result = spawnSync('node', [CLI, 'hook-inject'], {
+      input: JSON.stringify({ prompt: 'how do we deploy the project' }),
+      encoding: 'utf-8',
+      timeout: 15000,
+      env,
+      cwd: home,
+    })
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('additionalContext')
+    expect(result.stdout).toContain('[PLUR Memory — session started')
+    expect(result.stdout).toContain('deploys to the staging server')
+  }, 30000)
 })


### PR DESCRIPTION
## Summary

Implements both low-pri follow-up items from the #285 (bounded-nudge session guard) review.

## Changes

**1. Deny-reason wording assertions** (`hook-session-guard.test.ts`)

The bounded-nudge test now asserts the anti-batching guidance content of the first deny, not just the behavior:
- `ToolSearch` (load the deferred tool as its own step)
- `Do not batch`
- `This reminder fires only once`

Any rewording of the nudge now fails a test instead of silently degrading the guidance.

**2. Sentinel-independence test for the memory path**

Confirmed by code inspection and locked with a test: `hook-inject` (UserPromptSubmit) keys its own session marker on `ppid` under `$TMPDIR/plur-sessions/` and never reads the guard's `plur-session-{session_id}` sentinel. New test seeds an engram, never creates a guard sentinel, and asserts `hook-inject` still starts a session and injects the engram into `additionalContext`. This proves the fail-open guard design is safe: even if `plur_session_start` truly never runs, the session still gets memory.

Test uses `PLUR_DISABLE_EMBEDDINGS=1` so `injectHybrid` degrades to BM25 — no model load in CI.

## Testing

- `test/hook-session-guard.test.ts`: 4/4 pass (1 new test, 3 new assertions in existing test)
- Full CLI suite: 204+10 passed, 4 skipped. Four tests across `hook-session-guard`/`list`/`sync` timed out at the 5s default under full-suite parallel load and pass cleanly in isolation (10/10) — pre-existing load flake, not introduced here (this PR touches only a test file).

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1