### PR TITLE
fix(cli): global-install check — version-manager paths + async concurrent execution (#190, #191)

### DIFF
--- a/packages/cli/src/global-install.ts
+++ b/packages/cli/src/global-install.ts
@@ -6,7 +6,18 @@ export interface GlobalInstallResult {
   plurBinaryPath: string | null
 }
 
-const GLOBAL_PATH_PATTERNS = ['/homebrew/', '/usr/local/', '/usr/bin/', '/usr/share/']
+const GLOBAL_PATH_PATTERNS = [
+  '/homebrew/',
+  '/usr/local/',
+  '/usr/bin/',
+  '/usr/share/',
+  // Node version managers (issue #190) — `npm install -g` inside a managed
+  // node lands under these prefixes, not the system paths above.
+  '/.nvm/', // nvm: ~/.nvm/versions/node/vX.Y.Z/bin/plur
+  '/.volta/', // volta: ~/.volta/bin/plur
+  '/fnm/', // fnm data dir: .../fnm/node-versions/vX.Y.Z/installation/bin/plur
+  '/fnm_multishells/', // fnm shell shims: .../fnm_multishells/<pid>_<ts>/bin/plur
+]
 
 /**
  * Detect globally installed plur packages that shadow `npx @latest` resolution.

--- a/packages/cli/src/global-install.ts
+++ b/packages/cli/src/global-install.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { exec } from 'child_process'
 
 export interface GlobalInstallResult {
   found: boolean
@@ -19,39 +19,45 @@ const GLOBAL_PATH_PATTERNS = [
   '/fnm_multishells/', // fnm shell shims: .../fnm_multishells/<pid>_<ts>/bin/plur
 ]
 
+/** Run a command, resolving with stdout; rejects on failure or timeout. */
+function run(command: string, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command, { encoding: 'utf8', timeout: timeoutMs }, (err, stdout) => {
+      if (err) reject(err)
+      else resolve(stdout)
+    })
+  })
+}
+
 /**
  * Detect globally installed plur packages that shadow `npx @latest` resolution.
- * Safe to call at startup — all subprocesses time out and failures are swallowed.
+ * Safe to call at startup — subprocesses run concurrently (issue #191: worst
+ * case is one timeout, ~5s, not their 12s sum), all time out, no event-loop
+ * blocking, and failures are swallowed.
  */
