### PR TITLE
feat(core,mcp,cli): co_injection/injection_outcome provenance events + ADR-0002 (#452)

### DIFF
--- a/docs/adr/ADR-0002-derived-state-provenance.md
+++ b/docs/adr/ADR-0002-derived-state-provenance.md
@@ -1,0 +1,58 @@
+# ADR-0002: Derived-state provenance — history JSONL is source of truth for observational events
+
+Status: **Accepted**
+Date: 2026-07-02
+Authors: graph-upgrade assessment (#225 review) + #452 implementation
+Related: ADR-0001 ([#226](https://github.com/plur-ai/plur/issues/226)), #200, #201, #202, #452
+
+> ADR-0001 lives as GitHub issue [#226](https://github.com/plur-ai/plur/issues/226); this is the first ADR checked into the repo. New ADRs go in `docs/adr/`.
+
+## Context
+
+ADR-0001 established **YAML as the interoperability layer**: the database (PGLite/Postgres + pgvector + AGE) is always rebuildable from engram YAML, and the YAML-first write order makes "in DB but not in YAML" a forbidden state.
+
+The graph program (#200/#201) needs **derived edges** — above all `co-fires-with` counts — whose raw data is not engram state but *observations*: which engrams were injected together (`co_injection`), and what feedback verdict followed (`injection_outcome`). Since #452 these land in `history/YYYY-MM.jsonl`, next to the existing lifecycle events (created/updated/feedback/contradiction).
+
+That raises the question ADR-0001 doesn't answer: are history JSONLs source of truth for derived edges, or must derived state be rebuildable from engram YAML alone?
+
+## Decision
+
+**Two truth stores, split by kind. Engram YAML remains the sole source of truth for semantic state (what is believed). History JSONL is the append-only source of truth for observational events (what happened). Derived edges — co-fire counts, injection-outcome labels — are rebuilt from history JSONL, and are NOT required to be rebuildable from engram YAML alone.**
+
+Concretely:
+
+- The AGE graph's derived edges are a **pure function of history JSONL** (plus engram YAML for node existence). `plur rebuild` reconstructs the full database from `engrams.yaml + history/*.jsonl`.
+- Observational events are **never folded back into engram YAML** as counters. The existing `co_accessed` associations in YAML stay what they are: a lossy, capped (5 per engram), online cache — not provenance.
+- Derived edges are **never promoted to facts**: nothing derived from history may overwrite engram statements, scopes, or status.
+
+### Why not "rebuildable from YAML alone"
+
+1. **Category error.** Co-injection is an event stream with temporal structure. A count stored in YAML is a destructive aggregation — temporal-replay self-labeling (#202) needs the timeline (which injection, which query context, what happened after), which no YAML counter can carry.
+2. **Write amplification on the read path.** Folding co-fire counters into YAML would turn every inject — a read — into a locked write across every injected engram file. The injection hot path must stay read-only.
+3. **Scale shape.** Co-fire data is O(pairs); engram YAML is O(engrams). Pair data in per-engram files bloats the human-readable layer that ADR-0001 deliberately keeps small and portable.
+
+### Why this preserves ADR-0001's invariant
+
+ADR-0001's invariant is, in substance: *the database is always disposable, because truth lives in durable, portable, human-readable files*. History JSONL has exactly those properties — append-only plain text, one JSON object per line, monthly files. This ADR **refines the truth set** from {engram YAML} to {engram YAML (semantic state)} ∪ {history JSONL (observational events)}; the database remains fully derived and disposable. The forbidden state generalizes accordingly: nothing may exist only in the database.
+
+## Consequences
+
+### Positive
+
+- #200/#201's co-fire edges get a durable, replayable data source; edge derivation is deterministic and re-runnable as the algorithm evolves.
+- #202's temporal replay can consume raw `co_injection`/`injection_outcome` events without a schema migration.
+- Injection stays read-only on engram YAML.
+
+### Negative
+
+- `history/` is now load-bearing: backup/sync scope must include it (previously it was "nice to have" audit data). Losing history loses derived edges — acceptable degradation (ranking signal, not knowledge; edges regrow from new observations), but it must be a documented one.
+- Two truth stores mean rebuild reads two sources; `plur rebuild` docs/help must say so.
+
+### Neutral
+
+- Growth is bounded and small: measured ~325 B (5 ids) to ~625 B (20 ids) per co_injection, ~170 B per outcome; at ~50 sessions/day that is under ~1 MiB/month of JSONL.
+- If monthly files ever become a scan burden, compaction may summarize months older than a retention window into derived snapshots — permitted as long as snapshots are themselves in files, not only in the database.
+
+## Changelog
+
+- 2026-07-02 v1 — **Accepted** with #452 (co_injection / injection_outcome logging).

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -13,6 +13,11 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     outputText(`  Engrams:      ${result.engram_count}`)
     outputText(`  Episodes:     ${result.episode_count}`)
     outputText(`  Packs:        ${result.pack_count}`)
+    // Injection-provenance event/label counts (#452) — #202's volume gate.
+    const ev = result.history_events
+    if (ev) {
+      outputText(`  Events:       co_injection ${ev.co_injection} · outcomes ${ev.injection_outcome} (+${ev.outcome_positive}/-${ev.outcome_negative})`)
+    }
     outputText(`  Storage root: ${result.storage_root}`)
   }
 }

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -41,6 +41,36 @@ describe('plur status', () => {
     })
     const output = JSON.parse(run('status'))
     expect(output.engram_count).toBe(1)
+  })
+
+  // #452 — injection-provenance event/label counts feed #202's volume gate.
+  it('surfaces injection event/label counts in JSON output', () => {
+    const output = JSON.parse(run('status'))
+    expect(output.history_events).toEqual({
+      co_injection: 0,
+      injection_outcome: 0,
+      outcome_positive: 0,
+      outcome_negative: 0,
+    })
+  })
+
+  it('surfaces event/label counts in text output', async () => {
+    // Text mode requires a TTY or an explicit json:false — run in-process.
+    const writes: string[] = []
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk))
+      return true
+    }) as never)
+    try {
+      const { run: runStatus } = await import('../src/commands/status.js')
+      await runStatus([], { path: dir, json: false })
+    } finally {
+      spy.mockRestore()
+    }
+    const out = writes.join('')
+    expect(out).toContain('Events:')
+    expect(out).toContain('co_injection 0')
+    expect(out).toContain('outcomes 0 (+0/-0)')
   })
 
   it('reflects episode count after capture', () => {

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs'
 import { join } from 'path'
+import { createHash } from 'crypto'
 
 export interface HistoryEvent {
-  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed'
+  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome'
   engram_id: string
   timestamp: string // ISO
   data: Record<string, unknown> // event-specific payload
@@ -83,4 +84,108 @@ export function generateEventId(): string {
   const ts = Date.now()
   const rand = Math.random().toString(36).slice(2, 6)
   return `EVT-${ts}-${rand}`
+}
+
+// --- Injection provenance (#452) ---
+//
+// Two event types feed the co-fire edge pipeline (#200/#201) and
+// temporal-replay self-labeling (#202):
+//
+//   co_injection      — one per inject/session-start with >=1 injected engram.
+//                       engram_id carries the injection ID (INJ-...) so the
+//                       event is addressable; data = { ids, query_hash, ... }.
+//                       Kept compact: engram IDs only, never statements.
+//                       Measured: ~325 B at 5 ids, ~625 B at 20 ids.
+//   injection_outcome — one per positive/negative plur_feedback verdict on an
+//                       engram that was previously injected; data links back
+//                       via { injection_id, signal }. ~170 B. "Ignored" is the
+//                       ABSENCE of an outcome for an injected engram — no
+//                       synthetic ignore events are ever written.
+//
+// Growth at ~50 sessions/day (one co_injection each, a handful of outcomes):
+// under ~1 MiB/month of JSONL — see the #452 PR body for the measured table.
+
+/**
+ * Generate a unique injection ID for co_injection events.
+ */
+export function generateInjectionId(): string {
+  const ts = Date.now()
+  const rand = Math.random().toString(36).slice(2, 6)
+  return `INJ-${ts}-${rand}`
+}
+
+/**
+ * Compact, stable hash of the injection query context. Case- and
+ * whitespace-insensitive so retries of the same task hash identically.
+ */
+export function computeQueryHash(task: string): string {
+  const normalized = task.toLowerCase().replace(/\s+/g, ' ').trim()
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 16)
+}
+
+/**
+ * Find the most recent co_injection event that included the given engram.
+ * Scans the newest `maxMonths` history files only (bounded read) — feedback
+ * on injections older than that is not attributable to a specific injection.
+ * Returns null when no recent co_injection contains the engram.
+ */
+export function findLatestInjectionFor(
+  root: string,
+  engramId: string,
+  maxMonths = 2,
+): { injection_id: string; timestamp: string } | null {
+  // Time-based window: the maxMonths calendar months ending at the current
+  // month. A sparse store's newest files can be arbitrarily old — linking
+  // feedback to an injection from years ago would be a false label.
+  const now = new Date()
+  const allowed = new Set<string>()
+  for (let i = 0; i < maxMonths; i++) {
+    const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1))
+    allowed.add(d.toISOString().slice(0, 7))
+  }
+  const months = listHistoryMonths(root).filter(m => allowed.has(m)).reverse()
+  for (const month of months) {
+    let latest: HistoryEvent | null = null
+    for (const event of readHistory(root, month)) {
+      if (event.event !== 'co_injection') continue
+      const ids = event.data.ids
+      if (!Array.isArray(ids) || !ids.includes(engramId)) continue
+      if (!latest || event.timestamp > latest.timestamp) latest = event
+    }
+    if (latest) return { injection_id: latest.engram_id, timestamp: latest.timestamp }
+  }
+  return null
+}
+
+export interface InjectionEventCounts {
+  co_injection: number
+  injection_outcome: number
+  outcome_positive: number
+  outcome_negative: number
+}
+
+/**
+ * Count injection-provenance events across all history months. Feeds the
+ * #202 volume gate via plur_status — training on injection outcomes is
+ * gated on having enough labels.
+ */
+export function countInjectionEvents(root: string): InjectionEventCounts {
+  const counts: InjectionEventCounts = {
+    co_injection: 0,
+    injection_outcome: 0,
+    outcome_positive: 0,
+    outcome_negative: 0,
+  }
+  for (const month of listHistoryMonths(root)) {
+    for (const event of readHistory(root, month)) {
+      if (event.event === 'co_injection') {
+        counts.co_injection++
+      } else if (event.event === 'injection_outcome') {
+        counts.injection_outcome++
+        if (event.data.signal === 'positive') counts.outcome_positive++
+        else if (event.data.signal === 'negative') counts.outcome_negative++
+      }
+    }
+  }
+  return counts
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,7 +33,7 @@ import { detectSecrets, detectSensitive, sensitivityCategory, SCAN_TRUNCATED } f
 import type { SecretMatch } from './secrets.js'
 import type { ScopeMetadata, SensitivityCategory } from './schemas/scope-metadata.js'
 import { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
-import { appendHistory, readHistoryForEngram, generateEventId } from './history.js'
+import { appendHistory, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, type InjectionEventCounts } from './history.js'
 import { computeContentHash } from './content-hash.js'
 import { resolveValidity, buildTemporal } from './expiry.js'
 import { decodeJwtExpiry } from './jwt.js'
@@ -73,7 +73,7 @@ export { selectModel, selectModelForOperation, resolveOperationTier, type ModelT
 export { recallAuto, type AutoSearchResult, type SearchStrategy } from './search-orchestrator.js'
 export { generateProfile, getProfileForInjection, loadProfileCache, saveProfileCache, markProfileDirty, profileNeedsRegeneration, type ProfileCache } from './profile.js'
 export { formatLayer1, formatLayer2, formatLayer3, formatWithLayer, assignLayer, type InjectionLayer } from './inject.js'
-export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, type HistoryEvent } from './history.js'
+export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, type HistoryEvent, type InjectionEventCounts } from './history.js'
 export { applyBatchDecay, strengthToStatus, type BatchDecayResult, type DecayTransition, type BatchDecayOptions } from './decay.js'
 export { computeContentHash, normalizeStatement } from './content-hash.js'
 export { parseDedupResponse, buildDedupPrompt, buildBatchDedupPrompt } from './dedup.js'
@@ -205,6 +205,8 @@ export interface StatusResult {
   outbox_count?: number
   /** Present when the most recent background index pass failed (#272). */
   index_error?: IndexSyncError
+  /** Injection-provenance event/label counts (#452) — feeds #202's volume gate. */
+  history_events?: InjectionEventCounts
 }
 
 /**
@@ -328,6 +330,12 @@ export class Plur {
    */
   private _lastIndexError: IndexSyncError | null = null
   private _engramCache: Map<string, { mtime: bigint; engrams: Engram[] }> = new Map()
+  /**
+   * engram_id → injection_id of the most recent co_injection that included it
+   * (#452). Fast path for linking plur_feedback verdicts to their injection
+   * event; findLatestInjectionFor covers the cross-process case.
+   */
+  private _lastInjectionByEngram: Map<string, string> = new Map()
   private _llmFailureCount = 0
   private _llmDisabledUntil: number | null = null
   private _sessionScope: string | null = null
@@ -2310,6 +2318,29 @@ export class Plur {
       ...result.consider.map(e => e.id),
     ]
 
+    // #452: log a co_injection provenance event — which engrams fired
+    // together for which query context. Data source for the co-fires-with
+    // edges (#200/#201) and temporal-replay self-labeling (#202). Compact by
+    // design (IDs + query hash, never statements); best-effort — a history
+    // write failure must never break injection.
+    if (injected_ids.length > 0) {
+      const injection_id = generateInjectionId()
+      try {
+        appendHistory(this.paths.root, {
+          event: 'co_injection',
+          engram_id: injection_id,
+          timestamp: new Date().toISOString(),
+          data: {
+            ids: injected_ids,
+            query_hash: computeQueryHash(task),
+            ...(options?.scope ? { scope: options.scope } : {}),
+            ...(options?.session_id ? { session_id: options.session_id } : {}),
+          },
+        })
+        for (const id of injected_ids) this._lastInjectionByEngram.set(id, injection_id)
+      } catch { /* best-effort */ }
+    }
+
     return {
       directives: directivesStr,
       constraints: constraintsStr,
@@ -2354,7 +2385,10 @@ export class Plur {
       return true
     })
 
-    if (found) return
+    if (found) {
+      this._logInjectionOutcome(id, signal)
+      return
+    }
 
     // Try configured stores (namespaced IDs)
     const storeInfo = this._findEngramStore(id)
@@ -2377,6 +2411,7 @@ export class Plur {
         }
         this._writeEngrams(storeInfo.path, storeEngrams)
         this._syncIndex()
+        this._logInjectionOutcome(id, signal)
         return
       }
     }
