### PR TITLE
fix(mcp): harden array-typed tool arguments against client serialization bug

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -155,7 +155,32 @@ function jsonSchemaPropToZod(prop: any): z.ZodTypeAny {
   if (prop.type === 'boolean') return z.boolean()
   if (prop.type === 'array') {
     const itemSchema = prop.items ? jsonSchemaPropToZod(prop.items) : z.unknown()
-    return z.array(itemSchema)
+    // #297 defense: some MCP clients mis-serialize array-typed arguments (in
+    // the worst case dropping the ENTIRE arguments payload). The documented
+    // workarounds pass arrays as strings — coerce those back into real arrays
+    // so the workaround round-trips instead of failing validation:
+    //   '["a","b"]'  → JSON parse → ['a','b']   (any item type)
+    //   'a, b'       → comma split → ['a','b']  (string items only)
+    //   'solo'       → wrap        → ['solo']   (string items only)
+    // A string that LOOKS like JSON ('[...') but fails to parse is passed
+    // through unchanged so z.array rejects it loudly, naming the field —
+    // never silently reinterpreted as a single tag.
+    return z.preprocess((val) => {
+      if (typeof val !== 'string') return val
+      const trimmed = val.trim()
+      if (trimmed.startsWith('[')) {
+        try {
+          const parsed = JSON.parse(trimmed)
+          return Array.isArray(parsed) ? parsed : val
+        } catch {
+          return val
+        }
+      }
+      if (prop.items?.type === 'string') {
+        return trimmed.length === 0 ? [] : trimmed.split(',').map(s => s.trim()).filter(s => s.length > 0)
+      }
+      return val
+    }, z.array(itemSchema))
   }
   if (prop.type === 'object' && prop.properties) {
     const shape: Record<string, z.ZodTypeAny> = {}
@@ -217,7 +242,7 @@ export async function createServer(plur?: Plur): Promise<Server> {
     mcpCanary.tick()
     try {
       // Validate arguments against input schema
-      const args = request.params.arguments ?? {}
+      let args = request.params.arguments ?? {}
       const schema = tool.inputSchema as any
       if (schema?.properties) {
         const shape: Record<string, z.ZodTypeAny> = {}
@@ -235,17 +260,35 @@ export async function createServer(plur?: Plur): Promise<Server> {
           const receivedNote = receivedFields.length > 0
             ? `Received fields: [${receivedFields.join(', ')}].`
             : 'Received no fields (the arguments object was empty).'
+          // #297: an empty payload on a tool that declares array-typed params is
+          // the signature of a known client-side serialization bug — the client
+          // drops the ENTIRE arguments object when an array value is present.
+          // Name the bug and the coercible retry shapes so the caller can
+          // self-correct instead of abandoning the write.
+          const hasArrayParam = Object.values(schema.properties as Record<string, any>)
+            .some(p => p?.type === 'array')
+          const arrayBugHint = receivedFields.length === 0 && hasArrayParam
+            ? ' Known client-side bug (plur-ai/plur#297): some MCP clients drop the entire arguments payload ' +
+              'when an array-typed parameter is included. Retry passing array parameters as a JSON string ' +
+              '(e.g. tags: "[\\"a\\",\\"b\\"]") or a comma-separated string (tags: "a, b") — the server coerces ' +
+              'both back into arrays.'
+            : ''
           return {
             content: [{ type: 'text', text: JSON.stringify({
               error: `Invalid arguments: ${details}. ${receivedNote} ` +
                 'The call reached the server — this is a malformed-arguments error, not a transport failure. ' +
-                'Fix the field(s) named above and retry; do not abandon the call.',
+                'Fix the field(s) named above and retry; do not abandon the call.' + arrayBugHint,
               success: false,
               received_fields: receivedFields,
             }) }],
             isError: true,
           }
         }
+        // Hand the handler the VALIDATED data, not the raw payload — this is
+        // what applies the #297 string→array coercion (and any future
+        // preprocessing) to the values handlers actually see. .passthrough()
+        // above keeps fields outside the declared schema intact.
+        args = parsed.data as Record<string, unknown>
       }
       const result = await tool.handler(args, instance)
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -10,10 +10,12 @@ import { createServer } from '../src/server.js'
 describe('MCP server (wire protocol)', () => {
   let client: Client
   let dir: string
+  let plurInstance: Plur
 
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), 'plur-mcp-server-'))
     const plur = new Plur({ path: dir })
+    plurInstance = plur
     const server = await createServer(plur)
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
@@ -72,6 +74,90 @@ describe('MCP server (wire protocol)', () => {
     const parsed = JSON.parse((result.content as any)[0].text)
     expect(parsed.id).toBeDefined()
     expect(parsed.statement).toBe('Test with tags')
+  })
+
+  // Issue #297 hardening — array params must either work or fail loudly with a
+  // useful message. The empty-payload symptom is a CLIENT-side serialization bug
+  // (the server provably handles real arrays — test above), but the server can
+  // (a) coerce the natural string workarounds back into arrays, and (b) name the
+  // known client bug when the payload arrives empty, so the caller can retry
+  // with a coercible shape instead of abandoning the write.
+  describe('array argument hardening (#297)', () => {
+    it('coerces a JSON-stringified array into a real array', async () => {
+      const result = await client.callTool({
+        name: 'plur_learn',
+        arguments: { statement: 'Coerce JSON string tags', tags: '["alpha","beta"]' },
+      })
+      expect(result.isError).toBeFalsy()
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.id).toBeDefined()
+      const stored = plurInstance.getById(parsed.id)
+      expect(stored?.tags).toEqual(['alpha', 'beta'])
+    })
+
+    it('coerces a comma-separated string into a string array', async () => {
+      const result = await client.callTool({
+        name: 'plur_learn',
+        arguments: { statement: 'Coerce comma-separated tags', tags: 'alpha, beta' },
+      })
+      expect(result.isError).toBeFalsy()
+      const parsed = JSON.parse((result.content as any)[0].text)
+      const stored = plurInstance.getById(parsed.id)
+      expect(stored?.tags).toEqual(['alpha', 'beta'])
+    })
+
+    it('coerces a single bare string into a one-element array', async () => {
+      const result = await client.callTool({
+        name: 'plur_learn',
+        arguments: { statement: 'Coerce bare string tag', tags: 'solo' },
+      })
+      expect(result.isError).toBeFalsy()
+      const parsed = JSON.parse((result.content as any)[0].text)
+      const stored = plurInstance.getById(parsed.id)
+      expect(stored?.tags).toEqual(['solo'])
+    })
+
+    it('malformed JSON array string fails loudly naming the field', async () => {
+      const result = await client.callTool({
+        name: 'plur_learn',
+        arguments: { statement: 'Malformed tags', tags: '["unterminated' },
+      })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.success).toBe(false)
+      expect(parsed.error).toContain('tags')
+    })
+
+    it('non-string non-array value still fails loudly naming the field', async () => {
+      const result = await client.callTool({
+        name: 'plur_learn',
+        arguments: { statement: 'Numeric tags', tags: 42 },
+      })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.success).toBe(false)
+      expect(parsed.error).toContain('tags')
+    })
+
+    it('empty arguments on a tool with array params names the client bug (#297)', async () => {
+      const result = await client.callTool({ name: 'plur_learn', arguments: {} })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.error).toContain('arguments object was empty')
+      // The targeted hint: names the known client-side array serialization bug
+      // and the coercible retry shapes, so the agent self-corrects.
+      expect(parsed.error).toContain('plur-ai/plur#297')
+      expect(parsed.error).toMatch(/JSON string|comma-separated/)
+    })
+
+    it('empty arguments on a tool WITHOUT array params does not mention #297', async () => {
+      // plur_recall has no array-typed params — the hint would be noise.
+      const result = await client.callTool({ name: 'plur_recall', arguments: {} })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.error).toContain('arguments object was empty')
+      expect(parsed.error).not.toContain('plur-ai/plur#297')
+    })
   })
 
   it('learn → recall → feedback roundtrip', async () => {


### PR DESCRIPTION
Closes #297

## Root cause

The empty-payload symptom is **client-side**, not ours:

- The existing wire-protocol regression test (`plur_learn accepts tags array (#297)`, InMemoryTransport, real MCP `Client`) passes on main — the server validates and stores real arrays correctly.
- Probed the MCP SDK directly (`@modelcontextprotocol/sdk` ^1.12.0): `CallToolRequestSchema` round-trips `arguments: { statement, tags: ["y"] }` byte-identically, and **rejects** a JSON-stringified `arguments` payload at the protocol layer (`expected record, received string`, -32602) — meaning a stringified payload would never reach our app-level validator. Since the reported error IS our app-level validator with `Received fields: []`, the client transmitted an empty arguments record.
- Conclusion matches the triage in #297: Claude Code's MCP client drops the entire `arguments` object when an array-typed parameter is present. **Not an SDK bug** — no SDK issue to file; the upstream report belongs with the Claude Code client team (wire log comparing `tools/call` bodies for scalar vs array params, as described in the issue's triage comment).

## Hardening (this PR — our side)

A tags array now either **works** or **fails loudly with a useful message** — never a silent empty payload:

1. **String→array coercion** in the JSON-Schema→Zod validation layer (`jsonSchemaPropToZod`), applied at any nesting depth:
   - `'["a","b"]'` → JSON parse → `['a','b']` (any item type)
   - `'a, b'` → comma split → `['a','b']` (string-item arrays only)
   - `'solo'` → `['solo']` (string-item arrays only)
   - A malformed JSON-looking string (`'["unterminated'`) is passed through unchanged so `z.array` rejects it loudly, naming the field — never silently reinterpreted as a single tag.
2. **Handlers now receive the validated parse result** instead of the raw payload — previously coercion could never reach handlers. `.passthrough()` preserves undeclared fields.
3. **Targeted diagnostic**: when validation fails with zero received fields on a tool declaring array-typed params (the #297 signature), the error names the client bug and the coercible retry shapes:

   > Known client-side bug (plur-ai/plur#297): some MCP clients drop the entire arguments payload when an array-typed parameter is included. Retry passing array parameters as a JSON string (e.g. tags: "[\"a\",\"b\"]") or a comma-separated string (tags: "a, b") — the server coerces both back into arrays.

   The hint is suppressed on tools without array params (verified by test) so it never becomes noise.

## Tests

- 7 new wire-protocol tests (InMemoryTransport) in `packages/mcp/test/server.test.ts`; coercion results verified against the **stored engram** (`plur.getById(...).tags`), not just the tool response.
- Full `@plur-ai/mcp` suite: 172 tests, all passing (one known flaky-under-load timeout in `session.test.ts` during the parallel run; passes in isolation, untouched by this change).

## Upstream status

#297 stays accurate as the tracking issue for the Claude Code client fix; this PR closes the *server-side hardening* half — after this, the failure mode is self-describing and the documented workaround actually round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1