### PR TITLE
feat(core,cli): migration importers — plur import --from generic|gp-engram|mem0 (#441)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -59,8 +59,43 @@ plur forget ENG-2026-0329-001
 | `plur sync` | Cross-device sync via git (engram data only — secrets and derived files are never committed) |
 | `plur packs list` | List installed engram packs |
 | `plur packs install <source>` | Install an engram pack |
+| `plur import --from <source> --path <file>` | Import memories from another system (see below) |
 | `plur init` | Install Claude Code hooks + local hook binary for automatic injection |
 | `plur doctor` | Diagnose installation health (hooks, MCP, shim, embedder) |
+
+## Importing from other memory systems
+
+Bring existing memory with you — `plur import` migrates competitor exports
+into engrams, routed through the same dedup gates as `plur learn` (duplicates
+are skipped, never re-added), and prints a migration report: N imported,
+M skipped (dedup), K conflicts.
+
+```bash
+# Gentleman-Programming/engram (Go + SQLite memory tool)
+plur import --from gp-engram --path ~/.engram/engram.db
+
+# mem0 JSON export (Memory.get_all() shape)
+plur import --from mem0 --path ./memories.json
+
+# Any JSON / JSONL / CSV export, optionally with a field-mapping config
+plur import --from generic --path ./export.csv
+plur import --from generic --path ./export.json --mapping ./mapping.json
+
+# Preview without writing
+plur import --from mem0 --path ./memories.json --dry-run
+```
+
+Flags: `--dry-run` (report only), `--scope <scope>` (force a scope for all
+imported engrams), `--mapping <file>` (generic only: `{"fields": {"statement":
+"text", "domain": "meta.area"}, "defaults": {...}}` with dot-path support).
+
+> Note: for `import`, `--path` is the **input file** (per the issue spec);
+> use `--store <dir>` to override the storage directory instead.
+
+Temporal metadata is preserved where the source has it (`created_at` →
+`temporal.learned_at`, last access → `activation.last_accessed`, expiry →
+`temporal.valid_until`). Zep and Letta adapters are registered but stubbed —
+export to JSON and use `--from generic` in the meantime.
 
 ## Global Flags
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,8 @@
     "@plur-ai/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0"
+    "@types/node": "^25.5.0",
+    "better-sqlite3": "^11.0.0"
   },
   "peerDependencies": {
     "@plur-ai/core": ">=0.3.0"

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -1,0 +1,91 @@
+/**
+ * `plur import --from <source> --path <file>` (issue #441).
+ *
+ * FLAG SPLIT — deliberate deviation from the other commands: per the issue
+ * spec, `--path` here is the INPUT FILE to import. The storage-directory
+ * override (what the global `--path` means everywhere else) is `--store` for
+ * this command. `$PLUR_PATH` still applies when `--store` is not given.
+ *
+ * All imports route through core's importFrom → runImport → plur.learn(), so
+ * the content-hash dedup gate and the secret guard apply — never raw-append.
+ */
+import { readFileSync } from 'fs'
+import { Plur, importFrom, listImportSources, type FieldMapping, type MigrationReport } from '@plur-ai/core'
+import type { GlobalFlags } from '../plur.js'
+import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+
+function usage(): string {
+  const implemented = listImportSources().filter(s => s.implemented).map(s => s.name).join('|')
+  const stubbed = listImportSources().filter(s => !s.implemented).map(s => s.name).join(', ')
+  return `Usage: plur import --from <${implemented}> --path <input-file> [--dry-run] [--scope <scope>] [--mapping <file.json>] [--store <dir>]
+
+  --from <source>   Source system: generic (JSON/JSONL/CSV), gp-engram (SQLite .db), mem0 (JSON export)
+                    Planned (stubbed): ${stubbed}
+  --path <file>     Input file to import (for this command --path is the INPUT; use --store for storage)
+  --dry-run         Analyze and print the migration report without writing
+  --scope <scope>   Force all imported engrams into this scope
+  --mapping <file>  Field-mapping config for --from generic ({"fields": {...}, "defaults": {...}})
+  --store <dir>     Override the PLUR storage directory (default: $PLUR_PATH or ~/.plur)`
+}
+
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  let from: string | undefined
+  // The global flag parser consumed `--path <value>` into flags.path — for
+  // import that value is the input file (see header comment).
+  let file: string | undefined = flags.path
+  let store: string | undefined
+  let scope: string | undefined
+  let mappingPath: string | undefined
+  let dryRun = false
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    if (arg === '--from' && i + 1 < args.length) { from = args[++i]; i++ }
+    else if (arg === '--file' && i + 1 < args.length) { file = args[++i]; i++ }
+    else if (arg === '--store' && i + 1 < args.length) { store = args[++i]; i++ }
+    else if (arg === '--scope' && i + 1 < args.length) { scope = args[++i]; i++ }
+    else if (arg === '--mapping' && i + 1 < args.length) { mappingPath = args[++i]; i++ }
+    else if (arg === '--dry-run') { dryRun = true; i++ }
+    else { i++ }
+  }
+
+  if (!from || !file) {
+    exit(1, usage())
+  }
+
+  let mapping: FieldMapping | undefined
+  if (mappingPath) {
+    try {
+      mapping = JSON.parse(readFileSync(mappingPath, 'utf-8'))
+    } catch (err) {
+      exit(1, `Failed to read mapping file ${mappingPath}: ${(err as Error).message}`)
+    }
+  }
+
+  const plur = new Plur({ path: store || process.env.PLUR_PATH || undefined })
+  const report = importFrom(plur, { from, path: file, mapping, dryRun, scope })
+
+  if (shouldOutputJson(flags)) {
+    outputJson(report)
+    return
+  }
+  printReport(report)
+}
+
+function printReport(report: MigrationReport): void {
+  const prefix = report.dry_run ? '[dry-run] ' : ''
+  outputText(`${prefix}Migration report — ${report.from} (${report.path ?? 'stdin'})`)
+  outputText(`  ${report.imported} imported, ${report.skipped} skipped (dedup), ${report.conflicts} conflict(s), ${report.errors} error(s) of ${report.total} total`)
+  for (const rec of report.records) {
+    if (rec.action === 'error') {
+      outputText(`  ✗ error: ${truncate(rec.statement)} — ${rec.error}`)
+    } else if (rec.conflicts && rec.conflicts.length > 0) {
+      outputText(`  ⚠ conflict: ${truncate(rec.statement)} — potentially contradicts ${rec.conflicts.join(', ')} (review with: plur tensions --scan)`)
+    }
+  }
+}
+
+function truncate(s: string, max = 60): string {
+  return s.length > max ? s.slice(0, max) + '…' : s
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,10 @@ Commands:
   list                    List all engrams
   forget <id>             Retire an engram
   ingest <content>        Extract and save engrams from content
+  import                  Import memories from another system (issue #441)
+                          --from <generic|gp-engram|mem0> --path <input-file>
+                          [--dry-run] [--scope <s>] [--mapping <f>] [--store <dir>]
+                          (for import, --path is the INPUT file; --store overrides storage)
   feedback <id> <signal>  Rate an engram (positive|negative|neutral)
   capture <summary>       Record an episode
   timeline [query]        Query episode timeline
@@ -81,6 +85,7 @@ const COMMANDS: Record<string, string> = {
   sync: './commands/sync.js',
   packs: './commands/packs.js',
   ingest: './commands/ingest.js',
+  import: './commands/import.js',
   promote: './commands/promote.js',
   'similarity-search': './commands/similarity-search.js',
   'batch-decay': './commands/batch-decay.js',

--- a/packages/cli/test/import.test.ts
+++ b/packages/cli/test/import.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+import { createRequire } from 'module'
+import { Plur } from '@plur-ai/core'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+// Checked-in format fixtures live in core (single source of truth for the
+// format contracts); the CLI suite reuses them for end-to-end runs.
+const CORE_FIXTURES = join(__dirname, '..', '..', 'core', 'test', 'fixtures', 'import')
+
+// Issue #441 — `plur import --from <source> --path <file>`.
+//
+// NOTE the flag split: for `import`, `--path` is the INPUT FILE (per the issue
+// spec). The storage directory override (what --path means on every other
+// command) is `--store` here.
+
+describe('plur import', () => {
+  let store: string
+  let work: string
+
+  beforeEach(() => {
+    store = mkdtempSync(join(tmpdir(), 'plur-cli-import-store-'))
+    work = mkdtempSync(join(tmpdir(), 'plur-cli-import-work-'))
+  })
+  afterEach(() => {
+    rmSync(store, { recursive: true, force: true })
+    rmSync(work, { recursive: true, force: true })
+  })
+
+  function run(args: string): string {
+    return execSync(`node ${CLI} import ${args} --store ${store} --json`, {
+      encoding: 'utf-8',
+      timeout: 20000,
+    }).trim()
+  }
+
+  it('imports a generic JSON file and prints a migration report', () => {
+    const input = join(work, 'memories.json')
+    writeFileSync(input, JSON.stringify([
+      { statement: 'cli import fact one' },
+      { statement: 'cli import fact two' },
+      { statement: 'cli import fact one' },
+    ]))
+    const report = JSON.parse(run(`--from generic --path ${input}`))
+    expect(report.from).toBe('generic')
+    expect(report.total).toBe(3)
+    expect(report.imported).toBe(2)
+    expect(report.skipped).toBe(1)
+    expect(report.conflicts).toBe(0)
+    const plur = new Plur({ path: store })
+    expect(plur.list({})).toHaveLength(2)
+  })
+
+  it('imports the mem0 fixture', () => {
+    const report = JSON.parse(run(`--from mem0 --path ${join(CORE_FIXTURES, 'mem0-export.json')}`))
+    expect(report.imported).toBe(3)
+    const plur = new Plur({ path: store })
+    const darkMode = plur.list({}).find(e => e.statement.includes('dark mode'))
+    expect(darkMode?.scope).toBe('user:alice')
+  })
+
+  it('imports a gp-engram .db', () => {
+    const require = createRequire(import.meta.url)
+    const Database = require('better-sqlite3')
+    const dbPath = join(work, 'engram.db')
+    const db = new Database(dbPath)
+    db.exec(readFileSync(join(CORE_FIXTURES, 'gp-engram-fixture.sql'), 'utf-8'))
+    db.close()
+
+    const report = JSON.parse(run(`--from gp-engram --path ${dbPath}`))
+    expect(report.imported).toBe(3)
+    expect(report.skipped).toBe(0)
+  })
+
+  it('supports --dry-run (report only, no writes)', () => {
+    const input = join(work, 'memories.json')
+    writeFileSync(input, JSON.stringify([{ statement: 'dry run fact' }]))
+    const report = JSON.parse(run(`--from generic --path ${input} --dry-run`))
+    expect(report.dry_run).toBe(true)
+    expect(report.imported).toBe(1)
+    const plur = new Plur({ path: store })
+    expect(plur.list({})).toHaveLength(0)
+  })
+
+  it('supports --scope override', () => {
+    const input = join(work, 'memories.json')
+    writeFileSync(input, JSON.stringify([{ statement: 'scoped cli fact' }]))
+    run(`--from generic --path ${input} --scope project:cli-test`)
+    const plur = new Plur({ path: store })
+    expect(plur.list({})[0].scope).toBe('project:cli-test')
+  })
+
+  it('supports --mapping for generic imports', () => {
+    const input = join(work, 'custom.json')
+    writeFileSync(input, JSON.stringify([{ note: 'mapped cli fact', area: 'dev.cli' }]))
+    const mapping = join(work, 'mapping.json')
+    writeFileSync(mapping, JSON.stringify({ fields: { statement: 'note', domain: 'area' } }))
+    const report = JSON.parse(run(`--from generic --path ${input} --mapping ${mapping}`))
+    expect(report.imported).toBe(1)
+    const plur = new Plur({ path: store })
+    expect(plur.list({})[0].domain).toBe('dev.cli')
+  })
+
+  it('exits 1 with a clear error for an unknown --from', () => {
+    const input = join(work, 'x.json')
+    writeFileSync(input, '[]')
+    expect(() => run(`--from supermemory --path ${input}`)).toThrow()
+  })
+
+  it('exits 1 with a not-implemented error for the zep stub', () => {
+    const input = join(work, 'x.json')
+    writeFileSync(input, '[]')
+    let message = ''
+    try {
+      run(`--from zep --path ${input}`)
+    } catch (err: any) {
+      message = String(err.stdout ?? '') + String(err.stderr ?? '') + String(err.message ?? '')
+    }
+    expect(message).toMatch(/not.*implemented/i)
+  })
+
+  it('exits 1 when --path is missing', () => {
+    expect(() => run('--from generic')).toThrow()
+  })
+})

--- a/packages/core/src/importers/engine.ts
+++ b/packages/core/src/importers/engine.ts
@@ -1,0 +1,218 @@
+/**
+ * Import engine (issue #441) — routes normalized ImportRecords through
+ * `plur.learn()` so every existing write gate applies:
+ *
+ *   - content-hash fast-path dedup (same scope → reference_count bump),
+ *   - cross-scope recurrence (same statement, different scope → graduation),
+ *   - secret detection and the sensitive-scope guard.
+ *
+ * Imports NEVER raw-append to the store. A record whose learn() resolves to a
+ * pre-existing (or earlier-in-this-run) engram is reported as skipped.
+ *
+ * Conflicts are detected with the same non-LLM heuristic pre-filter the
+ * tension scan uses (scope partition → domain overlap → subject overlap,
+ * tensions.ts). Conflicted records are still imported — dropping data on a
+ * heuristic would be worse — but they are counted in the report, and the new
+ * engram's relations.conflicts links the suspects so `plur tensions --scan`
+ * can confirm with an LLM later. Conflicts are evaluated against the engrams
+ * that existed before the run, not between records of the same import.
+ *
+ * Temporal metadata is preserved where the source has it: created_at becomes
+ * temporal.learned_at (with ingested_at stamped to import time), last_accessed
+ * becomes activation.last_accessed. Dedup-skipped records never overwrite the
+ * existing engram's temporal data.
+ */
+import type { Plur } from '../index.js'
+import type { Engram } from '../schemas/engram.js'
+import type { LearnContext } from '../types.js'
+import { computeContentHash } from '../content-hash.js'
+import { detectSecrets } from '../secrets.js'
+import { scopesOverlap, domainSegmentsOverlap, subjectsOverlap } from '../tensions.js'
+import type { ImportRecord, ImportRecordResult, MigrationReport } from './types.js'
+
+export interface RunImportOptions {
+  /** Source name for the report (generic | gp-engram | mem0 | ...). */
+  from: string
+  /** Input file path, echoed into the report. */
+  path?: string
+  /** Analyze and report without writing. */
+  dryRun?: boolean
+  /** Force every record into this scope (overrides record-level scopes). */
+  scope?: string
+  /** Source label for records that carry none (e.g. `import:mem0:memories.json`). */
+  defaultSource?: string
+}
+
+/** Max conflict links recorded per imported record. */
+const CONFLICT_CAP = 5
+
+export function runImport(plur: Plur, records: ImportRecord[], opts: RunImportOptions): MigrationReport {
+  const dryRun = opts.dryRun === true
+  const now = new Date().toISOString()
+
+  // Pre-existing view: dedup identity + conflict candidates. include_expired
+  // for parity with learn()'s content-hash gate, which ignores temporal
+  // validity — a plain list() would drop already-expired engrams and make the
+  // engine misreport their duplicates as fresh imports (re-patching temporal
+  // metadata on the existing engram along the way).
+  const preExisting = plur.list({ include_expired: true })
+  const knownIds = new Set(preExisting.map(e => e.id))
+  const hashToId = new Map<string, string>()
+  for (const e of preExisting) {
+    const hash = (e as any).content_hash ?? computeContentHash(e.statement)
+    if (!hashToId.has(hash)) hashToId.set(hash, e.id)
+  }
+  const allowSecrets = plur.status().config?.allow_secrets === true
+
+  const results: ImportRecordResult[] = []
+  let imported = 0
+  let skipped = 0
+  let conflicts = 0
+  let errors = 0
+
+  for (const record of records) {
+    const statement = (record.statement ?? '').trim()
+    if (!statement) {
+      errors++
+      results.push({ statement: record.statement ?? '', action: 'error', error: 'empty statement' })
+      continue
+    }
+    const scope = opts.scope ?? record.scope
+
+    if (dryRun) {
+      // Mirror the learn() gates without writing.
+      if (!allowSecrets) {
+        const secretText = [statement, record.domain, ...(record.tags ?? [])].filter(Boolean).join(' ')
+        const secrets = detectSecrets(secretText)
+        if (secrets.length > 0) {
+          errors++
+          results.push({ statement, action: 'error', error: `Secret detected in statement/domain/tags: ${secrets[0].pattern}` })
+          continue
+        }
+      }
+      const hash = computeContentHash(statement)
+      if (hashToId.has(hash)) {
+        skipped++
+        results.push({ statement, action: 'skipped', id: hashToId.get(hash) })
+        continue
+      }
+      hashToId.set(hash, '') // in-file duplicates dedup against each other too
+      const conflictIds = findConflicts(statement, scope, record.domain, preExisting)
+      imported++
+      if (conflictIds.length > 0) conflicts++
+      results.push({ statement, action: 'imported', ...(conflictIds.length > 0 ? { conflicts: conflictIds } : {}) })
+      continue
+    }
+
+    try {
+      const context: LearnContext = {
+        source: record.source ?? opts.defaultSource ?? `import:${opts.from}`,
+      }
+      if (record.type) context.type = record.type
+      if (scope) context.scope = scope
+      if (record.domain) context.domain = record.domain
+      if (record.tags && record.tags.length > 0) context.tags = record.tags
+      if (record.valid_from) context.valid_from = record.valid_from.slice(0, 10)
+      if (record.valid_until) context.valid_until = record.valid_until.slice(0, 10)
+      if (record.pinned) context.pinned = true
+
+      const engram = plur.learn(statement, context)
+
+      if (knownIds.has(engram.id)) {
+        // learn() resolved to an existing engram (hash dedup or cross-scope
+        // recurrence) — the dedup gate did its job.
+        skipped++
+        results.push({ statement, action: 'skipped', id: engram.id })
+        continue
+      }
+      knownIds.add(engram.id)
+
+      const conflictIds = findConflicts(statement, scope, record.domain, preExisting)
+      const patched = applyImportMetadata(engram, record, conflictIds, now)
+      if (patched) plur.updateEngram(patched)
+
+      imported++
+      if (conflictIds.length > 0) conflicts++
+      results.push({ statement, action: 'imported', id: engram.id, ...(conflictIds.length > 0 ? { conflicts: conflictIds } : {}) })
+    } catch (err) {
+      errors++
+      results.push({ statement, action: 'error', error: (err as Error).message })
+    }
+  }
+
+  return {
+    from: opts.from,
+    ...(opts.path ? { path: opts.path } : {}),
+    dry_run: dryRun,
+    total: records.length,
+    imported,
+    skipped,
+    conflicts,
+    errors,
+    records: results,
+  }
+}
+
+/**
+ * Heuristic conflict candidates: the tension scan's non-LLM pre-filter
+ * (tensions.ts getCandidatePairs stages) applied between one incoming record
+ * and the pre-existing active engrams.
+ */
+function findConflicts(statement: string, scope: string | undefined, domain: string | undefined, existing: Engram[]): string[] {
+  const effScope = scope ?? 'global'
+  const out: string[] = []
+  for (const e of existing) {
+    if (e.status !== 'active') continue
+    if (!scopesOverlap(e.scope, effScope)) continue
+    if (!domainSegmentsOverlap(e.domain, domain)) continue
+    if (!subjectsOverlap(e.statement, statement)) continue
+    out.push(e.id)
+    if (out.length >= CONFLICT_CAP) break
+  }
+  return out
+}
+
+/**
+ * Post-learn metadata the LearnContext cannot express: source-preserved
+ * temporal anchors, confidence, and heuristic conflict links. Returns the
+ * patched engram, or null when the record adds nothing.
+ */
+function applyImportMetadata(engram: Engram, record: ImportRecord, conflictIds: string[], now: string): Engram | null {
+  let changed = false
+  const out: Engram = { ...engram }
+
+  if (record.created_at || record.last_accessed) {
+    out.temporal = {
+      learned_at: record.created_at ?? engram.temporal?.learned_at ?? now,
+      ...(engram.temporal?.valid_from ? { valid_from: engram.temporal.valid_from } : {}),
+      ...(engram.temporal?.valid_until ? { valid_until: engram.temporal.valid_until } : {}),
+      ingested_at: now,
+    }
+    const lastAccessed = record.last_accessed ?? record.created_at ?? now
+    out.activation = { ...engram.activation, last_accessed: lastAccessed.slice(0, 10) }
+    changed = true
+  }
+
+  if (record.confidence !== undefined) {
+    const conf = Math.min(10, Math.max(1, Math.round(1 + record.confidence * 9)))
+    out.episodic = {
+      emotional_weight: engram.episodic?.emotional_weight ?? 5,
+      confidence: conf,
+      ...(engram.episodic?.trigger_context ? { trigger_context: engram.episodic.trigger_context } : {}),
+      ...(engram.episodic?.journal_ref ? { journal_ref: engram.episodic.journal_ref } : {}),
+    }
+    changed = true
+  }
+
+  if (conflictIds.length > 0) {
+    out.relations = {
+      broader: engram.relations?.broader ?? [],
+      narrower: engram.relations?.narrower ?? [],
+      related: engram.relations?.related ?? [],
+      conflicts: [...new Set([...(engram.relations?.conflicts ?? []), ...conflictIds])],
+    }
+    changed = true
+  }
+
+  return changed ? out : null
+}

--- a/packages/core/src/importers/generic.ts
+++ b/packages/core/src/importers/generic.ts
@@ -1,0 +1,168 @@
+/**
+ * Generic JSON / JSONL / CSV importer (issue #441).
+ *
+ * The foundation importer: any memory store that can export rows can be
+ * imported. Field names are resolved in three steps:
+ *   1. explicit `FieldMapping.fields` dot-paths (e.g. "domain": "meta.area"),
+ *   2. the engram field name itself (statement, type, domain, ...) with
+ *      common aliases for `statement` (text, memory, content, note, fact),
+ *   3. `FieldMapping.defaults` constants.
+ */
+import type { FieldMapping, ImportRecord, MappableField } from './types.js'
+import { getPath, normalizeConfidence, normalizeImportType, normalizeTags, normalizeTimestamp } from './normalize.js'
+
+const STATEMENT_ALIASES = ['statement', 'text', 'memory', 'content', 'note', 'fact']
+const WRAPPER_KEYS = ['results', 'memories', 'records', 'engrams', 'items', 'data']
+
+export interface ParseGenericOptions {
+  /** Used for format detection (.json/.jsonl/.ndjson/.csv). */
+  filename?: string
+  mapping?: FieldMapping
+}
+
+export function parseGenericContent(content: string, opts: ParseGenericOptions = {}): ImportRecord[] {
+  const name = (opts.filename ?? '').toLowerCase()
+  let rows: Record<string, unknown>[]
+  if (name.endsWith('.csv')) {
+    rows = parseCsv(content)
+  } else if (name.endsWith('.jsonl') || name.endsWith('.ndjson')) {
+    rows = parseJsonl(content)
+  } else {
+    rows = parseJsonRows(content)
+  }
+  return rows.map(row => mapRow(row, opts.mapping))
+}
+
+function parseJsonRows(content: string): Record<string, unknown>[] {
+  let data: unknown
+  try {
+    data = JSON.parse(content)
+  } catch {
+    // Not a single JSON document — a .json extension on line-delimited
+    // exports is common, so fall back to JSONL before giving up.
+    try {
+      return parseJsonl(content)
+    } catch {
+      throw new Error('Failed to parse input as JSON (or JSONL). Check the file or pass a supported format (.json, .jsonl, .csv).')
+    }
+  }
+  if (Array.isArray(data)) return data as Record<string, unknown>[]
+  if (data && typeof data === 'object') {
+    for (const key of WRAPPER_KEYS) {
+      const inner = (data as Record<string, unknown>)[key]
+      if (Array.isArray(inner)) return inner as Record<string, unknown>[]
+    }
+    return [data as Record<string, unknown>]
+  }
+  throw new Error('Failed to parse input: expected a JSON array of records (or a {results|memories|records: [...]} wrapper).')
+}
+
+function parseJsonl(content: string): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = []
+  const lines = content.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (!line) continue
+    try {
+      rows.push(JSON.parse(line))
+    } catch {
+      throw new Error(`Failed to parse JSONL line ${i + 1}.`)
+    }
+  }
+  return rows
+}
+
+/** Minimal RFC 4180 CSV parser: quoted fields, "" escapes, embedded commas/newlines. */
+export function parseCsv(content: string): Record<string, string>[] {
+  const table: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+  let i = 0
+  const pushField = () => { row.push(field); field = '' }
+  const pushRow = () => {
+    // Skip fully empty trailing rows.
+    if (row.length > 1 || (row.length === 1 && row[0].trim() !== '')) table.push(row)
+    row = []
+  }
+  while (i < content.length) {
+    const ch = content[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (content[i + 1] === '"') { field += '"'; i += 2; continue }
+        inQuotes = false; i++; continue
+      }
+      field += ch; i++; continue
+    }
+    if (ch === '"') { inQuotes = true; i++; continue }
+    if (ch === ',') { pushField(); i++; continue }
+    if (ch === '\r') { i++; continue }
+    if (ch === '\n') { pushField(); pushRow(); i++; continue }
+    field += ch; i++
+  }
+  if (field.length > 0 || row.length > 0) { pushField(); pushRow() }
+
+  if (table.length === 0) return []
+  const header = table[0].map(h => h.trim())
+  return table.slice(1).map(cells => {
+    const obj: Record<string, string> = {}
+    header.forEach((h, idx) => { obj[h] = cells[idx] ?? '' })
+    return obj
+  })
+}
+
+function resolveField(row: Record<string, unknown>, field: MappableField, mapping?: FieldMapping): unknown {
+  const path = mapping?.fields?.[field]
+  let value: unknown
+  if (path) {
+    value = getPath(row, path)
+  } else if (field === 'statement') {
+    for (const alias of STATEMENT_ALIASES) {
+      const v = row[alias]
+      if (v !== undefined && v !== null && v !== '') { value = v; break }
+    }
+  } else {
+    value = row[field]
+  }
+  if (value === undefined || value === null || value === '') {
+    value = mapping?.defaults?.[field]
+  }
+  if (value === '') return undefined
+  return value ?? undefined
+}
+
+function str(v: unknown): string | undefined {
+  if (v === undefined || v === null) return undefined
+  const s = String(v).trim()
+  return s.length > 0 ? s : undefined
+}
+
+export function mapRow(row: Record<string, unknown>, mapping?: FieldMapping): ImportRecord {
+  const get = (field: MappableField) => resolveField(row, field, mapping)
+  const rawType = str(get('type'))
+  const pinnedRaw = get('pinned')
+  const record: ImportRecord = {
+    statement: str(get('statement')) ?? '',
+  }
+  if (rawType) record.type = normalizeImportType(rawType)
+  const domain = str(get('domain'))
+  if (domain) record.domain = domain
+  const scope = str(get('scope'))
+  if (scope) record.scope = scope
+  const tags = normalizeTags(get('tags'))
+  if (tags) record.tags = tags
+  const confidence = normalizeConfidence(get('confidence'))
+  if (confidence !== undefined) record.confidence = confidence
+  const source = str(get('source'))
+  if (source) record.source = source
+  const createdAt = normalizeTimestamp(get('created_at'))
+  if (createdAt) record.created_at = createdAt
+  const lastAccessed = normalizeTimestamp(get('last_accessed'))
+  if (lastAccessed) record.last_accessed = lastAccessed
+  const validFrom = str(get('valid_from'))
+  if (validFrom) record.valid_from = validFrom
+  const validUntil = str(get('valid_until'))
+  if (validUntil) record.valid_until = validUntil
+  if (pinnedRaw === true || pinnedRaw === 1 || pinnedRaw === '1' || pinnedRaw === 'true') record.pinned = true
+  return record
+}

