### PR TITLE
fix(core,mcp): surface reranker non-engagement at runtime (#341)

### DIFF
--- a/packages/core/src/hybrid-search.ts
+++ b/packages/core/src/hybrid-search.ts
@@ -3,7 +3,7 @@ import { searchEngrams } from './fts.js'
 import { embeddingSearch, embedderStatus } from './embeddings.js'
 import { logger } from './logger.js'
 import type { RerankerAdapter } from './rerankers/types.js'
-import { isRerankerOff } from './rerankers/index.js'
+import { isRerankerOff, recordRerankerEngaged, recordRerankerFailure, hfCacheDirName } from './rerankers/index.js'
 
 /** Result of a hybrid search call with diagnostic metadata. */
 export interface HybridSearchResult {
@@ -214,20 +214,42 @@ export async function applyReranker(
     const docs = head.map(e => e.statement)
     const scores = await rerank.reranker.scoreBatch(query, docs)
     if (scores.length !== head.length) {
-      logger.warning(
-        `[hybrid-search] reranker returned ${scores.length} scores for ${head.length} candidates; skipping rerank.`,
-      )
+      const message = `returned ${scores.length} scores for ${head.length} candidates`
+      // #341: a mismatch is a non-engagement too — record it so doctor/recall
+      // can surface that results are RRF-only despite reranking being on.
+      logRerankerFailure(rerank.reranker, message)
       return { engrams: candidates, count: 0 }
     }
     const ranked = head
       .map((engram, i) => ({ engram, score: scores[i] }))
       .sort((a, b) => b.score - a.score)
       .map(r => r.engram)
+    recordRerankerEngaged()
     return { engrams: [...ranked, ...tail], count: head.length }
   } catch (err) {
-    logger.warning(
-      `[hybrid-search] reranker "${rerank.reranker.name}" failed: ${(err as Error).message}. Falling back to RRF order.`,
-    )
+    logRerankerFailure(rerank.reranker, (err as Error).message)
     return { engrams: candidates, count: 0 }
   }
+}
+
+/**
+ * Record a rerank failure and log it loud-once (#341): the first occurrence
+ * of a message logs at warning with the classification + remediation pointer;
+ * repeats of the same message are demoted to debug so a broken model doesn't
+ * flood one warning per query. The runtime tracker keeps the state that
+ * plur_doctor and the MCP recall path surface.
+ */
+function logRerankerFailure(reranker: RerankerAdapter, message: string): void {
+  const rec = recordRerankerFailure(reranker.name, message)
+  const base =
+    `[hybrid-search] reranker "${reranker.name}" failed: ${message}. ` +
+    `Falling back to RRF order — results are NOT cross-encoder reranked.`
+  if (!rec.firstFailure) {
+    logger.debug(base)
+    return
+  }
+  const hint = rec.kind === 'corrupt-cache'
+    ? ` Model cache looks corrupt (truncated download, see #340) — delete ~/.cache/huggingface/hub/${hfCacheDirName(reranker.modelId)}/ to force a clean re-download.`
+    : ''
+  logger.warning(`${base}${hint} Run plur_doctor for diagnosis. Repeats of this failure log at debug level.`)
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,8 @@ import { captureEpisode, queryTimeline } from './episodes.js'
 import { agenticSearch } from './agentic-search.js'
 import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } from './embeddings.js'
 import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as pgliteRrfMerge, type HybridSearchResult, type RerankOptions } from './hybrid-search.js'
-import { getReranker, resolveRerankerName, isRerankerOff, type RerankerAdapter } from './rerankers/index.js'
+import { getReranker, resolveRerankerName, isRerankerOff, rerankerStatus, resetRerankerStatus, _resetRerankerCache, type RerankerAdapter, type RerankerRuntimeStatus } from './rerankers/index.js'
+import { _resetBgeRerankerCache } from './rerankers/bge-reranker-v2-m3.js'
 import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, isEntityDomain, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
 import { getEmbedder, resolveEmbedderName } from './embedders/index.js'
 import { emitMissSignal } from './telemetry-miss-signal.js'
@@ -98,6 +99,17 @@ export { withAsyncLock, asyncAtomicWrite } from './store/index.js'
 // for any consumer that persists vectors. See embeddings.ts.
 export { embed, EMBED_DIM, activeEmbedderDim, embedderStatus, cosineSimilarity, type EmbedderStatus } from './embeddings.js'
 export { EMBEDDER_NAMES, DEFAULT_EMBEDDER, resolveEmbedderName, type EmbedderName, type EmbedderAdapter } from './embedders/index.js'
