### PR TITLE
fix(sync): surface background index/reembed failures instead of swallowing them

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,3 +1,4 @@
+import type { IndexSyncError } from '@plur-ai/core'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText } from '../output.js'
 
@@ -31,13 +32,24 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (typeof (plur as { waitForIndex?: () => Promise<void> }).waitForIndex === 'function') {
     await (plur as { waitForIndex: () => Promise<void> }).waitForIndex()
   }
+  // #272: the background index/reembed chain swallows its own rejection
+  // (waitForIndex resolves either way) — read the recorded failure so a
+  // broken index doesn't report "Sync: ok".
+  const indexError =
+    typeof (plur as { lastIndexError?: () => IndexSyncError | null }).lastIndexError === 'function'
+      ? (plur as { lastIndexError: () => IndexSyncError | null }).lastIndexError()
+      : null
 
   if (shouldOutputJson(flags)) {
-    outputJson({ ...result, full })
+    outputJson({ ...result, full, ...(indexError ? { index_error: indexError } : {}) })
   } else {
     outputText(`Sync: ${result.action}${full ? ' (full reindex)' : ''}`)
     if (result.message) outputText(`  ${result.message}`)
     if (result.files_changed > 0) outputText(`  Files changed: ${result.files_changed}`)
     if (full) outputText('  Index rebuilt from YAML.')
+    if (indexError) {
+      outputText(`  Warning: index ${indexError.op} failed — ${indexError.message}`)
+      outputText("  YAML is still the source of truth. Run 'plur sync --full' to rebuild the index.")
+    }
   }
 }