--- a/packages/core/src/importers/gp-engram.ts
+++ b/packages/core/src/importers/gp-engram.ts
@@ -1,0 +1,124 @@
+/**
+ * Gentleman-Programming/engram importer (issue #441) — the flagship importer.
+ *
+ * gp-engram is a Go + SQLite(FTS5) memory tool for AI coding agents. Its
+ * source of truth is the `observations` table (internal/store/store.go):
+ *
+ *   observations(id, sync_id, session_id, type, title, content, tool_name,
+ *                project, scope['project'|'personal'|'global'], topic_key,
+ *                normalized_hash, revision_count, duplicate_count,
+ *                last_seen_at, review_after, pinned, created_at, updated_at,
+ *                deleted_at)
+ *
+ * Mapping:
+ *   title + content → statement ("title: content")
+ *   type            → PLUR type via normalizeImportType (decision→architectural,
+ *                     config/setup/ci→procedural, pattern/learning→behavioral, ...)
+ *                     with the original type preserved as a tag
+ *   topic_key       → domain (slashes → dots, e.g. decision/storage → decision.storage)
+ *   scope+project   → 'global' → global; 'project' → project:<name>;
+ *                     'personal' (or projectless) → unset, so core routing applies
+ *   pinned          → pinned
+ *   created_at      → temporal.learned_at (SQLite datetimes are UTC → normalized to ISO Z)
+ *   last_seen_at    → activation.last_accessed (updated_at fallback)
+ *   expires_at      → temporal.valid_until (a real expiry; upstream keeps it
+ *                     NULL in "Phase 1" but the migration column exists)
+ *   row id          → source `gp-engram:<file>#<id>`
+ *
+ * Deliberately NOT mapped: `review_after` (gp-engram's decay "review by" date —
+ * mapping it to valid_until would make PLUR hard-skip the engram after that
+ * date, which is stronger than the source semantics), soft-deleted rows
+ * (deleted_at IS NOT NULL), sessions/user_prompts/memory_relations tables.
+ *
+ * Reuses the workspace's existing better-sqlite3 (already an optional
+ * dependency of @plur-ai/core) via the same createRequire pattern as
+ * store/sqlite-store.ts — no new dependencies.
+ */
+import { existsSync } from 'fs'
+import { basename } from 'path'
+import { createRequire } from 'module'
+import type { ImportRecord } from './types.js'
+import { normalizeImportType, normalizeTimestamp } from './normalize.js'
+
+const require = createRequire(import.meta.url)
+
+let Database: any = null
+
+function getDatabase(): any {
+  if (!Database) {
+    try {
+      Database = require('better-sqlite3')
+    } catch {
+      throw new Error(
+        'better-sqlite3 is required to import a gp-engram .db. Install it with: npm install better-sqlite3'
+      )
+    }
+  }
+  return Database
+}
+
+/** Columns beyond the base set that later gp-engram migrations added — select only what exists. */
+const OPTIONAL_COLUMNS = [
+  'tool_name', 'project', 'scope', 'topic_key', 'pinned',
+  'last_seen_at', 'updated_at', 'deleted_at', 'expires_at',
+] as const
+
+export function parseGpEngramDb(path: string): ImportRecord[] {
+  if (!existsSync(path)) {
+    throw new Error(`gp-engram database not found: ${path}`)
+  }
+  const DB = getDatabase()
+  const db = new DB(path, { readonly: true, fileMustExist: true })
+  try {
+    const cols = new Set<string>(
+      (db.prepare('PRAGMA table_info(observations)').all() as Array<{ name: string }>).map(c => c.name),
+    )
+    for (const required of ['id', 'type', 'title', 'content', 'created_at']) {
+      if (!cols.has(required)) {
+        throw new Error(`Not a gp-engram database (observations table missing column '${required}'): ${path}`)
+      }
+    }
+    const select = ['id', 'type', 'title', 'content', 'created_at', ...OPTIONAL_COLUMNS.filter(c => cols.has(c))]
+    const where = cols.has('deleted_at') ? 'WHERE deleted_at IS NULL' : ''
+    const rows = db.prepare(`SELECT ${select.join(', ')} FROM observations ${where} ORDER BY id`).all() as Array<Record<string, unknown>>
+    const file = basename(path)
+    return rows.map(row => mapObservation(row, file))
+  } finally {
+    db.close()
+  }
+}
+
+function mapObservation(row: Record<string, unknown>, file: string): ImportRecord {
+  const title = typeof row.title === 'string' ? row.title.trim() : ''
+  const content = typeof row.content === 'string' ? row.content.trim() : ''
+  const statement = title && content ? `${title}: ${content}` : (content || title)
+
+  const record: ImportRecord = {
+    statement,
+    source: `gp-engram:${file}#${row.id}`,
+  }
+
+  const rawType = typeof row.type === 'string' ? row.type.trim() : ''
+  record.type = normalizeImportType(rawType)
+  if (rawType) record.tags = [rawType]
+
+  const topicKey = typeof row.topic_key === 'string' ? row.topic_key.trim() : ''
+  if (topicKey) record.domain = topicKey.replace(/\//g, '.')
+
+  const gpScope = typeof row.scope === 'string' ? row.scope.trim().toLowerCase() : 'project'
+  const project = typeof row.project === 'string' ? row.project.trim() : ''
+  if (gpScope === 'global') record.scope = 'global'
+  else if (gpScope !== 'personal' && project) record.scope = `project:${project}`
+  // 'personal' (and projectless 'project' rows) stay unset → core scope routing.
+
+  if (row.pinned === 1 || row.pinned === true) record.pinned = true
+
+  const createdAt = normalizeTimestamp(row.created_at)
+  if (createdAt) record.created_at = createdAt
+  const lastAccessed = normalizeTimestamp(row.last_seen_at) ?? normalizeTimestamp(row.updated_at)
+  if (lastAccessed) record.last_accessed = lastAccessed
+  const expiresAt = normalizeTimestamp(row.expires_at)
+  if (expiresAt) record.valid_until = expiresAt
+
+  return record
+}

--- a/packages/core/src/importers/index.ts
+++ b/packages/core/src/importers/index.ts
@@ -1,0 +1,94 @@
+/**
+ * Migration importers (issue #441): `plur import --from <source> --path <file>`.
+ *
+ * Registry of import sources + the file → parse → learn pipeline. See
+ * engine.ts for the dedup/conflict semantics and each adapter for its
+ * source-format mapping.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { basename } from 'path'
+import type { Plur } from '../index.js'
+import type { FieldMapping, ImportInput, ImportSource, MigrationReport } from './types.js'
+import { parseGenericContent } from './generic.js'
+import { parseMem0Content } from './mem0.js'
+import { parseGpEngramDb } from './gp-engram.js'
+import { runImport } from './engine.js'
+import { zepSource, lettaSource } from './stubs.js'
+
+export type {
+  ImportEngramType, ImportRecord, ImportInput, ImportSource,
+  FieldMapping, MappableField, ImportRecordResult, MigrationReport,
+} from './types.js'
+export type { RunImportOptions } from './engine.js'
+export { runImport } from './engine.js'
+export { parseGenericContent, parseCsv } from './generic.js'
+export { parseMem0Content } from './mem0.js'
+export { parseGpEngramDb } from './gp-engram.js'
+export { normalizeImportType, normalizeTimestamp, normalizeConfidence, normalizeTags } from './normalize.js'
+
+function readText(input: ImportInput): string {
+  if (input.content !== undefined) return input.content
+  if (!existsSync(input.path)) throw new Error(`Input file not found: ${input.path}`)
+  return readFileSync(input.path, 'utf-8')
+}
+
+export const IMPORT_SOURCES: ImportSource[] = [
+  {
+    name: 'generic',
+    description: 'Generic JSON / JSONL / CSV export with optional --mapping field-mapping config',
+    implemented: true,
+    parse: (input) => parseGenericContent(readText(input), { filename: basename(input.path), mapping: input.mapping }),
+  },
+  {
+    name: 'gp-engram',
+    description: 'Gentleman-Programming/engram SQLite database (~/.engram/engram.db)',
+    implemented: true,
+    parse: (input) => {
+      if (!existsSync(input.path)) throw new Error(`Input file not found: ${input.path}`)
+      return parseGpEngramDb(input.path)
+    },
+  },
+  {
+    name: 'mem0',
+    description: 'mem0 JSON export (Memory.get_all() {"results": [...]} shape)',
+    implemented: true,
+    parse: (input) => parseMem0Content(readText(input), { filename: basename(input.path) }),
+  },
+  zepSource,
+  lettaSource,
+]
+
+export function listImportSources(): ImportSource[] {
+  return IMPORT_SOURCES
+}
+
+export function getImportSource(name: string): ImportSource {
+  const source = IMPORT_SOURCES.find(s => s.name === name)
+  if (!source) {
+    const implemented = IMPORT_SOURCES.filter(s => s.implemented).map(s => s.name).join(', ')
+    const stubbed = IMPORT_SOURCES.filter(s => !s.implemented).map(s => s.name).join(', ')
+    throw new Error(`Unknown import source "${name}". Available: ${implemented} (stubbed: ${stubbed}).`)
+  }
+  return source
+}
+
+export interface ImportFromOptions {
+  from: string
+  path: string
+  mapping?: FieldMapping
+  dryRun?: boolean
+  scope?: string
+}
+
+/** File → parse → dedup-gated learn, in one call. Used by the CLI command. */
+export function importFrom(plur: Plur, opts: ImportFromOptions): MigrationReport {
+  const source = getImportSource(opts.from)
+  const records = source.parse({ path: opts.path, mapping: opts.mapping })
+  return runImport(plur, records, {
+    from: opts.from,
+    path: opts.path,
+    dryRun: opts.dryRun,
+    scope: opts.scope,
+    defaultSource: `import:${opts.from}:${basename(opts.path)}`,
+  })
+}

--- a/packages/core/src/importers/mem0.ts
+++ b/packages/core/src/importers/mem0.ts
@@ -1,0 +1,78 @@
+/**
+ * mem0 importer (issue #441).
+ *
+ * Parses mem0's JSON export shape — the `{"results": [...]}` envelope that
+ * `Memory.get_all()` returns (v1.1+, mem0 OSS `mem0/memory/main.py`) and the
+ * platform export equivalents. Each memory item carries:
+ *   id, memory (the text), hash, created_at, updated_at, plus promoted payload
+ *   keys user_id / agent_id / run_id / actor_id / role / expiration_date, an
+ *   optional metadata object, and (platform) categories.
+ *
+ * Mapping:
+ *   memory          → statement
+ *   user_id         → scope `user:<id>`   (agent_id → `agent:<id>` fallback)
+ *   categories      → tags
+ *   created_at      → temporal.learned_at (via ImportRecord.created_at)
+ *   updated_at      → activation.last_accessed (via ImportRecord.last_accessed)
+ *   expiration_date → temporal.valid_until
+ *   id              → source `mem0:<id>`
+ * Graph `relations` arrays and free-form `metadata` are not imported.
+ */
+import type { ImportRecord } from './types.js'
+import { normalizeTags, normalizeTimestamp } from './normalize.js'
+
+export interface ParseMem0Options {
+  filename?: string
+}
+
+export function parseMem0Content(content: string, opts: ParseMem0Options = {}): ImportRecord[] {
+  let data: unknown
+  try {
+    data = JSON.parse(content)
+  } catch {
+    throw new Error('Failed to parse mem0 export: not valid JSON.')
+  }
+
+  let rows: unknown[]
+  if (Array.isArray(data)) {
+    rows = data
+  } else if (data && typeof data === 'object' && Array.isArray((data as any).results)) {
+    rows = (data as any).results
+  } else if (data && typeof data === 'object' && Array.isArray((data as any).memories)) {
+    rows = (data as any).memories
+  } else {
+    throw new Error('Failed to parse mem0 export: expected {"results": [...]} (Memory.get_all() shape) or a bare array of memories.')
+  }
+
+  return rows.map((raw, idx) => {
+    const m = (raw ?? {}) as Record<string, unknown>
+    const statement = firstString(m.memory, m.text, m.data) ?? ''
+    const record: ImportRecord = { statement }
+
+    const userId = firstString(m.user_id)
+    const agentId = firstString(m.agent_id)
+    if (userId) record.scope = `user:${userId}`
+    else if (agentId) record.scope = `agent:${agentId}`
+
+    const tags = normalizeTags(m.categories)
+    if (tags) record.tags = tags
+
+    const createdAt = normalizeTimestamp(m.created_at)
+    if (createdAt) record.created_at = createdAt
+    const updatedAt = normalizeTimestamp(m.updated_at)
+    if (updatedAt) record.last_accessed = updatedAt
+    const expiration = firstString(m.expiration_date)
+    if (expiration) record.valid_until = expiration
+
+    const id = firstString(m.id)
+    record.source = id ? `mem0:${id}` : `mem0:${opts.filename ?? 'export'}#${idx}`
+    return record
+  })
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim().length > 0) return v.trim()
+  }
+  return undefined
+}