+// Reranker surface (#220/#341) — factory + runtime status so MCP/CLI can
+// probe reranker health (plur_doctor) and surface non-engagement on recall.
+// _setCachedReranker/_resetRerankerCache are test seams for exercising
+// failure paths without downloading the real ~300 MB model.
+export {
+  getReranker, isRerankerOff, resolveRerankerName, RERANKER_NAMES, DEFAULT_RERANKER,
+  rerankerStatus, resetRerankerStatus, classifyRerankerFailure, hfCacheDirName,
+  _resetRerankerCache, _setCachedReranker,
+  type RerankerName, type RerankerRuntimeStatus, type RerankerFailureKind,
+} from './rerankers/index.js'
+export type { RerankerAdapter } from './rerankers/types.js'
 export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus } from './sync.js'
 export { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'
@@ -1924,6 +1936,27 @@ export class Plur {
   /** Reset cached embedder failure state — next call will retry the model load. */
   resetEmbedder(): void {
     resetEmbedder()
+  }
+
+  /**
+   * Inspect reranker runtime state (#341) — engaged/failed counters and the
+   * last failure with its classification (corrupt-cache vs unavailable).
+   * Lets doctor/recall surface "reranking requested but not happening".
+   */
+  rerankerStatus(): RerankerRuntimeStatus {
+    return rerankerStatus()
+  }
+
+  /**
+   * Reset cached reranker state (#341) — adapter cache, load-pipeline cache,
+   * and the runtime failure tracker. The next rerank call retries the model
+   * load from scratch (e.g. after purging a corrupt HF cache).
+   */
+  resetReranker(): void {
+    _resetRerankerCache()
+    _resetBgeRerankerCache()
+    resetRerankerStatus()
+    this._reranker = null
   }
 
   /** Embedding search returning {engram, score}[] with cosine similarity scores. Async, no API calls. */

--- a/packages/core/src/rerankers/index.ts
+++ b/packages/core/src/rerankers/index.ts
@@ -51,6 +51,108 @@ export function _resetRerankerCache(): void {
 }
 
 /**
+ * Seed the adapter cache with a stub. Test-only — lets MCP/CLI tests exercise
+ * reranker failure paths without loading (or downloading) the real model.
+ */
+export function _setCachedReranker(name: RerankerName, adapter: RerankerAdapter): void {
+  adapterCache.set(name, adapter)
+}
+
+// --- Runtime status tracking (#341) ---
+//
+// applyReranker catches load/score errors and falls back to RRF order so
+// recall always returns something — but that made non-engagement invisible
+// beyond a per-call logger.warning. This module-level tracker records what
+// the rerank stage actually did, so plur_doctor and the MCP recall path can
+// say "you asked for reranking and it is NOT happening" loudly, once.
+
+/**
+ * Classification of a reranker failure (#341, ties into #340):
+ *   - `corrupt-cache`: the model downloaded but cannot be parsed (the classic
+ *     symptom of a truncated/corrupt download, e.g. "Protobuf parsing
+ *     failed"). Remediation is purge + re-download.
+ *   - `unavailable`: everything else — network unreachable, model id not
+ *     found, dependency resolution failure. Remediation is connectivity/setup.
+ */
+export type RerankerFailureKind = 'corrupt-cache' | 'unavailable'
+
+/** Snapshot of what the rerank stage did in this process (#341). */
+export interface RerankerRuntimeStatus {
+  /** Rerank calls that engaged (cross-encoder actually scored) this process. */
+  engaged_count: number
+  /** Rerank calls that failed and fell back to RRF order this process. */
+  failure_count: number
+  lastError: string | null
+  lastErrorKind: RerankerFailureKind | null
+  /** Adapter name of the last failure. */
+  lastFailedReranker: string | null
+}
+
+const cleanStatus = (): RerankerRuntimeStatus => ({
+  engaged_count: 0,
+  failure_count: 0,
+  lastError: null,
+  lastErrorKind: null,
+  lastFailedReranker: null,
+})
+
+let runtimeStatus = cleanStatus()
+
+/** Inspect reranker runtime state without forcing a load. Used by plur_doctor and the MCP recall path. */
+export function rerankerStatus(): RerankerRuntimeStatus {
+  return { ...runtimeStatus }
+}
+
+/** Record a successful cross-encoder engagement. */
+export function recordRerankerEngaged(): void {
+  runtimeStatus.engaged_count += 1
+}
+
+/**
+ * Record a rerank failure. Returns the classification plus whether this
+ * message is news (`firstFailure`) — callers log the first occurrence loudly
+ * and demote repeats to debug, so a broken model warns once instead of
+ * flooding one warning per query.
+ */
+export function recordRerankerFailure(
+  name: string,
+  message: string,
+): { kind: RerankerFailureKind; firstFailure: boolean } {
+  const firstFailure = runtimeStatus.lastError !== message
+  const kind = classifyRerankerFailure(message)
+  runtimeStatus.failure_count += 1
+  runtimeStatus.lastError = message
+  runtimeStatus.lastErrorKind = kind
+  runtimeStatus.lastFailedReranker = name
+  return { kind, firstFailure }
+}
+
+/** Reset the runtime tracker — doctor retry and tests. */
+export function resetRerankerStatus(): void {
+  runtimeStatus = cleanStatus()
+}
+
+/**
+ * Corrupt-model indicators. "Protobuf parsing failed" is the observed #340
+ * shape (truncated Xet download); the rest are conservative synonyms for a
+ * damaged on-disk artifact. Anything else is treated as `unavailable`.
+ */
+const CORRUPT_RE = /protobuf parsing failed|corrupt|truncat|unexpected end of (?:file|data|input)|invalid model/i
+
+/** Classify a reranker failure message: corrupt-cache vs unavailable (#341). */
+export function classifyRerankerFailure(message: string): RerankerFailureKind {
+  return CORRUPT_RE.test(message) ? 'corrupt-cache' : 'unavailable'
+}
+
+/**
+ * HF hub cache directory name for a model id — the purge target when the
+ * cache is corrupt: `~/.cache/huggingface/hub/<this>/`.
+ */
+export function hfCacheDirName(modelId: string): string {
+  return `models--${modelId.replace(/\//g, '--')}`
+}
+
+/**
  * The "off" adapter. Returns zero for every pair — the recall path treats
  * this as "no reranking happened" and falls back to the RRF order.
  *

--- a/packages/core/test/hybrid-rerank.test.ts
+++ b/packages/core/test/hybrid-rerank.test.ts
@@ -13,6 +13,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '../src/index.js'
 import { applyReranker } from '../src/hybrid-search.js'
+import { rerankerStatus, resetRerankerStatus, recordRerankerFailure } from '../src/rerankers/index.js'
 import type { RerankerAdapter } from '../src/rerankers/types.js'
 
 /**
@@ -133,6 +134,93 @@ describe('hybrid search reranker stage — applyReranker (unit)', () => {
   })
 })
 
+// #341 — applyReranker must leave an observable trace when it engages or
+// silently falls back, and the per-query warning flood must collapse to a
+// loud-once pattern (first failure at warning, repeats at debug).
+describe('applyReranker runtime surfacing (#341)', () => {
+  beforeEach(() => {
+    resetRerankerStatus()
+  })
+  afterEach(() => {
+    resetRerankerStatus()
+  })
+
+  const broken = (message: string): RerankerAdapter => ({
+    name: 'bge-reranker-v2-m3',
+    modelId: 'onnx-community/bge-reranker-v2-m3-ONNX',
+    async score() { throw new Error(message) },
+    async scoreBatch() { throw new Error(message) },
+  })
+
+  it('records an engagement on success', async () => {
+    const engrams = [makeEngram('a', 'apple pie'), makeEngram('b', 'banana bread')]
+    const out = await applyReranker(engrams, 'apple', { reranker: makeFakeReranker() })
+    expect(out.count).toBe(2)
+    expect(rerankerStatus().engaged_count).toBe(1)
+    expect(rerankerStatus().failure_count).toBe(0)
+  })
+
+  it('records the failure with classification when the reranker throws', async () => {
+    const engrams = [makeEngram('a', 'foo'), makeEngram('b', 'bar')]
+    const out = await applyReranker(engrams, 'foo', { reranker: broken('Protobuf parsing failed.') })
+    expect(out.count).toBe(0)
+    const status = rerankerStatus()
+    expect(status.failure_count).toBe(1)
+    expect(status.engaged_count).toBe(0)
+    expect(status.lastError).toBe('Protobuf parsing failed.')
+    expect(status.lastErrorKind).toBe('corrupt-cache')
+    expect(status.lastFailedReranker).toBe('bge-reranker-v2-m3')
+  })
+
+  it('records a failure when scoreBatch returns wrong-length output', async () => {
+    const engrams = [makeEngram('a', 'foo'), makeEngram('b', 'bar')]
+    const buggy: RerankerAdapter = {
+      name: 'buggy',
+      modelId: 'buggy://test',
+      async score() { return 1 },
+      async scoreBatch() { return [1] }, // wrong length
+    }
+    const out = await applyReranker(engrams, 'foo', { reranker: buggy })
+    expect(out.count).toBe(0)
+    expect(rerankerStatus().failure_count).toBe(1)
+    expect(rerankerStatus().lastError).toContain('1 scores for 2 candidates')
+  })
+
+  it('warns loudly on the first failure only; repeats are demoted to debug', async () => {
+    const engrams = [makeEngram('a', 'foo'), makeEngram('b', 'bar')]
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await applyReranker(engrams, 'foo', { reranker: broken('Protobuf parsing failed.') })
+      const firstWarnings = spy.mock.calls.filter(c => String(c[0]).includes('plur:warning')).length
+      expect(firstWarnings).toBe(1)
+      // Same failure again — default log level suppresses the debug repeat.
+      await applyReranker(engrams, 'foo', { reranker: broken('Protobuf parsing failed.') })
+      await applyReranker(engrams, 'foo', { reranker: broken('Protobuf parsing failed.') })
+      const totalWarnings = spy.mock.calls.filter(c => String(c[0]).includes('plur:warning')).length
+      expect(totalWarnings).toBe(1)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('the first-failure warning names the corrupt cache and points at plur_doctor', async () => {
+    const engrams = [makeEngram('a', 'foo')]
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await applyReranker(engrams, 'foo', { reranker: broken('Protobuf parsing failed.') })
+      const warning = spy.mock.calls.find(c => String(c[0]).includes('plur:warning'))
+      expect(warning).toBeDefined()
+      const text = warning!.map(String).join(' ')
+      expect(text).toContain('RRF')
+      expect(text).toContain('corrupt')
+      expect(text).toContain('models--onnx-community--bge-reranker-v2-m3-ONNX')
+      expect(text).toContain('plur_doctor')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})
+
 describe('Plur.recallHybrid with rerank=true (integration)', () => {
   let dir: string
   let plur: Plur
@@ -196,6 +284,18 @@ describe('Plur.recallHybrid with rerank=true (integration)', () => {
   // Belt-and-suspenders: silence unused-import warnings from vi.
   it('vi mock surface stays available for future opt-in test rigs', () => {
     expect(typeof vi.fn).toBe('function')
+  })
+
+  // #341 — the tracker is reachable from the Plur instance (MCP consumes it
+  // there) and resetReranker clears recorded failures for a doctor retry.
+  it('Plur.rerankerStatus exposes the tracker; resetReranker clears it', () => {
+    resetRerankerStatus()
+    recordRerankerFailure('bge-reranker-v2-m3', 'Protobuf parsing failed.')
+    expect(plur.rerankerStatus().failure_count).toBe(1)
+    expect(plur.rerankerStatus().lastErrorKind).toBe('corrupt-cache')
+    plur.resetReranker()
+    expect(plur.rerankerStatus().failure_count).toBe(0)
+    expect(plur.rerankerStatus().lastError).toBeNull()
   })
 })
 

--- a/packages/core/test/reranker.test.ts
+++ b/packages/core/test/reranker.test.ts
@@ -31,6 +31,12 @@ import {
   DEFAULT_RERANKER,
   _resetRerankerCache,
   _resetResolveWarnings,
+  classifyRerankerFailure,
+  rerankerStatus,
+  recordRerankerFailure,
+  recordRerankerEngaged,
+  resetRerankerStatus,
+  hfCacheDirName,
   type RerankerAdapter,
   type RerankerName,
 } from '../src/rerankers/index.js'
@@ -131,6 +137,82 @@ describe('resolveRerankerName — env var handling', () => {
   it('trims whitespace', () => {
     const name = resolveRerankerName({ PLUR_RERANKER: '  bge-reranker-v2-m3  ' } as NodeJS.ProcessEnv)
     expect(name).toBe('bge-reranker-v2-m3')
+  })
+})
+
+// #341 — reranker non-engagement must be observable at runtime, not just a
+// per-call logger.warning. The module tracks engaged/failed counts and
+// classifies the last failure (corrupt-cache vs unavailable) so plur_doctor
+// and the MCP recall path can surface it.
+describe('reranker runtime status + failure classification (#341)', () => {
+  beforeEach(() => {
+    resetRerankerStatus()
+  })
+
+  it('classifies corrupt-model failures as corrupt-cache', () => {
+    // The observed #340 shape: a truncated Xet download fails protobuf parsing.
+    expect(classifyRerankerFailure('Protobuf parsing failed.')).toBe('corrupt-cache')
+    expect(classifyRerankerFailure('unexpected end of file while reading model.onnx')).toBe('corrupt-cache')
+    expect(classifyRerankerFailure('model file appears corrupt')).toBe('corrupt-cache')
+    expect(classifyRerankerFailure('Download truncated at 12MB of 300MB')).toBe('corrupt-cache')
+  })
+
+  it('classifies everything else as unavailable', () => {
+    expect(classifyRerankerFailure('fetch failed: getaddrinfo ENOTFOUND huggingface.co')).toBe('unavailable')
+    expect(classifyRerankerFailure('404 Not Found')).toBe('unavailable')
+    expect(classifyRerankerFailure('some novel error')).toBe('unavailable')
+  })
+
+  it('starts clean and records failures with classification', () => {
+    expect(rerankerStatus()).toMatchObject({
+      engaged_count: 0,
+      failure_count: 0,
+      lastError: null,
+      lastErrorKind: null,
+      lastFailedReranker: null,
+    })
+    const rec = recordRerankerFailure('bge-reranker-v2-m3', 'Protobuf parsing failed.')
+    expect(rec.kind).toBe('corrupt-cache')
+    expect(rec.firstFailure).toBe(true)
+    expect(rerankerStatus()).toMatchObject({
+      failure_count: 1,
+      lastError: 'Protobuf parsing failed.',
+      lastErrorKind: 'corrupt-cache',
+      lastFailedReranker: 'bge-reranker-v2-m3',
+    })
+  })
+
+  it('flags repeats of the same message as not-first (loud-once, no per-query flood)', () => {
+    expect(recordRerankerFailure('x', 'same error').firstFailure).toBe(true)
+    expect(recordRerankerFailure('x', 'same error').firstFailure).toBe(false)
+    expect(recordRerankerFailure('x', 'same error').firstFailure).toBe(false)
+    // A different message is news again.
+    expect(recordRerankerFailure('x', 'different error').firstFailure).toBe(true)
+    expect(rerankerStatus().failure_count).toBe(4)
+  })
+
+  it('records engagements', () => {
+    recordRerankerEngaged()
+    recordRerankerEngaged()
+    expect(rerankerStatus().engaged_count).toBe(2)
+  })
+
+  it('resetRerankerStatus clears everything', () => {
+    recordRerankerEngaged()
+    recordRerankerFailure('x', 'boom')
+    resetRerankerStatus()
+    expect(rerankerStatus()).toMatchObject({
+      engaged_count: 0,
+      failure_count: 0,
+      lastError: null,
+      lastErrorKind: null,
+      lastFailedReranker: null,
+    })
+  })
+
+  it('hfCacheDirName maps a model id to its HF hub cache directory (purge target)', () => {
+    expect(hfCacheDirName('onnx-community/bge-reranker-v2-m3-ONNX'))
+      .toBe('models--onnx-community--bge-reranker-v2-m3-ONNX')
   })
 })
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,7 +1,7 @@
 import { existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope } from '@plur-ai/core'
+import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName } from '@plur-ai/core'
 import type { LlmFunction, MetaField } from '@plur-ai/core'
 import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
@@ -351,6 +351,22 @@ export function getToolDefinitions(): ToolDefinition[] {
         }
         if (meta.mode === 'hybrid-degraded') {
           response.warning = `Embedding layer unavailable — results are BM25-only. Run plur_doctor for diagnosis. Last error: ${meta.embedderError ?? 'unknown'}`
+        }
+        // #341: reranker non-engagement surfacing. When PLUR_RERANKER requests
+        // reranking, report how many candidates the cross-encoder actually
+        // re-scored — and if it never engaged on a non-empty result set, say
+        // so in the response instead of a per-call stderr warning nobody
+        // reads. The caller believes reranking is on; RRF-only results must
+        // not be silently mislabeled.
+        if (resolveRerankerName() !== 'off') {
+          response.reranked = meta.reranked ?? 0
+          const rr = plur.rerankerStatus()
+          if (boundedResults.length > 0 && (meta.reranked ?? 0) === 0 && rr.lastError) {
+            const corruptNote = rr.lastErrorKind === 'corrupt-cache'
+              ? ' The model cache looks corrupt (truncated download) — purge and re-download, see plur_doctor.'
+              : ''
+            response.reranker_warning = `PLUR_RERANKER is set but the reranker did not engage — results are RRF-only (fusion order, no cross-encoder rerank).${corruptNote} Last error: ${rr.lastError}. Run plur_doctor for diagnosis.`
+          }
         }
         return response
       },
@@ -1026,6 +1042,9 @@ export function getToolDefinitions(): ToolDefinition[] {
       handler: async (args, plur) => {
         if (args.retry === true) {
           plur.resetEmbedder()
+          // #341: also reset reranker caches + failure tracker so a purged
+          // corrupt model cache can be re-probed without a process restart.
+          plur.resetReranker()
         }
         const status = plur.status()
         const before = plur.embedderStatus()
@@ -1089,6 +1108,41 @@ export function getToolDefinitions(): ToolDefinition[] {
             '  • Manual fix: from the @plur-ai/core package directory, run a script that imports @huggingface/transformers and calls pipeline() to trigger the download',
             '  • Or opt out: set PLUR_DISABLE_EMBEDDINGS=1, or write `embeddings: { enabled: false }` to ~/.plur/config.yaml — hybrid search will run BM25-only',
           )
+        }
+        // Reranker health (#341) — only when PLUR_RERANKER opts in; off (the
+        // default) is healthy silence, not a check. The probe scores one pair
+        // through the real adapter: per #220 that is seconds-scale on CPU
+        // (plus a one-time model download on first run), which is acceptable
+        // for an explicit doctor run and the only way to catch a corrupt
+        // cache before recall silently degrades to RRF order.
+        const rerankerName = resolveRerankerName()
+        if (rerankerName !== 'off') {
+          const adapter = getReranker(rerankerName)
+          let rerankerOk = false
+          let rerankerDetail: string
+          const probeStart = Date.now()
+          try {
+            const scores = await adapter.scoreBatch('plur doctor probe', ['probe document'])
+            rerankerOk = scores.length === 1 && Number.isFinite(scores[0])
+            rerankerDetail = rerankerOk
+              ? `${rerankerName} loaded and scoring (probe ${Date.now() - probeStart}ms; seconds-scale per recall on CPU is expected — #220)`
+              : `Probe returned malformed scores (${JSON.stringify(scores)}) — recall silently falls back to RRF-only`
+          } catch (err) {
+            const message = (err as Error).message
+            const kind = classifyRerankerFailure(message)
+            if (kind === 'corrupt-cache') {
+              rerankerDetail = `Model cache looks corrupt (${message}) — recall silently falls back to RRF-only`
+              remediation.push(
+                `Reranker model cache is corrupt — the classic symptom of a truncated download (#340). Delete ~/.cache/huggingface/hub/${hfCacheDirName(adapter.modelId)}/ and run plur_doctor with retry:true — the model will redownload via the classic (non-Xet) path.`,
+              )
+            } else {
+              rerankerDetail = `Failed to load: ${message} — recall silently falls back to RRF-only`
+              remediation.push(
+                `Reranker "${rerankerName}" is unavailable while PLUR_RERANKER requests it — recall degrades to RRF order without it. Check connectivity to huggingface.co (first-run download), or unset PLUR_RERANKER to opt out deliberately.`,
+              )
+            }
+          }
+          checks.push({ check: 'reranker available', ok: rerankerOk, detail: rerankerDetail })
         }
         const canaryStatuses = mcpCanary.status()
         for (const cs of canaryStatuses) {

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { Plur } from '@plur-ai/core'
+import { Plur, _setCachedReranker, _resetRerankerCache, resetRerankerStatus, rerankerStatus } from '@plur-ai/core'
+import type { RerankerAdapter } from '@plur-ai/core'
 import { getToolDefinitions } from '../src/tools.js'
 
 describe('MCP tools', () => {
@@ -249,6 +250,124 @@ describe('MCP tools', () => {
       const list = await callTool('plur_stores_list', {}) as any
       const engineering = list.stores.filter((s: any) => s.scope === 'group:plur/plur-ai/engineering')
       expect(engineering).toHaveLength(1)
+    })
+  })
+
+  // #341 — reranker non-engagement is silent at runtime. When PLUR_RERANKER
+  // requests reranking but the cross-encoder can't engage (corrupt download,
+  // model unavailable), recall silently degrades to RRF order. These tests
+  // pin the surfacing: a warning on the recall response and a plur_doctor
+  // check with corrupt-vs-unavailable remediation. Fakes are seeded into the
+  // adapter cache so no test touches the real ~300 MB model.
+  describe('reranker non-engagement surfacing (#341)', () => {
+    const BGE = 'bge-reranker-v2-m3' as const
+    const BGE_MODEL_ID = 'onnx-community/bge-reranker-v2-m3-ONNX'
+
+    const failing = (message: string): RerankerAdapter => ({
+      name: BGE,
+      modelId: BGE_MODEL_ID,
+      async score(): Promise<number> { throw new Error(message) },
+      async scoreBatch(): Promise<number[]> { throw new Error(message) },
+    })
+
+    const working = (): RerankerAdapter => ({
+      name: BGE,
+      modelId: BGE_MODEL_ID,
+      async score(): Promise<number> { return 0.5 },
+      async scoreBatch(_q: string, docs: string[]): Promise<number[]> { return docs.map(() => 0.5) },
+    })
+
+    beforeEach(() => {
+      process.env.PLUR_RERANKER = BGE
+      _resetRerankerCache()
+      resetRerankerStatus()
+      plur.learn('The deploy target for staging is cluster-2', { scope: 'global' })
+    })
+    afterEach(() => {
+      delete process.env.PLUR_RERANKER
+      _resetRerankerCache()
+      resetRerankerStatus()
+    })
+
+    it('plur_recall_hybrid warns when reranking is requested but never engages', async () => {
+      _setCachedReranker(BGE, failing('fetch failed: getaddrinfo ENOTFOUND huggingface.co'))
+      const result = await callTool('plur_recall_hybrid', { query: 'deploy target staging' }) as any
+      expect(result.count).toBeGreaterThan(0)   // recall still returns results
+      expect(result.reranked).toBe(0)
+      expect(result.reranker_warning).toContain('RRF-only')
+      expect(result.reranker_warning).toContain('plur_doctor')
+    })
+
+    it('the recall warning flags a corrupt model cache distinctly', async () => {
+      _setCachedReranker(BGE, failing('Protobuf parsing failed.'))
+      const result = await callTool('plur_recall_hybrid', { query: 'deploy target staging' }) as any
+      expect(result.reranker_warning).toContain('corrupt')
+      expect(result.reranker_warning).toContain('Protobuf parsing failed.')
+    })
+
+    it('does not warn when the reranker engages', async () => {
+      _setCachedReranker(BGE, working())
+      const result = await callTool('plur_recall_hybrid', { query: 'deploy target staging' }) as any
+      expect(result.reranked).toBeGreaterThan(0)
+      expect(result.reranker_warning).toBeUndefined()
+    })
+
+    it('omits the reranked field and never warns when PLUR_RERANKER is off', async () => {
+      delete process.env.PLUR_RERANKER
+      const result = await callTool('plur_recall_hybrid', { query: 'deploy target staging' }) as any
+      expect(result.count).toBeGreaterThan(0)
+      expect(result.reranked).toBeUndefined()
+      expect(result.reranker_warning).toBeUndefined()
+    })
+
+    it('plur_doctor reports a corrupt reranker cache with purge remediation', async () => {
+      _setCachedReranker(BGE, failing('Protobuf parsing failed.'))
+      const result = await callTool('plur_doctor') as any
+      const check = result.checks.find((c: any) => c.check === 'reranker available')
+      expect(check).toBeDefined()
+      expect(check.ok).toBe(false)
+      expect(check.detail).toContain('corrupt')
+      expect(check.detail).toContain('RRF-only')
+      const remediation = result.remediation.join('\n')
+      expect(remediation).toContain('models--onnx-community--bge-reranker-v2-m3-ONNX')
+      expect(result.ok).toBe(false)
+    })
+
+    it('plur_doctor reports an unavailable reranker with connectivity remediation', async () => {
+      _setCachedReranker(BGE, failing('fetch failed: getaddrinfo ENOTFOUND huggingface.co'))
+      const result = await callTool('plur_doctor') as any
+      const check = result.checks.find((c: any) => c.check === 'reranker available')
+      expect(check.ok).toBe(false)
+      expect(check.detail).toContain('Failed to load')
+      expect(result.remediation.join('\n')).toContain('huggingface.co')
+    })
+
+    it('plur_doctor reports a healthy reranker when the probe scores', async () => {
+      _setCachedReranker(BGE, working())
+      const result = await callTool('plur_doctor') as any
+      const check = result.checks.find((c: any) => c.check === 'reranker available')
+      expect(check.ok).toBe(true)
+      // #220: seconds-scale per recall on CPU is expected, not a fault — the
+      // healthy detail says so instead of letting users misread the latency.
+      expect(check.detail).toContain('seconds')
+    })
+
+    it('plur_doctor skips the reranker check when PLUR_RERANKER is off', async () => {
+      delete process.env.PLUR_RERANKER
+      const result = await callTool('plur_doctor') as any
+      expect(result.checks.find((c: any) => c.check === 'reranker available')).toBeUndefined()
+    })
+
+    it('plur_doctor retry:true clears recorded reranker failures', async () => {
+      _setCachedReranker(BGE, failing('Protobuf parsing failed.'))
+      await callTool('plur_recall_hybrid', { query: 'deploy target staging' })
+      expect(rerankerStatus().failure_count).toBeGreaterThan(0)
+      // Turn the env off so the doctor probe does not attempt a real model
+      // load after the cache reset — we only assert the state reset here.
+      delete process.env.PLUR_RERANKER
+      await callTool('plur_doctor', { retry: true })
+      expect(rerankerStatus().failure_count).toBe(0)
+      expect(rerankerStatus().lastError).toBeNull()
     })
   })
 


### PR DESCRIPTION
Closes #341

## What

When `PLUR_RERANKER` is set but the cross-encoder can't load — model unavailable, or a corrupt/truncated download (#340) — `applyReranker` catches the error and falls back to RRF order. Recall still returns results, but they are **RRF-only while the caller believes reranking is on**. The only signal was a per-call `logger.warning`: easy to miss, and it floods one line per query.

## Relationship to #435

PR #435 (`fix/341-benchmark-reranker-preflight`) covers the issue's **item 1** — the benchmark-harness pre-flight probe — and explicitly defers the library/runtime silence. This PR covers the remaining **items 2 and 3** (runtime/MCP surfacing + corrupt-model detection). The two PRs touch disjoint files and complement each other.

## Changes

**Item 2 — runtime/MCP surfacing**
- `packages/core/src/rerankers/index.ts`: runtime status tracker — `rerankerStatus()` reports engaged/failed counts, last error, and its classification. `resetRerankerStatus()` clears it.
- `packages/core/src/hybrid-search.ts`: `applyReranker` records engagement/failure. **Loud-once logging**: the first occurrence of a failure message logs at `warning` (with classification, purge hint when corrupt, and a `plur_doctor` pointer); repeats of the same message are demoted to `debug` — no more one-warning-per-query flood. A score-length mismatch now also records as non-engagement.
- `packages/mcp/src/tools.ts` `plur_recall_hybrid`: when `PLUR_RERANKER` is set, the response includes `reranked` (count actually re-scored); when the reranker never engaged on a non-empty result set, a `reranker_warning` states the results are RRF-only and points at `plur_doctor`. Mirrors the existing `hybrid-degraded` embedder warning.
- `packages/mcp/src/tools.ts` `plur_doctor`: new `reranker available` check, only when `PLUR_RERANKER` opts in (off = healthy silence, no check). Probes one score pair through the real adapter; per #220 (bge-reranker-v2-m3 is seconds-scale per query on CPU) the healthy detail states the probe time and that seconds-scale latency is expected, so operators don't misread it as a fault. `retry: true` now also resets reranker caches + the failure tracker (so a purged cache can be re-probed without restarting the MCP server).
- `Plur.rerankerStatus()` / `Plur.resetReranker()` methods, mirroring `embedderStatus()` / `resetEmbedder()`.

**Item 3 — corrupt-model detection**
- `classifyRerankerFailure()`: `corrupt-cache` (e.g. `Protobuf parsing failed` — the observed #340 truncated-Xet-download shape — plus conservative synonyms: corrupt / truncated / unexpected end of file) vs `unavailable` (everything else). Corrupt failures get targeted remediation everywhere they surface: delete `~/.cache/huggingface/hub/<models--dir>/` (via `hfCacheDirName(modelId)`) and re-download — which now goes through the classic non-Xet path thanks to #340.

**Test seam**: `_setCachedReranker()` (exported alongside the existing `_resetRerankerCache()`) lets MCP tests seed fake adapters so failure paths are exercised without downloading the real ~300 MB model.

## Tests

TDD — all new tests written first and failing, then implementation:
- `packages/core/test/reranker.test.ts`: +7 (classification, tracker record/reset, loud-once flag, cache-dir mapping)
- `packages/core/test/hybrid-rerank.test.ts`: +6 (engagement/failure/mismatch recording, warn-once console behavior, corrupt hint content, `Plur.rerankerStatus`/`resetReranker`)
- `packages/mcp/test/tools.test.ts`: +9 (recall warning incl. corrupt flavor, no-warning on engagement, off-by-default silence, doctor corrupt/unavailable/healthy/skip/retry)

Suites: core 1574 passed / 28 skipped (full suite, no flakes this run) · mcp 146 passed · claw 107 passed (against rebuilt core dist) · `pnpm build` green.

## Notes / limitations

- The recall-path warning keys off `PLUR_RERANKER` since the MCP tool does not expose a per-call `rerank` flag; direct API callers passing `rerank: true` get the same loud-once core logging and can consult `plur.rerankerStatus()`.
- Doctor's probe intentionally loads the model (only when opted in) — that is the only way to catch a corrupt cache before recall degrades; per #220 this is seconds-scale on CPU plus a one-time download on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1