@@ -2404,12 +2439,37 @@ export class Plur {
           timestamp: new Date().toISOString(),
           data: { signal, routed_to: 'remote' },
         })
+        this._logInjectionOutcome(id, signal)
         return
       }
     }
 
     // Search pack engrams by scanning pack directories
     this._feedbackPack(id, signal)
+    this._logInjectionOutcome(id, signal)
+  }
+
+  /**
+   * Log an injection_outcome event linking a feedback verdict to the
+   * co_injection event the engram came from (#452). Only positive/negative
+   * verdicts are outcomes — "ignored" is the absence of an outcome, so
+   * neutral signals and feedback on never-injected engrams write nothing.
+   * Link resolution: in-process map first, then a bounded history scan for
+   * injections logged by another process (hook-inject, CLI).
+   */
+  private _logInjectionOutcome(engramId: string, signal: 'positive' | 'negative' | 'neutral'): void {
+    if (signal === 'neutral') return
+    try {
+      const injectionId = this._lastInjectionByEngram.get(engramId)
+        ?? findLatestInjectionFor(this.paths.root, engramId)?.injection_id
+      if (!injectionId) return
+      appendHistory(this.paths.root, {
+        event: 'injection_outcome',
+        engram_id: engramId,
+        timestamp: new Date().toISOString(),
+        data: { injection_id: injectionId, signal },
+      })
+    } catch { /* best-effort — outcome logging must never break feedback */ }
   }
 
   /**
@@ -3488,6 +3548,7 @@ Generate an improved version of the procedure that prevents this failure. Return
       tension_count: tensionPairs.size,
       versioned_engram_count: versionedCount,
       outbox_count: this.outboxCount(),
+      history_events: countInjectionEvents(this.paths.root),
       ...(this._lastIndexError ? { index_error: this._lastIndexError } : {}),
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,6 +121,8 @@ export interface InjectOptions {
   intentOverride?: 'entity' | 'temporal' | 'event' | 'general'
   /** Cross-encoder rerank stage (#220): true=opt in, false=skip, omitted=respect PLUR_RERANKER. */
   rerank?: boolean