--- a/packages/core/src/importers/normalize.ts
+++ b/packages/core/src/importers/normalize.ts
@@ -1,0 +1,115 @@
+/**
+ * Normalization helpers shared by the migration importers (issue #441).
+ */
+import type { ImportEngramType } from './types.js'
+
+/**
+ * Map competitor type/kind names onto the 4 PLUR engram types. Unknown or
+ * missing types default to 'behavioral' (the same default `learn()` applies).
+ */
+const TYPE_MAP: Record<string, ImportEngramType> = {
+  // native
+  behavioral: 'behavioral',
+  terminological: 'terminological',
+  procedural: 'procedural',
+  architectural: 'architectural',
+  // architectural family (decisions & structure)
+  decision: 'architectural',
+  adr: 'architectural',
+  architecture: 'architectural',
+  design: 'architectural',
+  refactor: 'architectural',
+  // procedural family (how-to & setup)
+  procedure: 'procedural',
+  howto: 'procedural',
+  'how-to': 'procedural',
+  how_to: 'procedural',
+  workflow: 'procedural',
+  runbook: 'procedural',
+  config: 'procedural',
+  setup: 'procedural',
+  infra: 'procedural',
+  infrastructure: 'procedural',
+  ci: 'procedural',
+  // terminological family (definitions)
+  definition: 'terminological',
+  term: 'terminological',
+  glossary: 'terminological',
+  concept: 'terminological',
+  // behavioral family (facts, preferences, conventions, findings)
+  preference: 'behavioral',
+  policy: 'behavioral',
+  pattern: 'behavioral',
+  convention: 'behavioral',
+  guideline: 'behavioral',
+  fact: 'behavioral',
+  learning: 'behavioral',
+  learn: 'behavioral',
+  bug: 'behavioral',
+  bugfix: 'behavioral',
+  fix: 'behavioral',
+  incident: 'behavioral',
+  hotfix: 'behavioral',
+  discovery: 'behavioral',
+  investigation: 'behavioral',
+  root_cause: 'behavioral',
+  'root-cause': 'behavioral',
+  session_summary: 'behavioral',
+  manual: 'behavioral',
+}
+
+export function normalizeImportType(raw: string | undefined): ImportEngramType {
+  if (!raw) return 'behavioral'
+  return TYPE_MAP[raw.trim().toLowerCase()] ?? 'behavioral'
+}
+
+/**
+ * Normalize a source timestamp toward ISO 8601 without inventing precision:
+ *   - SQLite `datetime('now')` values ("2025-12-01 09:15:00", UTC by contract)
+ *     become "2025-12-01T09:15:00Z".
+ *   - Anything already ISO-shaped (with T / timezone / date-only) passes
+ *     through untouched so source fidelity is preserved.
+ */
+export function normalizeTimestamp(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  const s = raw.trim()
+  if (!s) return undefined
+  const sqliteShape = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})$/.exec(s)
+  if (sqliteShape) return `${sqliteShape[1]}T${sqliteShape[2]}Z`
+  return s
+}
+
+/**
+ * Normalize a confidence value into [0,1]. Accepts native 0-1 floats, 1-10
+ * scales (÷10), and 0-100 scales (÷100). Non-numeric → undefined.
+ */
+export function normalizeConfidence(raw: unknown): number | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return undefined
+  if (n < 0) return 0
+  if (n <= 1) return n
+  if (n <= 10) return n / 10
+  if (n <= 100) return n / 100
+  return 1
+}
+
+/** Coerce tag input (array or delimited string) into a clean string array. */
+export function normalizeTags(raw: unknown): string[] | undefined {
+  let parts: string[]
+  if (Array.isArray(raw)) parts = raw.map(t => String(t))
+  else if (typeof raw === 'string') parts = raw.split(/[|;,]/)
+  else return undefined
+  const tags = parts.map(t => t.trim()).filter(t => t.length > 0)
+  return tags.length > 0 ? tags : undefined
+}
+
+/** Resolve a dot-path (e.g. "meta.area") into a nested object. */
+export function getPath(obj: unknown, path: string): unknown {
+  let cur: any = obj
+  for (const seg of path.split('.')) {
+    if (cur === null || cur === undefined || typeof cur !== 'object') return undefined
+    cur = cur[seg]
+  }
+  return cur
+}

