### PR TITLE
fix(pglite): make AsyncMutex queue chaining explicit + behavioral contract tests

### DIFF
--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -33,14 +33,23 @@ import type { StorageAdapter, StorageFilter, VectorSearchHit } from './storage-a
 /** Vector dimension used by the default BGE-small-en-v1.5 model. */
 const DEFAULT_VECTOR_DIM = 384
 
-/** Minimal async mutex — serializes writes inside the adapter. */
-class AsyncMutex {
+/**
+ * Minimal async mutex — serializes writes inside the adapter.
+ *
+ * Exported for direct testing only (#271); not part of the public API.
+ */
+export class AsyncMutex {
   private queue: Promise<void> = Promise.resolve()
   async run<T>(fn: () => Promise<T>): Promise<T> {
     let release: () => void
     const wait = new Promise<void>((res) => { release = res })
+    // Chain, don't replace (#271, F-DIJK-002): the next caller queues after
+    // both `prev` AND this run. `wait` only resolves when release() fires in
+    // the finally below, so `prev.then(() => wait)` reads in execution order.
+    // (The read-then-write of `this.queue` is safe from interleaving — this
+    // method body runs synchronously up to the first await.)
     const prev = this.queue
-    this.queue = wait
+    this.queue = prev.then(() => wait)
     await prev
     try {
       return await fn()

--- a/packages/core/test/async-mutex.test.ts
+++ b/packages/core/test/async-mutex.test.ts
@@ -1,0 +1,78 @@
+/**
+ * AsyncMutex ordering contract — closes #271 (iter-1 audit gap M-10,
+ * Dijkstra F-DIJK-002).
+ *
+ * The mutex serializes writes inside the PGLite adapter. Its original body
+ *
+ *   const prev = this.queue
+ *   this.queue = wait
+ *   await prev
+ *
+ * was correct only via a non-obvious invariant (JS single-threadedness means
+ * nothing interleaves between reading and writing `this.queue`), and read
+ * backwards: `this.queue` pointed at `wait` before `prev` had resolved. #271
+ * rewrites it to the idiomatic `this.queue = prev.then(() => wait)`, which
+ * makes "the next caller queues after both prev AND this run" explicit.
+ *
+ * These tests lock in the behavioral contract the rewrite must preserve:
+ * mutual exclusion, FIFO ordering, release-on-throw, and value/error
+ * propagation.
+ */
+import { describe, it, expect } from 'vitest'
+import { AsyncMutex } from '../src/storage-pglite.js'
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0))
+
+describe('AsyncMutex (#271)', () => {
+  it('serializes overlapping runs — no interleaving', async () => {
+    const mutex = new AsyncMutex()
+    const events: string[] = []
+    const job = (name: string, ticks: number) =>
+      mutex.run(async () => {
+        events.push(`${name}:start`)
+        for (let i = 0; i < ticks; i++) await tick()
+        events.push(`${name}:end`)
+      })
+    // Start both before either can finish; b must not start until a ends.
+    await Promise.all([job('a', 3), job('b', 1)])
+    expect(events).toEqual(['a:start', 'a:end', 'b:start', 'b:end'])
+  })
+
+  it('runs callers in FIFO order, including one arriving mid-run', async () => {
+    const mutex = new AsyncMutex()
+    const order: number[] = []
+    const first = mutex.run(async () => {
+      order.push(1)
+      // Third caller arrives while the first still holds the lock — it must
+      // queue after BOTH the in-flight run and the already-queued second.
+      void mutex.run(async () => { order.push(3) })
+      await tick()
+    })
+    const second = mutex.run(async () => { order.push(2) })
+    await Promise.all([first, second])
+    await mutex.run(async () => { order.push(4) })
+    expect(order).toEqual([1, 2, 3, 4])
+  })
+
+  it('releases the lock when fn throws — next caller still runs', async () => {
+    const mutex = new AsyncMutex()
+    await expect(mutex.run(async () => { throw new Error('boom') })).rejects.toThrow('boom')
+    // A rejected run must not poison the queue.
+    await expect(mutex.run(async () => 'after')).resolves.toBe('after')
+  })
+
+  it('propagates the return value of fn', async () => {
+    const mutex = new AsyncMutex()
+    await expect(mutex.run(async () => 42)).resolves.toBe(42)
+  })
+
+  it('rejection of one run does not reject queued runs', async () => {
+    const mutex = new AsyncMutex()
+    const results: string[] = []
+    const failing = mutex.run(async () => { throw new Error('first fails') })
+    const queued = mutex.run(async () => { results.push('second ran'); return 'ok' })
+    await expect(failing).rejects.toThrow('first fails')
+    await expect(queued).resolves.toBe('ok')
+    expect(results).toEqual(['second ran'])
+  })
+})


### PR DESCRIPTION
Closes #271

## What

Iter-1 audit gap M-10 (Dijkstra F-DIJK-002): `AsyncMutex.run` in `packages/core/src/storage-pglite.ts` assigned `this.queue = wait` before `await prev` — functionally correct, but only via the non-obvious invariant that no other caller can interleave between reading and writing `this.queue`, and reading backwards (by the time `prev` is awaited, `this.queue` already points at `wait`).

This PR applies the issue's recommended idiomatic form:

```ts
const prev = this.queue
this.queue = prev.then(() => wait)
await prev
```

which states "the next caller queues after both `prev` AND this run" directly, plus an inline comment asserting the single-threaded no-interleave invariant.

## Tests

`AsyncMutex` is now exported (documented as test-only, not public API) with a new 5-test behavioral contract in `packages/core/test/async-mutex.test.ts`:

- mutual exclusion: overlapping runs never interleave
- FIFO ordering, including a caller arriving mid-run (the exact scenario the issue describes)
- lock release when `fn` throws — a rejected run does not poison the queue
- return-value propagation
- rejection isolation: one run's failure does not reject queued runs

TDD: tests written first (red — `AsyncMutex` not exported), then the rewrite (green).

Full `@plur-ai/core` suite: green on final run (1594 tests; one earlier run under load showed 3 flakes in known-flaky pglite/packs files, which pass in isolation and on rerun). `pglite-adapter.test.ts` + `pglite-recall-wiring.test.ts` — the mutex's real consumers — pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1