--- a/packages/cli/test/sync-index-error.test.ts
+++ b/packages/cli/test/sync-index-error.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `plur sync` surfaces background index failures — closes #272 (iter-1 audit
+ * gap M-11, Critic F-CRIT-006).
+ *
+ * The command awaits waitForIndex(), but the background chain's .catch has
+ * already absorbed any rejection — so a failed index/reembed pass printed
+ * "Sync: ok" with no indication. The command now reads plur.lastIndexError()
+ * after the index quiesces and surfaces it in both text and JSON output.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { IndexSyncError } from '@plur-ai/core'
+
+const mockPlur = {
+  sync: vi.fn(),
+  waitForIndex: vi.fn(async () => undefined),
+  lastIndexError: vi.fn((): IndexSyncError | null => null),
+}
+
+vi.mock('../src/plur.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/plur.js')>()
+  return { ...mod, createPlur: () => mockPlur as never }
+})
+
+import { run } from '../src/commands/sync.js'
+
+describe('plur sync index-error surfacing (#272)', () => {
+  let writes: string[]
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    writes = []
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk))
+      return true
+    }) as never)
+    mockPlur.sync.mockReturnValue({ action: 'up-to-date', message: '', remote: null, files_changed: 0 })
+    mockPlur.lastIndexError.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+    vi.clearAllMocks()
+  })
+
+  it('prints a warning in text mode when the background index pass failed', async () => {
+    mockPlur.lastIndexError.mockReturnValue({
+      op: 'sync-from-yaml',
+      message: 'disk on fire',
+      at: '2026-07-02T00:00:00.000Z',
+    })
+    await run([], { json: false })
+    const out = writes.join('')
+    expect(out).toContain('Sync: up-to-date')
+    expect(out).toContain('sync-from-yaml')
+    expect(out).toContain('disk on fire')
+    // Must wait for the index before reading the error state.
+    expect(mockPlur.waitForIndex).toHaveBeenCalled()
+  })
+
+  it('includes index_error in JSON output', async () => {
+    const err: IndexSyncError = {
+      op: 'reindex',
+      message: 'rebuild exploded',
+      at: '2026-07-02T00:00:00.000Z',
+    }
+    mockPlur.lastIndexError.mockReturnValue(err)
+    await run(['--full'], { json: true })
+    const parsed = JSON.parse(writes.join(''))
+    expect(parsed.index_error).toEqual(err)
+  })
+
+  it('stays quiet when the index pass succeeded', async () => {
+    await run([], { json: true })
+    const parsed = JSON.parse(writes.join(''))
+    expect(parsed.index_error).toBeUndefined()
+    expect(parsed.action).toBe('up-to-date')
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -164,6 +164,22 @@ export interface IngestCandidate {
   source?: string
 }
 
+/**
+ * Last failure of a background index operation (#272). The PGLite index
+ * refresh (and the auto-embed/reembed pass that rides on it) runs in a
+ * fire-and-forget promise whose .catch used to swallow the error entirely —
+ * a failed refresh reported "Sync: ok". Recorded and exposed via
+ * `lastIndexError()` / `status().index_error` so CLI and MCP callers can
+ * surface it. Cleared when the next background pass succeeds.
+ */
+export interface IndexSyncError {
+  /** Which background operation failed. */
+  op: 'initial-sync' | 'sync-from-yaml' | 'reindex' | 'auto-embed'
+  message: string
+  /** ISO timestamp of when the failure was recorded. */
+  at: string
+}
+
 export interface StatusResult {
   engram_count: number
   episode_count: number
@@ -174,6 +190,8 @@ export interface StatusResult {
   tension_count?: number
   versioned_engram_count?: number
   outbox_count?: number
+  /** Present when the most recent background index pass failed (#272). */
+  index_error?: IndexSyncError
 }
 
 /**
@@ -289,6 +307,13 @@ export class Plur {
    */
   private pgliteAdapter: PGLiteAdapter | null = null
   private _pgliteInitPromise: Promise<void> | null = null
+  /**
+   * Last background index failure (#272). Set by the .catch of the
+   * fire-and-forget index chains (initial sync, syncFromYaml, reindex,
+   * auto-embed); reset when a new chain is kicked off so a completed
+   * successful pass leaves it null. Read via lastIndexError()/status().
+   */
+  private _lastIndexError: IndexSyncError | null = null
   private _engramCache: Map<string, { mtime: bigint; engrams: Engram[] }> = new Map()
   private _llmFailureCount = 0
   private _llmDisabledUntil: number | null = null
@@ -320,6 +345,7 @@ export class Plur {
       // so reads served from the YAML fallthrough remain correct while the
       // index warms up.
       this._pgliteInitPromise = this.pgliteAdapter.syncFromYaml().catch((err: unknown) => {
+        this._recordIndexError('initial-sync', err)
         logger.warning(`[plur] PGLite initial sync failed: ${(err as Error).message}. Run 'plur sync --full' to rebuild.`)
       })
     } else if (this.config.index) {
@@ -2740,9 +2766,11 @@ export class Plur {
     if (this.pgliteAdapter) {
       // Fire-and-track. Callers that need to block use reindexAsync().
       const adapter = this.pgliteAdapter
+      this._lastIndexError = null // new pass — stale failures cleared on success
       this._pgliteInitPromise = adapter.reindex()
         .then(() => this._autoEmbedNewEngrams(adapter))
         .catch((err: unknown) => {
+          this._recordIndexError('reindex', err)
           logger.warning(`[plur] PGLite reindex failed: ${(err as Error).message}`)
         })
       return
@@ -2795,8 +2823,29 @@ export class Plur {
         await adapter.upsertEmbedding(engram.id, vec)
       }
     } catch (err) {
+      this._recordIndexError('auto-embed', err)
       logger.warning(`[plur] auto-embed failed: ${(err as Error).message}`)
     }
+  }
+
+  /** Record a background index failure for later surfacing (#272). */
+  private _recordIndexError(op: IndexSyncError['op'], err: unknown): void {
+    this._lastIndexError = {
+      op,
+      message: (err as Error)?.message ?? String(err),
+      at: new Date().toISOString(),
+    }
+  }
+
+  /**
+   * Last background index failure, or null when the most recent pass
+   * succeeded (#272). The background chains (initial sync, syncFromYaml,
+   * reindex, auto-embed) swallow rejections so waitForIndex() never throws;
+   * this is the state-based surface for CLI/MCP callers. Also included in
+   * status().index_error.
+   */
+  lastIndexError(): IndexSyncError | null {
+    return this._lastIndexError
   }
 
   /** Sync index after YAML write (no-op if no index is active). */
@@ -2806,9 +2855,11 @@ export class Plur {
       // The YAML write already happened — this is the index catching up, then
       // auto-embed any new engrams so they're vector-searchable.
       const adapter = this.pgliteAdapter
+      this._lastIndexError = null // new pass — stale failures cleared on success
       this._pgliteInitPromise = adapter.syncFromYaml()
         .then(() => this._autoEmbedNewEngrams(adapter))
         .catch((err: unknown) => {
+          this._recordIndexError('sync-from-yaml', err)
           logger.warning(`[plur] PGLite syncFromYaml failed (YAML is still source of truth): ${(err as Error).message}`)
         })
       return
@@ -3370,6 +3421,7 @@ Generate an improved version of the procedure that prevents this failure. Return
       tension_count: tensionPairs.size,
       versioned_engram_count: versionedCount,
       outbox_count: this.outboxCount(),
+      ...(this._lastIndexError ? { index_error: this._lastIndexError } : {}),
     }
   }
 

--- a/packages/core/test/sync-index-error.test.ts
+++ b/packages/core/test/sync-index-error.test.ts
@@ -1,0 +1,111 @@
+/**
+ * sync() background index-error surfacing — closes #272 (iter-1 audit gap
+ * M-11, Critic F-CRIT-006).
+ *
+ * Plur.sync() kicks the PGLite index refresh — and the auto-embed/reembed
+ * work that rides on it — into a background promise whose .catch logs a
+ * warning and swallows the failure. The CLI awaits waitForIndex() but the
+ * catch has already absorbed the rejection, so a failed refresh reports
+ * "Sync: ok" and plur_status shows nothing.
+ *
+ * Contract under test (the issue's "store a _lastReembedError and expose via
+ * status()" option, generalized to every background index op on current main):
+ *
+ *   - a failed background syncFromYaml / reindex / auto-embed pass is
+ *     recorded and exposed via lastIndexError() and status().index_error
+ *     ({ op, message, at })
+ *   - a subsequent successful pass clears the recorded error
+ *   - waitForIndex() still resolves (never rejects) — surfacing is via
+ *     state, not a thrown rejection, so existing callers keep working
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+
+const PGLITE_TIMEOUT = 30_000
+
+describe('sync() surfaces background index failures (#272)', () => {
+  let dir: string
+  const originalBackend = process.env.PLUR_BACKEND
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-index-error-'))
+    process.env.PLUR_BACKEND = 'pglite'
+  })
+
+  afterEach(() => {
+    if (originalBackend === undefined) delete process.env.PLUR_BACKEND
+    else process.env.PLUR_BACKEND = originalBackend
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('records a failed incremental syncFromYaml and clears it on the next success', async () => {
+    const plur = new Plur({ path: dir })
+    await plur.waitForIndex() // let the constructor's initial sync settle
+    expect(plur.lastIndexError()).toBeNull()
+
+    const adapter = (plur as any).pgliteAdapter
+    const realSyncFromYaml = adapter.syncFromYaml.bind(adapter)
+    adapter.syncFromYaml = () => Promise.reject(new Error('disk on fire'))
+
+    const result = plur.sync()
+    expect(result.action).toBeTruthy() // git SyncResult shape unchanged
+    await plur.waitForIndex() // must resolve, not reject
+
+    const err = plur.lastIndexError()
+    expect(err).not.toBeNull()
+    expect(err!.op).toBe('sync-from-yaml')
+    expect(err!.message).toContain('disk on fire')
+    expect(new Date(err!.at).getTime()).not.toBeNaN()
+    expect(plur.status().index_error).toEqual(err)
+
+    // Recovery: the next successful pass clears the recorded error.
+    adapter.syncFromYaml = realSyncFromYaml
+    plur.sync()
+    await plur.waitForIndex()
+    expect(plur.lastIndexError()).toBeNull()
+    expect(plur.status().index_error).toBeUndefined()
+  }, PGLITE_TIMEOUT)
+
+  it('records a failed full reindex under op "reindex"', async () => {
+    const plur = new Plur({ path: dir })
+    await plur.waitForIndex()
+
+    const adapter = (plur as any).pgliteAdapter
+    adapter.reindex = () => Promise.reject(new Error('rebuild exploded'))
+
+    plur.sync(undefined, { full: true })
+    await plur.waitForIndex()
+
+    const err = plur.lastIndexError()
+    expect(err).not.toBeNull()
+    expect(err!.op).toBe('reindex')
+    expect(err!.message).toContain('rebuild exploded')
+  }, PGLITE_TIMEOUT)
+
+  it('records a failed auto-embed pass under op "auto-embed"', async () => {
+    const plur = new Plur({ path: dir })
+    // Seed one active engram so the auto-embed pass has work to attempt.
+    plur.learn('index errors must be surfaced, not swallowed', {
+      type: 'behavioral',
+      scope: 'global',
+    })
+    await plur.waitForIndex()
+
+    const adapter = (plur as any).pgliteAdapter
+    // getVectorColumnDim runs at the top of _autoEmbedNewEngrams, before the
+    // dim-mismatch skip — rejecting here fails the embed pass itself while
+    // the preceding syncFromYaml still succeeds.
+    adapter.getVectorColumnDim = () => Promise.reject(new Error('vector column gone'))
+
+    plur.sync()
+    await plur.waitForIndex()
+
+    const err = plur.lastIndexError()
+    expect(err).not.toBeNull()
+    expect(err!.op).toBe('auto-embed')
+    expect(err!.message).toContain('vector column gone')
+  }, PGLITE_TIMEOUT)
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -781,6 +781,12 @@ export function getToolDefinitions(): ToolDefinition[] {
       handler: async (args, plur) => {
         const result = plur.sync(args.remote as string | undefined, { full: args.full === true })
 
+        // #272: block on the background index/reembed chain and surface its
+        // failure — the chain's .catch swallows the rejection, so without
+        // this a failed index pass reported plain success.
+        await plur.waitForIndex()
+        const indexError = plur.lastIndexError()
+
         // Flush outbox after git sync (issue #26)
         let outbox_result: { flushed: number; failed: number; expired_warnings: string[] } | undefined
         try {
@@ -789,6 +795,10 @@ export function getToolDefinitions(): ToolDefinition[] {
 
         return {
           ...result,
+          ...(indexError ? {
+            index_error: indexError,
+            warning: `Index ${indexError.op} failed — ${indexError.message}. YAML is still the source of truth; run plur_sync with full=true to rebuild the index.`,
+          } : {}),
           ...(outbox_result && (outbox_result.flushed > 0 || outbox_result.failed > 0) ? {
             outbox: {
               flushed: outbox_result.flushed,
@@ -1000,6 +1010,8 @@ export function getToolDefinitions(): ToolDefinition[] {
           tension_count: status.tension_count,
           versioned_engram_count: status.versioned_engram_count ?? 0,
           outbox_count: status.outbox_count ?? 0,
+          // Last background index/reembed failure (#272) — absent when healthy.
+          ...(status.index_error ? { index_error: status.index_error } : {}),
           // Version check (issue #151)
           ...(versionCheck?.updateAvailable && versionCheck.latest ? {
             update_available: {

--- a/packages/mcp/test/sync-index-error.test.ts
+++ b/packages/mcp/test/sync-index-error.test.ts
@@ -1,0 +1,66 @@
+/**
+ * plur_sync / plur_status surface background index failures — closes #272
+ * (iter-1 audit gap M-11, Critic F-CRIT-006).
+ *
+ * The MCP plur_sync handler returned the git SyncResult while the background
+ * index/reembed chain was still in flight, and that chain's .catch swallowed
+ * any rejection — a failed pass reported success. The handler now blocks on
+ * waitForIndex() and attaches index_error + warning when the pass failed.
+ * plur_status passes status().index_error through.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, type IndexSyncError } from '@plur-ai/core'
+import { getToolDefinitions } from '../src/tools.js'
+
+describe('MCP index-error surfacing (#272)', () => {
+  let plur: Plur
+  let dir: string
+  let tools: ReturnType<typeof getToolDefinitions>
+
+  const fail: IndexSyncError = {
+    op: 'sync-from-yaml',
+    message: 'disk on fire',
+    at: '2026-07-02T00:00:00.000Z',
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-mcp-idxerr-'))
+    plur = new Plur({ path: dir })
+    tools = getToolDefinitions()
+  })
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.find(t => t.name === name)
+    if (!tool) throw new Error(`Unknown tool: ${name}`)
+    return tool.handler(args, plur)
+  }
+
+  it('plur_sync attaches index_error and a warning when the background pass failed', async () => {
+    ;(plur as any).lastIndexError = () => fail
+    const result = await callTool('plur_sync') as any
+    expect(result.action).toBeTruthy()
+    expect(result.index_error).toEqual(fail)
+    expect(String(result.warning)).toContain('sync-from-yaml')
+  })
+
+  it('plur_sync omits index_error when the pass succeeded', async () => {
+    const result = await callTool('plur_sync') as any
+    expect(result.index_error).toBeUndefined()
+  })
+
+  it('plur_status passes status().index_error through', async () => {
+    const realStatus = plur.status.bind(plur)
+    ;(plur as any).status = () => ({ ...realStatus(), index_error: fail })
+    const result = await callTool('plur_status') as any
+    expect(result.index_error).toEqual(fail)
+  })
+
+  it('plur_status omits index_error on a healthy instance', async () => {
+    const result = await callTool('plur_status') as any
+    expect(result.index_error).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #272

## What

Iter-1 audit gap M-11 (Critic F-CRIT-006): `Plur.sync()` fires the PGLite index refresh — and the auto-embed/reembed pass that rides on it — into a fire-and-forget promise whose `.catch` logs a warning and swallows the failure. The CLI awaits `waitForIndex()`, but by then the catch has already absorbed the rejection: a failed pass printed **"Sync: ok"** and the MCP handler returned plain success.

Note on the issue's quoted snippet: the `reembedAll({ full, embedder })` code it references is from the retired epic branch and was never re-landed on current main. The same defect exists on main in the re-landed form — `sync()`'s PGLite branch goes through `reindex()` / `_syncIndex()`, whose catches swallow. This PR implements the issue's first fix option ("store a `_lastReembedError` on the Plur instance and expose via `status()` / `plur_status`"), generalized to every background index op.

## Changes

**core** (`packages/core/src/index.ts`)
- New exported `IndexSyncError { op, message, at }` with `op ∈ initial-sync | sync-from-yaml | reindex | auto-embed`
- Every background index chain's `.catch` (and `_autoEmbedNewEngrams`'s internal catch) records it; kicking off a new pass resets it, so a successful pass leaves it null
- Exposed via new `Plur.lastIndexError()` and `status().index_error` (additive optional field on `StatusResult`)
- `waitForIndex()` still never rejects — surfacing is state-based, so no existing caller breaks

**cli** (`packages/cli/src/commands/sync.ts`)
- After `waitForIndex()`, reads `lastIndexError()`; text mode prints `Warning: index <op> failed — <message>` plus a recovery hint, JSON mode includes `index_error`

**mcp** (`packages/mcp/src/tools.ts`)
- `plur_sync` now blocks on `waitForIndex()` and attaches `index_error` + human-readable `warning` to its result
- `plur_status` passes `status().index_error` through

## Tests (TDD — all written red first)

- `packages/core/test/sync-index-error.test.ts` (3): real PGLite backend with fault-injected adapter methods — failed incremental `syncFromYaml` recorded + cleared on next success, failed full `reindex` under op `reindex`, failed embed pass under op `auto-embed`; asserts `waitForIndex()` resolves rather than rejects
- `packages/cli/test/sync-index-error.test.ts` (3): text warning, JSON `index_error` field, quiet when healthy
- `packages/mcp/test/sync-index-error.test.ts` (4): `plur_sync` attaches/omits, `plur_status` passes through/omits

Suites: core 1564 passed / 28 skipped (fully green), cli 216 passed, mcp 141 passed, claw 107 passed (imports core dist, rebuilt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1