--- a/packages/core/src/importers/stubs.ts
+++ b/packages/core/src/importers/stubs.ts
@@ -1,0 +1,38 @@
+/**
+ * Declared-but-stubbed import sources (issue #441).
+ *
+ * Zep and Letta are registered so `--from zep|letta` fails with a clear,
+ * actionable message — and so implementing them later is a matter of
+ * replacing parse(), not designing a new surface. They are intentionally NOT
+ * implemented yet: both export formats churn across versions (Zep's
+ * session-graph shape, Letta's agent-file memory blocks), so pinning a parser
+ * today would rot quickly.
+ */
+import type { ImportSource } from './types.js'
+
+function stub(name: string, description: string, detail: string): ImportSource {
+  return {
+    name,
+    description,
+    implemented: false,
+    parse() {
+      throw new Error(
+        `The "${name}" importer is not implemented yet. ${detail} ` +
+        'The adapter interface is stubbed so it can be added — see https://github.com/plur-ai/plur/issues/441. ' +
+        'In the meantime, export to JSON and use --from generic with a --mapping config.'
+      )
+    },
+  }
+}
+
+export const zepSource = stub(
+  'zep',
+  'Zep session graphs (stub — not yet implemented)',
+  "Zep's session-graph export format is still churning across versions.",
+)
+
+export const lettaSource = stub(
+  'letta',
+  'Letta agent memory blocks (stub — not yet implemented)',
+  "Letta's agent-file memory-block format is still churning across versions.",
+)

