### PR TITLE
feat(core,mcp): ms-marco-MiniLM-L6 tiny-tier reranker adapter

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } fro
 import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as pgliteRrfMerge, type HybridSearchResult, type RerankOptions } from './hybrid-search.js'
 import { getReranker, resolveRerankerName, isRerankerOff, rerankerStatus, resetRerankerStatus, _resetRerankerCache, type RerankerAdapter, type RerankerRuntimeStatus } from './rerankers/index.js'
 import { _resetBgeRerankerCache } from './rerankers/bge-reranker-v2-m3.js'
+import { _resetMsMarcoMiniLmCache } from './rerankers/ms-marco-minilm-l6.js'
 import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, isEntityDomain, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
 import { getEmbedder, resolveEmbedderName } from './embedders/index.js'
 import { emitMissSignal } from './telemetry-miss-signal.js'
@@ -2014,6 +2015,7 @@ export class Plur {
   resetReranker(): void {
     _resetRerankerCache()
     _resetBgeRerankerCache()
+    _resetMsMarcoMiniLmCache()
     resetRerankerStatus()
     this._reranker = null
   }

--- a/packages/core/src/rerankers/index.ts
+++ b/packages/core/src/rerankers/index.ts
@@ -21,12 +21,21 @@
  */
 import { logger } from '../logger.js'
 import { makeBgeRerankerV2M3Adapter } from './bge-reranker-v2-m3.js'
+import { makeMsMarcoMiniLmL6Adapter } from './ms-marco-minilm-l6.js'
 import type { RerankerAdapter } from './types.js'
 
 export type { RerankerAdapter } from './types.js'
 
-/** All reranker names supported by the factory. */
-export const RERANKER_NAMES = ['bge-reranker-v2-m3', 'off'] as const
+/**
+ * All reranker names supported by the factory.
+ *
+ * Two tiers (#451):
+ *   - bge-reranker-v2-m3  quality tier — 568M multilingual, seconds/query on
+ *     CPU. For offline/batch pipelines where quality dominates.
+ *   - ms-marco-minilm-l6  tiny tier — 22.7M English cross-encoder, tens of
+ *     ms/query on CPU. The hot-path candidate.
+ */
+export const RERANKER_NAMES = ['bge-reranker-v2-m3', 'ms-marco-minilm-l6', 'off'] as const
 export type RerankerName = typeof RERANKER_NAMES[number]
 
 /**
@@ -188,8 +197,9 @@ export function getReranker(name?: RerankerName): RerankerAdapter {
 
 function build(name: RerankerName): RerankerAdapter {
   switch (name) {
-    case 'bge-reranker-v2-m3': return makeBgeRerankerV2M3Adapter()
-    case 'off':                return OFF_ADAPTER
+    case 'bge-reranker-v2-m3':  return makeBgeRerankerV2M3Adapter()
+    case 'ms-marco-minilm-l6':  return makeMsMarcoMiniLmL6Adapter()
+    case 'off':                 return OFF_ADAPTER
     default: {
       const _exhaustive: never = name
       throw new Error(`Unhandled reranker name: ${String(_exhaustive)}`)

--- a/packages/core/src/rerankers/ms-marco-minilm-l6.ts
+++ b/packages/core/src/rerankers/ms-marco-minilm-l6.ts
@@ -1,0 +1,119 @@
+/**
+ * MS MARCO MiniLM-L-6 adapter — cross-encoder/ms-marco-MiniLM-L-6-v2 via
+ * @huggingface/transformers (Xenova ONNX conversion).
+ *
+ * The tiny-tier reranker (#451, #220). ~22.7M params — 25× smaller than
+ * bge-reranker-v2-m3 (568M). English-only, trained on MS MARCO passage
+ * ranking. Apache-2.0. q8-quantized weights are ~23 MB on disk.
+ *
+ * Why this tier exists: bge-reranker-v2-m3 measures seconds-per-query on
+ * CPU, which is unusable on the agent hot path. The 4–25M cross-encoder
+ * class (FlashRank/TinyBERT/MiniLM) reranks 10–50 candidates in tens of
+ * milliseconds on the same hardware while keeping most of the quality lift
+ * over plain RRF fusion. Benchmarked head-to-head in issue #451.
+ *
+ * Architecture: identical to the bge adapter — AutoTokenizer +
+ * AutoModelForSequenceClassification driving the sentence-pair tokenization
+ * ([CLS] query [SEP] document [SEP]) directly, single-logit relevance
+ * output. Higher = more relevant; absolute scale is model-specific and only
+ * the ordering matters for the recall path.
+ *
+ * Lazy load: tokenizer + model are loaded on first score call and cached
+ * module-locally so repeated PLUR sessions in the same process share the
+ * weight memory.
+ */
+import type { RerankerAdapter } from './types.js'
+
+// Xenova's ONNX conversion of cross-encoder/ms-marco-MiniLM-L-6-v2 — the
+// canonical transformers.js layout, resolves via the same AutoTokenizer +
+// AutoModelForSequenceClassification path as the bge adapter.
+export const MS_MARCO_MINILM_L6_MODEL_ID = 'Xenova/ms-marco-MiniLM-L-6-v2'
+
+interface LoadedPipeline {
+  tokenizer: {
+    (
+      text: string | string[],
+      opts?: {
+        text_pair?: string | string[]
+        padding?: boolean
+        truncation?: boolean
+        return_tensor?: boolean
+      },
+    ): Promise<Record<string, unknown>> | Record<string, unknown>
+  }
+  model: {
+    (inputs: Record<string, unknown>): Promise<{ logits: { data: Float32Array | number[]; dims: number[] } }>
+  }
+}
+
+let pending: Promise<LoadedPipeline> | null = null
+
+async function loadPipeline(modelId: string, dtype: 'q8' | 'fp32'): Promise<LoadedPipeline> {
+  if (!pending) {
+    pending = (async () => {
+      // Force the classic HF download path — the Xet transfer protocol truncates
+      // ONNX downloads in this stack, corrupting the model ("Protobuf parsing
+      // failed") so the reranker silently falls back to RRF order. Never use Xet. (#340)
+      process.env.HF_HUB_DISABLE_XET ??= '1'
+      const { AutoTokenizer, AutoModelForSequenceClassification } = await import('@huggingface/transformers')
+      const [tokenizer, model] = await Promise.all([
+        AutoTokenizer.from_pretrained(modelId),
+        AutoModelForSequenceClassification.from_pretrained(modelId, { dtype } as { dtype: 'q8' | 'fp32' }),
+      ])
+      return {
+        tokenizer: tokenizer as unknown as LoadedPipeline['tokenizer'],
+        model: model as unknown as LoadedPipeline['model'],
+      }
+    })()
+  }
+  return await pending
+}
+
+/** Reset the shared pipeline cache. Test-only. */
+export function _resetMsMarcoMiniLmCache(): void {
+  pending = null
+}
+
+export function makeMsMarcoMiniLmL6Adapter(): RerankerAdapter {
+  const modelId = MS_MARCO_MINILM_L6_MODEL_ID
+  const dtype: 'q8' | 'fp32' = 'q8'
+
+  async function scoreBatch(query: string, documents: string[]): Promise<number[]> {
+    if (documents.length === 0) return []
+    const pipe = await loadPipeline(modelId, dtype)
+    // Batch (query, document) pairs: `text` as a repeated query array and
+    // `text_pair` as the document array — the bert tokenizer encodes each
+    // pair into [CLS] query [SEP] document [SEP] in one go.
+    const queries = documents.map(() => query)
+    const inputs = (await pipe.tokenizer(queries, {
+      text_pair: documents,
+      padding: true,
+      truncation: true,
+      return_tensor: true,
+    })) as Record<string, unknown>
+    const output = await pipe.model(inputs)
+    const logits = output.logits
+    const data = logits.data instanceof Float32Array ? logits.data : new Float32Array(logits.data)
+    // logits.dims is [batch, num_labels]. ms-marco-MiniLM-L-6-v2 uses
+    // num_labels=1 (a single relevance scalar). We extract the first column.
+    const numLabels = logits.dims[logits.dims.length - 1] ?? 1
+    const batch = documents.length
+    const scores: number[] = new Array(batch)
+    for (let i = 0; i < batch; i++) {
+      scores[i] = data[i * numLabels]
+    }
+    return scores
+  }
+
+  async function score(query: string, document: string): Promise<number> {
+    const out = await scoreBatch(query, [document])
+    return out[0]
+  }
+
+  return {
+    name: 'ms-marco-minilm-l6',
+    modelId,
+    score,
+    scoreBatch,
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -103,6 +103,10 @@ export interface RecallOptions {
    *     bge-reranker-v2-m3 if PLUR_RERANKER is unset/off).
    *   - `false` → skip the rerank stage even if PLUR_RERANKER is set.
    *   - omitted → respect PLUR_RERANKER (default off → zero cost).
+   *
+   * Two reranker tiers exist (#451): `ms-marco-minilm-l6` (tiny, ~ms-scale
+   * on CPU — hot-path candidate) and `bge-reranker-v2-m3` (quality,
+   * seconds-scale on CPU — offline/batch). Select via PLUR_RERANKER.
    */
   rerank?: boolean
 }

--- a/packages/core/test/reranker.test.ts
+++ b/packages/core/test/reranker.test.ts
@@ -41,13 +41,15 @@ import {
   type RerankerName,
 } from '../src/rerankers/index.js'
 import { BGE_RERANKER_V2_M3_MODEL_ID } from '../src/rerankers/bge-reranker-v2-m3.js'
+import { MS_MARCO_MINILM_L6_MODEL_ID } from '../src/rerankers/ms-marco-minilm-l6.js'
 
 const NETWORK = process.env.PLUR_RERANKER_NETWORK_TESTS === '1'
 
 /** Expected metadata per adapter — checked even when the network is offline. */
 const EXPECTED: Record<RerankerName, { modelId: string }> = {
-  'bge-reranker-v2-m3': { modelId: BGE_RERANKER_V2_M3_MODEL_ID },
-  'off':                { modelId: '<off>' },
+  'bge-reranker-v2-m3':  { modelId: BGE_RERANKER_V2_M3_MODEL_ID },
+  'ms-marco-minilm-l6':  { modelId: MS_MARCO_MINILM_L6_MODEL_ID },
+  'off':                 { modelId: '<off>' },
 }
 
 describe('RerankerAdapter factory — metadata contract', () => {
@@ -56,8 +58,8 @@ describe('RerankerAdapter factory — metadata contract', () => {
     _resetResolveWarnings()
   })
 
-  it('exports the two expected names', () => {
-    expect([...RERANKER_NAMES].sort()).toEqual(['bge-reranker-v2-m3', 'off'])
+  it('exports the three expected names', () => {
+    expect([...RERANKER_NAMES].sort()).toEqual(['bge-reranker-v2-m3', 'ms-marco-minilm-l6', 'off'])
   })
 
   it('defaults to off — opt-in posture', () => {
@@ -96,6 +98,11 @@ describe('the "off" sentinel', () => {
     expect(isRerankerOff(real)).toBe(false)
   })
 
+  it('isRerankerOff returns false for the ms-marco tiny-tier adapter', () => {
+    const real = getReranker('ms-marco-minilm-l6')
+    expect(isRerankerOff(real)).toBe(false)
+  })
+
   it('off.scoreBatch returns one zero per document, preserving order semantics', async () => {
     const off = getReranker('off')
     const out = await off.scoreBatch('q', ['a', 'b', 'c'])
@@ -122,6 +129,11 @@ describe('resolveRerankerName — env var handling', () => {
   it('respects a recognised PLUR_RERANKER value', () => {
     const name = resolveRerankerName({ PLUR_RERANKER: 'bge-reranker-v2-m3' } as NodeJS.ProcessEnv)
     expect(name).toBe('bge-reranker-v2-m3')
+  })
+
+  it('respects the tiny-tier name (#451)', () => {
+    const name = resolveRerankerName({ PLUR_RERANKER: 'ms-marco-minilm-l6' } as NodeJS.ProcessEnv)
+    expect(name).toBe('ms-marco-minilm-l6')
   })
 
   it('respects "off" explicitly', () => {
@@ -243,6 +255,43 @@ describe.skipIf(!NETWORK)(
       // The matching document should score highest.
       const top = scores.indexOf(Math.max(...scores))
       expect(top).toBe(0)
+    }, LIVE_TIMEOUT)
+  },
+)
+
+describe.skipIf(!NETWORK)(
+  'ms-marco tiny-tier reranker — live model (PLUR_RERANKER_NETWORK_TESTS=1)',
+  () => {
+    // The tiny tier is ~23 MB quantized — loads far faster than bge, but the
+    // first call may still download, so keep a generous timeout.
+    const LIVE_TIMEOUT = 180_000
+    let adapter: RerankerAdapter
+
+    beforeEach(() => {
+      adapter = getReranker('ms-marco-minilm-l6')
+    })
+
+    it('score returns a finite number', async () => {
+      const s = await adapter.score('what is the capital of France?', 'Paris is the capital of France.')
+      expect(Number.isFinite(s)).toBe(true)
+    }, LIVE_TIMEOUT)
+
+    it('scoreBatch returns one score per document, in input order', async () => {
+      const docs = [
+        'Paris is the capital of France.',
+        'Tokyo is the capital of Japan.',
+        'My cat is named Whiskers.',
+      ]
+      const scores = await adapter.scoreBatch('what is the capital of France?', docs)
+      expect(scores.length).toBe(docs.length)
+      // The matching document should score highest.
+      const top = scores.indexOf(Math.max(...scores))
+      expect(top).toBe(0)
+    }, LIVE_TIMEOUT)
+
+    it('scoreBatch on empty array returns empty array without loading trouble', async () => {
+      const out = await adapter.scoreBatch('q', [])
+      expect(out).toEqual([])
     }, LIVE_TIMEOUT)
   },
 )

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1156,8 +1156,15 @@ export function getToolDefinitions(): ToolDefinition[] {
           try {
             const scores = await adapter.scoreBatch('plur doctor probe', ['probe document'])
             rerankerOk = scores.length === 1 && Number.isFinite(scores[0])
+            // Tier-aware latency framing (#451): the bge quality tier is
+            // seconds-scale per recall on CPU (#220); the ms-marco tiny tier
+            // is ms-scale — telling tiny-tier users to expect seconds would
+            // mask a real fault.
+            const latencyNote = rerankerName === 'bge-reranker-v2-m3'
+              ? 'seconds-scale per recall on CPU is expected — #220'
+              : 'ms-scale per recall on CPU is expected — #451'
             rerankerDetail = rerankerOk
-              ? `${rerankerName} loaded and scoring (probe ${Date.now() - probeStart}ms; seconds-scale per recall on CPU is expected — #220)`
+              ? `${rerankerName} loaded and scoring (probe ${Date.now() - probeStart}ms; ${latencyNote})`
               : `Probe returned malformed scores (${JSON.stringify(scores)}) — recall silently falls back to RRF-only`
           } catch (err) {
             const message = (err as Error).message

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -394,6 +394,24 @@ describe('MCP tools', () => {
       expect(check.detail).toContain('seconds')
     })
 
+    it('plur_doctor healthy detail is tier-aware for the tiny reranker (#451)', async () => {
+      // The tiny tier's whole point is ms-scale on the hot path — the healthy
+      // detail must not repeat the bge "seconds-scale is expected" framing.
+      const TINY = 'ms-marco-minilm-l6' as const
+      process.env.PLUR_RERANKER = TINY
+      _setCachedReranker(TINY, {
+        name: TINY,
+        modelId: 'Xenova/ms-marco-MiniLM-L-6-v2',
+        async score(): Promise<number> { return 0.5 },
+        async scoreBatch(_q: string, docs: string[]): Promise<number[]> { return docs.map(() => 0.5) },
+      })
+      const result = await callTool('plur_doctor') as any
+      const check = result.checks.find((c: any) => c.check === 'reranker available')
+      expect(check.ok).toBe(true)
+      expect(check.detail).not.toContain('seconds-scale')
+      expect(check.detail).toContain('ms-scale')
+    })
+
     it('plur_doctor skips the reranker check when PLUR_RERANKER is off', async () => {
       delete process.env.PLUR_RERANKER
       const result = await callTool('plur_doctor') as any


### PR DESCRIPTION
## What

Adds a second, tiny reranker tier: `cross-encoder/ms-marco-MiniLM-L-6-v2` (Xenova ONNX conversion, 22.7M params, ~23 MB q8 download) selectable via `PLUR_RERANKER=ms-marco-minilm-l6`. Local ONNX inference through `@huggingface/transformers` — zero API calls, same `AutoTokenizer` + `AutoModelForSequenceClassification` pattern as the existing `bge-reranker-v2-m3` adapter.

The two tiers:

| Tier | Model | Params | CPU latency | Intended use |
|---|---|---|---|---|
| quality | `bge-reranker-v2-m3` | 568M | seconds/query | offline/batch (consolidation, nightly re-scoring, harness) |
| tiny | `ms-marco-minilm-l6` (new) | 22.7M | ms-scale/query | hot-path candidate |

## Why

#451 measured rerank-ON in the shipping config for the first time: bge lifts R@5 by +13.3pp but at ~5s p50 per query on CPU — unusable on the agent hot path (#220's 30–80ms envelope was ~100× optimistic). The tiny tier recovers half that lift at hot-path-viable latency (fixture n=30, shipping config: embedder `bge-small`, hybrid, seed 1337):

| Config | R@5 | R@1 | Acc | Latency p50 / p95 | Peak RSS |
|---|---|---|---|---|---|
| shipping default (rerank OFF) | 76.7% | 46.7% | 80.0% | 35–83 / 52–139 ms | 364–511 MB |
| + `ms-marco-minilm-l6` (this PR) | **83.3%** | 50.0% | 80.0% | 245–1,424 / 827–5,248 ms* | 223–323 MB |
| + `bge-reranker-v2-m3` | 90.0% | 66.7% | 83.3% | 4,957–5,856 / 18,845–22,623 ms* | 537–832 MB |

*Latencies measured at loadavg 22–165 (upper bounds); quality bit-identical across three tiny-tier runs. The lift is entirely in the hard categories: temporal_reasoning 60→80%, multi_session_reasoning 40→60%. Full measurement detail in the [#451 results comment](https://github.com/plur-ai/plur/issues/451#issuecomment-4866945424).

**Default stays `off`.** The flip to default-ON is gated on the per-store eval self-check (#451 task 5, not in this PR) — cross-encoders can be net-negative out-of-domain.

## Changes

- `packages/core/src/rerankers/ms-marco-minilm-l6.ts` — new adapter (lazy load, module-local pipeline cache, Xet disabled per #340)
- `packages/core/src/rerankers/index.ts` — registered in `RERANKER_NAMES` + factory; tier docs
- `packages/core/src/index.ts` — `resetReranker()` also clears the new adapter cache
- `packages/core/src/types.ts` — `RecallOptions.rerank` doc mentions both tiers
- `packages/mcp/src/tools.ts` — `plur_doctor` healthy-reranker detail is tier-aware: ms-scale expected for tiny, seconds-scale for bge (so tiny users don't misread a real fault as expected latency)
- tests: factory/metadata/env-resolution coverage for the new name, live-model contract tests (gated behind `PLUR_RERANKER_NETWORK_TESTS=1`), mcp doctor tier-aware detail test

## Testing

- `reranker.test.ts`: 32/32 with live model tests, 26 offline
- full core suite: 1,637 passed / 31 skipped
- mcp + claw: 272 passed (25 files)
- combined re-run on rebased main: only failures were `secrets.test.ts`/`sync.test.ts` timing tests under loadavg 30–58; both pass 136/136 in isolation (pre-existing, untouched by this PR)
- benchmark confirmation run post-completion reproduces the posted tiny-tier quality bit-for-bit (R@5 83.3%, `reranked_queries` 30/30)

Refs #451, #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1
