### PR TITLE
fix(mcp): reset CapabilityCanary on session_start for per-session health detection (#192)

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -11,7 +11,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js'
 import { Plur, checkForUpdate } from '@plur-ai/core'
-import { getToolDefinitions } from './tools.js'
+import { getToolDefinitions, mcpCanary } from './tools.js'
 import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
 import { z } from 'zod'
@@ -211,6 +211,10 @@ export async function createServer(plur?: Plur): Promise<Server> {
         isError: true,
       }
     }
+    // #192: one tick per tool call = one "turn" for capability health.
+    // plur_session_start resets the canary, giving a per-session window:
+    // `threshold` turns without an expected signal flags the capability.
+    mcpCanary.tick()
     try {
       // Validate arguments against input schema
       const args = request.params.arguments ?? {}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -101,7 +101,8 @@ function sanitizeStatement(raw: string): string {
   return raw.slice(0, cut).trimEnd()
 }
 
-const mcpCanary = new CapabilityCanary({ threshold: 10 })
+// Exported so the server dispatch loop can tick it once per tool call (#192).
+export const mcpCanary = new CapabilityCanary({ threshold: 10 })
 mcpCanary.expect({
   id: 'session_start_hook',
   description: 'Automatic memory injection via hooks',
@@ -1152,7 +1153,12 @@ export function getToolDefinitions(): ToolDefinition[] {
         required: ['task'],
       },
       handler: async (args, plur) => {
-        mcpCanary.tick()
+        // #192: fresh canary window per session — health detection is
+        // per-session, not per-process. Without this, a single learn_activity
+        // signal kept the canary healthy for the whole server lifetime, and
+        // ticks accumulated across sessions. Ticking now happens once per
+        // tool call in the server dispatch loop.
+        mcpCanary.reset()
         mcpCanary.signal('session_start_hook')
         const crypto = await import('crypto')
         const session_id = crypto.randomUUID()

--- a/packages/mcp/test/canary.test.ts
+++ b/packages/mcp/test/canary.test.ts
@@ -1,0 +1,102 @@
+// Issue #192 — CapabilityCanary must reset on plur_session_start so health
+// detection is per-session, not per-process. Before this fix the module-level
+// canary accumulated state forever: once learn_activity fired once, it stayed
+// healthy for the rest of the MCP server's lifetime, and ticks only advanced
+// on session_start, so within a session no staleness could ever be detected.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { Plur } from '@plur-ai/core'
+import { getToolDefinitions } from '../src/tools.js'
+import { createServer } from '../src/server.js'
+
+const CANARY_THRESHOLD = 10
+
+describe('CapabilityCanary session reset (#192)', () => {
+  let plur: Plur
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-canary-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  const callDirect = async (name: string, args: Record<string, unknown> = {}) => {
+    const tools = getToolDefinitions()
+    const tool = tools.find(t => t.name === name)
+    if (!tool) throw new Error(`Unknown tool: ${name}`)
+    return tool.handler(args, plur)
+  }
+
+  const capability = (status: any, id: string) => {
+    const cap = (status.capabilities as any[]).find(c => c.capability === id)
+    if (!cap) throw new Error(`Capability ${id} not in status`)
+    return cap
+  }
+
+  it('session_start clears learn_activity carried over from a previous session', async () => {
+    // Session A: user learns something — canary records it
+    await callDirect('plur_learn', { statement: 'Canary reset test engram' })
+
+    // Session B starts: prior session's activity must not count as current health
+    await callDirect('plur_session_start', { task: 'canary reset test' })
+
+    const status = await callDirect('plur_status') as any
+    expect(capability(status, 'learn_activity').firedCount).toBe(0)
+    // The session_start itself fired the injection capability for this session
+    expect(capability(status, 'session_start_hook').firedCount).toBeGreaterThan(0)
+  })
+
+  describe('wire protocol (per-turn ticks)', () => {
+    let client: Client
+
+    beforeEach(async () => {
+      const server = await createServer(plur)
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+      await server.connect(serverTransport)
+      client = new Client({ name: 'canary-test-client', version: '1.0.0' })
+      await client.connect(clientTransport)
+    })
+
+    const callWire = async (name: string, args: Record<string, unknown> = {}) => {
+      const result = await client.callTool({ name, arguments: args })
+      return JSON.parse((result.content as any)[0].text)
+    }
+
+    it('flags learn_activity unhealthy after threshold turns without learning, then recovers on new session', async () => {
+      await callWire('plur_session_start', { task: 'long session, no learning' })
+
+      // Burn through a session's worth of turns with zero plur_learn calls
+      let status: any
+      for (let i = 0; i < CANARY_THRESHOLD; i++) {
+        status = await callWire('plur_status')
+      }
+      expect(capability(status, 'learn_activity').healthy).toBe(false)
+      expect(capability(status, 'learn_activity').warning).toContain('learn_activity')
+      // session_start fired this session, so injection stays healthy
+      expect(capability(status, 'session_start_hook').healthy).toBe(true)
+
+      // A new session opens a fresh detection window
+      await callWire('plur_session_start', { task: 'fresh session' })
+      status = await callWire('plur_status')
+      expect(capability(status, 'learn_activity').healthy).toBe(true)
+      expect(capability(status, 'learn_activity').firedCount).toBe(0)
+    })
+
+    it('stays healthy through many turns when learning happens in the session', async () => {
+      await callWire('plur_session_start', { task: 'productive session' })
+      await callWire('plur_learn', { statement: 'Engram learned mid-session' })
+
+      let status: any
+      for (let i = 0; i < CANARY_THRESHOLD + 2; i++) {
+        status = await callWire('plur_status')
+      }
+      expect(capability(status, 'learn_activity').healthy).toBe(true)
+      expect(capability(status, 'learn_activity').firedCount).toBeGreaterThan(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up from the PR #167 review (reviewer: @crtahlin). The module-level `mcpCanary` accumulated state across the whole MCP server lifetime — once `learn_activity` fired once, it stayed healthy forever, even if the user stopped learning for hundreds of turns.

Per the reviewer's suggestion, `plur_session_start` now calls `canary.reset()`, giving per-session health detection rather than per-process.

One necessary companion change: ticks previously only advanced inside `plur_session_start` itself, so after a reset the tick count could never exceed 1 and the canary could never flag anything (`ticks < threshold` would be permanently true — reset alone would have made the canary dead code). Ticking is relocated to the server dispatch loop: **one tick per tool call = one turn**. Ten turns (threshold) in a session without `plur_learn` now flags `learn_activity` in `plur_status`/`plur_doctor`; a learn call marks it healthy again; the next `session_start` opens a fresh window. `mcpCanary` is exported from `tools.ts` so `server.ts` can tick it.

## Test plan

TDD — 2 of 3 new tests failed on the old behavior before the fix:
- [x] `session_start` clears `learn_activity` carried over from a previous session (direct handler)
- [x] Wire protocol: `learn_activity` flagged unhealthy after 10 turns with no learning, `session_start_hook` stays healthy, fresh window after next `session_start`
- [x] Wire protocol: stays healthy through threshold+ turns when learning happens mid-session
- [x] `packages/mcp/test/canary.test.ts` — 3/3 pass
- [x] Full `@plur-ai/mcp` suite: 140 passed, 0 failed (baseline was 137)
- [x] `pnpm --filter @plur-ai/mcp build` (incl. DTS type-check) passes

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1


Closes #460 (canary ticking relocation — split out for explicit review).