--- a/packages/core/src/importers/types.ts
+++ b/packages/core/src/importers/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Migration importers (issue #441) — shared types.
+ *
+ * Every importer parses a competitor export into normalized `ImportRecord`s;
+ * the engine (`runImport`) then routes each record through `plur.learn()` so
+ * the existing dedup gates (content-hash fast path, cross-scope recurrence)
+ * and the secret guard apply. Imports never raw-append to the store.
+ */
+
+export type ImportEngramType = 'behavioral' | 'terminological' | 'procedural' | 'architectural'
+
+/** Normalized intermediate representation of one source memory. */
+export interface ImportRecord {
+  /** The assertion to learn. Required — empty statements become report errors. */
+  statement: string
+  /** PLUR engram type (already normalized by the parser). */
+  type?: ImportEngramType
+  /** Dotted domain path, e.g. 'infra.deploy'. */
+  domain?: string
+  /** PLUR scope, e.g. 'global', 'project:acme', 'user:alice'. Unset → core routing. */
+  scope?: string
+  tags?: string[]
+  /** Normalized confidence in [0,1]. Mapped onto episodic.confidence (1-10). */
+  confidence?: number
+  /** Free-text origin. Unset → the engine stamps `import:<from>:<file>`. */
+  source?: string
+  /** Source-system creation timestamp (ISO 8601) → temporal.learned_at. */
+  created_at?: string
+  /** Source-system last-access timestamp (ISO 8601) → activation.last_accessed. */
+  last_accessed?: string
+  /** Validity window start (ISO date) → temporal.valid_from. */
+  valid_from?: string
+  /** Validity window end / expiry (ISO date) → temporal.valid_until. */
+  valid_until?: string
+  pinned?: boolean
+}
+
+/** Engram fields addressable from a generic field-mapping config. */
+export type MappableField =
+  | 'statement' | 'type' | 'domain' | 'scope' | 'tags' | 'confidence'
+  | 'source' | 'created_at' | 'last_accessed' | 'valid_from' | 'valid_until' | 'pinned'
+
+/**
+ * Field-mapping config for the generic importer. `fields` maps engram fields
+ * to dot-paths into each source row (e.g. `"domain": "meta.area"`); `defaults`
+ * supplies constants for rows that lack a field.
+ */
+export interface FieldMapping {
+  fields?: Partial<Record<MappableField, string>>
+  defaults?: Partial<Record<MappableField, unknown>>
+}
+
+/** Input handed to an adapter's parse(). Text adapters may receive pre-read content. */
+export interface ImportInput {
+  /** Path to the input file (.json/.jsonl/.csv/.db). */
+  path: string
+  /** Pre-read text content — parse() reads `path` when omitted. */
+  content?: string
+  /** Field-mapping config (generic importer only). */
+  mapping?: FieldMapping
+}
+
+/** A registered import source (`plur import --from <name>`). */
+export interface ImportSource {
+  name: string
+  description: string
+  /** false for declared-but-stubbed adapters (zep, letta) — parse() throws. */
+  implemented: boolean
+  parse(input: ImportInput): ImportRecord[]
+}
+
+export interface ImportRecordResult {
+  statement: string
+  action: 'imported' | 'skipped' | 'error'
+  /** New engram id when imported; the existing engram's id when skipped (dedup). */
+  id?: string
+  /** Pre-existing engram ids this record potentially contradicts (heuristic). */
+  conflicts?: string[]
+  error?: string
+}
+
+/** Migration report: N imported, M skipped (dedup), K conflicts (+ errors). */
+export interface MigrationReport {
+  from: string
+  path?: string
+  dry_run: boolean
+  total: number
+  imported: number
+  skipped: number
+  conflicts: number
+  errors: number
+  records: ImportRecordResult[]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,15 @@ export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus } from './sync.js'
 export { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'
 export { scanForTensions, getCandidatePairs, scopesOverlap, domainSegmentsOverlap, subjectsOverlap, statementOverlap, buildContradictionPrompt, parseContradictionResponse, buildBatchContradictionPrompt, parseBatchContradictionResponse, type ContradictionVerdict, type TensionPair, type TensionScanResult } from './tensions.js'
+// Migration importers (issue #441) — `plur import --from <source> --path <file>`.
+export {
+  importFrom, runImport, getImportSource, listImportSources, IMPORT_SOURCES,
+  parseGenericContent, parseCsv, parseMem0Content, parseGpEngramDb,
+  normalizeImportType, normalizeTimestamp, normalizeConfidence, normalizeTags,
+  type ImportRecord, type ImportSource, type ImportInput, type ImportEngramType,
+  type FieldMapping, type MappableField, type ImportRecordResult, type MigrationReport,
+  type RunImportOptions, type ImportFromOptions,
+} from './importers/index.js'
 export { CapabilityCanary, type Capability, type CanaryStatus } from './capability-canary.js'
 export type { Engram, PreviousVersionRef } from './schemas/engram.js'
 export type { Episode } from './schemas/episode.js'
@@ -2066,12 +2075,12 @@ export class Plur {
   }
 
   /** List all active engrams, optionally filtered by scope/domain. No search — returns all matches. */
-  list(options?: { scope?: string; domain?: string; min_strength?: number }): Engram[] {
+  list(options?: { scope?: string; domain?: string; min_strength?: number; include_expired?: boolean }): Engram[] {
     return this._filterEngrams(options)
   }
 
   /** Filter engrams by scope/domain/strength (shared by both modes) */
-  private _filterEngrams(options?: RecallOptions): Engram[] {
+  private _filterEngrams(options?: RecallOptions & { include_expired?: boolean }): Engram[] {
     let engrams: Engram[]
     if (this.indexedStorage) {
       engrams = this.indexedStorage.loadFiltered({
@@ -2106,13 +2115,18 @@ export class Plur {
         )
       }
     }
-    // Temporal validity: exclude expired or not-yet-valid engrams
-    const today = new Date().toISOString().slice(0, 10)
-    engrams = engrams.filter(e => {
-      if (e.temporal?.valid_until && e.temporal.valid_until < today) return false
-      if (e.temporal?.valid_from && e.temporal.valid_from > today) return false
-      return true
-    })
+    // Temporal validity: exclude expired or not-yet-valid engrams.
+    // `include_expired` opts out — callers that need dedup-identity parity
+    // with learn()'s content-hash gate (which ignores temporal validity,
+    // e.g. the migration import engine, #441) must see the full active set.
+    if (!options?.include_expired) {
+      const today = new Date().toISOString().slice(0, 10)
+      engrams = engrams.filter(e => {
+        if (e.temporal?.valid_until && e.temporal.valid_until < today) return false
+        if (e.temporal?.valid_from && e.temporal.valid_from > today) return false
+        return true
+      })
+    }
     if (options?.min_strength !== undefined) {
       engrams = engrams.filter(e => e.activation.retrieval_strength >= options.min_strength!)
     }

--- a/packages/core/test/fixtures/import/generic-mapped.jsonl
+++ b/packages/core/test/fixtures/import/generic-mapped.jsonl
@@ -1,0 +1,2 @@
+{"text":"Deploy target is fly.io","kind":"decision","meta":{"area":"infra.deploy","when":"2025-08-15T09:30:00Z"},"labels":["deploy"],"score":0.8}
+{"text":"Never commit .env files to the repository","kind":"policy","meta":{"area":"security"},"labels":["git","hygiene"]}

--- a/packages/core/test/fixtures/import/generic.csv
+++ b/packages/core/test/fixtures/import/generic.csv
@@ -1,0 +1,3 @@
+statement,domain,tags,confidence,created_at
+"Standups happen at 09:30 CET, daily",team.rituals,standup|team,0.7,2025-06-01T08:00:00Z
+Feature flags live in flags.yaml,dev.config,flags,,2025-06-02T08:00:00Z

--- a/packages/core/test/fixtures/import/generic.json
+++ b/packages/core/test/fixtures/import/generic.json
@@ -1,0 +1,19 @@
+[
+  {
+    "statement": "Use pnpm for all installs in the monorepo",
+    "type": "procedural",
+    "domain": "dev.tooling",
+    "tags": ["pnpm", "monorepo"],
+    "confidence": 0.9,
+    "created_at": "2025-11-02T10:00:00Z",
+    "source": "notes/dev.md"
+  },
+  {
+    "statement": "The staging API base URL is https://staging.example.test",
+    "domain": "infra.endpoints",
+    "valid_until": "2026-12-31"
+  },
+  {
+    "statement": "Use pnpm for all installs in the monorepo"
+  }
+]

--- a/packages/core/test/fixtures/import/gp-engram-fixture.sql
+++ b/packages/core/test/fixtures/import/gp-engram-fixture.sql
@@ -1,0 +1,65 @@
+-- Hand-written fixture mirroring Gentleman-Programming/engram's SQLite schema
+-- (internal/store/store.go migrate() DDL, trimmed to the tables the importer
+-- reads: sessions + observations). No network involved — tests build a .db
+-- from this file with better-sqlite3 in beforeAll.
+CREATE TABLE IF NOT EXISTS sessions (
+  id         TEXT PRIMARY KEY,
+  project    TEXT NOT NULL,
+  directory  TEXT NOT NULL,
+  started_at TEXT NOT NULL DEFAULT (datetime('now')),
+  ended_at   TEXT,
+  summary    TEXT
+);
+
+CREATE TABLE IF NOT EXISTS observations (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  sync_id         TEXT,
+  session_id      TEXT    NOT NULL,
+  type            TEXT    NOT NULL,
+  title           TEXT    NOT NULL,
+  content         TEXT    NOT NULL,
+  tool_name       TEXT,
+  project         TEXT,
+  scope           TEXT    NOT NULL DEFAULT 'project',
+  topic_key       TEXT,
+  normalized_hash TEXT,
+  revision_count  INTEGER NOT NULL DEFAULT 1,
+  duplicate_count INTEGER NOT NULL DEFAULT 1,
+  last_seen_at    TEXT,
+  review_after    TEXT,
+  expires_at      TEXT,
+  pinned          BOOLEAN NOT NULL DEFAULT 0,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+  deleted_at      TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions(id)
+);
+
+INSERT INTO sessions (id, project, directory, started_at, ended_at, summary) VALUES
+  ('sess-1', 'acme-api', '/home/dev/acme-api', '2025-12-01 09:00:00', NULL, NULL);
+
+INSERT INTO observations
+  (id, sync_id, session_id, type, title, content, tool_name, project, scope, topic_key,
+   normalized_hash, revision_count, duplicate_count, last_seen_at, review_after, expires_at, pinned,
+   created_at, updated_at, deleted_at)
+VALUES
+  (1, NULL, 'sess-1', 'decision', 'Use SQLite for local persistence',
+   'Chose SQLite over Postgres for zero-config local storage',
+   NULL, 'acme-api', 'project', 'decision/storage',
+   'h1', 1, 1, '2025-12-02 10:00:00', '2026-06-01 09:15:00', NULL, 0,
+   '2025-12-01 09:15:00', '2025-12-01 09:15:00', NULL),
+  (2, NULL, 'sess-1', 'pattern', 'Error wrapping convention',
+   'Wrap errors with fmt.Errorf and %w so callers can unwrap',
+   NULL, 'acme-api', 'project', 'pattern/errors',
+   'h2', 1, 2, NULL, NULL, NULL, 1,
+   '2025-12-01 10:00:00', '2025-12-01 10:00:00', NULL),
+  (3, NULL, 'sess-1', 'config', 'CI runs on push to main',
+   'GitHub Actions workflow triggers on every push to main',
+   'Bash', NULL, 'global', 'config/ci',
+   'h3', 1, 1, NULL, NULL, '2026-12-31 00:00:00', 0,
+   '2025-12-01 11:00:00', '2025-12-01 11:00:00', NULL),
+  (4, NULL, 'sess-1', 'bugfix', 'Deleted observation',
+   'This observation is soft-deleted and must not be imported',
+   NULL, 'acme-api', 'project', 'bug/deleted',
+   'h4', 1, 1, NULL, NULL, NULL, 0,
+   '2025-12-01 12:00:00', '2025-12-05 12:00:00', '2025-12-05 12:00:00');

--- a/packages/core/test/fixtures/import/mapping.json
+++ b/packages/core/test/fixtures/import/mapping.json
@@ -1,0 +1,13 @@
+{
+  "fields": {
+    "statement": "text",
+    "type": "kind",
+    "domain": "meta.area",
+    "created_at": "meta.when",
+    "tags": "labels",
+    "confidence": "score"
+  },
+  "defaults": {
+    "scope": "project:demo"
+  }
+}

--- a/packages/core/test/fixtures/import/mem0-export.json
+++ b/packages/core/test/fixtures/import/mem0-export.json
@@ -1,0 +1,28 @@
+{
+  "results": [
+    {
+      "id": "a1b2c3d4-0001",
+      "memory": "User prefers dark mode in all editors",
+      "hash": "d41d8cd98f00b204",
+      "created_at": "2025-09-14T12:00:00.000000-07:00",
+      "updated_at": "2025-10-01T08:30:00.000000-07:00",
+      "user_id": "alice",
+      "metadata": { "surface": "settings" },
+      "categories": ["preferences", "ui"]
+    },
+    {
+      "id": "a1b2c3d4-0002",
+      "memory": "The team ships releases on Fridays",
+      "created_at": "2025-09-20T12:00:00Z",
+      "agent_id": "scheduler",
+      "expiration_date": "2026-06-30"
+    },
+    {
+      "id": "a1b2c3d4-0003",
+      "memory": "Vegetarian, avoids peanuts",
+      "user_id": "alice",
+      "run_id": "trip-planning-042"
+    }
+  ],
+  "relations": []
+}

--- a/packages/core/test/importers.test.ts
+++ b/packages/core/test/importers.test.ts
@@ -1,0 +1,494 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createRequire } from 'module'
+import { Plur } from '../src/index.js'
+import {
+  parseGenericContent,
+  parseMem0Content,
+  parseGpEngramDb,
+  getImportSource,
+  listImportSources,
+  runImport,
+  importFrom,
+  normalizeImportType,
+  type ImportRecord,
+} from '../src/importers/index.js'
+
+const FIXTURES = join(__dirname, 'fixtures', 'import')
+
+// ─── Issue #441: migration importers ────────────────────────────────────────
+//
+// Three implemented sources (generic JSON/JSONL/CSV, gp-engram SQLite, mem0
+// JSON export) + stubbed adapters for zep/letta. All imports route through
+// plur.learn() so the content-hash dedup gate and secret guard apply — never
+// raw-append. Reports N imported / M skipped (dedup) / K conflicts.
+
+// ─── Type normalization ──────────────────────────────────────────────────────
+
+describe('normalizeImportType', () => {
+  it('passes through native PLUR types', () => {
+    expect(normalizeImportType('behavioral')).toBe('behavioral')
+    expect(normalizeImportType('procedural')).toBe('procedural')
+    expect(normalizeImportType('terminological')).toBe('terminological')
+    expect(normalizeImportType('architectural')).toBe('architectural')
+  })
+
+  it('maps common competitor type names onto the 4 PLUR types', () => {
+    expect(normalizeImportType('decision')).toBe('architectural')
+    expect(normalizeImportType('adr')).toBe('architectural')
+    expect(normalizeImportType('config')).toBe('procedural')
+    expect(normalizeImportType('how-to')).toBe('procedural')
+    expect(normalizeImportType('definition')).toBe('terminological')
+    expect(normalizeImportType('preference')).toBe('behavioral')
+    expect(normalizeImportType('pattern')).toBe('behavioral')
+  })
+
+  it('defaults unknown or missing types to behavioral', () => {
+    expect(normalizeImportType('xyzzy')).toBe('behavioral')
+    expect(normalizeImportType(undefined)).toBe('behavioral')
+    expect(normalizeImportType('')).toBe('behavioral')
+  })
+})
+
+// ─── Generic JSON / JSONL / CSV parser ───────────────────────────────────────
+
+describe('generic importer parsing', () => {
+  it('parses a JSON array with default field names', () => {
+    const content = readFileSync(join(FIXTURES, 'generic.json'), 'utf-8')
+    const records = parseGenericContent(content, { filename: 'generic.json' })
+    expect(records).toHaveLength(3)
+    expect(records[0].statement).toBe('Use pnpm for all installs in the monorepo')
+    expect(records[0].type).toBe('procedural')
+    expect(records[0].domain).toBe('dev.tooling')
+    expect(records[0].tags).toEqual(['pnpm', 'monorepo'])
+    expect(records[0].confidence).toBe(0.9)
+    expect(records[0].created_at).toBe('2025-11-02T10:00:00Z')
+    expect(records[0].source).toBe('notes/dev.md')
+    expect(records[1].valid_until).toBe('2026-12-31')
+  })
+
+  it('parses JSONL with a field-mapping config (dot-paths, defaults, type normalization)', () => {
+    const content = readFileSync(join(FIXTURES, 'generic-mapped.jsonl'), 'utf-8')
+    const mapping = JSON.parse(readFileSync(join(FIXTURES, 'mapping.json'), 'utf-8'))
+    const records = parseGenericContent(content, { filename: 'generic-mapped.jsonl', mapping })
+    expect(records).toHaveLength(2)
+    expect(records[0].statement).toBe('Deploy target is fly.io')
+    expect(records[0].type).toBe('architectural') // "decision" normalized
+    expect(records[0].domain).toBe('infra.deploy') // dot-path meta.area
+    expect(records[0].created_at).toBe('2025-08-15T09:30:00Z') // dot-path meta.when
+    expect(records[0].tags).toEqual(['deploy'])
+    expect(records[0].confidence).toBe(0.8)
+    expect(records[0].scope).toBe('project:demo') // mapping default
+    expect(records[1].type).toBe('behavioral') // "policy" normalized
+    expect(records[1].scope).toBe('project:demo')
+  })
+
+  it('parses CSV with quoted commas and pipe-separated tags', () => {
+    const content = readFileSync(join(FIXTURES, 'generic.csv'), 'utf-8')
+    const records = parseGenericContent(content, { filename: 'generic.csv' })
+    expect(records).toHaveLength(2)
+    expect(records[0].statement).toBe('Standups happen at 09:30 CET, daily')
+    expect(records[0].domain).toBe('team.rituals')
+    expect(records[0].tags).toEqual(['standup', 'team'])
+    expect(records[0].confidence).toBe(0.7)
+    expect(records[1].statement).toBe('Feature flags live in flags.yaml')
+    expect(records[1].confidence).toBeUndefined() // empty cell
+  })
+
+  it('accepts alternate statement field names (text, memory, content)', () => {
+    const records = parseGenericContent(
+      JSON.stringify([{ text: 'a fact' }, { memory: 'b fact' }, { content: 'c fact' }]),
+      { filename: 'x.json' },
+    )
+    expect(records.map(r => r.statement)).toEqual(['a fact', 'b fact', 'c fact'])
+  })
+
+  it('unwraps common top-level wrappers ({results}, {memories}, {records})', () => {
+    for (const key of ['results', 'memories', 'records']) {
+      const records = parseGenericContent(
+        JSON.stringify({ [key]: [{ statement: 'wrapped fact' }] }),
+        { filename: 'x.json' },
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0].statement).toBe('wrapped fact')
+    }
+  })
+
+  it('throws a clear error on malformed JSON', () => {
+    expect(() => parseGenericContent('{not json', { filename: 'x.json' })).toThrow(/parse/i)
+  })
+
+  it('normalizes 1-10 confidence scales down to 0-1', () => {
+    const records = parseGenericContent(
+      JSON.stringify([{ statement: 'scaled', confidence: 8 }]),
+      { filename: 'x.json' },
+    )
+    expect(records[0].confidence).toBeCloseTo(0.8)
+  })
+})
+
+// ─── mem0 parser ─────────────────────────────────────────────────────────────
+
+describe('mem0 importer parsing', () => {
+  const records = () => parseMem0Content(
+    readFileSync(join(FIXTURES, 'mem0-export.json'), 'utf-8'),
+    { filename: 'mem0-export.json' },
+  )
+
+  it('parses the {results: [...]} export shape', () => {
+    expect(records()).toHaveLength(3)
+  })
+
+  it('maps memory → statement and categories → tags', () => {
+    const [first] = records()
+    expect(first.statement).toBe('User prefers dark mode in all editors')
+    expect(first.tags).toEqual(['preferences', 'ui'])
+  })
+
+  it('derives scope from user_id / agent_id', () => {
+    const [first, second] = records()
+    expect(first.scope).toBe('user:alice')
+    expect(second.scope).toBe('agent:scheduler')
+  })
+
+  it('preserves temporal metadata (created_at, updated_at → last_accessed, expiration_date → valid_until)', () => {
+    const [first, second] = records()
+    expect(first.created_at).toBe('2025-09-14T12:00:00.000000-07:00')
+    expect(first.last_accessed).toBe('2025-10-01T08:30:00.000000-07:00')
+    expect(second.valid_until).toBe('2026-06-30')
+  })
+
+  it('stamps the mem0 id into source', () => {
+    const [first] = records()
+    expect(first.source).toContain('mem0')
+    expect(first.source).toContain('a1b2c3d4-0001')
+  })
+
+  it('also accepts a bare array export', () => {
+    const bare = parseMem0Content(
+      JSON.stringify([{ id: 'x-1', memory: 'bare memory' }]),
+      { filename: 'bare.json' },
+    )
+    expect(bare).toHaveLength(1)
+    expect(bare[0].statement).toBe('bare memory')
+  })
+})
+
+// ─── gp-engram (Gentleman-Programming/engram) SQLite parser ──────────────────
+
+describe('gp-engram importer parsing', () => {
+  let dbPath: string
+
+  beforeAll(() => {
+    // Build the .db from the hand-written SQL fixture (no network).
+    const require = createRequire(import.meta.url)
+    const Database = require('better-sqlite3')
+    const dir = mkdtempSync(join(tmpdir(), 'plur-gp-fixture-'))
+    dbPath = join(dir, 'engram.db')
+    const db = new Database(dbPath)
+    db.exec(readFileSync(join(FIXTURES, 'gp-engram-fixture.sql'), 'utf-8'))
+    db.close()
+  })
+
+  it('reads observations and excludes soft-deleted rows', () => {
+    const records = parseGpEngramDb(dbPath)
+    expect(records).toHaveLength(3) // row 4 is deleted
+    expect(records.every(r => !r.statement.includes('soft-deleted'))).toBe(true)
+  })
+
+  it('joins title and content into the statement', () => {
+    const [first] = parseGpEngramDb(dbPath)
+    expect(first.statement).toBe(
+      'Use SQLite for local persistence: Chose SQLite over Postgres for zero-config local storage',
+    )
+  })
+
+  it('maps observation types onto PLUR types and keeps the original as a tag', () => {
+    const [decision, pattern, config] = parseGpEngramDb(dbPath)
+    expect(decision.type).toBe('architectural')
+    expect(decision.tags).toContain('decision')
+    expect(pattern.type).toBe('behavioral')
+    expect(config.type).toBe('procedural')
+  })
+
+  it('maps scope: project → project:<name>, global → global', () => {
+    const [decision, , config] = parseGpEngramDb(dbPath)
+    expect(decision.scope).toBe('project:acme-api')
+    expect(config.scope).toBe('global')
+  })
+
+  it('converts topic_key to a dotted domain', () => {
+    const [decision] = parseGpEngramDb(dbPath)
+    expect(decision.domain).toBe('decision.storage')
+  })
+
+  it('preserves temporal metadata with SQLite datetimes normalized to ISO', () => {
+    const [decision] = parseGpEngramDb(dbPath)
+    expect(decision.created_at).toBe('2025-12-01T09:15:00Z')
+    expect(decision.last_accessed).toBe('2025-12-02T10:00:00Z') // last_seen_at
+  })
+
+  it('carries pinned through', () => {
+    const [, pattern] = parseGpEngramDb(dbPath)
+    expect(pattern.pinned).toBe(true)
+  })
+
+  it('maps expires_at → valid_until but never maps review_after', () => {
+    const [decision, , config] = parseGpEngramDb(dbPath)
+    // Row 3 has expires_at (a real expiry, Phase 2 upstream) → valid_until.
+    expect(config.valid_until).toBe('2026-12-31T00:00:00Z')
+    // Row 1 has review_after only — a decay "review by" date, NOT an expiry.
+    expect(decision.valid_until).toBeUndefined()
+  })
+
+  it('stamps the observation row into source', () => {
+    const [decision] = parseGpEngramDb(dbPath)
+    expect(decision.source).toContain('gp-engram')
+    expect(decision.source).toContain('#1')
+  })
+
+  it('throws a clear error for a missing db file', () => {
+    expect(() => parseGpEngramDb('/nonexistent/nope.db')).toThrow()
+  })
+})
+
+// ─── Adapter registry ────────────────────────────────────────────────────────
+
+describe('import source registry', () => {
+  it('lists implemented and stubbed sources', () => {
+    const sources = listImportSources()
+    const names = sources.map(s => s.name)
+    expect(names).toEqual(expect.arrayContaining(['generic', 'gp-engram', 'mem0', 'zep', 'letta']))
+    expect(sources.find(s => s.name === 'generic')?.implemented).toBe(true)
+    expect(sources.find(s => s.name === 'gp-engram')?.implemented).toBe(true)
+    expect(sources.find(s => s.name === 'mem0')?.implemented).toBe(true)
+    expect(sources.find(s => s.name === 'zep')?.implemented).toBe(false)
+    expect(sources.find(s => s.name === 'letta')?.implemented).toBe(false)
+  })
+
+  it('zep and letta stubs throw a clear not-implemented error', () => {
+    expect(() => getImportSource('zep').parse({ path: 'x.json' })).toThrow(/not.*implemented/i)
+    expect(() => getImportSource('letta').parse({ path: 'x.json' })).toThrow(/not.*implemented/i)
+  })
+
+  it('unknown source names list the available ones', () => {
+    expect(() => getImportSource('supermemory')).toThrow(/generic.*gp-engram.*mem0/s)
+  })
+})
+
+// ─── Import engine (dedup gates, report, temporal, conflicts) ────────────────
+
+describe('runImport engine', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-import-test-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  const rec = (statement: string, extra: Partial<ImportRecord> = {}): ImportRecord =>
+    ({ statement, ...extra })
+
+  it('imports records through learn() and reports counts', () => {
+    const report = runImport(plur, [rec('fact one'), rec('fact two')], { from: 'generic' })
+    expect(report.total).toBe(2)
+    expect(report.imported).toBe(2)
+    expect(report.skipped).toBe(0)
+    expect(report.conflicts).toBe(0)
+    expect(report.errors).toBe(0)
+    expect(plur.list({})).toHaveLength(2)
+    expect(report.records.filter(r => r.action === 'imported')).toHaveLength(2)
+    expect(report.records[0].id).toMatch(/^ENG-/)
+  })
+
+  it('routes duplicates through the content-hash dedup gate (skipped, not re-added)', () => {
+    plur.learn('fact one', { scope: 'global' })
+    const report = runImport(plur, [rec('fact one', { scope: 'global' }), rec('fact two')], { from: 'generic' })
+    expect(report.imported).toBe(1)
+    expect(report.skipped).toBe(1)
+    expect(plur.list({})).toHaveLength(2)
+    const skipped = report.records.find(r => r.action === 'skipped')
+    expect(skipped?.id).toMatch(/^ENG-/) // points at the existing engram
+  })
+
+  it('dedups repeated statements within one import run', () => {
+    const report = runImport(plur, [rec('same fact'), rec('same fact')], { from: 'generic' })
+    expect(report.imported).toBe(1)
+    expect(report.skipped).toBe(1)
+    expect(plur.list({})).toHaveLength(1)
+  })
+
+  it('re-importing the same file is idempotent (all skipped)', () => {
+    runImport(plur, [rec('idem one'), rec('idem two')], { from: 'generic' })
+    const second = runImport(plur, [rec('idem one'), rec('idem two')], { from: 'generic' })
+    expect(second.imported).toBe(0)
+    expect(second.skipped).toBe(2)
+    expect(plur.list({})).toHaveLength(2)
+  })
+
+  it('re-importing an ALREADY-EXPIRED record is still a skip (learn-dedup parity)', () => {
+    // learn()'s content-hash dedup ignores temporal validity, so the engine's
+    // pre-existing snapshot must too — a plain list() drops engrams whose
+    // valid_until has passed, which would misreport the second run as
+    // "imported" and re-patch the existing engram's temporal metadata.
+    const expired = rec('conference wifi password is hunter2', { valid_until: '2020-01-01' })
+    const first = runImport(plur, [expired], { from: 'generic' })
+    expect(first.imported).toBe(1)
+    const learnedAt = plur.list({ include_expired: true })[0].temporal?.learned_at
+
+    const second = runImport(plur, [rec('conference wifi password is hunter2', {
+      valid_until: '2020-01-01',
+      created_at: '2010-05-05T00:00:00Z', // must NOT overwrite the existing engram
+    })], { from: 'generic' })
+    expect(second.imported).toBe(0)
+    expect(second.skipped).toBe(1)
+    expect(second.records[0].id).toMatch(/^ENG-/)
+
+    const engrams = plur.list({ include_expired: true })
+    expect(engrams).toHaveLength(1)
+    expect(engrams[0].temporal?.learned_at).toBe(learnedAt)
+
+    // dry-run predicts the same
+    const dry = runImport(plur, [expired], { from: 'generic', dryRun: true })
+    expect(dry.skipped).toBe(1)
+    expect(dry.imported).toBe(0)
+  })
+
+  it('dry-run predicts the report without writing anything', () => {
+    plur.learn('already here', { scope: 'global' })
+    const report = runImport(
+      plur,
+      [rec('already here', { scope: 'global' }), rec('brand new'), rec('brand new')],
+      { from: 'generic', dryRun: true },
+    )
+    expect(report.dry_run).toBe(true)
+    expect(report.total).toBe(3)
+    expect(report.imported).toBe(1)
+    expect(report.skipped).toBe(2) // one pre-existing dup + one in-file dup
+    expect(plur.list({})).toHaveLength(1) // nothing written
+  })
+
+  it('applies a scope override to every record', () => {
+    runImport(plur, [rec('scoped fact', { scope: 'user:bob' })], { from: 'generic', scope: 'project:acme' })
+    const [engram] = plur.list({})
+    expect(engram.scope).toBe('project:acme')
+  })
+
+  it('preserves temporal metadata from the source', () => {
+    runImport(plur, [rec('old knowledge', {
+      created_at: '2024-03-01T08:00:00Z',
+      last_accessed: '2025-01-15T09:00:00Z',
+      valid_until: '2027-01-01',
+    })], { from: 'generic' })
+    const [engram] = plur.list({})
+    expect(engram.temporal?.learned_at).toBe('2024-03-01T08:00:00Z')
+    expect(engram.temporal?.valid_until).toBe('2027-01-01')
+    expect(engram.temporal?.ingested_at).toBeDefined()
+    expect(engram.activation.last_accessed).toBe('2025-01-15')
+  })
+
+  it('maps confidence onto episodic.confidence (1-10)', () => {
+    runImport(plur, [rec('confident fact', { confidence: 0.9 })], { from: 'generic' })
+    const [engram] = plur.list({})
+    expect(engram.episodic?.confidence).toBe(9)
+  })
+
+  it('flags conflicts against pre-existing engrams and links relations.conflicts', () => {
+    const existing = plur.learn('The deploy target is fly.io', { scope: 'global', domain: 'infra.deploy' })
+    const report = runImport(
+      plur,
+      [rec('The deploy target is render.com', { scope: 'global', domain: 'infra.deploy' })],
+      { from: 'generic' },
+    )
+    expect(report.imported).toBe(1)
+    expect(report.conflicts).toBe(1)
+    const imported = report.records[0]
+    expect(imported.conflicts).toContain(existing.id)
+    const newEngram = plur.list({}).find(e => e.id === imported.id)
+    expect(newEngram?.relations?.conflicts).toContain(existing.id)
+  })
+
+  it('counts records that fail the learn gates as errors (e.g. secrets)', () => {
+    const report = runImport(
+      plur,
+      [rec('api key is sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGH'), rec('a clean fact')],
+      { from: 'generic' },
+    )
+    expect(report.imported).toBe(1)
+    expect(report.errors).toBe(1)
+    expect(report.records.find(r => r.action === 'error')?.error).toMatch(/secret/i)
+    expect(plur.list({})).toHaveLength(1)
+  })
+
+  it('counts empty statements as errors', () => {
+    const report = runImport(plur, [rec('')], { from: 'generic' })
+    expect(report.errors).toBe(1)
+    expect(report.imported).toBe(0)
+  })
+
+  it('stamps a default source label when the record has none', () => {
+    runImport(plur, [rec('unlabeled fact')], { from: 'mem0', defaultSource: 'import:mem0:memories.json' })
+    const [engram] = plur.list({})
+    expect(engram.source).toBe('import:mem0:memories.json')
+  })
+})
+
+// ─── importFrom: file → parse → engine end-to-end ────────────────────────────
+
+describe('importFrom end-to-end', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-importfrom-test-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('imports the generic JSON fixture with dedup of the in-file duplicate', () => {
+    const report = importFrom(plur, { from: 'generic', path: join(FIXTURES, 'generic.json') })
+    expect(report.from).toBe('generic')
+    expect(report.total).toBe(3)
+    expect(report.imported).toBe(2)
+    expect(report.skipped).toBe(1)
+    const engrams = plur.list({})
+    expect(engrams).toHaveLength(2)
+    const staged = engrams.find(e => e.statement.includes('staging API'))
+    expect(staged?.temporal?.valid_until).toBe('2026-12-31')
+  })
+
+  it('imports the mem0 fixture preserving scopes and temporal metadata', () => {
+    const report = importFrom(plur, { from: 'mem0', path: join(FIXTURES, 'mem0-export.json') })
+    expect(report.imported).toBe(3)
+    const engrams = plur.list({})
+    const darkMode = engrams.find(e => e.statement.includes('dark mode'))
+    expect(darkMode?.scope).toBe('user:alice')
+    expect(darkMode?.temporal?.learned_at).toBe('2025-09-14T12:00:00.000000-07:00')
+    expect(darkMode?.tags).toEqual(['preferences', 'ui'])
+  })
+
+  it('imports a gp-engram .db end-to-end', () => {
+    const require = createRequire(import.meta.url)
+    const Database = require('better-sqlite3')
+    const dbPath = join(dir, 'engram.db')
+    const db = new Database(dbPath)
+    db.exec(readFileSync(join(FIXTURES, 'gp-engram-fixture.sql'), 'utf-8'))
+    db.close()
+
+    const report = importFrom(plur, { from: 'gp-engram', path: dbPath })
+    expect(report.imported).toBe(3)
+    const engrams = plur.list({})
+    const pinned = engrams.find(e => e.statement.includes('Error wrapping'))
+    expect(pinned?.pinned).toBe(true)
+    expect(pinned?.scope).toBe('project:acme-api')
+  })
+
+  it('throws for a missing input file', () => {
+    expect(() => importFrom(plur, { from: 'generic', path: join(dir, 'nope.json') })).toThrow()
+    expect(existsSync(join(dir, 'nope.json'))).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      better-sqlite3:
+        specifier: ^11.0.0
+        version: 11.10.0
 
   packages/core:
     dependencies:
@@ -4350,21 +4353,18 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
-    optional: true
 
   bignumber.js@9.3.1: {}
 
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
-    optional: true
 
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   bn.js@4.12.3: {}
 
@@ -4405,7 +4405,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    optional: true
 
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
@@ -4445,8 +4444,7 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4:
-    optional: true
+  chownr@1.1.4: {}
 
   chownr@3.0.0: {}
 
@@ -4543,10 +4541,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-    optional: true
 
-  deep-extend@0.6.0:
-    optional: true
+  deep-extend@0.6.0: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -4575,8 +4571,7 @@ snapshots:
 
   depd@2.0.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node@2.1.0:
     optional: true
@@ -4734,8 +4729,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -4847,8 +4841,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  file-uri-to-path@1.0.0:
-    optional: true
+  file-uri-to-path@1.0.0: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -4883,8 +4876,7 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -4949,8 +4941,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
 
   glob@13.0.6:
     dependencies:
@@ -5089,8 +5080,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   ip-address@10.2.0: {}
 
@@ -5227,8 +5217,7 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  mimic-response@3.1.0:
-    optional: true
+  mimic-response@3.1.0: {}
 
   minimalistic-assert@1.0.1: {}
 
@@ -5244,8 +5233,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -5264,8 +5252,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
+  napi-build-utils@2.0.0: {}
 
   negotiator@1.0.0: {}
 
@@ -5274,7 +5261,6 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
-    optional: true
 
   node-addon-api@8.7.0: {}
 
@@ -5557,7 +5543,6 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
-    optional: true
 
   process-nextick-args@2.0.1: {}
 
@@ -5640,7 +5625,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
 
   readable-stream@2.3.8:
     dependencies:
@@ -5657,7 +5641,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-    optional: true
 
   readdirp@4.1.2: {}
 
@@ -5847,15 +5830,13 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
 
   sisteransi@1.0.5: {}
 
@@ -5944,8 +5925,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   strnum@2.3.0: {}
 
@@ -5977,7 +5957,6 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
-    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -5986,7 +5965,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   tar@7.5.11:
     dependencies:
@@ -6099,7 +6077,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   type-fest@0.13.1:
     optional: true


### PR DESCRIPTION
## What

`plur import --from <source> --path <file>` — bring existing memory from competitor systems into PLUR. All imports route through the existing `learn()` dedup gates (content-hash fast path, cross-scope recurrence) and the secret guard — **never raw-appended**. Prints a migration report: N imported, M skipped (dedup), K conflicts, errors.

## Importers

| Source | Status | Notes |
|--------|--------|-------|
| `generic` | ✅ | JSON / JSONL / CSV; optional `--mapping` config with dot-paths + defaults; statement-field aliases (`text`, `memory`, `content`, ...); wrapper unwrapping; minimal RFC 4180 CSV parser |
| `gp-engram` | ✅ flagship | [Gentleman-Programming/engram](https://github.com/Gentleman-Programming/engram) SQLite `.db`. Schema verified against upstream `internal/store/store.go` — `observations` table, `normalizeScope` (`project`\|`personal`\|`global`), soft-delete filtering, migration-added columns selected only when present |
| `mem0` | ✅ | `Memory.get_all()` `{"results": [...]}` shape; `user_id`/`agent_id` → scope, `categories` → tags, `expiration_date` → `valid_until` |
| `zep`, `letta` | 🔜 stubs | Registered adapters with actionable not-implemented errors — both export formats still churn across versions. `--from generic` + `--mapping` works meanwhile |

## gp-engram mapping highlights

- `title + content` → statement; `type` → PLUR type via a normalization table covering upstream's full type vocabulary, original type preserved as a tag
- `topic_key` → dotted domain (`decision/storage` → `decision.storage`)
- `scope`+`project` → `global` / `project:<name>` / unset (personal → core routing)
- `created_at`/`last_seen_at` → `temporal.learned_at` / `activation.last_accessed` (SQLite UTC datetimes normalized to ISO Z)
- `expires_at` → `temporal.valid_until` (upstream keeps it NULL in Phase 1, but the migration column exists); `review_after` deliberately **not** mapped — it's a decay "review by" date, not an expiry

## Conflict handling

Heuristic pre-filter reused from the tension scan (scope partition → domain overlap → subject overlap). Conflicted records are still imported (dropping data on a heuristic would be worse), counted in the report, and linked via `relations.conflicts` so `plur tensions --scan` can confirm with an LLM later.

## Bug fixed along the way

`list()` drops temporally-expired engrams, but `learn()`'s content-hash dedup does not — so re-importing an already-expired record was misreported as a fresh import and re-patched the existing engram's temporal metadata. `list()` gains an `include_expired` option and the import engine uses it for dedup-identity parity. Regression test included; verified end-to-end (re-import of the mem0 fixture is now fully idempotent: 0 imported / 3 skipped).

## CLI

```bash
plur import --from gp-engram --path ~/.engram/engram.db
plur import --from mem0 --path ./memories.json --dry-run
plur import --from generic --path ./export.csv --mapping ./mapping.json --scope project:acme
```

Note the flag split (documented in README + help): for `import`, `--path` is the **input file** per the issue spec; `--store <dir>` overrides the storage directory.

## Tests

- 46 core tests (parsers, normalization, registry, engine dedup/dry-run/temporal/conflicts/secrets, fixture end-to-end)
- 9 CLI tests (subprocess runs against `dist`)
- Hand-written fixtures per format checked in; the gp-engram `.db` is built at test time from a SQL fixture — **no network in tests**
- Full suites green: core 1679, cli 236, mcp 161, claw 110; new suites stable under 3× concurrent load

## Dependencies

`better-sqlite3` added to **cli devDependencies only** (test fixture building); runtime reuses core's existing `optionalDependency` via the same `createRequire` pattern as `store/sqlite-store.ts`. No new runtime dependencies.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1