-export function checkGlobalInstall(): GlobalInstallResult {
-  const packages: Array<{ name: string; version: string }> = []
-
-  for (const pkg of ['@plur-ai/mcp', '@plur-ai/cli']) {
+export async function checkGlobalInstall(): Promise<GlobalInstallResult> {
+  const packageChecks = ['@plur-ai/mcp', '@plur-ai/cli'].map(async (pkg) => {
     try {
-      const out = execSync(`npm list -g ${pkg} --depth=0`, {
-        encoding: 'utf8',
-        timeout: 5000,
-        stdio: ['ignore', 'pipe', 'ignore'],
-      })
+      const out = await run(`npm list -g ${pkg} --depth=0`, 5000)
       // Output: /opt/homebrew/lib\n└── @plur-ai/mcp@0.7.7\n
       const m = out.match(/@[\w-]+\/[\w-]+@([\w.+-]+)/)
-      if (m) packages.push({ name: pkg, version: m[1] })
+      return m ? { name: pkg, version: m[1] } : null
     } catch {
-      // not globally installed or npm unavailable
+      return null // not globally installed or npm unavailable
     }
-  }
+  })
 
-  let plurBinaryPath: string | null = null
-  try {
-    const p = execSync('which plur', {
-      encoding: 'utf8',
-      timeout: 2000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim()
-    if (p && GLOBAL_PATH_PATTERNS.some((pat) => p.includes(pat))) plurBinaryPath = p
-  } catch {
-    // `which` failed or plur not on PATH
-  }
+  const binaryCheck = (async () => {
+    try {
+      const p = (await run('which plur', 2000)).trim()
+      return p && GLOBAL_PATH_PATTERNS.some((pat) => p.includes(pat)) ? p : null
+    } catch {
+      return null // `which` failed or plur not on PATH
+    }
+  })()
+
+  const [pkgResults, plurBinaryPath] = await Promise.all([Promise.all(packageChecks), binaryCheck])
+  const packages = pkgResults.filter((p): p is { name: string; version: string } => p !== null)
 
   return { found: packages.length > 0 || plurBinaryPath !== null, packages, plurBinaryPath }
 }

--- a/packages/cli/test/global-install.test.ts
+++ b/packages/cli/test/global-install.test.ts
@@ -74,6 +74,24 @@ describe('checkGlobalInstall', () => {
     expect(result.found).toBe(false)
     expect(result.plurBinaryPath).toBeNull()
   })
+
+  // Issue #190 — version-manager global installs (nvm/fnm/volta) must be detected
+  it.each([
+    ['nvm', '/Users/dev/.nvm/versions/node/v20.11.1/bin/plur'],
+    ['volta', '/Users/dev/.volta/bin/plur'],
+    ['fnm (macOS data dir)', '/Users/dev/Library/Application Support/fnm/node-versions/v20.12.2/installation/bin/plur'],
+    ['fnm (Linux data dir)', '/home/dev/.local/share/fnm/node-versions/v20.12.2/installation/bin/plur'],
+    ['fnm (multishell symlink)', '/run/user/1000/fnm_multishells/12345_1700000000000/bin/plur'],
+  ])('detects global binary installed via %s', (_manager, path) => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = cmd as string
+      if (c.startsWith('which')) return path
+      throw new Error('not found')
+    })
+    const result = checkGlobalInstall()
+    expect(result.found).toBe(true)
+    expect(result.plurBinaryPath).toBe(path)
+  })
 })
 
 describe('formatGlobalInstallWarning', () => {

--- a/packages/cli/test/global-install.test.ts
+++ b/packages/cli/test/global-install.test.ts
@@ -1,76 +1,79 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 
 vi.mock('child_process', () => ({
-  execSync: vi.fn(),
+  exec: vi.fn(),
 }))
 
-import { execSync } from 'child_process'
+import { exec } from 'child_process'
 import { checkGlobalInstall, formatGlobalInstallWarning } from '../src/global-install.js'
 
-const mockExecSync = vi.mocked(execSync)
+type ExecCallback = (err: Error | null, stdout: string, stderr: string) => void
+
+const mockExec = vi.mocked(exec)
+
+/** Answer each subprocess by command string; return an Error to simulate failure. */
+function mockCommands(respond: (cmd: string) => string | Error) {
+  mockExec.mockImplementation(((cmd: string, _opts: unknown, cb: ExecCallback) => {
+    const result = respond(cmd)
+    // Deliver asynchronously, like real exec
+    queueMicrotask(() => {
+      if (result instanceof Error) cb(result, '', '')
+      else cb(null, result, '')
+    })
+    return undefined as never
+  }) as never)
+}
 
 afterEach(() => vi.clearAllMocks())
 
 describe('checkGlobalInstall', () => {
-  it('returns found:false when no global packages installed', () => {
-    mockExecSync.mockImplementation(() => {
-      throw new Error('not found')
-    })
-    const result = checkGlobalInstall()
+  it('returns found:false when no global packages installed', async () => {
+    mockCommands(() => new Error('not found'))
+    const result = await checkGlobalInstall()
     expect(result.found).toBe(false)
     expect(result.packages).toEqual([])
     expect(result.plurBinaryPath).toBeNull()
   })
 
-  it('detects a single globally installed package', () => {
-    mockExecSync.mockImplementation((cmd: unknown) => {
-      const c = cmd as string
-      if (c.includes('@plur-ai/mcp') && !c.includes('which')) {
+  it('detects a single globally installed package', async () => {
+    mockCommands((c) => {
+      if (c.includes('@plur-ai/mcp') && !c.startsWith('which')) {
         return '/opt/homebrew/lib\n└── @plur-ai/mcp@0.7.7\n'
       }
-      throw new Error('not found')
+      return new Error('not found')
     })
-    const result = checkGlobalInstall()
+    const result = await checkGlobalInstall()
     expect(result.found).toBe(true)
     expect(result.packages).toEqual([{ name: '@plur-ai/mcp', version: '0.7.7' }])
   })
 
-  it('detects both packages when both are globally installed', () => {
-    mockExecSync.mockImplementation((cmd: unknown) => {
-      const c = cmd as string
+  it('detects both packages when both are globally installed', async () => {
+    mockCommands((c) => {
       if (c.includes('@plur-ai/mcp') && !c.startsWith('which')) {
         return '/opt/homebrew/lib\n└── @plur-ai/mcp@0.9.0\n'
       }
       if (c.includes('@plur-ai/cli') && !c.startsWith('which')) {
         return '/opt/homebrew/lib\n└── @plur-ai/cli@0.9.0\n'
       }
-      throw new Error('not found')
+      return new Error('not found')
     })
-    const result = checkGlobalInstall()
+    const result = await checkGlobalInstall()
     expect(result.found).toBe(true)
     expect(result.packages).toHaveLength(2)
     expect(result.packages[0]).toEqual({ name: '@plur-ai/mcp', version: '0.9.0' })
     expect(result.packages[1]).toEqual({ name: '@plur-ai/cli', version: '0.9.0' })
   })
 
-  it('detects global binary via which', () => {
-    mockExecSync.mockImplementation((cmd: unknown) => {
-      const c = cmd as string
-      if (c.startsWith('which')) return '/opt/homebrew/bin/plur'
-      throw new Error('not found')
-    })
-    const result = checkGlobalInstall()
+  it('detects global binary via which', async () => {
+    mockCommands((c) => (c.startsWith('which') ? '/opt/homebrew/bin/plur\n' : new Error('not found')))
+    const result = await checkGlobalInstall()
     expect(result.found).toBe(true)
     expect(result.plurBinaryPath).toBe('/opt/homebrew/bin/plur')
   })
 
-  it('ignores which result that is not on a global path', () => {
-    mockExecSync.mockImplementation((cmd: unknown) => {
-      const c = cmd as string
-      if (c.startsWith('which')) return '/home/user/.local/bin/plur'
-      throw new Error('not found')
-    })
-    const result = checkGlobalInstall()
+  it('ignores which result that is not on a global path', async () => {
+    mockCommands((c) => (c.startsWith('which') ? '/home/user/.local/bin/plur' : new Error('not found')))
+    const result = await checkGlobalInstall()
     expect(result.found).toBe(false)
     expect(result.plurBinaryPath).toBeNull()
   })
@@ -82,15 +85,41 @@ describe('checkGlobalInstall', () => {
     ['fnm (macOS data dir)', '/Users/dev/Library/Application Support/fnm/node-versions/v20.12.2/installation/bin/plur'],
     ['fnm (Linux data dir)', '/home/dev/.local/share/fnm/node-versions/v20.12.2/installation/bin/plur'],
     ['fnm (multishell symlink)', '/run/user/1000/fnm_multishells/12345_1700000000000/bin/plur'],
-  ])('detects global binary installed via %s', (_manager, path) => {
-    mockExecSync.mockImplementation((cmd: unknown) => {
-      const c = cmd as string
-      if (c.startsWith('which')) return path
-      throw new Error('not found')
-    })
-    const result = checkGlobalInstall()
+  ])('detects global binary installed via %s', async (_manager, path) => {
+    mockCommands((c) => (c.startsWith('which') ? path : new Error('not found')))
+    const result = await checkGlobalInstall()
     expect(result.found).toBe(true)
     expect(result.plurBinaryPath).toBe(path)
+  })
+
+  // Issue #191 — subprocess checks must run concurrently, not serially.
+  // Serial execSync meant up to 5s + 5s + 2s of blocking on the startup path.
+  it('dispatches all subprocess checks before any completes (#191)', async () => {
+    const pending: ExecCallback[] = []
+    mockExec.mockImplementation(((_cmd: string, _opts: unknown, cb: ExecCallback) => {
+      pending.push(cb)
+      return undefined as never
+    }) as never)
+
+    const promise = checkGlobalInstall()
+    // 2x `npm list` + 1x `which` all started before the first one answers.
+    // A serial implementation would show 1 here.
+    expect(pending).toHaveLength(3)
+    for (const cb of pending) cb(new Error('not found'), '', '')
+    const result = await promise
+    expect(result.found).toBe(false)
+  })
+
+  it('bounds every subprocess with a timeout', async () => {
+    const timeouts: number[] = []
+    mockExec.mockImplementation(((_cmd: string, opts: { timeout?: number }, cb: ExecCallback) => {
+      timeouts.push(opts?.timeout ?? 0)
+      queueMicrotask(() => cb(new Error('not found'), '', ''))
+      return undefined as never
+    }) as never)
+    await checkGlobalInstall()
+    expect(timeouts).toHaveLength(3)
+    for (const t of timeouts) expect(t).toBeGreaterThan(0)
   })
 })
 


### PR DESCRIPTION
## Summary

Two follow-ups from the PR #174 review (reviewer: @crtahlin), combined because both rewrite `checkGlobalInstall()` and its test mocks — separate PRs would conflict in both files.

**#190 — GLOBAL_PATH_PATTERNS missing nvm/fnm/volta paths** (commit 1)
The `which plur` binary check only matched `/homebrew/`, `/usr/local/`, `/usr/bin/`, `/usr/share/`. A global install inside an nvm/fnm/volta-managed node returned a path matching none of them. Added `/.nvm/`, `/.volta/`, `/fnm/` (data dir), `/fnm_multishells/` (shell shims).

**#191 — synchronous execSync up to 15s startup latency** (commit 2)
Three serial `execSync` calls meant 5s + 5s + 2s of event-loop blocking worst case. Converted to callback `exec` wrapped in promises, all three checks dispatched concurrently — worst case is now a single 5s timeout and the event loop stays free. Behavior parity preserved: same shell-resolved commands (npm.cmd on Windows still works), same timeouts, same swallow-all-failures contract. The function had no production call sites yet, so the async signature change breaks nothing.

## Test plan

TDD — failing tests written first for each issue:
- [x] 5 new tests: nvm, volta, fnm (macOS/Linux data dirs), fnm multishell binary paths
- [x] Concurrency test: all 3 subprocesses dispatched before any completes (serial impl shows 1)
- [x] Timeout test: every subprocess bounded
- [x] `packages/cli/test/global-install.test.ts` — 16/16 pass
- [x] Full `@plur-ai/cli` suite: 220 passed, 4 skipped (was 213/4)
- [x] `pnpm --filter @plur-ai/cli build` (incl. DTS type-check) passes

Closes #190
Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1