### PR TITLE
feat(core): halfvec (fp16) precision tier for the PGLite embedding column

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,7 +90,7 @@ export { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandida
 export { isSharedScope, isPersonalScope, SHARED_SCOPE_PREFIXES } from './scope-util.js'
 export { detectPlurStorage, type PlurPaths } from './storage.js'
 export { IndexedStorage } from './storage-indexed.js'
-export { PGLiteAdapter, type PGLiteAdapterOptions } from './storage-pglite.js'
+export { PGLiteAdapter, type PGLiteAdapterOptions, type VectorPrecision } from './storage-pglite.js'
 export type { StorageAdapter, StorageFilter, VectorSearchHit } from './storage-adapter.js'
 export { YamlStore, SqliteStore, createStore, migrateStore, type EngramStore, type StorageBackend, type StorageConfig } from './store/index.js'
 export { withAsyncLock, asyncAtomicWrite } from './store/index.js'
@@ -353,7 +353,11 @@ export class Plur {
     const backend = this._resolveBackend()
     if (backend === 'pglite') {
       // PGLite path. Keep SQLite indexedStorage null so we don't double-index.
-      this.pgliteAdapter = new PGLiteAdapter(this.paths.engrams, this.paths.pglite)
+      // vector.precision (#223): unset = keep the store's existing column
+      // type; 'halfvec' opts in to fp16 storage (lazy in-place migration).
+      this.pgliteAdapter = new PGLiteAdapter(this.paths.engrams, this.paths.pglite, {
+        precision: this.config.vector?.precision,
+      })
       // Initial sync runs in the background — YAML is already authoritative,
       // so reads served from the YAML fallthrough remain correct while the
       // index warms up.

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -95,6 +95,35 @@ export const EmbeddingsConfigSchema = z.object({
 
 export type EmbeddingsConfigYaml = z.infer<typeof EmbeddingsConfigSchema>
 
+/**
+ * Vector-column configuration for the PGLite/pgvector index (#223).
+ *
+ * `precision` selects the pgvector storage type for the embedding column:
+ *   - `float32` — pgvector `vector(N)`, 4 bytes/dim (the historical layout)
+ *   - `halfvec` — pgvector `halfvec(N)`, 2 bytes/dim (~50% smaller,
+ *     -0.2 to -0.5pp recall). Requires pgvector >= 0.7; PGLite 0.4.x bundles
+ *     0.8.1, verified working in the WASM build. Note: in PGLite (WASM, no
+ *     F16C) halfvec exact scans cost ~3-10x more CPU than float32 — pick it
+ *     for storage-constrained stores, not for speed.
+ *
+ * When UNSET, the adapter keeps whatever the existing store already uses
+ * (float32 for new stores) — omitting the knob never migrates a store.
+ * Setting it migrates lazily on next init via an atomic in-place
+ * `ALTER TABLE ... USING embedding::<type>(N)` cast (no re-embed needed);
+ * `plur sync --full` drops and rebuilds the derived index from YAML at the
+ * configured precision per ADR-0001's rebuildability invariant.
+ *
+ * int8 scalar and binary quantization are deferred: pgvector has no int8
+ * vector column type (its types are vector/halfvec/sparsevec/bit), and
+ * binary-quantized retrieval only makes sense paired with the #220
+ * cross-encoder rerank pass.
+ */
+export const VectorConfigSchema = z.object({
+  precision: z.enum(['float32', 'halfvec']),
+}).partial()
+
+export type VectorConfigYaml = z.infer<typeof VectorConfigSchema>
+
 export const PlurConfigSchema = z.object({
   auto_learn: z.boolean().default(true),
   auto_capture: z.boolean().default(true),
@@ -134,6 +163,7 @@ export const PlurConfigSchema = z.object({
   backend: z.enum(['sqlite', 'pglite']).default('sqlite'),
   storage: StorageConfigSchema.default({}),
   embeddings: EmbeddingsConfigSchema.default({}),
+  vector: VectorConfigSchema.default({}),
   stores: z.array(StoreEntrySchema).default([]),
   llm: LlmTierConfigSchema.default({}),
   profile: ProfileConfigSchema.default({}),

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -10,9 +10,10 @@
  * If step 2 fails, YAML still wins on next `plur sync`.
  *
  * Vector storage: when pgvector loads cleanly, we use a `vector(N)` column
- * with a cosine-similarity ORDER BY. When pgvector isn't available (rare —
- * the extension ships in PGLite as of 0.4.x), we fall back to BYTEA storage
- * and compute cosine in TypeScript. Same external behavior either way.
+ * (or `halfvec(N)` at the fp16 precision tier, #223) with a cosine-similarity
+ * ORDER BY. When pgvector isn't available (rare — the extension ships in
+ * PGLite as of 0.4.x), we fall back to BYTEA storage and compute cosine in
+ * TypeScript. Same external behavior either way.
  *
  * Concurrency: PGLite is single-writer per process. We serialize through a
  * lightweight async mutex on this adapter so concurrent `reindex()` /
@@ -85,15 +86,57 @@ async function loadPgliteAge(): Promise<unknown | null> {
   }
 }
 
+/**
+ * Precision tier for the embedding column (#223).
+ *   - `float32` → pgvector `vector(N)`  (4 bytes/dim — historical layout)
+ *   - `halfvec` → pgvector `halfvec(N)` (2 bytes/dim — ~50% smaller,
+ *      -0.2 to -0.5pp recall; pgvector >= 0.7, bundled 0.8.1 in PGLite 0.4.x)
+ *
+ * Latency caveat (measured 2026-07-02, 1k engrams @ 384d): halfvec exact
+ * scans are ~3-10x slower than float32 in PGLite because the WASM build has
+ * no F16C — every fp16 element is software-converted per distance call
+ * (~3ms → ~11-33ms mean per search at 1k rows; both fine interactively).
+ * halfvec trades CPU for storage here; float32 stays the default.
+ */
+export type VectorPrecision = 'float32' | 'halfvec'
+
+/** Map precision tier → pgvector column type name. */
+const PRECISION_TYPE: Record<VectorPrecision, 'vector' | 'halfvec'> = {
+  float32: 'vector',
+  halfvec: 'halfvec',
+}
+
 export interface PGLiteAdapterOptions {
   /** Vector dimension for the embedding column (default: 384 — BGE-small). */
   vectorDim?: number
+  /**
+   * Desired precision for the embedding column (#223).
+   *
+   * UNSET means "keep whatever the store already uses" (float32 for new
+   * stores) — option-less constructors (dim-check, tests, older callers)
+   * must never silently migrate a store. When SET and the existing column
+   * differs, the column is migrated lazily on init via an atomic in-place
+   * `ALTER TABLE ... USING embedding::<type>(N)` cast: embeddings are
+   * preserved (cast, not re-embedded), and the existing column dim is kept
+   * so the #219 dim-mismatch check stays honest. YAML remains the source of
+   * truth either way — `plur sync --full` drops and rebuilds the index from
+   * YAML at the configured precision (ADR-0001 rebuildability invariant).
+   */
+  precision?: VectorPrecision
 }
 
 export class PGLiteAdapter implements StorageAdapter {
   private yamlPath: string
   private dbPath: string
   private vectorDim: number
+  /** Desired precision; undefined = keep whatever the store already has. */
+  private precision: VectorPrecision | undefined
+  /**
+   * ACTUAL type of the embedding column after init ('vector' | 'halfvec').
+   * All SQL casts use this — so even when a requested migration fails, reads
+   * and writes keep matching the on-disk column instead of erroring.
+   */
+  private activeVecType: 'vector' | 'halfvec' = 'vector'
   private db: any = null
   private initialized = false
   private hasVector = false
@@ -104,6 +147,7 @@ export class PGLiteAdapter implements StorageAdapter {
     this.yamlPath = yamlPath
     this.dbPath = dbPath
     this.vectorDim = opts?.vectorDim ?? DEFAULT_VECTOR_DIM
+    this.precision = opts?.precision
   }
 
   /** Open the PGLite DB and create schema if needed. */
@@ -171,12 +215,16 @@ export class PGLiteAdapter implements StorageAdapter {
     // Embedding table: separate so adding/replacing embeddings is cheap and
     // doesn't churn engram rows. Use vector when available, BYTEA fallback.
     if (this.hasVector) {
+      // New stores are created at the requested precision (float32 when the
+      // knob is unset — the historical layout).
+      const wantType = PRECISION_TYPE[this.precision ?? 'float32']
       await db.exec(`
         CREATE TABLE IF NOT EXISTS engram_embeddings (
           engram_id TEXT PRIMARY KEY,
-          embedding vector(${this.vectorDim}) NOT NULL
+          embedding ${wantType}(${this.vectorDim}) NOT NULL
         );
       `)
+      await this.ensureColumnPrecision(db)
     } else {
       await db.exec(`
         CREATE TABLE IF NOT EXISTS engram_embeddings (
@@ -196,6 +244,95 @@ export class PGLiteAdapter implements StorageAdapter {
       } catch (err) {
         logger.debug(`[pglite] AGE graph init skipped: ${(err as Error).message}`)
       }
+    }
+  }
+
+  /**
+   * Read the actual type + dim of engram_embeddings.embedding from the
+   * catalog: format_type() returns "vector(N)" or "halfvec(N)".
+   */
+  private async readEmbeddingColumnInfo(db: any): Promise<{ type: 'vector' | 'halfvec'; dim: number } | null> {
+    const res = await db.query(
+      `SELECT format_type(a.atttypid, a.atttypmod) AS t
+       FROM pg_attribute a
+       JOIN pg_class c ON c.oid = a.attrelid
+       WHERE c.relname = 'engram_embeddings' AND a.attname = 'embedding' AND a.attnum > 0`,
+    )
+    if (res.rows.length === 0) return null
+    const m = String(res.rows[0].t).match(/^(vector|halfvec)\((\d+)\)$/i)
+    if (!m) return null
+    return { type: m[1].toLowerCase() as 'vector' | 'halfvec', dim: Number(m[2]) }
+  }
+
+  /**
+   * Lazy precision migration (#223). Runs once per init, inside initSchema.
+   *
+   * - `precision` unset → adopt the existing column type, migrate nothing.
+   * - `precision` set and column differs → atomic in-place
+   *   `ALTER TABLE ... TYPE <type>(dim) USING embedding::<type>(dim)`.
+   *   The cast preserves every stored embedding (float32→float16 rounds,
+   *   float16→float32 widens) — no re-embedding, no seq-scan window: DDL in
+   *   Postgres is transactional, so readers see the old or the new column,
+   *   never neither. The EXISTING dim is kept (not this.vectorDim) so a
+   *   precision migration can't mask a #219 dim mismatch.
+   * - Any dependent hnsw/ivfflat index is dropped first (its opclass is
+   *   type-specific and would abort the ALTER) and recreated with the
+   *   matching opclass inside the same transaction — the gbrain pattern.
+   *   (This adapter itself creates no vector index yet; exact scan at
+   *   current corpus sizes. The recreation is for stores where one was
+   *   added out-of-band.)
+   * - Failure is non-fatal: activeVecType keeps tracking the on-disk
+   *   column, so reads/writes continue at the old precision.
+   */
+  private async ensureColumnPrecision(db: any): Promise<void> {
+    const info = await this.readEmbeddingColumnInfo(db)
+    if (!info) return // BYTEA fallback or exotic column — nothing to manage
+    this.activeVecType = info.type
+    if (this.precision === undefined) return // keep-existing semantics
+    const wantType = PRECISION_TYPE[this.precision]
+    if (info.type === wantType) return
+    const opclassFor = (t: 'vector' | 'halfvec', old: string): string => {
+      // vector_cosine_ops → halfvec_cosine_ops (and back) — same suffix,
+      // target type's prefix.
+      const suffix = old.replace(/^(vector|halfvec)_/, '')
+      return `${t}_${suffix}`
+    }
+    try {
+      await db.exec('BEGIN')
+      // Collect vector-opclass indexes on the embedding column; they block
+      // the ALTER and need their opclass swapped to the target type's.
+      const idxRes = await db.query(
+        `SELECT i.relname AS name, am.amname AS method, opc.opcname AS opclass
+         FROM pg_index x
+         JOIN pg_class i ON i.oid = x.indexrelid
+         JOIN pg_class t ON t.oid = x.indrelid
+         JOIN pg_am am ON am.oid = i.relam
+         JOIN pg_opclass opc ON opc.oid = x.indclass[0]
+         WHERE t.relname = 'engram_embeddings'
+           AND am.amname IN ('hnsw', 'ivfflat')`,
+      )
+      for (const row of idxRes.rows) {
+        await db.exec(`DROP INDEX "${row.name}"`)
+      }
+      await db.exec(
+        `ALTER TABLE engram_embeddings
+         ALTER COLUMN embedding TYPE ${wantType}(${info.dim})
+         USING embedding::${wantType}(${info.dim})`,
+      )
+      for (const row of idxRes.rows) {
+        const opclass = opclassFor(wantType, String(row.opclass))
+        await db.exec(
+          `CREATE INDEX "${row.name}" ON engram_embeddings USING ${row.method} (embedding ${opclass})`,
+        )
+      }
+      await db.exec('COMMIT')
+      this.activeVecType = wantType
+      logger.info(`[pglite] migrated embedding column ${info.type}(${info.dim}) -> ${wantType}(${info.dim})`)
+    } catch (err) {
+      await db.exec('ROLLBACK').catch(() => {})
+      logger.warning(
+        `[pglite] precision migration to ${wantType} failed (staying on ${info.type}): ${(err as Error).message}`,
+      )
     }
   }
 
@@ -368,14 +505,17 @@ export class PGLiteAdapter implements StorageAdapter {
     const totalRes = await db.query('SELECT COUNT(*)::int AS c FROM engram_embeddings')
     if (Number(totalRes.rows[0].c) === 0) return []
     if (this.hasVector) {
-      // pgvector path. Cosine distance = 1 - cosine similarity.
+      // pgvector path. Cosine distance = 1 - cosine similarity. The query
+      // param is cast to the column's ACTUAL type (#223) — pgvector's <=>
+      // operators are per-type, so a halfvec column needs a halfvec operand.
+      const t = this.activeVecType
       const literal = vectorLiteral(query)
       const res = await db.query(
-        `SELECT e.data, 1 - (em.embedding <=> $1::vector) AS score
+        `SELECT e.data, 1 - (em.embedding <=> $1::${t}) AS score
          FROM engram_embeddings em
          JOIN engrams e ON e.id = em.engram_id
          WHERE e.status = 'active'
-         ORDER BY em.embedding <=> $1::vector
+         ORDER BY em.embedding <=> $1::${t}
          LIMIT $2`,
         [literal, limit],
       )
@@ -403,10 +543,12 @@ export class PGLiteAdapter implements StorageAdapter {
     return this.mutex.run(async () => {
       const db = await this.getDb()
       if (this.hasVector) {
+        // Cast to the column's actual type (#223): halfvec parses the same
+        // "[...]" literal and rounds to fp16 on write.
         const literal = vectorLiteral(vector)
         await db.query(
           `INSERT INTO engram_embeddings (engram_id, embedding)
-           VALUES ($1, $2::vector)
+           VALUES ($1, $2::${this.activeVecType})
            ON CONFLICT (engram_id) DO UPDATE SET embedding = EXCLUDED.embedding`,
           [engramId, literal],
         )
@@ -432,22 +574,20 @@ export class PGLiteAdapter implements StorageAdapter {
     return res.rows.length > 0
   }
 
-  /** Dimension the embedding column was sized to (vector(N)), or null when not a pgvector column. Lets the auto-embed path skip when the active embedder dim differs from the indexed dim. */
+  /** Dimension the embedding column was sized to (vector(N) or halfvec(N)), or null when not a pgvector column. Lets the auto-embed path skip when the active embedder dim differs from the indexed dim. */
   async getVectorColumnDim(): Promise<number | null> {
     const db = await this.getDb()
     if (!this.hasVector) return null
-    // format_type(atttypid, atttypmod) on a `vector(N)` column returns the
-    // literal string "vector(N)" — parse the N back out.
-    const res = await db.query(
-      `SELECT format_type(a.atttypid, a.atttypmod) AS t
-       FROM pg_attribute a
-       JOIN pg_class c ON c.oid = a.attrelid
-       WHERE c.relname = 'engram_embeddings' AND a.attname = 'embedding' AND a.attnum > 0`,
-    )
-    if (res.rows.length === 0) return null
-    const t = String(res.rows[0].t)
-    const m = t.match(/vector\((\d+)\)/i)
-    return m ? Number(m[1]) : null
+    const info = await this.readEmbeddingColumnInfo(db)
+    return info?.dim ?? null
+  }
+
+  /** Actual pgvector type of the embedding column ('vector' | 'halfvec'), or null on the BYTEA fallback. Used by tests + diagnostics for the #223 precision tiers. */
+  async getVectorColumnType(): Promise<'vector' | 'halfvec' | null> {
+    const db = await this.getDb()
+    if (!this.hasVector) return null
+    const info = await this.readEmbeddingColumnInfo(db)
+    return info?.type ?? null
   }
 
   /** Number of rows in engram_embeddings. Used by tests + diagnostics to confirm the vector index is populated. */

--- a/packages/core/test/pglite-precision.test.ts
+++ b/packages/core/test/pglite-precision.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Vector precision tiers on the PGLite embedding column — issue #223.
+ *
+ * Contract:
+ * - `precision: 'halfvec'` stores embeddings in a pgvector `halfvec(N)`
+ *   (float16) column — ~50% the storage of the float32 `vector(N)` default.
+ * - The knob is a DB-only concern. YAML stays the source of truth (ADR-0001);
+ *   the column can be migrated in place or rebuilt from YAML at any time.
+ * - Backward compatible both ways:
+ *     - An EXISTING float32 store opened with `precision: 'halfvec'` is
+ *       migrated lazily on init via an atomic
+ *       `ALTER TABLE ... TYPE halfvec(N) USING embedding::halfvec(N)`.
+ *       Embeddings are preserved (cast, not re-embedded).
+ *     - An existing halfvec store opened WITHOUT a precision option keeps its
+ *       halfvec column — omitting the option means "keep what's there",
+ *       never "migrate back to float32".
+ * - Search behavior is unchanged: same SQL shape, same score orientation
+ *   (cosine similarity, higher = closer), fp16 rounding on the stored side.
+ *
+ * Feasibility (verified 2026-07-02 against the runtime this repo ships):
+ * PGLite 0.4.6 bundles PostgreSQL 17.5 + pgvector 0.8.1 (halfvec landed in
+ * pgvector 0.7.0). halfvec columns, `<=>` cosine, the vector→halfvec ALTER
+ * cast, and hnsw halfvec_cosine_ops all work in the WASM build.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import { PlurConfigSchema } from '../src/schemas/config.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function mkEngram(id: string, statement: string, opts: Partial<Engram> = {}): Engram {
+  return {
+    id,
+    statement,
+    type: 'behavioral',
+    scope: 'project:plur',
+    domain: 'plur.test',
+    status: 'active',
+    tags: [],
+    activation: {
+      retrieval_strength: 1.0,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-07-02',
+    },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    ...(opts as any),
+  } as Engram
+}
+
+function seedYaml(path: string, engrams: Engram[]): void {
+  writeFileSync(path, yaml.dump({ engrams }), 'utf8')
+}
+
+/** Deterministic 8-dim unit-ish vectors with well-separated directions. */
+function vec(values: number[]): Float32Array {
+  return new Float32Array(values)
+}
+
+const PGLITE_TIMEOUT = 30_000
+
+describe('PGLite vector precision (#223)', () => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-pglite-prec-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'store.pglite')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  describe('column type selection', () => {
+    it('defaults to float32 vector(N) when precision is omitted (existing behavior)', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0702-001', 'alpha')])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8 })
+      await adapter.reindex()
+      expect(await adapter.getVectorColumnType()).toBe('vector')
+      expect(await adapter.getVectorColumnDim()).toBe(8)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it("creates a halfvec(N) column when precision is 'halfvec'", async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0702-001', 'alpha')])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8, precision: 'halfvec' })
+      await adapter.reindex()
+      expect(await adapter.getVectorColumnType()).toBe('halfvec')
+      // getVectorColumnDim must parse halfvec(N) too — the auto-embed
+      // dim-check depends on it.
+      expect(await adapter.getVectorColumnDim()).toBe(8)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('search at halfvec precision', () => {
+    it('upsert + searchVector work on a halfvec column with correct ordering', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0702-001', 'north'),
+        mkEngram('ENG-2026-0702-002', 'east'),
+        mkEngram('ENG-2026-0702-003', 'diagonal'),
+      ])
+      const adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8, precision: 'halfvec' })
+      await adapter.reindex()
+      await adapter.upsertEmbedding('ENG-2026-0702-001', vec([1, 0, 0, 0, 0, 0, 0, 0]))
+      await adapter.upsertEmbedding('ENG-2026-0702-002', vec([0, 1, 0, 0, 0, 0, 0, 0]))
+      await adapter.upsertEmbedding('ENG-2026-0702-003', vec([0.9, 0.1, 0, 0, 0, 0, 0, 0]))
+
+      const hits = await adapter.searchVector(vec([1, 0, 0, 0, 0, 0, 0, 0]), 3)
+      expect(hits.map(h => h.engram.id)).toEqual([
+        'ENG-2026-0702-001',
+        'ENG-2026-0702-003',
+        'ENG-2026-0702-002',
+      ])
+      // Cosine similarity orientation preserved: exact match ≈ 1 (fp16 rounding).
+      expect(hits[0].score).toBeGreaterThan(0.999)
+      expect(hits[2].score).toBeLessThan(0.01)
+      await adapter.close()
+    }, PGLITE_TIMEOUT)
+
+    it('halfvec ranking matches float32 ranking on the same data (recall parity)', async () => {
+      const ids = ['ENG-2026-0702-001', 'ENG-2026-0702-002', 'ENG-2026-0702-003', 'ENG-2026-0702-004']
+      seedYaml(yamlPath, ids.map((id, i) => mkEngram(id, `engram ${i}`)))
+      // Deterministic pseudo-random vectors, same for both stores.
+      const vectors = ids.map((_, i) =>
+        vec(Array.from({ length: 8 }, (_, j) => Math.sin(i * 8 + j + 1))),
+      )
+      const query = vec(Array.from({ length: 8 }, (_, j) => Math.cos(j * 0.7)))
+
+      const dbFull = join(dir, 'full.pglite')
+      const dbHalf = join(dir, 'half.pglite')
+      const full = new PGLiteAdapter(yamlPath, dbFull, { vectorDim: 8 })
+      const half = new PGLiteAdapter(yamlPath, dbHalf, { vectorDim: 8, precision: 'halfvec' })
+      await full.reindex()
+      await half.reindex()
+      for (let i = 0; i < ids.length; i++) {
+        await full.upsertEmbedding(ids[i], vectors[i])
+        await half.upsertEmbedding(ids[i], vectors[i])
+      }
+      const fullHits = await full.searchVector(query, 4)
+      const halfHits = await half.searchVector(query, 4)
+      expect(halfHits.map(h => h.engram.id)).toEqual(fullHits.map(h => h.engram.id))
+      for (let i = 0; i < fullHits.length; i++) {
+        expect(halfHits[i].score).toBeCloseTo(fullHits[i].score, 2)
+      }
+      await full.close()
+      await half.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('lazy migration on init', () => {
+    it('migrates an existing float32 store to halfvec, preserving embeddings', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0702-001', 'north'),
+        mkEngram('ENG-2026-0702-002', 'east'),
+      ])
+      const v1 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8 })
+      await v1.reindex()
+      await v1.upsertEmbedding('ENG-2026-0702-001', vec([1, 0, 0, 0, 0, 0, 0, 0]))
+      await v1.upsertEmbedding('ENG-2026-0702-002', vec([0, 1, 0, 0, 0, 0, 0, 0]))
+      expect(await v1.getVectorColumnType()).toBe('vector')
+      await v1.close()
+
+      // Reopen at halfvec precision — lazy ALTER, no re-embed.
+      const v2 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8, precision: 'halfvec' })
+      expect(await v2.getVectorColumnType()).toBe('halfvec')
+      expect(await v2.countEmbeddings()).toBe(2) // embeddings preserved via cast
+      const hits = await v2.searchVector(vec([1, 0, 0, 0, 0, 0, 0, 0]), 2)
+      expect(hits[0].engram.id).toBe('ENG-2026-0702-001')
+      expect(hits[0].score).toBeGreaterThan(0.999)
+      await v2.close()
+    }, PGLITE_TIMEOUT)
+
+    it('migrates a halfvec store back to float32 when precision is explicitly float32', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0702-001', 'north')])
+      const v1 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8, precision: 'halfvec' })
+      await v1.reindex()
+      await v1.upsertEmbedding('ENG-2026-0702-001', vec([1, 0, 0, 0, 0, 0, 0, 0]))
+      await v1.close()
+
+      const v2 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8, precision: 'float32' })
+      expect(await v2.getVectorColumnType()).toBe('vector')
+      expect(await v2.countEmbeddings()).toBe(1)
+      const hits = await v2.searchVector(vec([1, 0, 0, 0, 0, 0, 0, 0]), 1)
+      expect(hits[0].engram.id).toBe('ENG-2026-0702-001')
+      await v2.close()
+    }, PGLITE_TIMEOUT)
+
+    it('keeps a halfvec column when reopened WITHOUT a precision option (no silent down-migration)', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0702-001', 'north')])
+      const v1 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8, precision: 'halfvec' })
+      await v1.reindex()
+      await v1.upsertEmbedding('ENG-2026-0702-001', vec([1, 0, 0, 0, 0, 0, 0, 0]))
+      await v1.close()
+
+      // Option-less open — the shape used by dim-check and older callers.
+      const v2 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8 })
+      expect(await v2.getVectorColumnType()).toBe('halfvec')
+      // Reads AND writes still work against the existing halfvec column.
+      const hits = await v2.searchVector(vec([1, 0, 0, 0, 0, 0, 0, 0]), 1)
+      expect(hits[0].engram.id).toBe('ENG-2026-0702-001')
+      await v2.upsertEmbedding('ENG-2026-0702-001', vec([0, 1, 0, 0, 0, 0, 0, 0]))
+      await v2.close()
+    }, PGLITE_TIMEOUT)
+
+    it('migration preserves the EXISTING column dim, not the configured one', async () => {
+      seedYaml(yamlPath, [mkEngram('ENG-2026-0702-001', 'north')])
+      // Store created at 8d.
+      const v1 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8 })
+      await v1.reindex()
+      await v1.upsertEmbedding('ENG-2026-0702-001', vec([1, 0, 0, 0, 0, 0, 0, 0]))
+      await v1.close()
+
+      // Reopened with a DIFFERENT configured dim (the dim-mismatch scenario,
+      // #219) + halfvec. Precision migrates; dim must stay 8 so the
+      // auto-embed dim-check keeps flagging the mismatch honestly.
+      const v2 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 384, precision: 'halfvec' })
+      expect(await v2.getVectorColumnType()).toBe('halfvec')
+      expect(await v2.getVectorColumnDim()).toBe(8)
+      await v2.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('index recreation during migration (gbrain pattern)', () => {
+    it('drops and recreates an out-of-band HNSW index with the matching opclass, atomically', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0702-001', 'north'),
+        mkEngram('ENG-2026-0702-002', 'east'),
+      ])
+      const v1 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8 })
+      await v1.reindex()
+      await v1.upsertEmbedding('ENG-2026-0702-001', vec([1, 0, 0, 0, 0, 0, 0, 0]))
+      await v1.upsertEmbedding('ENG-2026-0702-002', vec([0, 1, 0, 0, 0, 0, 0, 0]))
+      // Simulate a store where an HNSW index was added out-of-band. Its
+      // vector_cosine_ops opclass is type-specific and would block the ALTER.
+      const db1 = await (v1 as any).getDb()
+      await db1.exec(
+        'CREATE INDEX engram_embeddings_hnsw ON engram_embeddings USING hnsw (embedding vector_cosine_ops)',
+      )
+      await v1.close()
+
+      const v2 = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: 8, precision: 'halfvec' })
+      expect(await v2.getVectorColumnType()).toBe('halfvec') // migration succeeded despite the index
+      const db2 = await (v2 as any).getDb()
+      const idx = await db2.query(
+        `SELECT am.amname AS method, opc.opcname AS opclass
+         FROM pg_index x
+         JOIN pg_class i ON i.oid = x.indexrelid
+         JOIN pg_am am ON am.oid = i.relam
+         JOIN pg_opclass opc ON opc.oid = x.indclass[0]
+         WHERE i.relname = 'engram_embeddings_hnsw'`,
+      )
+      expect(idx.rows).toHaveLength(1) // index survived the migration...
+      expect(idx.rows[0].method).toBe('hnsw')
+      expect(idx.rows[0].opclass).toBe('halfvec_cosine_ops') // ...with the swapped opclass
+      // Search still works and still ranks correctly through the new column.
+      const hits = await v2.searchVector(vec([1, 0, 0, 0, 0, 0, 0, 0]), 2)
+      expect(hits[0].engram.id).toBe('ENG-2026-0702-001')
+      await v2.close()
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('config knob', () => {
+    it('parses vector.precision from config', () => {
+      const cfg = PlurConfigSchema.parse({ vector: { precision: 'halfvec' } })
+      expect(cfg.vector?.precision).toBe('halfvec')
+    })
+
+    it('leaves precision undefined when absent (keep-existing semantics)', () => {
+      const cfg = PlurConfigSchema.parse({})
+      expect(cfg.vector?.precision).toBeUndefined()
+    })
+
+    it('rejects unknown precision values', () => {
+      expect(() => PlurConfigSchema.parse({ vector: { precision: 'int4' } })).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Closes #223

## What

Opt-in `halfvec` (float16) precision tier for the PGLite/pgvector embedding column, behind a new `vector.precision` config knob (`float32` | `halfvec`). Default unchanged: `float32` for new stores, and an **unset knob never migrates an existing store**.

## Feasibility gate (verified in this runtime, 2026-07-02)

PGLite 0.4.6 bundles PostgreSQL 17.5 + pgvector **0.8.1** (halfvec landed in pgvector 0.7.0). Verified against a scratch PGLite instance in this repo's WASM build:

- `CREATE TABLE t (v halfvec(384))` — OK
- `<=>` cosine distance on halfvec operands — OK
- `ALTER TABLE ... ALTER COLUMN ... TYPE halfvec(N) USING v::halfvec(N)` — OK
- `CREATE INDEX ... USING hnsw (v halfvec_cosine_ops)` — OK

## Migration path (documented choice: lazy in-place, per ADR-0001)

**Lazy in-place migration** on adapter init, not rebuild-from-YAML:

- `precision` set + column differs → one transaction: drop any dependent hnsw/ivfflat index (its opclass is type-specific and blocks the ALTER) → `ALTER TABLE engram_embeddings ALTER COLUMN embedding TYPE <type>(dim) USING embedding::<type>(dim)` → recreate the index with the matching opclass (`vector_cosine_ops` ↔ `halfvec_cosine_ops`) → commit. The gbrain pattern — no seq-scan window, embeddings preserved via cast (no re-embed).
- `precision` unset → adopt whatever the column already is (`activeVecType`), migrate nothing. Option-less constructors (dim-check #219, tests, older callers) can never silently migrate a store.
- Migration keeps the **existing** column dim, not the configured one, so a precision migration can't mask a #219 dim mismatch.
- Migration failure is non-fatal: `activeVecType` keeps tracking the on-disk column, reads/writes continue at the old precision.
- Rebuild-from-YAML stays available as the recovery path per ADR-0001: `plur sync --full` drops the derived index and recreates it at the configured precision (YAML remains the source of truth; precision is a DB-only concern).

Why lazy over rebuild-as-default: the ALTER cast is ~1.2s for 1k embeddings with zero re-embedding cost, while a YAML rebuild re-embeds the whole corpus (minutes at 1k+, needs the embedder loaded). Rebuild remains the escape hatch.

All SQL casts (`searchVector`, `upsertEmbedding`) use the column's *actual* type, so a store whose migration failed — or that was created by an older version — keeps working.

## Numbers (1k engrams @ 384d, PGLite 0.4.6 WASM, M-series macOS)

**Storage**

| | float32 `vector(384)` | halfvec `halfvec(384)` | delta |
|---|---|---|---|
| embedding relation (total) | 1.65 MB | 0.96 MB | **−41.7%** |
| embedding table (heap only) | 1.56 MB | 0.88 MB | **−44.0%** |
| whole database | 10.55 MB | 9.86 MB | −6.5% (fixed PG overhead dominates at 1k) |

(Not the theoretical −50% because of per-row overhead: engram_id key, tuple headers, varlena header.)

**Recall parity** (50 deterministic queries, exact scan): top-1 identical **50/50**, mean top-10 overlap **1.000**. The suite also asserts halfvec vs float32 ranking equality and score parity to 2 decimals on separate stores.

**Latency (the honest note)**: halfvec exact scans are ~3–10x *slower* in PGLite — mean per-search at 1k rows was 3.1–3.3ms (float32, stable) vs 11–33ms (halfvec, load-dependent) across two runs. The WASM build has no F16C, so every fp16 element is software-converted per distance call. Both are interactive-fine at this corpus size, but halfvec here trades CPU for storage — which is why **float32 stays the default** and halfvec is opt-in for storage-constrained stores, rather than the "new default > 10k engrams" floated in the issue. Documented in the config schema and adapter docblocks.

**Migration**: float32 → halfvec on a populated 1k store: **1.2s**, all 1000 embeddings preserved, column verified `halfvec(384)` after.

## Scope notes

- `int8` scalar quantization deferred: pgvector has no int8 vector column type (its types are vector/halfvec/sparsevec/bit).
- Binary + rerank deferred to pair with #220, per the issue.
- LongMemEval recall benchmark (#222) not run here — the memorybench harness lives outside this repo; the in-repo parity tests cover ranking equivalence at this scale.

## Tests

- New `packages/core/test/pglite-precision.test.ts` — 12 tests: column type selection, halfvec search ordering + score orientation, float32↔halfvec ranking parity, lazy migration both directions, no silent down-migration on option-less open, dim preservation under #219 mismatch, out-of-band HNSW index drop/recreate with opclass swap, config knob parse/reject.
- Existing vector-search suites (pglite-adapter, pglite-recall-wiring, yaml-truth-rebuild, sync-index-error, async-mutex) pass unmodified — no test loosened.
- Full monorepo suite green (see checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1