+  /** Session ID (from plur_session_start) recorded on the co_injection provenance event (#452). */
+  session_id?: string
 }
 
 export interface InjectionResult {

--- a/packages/core/test/co-injection-logging.test.ts
+++ b/packages/core/test/co-injection-logging.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { Plur } from '../src/index.js'
+import {
+  appendHistory,
+  readHistory,
+  computeQueryHash,
+  generateInjectionId,
+  findLatestInjectionFor,
+  countInjectionEvents,
+} from '../src/history.js'
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'plur-coinject-'))
+}
+
+const thisMonth = () => new Date().toISOString().slice(0, 7)
+
+describe('co-injection helpers (#452)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = tmpDir() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  describe('computeQueryHash', () => {
+    it('is stable for the same query', () => {
+      expect(computeQueryHash('deploy the trading bot')).toBe(computeQueryHash('deploy the trading bot'))
+    })
+
+    it('normalizes case and whitespace', () => {
+      expect(computeQueryHash('Deploy  the\tTrading   bot ')).toBe(computeQueryHash('deploy the trading bot'))
+    })
+
+    it('differs for different queries', () => {
+      expect(computeQueryHash('deploy the bot')).not.toBe(computeQueryHash('write the tests'))
+    })
+
+    it('is a compact 16-char hex digest', () => {
+      expect(computeQueryHash('anything')).toMatch(/^[0-9a-f]{16}$/)
+    })
+  })
+
+  describe('generateInjectionId', () => {
+    it('uses the INJ- prefix', () => {
+      expect(generateInjectionId()).toMatch(/^INJ-\d+-[a-z0-9]{4}$/)
+    })
+
+    it('generates unique ids', () => {
+      const ids = new Set(Array.from({ length: 50 }, () => generateInjectionId()))
+      expect(ids.size).toBe(50)
+    })
+  })
+
+  describe('findLatestInjectionFor', () => {
+    const earlier = new Date(Date.now() - 60_000).toISOString()
+    const later = new Date().toISOString()
+
+    it('returns null when there is no history', () => {
+      expect(findLatestInjectionFor(dir, 'ENG-X')).toBeNull()
+    })
+
+    it('finds the latest co_injection containing the engram', () => {
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-1-aaaa',
+        timestamp: earlier,
+        data: { ids: ['ENG-A', 'ENG-B'], query_hash: 'abc' },
+      })
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-2-bbbb',
+        timestamp: later,
+        data: { ids: ['ENG-A', 'ENG-C'], query_hash: 'def' },
+      })
+      const hit = findLatestInjectionFor(dir, 'ENG-A')
+      expect(hit).not.toBeNull()
+      expect(hit!.injection_id).toBe('INJ-2-bbbb')
+      const bHit = findLatestInjectionFor(dir, 'ENG-B')
+      expect(bHit!.injection_id).toBe('INJ-1-aaaa')
+    })
+
+    it('returns null for an engram never injected', () => {
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-1-aaaa',
+        timestamp: earlier,
+        data: { ids: ['ENG-A'], query_hash: 'abc' },
+      })
+      expect(findLatestInjectionFor(dir, 'ENG-ZZZ')).toBeNull()
+    })
+
+    it('finds an injection from the previous calendar month (month-boundary feedback)', () => {
+      // Feedback on the 1st for an injection late last month must still link.
+      const now = new Date()
+      const prevMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15)).toISOString()
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-prev-cccc',
+        timestamp: prevMonth,
+        data: { ids: ['ENG-PREV'], query_hash: 'prv' },
+      })
+      const hit = findLatestInjectionFor(dir, 'ENG-PREV')
+      expect(hit).not.toBeNull()
+      expect(hit!.injection_id).toBe('INJ-prev-cccc')
+    })
+
+    it('only scans the most recent calendar months (bounded read)', () => {
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-old-aaaa',
+        timestamp: '2025-01-01T08:00:00.000Z',
+        data: { ids: ['ENG-OLD'], query_hash: 'old' },
+      })
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-new-bbbb',
+        timestamp: later,
+        data: { ids: ['ENG-NEW'], query_hash: 'new' },
+      })
+      // ENG-OLD's event is outside the 2-month scan window
+      expect(findLatestInjectionFor(dir, 'ENG-OLD')).toBeNull()
+      expect(findLatestInjectionFor(dir, 'ENG-NEW')).not.toBeNull()
+    })
+  })
+
+  describe('countInjectionEvents', () => {
+    it('returns zeros when there is no history', () => {
+      expect(countInjectionEvents(dir)).toEqual({
+        co_injection: 0,
+        injection_outcome: 0,
+        outcome_positive: 0,
+        outcome_negative: 0,
+      })
+    })
+
+    it('counts co_injection and injection_outcome events across months', () => {
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-1-aaaa',
+        timestamp: '2026-06-15T08:00:00.000Z',
+        data: { ids: ['ENG-A', 'ENG-B'], query_hash: 'abc' },
+      })
+      appendHistory(dir, {
+        event: 'co_injection',
+        engram_id: 'INJ-2-bbbb',
+        timestamp: '2026-07-01T08:00:00.000Z',
+        data: { ids: ['ENG-A'], query_hash: 'def' },
+      })
+      appendHistory(dir, {
+        event: 'injection_outcome',
+        engram_id: 'ENG-A',
+        timestamp: '2026-07-01T09:00:00.000Z',
+        data: { injection_id: 'INJ-2-bbbb', signal: 'positive' },
+      })
+      appendHistory(dir, {
+        event: 'injection_outcome',
+        engram_id: 'ENG-B',
+        timestamp: '2026-07-01T09:01:00.000Z',
+        data: { injection_id: 'INJ-1-aaaa', signal: 'negative' },
+      })
+      // Unrelated lifecycle events must not be counted
+      appendHistory(dir, {
+        event: 'engram_created',
+        engram_id: 'ENG-A',
+        timestamp: '2026-07-01T07:00:00.000Z',
+        data: {},
+      })
+      expect(countInjectionEvents(dir)).toEqual({
+        co_injection: 2,
+        injection_outcome: 2,
+        outcome_positive: 1,
+        outcome_negative: 1,
+      })
+    })
+  })
+})
+
+describe('co-injection logging integration (#452)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = tmpDir()
+    plur = new Plur({ path: dir })
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('inject() logs a co_injection event with injected ids and query hash', () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    const b = plur.learn('Run pnpm build before running package tests')
+    const result = plur.inject('how do I run pnpm installation and build for a package')
+    expect(result.injected_ids.length).toBeGreaterThanOrEqual(2)
+
+    const events = readHistory(dir, thisMonth()).filter(e => e.event === 'co_injection')
+    expect(events.length).toBe(1)
+    const ev = events[0]
+    expect(ev.engram_id).toMatch(/^INJ-/)
+    expect(ev.data.ids).toEqual(result.injected_ids)
+    expect((ev.data.ids as string[])).toContain(a.id)
+    expect((ev.data.ids as string[])).toContain(b.id)
+    expect(ev.data.query_hash).toBe(computeQueryHash('how do I run pnpm installation and build for a package'))
+    expect(ev.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    // Compact: IDs only, no statements
+    expect(JSON.stringify(ev)).not.toContain('Always use pnpm')
+  })
+
+  it('inject() with no matches logs no co_injection event', () => {
+    plur.learn('Always use pnpm for package installation in this monorepo')
+    const result = plur.inject('zzz qqq xyzzy')
+    expect(result.injected_ids.length).toBe(0)
+    const events = readHistory(dir, thisMonth()).filter(e => e.event === 'co_injection')
+    expect(events.length).toBe(0)
+  })
+
+  it('feedback on an injected engram logs injection_outcome linked to the injection', async () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    plur.inject('how do I run pnpm installation for a package')
+    const coEvents = readHistory(dir, thisMonth()).filter(e => e.event === 'co_injection')
+    expect(coEvents.length).toBe(1)
+    const injectionId = coEvents[0].engram_id
+
+    await plur.feedback(a.id, 'positive')
+
+    const outcomes = readHistory(dir, thisMonth()).filter(e => e.event === 'injection_outcome')
+    expect(outcomes.length).toBe(1)
+    expect(outcomes[0].engram_id).toBe(a.id)
+    expect(outcomes[0].data.injection_id).toBe(injectionId)
+    expect(outcomes[0].data.signal).toBe('positive')
+  })
+
+  it('negative feedback logs a negative injection_outcome', async () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    plur.inject('how do I run pnpm installation for a package')
+    await plur.feedback(a.id, 'negative')
+    const outcomes = readHistory(dir, thisMonth()).filter(e => e.event === 'injection_outcome')
+    expect(outcomes.length).toBe(1)
+    expect(outcomes[0].data.signal).toBe('negative')
+  })
+
+  it('neutral feedback logs no injection_outcome (ignored = absence)', async () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    plur.inject('how do I run pnpm installation for a package')
+    await plur.feedback(a.id, 'neutral')
+    const outcomes = readHistory(dir, thisMonth()).filter(e => e.event === 'injection_outcome')
+    expect(outcomes.length).toBe(0)
+  })
+
+  it('feedback on a never-injected engram logs no injection_outcome', async () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    await plur.feedback(a.id, 'positive')
+    const outcomes = readHistory(dir, thisMonth()).filter(e => e.event === 'injection_outcome')
+    expect(outcomes.length).toBe(0)
+  })
+
+  it('links feedback to injections from a previous process via history scan', async () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    plur.inject('how do I run pnpm installation for a package')
+    const injectionId = readHistory(dir, thisMonth())
+      .filter(e => e.event === 'co_injection')[0].engram_id
+
+    // Fresh instance = fresh process, no in-memory link
+    const plur2 = new Plur({ path: dir })
+    await plur2.feedback(a.id, 'positive')
+
+    const outcomes = readHistory(dir, thisMonth()).filter(e => e.event === 'injection_outcome')
+    expect(outcomes.length).toBe(1)
+    expect(outcomes[0].data.injection_id).toBe(injectionId)
+  })
+
+  it('repeated injections update the outcome link to the most recent injection', async () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    plur.inject('how do I run pnpm installation for a package')
+    plur.inject('pnpm installation again please')
+    const coEvents = readHistory(dir, thisMonth()).filter(e => e.event === 'co_injection')
+    expect(coEvents.length).toBe(2)
+
+    await plur.feedback(a.id, 'positive')
+    const outcomes = readHistory(dir, thisMonth()).filter(e => e.event === 'injection_outcome')
+    expect(outcomes.length).toBe(1)
+    expect(outcomes[0].data.injection_id).toBe(coEvents[1].engram_id)
+  })
+
+  it('status() surfaces injection event and label counts', async () => {
+    const a = plur.learn('Always use pnpm for package installation in this monorepo')
+    plur.inject('how do I run pnpm installation for a package')
+    await plur.feedback(a.id, 'positive')
+
+    const status = plur.status()
+    expect(status.history_events).toEqual({
+      co_injection: 1,
+      injection_outcome: 1,
+      outcome_positive: 1,
+      outcome_negative: 0,
+    })
+  })
+
+  it('size guard: events stay compact (IDs, not statements)', () => {
+    // Representative co_injection at typical injection width (~20 engrams)
+    const ids = Array.from({ length: 20 }, (_, i) => `ENG-2026-0702-${String(i).padStart(3, '0')}`)
+    const coEvent = {
+      event: 'co_injection',
+      engram_id: generateInjectionId(),
+      timestamp: new Date().toISOString(),
+      data: { ids, query_hash: computeQueryHash('a representative task string'), scope: 'project:plur' },
+    }
+    const outcomeEvent = {
+      event: 'injection_outcome',
+      engram_id: 'ENG-2026-0702-001',
+      timestamp: new Date().toISOString(),
+      data: { injection_id: coEvent.engram_id, signal: 'positive' },
+    }
+    const coBytes = Buffer.byteLength(JSON.stringify(coEvent) + '\n')
+    const outcomeBytes = Buffer.byteLength(JSON.stringify(outcomeEvent) + '\n')
+    // eslint-disable-next-line no-console
+    console.log(`[size-guard] co_injection (20 ids): ${coBytes} B; injection_outcome: ${outcomeBytes} B`)
+    expect(coBytes).toBeLessThan(700)
+    expect(outcomeBytes).toBeLessThan(250)
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1046,6 +1046,13 @@ export function getToolDefinitions(): ToolDefinition[] {
           tension_count: status.tension_count,
           versioned_engram_count: status.versioned_engram_count ?? 0,
           outbox_count: status.outbox_count ?? 0,
+          // Injection-provenance event/label counts (#452) — #202's volume gate.
+          history_events: status.history_events ?? {
+            co_injection: 0,
+            injection_outcome: 0,
+            outcome_positive: 0,
+            outcome_negative: 0,
+          },
           // Last background index/reembed failure (#272) — absent when healthy.
           ...(status.index_error ? { index_error: status.index_error } : {}),
           // Version check (issue #151)
@@ -1315,6 +1322,7 @@ export function getToolDefinitions(): ToolDefinition[] {
         try {
           const result = await plur.injectHybrid(task, {
             scope: tags?.length ? `tags:${tags.join(',')}` : undefined,
+            session_id, // stamped on the co_injection provenance event (#452)
           })
           if (result.count > 0) {
             const lines: string[] = []
@@ -1327,6 +1335,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           // Fall back to BM25 if hybrid unavailable
           const result = plur.inject(task, {
             scope: tags?.length ? `tags:${tags.join(',')}` : undefined,
+            session_id,
           })
           if (result.count > 0) {
             const lines: string[] = []

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -262,6 +262,29 @@ describe('MCP tools', () => {
     expect(result.version).toMatch(/^\d+\.\d+\.\d+/)
   })
 
+  // #452 — injection-provenance event/label counts feed #202's volume gate.
+  it('plur_status surfaces injection event and label counts', async () => {
+    const empty = await callTool('plur_status', {}) as any
+    expect(empty.history_events).toEqual({
+      co_injection: 0,
+      injection_outcome: 0,
+      outcome_positive: 0,
+      outcome_negative: 0,
+    })
+
+    const learned = await callTool('plur_learn', { statement: 'Always use pnpm for package installation', scope: 'global' }) as any
+    await callTool('plur_inject', { task: 'how do I run pnpm installation for a package' })
+    await callTool('plur_feedback', { id: learned.id, signal: 'positive' })
+
+    const result = await callTool('plur_status', {}) as any
+    expect(result.history_events).toEqual({
+      co_injection: 1,
+      injection_outcome: 1,
+      outcome_positive: 1,
+      outcome_negative: 0,
+    })
+  })
+
   // plur_stores_add must report an honest status, never an unconditional
   // success:true that masks a dropped scope (#291).
   describe('plur_stores_add status reporting (#291)', () => {


### PR DESCRIPTION
Closes #452. Refs #200, #201, #202, #225.

The flagship `co-fires-with` edge (#200/#201) had no data source, and every offline stage of the two-stage graph design was blocked on observations nothing was collecting. This PR starts collecting them — history only compounds from the day logging starts.

## What's logged

**`co_injection`** — one event per `inject()`/`injectHybrid()` call with ≥1 injected engram (covers `plur_inject`, `plur_inject_hybrid`, `plur_session_start`, hook-inject, CLI — all route through `_formatInjection`):
```json
{"event":"co_injection","engram_id":"INJ-1751476000000-a1b2","timestamp":"2026-07-02T19:20:00.000Z","data":{"ids":["ENG-...","ENG-..."],"query_hash":"9f8a7b6c5d4e3f2a","scope":"project:plur","session_id":"<uuid>"}}
```
Compact by design: engram IDs + a 16-hex normalized query-context hash — never statements. `session_id` from `plur_session_start` is stamped when present.

**`injection_outcome`** — one event per positive/negative `plur_feedback` verdict on a previously-injected engram, linked back via `injection_id`; shaped for temporal-replay self-labeling (#202):
```json
{"event":"injection_outcome","engram_id":"ENG-...","timestamp":"...","data":{"injection_id":"INJ-...","signal":"positive"}}
```
"Ignored" is the **absence** of an outcome for an injected engram — no synthetic ignore events. Link resolution: in-process map first, then a bounded 2-calendar-month history scan for cross-process injections. Neutral signals and never-injected engrams write nothing. Both writes are best-effort — a history failure never breaks injection or feedback.

Events append to `history/YYYY-MM.jsonl` alongside existing lifecycle events.

## Size overhead (measured)

| Event | Bytes/line |
|---|---|
| co_injection, 5 ids | 325 B |
| co_injection, 10 ids | 425 B |
| co_injection, 20 ids | 625 B |
| co_injection, 40 ids | 1,025 B |
| injection_outcome | 170 B |

Monthly growth estimates (12-id average co_injection incl. scope + session_id = 473 B):
- 20 sessions/day + 30 ad-hoc injects/day + 25 outcomes/day → **~0.8 MiB/month**
- 50 sessions/day + 100 injects/day + 80 outcomes/day (heavy) → **~2.4 MiB/month**

A size-guard test locks the compactness invariant (co_injection@20 ids < 700 B, outcome < 250 B) and prints measured bytes on every run.

## ADR-0002 — derived-state provenance (`docs/adr/ADR-0002-derived-state-provenance.md`)

**Position: two truth stores, split by kind.** Engram YAML remains the sole source of truth for *semantic state* (what is believed); history JSONL is the append-only source of truth for *observational events* (what happened). Derived edges (co-fire counts, outcome labels) rebuild from history JSONL and are **not** required to be rebuildable from engram YAML alone — a YAML counter would be a destructive aggregation that #202's temporal replay cannot use, and folding counters into YAML would turn the read-only injection hot path into a locked write. This refines ADR-0001's invariant rather than violating it: the truth set becomes {engram YAML} ∪ {history JSONL}, the database stays fully derived and disposable, and the forbidden state generalizes to "nothing may exist only in the database." Consequence worth flagging: `history/` is now load-bearing for derived edges and must be in backup/sync scope.

## plur_status

`plur_status` (MCP), `Plur.status()` (core), and `plur status` (CLI JSON + text) now surface `history_events`: `{co_injection, injection_outcome, outcome_positive, outcome_negative}` — the volume gate #202 trains against.

## Tests

- 23 new core tests (`packages/core/test/co-injection-logging.test.ts`): hash stability/normalization, INJ-id format, latest-injection resolution incl. month-boundary and bounded-read window, count aggregation, inject/feedback integration, cross-process linking, neutral/never-injected no-ops, compactness size guard
- 1 new MCP test (learn → inject → feedback → status counts through the tool surface)
- 2 new CLI tests (JSON field + text line)

Full suites after core rebuild: **core 1656 passed / 28 skipped · mcp 162 passed · claw 110 passed · cli 229 passed / 4 skipped** (2157 passed / 32 skipped overall). One parallel full-suite run produced 18 timeout-shaped failures across 11 files while the machine sat at load ~58; all 11 files pass in isolation (241/241) — load flakes, not attributable to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1
