### PR TITLE
fix(test): warm BGE embedder in beforeAll to eliminate cold-runner CI flake (#469)

### DIFF
--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -9,6 +9,22 @@ describe('MCP tools', () => {
   let plur: Plur
   let dir: string
   let tools: ReturnType<typeof getToolDefinitions>
+
+  // Warm the BGE text-embedder pipeline once before any test runs (#469).
+  // The pipeline is a module-level singleton (transformers-base.ts pipelineCache)
+  // so one load covers the whole suite. Without this, the first test that calls
+  // learn/recall/inject bears the cold-load cost (~5s on a fresh CI runner) against
+  // its per-test timeout. Charging it to hookTimeout (30s) here eliminates the flake.
+  beforeAll(async () => {
+    const warmDir = mkdtempSync(join(tmpdir(), 'plur-mcp-warm-'))
+    const warmPlur = new Plur({ path: warmDir })
+    try {
+      await warmPlur.learn('embedder warmup', { scope: 'global' })
+      await warmPlur.recall('embedder warmup')
+    } finally {
+      rmSync(warmDir, { recursive: true })
+    }
+  })
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'plur-mcp-'))


### PR DESCRIPTION
## Root cause

`packages/mcp/test/tools.test.ts` creates a new `Plur` instance in `beforeEach`. On cold CI runners the BGE text-embedder pipeline (a module-level singleton in `transformers-base.ts`) hasn't been initialized yet, so the first test that triggers an embedding call pays the cold-load cost (~5 s). If that load exceeds the per-test timeout the test fails.

The `vitest.config.ts` sets `testTimeout: 30000` and `hookTimeout: 30000`, but the cold load was landing inside a test body rather than a hook, making it susceptible to races on slow runners.

## Fix

Add a single `beforeAll` to the outer `describe('MCP tools')` block that warms the singleton pipeline before any test runs. Because the pipeline is module-level, one load covers all subsequent tests. The cost is charged to `hookTimeout` (30 s), not per-test timeout.

## Impact

- Eliminates the flake observed on PR #465 (Node 22) and #467 (Node 20)
- Zero behavioral change to any test assertion
- PR #465 should rebase onto this once merged

## Test plan

- [x] `pnpm vitest run packages/mcp/test/tools.test.ts` — all 21 tests pass
- [ ] CI green on this PR across both Node 20 and Node 22

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)