### PR TITLE
feat(core): populate temporal.valid_until on the write path (#347)

### DIFF
--- a/packages/core/src/expiry.ts
+++ b/packages/core/src/expiry.ts
@@ -1,0 +1,180 @@
+/**
+ * Explicit-expiry extraction for the write path (#347).
+ *
+ * The deterministic expiry machinery (inject/recall skip engrams whose
+ * `temporal.valid_until` is in the past) existed long before anything
+ * populated the field — time-bound facts were stored with the date only in
+ * free text and kept injecting at full strength after going stale.
+ *
+ * This module lifts EXPLICIT expiry phrases ("valid until 31 May 2026",
+ * "expires 2026-12-01") out of the statement into the structured field.
+ * It is conservative by design — NEVER silently guess:
+ *   - only fires when an expiry keyword is immediately followed by a date
+ *   - only fully-specified, unambiguous dates parse (a missing year, or a
+ *     numeric slash date like 05/31/2026 with its US/EU ambiguity, is a miss)
+ *   - the parsed ISO date is echoed back to the caller for confirmation
+ *     (see the `_expiry_extracted` marker and the plur_learn `expiry_note`)
+ */
+
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+}
+
+/** Month name — full or 3-letter abbreviation (plus "sept"), case-insensitive. */
+const MONTH_RE =
+  '(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)'
+
+/**
+ * Date alternatives, all requiring an explicit 4-digit year:
+ *   1. ISO           2026-05-31
+ *   2. D Month YYYY  31 May 2026 / 31st May 2026
+ *   3. Month D, YYYY May 31, 2026 / May 31 2026
+ */
+const DATE_RE =
+  `(\\d{4}-\\d{2}-\\d{2})` +
+  `|(\\d{1,2})(?:st|nd|rd|th)?\\s+(${MONTH_RE})\\.?,?\\s+(\\d{4})` +
+  `|(${MONTH_RE})\\.?\\s+(\\d{1,2})(?:st|nd|rd|th)?,?\\s+(\\d{4})`
+
+/**
+ * Expiry keywords. `valid until|through|thru` and bare `valid <date>` (the
+ * observed offer-engram shape), `expires [on|at]`, `expiry [date]`,
+ * `expiration [date]`. `valid from` never matches — the date must follow the
+ * keyword directly, and "from" is not a date.
+ */
+const KEYWORD_RE =
+  '(?:valid\\s+(?:until|through|thru)|valid|expires?\\s+(?:on\\s+|at\\s+)?|expiry(?:\\s+date)?:?\\s*|expiration(?:\\s+date)?:?\\s*)'
+
+const EXPIRY_RE = new RegExp(`\\b${KEYWORD_RE}\\s*(?:${DATE_RE})`, 'i')
+
+export interface ExtractedExpiry {
+  /** Normalized ISO date (YYYY-MM-DD). */
+  valid_until: string
+  /** The matched source phrase, echoed back for confirmation. */
+  phrase: string
+}
+
+/** True when Y-M-D is a real calendar date (rejects 2026-02-30 etc.). */
+function isRealDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false
+  const d = new Date(Date.UTC(year, month - 1, day))
+  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === day
+}
+
+const pad = (n: number) => String(n).padStart(2, '0')
+
+/**
+ * Validate + normalize a strict ISO date string (YYYY-MM-DD).
+ * Returns the normalized date, or null when malformed or not a real
+ * calendar date. Used for caller-provided valid_from / valid_until.
+ */
+export function normalizeIsoDate(input: string): string | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(input)
+  if (!m) return null
+  const [, y, mo, d] = m
+  if (!isRealDate(Number(y), Number(mo), Number(d))) return null
+  return `${y}-${mo}-${d}`
+}
+
+/** Resolved validity window for a learn() write (#347). */
+export interface ResolvedValidity {
+  valid_from?: string
+  valid_until?: string
+  /** Set when valid_until came from statement extraction, not the caller. */
+  extracted?: ExtractedExpiry
+}
+
+/**
+ * Resolve the validity window for a new engram. Explicit caller params win
+ * and are strictly validated (throws on malformed dates or an inverted
+ * window); with no explicit valid_until, an explicit expiry phrase in the
+ * statement is lifted into valid_until and flagged as `extracted` so the
+ * caller can echo it back for confirmation. Pure — safe to call before
+ * dedup/locking so malformed input fails fast.
+ */
+export function resolveValidity(
+  statement: string,
+  context: { valid_from?: string; valid_until?: string } | undefined,
+): ResolvedValidity {
+  let validFrom: string | undefined
+  let validUntil: string | undefined
+  let extracted: ExtractedExpiry | undefined
+
+  if (context?.valid_from !== undefined) {
+    const norm = normalizeIsoDate(context.valid_from)
+    if (!norm) throw new TypeError(`plur.learn: valid_from must be an ISO date (YYYY-MM-DD), got "${context.valid_from}"`)
+    validFrom = norm
+  }
+  if (context?.valid_until !== undefined) {
+    const norm = normalizeIsoDate(context.valid_until)
+    if (!norm) throw new TypeError(`plur.learn: valid_until must be an ISO date (YYYY-MM-DD), got "${context.valid_until}"`)
+    validUntil = norm
+  } else {
+    const hit = extractExpiry(statement)
+    if (hit) {
+      validUntil = hit.valid_until
+      extracted = hit
+    }
+  }
+
+  if (validFrom && validUntil && validFrom > validUntil) {
+    if (extracted) {
+      // The inversion came from extraction, not the caller — drop the
+      // extracted date rather than failing a write the caller didn't shape.
+      validUntil = undefined
+      extracted = undefined
+    } else {
+      throw new RangeError(`plur.learn: valid_from (${validFrom}) must not be after valid_until (${validUntil})`)
+    }
+  }
+
+  return { valid_from: validFrom, valid_until: validUntil, extracted }
+}
+
+/**
+ * Build the engram `temporal` block from a resolved validity window.
+ * Returns undefined when there is no window — `temporal` stays unset for
+ * ordinary engrams (schema field is optional; quality scoring counts it).
+ */
+export function buildTemporal(
+  validity: ResolvedValidity,
+  now: string,
+): { learned_at: string; valid_from?: string; valid_until?: string } | undefined {
+  if (!validity.valid_from && !validity.valid_until) return undefined
+  return {
+    learned_at: now,
+    ...(validity.valid_from ? { valid_from: validity.valid_from } : {}),
+    ...(validity.valid_until ? { valid_until: validity.valid_until } : {}),
+  }
+}
+
+/**
+ * Detect an explicit expiry phrase in a statement and parse it into an
+ * ISO valid_until. Returns null when nothing unambiguous matches — the
+ * caller must NOT infer a date any other way.
+ */
+export function extractExpiry(statement: string): ExtractedExpiry | null {
+  const m = EXPIRY_RE.exec(statement)
+  if (!m) return null
+
+  let year: number, month: number, day: number
+  if (m[1]) {
+    // ISO: 2026-05-31
+    const parts = m[1].split('-')
+    year = Number(parts[0]); month = Number(parts[1]); day = Number(parts[2])
+  } else if (m[2] && m[3] && m[4]) {
+    // D Month YYYY
+    day = Number(m[2]); month = MONTHS[m[3].slice(0, 3).toLowerCase()]; year = Number(m[4])
+  } else if (m[5] && m[6] && m[7]) {
+    // Month D, YYYY
+    month = MONTHS[m[5].slice(0, 3).toLowerCase()]; day = Number(m[6]); year = Number(m[7])
+  } else {
+    return null
+  }
+
+  if (!isRealDate(year, month, day)) return null
+  return {
+    valid_until: `${year}-${pad(month)}-${pad(day)}`,
+    phrase: m[0].trim(),
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ import type { ScopeMetadata, SensitivityCategory } from './schemas/scope-metadat
 import { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
 import { appendHistory, readHistoryForEngram, generateEventId } from './history.js'
 import { computeContentHash } from './content-hash.js'
+import { resolveValidity, buildTemporal } from './expiry.js'
 import { decodeJwtExpiry } from './jwt.js'
 import { RemoteStore } from './store/remote-store.js'
 import { isSharedScope, isPersonalScope, isScopeWithin } from './scope-util.js'
@@ -1232,6 +1233,10 @@ export class Plur {
     }
     const guarded = this._guardSensitiveScope(statement, context)
     context = guarded.context
+    // #347: resolve the validity window up-front (pure) so malformed
+    // valid_from/valid_until fail fast — even when the write would dedup
+    // into an existing engram below.
+    const validity = resolveValidity(statement, context)
     return withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)
       const allEngrams = this._loadAllEngrams()
@@ -1289,6 +1294,10 @@ export class Plur {
         rationale: context?.rationale,
         source: context?.source,
         domain: context?.domain,
+        // #347: validity window — explicit valid_from/valid_until params, or
+        // an explicit expiry phrase lifted from the statement. Unset for
+        // ordinary engrams.
+        temporal: buildTemporal(validity, now),
         activation: {
           retrieval_strength: 0.7,
           storage_strength: 1.0,
@@ -1327,6 +1336,16 @@ export class Plur {
           conflicts: conflictIds,
         } : undefined,
         pinned: context?.pinned === true ? true : undefined,
+      }
+
+      // Stamp the extraction marker (#347) so the plur_learn MCP response can
+      // echo the parsed expiry date back for confirmation — extraction must
+      // never silently guess.
+      if (validity.extracted) {
+        ;(engram as any).structured_data = {
+          ...((engram as any).structured_data ?? {}),
+          _expiry_extracted: { valid_until: validity.extracted.valid_until, phrase: validity.extracted.phrase },
+        }
       }
 
       // Stamp the demotion marker (#326 review, finding 2) so the plur_learn MCP
@@ -1477,6 +1496,9 @@ export class Plur {
     const guarded = this._guardSensitiveScope(statement, context)
     const scope = guarded.scope
     context = guarded.context
+    // #347: fail fast on malformed valid_from/valid_until (pure validation),
+    // mirroring learn() — before dedup can short-circuit the write.
+    resolveValidity(statement, context)
     const remoteDriver = this._resolveRemoteStoreForScope(scope)
     if (!remoteDriver) {
       // Local route — sync learn() owns dedup, build, write, history. learn()'s
@@ -1603,7 +1625,9 @@ export class Plur {
     }
     const memoryClass = context?.memory_class ?? TYPE_TO_MEMORY_CLASS[type] ?? 'semantic'
     const commitment = context?.commitment ?? 'leaning'
-    return {
+    // #347: validity window — same resolution as the sync learn() constructor.
+    const validity = resolveValidity(statement, context)
+    const shape: Engram = {
       // Placeholder id — overwritten by the server's assigned id before return.
       // Any consumer that observes this id directly (rather than via learnRouted's
       // return value) is doing it wrong — log says so.
@@ -1623,6 +1647,7 @@ export class Plur {
       rationale: context?.rationale,
       source: context?.source,
       domain: context?.domain,
+      temporal: buildTemporal(validity, now),
       activation: {
         retrieval_strength: 0.7,
         storage_strength: 1.0,
@@ -1656,6 +1681,14 @@ export class Plur {
       episode_ids: context?.session_episode_id ? [context.session_episode_id] : [],
       pinned: context?.pinned === true ? true : undefined,
     }
+    // Echo marker for extracted expiry (#347) — mirrors the learn() stamping
+    // so the remote-routed MCP response can confirm the parse too.
+    if (validity.extracted) {
+      ;(shape as any).structured_data = {
+        _expiry_extracted: { valid_until: validity.extracted.valid_until, phrase: validity.extracted.phrase },
+      }
+    }
+    return shape
   }
 
   /** Build deps for learn-async module. */
@@ -2201,6 +2234,7 @@ export class Plur {
       {
         spread_cap: this.config.injection?.spread_cap,
         spread_budget: this.config.injection?.spread_budget,
+        expiry: this.config.expiry,
       },
       embeddingBoosts,
     )

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -67,6 +67,54 @@ const PINNED_TOKEN_BUDGET_RATIO = 0.5
 const DIP19_CONSIDER_MAX = 5
 const DIP19_CONSIDER_BUDGET = 200
 
+// --- Expiry handling (#347) ---
+
+/**
+ * Injection-time expiry policy (#347). `hard` (default) skips any engram
+ * whose `temporal.valid_until` is in the past. `soft` keeps injecting a
+ * recently-expired engram for `grace_days` days after expiry, rendered with
+ * a loud "⚠ EXPIRED <date> — verify before use" marker.
+ */
+export interface ExpiryConfig {
+  mode?: 'hard' | 'soft'
+  grace_days?: number
+}
+
+const DEFAULT_GRACE_DAYS = 30
+
+/**
+ * True when the engram must be skipped for temporal validity. Not-yet-valid
+ * engrams (`valid_from` in the future) are always skipped; expired engrams
+ * are skipped in hard mode, and in soft mode once past the grace cutoff.
+ */
+function skipForValidity(
+  engram: Engram,
+  today: string,
+  mode: 'hard' | 'soft',
+  graceCutoff: string,
+): boolean {
+  const t = engram.temporal
+  if (t?.valid_from && t.valid_from > today) return true
+  if (t?.valid_until && t.valid_until < today) {
+    if (mode !== 'soft') return true
+    if (t.valid_until < graceCutoff) return true
+  }
+  return false
+}
+
+/**
+ * "⚠ EXPIRED <date> — verify before use: " prefix for an engram whose
+ * `valid_until` is in the past. Only soft-expiry mode lets expired engrams
+ * reach the formatters, so in hard mode this never fires.
+ */
+function expiredMarker(engram: WireEngram): string {
+  const until = engram.temporal?.valid_until
+  if (until && until < new Date().toISOString().slice(0, 10)) {
+    return `⚠ EXPIRED ${until} — verify before use: `
+  }
+  return ''
+}
+
 // --- Pack metadata helper ---
 
 function getPackMetadata(manifest: PackManifest) {
@@ -301,7 +349,7 @@ export function selectAndSpread(
   ctx: InjectionContext,
   personalEngrams: Engram[],
   packs: LoadedPack[],
-  config?: { spread_cap?: number; spread_budget?: number },
+  config?: { spread_cap?: number; spread_budget?: number; expiry?: ExpiryConfig },
   embeddingBoosts?: Map<string, number>,
 ): InternalInjectionResult {
   const spreadCap = config?.spread_cap ?? 3
@@ -312,6 +360,9 @@ export function selectAndSpread(
   const maxTokens = ctx.maxTokens ?? DEFAULT_MAX_TOKENS
   const minRelevance = ctx.minRelevance ?? DEFAULT_MIN_RELEVANCE
   const today = new Date().toISOString().slice(0, 10)
+  const expiryMode = config?.expiry?.mode ?? 'hard'
+  const graceDays = config?.expiry?.grace_days ?? DEFAULT_GRACE_DAYS
+  const graceCutoff = new Date(Date.now() - graceDays * 86400000).toISOString().slice(0, 10)
 
   // Step 0: Build engram map for spreading activation
   const engramMap = new Map<string, Engram>()
@@ -321,8 +372,7 @@ export function selectAndSpread(
 
   for (const engram of personalEngrams) {
     if (engram.status !== 'active') continue
-    if (engram.temporal?.valid_until && engram.temporal.valid_until < today) continue
-    if (engram.temporal?.valid_from && engram.temporal.valid_from > today) continue
+    if (skipForValidity(engram, today, expiryMode, graceCutoff)) continue
     engramMap.set(engram.id, engram)
     let raw = scoreEngram(engram, promptLower, promptWords, [], ctx.scope, false)
     // Embedding boost: semantically similar engrams with zero keyword hits still get scored.
@@ -353,8 +403,7 @@ export function selectAndSpread(
     const matchTerms = packMeta.match_terms
     for (const engram of pack.engrams) {
       if (engram.status !== 'active') continue
-      if (engram.temporal?.valid_until && engram.temporal.valid_until < today) continue
-      if (engram.temporal?.valid_from && engram.temporal.valid_from > today) continue
+      if (skipForValidity(engram, today, expiryMode, graceCutoff)) continue
       engramMap.set(engram.id, engram)
       let raw = scoreEngram(engram, promptLower, promptWords, matchTerms, ctx.scope, true)
       const embBoost = embeddingBoosts?.get(engram.id) ?? 0
@@ -527,15 +576,15 @@ export function selectAndSpread(
 
 export function formatLayer1(engram: WireEngram): string {
   const display = (engram as any).summary ?? engram.statement.slice(0, 60)
-  return `[${engram.id}] ${display}`
+  return `[${engram.id}] ${expiredMarker(engram)}${display}`
 }
 
 export function formatLayer2(engram: WireEngram): string {
-  return `[${engram.id}] ${engram.statement}`
+  return `[${engram.id}] ${expiredMarker(engram)}${engram.statement}`
 }
 
 export function formatLayer3(engram: WireEngram): string {
-  const lines = [`[${engram.id}] ${engram.statement}`]
+  const lines = [`[${engram.id}] ${expiredMarker(engram)}${engram.statement}`]
   if (engram.rationale) lines.push(`  Rationale: ${engram.rationale}`)
   const meta: string[] = []
   if (engram.domain) meta.push(`Domain: ${engram.domain}`)

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -108,6 +108,18 @@ export const PlurConfigSchema = z.object({
     co_access: z.boolean().default(true),
   }).default({}),
   dedup: DedupConfigSchema.default({}),
+  /**
+   * Expiry handling at injection time (#347). `hard` (default) skips any
+   * engram whose `temporal.valid_until` is in the past. `soft` keeps
+   * injecting a recently-expired engram for `grace_days` days after expiry,
+   * rendered with a loud "⚠ EXPIRED <date> — verify before use" marker —
+   * some facts stay useful as history. Recall filtering is unaffected
+   * (always hard).
+   */
+  expiry: z.object({
+    mode: z.enum(['hard', 'soft']).default('hard'),
+    grace_days: z.number().default(30),
+  }).default({}),
   decay_baseline: z.string().optional(),
   allow_secrets: z.boolean().default(false),
   index: z.boolean().default(true),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,6 +26,19 @@ export interface LearnContext {
   session_episode_id?: string
   /** Always-load flag — bypass keyword-relevance gate during injection. */
   pinned?: boolean
+  /**
+   * Start of the knowledge's validity window (ISO YYYY-MM-DD, #347). Stored in
+   * `temporal.valid_from`; inject/recall skip the engram before this date.
+   */
+  valid_from?: string
+  /**
+   * Expiry of the knowledge (ISO YYYY-MM-DD, #347). Stored in
+   * `temporal.valid_until`; inject/recall skip the engram after this date.
+   * When omitted, an explicit expiry phrase in the statement ("valid until
+   * 31 May 2026", "expires 2026-12-01") is auto-extracted — the parsed date
+   * is echoed back via `structured_data._expiry_extracted`, never guessed.
+   */
+  valid_until?: string
 }
 
 /** Extended context for async learn with LLM dedup. */

--- a/packages/core/test/expiry.test.ts
+++ b/packages/core/test/expiry.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { extractExpiry, normalizeIsoDate } from '../src/expiry.js'
+
+// #347 — explicit-expiry extraction. Conservative by design: only an explicit
+// expiry keyword immediately followed by an unambiguous, fully-specified date
+// produces a match. Anything fuzzy (no year, numeric slash formats, relative
+// phrases) returns null — never silently guess.
+describe('normalizeIsoDate', () => {
+  it('accepts a valid ISO date', () => {
+    expect(normalizeIsoDate('2026-05-31')).toBe('2026-05-31')
+  })
+
+  it('rejects a non-existent calendar date', () => {
+    expect(normalizeIsoDate('2026-02-30')).toBeNull()
+  })
+
+  it('rejects malformed strings', () => {
+    expect(normalizeIsoDate('31 May 2026')).toBeNull()
+    expect(normalizeIsoDate('2026-5-31')).toBeNull()
+    expect(normalizeIsoDate('2026/05/31')).toBeNull()
+    expect(normalizeIsoDate('')).toBeNull()
+    expect(normalizeIsoDate('soon')).toBeNull()
+  })
+})
+
+describe('extractExpiry', () => {
+  it('parses "valid until <ISO date>"', () => {
+    const hit = extractExpiry('Discount code SAVE20 is valid until 2026-05-31')
+    expect(hit).not.toBeNull()
+    expect(hit!.valid_until).toBe('2026-05-31')
+    expect(hit!.phrase).toContain('valid until 2026-05-31')
+  })
+
+  it('parses "valid until 31 May 2026" (the observed offer-engram shape)', () => {
+    const hit = extractExpiry('Offer REV.002 sent 2026-04-28, valid until 31 May 2026')
+    expect(hit).not.toBeNull()
+    expect(hit!.valid_until).toBe('2026-05-31')
+  })
+
+  it('parses bare "valid <date>" (offer shorthand)', () => {
+    const hit = extractExpiry('IGEA Enterprise offer, valid 31 May 2026')
+    expect(hit).not.toBeNull()
+    expect(hit!.valid_until).toBe('2026-05-31')
+  })
+
+  it('parses "expires <date>" and "expires on <date>"', () => {
+    expect(extractExpiry('The token expires 2026-12-01')!.valid_until).toBe('2026-12-01')
+    expect(extractExpiry('Cert expires on January 15, 2027')!.valid_until).toBe('2027-01-15')
+  })
+
+  it('parses "valid through <date>"', () => {
+    expect(extractExpiry('Promo valid through 30 June 2026')!.valid_until).toBe('2026-06-30')
+  })
+
+  it('parses "Month D, YYYY" and abbreviated month names', () => {
+    expect(extractExpiry('valid until May 31, 2026')!.valid_until).toBe('2026-05-31')
+    expect(extractExpiry('expires 1 Jan 2027')!.valid_until).toBe('2027-01-01')
+  })
+
+  it('parses ordinal day suffixes', () => {
+    expect(extractExpiry('valid until 31st May 2026')!.valid_until).toBe('2026-05-31')
+  })
+
+  it('does NOT match "valid from <date>" (that is a start, not an expiry)', () => {
+    expect(extractExpiry('Policy valid from 2026-01-01')).toBeNull()
+  })
+
+  it('does NOT guess when the year is missing', () => {
+    expect(extractExpiry('valid through end of Q2')).toBeNull()
+    expect(extractExpiry('expires 31 May')).toBeNull()
+  })
+
+  it('does NOT parse ambiguous numeric slash dates', () => {
+    expect(extractExpiry('valid until 05/31/2026')).toBeNull()
+  })
+
+  it('does NOT match dates without an expiry keyword', () => {
+    expect(extractExpiry('Meeting scheduled for 2026-05-31')).toBeNull()
+  })
+
+  it('rejects a non-existent calendar date after the keyword', () => {
+    expect(extractExpiry('valid until 30 February 2026')).toBeNull()
+  })
+
+  it('returns null for statements with no temporal content', () => {
+    expect(extractExpiry('API uses snake_case for all endpoints')).toBeNull()
+  })
+})

--- a/packages/core/test/inject.test.ts
+++ b/packages/core/test/inject.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { scoreEngram, selectAndSpread, estimateTokens, fillTokenBudget } from '../src/inject.js'
+import { scoreEngram, selectAndSpread, estimateTokens, fillTokenBudget, formatWithLayer } from '../src/inject.js'
 import { EngramSchema } from '../src/schemas/engram.js'
 import { daysSince } from '../src/decay.js'
 
@@ -111,6 +111,99 @@ describe('injection engine', () => {
       ...result.consider.map(c => c.id),
     ]
     expect(allIds).not.toContain('ENG-2026-0330-001')
+  })
+
+  // #347 — soft-expiry mode: recently-expired engrams inject with a loud
+  // marker for a grace window instead of being hard-skipped. Hard remains
+  // the default.
+  describe('soft-expiry mode (#347)', () => {
+    const isoDaysAgo = (days: number) => new Date(Date.now() - days * 86400000).toISOString().slice(0, 10)
+
+    const recentlyExpired = () => makeEngram({
+      id: 'ENG-2026-0347-001',
+      statement: 'Deploy to staging server first',
+      temporal: { learned_at: '2026-01-01', valid_until: isoDaysAgo(5) },
+    })
+
+    it('hard mode (default) skips recently-expired engrams', () => {
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens: 5000 },
+        [recentlyExpired()], [],
+      )
+      const allIds = [...result.directives, ...result.constraints, ...result.consider].map(e => e.id)
+      expect(allIds).not.toContain('ENG-2026-0347-001')
+    })
+
+    it('soft mode injects a recently-expired engram (within grace window)', () => {
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens: 5000 },
+        [recentlyExpired()], [],
+        { expiry: { mode: 'soft', grace_days: 30 } },
+      )
+      const allIds = [...result.directives, ...result.constraints, ...result.consider].map(e => e.id)
+      expect(allIds).toContain('ENG-2026-0347-001')
+    })
+
+    it('soft mode still skips engrams expired beyond the grace window', () => {
+      const longExpired = makeEngram({
+        id: 'ENG-2026-0347-002',
+        statement: 'Deploy to staging server first',
+        temporal: { learned_at: '2026-01-01', valid_until: isoDaysAgo(60) },
+      })
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens: 5000 },
+        [longExpired], [],
+        { expiry: { mode: 'soft', grace_days: 30 } },
+      )
+      const allIds = [...result.directives, ...result.constraints, ...result.consider].map(e => e.id)
+      expect(allIds).not.toContain('ENG-2026-0347-002')
+    })
+
+    it('soft mode still skips not-yet-valid engrams (valid_from in the future)', () => {
+      const notYet = makeEngram({
+        id: 'ENG-2026-0347-003',
+        statement: 'Deploy to staging server first',
+        temporal: { learned_at: '2026-01-01', valid_from: '2099-01-01' },
+      })
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens: 5000 },
+        [notYet], [],
+        { expiry: { mode: 'soft', grace_days: 30 } },
+      )
+      const allIds = [...result.directives, ...result.constraints, ...result.consider].map(e => e.id)
+      expect(allIds).not.toContain('ENG-2026-0347-003')
+    })
+
+    it('formats an expired engram with the ⚠ EXPIRED marker at every layer', () => {
+      const until = isoDaysAgo(5)
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens: 5000 },
+        [recentlyExpired()], [],
+        { expiry: { mode: 'soft', grace_days: 30 } },
+      )
+      const wire = [...result.directives, ...result.constraints, ...result.consider]
+        .find(e => e.id === 'ENG-2026-0347-001')!
+      for (const layer of [1, 2, 3] as const) {
+        const text = formatWithLayer([wire], layer)
+        expect(text).toContain(`⚠ EXPIRED ${until} — verify before use`)
+      }
+    })
+
+    it('does not mark non-expired engrams', () => {
+      const valid = makeEngram({
+        id: 'ENG-2026-0347-004',
+        statement: 'Deploy using blue-green strategy',
+        temporal: { learned_at: '2026-01-01', valid_until: '2099-12-31' },
+      })
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens: 5000 },
+        [valid], [],
+        { expiry: { mode: 'soft', grace_days: 30 } },
+      )
+      const wire = [...result.directives, ...result.constraints, ...result.consider]
+        .find(e => e.id === 'ENG-2026-0347-004')!
+      expect(formatWithLayer([wire], 3)).not.toContain('EXPIRED')
+    })
   })
 
   it('emotional weight boosts scoring for high-weight engrams', () => {

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -299,6 +299,101 @@ describe('Plur', () => {
     expect(results.length).toBeGreaterThan(0)
   })
 
+  // #347 — populate temporal.valid_until on the write path.
+  describe('temporal validity on the write path (#347)', () => {
+    it('learn stores explicit valid_until in temporal', () => {
+      const engram = plur.learn('Conference discount code is CONF20', {
+        scope: 'global',
+        valid_until: '2099-12-31',
+      })
+      expect(engram.temporal?.valid_until).toBe('2099-12-31')
+      expect(engram.temporal?.learned_at).toBeDefined()
+    })
+
+    it('learn stores explicit valid_from in temporal', () => {
+      const engram = plur.learn('New pricing takes effect next quarter', {
+        scope: 'global',
+        valid_from: '2099-01-01',
+      })
+      expect(engram.temporal?.valid_from).toBe('2099-01-01')
+    })
+
+    it('learn leaves temporal unset when no validity is provided or detected', () => {
+      const engram = plur.learn('API uses snake_case everywhere', { scope: 'global' })
+      expect(engram.temporal).toBeUndefined()
+    })
+
+    it('learn rejects malformed valid_until', () => {
+      expect(() => plur.learn('Something', { valid_until: 'end of Q2' })).toThrow(/valid_until/)
+      expect(() => plur.learn('Something', { valid_until: '2026-02-30' })).toThrow(/valid_until/)
+    })
+
+    it('learn rejects malformed valid_from', () => {
+      expect(() => plur.learn('Something', { valid_from: 'someday' })).toThrow(/valid_from/)
+    })
+
+    it('learn rejects an inverted validity window (valid_from after valid_until)', () => {
+      expect(() => plur.learn('Something', { valid_from: '2026-06-01', valid_until: '2026-05-01' }))
+        .toThrow(/valid_from/)
+    })
+
+    it('extraction round-trip: expiry phrase in statement → structured valid_until → hard-skipped after expiry', () => {
+      // The observed #347 failure shape: statement says "valid 31 May 2026",
+      // engram kept injecting past expiry because temporal.valid_until was empty.
+      const engram = plur.learn('IGEA Enterprise offer REV.002, valid 31 May 2026', { scope: 'global' })
+      expect(engram.temporal?.valid_until).toBe('2026-05-31')
+      // Echo marker so the caller can confirm the parse (never silently guess).
+      expect((engram as any).structured_data?._expiry_extracted).toMatchObject({ valid_until: '2026-05-31' })
+      // 2026-05-31 is in the past relative to the test run → recall hard-skips it.
+      const results = plur.recall('IGEA Enterprise offer')
+      expect(results).toHaveLength(0)
+    })
+
+    it('explicit valid_until wins over an extracted phrase', () => {
+      const engram = plur.learn('Offer valid until 31 May 2026, extended', {
+        scope: 'global',
+        valid_until: '2099-12-31',
+      })
+      expect(engram.temporal?.valid_until).toBe('2099-12-31')
+      expect((engram as any).structured_data?._expiry_extracted).toBeUndefined()
+    })
+
+    it('learn with future valid_from is skipped by inject (not-yet-valid)', () => {
+      plur.learn('Next-gen deploy pipeline goes live for everyone', {
+        scope: 'global',
+        valid_from: '2099-01-01',
+      })
+      const result = plur.inject('deploy pipeline live')
+      expect(result.injected_ids).toHaveLength(0)
+    })
+
+    it('config expiry.mode=soft injects recently-expired engrams with the EXPIRED marker', () => {
+      const softDir = mkdtempSync(join(tmpdir(), 'plur-soft-expiry-'))
+      try {
+        writeFileSync(join(softDir, 'config.yaml'), yaml.dump({ expiry: { mode: 'soft', grace_days: 30 } }))
+        const soft = new Plur({ path: softDir })
+        const until = new Date(Date.now() - 5 * 86400000).toISOString().slice(0, 10)
+        const engram = soft.learn('Deploy target for the beta is staging-2', { scope: 'global' })
+        engram.temporal = { learned_at: '2026-01-01', valid_until: until }
+        soft.updateEngram(engram)
+        const result = soft.inject('deploy beta staging')
+        expect(result.injected_ids).toContain(engram.id)
+        const rendered = [result.directives, result.constraints, result.consider].join('\n')
+        expect(rendered).toContain(`⚠ EXPIRED ${until} — verify before use`)
+      } finally {
+        rmSync(softDir, { recursive: true })
+      }
+    })
+
+    it('default (hard) config keeps skipping expired engrams from inject', () => {
+      const engram = plur.learn('Deploy target for the beta is staging-2', { scope: 'global' })
+      engram.temporal = { learned_at: '2026-01-01', valid_until: '2026-01-31' }
+      plur.updateEngram(engram)
+      const result = plur.inject('deploy beta staging')
+      expect(result.injected_ids).not.toContain(engram.id)
+    })
+  })
+
   it('learn rejects statements containing secrets', () => {
     expect(() => plur.learn('API key is sk-1234567890abcdefghijklmn')).toThrow('Secret detected')
   })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -140,6 +140,8 @@ export function getToolDefinitions(): ToolDefinition[] {
           pinned: { type: 'boolean', description: 'Always-load flag. If true, this engram bypasses the keyword-relevance gate at injection time. Use sparingly: meta-rules, safety conventions, core operating principles only.' },
           commitment: { type: 'string', enum: ['exploring', 'leaning', 'decided', 'locked'], description: 'How firmly the user has committed to this belief (default: leaning)' },
           locked_reason: { type: 'string', description: 'Why this engram is locked (only meaningful when commitment=locked)' },
+          valid_from: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge becomes valid — inject/recall skip the engram before this date (#347)' },
+          valid_until: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge expires — inject/recall skip the engram after this date. Set this for any time-bound fact (offers, deadlines, temporary endpoints). When omitted, an explicit expiry phrase in the statement ("valid until 31 May 2026") is auto-parsed and echoed back (#347)' },
         },
         required: ['statement'],
       },
@@ -161,6 +163,8 @@ export function getToolDefinitions(): ToolDefinition[] {
           commitment: args.commitment as any,
           locked_reason: args.locked_reason as string | undefined,
           pinned: args.pinned as boolean | undefined,
+          valid_from: args.valid_from as string | undefined,
+          valid_until: args.valid_until as string | undefined,
           llm,
         }
         // Route through learnRouted FIRST so remote-scope writes get
@@ -200,6 +204,19 @@ export function getToolDefinitions(): ToolDefinition[] {
             `store; keep genuinely personal notes at the default scope.` }
         }
 
+        // Temporal validity echo (#347): report the stored window back, and
+        // when valid_until was auto-extracted from the statement (not passed
+        // by the caller), confirm the parse loudly — extraction must never
+        // silently guess.
+        const temporalEcho = (engram: { temporal?: { valid_from?: string; valid_until?: string } }) => {
+          const extracted = (engram as any).structured_data?._expiry_extracted as { valid_until: string; phrase: string } | undefined
+          return {
+            ...(engram.temporal?.valid_from ? { valid_from: engram.temporal.valid_from } : {}),
+            ...(engram.temporal?.valid_until ? { valid_until: engram.temporal.valid_until } : {}),
+            ...(extracted ? { expiry_note: `Parsed expiry phrase "${extracted.phrase}" from the statement → temporal.valid_until=${extracted.valid_until}. The engram stops injecting/recalling after that date. If this is wrong, re-learn with an explicit valid_until.` } : {}),
+          }
+        }
+
         const statement = sanitizeStatement(args.statement as string)
         try {
           const engram = await plur.learnRouted(statement, context)
@@ -214,6 +231,7 @@ export function getToolDefinitions(): ToolDefinition[] {
             scope: engram.scope, type: engram.type,
             pinned: (engram as any).pinned === true,
             decision: 'ADD',
+            ...temporalEcho(engram),
             ...scopeHint(engram.scope, !!routed),
             ...(isOutbox ? { outbox: true, warning: 'Remote write failed; engram queued locally for retry on next session start or plur_sync.' } : {}),
             ...(demoted ? { demoted: true, requested_scope: demoted.from, warning: `Sensitive content (${demoted.patterns}) detected — stored at "${demoted.to}"/private instead of the requested shared scope "${demoted.from}". If this is a false positive, re-scope deliberately.` } : {}),
@@ -231,6 +249,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type, decision: 'ADD',
+            ...temporalEcho(engram),
             ...scopeHint(engram.scope, !!routedFallback),
             ...(isOutbox ? { outbox: true } : {}),
             warning: `Remote write failed (${(err as Error).message}); engram queued for retry.`,

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -44,6 +44,48 @@ describe('MCP tools', () => {
     expect(result.statement).toBe('Test learning')
   })
 
+  // #347 — temporal validity params on the write path.
+  describe('plur_learn temporal validity (#347)', () => {
+    it('accepts explicit valid_until and echoes it back', async () => {
+      const result = await callTool('plur_learn', {
+        statement: 'Conference discount code is CONF20',
+        scope: 'global',
+        valid_until: '2099-12-31',
+      }) as any
+      expect(result.valid_until).toBe('2099-12-31')
+      const stored = plur.getById(result.id)
+      expect(stored?.temporal?.valid_until).toBe('2099-12-31')
+    })
+
+    it('accepts explicit valid_from and echoes it back', async () => {
+      const result = await callTool('plur_learn', {
+        statement: 'New pricing takes effect next fiscal year',
+        scope: 'global',
+        valid_from: '2099-01-01',
+      }) as any
+      expect(result.valid_from).toBe('2099-01-01')
+    })
+
+    it('echoes an auto-extracted expiry date with a confirmation note', async () => {
+      const result = await callTool('plur_learn', {
+        statement: 'Enterprise offer REV.002, valid until 31 May 2026',
+        scope: 'global',
+      }) as any
+      expect(result.valid_until).toBe('2026-05-31')
+      expect(result.expiry_note).toContain('2026-05-31')
+      expect(result.expiry_note).toContain('valid_until')
+    })
+
+    it('does not add an expiry note for explicit params', async () => {
+      const result = await callTool('plur_learn', {
+        statement: 'Plain fact with no dates',
+        scope: 'global',
+        valid_until: '2099-12-31',
+      }) as any
+      expect(result.expiry_note).toBeUndefined()
+    })
+  })
+
   // #296 — team knowledge silently defaulting to 'global'. When a team store is
   // configured and no scope is passed, surface a hint at the moment of the write.
   describe('scope hint when a team store is configured (#296)', () => {


### PR DESCRIPTION
Closes #347

## What

The deterministic expiry machinery (inject/recall skip engrams whose `temporal.valid_until` is past — `inject.ts`, `index.ts` recall filter) existed, but nothing populated the field. Time-bound facts were stored with the date only in free text and kept injecting at full strength after going stale (observed: an offer engram saying "valid 31 May 2026" injected 12 days past expiry).

This implements the issue's proposal — the minimal conservative version, no invented heuristics:

1. **Explicit pass-through** — `core.learn()` / `learnRouted()` accept optional `valid_from` / `valid_until` (`LearnContext`), and `plur_learn` (MCP) exposes both params. Strict ISO `YYYY-MM-DD` validation with fail-fast *before* dedup can short-circuit the write; inverted windows (`valid_from > valid_until`) are rejected. Stored in the existing `TemporalSchema` block — no schema change.
2. **Explicit-phrase extraction** — when no explicit `valid_until` is passed, an explicit expiry phrase in the statement ("valid until 31 May 2026", "valid 31 May 2026", "expires 2026-12-01", "valid through 30 June 2026") is lifted into `temporal.valid_until`. Conservative by design: only an expiry keyword immediately followed by a fully-specified, unambiguous date fires — missing year, numeric slash dates (US/EU ambiguity), and relative phrases ("end of Q2") never parse. The parsed ISO date is echoed back for confirmation via `expiry_note` in the `plur_learn` response (`structured_data._expiry_extracted` marker, same convention as `_demoted`/`_routed`) — **never silently guessed**.
3. **Soft-expiry mode** — `expiry: { mode: soft, grace_days: 30 }` in config injects a recently-expired engram with a `⚠ EXPIRED <date> — verify before use` marker at all three formatting layers, for `grace_days` after expiry. **Hard-skip remains the default**; recall filtering is unaffected (always hard); not-yet-valid (`valid_from` future) is always skipped.
4. **Tests** — extraction unit suite (`expiry.test.ts`, 16 tests), write-path round-trips incl. the observed offer-engram shape, soft/hard inject behavior + marker rendering, `valid_from` not-yet-valid skip, MCP param echo (11 + 6 + 4 new tests).

`ingest()` saves candidates through `learn()`, and learn-async ADD paths delegate to `learn()`, so extraction covers those paths automatically.

## Limitations (stated, not solved)

- Extraction handles **explicit dates only** — no relative/fuzzy parsing ("next quarter", "in 30 days", "end of Q2"). Deliberate: parsing those requires guessing an anchor date, which the issue forbids.
- `valid_from` is pass-through only — no phrase extraction ("valid from …"), since the issue only proposed expiry extraction.
- learnAsync MERGE/UPDATE decisions mutate existing engrams and do not retro-populate `temporal` on them — only new writes (ADD) get the window.

## Tests

- `packages/core`: full suite 1594 passed / 28 skipped (a first run under full parallel load flaked 2 tests in `pr5-hardening.test.ts` — pass in isolation and on rerun; known flaky-under-load, unrelated to this diff).
- `packages/mcp`: 141 passed.
- `packages/claw`: 107 passed (against rebuilt core dist).
- `pnpm build`: all packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1