### PR TITLE
feat(core): ETL extraction provenance convention in structured_data.extraction (#463)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,7 @@ export {
 } from './importers/index.js'
 export { CapabilityCanary, type Capability, type CanaryStatus } from './capability-canary.js'
 export type { Engram, PreviousVersionRef } from './schemas/engram.js'
+export { ExtractionProvenanceSchema, getExtractionProvenance, type ExtractionProvenance } from './schemas/engram.js'
 export type { Episode } from './schemas/episode.js'
 export type { PackManifest } from './schemas/pack.js'
 export type { PreviewResult, RegistryEntry, PrivacyScanResult, PrivacyIssue } from './packs.js'

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -182,6 +182,65 @@ export const InsightFieldSchema = z.object({
   { message: 'A promoted insight must be grounded (grounding=verified); speculative dreams cannot be promoted until re-grounded.', path: ['grounding'] },
 )
 
+// === Convention: ETL extraction provenance (issue #463) ===
+//
+// The enterprise ETL CLI (enterprise#409) emits engrams carrying classifier-time
+// provenance in `structured_data.extraction`:
+//
+//   structured_data:
+//     extraction:
+//       confidence: 0.85        # 0-1 classifier score, frozen at extraction
+//       source_commit: "abc123" # git SHA at extraction time (reproducibility)
+//       extractor_version: "0.1.0"  # CLI version (schema-migration handle)
+//
+// This is a CONVENTION riding in the existing `structured_data` extension bag —
+// deliberately NOT wired into EngramSchema (zero schema change; promote to a
+// first-class sub-object only when a consumer needs to query/filter on it).
+// The schema below is a validation helper for producers/consumers of the
+// convention. `.passthrough()` keeps unknown keys so newer extractors can add
+// fields without invalidating older consumers.
+//
+// THREE DISTINCT "confidence" SEMANTICS — do not conflate:
+//   1. `structured_data.extraction.confidence` (here) — 0-1 CLASSIFIER score,
+//      frozen at extraction time. Never updated after write.
+//   2. `computeConfidence()` (src/confidence.ts) — 0-1 score DERIVED at read
+//      time from feedback_signals (+ consolidation bonus). Changes as feedback
+//      accumulates.
+//   3. `episodic.confidence` — 1-10 integer SUBJECTIVE certainty of an episodic
+//      memory (DIP-0019).
+// Mixing them (e.g. seeding feedback-derived scores from extraction confidence)
+// would corrupt the feedback loop.
+export const ExtractionProvenanceSchema = z.object({
+  confidence: z.number().min(0).max(1).optional()
+    .describe('0-1 classifier confidence at extraction time. Frozen at write; distinct from feedback-derived computeConfidence() and from episodic.confidence.'),
+  source_commit: z.string().optional()
+    .describe('Git SHA of the source repository at extraction time (reproducibility).'),
+  extractor_version: z.string().optional()
+    .describe('Version of the extracting CLI/tool (schema-migration handle). Complementary to the pack-level capsule producer field (#61).'),
+}).passthrough()
+  .describe('ETL extraction provenance convention carried in structured_data.extraction (#463). Not wired into EngramSchema.')
+
+export type ExtractionProvenance = z.infer<typeof ExtractionProvenanceSchema>
+
+/**
+ * Read and validate the #463 extraction-provenance convention from an engram.
+ *
+ * Returns the validated `structured_data.extraction` object, or `null` when it
+ * is absent or malformed (wrong container type, wrong field types, confidence
+ * out of [0,1]) — malformed provenance is ignored gracefully, never thrown.
+ *
+ * Accepts any object with an optional `structured_data` field so it works with
+ * Engram, WireEngram, or plain parsed YAML (same pattern as computeConfidence).
+ */
+export function getExtractionProvenance(
+  engram: { structured_data?: Record<string, unknown> | null },
+): ExtractionProvenance | null {
+  const extraction = engram.structured_data?.['extraction']
+  if (extraction === undefined || extraction === null) return null
+  const parsed = ExtractionProvenanceSchema.safeParse(extraction)
+  return parsed.success ? parsed.data : null
+}
+
 // === Main Engram Schema ===
 
 export const EngramSchema = z.object({

--- a/packages/core/test/extraction-provenance.test.ts
+++ b/packages/core/test/extraction-provenance.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ExtractionProvenanceSchema,
+  getExtractionProvenance,
+  EngramSchemaPassthrough,
+} from '../src/schemas/engram.js'
+
+// Issue #463 — ETL extraction provenance convention.
+//
+// The enterprise ETL CLI (enterprise#409) emits engrams whose classifier-time
+// provenance rides in `structured_data.extraction`:
+//
+//   structured_data:
+//     extraction:
+//       confidence: 0.85        # 0-1 classifier score, frozen at extraction
+//       source_commit: "abc123"
+//       extractor_version: "0.1.0"
+//
+// This is a CONVENTION, not a schema change: `structured_data` is already
+// z.record(z.string(), z.unknown()). The exported schema + helper validate the
+// convention for producers/consumers without wiring it into EngramSchema.
+
+describe('ExtractionProvenanceSchema (#463)', () => {
+  it('accepts the full canonical shape from the issue', () => {
+    const parsed = ExtractionProvenanceSchema.safeParse({
+      confidence: 0.85,
+      source_commit: 'abc123',
+      extractor_version: '0.1.0',
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.confidence).toBe(0.85)
+      expect(parsed.data.source_commit).toBe('abc123')
+      expect(parsed.data.extractor_version).toBe('0.1.0')
+    }
+  })
+
+  it('accepts partial provenance (fields are individually optional)', () => {
+    expect(ExtractionProvenanceSchema.safeParse({ confidence: 0.5 }).success).toBe(true)
+    expect(ExtractionProvenanceSchema.safeParse({ source_commit: 'deadbeef' }).success).toBe(true)
+    expect(ExtractionProvenanceSchema.safeParse({ extractor_version: '2.0.0' }).success).toBe(true)
+    expect(ExtractionProvenanceSchema.safeParse({}).success).toBe(true)
+  })
+
+  it('rejects confidence outside [0,1]', () => {
+    expect(ExtractionProvenanceSchema.safeParse({ confidence: 1.5 }).success).toBe(false)
+    expect(ExtractionProvenanceSchema.safeParse({ confidence: -0.1 }).success).toBe(false)
+    // Boundary values are valid
+    expect(ExtractionProvenanceSchema.safeParse({ confidence: 0 }).success).toBe(true)
+    expect(ExtractionProvenanceSchema.safeParse({ confidence: 1 }).success).toBe(true)
+  })
+
+  it('rejects wrong types', () => {
+    expect(ExtractionProvenanceSchema.safeParse({ confidence: 'high' }).success).toBe(false)
+    expect(ExtractionProvenanceSchema.safeParse({ source_commit: 123 }).success).toBe(false)
+    expect(ExtractionProvenanceSchema.safeParse({ extractor_version: ['0.1.0'] }).success).toBe(false)
+  })
+
+  it('preserves unknown keys (forward-compatible for newer extractors)', () => {
+    const parsed = ExtractionProvenanceSchema.safeParse({
+      confidence: 0.9,
+      future_field: 'something new',
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect((parsed.data as any).future_field).toBe('something new')
+  })
+})
+
+describe('getExtractionProvenance (#463)', () => {
+  const baseEngram = { structured_data: undefined as Record<string, unknown> | undefined }
+
+  it('returns validated provenance when present and valid', () => {
+    const engram = {
+      structured_data: {
+        extraction: { confidence: 0.85, source_commit: 'abc123', extractor_version: '0.1.0' },
+        other_key: 'untouched',
+      },
+    }
+    const prov = getExtractionProvenance(engram)
+    expect(prov).not.toBeNull()
+    expect(prov!.confidence).toBe(0.85)
+    expect(prov!.source_commit).toBe('abc123')
+    expect(prov!.extractor_version).toBe('0.1.0')
+  })
+
+  it('returns null when structured_data is absent', () => {
+    expect(getExtractionProvenance(baseEngram)).toBeNull()
+    expect(getExtractionProvenance({})).toBeNull()
+  })
+
+  it('returns null when extraction key is absent', () => {
+    expect(getExtractionProvenance({ structured_data: { unrelated: true } })).toBeNull()
+  })
+
+  it('returns null (gracefully, no throw) when extraction is malformed', () => {
+    // Wrong container types
+    expect(getExtractionProvenance({ structured_data: { extraction: 'not an object' } })).toBeNull()
+    expect(getExtractionProvenance({ structured_data: { extraction: 42 } })).toBeNull()
+    expect(getExtractionProvenance({ structured_data: { extraction: [0.85] } })).toBeNull()
+    expect(getExtractionProvenance({ structured_data: { extraction: null } })).toBeNull()
+    // Wrong field types inside the object
+    expect(getExtractionProvenance({ structured_data: { extraction: { confidence: 'high' } } })).toBeNull()
+    expect(getExtractionProvenance({ structured_data: { extraction: { confidence: 2 } } })).toBeNull()
+    expect(getExtractionProvenance({ structured_data: { extraction: { source_commit: 99 } } })).toBeNull()
+  })
+
+  it('round-trips through the engram schema unchanged (convention is additive)', () => {
+    // The engram schema itself stays untouched — extraction rides inside the
+    // existing structured_data extension bag and survives a parse round-trip.
+    const engram = EngramSchemaPassthrough.parse({
+      id: 'ENG-2026-0702-001',
+      status: 'active',
+      type: 'procedural',
+      scope: 'global',
+      statement: 'ETL-extracted knowledge',
+      structured_data: {
+        extraction: { confidence: 0.7, source_commit: '357f1ec', extractor_version: '0.1.0' },
+      },
+    })
+    const prov = getExtractionProvenance(engram)
+    expect(prov).toEqual({ confidence: 0.7, source_commit: '357f1ec', extractor_version: '0.1.0' })
+  })
+
+  it('distinct semantics: does NOT read feedback-derived or episodic confidence', () => {
+    // Three different "confidence" fields exist; the helper must only ever
+    // read the extraction-time classifier score, never the other two.
+    const engram = {
+      episodic: { emotional_weight: 5, confidence: 9 }, // 1-10 subjective certainty
+      feedback_signals: { positive: 10, negative: 0, neutral: 0 }, // drives computeConfidence()
+      structured_data: {},
+    }
+    expect(getExtractionProvenance(engram)).toBeNull()
+  })
+})

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -316,6 +316,37 @@ required when `knowledge_type` is present.
 | `structured_data` | object | arbitrary key→value | Domain-specific extension bag. |
 | `polarity` | string \| null | `do` \| `dont` \| null, default `null` | Directive vs prohibition classification. |
 
+#### 4.10.1 Convention: ETL extraction provenance (`structured_data.extraction`)
+
+ETL extractors (e.g. the enterprise ETL CLI, enterprise#409) SHOULD carry
+classifier-time provenance in `structured_data.extraction` (plur#463):
+
+| Key | Type | Range | Semantics |
+|---|---|---|---|
+| `extraction.confidence` | number? | `[0,1]` | Classifier confidence at extraction time, frozen at write. |
+| `extraction.source_commit` | string? | git SHA | Source repository commit at extraction time (reproducibility). |
+| `extraction.extractor_version` | string? | semver | Version of the extracting tool (schema-migration handle). Complementary to the pack-level capsule `producer` field (plur#61), which carries tool+version at the envelope level. |
+
+This is a **convention**, not a schema field: `structured_data` is already an
+arbitrary extension bag, so no engram-schema change is involved. Reference
+validation lives in `@plur-ai/core` as `ExtractionProvenanceSchema` /
+`getExtractionProvenance(engram)` (returns `null` when absent or malformed;
+unknown keys inside `extraction` are preserved for forward compatibility).
+Promote to a first-class optional sub-object only when a consumer needs to
+query/filter on it.
+
+**Three distinct `confidence` semantics — implementers MUST NOT conflate them:**
+
+1. `structured_data.extraction.confidence` — `[0,1]` **classifier** score,
+   frozen at extraction time; never updated after write.
+2. `computeConfidence()` — `[0,1]` score **derived from `feedback_signals`** at
+   read time (+ consolidation bonus); changes as feedback accumulates.
+3. `episodic.confidence` — `[1,10]` integer **subjective certainty** of an
+   episodic memory (§4.10, DIP-0019).
+
+Seeding one from another (e.g. initializing feedback-derived scores from
+extraction confidence) corrupts the feedback loop.
+
 ### 4.11 Exchange metadata — PROPOSED
 
 | Field | Type | Range | Semantics |


### PR DESCRIPTION
## Summary

Implements the #463 convention: enterprise ETL CLI extraction provenance carried in `structured_data.extraction` — additive, optional, zero engram-schema change.

```yaml
structured_data:
  extraction:
    confidence: 0.85        # 0-1 classifier score, frozen at extraction
    source_commit: "abc123" # git SHA at extraction time (reproducibility)
    extractor_version: "0.1.0"  # CLI version (schema-migration handle)
```

## Changes

- **`ExtractionProvenanceSchema`** (`packages/core/src/schemas/engram.ts`) — exported Zod validation helper for producers/consumers of the convention. All fields optional; `confidence` constrained to `[0,1]`; `.passthrough()` preserves unknown keys so newer extractors stay forward-compatible. Deliberately **not** wired into `EngramSchema` — `structured_data` is already `z.record(z.string(), z.unknown())`, so this is a convention, not a schema change. Promote to a first-class sub-object only when a consumer needs to query/filter on it.
- **`getExtractionProvenance(engram): ExtractionProvenance | null`** — validates `structured_data.extraction`; returns `null` when absent or malformed (wrong container type, wrong field types, out-of-range confidence) — graceful, never throws. Accepts Engram, WireEngram, or plain parsed YAML (same duck-typed pattern as `computeConfidence`).
- **Both exported** from `packages/core/src/index.ts` (schema, helper, and `ExtractionProvenance` type).
- **`spec/ENGRAM-STANDARD-v1.md` §4.10.1** — documents the convention table and the three distinct confidence semantics implementers MUST NOT conflate:
  1. `structured_data.extraction.confidence` — `[0,1]` classifier score, frozen at write
  2. `computeConfidence()` — `[0,1]` derived from `feedback_signals` at read time
  3. `episodic.confidence` — `[1,10]` subjective certainty (DIP-0019)

## Acceptance criteria (from #463)

- [x] Exported Zod schema `ExtractionProvenanceSchema` (not wired into `EngramSchema`)
- [x] Helper `getExtractionProvenance(engram): ExtractionProvenance | null`
- [x] Three confidence semantics documented in ENGRAM-STANDARD
- [x] Tests: valid, absent, malformed (wrong types ignored gracefully)

## Tests

- `packages/core/test/extraction-provenance.test.ts` — 11 tests: canonical/partial shapes, `[0,1]` boundary + range rejection, type rejection, unknown-key preservation, absent/malformed → `null` without throwing, `EngramSchemaPassthrough` round-trip, and confidence-semantics isolation (helper never reads episodic or feedback-derived confidence).
- Full core suite: **112 files / 1763 tests passed, 31 skipped, 0 failures**.

Closes #463

Refs: enterprise#409, plur#61, plur#323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1