### PR TITLE
feat(core,mcp,cli): per-store reranker eval gate — rerank-vs-RRF self-check (#451)

### DIFF
--- a/packages/cli/src/commands/rerank-eval.ts
+++ b/packages/cli/src/commands/rerank-eval.ts
@@ -1,0 +1,85 @@
+import { RERANKER_NAMES, type RerankerName } from '@plur-ai/core'
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { outputText, outputJson, shouldOutputJson, exit } from '../output.js'
+
+/**
+ * plur rerank-eval — per-store reranker self-eval gate (#451, final task).
+ *
+ * Samples this store's own engrams, synthesizes probe queries from their
+ * statements, and compares the cross-encoder's ordering against RRF-only.
+ * Cross-encoders can be net-negative out-of-domain; this is the quick
+ * self-check to run before enabling PLUR_RERANKER on a store.
+ *
+ * The verdict is cached in `<store>/.reranker-eval.json` (staleness bound:
+ * 7 days or >20% store-size drift) and surfaced by plur_doctor plus a
+ * loud-once advisory on the reranker-enable path. ADVISORY only — a harmful
+ * verdict never auto-disables reranking; it exits 1 so scripts can gate on it.
+ *
+ * Usage:
+ *   plur rerank-eval [--reranker <name>] [--sample N] [--seed N] [--force]
+ */
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  let reranker: string | undefined
+  let sample: number | undefined
+  let seed: number | undefined
+  let force = false
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === '--reranker' && i + 1 < args.length) { reranker = args[++i] }
+    else if (arg === '--sample' && i + 1 < args.length) { sample = Number.parseInt(args[++i], 10) }
+    else if (arg === '--seed' && i + 1 < args.length) { seed = Number.parseInt(args[++i], 10) }
+    else if (arg === '--force') { force = true }
+    else { exit(1, `Unknown argument: ${arg}\nUsage: plur rerank-eval [--reranker <name>] [--sample N] [--seed N] [--force]`) }
+  }
+
+  if (reranker !== undefined && (!RERANKER_NAMES.includes(reranker as RerankerName) || reranker === 'off')) {
+    const usable = RERANKER_NAMES.filter(n => n !== 'off')
+    exit(1, `Unknown reranker "${reranker}". Known: ${usable.join(', ')}`)
+  }
+  if (sample !== undefined && (!Number.isFinite(sample) || sample < 1)) {
+    exit(1, '--sample must be a positive integer')
+  }
+
+  const plur = createPlur(flags)
+  let outcome: Awaited<ReturnType<typeof plur.rerankerSelfEval>>
+  try {
+    outcome = await plur.rerankerSelfEval({
+      reranker: reranker as RerankerName | undefined,
+      sample,
+      seed,
+      force,
+    })
+  } catch (err) {
+    exit(1, `rerank-eval failed: ${(err as Error).message}`)
+  }
+
+  const { result, cached } = outcome
+  if (shouldOutputJson(flags)) {
+    outputJson({ ...result, cached })
+  } else {
+    const sign = result.delta_mrr >= 0 ? '+' : ''
+    outputText(`plur rerank-eval — per-store reranker self-eval (#451)${cached ? ' [cached]' : ''}`)
+    outputText('')
+    outputText(`  Reranker:   ${result.reranker} (${result.model_id})`)
+    outputText(`  Evaluated:  ${result.evaluated_at}`)
+    outputText(`  Store:      ${result.engram_count} active engrams, ${result.eligible_count} probe-eligible`)
+    outputText(`  Probes:     ${result.scored_probes}/${result.sample_size} scored (top-${result.top_k} pool, seed ${result.seed})`)
+    outputText(`  MRR:        RRF-only ${result.rrf_mrr.toFixed(3)} → reranked ${result.rerank_mrr.toFixed(3)} (Δ ${sign}${result.delta_mrr.toFixed(3)})`)
+    outputText(`  Hit@1:      ${(result.rrf_hit1 * 100).toFixed(0)}% → ${(result.rerank_hit1 * 100).toFixed(0)}%`)
+    outputText(`  Moves:      ${result.promotions} promoted, ${result.demotions} demoted`)
+    outputText(`  Latency:    ~${result.mean_rerank_ms.toFixed(0)}ms cross-encoder time per probe`)
+    outputText('')
+    outputText(`  Verdict:    ${result.verdict.toUpperCase()}`)
+    if (result.verdict === 'harmful') {
+      outputText('')
+      outputText('  ⚠  The reranker demotes known-relevant engrams on THIS store (out-of-domain).')
+      outputText('     Advisory only — reranking stays enabled. Consider unsetting PLUR_RERANKER.')
+    } else if (result.verdict === 'insufficient-data') {
+      outputText('')
+      outputText('  ○  Too few probe-eligible engrams for a verdict — grow the store and re-run.')
+    }
+  }
+
+  process.exit(result.verdict === 'harmful' ? 1 : 0)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,8 @@ Commands:
   init                    Install Claude Code hooks + register plur MCP server
   init-remote             Opt this project into recall from a PLUR Enterprise server
   doctor                  Diagnose Claude Code / Claude Desktop integration
+  rerank-eval             Per-store reranker self-eval gate (advisory, #451)
+                          [--reranker <name>] [--sample N] [--seed N] [--force]
   tensions [--scan]       List or scan for engram contradictions
   audit [--source X]      Audit working memory (claude-code|claw|hermes) for conflicts vs engrams
   hook-inject             (internal) Hook handler for engram injection
@@ -94,6 +96,7 @@ const COMMANDS: Record<string, string> = {
   init: './commands/init.js',
   'init-remote': './commands/init-remote.js',
   doctor: './commands/doctor.js',
+  'rerank-eval': './commands/rerank-eval.js',
   tensions: './commands/tensions.js',
   audit: './commands/audit.js',
   'hook-inject': './commands/hook-inject.js',

--- a/packages/cli/test/rerank-eval.test.ts
+++ b/packages/cli/test/rerank-eval.test.ts
@@ -1,0 +1,70 @@
+/**
+ * plur rerank-eval — CLI surface of the per-store eval gate (#451).
+ *
+ * The full eval path (probe synthesis, verdicts, caching, advisory) is
+ * covered in core (reranker-eval.test.ts) and MCP (reranker-eval-gate.test.ts)
+ * with stub adapters. The CLI subprocess can't seed adapter stubs, so these
+ * tests pin the offline-safe surface: argument validation and the
+ * no-reranker-configured error, which must fail fast without touching any
+ * model download.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('plur rerank-eval (CLI surface, #451)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-cli-revl-')) })
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  function run(args: string): { status: number; stderr: string } {
+    try {
+      execSync(`node ${CLI} rerank-eval ${args} --path ${dir}`, {
+        encoding: 'utf-8',
+        timeout: 15000,
+        env: { ...process.env, PLUR_RERANKER: '' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      return { status: 0, stderr: '' }
+    } catch (err: any) {
+      return { status: err.status ?? 1, stderr: String(err.stderr ?? '') }
+    }
+  }
+
+  it('exits 1 with guidance when no reranker is configured', () => {
+    const { status, stderr } = run('')
+    expect(status).toBe(1)
+    expect(stderr).toContain('PLUR_RERANKER')
+  })
+
+  it('rejects unknown reranker names, listing the usable ones', () => {
+    const { status, stderr } = run('--reranker nonsense-model')
+    expect(status).toBe(1)
+    expect(stderr).toContain('Unknown reranker')
+    expect(stderr).toContain('ms-marco-minilm-l6')
+    expect(stderr).toContain('bge-reranker-v2-m3')
+    expect(stderr).not.toMatch(/Known:.*\boff\b/) // "off" is not an evaluable tier
+  })
+
+  it('rejects --reranker off explicitly', () => {
+    const { status, stderr } = run('--reranker off')
+    expect(status).toBe(1)
+    expect(stderr).toContain('Unknown reranker')
+  })
+
+  it('rejects a non-positive --sample', () => {
+    const { status, stderr } = run('--reranker ms-marco-minilm-l6 --sample 0')
+    expect(status).toBe(1)
+    expect(stderr).toContain('--sample')
+  })
+
+  it('rejects unknown arguments with usage help', () => {
+    const { status, stderr } = run('--bogus')
+    expect(status).toBe(1)
+    expect(stderr).toContain('Usage: plur rerank-eval')
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,8 @@ import { captureEpisode, queryTimeline } from './episodes.js'
 import { agenticSearch } from './agentic-search.js'
 import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } from './embeddings.js'
 import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as pgliteRrfMerge, type HybridSearchResult, type RerankOptions } from './hybrid-search.js'
-import { getReranker, resolveRerankerName, isRerankerOff, rerankerStatus, resetRerankerStatus, _resetRerankerCache, type RerankerAdapter, type RerankerRuntimeStatus } from './rerankers/index.js'
+import { getReranker, resolveRerankerName, isRerankerOff, rerankerStatus, resetRerankerStatus, _resetRerankerCache, type RerankerAdapter, type RerankerRuntimeStatus, type RerankerName } from './rerankers/index.js'
+import { runRerankerSelfEval, loadRerankerEvalCache, saveRerankerEvalResult, isRerankerEvalStale, logRerankerEvalAdvisory, type RerankerEvalResult } from './reranker-eval.js'
 import { _resetBgeRerankerCache } from './rerankers/bge-reranker-v2-m3.js'
 import { _resetMsMarcoMiniLmCache } from './rerankers/ms-marco-minilm-l6.js'
 import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, isEntityDomain, rewriteLexicalQuery, isQueryRewriteDisabled, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
@@ -115,6 +116,16 @@ export {
   type RerankerName, type RerankerRuntimeStatus, type RerankerFailureKind,
 } from './rerankers/index.js'
 export type { RerankerAdapter } from './rerankers/types.js'
+// Per-store reranker eval gate (#451) — the self-check that must pass before
+// anyone flips reranking on by default for a store. Advisory only.
+export {
+  synthesizeProbeQuery, runRerankerSelfEval,
+  rerankerEvalCachePath, loadRerankerEvalCache, saveRerankerEvalResult,
+  isRerankerEvalStale, rerankerEvalAdvisory,
+  RERANKER_EVAL_STALENESS_MS, RERANKER_EVAL_COUNT_DRIFT, RERANKER_EVAL_MIN_PROBES,
+  RERANKER_EVAL_HARM_THRESHOLD, RERANKER_EVAL_BENEFIT_THRESHOLD,
+  type RerankerEvalResult, type RerankerEvalVerdict, type RerankerEvalOptions,
+} from './reranker-eval.js'
 export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus } from './sync.js'
 export { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'
@@ -362,6 +373,12 @@ export class Plur {
    * so existing call sites pay zero cost until they opt in.
    */
   private _reranker: RerankerAdapter | null = null
+  /**
+   * Per-store reranker eval gate advisory (#451) — logged at most once per
+   * instance when the enable path resolves a reranker whose cached self-eval
+   * verdict is 'harmful'. Advisory only: reranking is never auto-disabled.
+   */
+  private _rerankerEvalAdvisoryDone = false
   /** mtime (ms) of config.yaml at last load — drives reloadConfigIfChanged (#307). */
   private configMtimeMs = 0
 
@@ -1960,6 +1977,7 @@ export class Plur {
       const envName = resolveRerankerName()
       const name = envName === 'off' ? 'bge-reranker-v2-m3' : envName
       this._reranker = getReranker(name)
+      this._maybeLogRerankerEvalAdvisory(name)
       return { reranker: this._reranker }
     }
     // Implicit: follow the env. Off → undefined so the stage is skipped.
@@ -1968,7 +1986,75 @@ export class Plur {
     if (!this._reranker || isRerankerOff(this._reranker)) {
       this._reranker = getReranker(envName)
     }
+    this._maybeLogRerankerEvalAdvisory(envName)
     return { reranker: this._reranker }
+  }
+
+  /**
+   * Reranker-enable path advisory (#451): when this store's cached self-eval
+   * says the resolved reranker is net-negative HERE, warn once per instance.
+   * Never disables anything — the loud-once log is the whole intervention.
+   */
+  private _maybeLogRerankerEvalAdvisory(rerankerName: string): void {
+    if (this._rerankerEvalAdvisoryDone) return
+    this._rerankerEvalAdvisoryDone = true
+    try {
+      logRerankerEvalAdvisory(this.paths.root, rerankerName, this._filterEngrams().length)
+    } catch { /* advisory must never break recall */ }
+  }
+
+  /**
+   * Run the per-store reranker self-eval gate (#451): sample this store's own
+   * engrams, synthesize probe queries from their statements, and compare the
+   * cross-encoder's ordering against RRF-only. Returns the cached verdict when
+   * fresh (same reranker, within the staleness bound, store size stable)
+   * unless `force` is set. The result is persisted to `.reranker-eval.json`
+   * in the store root and surfaced by plur_doctor + the enable-path advisory.
+   */
+  async rerankerSelfEval(options?: {
+    /** Reranker to evaluate. Default: the PLUR_RERANKER-resolved adapter. */
+    reranker?: RerankerName
+    /** Max probes to sample (default 20). */
+    sample?: number
+    /** PRNG seed (default 1337). */
+    seed?: number
+    /** Re-run even when a fresh cached verdict exists. */
+    force?: boolean
+  }): Promise<{ result: RerankerEvalResult; cached: boolean }> {
+    const name = options?.reranker ?? resolveRerankerName()
+    if (name === 'off') {
+      throw new Error(
+        'No reranker configured — set PLUR_RERANKER (or pass { reranker }) to run the per-store self-eval.',
+      )
+    }
+    const engrams = this._filterEngrams()
+    if (!options?.force) {
+      const cached = loadRerankerEvalCache(this.paths.root)[name]
+      if (cached && !isRerankerEvalStale(cached, engrams.length)) {
+        return { result: cached, cached: true }
+      }
+    }
+    const adapter = getReranker(name)
+    const result = await runRerankerSelfEval(engrams, adapter, {
+      sample: options?.sample,
+      seed: options?.seed,
+      storagePath: this.paths.root,
+    })
+    saveRerankerEvalResult(this.paths.root, result)
+    return { result, cached: false }
+  }
+
+  /**
+   * Read this store's cached reranker self-eval verdict (#451) without
+   * running anything. Returns null when the store has never been evaluated
+   * for the given (or env-resolved) reranker.
+   */
+  rerankerEvalStatus(rerankerName?: string): { result: RerankerEvalResult; stale: boolean } | null {
+    const name = rerankerName ?? resolveRerankerName()
+    if (name === 'off') return null
+    const cached = loadRerankerEvalCache(this.paths.root)[name]
+    if (!cached) return null
+    return { result: cached, stale: isRerankerEvalStale(cached, this._filterEngrams().length) }
   }
 
   /** Resolve the query-intent routing profile for a call (#224). undefined = no routing (general). */

--- a/packages/core/src/reranker-eval.ts
+++ b/packages/core/src/reranker-eval.ts
@@ -1,0 +1,398 @@
+/**
+ * Per-store reranker eval gate — #451 (final task).
+ *
+ * Cross-encoder rerankers are trained on web/QA corpora; on an out-of-domain
+ * engram store they can be net-negative (one 2026 study measured bge-reranker
+ * degrading dense retrieval 34%). The #451 measurements show the lift lives
+ * in hard categories on the fixture corpus — but nothing guarantees that
+ * transfers to YOUR store. So before anyone flips reranking on by default,
+ * each store gets a quick self-check:
+ *
+ *   1. Sample the store's own engrams (deterministic, seeded).
+ *   2. Synthesize a probe query from each sampled engram's statement —
+ *      the source engram is the known-relevant document for that query.
+ *   3. Retrieve the RRF top-K for the probe (reranker OFF), note where the
+ *      source ranks.
+ *   4. Re-order the same pool with the cross-encoder, note the new rank.
+ *   5. Aggregate MRR / Hit@1 both ways. If the reranker systematically
+ *      demotes known-relevant sources, it is HARMFUL on this store.
+ *
+ * The probe queries are keyword extracts of the source statements, so BM25
+ * usually ranks the source highly already — by construction this gate has
+ * limited power to prove *benefit* (the benchmark harness does that); its
+ * job is to prove a reranker is NOT ACTIVELY HARMFUL on this store's
+ * domain, which is exactly what an enable-gate needs.
+ *
+ * The verdict is ADVISORY: cached per store (`.reranker-eval.json`), read by
+ * plur_doctor and logged loud-once on the reranker-enable path. It never
+ * silently disables reranking — the shipping-default decision stays human.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import type { Engram } from './schemas/engram.js'
+import { hybridSearch } from './hybrid-search.js'
+import { isRerankerOff } from './rerankers/index.js'
+import type { RerankerAdapter } from './rerankers/types.js'
+import { atomicWrite } from './sync.js'
+import { logger } from './logger.js'
+
+// ─── Tunables ────────────────────────────────────────────────────────
+
+/** Cached verdicts older than this are stale — the store may have drifted. */
+export const RERANKER_EVAL_STALENESS_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+/** Store-size drift (relative) beyond which a cached verdict is stale. */
+export const RERANKER_EVAL_COUNT_DRIFT = 0.2
+
+/** Fewer scored probes than this → 'insufficient-data' (no verdict). */
+export const RERANKER_EVAL_MIN_PROBES = 5
+
+/** ΔMRR below this → 'harmful'; above the positive twin → 'beneficial'. */
+export const RERANKER_EVAL_HARM_THRESHOLD = -0.05
+export const RERANKER_EVAL_BENEFIT_THRESHOLD = 0.05
+
+/** Default number of engrams sampled as probes. */
+const DEFAULT_SAMPLE = 20
+
+/** Candidate pool per probe — mirrors the shipping hybrid top-10 window. */
+const DEFAULT_TOP_K = 10
+
+/** Default PRNG seed — same as the benchmark harness for familiarity. */
+const DEFAULT_SEED = 1337
+
+/** Probe queries draw up to this many content words from the statement. */
+const MAX_QUERY_TOKENS = 6
+
+/** Statements need at least this many distinct content words to be probed. */
+const MIN_CONTENT_TOKENS = 4
+
+// ─── Result types ────────────────────────────────────────────────────
+
+export type RerankerEvalVerdict = 'beneficial' | 'neutral' | 'harmful' | 'insufficient-data'
+
+export interface RerankerEvalResult {
+  version: 1
+  /** Adapter name evaluated (e.g. ms-marco-minilm-l6). */
+  reranker: string
+  model_id: string
+  /** ISO timestamp of the run — drives the staleness bound. */
+  evaluated_at: string
+  /** Active engram count at eval time — drives the drift staleness check. */
+  engram_count: number
+  /** Engrams with statements long enough to synthesize a probe from. */
+  eligible_count: number
+  /** Probes attempted (min(eligible, sample option)). */
+  sample_size: number
+  /** Probes where RRF retrieved the source in the top-K (the scored set). */
+  scored_probes: number
+  seed: number
+  top_k: number
+  /** Mean reciprocal rank of the source engram under RRF-only ordering. */
+  rrf_mrr: number
+  /** Mean reciprocal rank of the source engram after cross-encoder rerank. */
+  rerank_mrr: number
+  /** rerank_mrr - rrf_mrr. Negative = the reranker demotes known-relevant docs. */
+  delta_mrr: number
+  rrf_hit1: number
+  rerank_hit1: number
+  /** Probes where the rerank improved the source's rank. */
+  promotions: number
+  /** Probes where the rerank worsened the source's rank. */
+  demotions: number
+  /** Mean cross-encoder scoring time per probe (ms) — advisory latency signal. */
+  mean_rerank_ms: number
+  verdict: RerankerEvalVerdict
+}
+
+export interface RerankerEvalOptions {
+  /** Max engrams sampled as probes. Default 20. */
+  sample?: number
+  /** PRNG seed for sampling + query synthesis. Default 1337. */
+  seed?: number
+  /** Candidate pool size per probe. Default 10 (the shipping hybrid window). */
+  topK?: number
+  /** Store root for the embeddings cache (same as hybridSearch's storagePath). */
+  storagePath?: string
+}
+
+// ─── Probe query synthesis ───────────────────────────────────────────
+
+/**
+ * Compact stopword list — enough to keep probe queries content-bearing.
+ * Not exhaustive; a stopword that slips through only makes the probe easier
+ * for BM25, which biases the gate toward "not harmful" (its conservative
+ * direction).
+ */
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'if', 'then', 'else', 'when', 'while',
+  'of', 'to', 'in', 'on', 'at', 'by', 'for', 'with', 'from', 'into', 'onto',
+  'is', 'are', 'was', 'were', 'be', 'been', 'being', 'am',
+  'it', 'its', 'this', 'that', 'these', 'those', 'there', 'here',
+  'he', 'she', 'they', 'we', 'you', 'i', 'his', 'her', 'their', 'our', 'your', 'my',
+  'do', 'does', 'did', 'done', 'doing', 'has', 'have', 'had', 'having',
+  'will', 'would', 'can', 'could', 'shall', 'should', 'may', 'might', 'must',
+  'not', 'no', 'nor', 'so', 'too', 'very', 'just', 'only', 'also', 'than',
+  'as', 'because', 'about', 'over', 'under', 'up', 'down', 'out', 'off',
+  'all', 'any', 'each', 'every', 'some', 'both', 'more', 'most', 'other',
+  'one', 'two', 'via', 'per', 'vs', 'etc', 'what', 'which', 'who', 'how', 'why', 'where',
+])
+
+/** FNV-1a 32-bit hash — mixes the statement into the seed so two identical-length statements sample differently. */
+function fnv1a(text: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+/** mulberry32 — tiny deterministic PRNG. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Seeded Fisher–Yates shuffle (returns a new array). */
+function seededShuffle<T>(items: T[], rand: () => number): T[] {
+  const out = items.slice()
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+/**
+ * Synthesize a deterministic probe query from an engram statement.
+ *
+ * Tokenizes, drops stopwords and sub-3-char tokens, dedupes, then draws up
+ * to {@link MAX_QUERY_TOKENS} content words — seeded-sampled (not a plain
+ * prefix) so probes exercise different parts of long statements — and joins
+ * them in original statement order to keep some phrase structure.
+ *
+ * Returns null when the statement has fewer than {@link MIN_CONTENT_TOKENS}
+ * distinct content words — too short to be a meaningful probe.
+ */
+export function synthesizeProbeQuery(statement: string, seed: number): string | null {
+  const tokens = (statement ?? '')
+    .toLowerCase()
+    .split(/[^a-z0-9-]+/)
+    .filter(t => t.length >= 3 && !STOPWORDS.has(t))
+  const unique: string[] = []
+  const seen = new Set<string>()
+  for (const t of tokens) {
+    if (!seen.has(t)) {
+      seen.add(t)
+      unique.push(t)
+    }
+  }
+  if (unique.length < MIN_CONTENT_TOKENS) return null
+  if (unique.length <= MAX_QUERY_TOKENS) return unique.join(' ')
+  const rand = mulberry32((seed ^ fnv1a(statement)) >>> 0)
+  const indices = seededShuffle(unique.map((_t, i) => i), rand)
+    .slice(0, MAX_QUERY_TOKENS)
+    .sort((a, b) => a - b)
+  return indices.map(i => unique[i]).join(' ')
+}
+
+// ─── The self-eval ───────────────────────────────────────────────────
+
+/**
+ * Run the per-store reranker self-eval.
+ *
+ * Failures in the adapter PROPAGATE — an eval run is an explicit health
+ * question and must not silently degrade the way the recall hot path does.
+ */
+export async function runRerankerSelfEval(
+  engrams: Engram[],
+  adapter: RerankerAdapter,
+  opts?: RerankerEvalOptions,
+): Promise<RerankerEvalResult> {
+  if (isRerankerOff(adapter)) {
+    throw new Error('Cannot self-eval the "off" reranker sentinel — configure PLUR_RERANKER or pass a real adapter.')
+  }
+  const seed = opts?.seed ?? DEFAULT_SEED
+  const sample = Math.max(1, opts?.sample ?? DEFAULT_SAMPLE)
+  const topK = Math.max(2, opts?.topK ?? DEFAULT_TOP_K)
+
+  const active = engrams.filter(e => e.status === 'active')
+  const eligible = active
+    .map(e => ({ engram: e, query: synthesizeProbeQuery(e.statement, seed) }))
+    .filter((p): p is { engram: Engram; query: string } => p.query !== null)
+
+  const rand = mulberry32(seed >>> 0)
+  const probes = seededShuffle(eligible, rand).slice(0, sample)
+
+  let scored = 0
+  let rrfMrrSum = 0
+  let rerankMrrSum = 0
+  let rrfHit1 = 0
+  let rerankHit1 = 0
+  let promotions = 0
+  let demotions = 0
+  let rerankMsSum = 0
+
+  for (const probe of probes) {
+    // RRF-only candidate pool (no reranker) — the shipping baseline order.
+    const candidates = await hybridSearch(active, probe.query, topK, opts?.storagePath)
+    const rrfRank = candidates.findIndex(e => e.id === probe.engram.id)
+    if (rrfRank === -1) continue // source not retrieved — reranking can't touch it either way
+
+    const started = Date.now()
+    const scores = await adapter.scoreBatch(probe.query, candidates.map(e => e.statement))
+    rerankMsSum += Date.now() - started
+    if (scores.length !== candidates.length) {
+      throw new Error(
+        `Reranker "${adapter.name}" returned ${scores.length} scores for ${candidates.length} candidates during self-eval`,
+      )
+    }
+    // Stable sort by descending score — ties keep RRF order, mirroring applyReranker.
+    const reranked = candidates
+      .map((engram, i) => ({ engram, score: scores[i] }))
+      .sort((a, b) => b.score - a.score)
+      .map(r => r.engram)
+    const rerankRank = reranked.findIndex(e => e.id === probe.engram.id)
+
+    scored += 1
+    rrfMrrSum += 1 / (rrfRank + 1)
+    rerankMrrSum += 1 / (rerankRank + 1)
+    if (rrfRank === 0) rrfHit1 += 1
+    if (rerankRank === 0) rerankHit1 += 1
+    if (rerankRank < rrfRank) promotions += 1
+    if (rerankRank > rrfRank) demotions += 1
+  }
+
+  const rrfMrr = scored > 0 ? rrfMrrSum / scored : 0
+  const rerankMrr = scored > 0 ? rerankMrrSum / scored : 0
+  const deltaMrr = rerankMrr - rrfMrr
+
+  let verdict: RerankerEvalVerdict
+  if (scored < RERANKER_EVAL_MIN_PROBES) {
+    verdict = 'insufficient-data'
+  } else if (deltaMrr < RERANKER_EVAL_HARM_THRESHOLD) {
+    verdict = 'harmful'
+  } else if (deltaMrr > RERANKER_EVAL_BENEFIT_THRESHOLD) {
+    verdict = 'beneficial'
+  } else {
+    verdict = 'neutral'
+  }
+
+  return {
+    version: 1,
+    reranker: adapter.name,
+    model_id: adapter.modelId,
+    evaluated_at: new Date().toISOString(),
+    engram_count: active.length,
+    eligible_count: eligible.length,
+    sample_size: probes.length,
+    scored_probes: scored,
+    seed,
+    top_k: topK,
+    rrf_mrr: rrfMrr,
+    rerank_mrr: rerankMrr,
+    delta_mrr: deltaMrr,
+    rrf_hit1: scored > 0 ? rrfHit1 / scored : 0,
+    rerank_hit1: scored > 0 ? rerankHit1 / scored : 0,
+    promotions,
+    demotions,
+    mean_rerank_ms: scored > 0 ? rerankMsSum / scored : 0,
+    verdict,
+  }
+}
+
+// ─── Per-store cache ─────────────────────────────────────────────────
+
+const CACHE_FILENAME = '.reranker-eval.json'
+
+/** Path of the per-store eval cache file. */
+export function rerankerEvalCachePath(storeRoot: string): string {
+  return join(storeRoot, CACHE_FILENAME)
+}
+
+/**
+ * Load the per-store eval cache: reranker name → last result. Corrupt or
+ * missing files load as empty — the gate is advisory, never a crash source.
+ */
+export function loadRerankerEvalCache(storeRoot: string): Record<string, RerankerEvalResult> {
+  const path = rerankerEvalCachePath(storeRoot)
+  if (!existsSync(path)) return {}
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf8'))
+    if (!raw || typeof raw !== 'object' || typeof raw.evals !== 'object' || raw.evals === null) return {}
+    return raw.evals as Record<string, RerankerEvalResult>
+  } catch {
+    return {}
+  }
+}
+
+/** Persist one eval result into the per-store cache (merge by reranker name). */
+export function saveRerankerEvalResult(storeRoot: string, result: RerankerEvalResult): void {
+  const evals = loadRerankerEvalCache(storeRoot)
+  evals[result.reranker] = result
+  atomicWrite(rerankerEvalCachePath(storeRoot), JSON.stringify({ version: 1, evals }, null, 2))
+}
+
+/**
+ * A cached verdict goes stale when it is older than the staleness bound or
+ * the store's engram count drifted more than 20% since the eval ran — either
+ * way the store may no longer look like what was measured.
+ */
+export function isRerankerEvalStale(
+  result: RerankerEvalResult,
+  currentEngramCount: number,
+  now: number = Date.now(),
+): boolean {
+  const evaluatedAt = Date.parse(result.evaluated_at)
+  if (Number.isNaN(evaluatedAt) || now - evaluatedAt > RERANKER_EVAL_STALENESS_MS) return true
+  const base = Math.max(1, result.engram_count)
+  return Math.abs(currentEngramCount - result.engram_count) / base > RERANKER_EVAL_COUNT_DRIFT
+}
+
+// ─── Advisory (log/doctor — never an auto-disable) ───────────────────
+
+/**
+ * Build the advisory message for a store+reranker pair, or null when there
+ * is nothing to warn about (no cached eval, or verdict is not harmful).
+ *
+ * ADVISORY by design (#451): the reranker stays enabled; this only makes the
+ * measured harm visible so a human can decide to unset PLUR_RERANKER.
+ */
+export function rerankerEvalAdvisory(
+  storeRoot: string,
+  rerankerName: string,
+  currentEngramCount: number,
+): string | null {
+  const cached = loadRerankerEvalCache(storeRoot)[rerankerName]
+  if (!cached || cached.verdict !== 'harmful') return null
+  const stale = isRerankerEvalStale(cached, currentEngramCount)
+  const staleNote = stale
+    ? ' The verdict is STALE (store changed or eval aged out) — re-run plur_doctor with rerank_eval:true for a fresh read.'
+    : ''
+  return (
+    `[reranker-eval] Per-store self-eval (${cached.evaluated_at}) measured reranker "${rerankerName}" as ` +
+    `net-negative on this store: ΔMRR ${cached.delta_mrr.toFixed(3)} over ${cached.scored_probes} probes ` +
+    `(demoted known-relevant sources in ${cached.demotions}). This is advisory — reranking remains ENABLED. ` +
+    `Consider unsetting PLUR_RERANKER for this store, or re-check via plur_doctor with rerank_eval:true.${staleNote}`
+  )
+}
+
+/**
+ * Log the advisory (loud-once semantics live in the caller — Plur memoizes
+ * per instance). Split from {@link rerankerEvalAdvisory} so tests can assert
+ * on the message without capturing stderr.
+ */
+export function logRerankerEvalAdvisory(
+  storeRoot: string,
+  rerankerName: string,
+  currentEngramCount: number,
+): void {
+  const message = rerankerEvalAdvisory(storeRoot, rerankerName, currentEngramCount)
+  if (message) logger.warning(message)
+}

--- a/packages/core/test/reranker-eval.test.ts
+++ b/packages/core/test/reranker-eval.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Per-store reranker eval gate — #451 (last task).
+ *
+ * A cross-encoder reranker can be net-negative out-of-domain. Before the
+ * default ever flips ON, each store needs a quick self-check: sample the
+ * store's own engrams, synthesize probe queries from their statements,
+ * and compare rerank-on ordering against the RRF-only ordering. The source
+ * engram of each probe is the known-relevant document, so a reranker that
+ * demotes it below distractors is measurably harmful ON THIS STORE.
+ *
+ * The verdict is ADVISORY: it is cached per store, surfaced via plur_doctor
+ * and a loud-once log line on the reranker-enable path — never a silent
+ * auto-disable. Stub rerankers stand in for the real models so no test
+ * downloads anything.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { setEmbeddingsEnabled } from '../src/embeddings.js'
+import {
+  synthesizeProbeQuery,
+  runRerankerSelfEval,
+  rerankerEvalCachePath,
+  loadRerankerEvalCache,
+  saveRerankerEvalResult,
+  isRerankerEvalStale,
+  rerankerEvalAdvisory,
+  RERANKER_EVAL_MIN_PROBES,
+  RERANKER_EVAL_STALENESS_MS,
+  type RerankerEvalResult,
+} from '../src/reranker-eval.js'
+import { _setCachedReranker, _resetRerankerCache, resetRerankerStatus } from '../src/rerankers/index.js'
+import type { RerankerAdapter } from '../src/rerankers/types.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+// Deterministic + offline: the eval gate's contract is about ORDERING
+// comparison, not embedding quality. BM25-only keeps the RRF baseline
+// bit-stable across machines and avoids the ONNX model load entirely.
+beforeAll(() => setEmbeddingsEnabled(false, 'reranker-eval tests run BM25-only'))
+afterAll(() => setEmbeddingsEnabled(true))
+
+// ─── Test corpus ─────────────────────────────────────────────────────
+
+/** Statements long enough to yield ≥4 content words each — probe-eligible. */
+const STATEMENTS = [
+  'The staging deploy target for the ingestion service is cluster-2 in Frankfurt',
+  'Karl prefers TypeScript strict mode enabled for every new package in the monorepo',
+  'The nightly benchmark harness runs LongMemEval fixtures against the hybrid search pipeline',
+  'Postgres connection pooling for the enterprise server uses pgbouncer in transaction mode',
+  'The Telegram bot forwards trading alerts to the meridian channel every morning',
+  'Grafana dashboards for the reranker latency live under the retrieval folder',
+  'The YAML store keeps engram truth while PGLite carries the derived vector index',
+  'OpenClaw sessions auto-inject engrams through the context engine assembler hook',
+  'The outbox queue retries failed remote writes on every session start event',
+  'BM25 tokenization lowercases statements and strips punctuation before scoring',
+  'Reciprocal rank fusion merges lexical and semantic result lists with constant sixty',
+  'The dedup pipeline hashes statement content before invoking the LLM judge',
+]
+
+function mkEngram(id: string, statement: string): Engram {
+  return {
+    id,
+    statement,
+    type: 'behavioral',
+    scope: 'global',
+    domain: 'plur.test',
+    status: 'active',
+    tags: [],
+    activation: {
+      retrieval_strength: 1.0,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-07-02',
+    },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+  } as unknown as Engram
+}
+
+const CORPUS: Engram[] = STATEMENTS.map((s, i) => mkEngram(`ENG-2026-0702-${String(i + 1).padStart(3, '0')}`, s))
+
+// ─── Stub rerankers ──────────────────────────────────────────────────
+
+/**
+ * Oracle: scores each doc by token overlap with the query — since probe
+ * queries are synthesized from the source statement's own tokens, the source
+ * doc wins. This is the "reranker helps (or at least does not hurt)" control.
+ */
+const oracle: RerankerAdapter = {
+  name: 'oracle',
+  modelId: 'fake://oracle',
+  async score(q, d) { return overlap(q, d) },
+  async scoreBatch(q, docs) { return docs.map(d => overlap(q, d)) },
+}
+
+function overlap(query: string, document: string): number {
+  const qs = new Set(query.toLowerCase().split(/\s+/).filter(Boolean))
+  let s = 0
+  for (const token of document.toLowerCase().split(/\s+/)) if (qs.has(token)) s += 1
+  return s
+}
+
+/**
+ * Adversary: inverts whatever order it is given (later docs score higher),
+ * so the RRF top-1 source engram gets demoted to the bottom of the pool.
+ * This is the "reranker is net-negative on this store" control.
+ */
+const adversary: RerankerAdapter = {
+  name: 'adversary',
+  modelId: 'fake://adversary',
+  async score() { return 0 },
+  async scoreBatch(_q, docs) { return docs.map((_d, i) => i) },
+}
+
+/** Broken: always throws — an eval run must propagate this, not swallow it. */
+const broken: RerankerAdapter = {
+  name: 'broken',
+  modelId: 'fake://broken',
+  async score() { throw new Error('model load failed') },
+  async scoreBatch() { throw new Error('model load failed') },
+}
+
+// ─── synthesizeProbeQuery ────────────────────────────────────────────
+
+describe('synthesizeProbeQuery (#451)', () => {
+  it('is deterministic for the same statement + seed', () => {
+    const s = STATEMENTS[0]
+    expect(synthesizeProbeQuery(s, 1337)).toBe(synthesizeProbeQuery(s, 1337))
+  })
+
+  it('draws only content words from the statement', () => {
+    const q = synthesizeProbeQuery(STATEMENTS[0], 1337)
+    expect(q).toBeTruthy()
+    const statementTokens = new Set(STATEMENTS[0].toLowerCase().split(/[^a-z0-9-]+/i).filter(Boolean))
+    for (const token of q!.split(' ')) {
+      expect(statementTokens.has(token)).toBe(true)
+    }
+  })
+
+  it('strips stopwords', () => {
+    const q = synthesizeProbeQuery('the cat is on the mat and it is very happy today', 1)
+    expect(q).toBeTruthy()
+    for (const stop of ['the', 'is', 'on', 'and', 'it', 'very']) {
+      expect(q!.split(' ')).not.toContain(stop)
+    }
+  })
+
+  it('returns null for statements too short to probe', () => {
+    expect(synthesizeProbeQuery('short one', 1337)).toBeNull()
+    expect(synthesizeProbeQuery('', 1337)).toBeNull()
+    expect(synthesizeProbeQuery('the of and to a in', 1337)).toBeNull()
+  })
+
+  it('different seeds can select different word subsets (seeded, not prefix-only)', () => {
+    const s = STATEMENTS.join(' ') // long statement, many content words
+    const variants = new Set([1, 2, 3, 4, 5, 6, 7, 8].map(seed => synthesizeProbeQuery(s, seed)))
+    expect(variants.size).toBeGreaterThan(1)
+  })
+})
+
+// ─── runRerankerSelfEval ─────────────────────────────────────────────
+
+describe('runRerankerSelfEval (#451)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rerank-eval-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('an order-agreeing reranker is not harmful on the store', async () => {
+    const result = await runRerankerSelfEval(CORPUS, oracle, { storagePath: dir, seed: 1337 })
+    expect(result.verdict).not.toBe('harmful')
+    expect(result.verdict).not.toBe('insufficient-data')
+    expect(result.delta_mrr).toBeGreaterThanOrEqual(-0.05)
+    expect(result.scored_probes).toBeGreaterThanOrEqual(RERANKER_EVAL_MIN_PROBES)
+    expect(result.reranker).toBe('oracle')
+    expect(result.model_id).toBe('fake://oracle')
+    expect(result.engram_count).toBe(CORPUS.length)
+    expect(result.seed).toBe(1337)
+    expect(Date.parse(result.evaluated_at)).not.toBeNaN()
+  })
+
+  it('an order-inverting reranker is harmful on the store', async () => {
+    const result = await runRerankerSelfEval(CORPUS, adversary, { storagePath: dir, seed: 1337 })
+    expect(result.verdict).toBe('harmful')
+    expect(result.delta_mrr).toBeLessThan(0)
+    expect(result.rerank_mrr).toBeLessThan(result.rrf_mrr)
+  })
+
+  it('is deterministic: same corpus + seed + adapter → identical metrics', async () => {
+    const a = await runRerankerSelfEval(CORPUS, adversary, { storagePath: dir, seed: 7 })
+    const b = await runRerankerSelfEval(CORPUS, adversary, { storagePath: dir, seed: 7 })
+    expect(a.rrf_mrr).toBe(b.rrf_mrr)
+    expect(a.rerank_mrr).toBe(b.rerank_mrr)
+    expect(a.sample_size).toBe(b.sample_size)
+    expect(a.verdict).toBe(b.verdict)
+  })
+
+  it('returns insufficient-data when too few engrams are probe-eligible', async () => {
+    const tiny = CORPUS.slice(0, 2)
+    const result = await runRerankerSelfEval(tiny, oracle, { storagePath: dir })
+    expect(result.verdict).toBe('insufficient-data')
+  })
+
+  it('throws when handed the off sentinel — evaluating nothing is a caller bug', async () => {
+    const off: RerankerAdapter = {
+      name: 'off',
+      modelId: '<off>',
+      async score() { return 0 },
+      async scoreBatch(_q, docs) { return docs.map(() => 0) },
+    }
+    await expect(runRerankerSelfEval(CORPUS, off, { storagePath: dir })).rejects.toThrow(/off/i)
+  })
+
+  it('propagates reranker failures instead of silently falling back', async () => {
+    await expect(runRerankerSelfEval(CORPUS, broken, { storagePath: dir })).rejects.toThrow('model load failed')
+  })
+
+  it('respects the sample option', async () => {
+    const result = await runRerankerSelfEval(CORPUS, oracle, { storagePath: dir, sample: 6 })
+    expect(result.sample_size).toBeLessThanOrEqual(6)
+  })
+})
+
+// ─── cache + staleness ───────────────────────────────────────────────
+
+describe('reranker eval cache (#451)', () => {
+  let dir: string
+
+  const result = (over: Partial<RerankerEvalResult> = {}): RerankerEvalResult => ({
+    version: 1,
+    reranker: 'ms-marco-minilm-l6',
+    model_id: 'Xenova/ms-marco-MiniLM-L-6-v2',
+    evaluated_at: new Date().toISOString(),
+    engram_count: 100,
+    eligible_count: 80,
+    sample_size: 20,
+    scored_probes: 18,
+    seed: 1337,
+    top_k: 10,
+    rrf_mrr: 0.8,
+    rerank_mrr: 0.85,
+    delta_mrr: 0.05,
+    rrf_hit1: 0.7,
+    rerank_hit1: 0.75,
+    promotions: 4,
+    demotions: 1,
+    mean_rerank_ms: 12,
+    verdict: 'beneficial',
+    ...over,
+  })
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rerank-cache-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('save + load roundtrips per reranker name', () => {
+    saveRerankerEvalResult(dir, result())
+    saveRerankerEvalResult(dir, result({ reranker: 'bge-reranker-v2-m3', verdict: 'harmful', delta_mrr: -0.2 }))
+    const cache = loadRerankerEvalCache(dir)
+    expect(cache['ms-marco-minilm-l6']?.verdict).toBe('beneficial')
+    expect(cache['bge-reranker-v2-m3']?.verdict).toBe('harmful')
+    expect(existsSync(rerankerEvalCachePath(dir))).toBe(true)
+  })
+
+  it('re-saving the same reranker overwrites its entry', () => {
+    saveRerankerEvalResult(dir, result({ verdict: 'neutral' }))
+    saveRerankerEvalResult(dir, result({ verdict: 'harmful' }))
+    expect(loadRerankerEvalCache(dir)['ms-marco-minilm-l6']?.verdict).toBe('harmful')
+  })
+
+  it('tolerates a corrupt cache file (returns empty, does not throw)', () => {
+    writeFileSync(rerankerEvalCachePath(dir), '{ not json')
+    expect(loadRerankerEvalCache(dir)).toEqual({})
+  })
+
+  it('missing cache file loads as empty', () => {
+    expect(loadRerankerEvalCache(dir)).toEqual({})
+  })
+
+  it('fresh result with stable store size is not stale', () => {
+    expect(isRerankerEvalStale(result(), 100)).toBe(false)
+    expect(isRerankerEvalStale(result(), 110)).toBe(false) // 10% drift ok
+  })
+
+  it('age beyond the staleness bound marks the result stale', () => {
+    const old = result({ evaluated_at: new Date(Date.now() - RERANKER_EVAL_STALENESS_MS - 1000).toISOString() })
+    expect(isRerankerEvalStale(old, 100)).toBe(true)
+  })
+
+  it('a store that grew or shrank >20% marks the result stale', () => {
+    expect(isRerankerEvalStale(result(), 130)).toBe(true)
+    expect(isRerankerEvalStale(result(), 70)).toBe(true)
+  })
+})
+
+// ─── advisory (log/doctor — never auto-disable) ──────────────────────
+
+describe('rerankerEvalAdvisory (#451)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rerank-adv-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const harmful: RerankerEvalResult = {
+    version: 1,
+    reranker: 'ms-marco-minilm-l6',
+    model_id: 'Xenova/ms-marco-MiniLM-L-6-v2',
+    evaluated_at: new Date().toISOString(),
+    engram_count: 12,
+    eligible_count: 12,
+    sample_size: 12,
+    scored_probes: 12,
+    seed: 1337,
+    top_k: 10,
+    rrf_mrr: 0.9,
+    rerank_mrr: 0.4,
+    delta_mrr: -0.5,
+    rrf_hit1: 0.9,
+    rerank_hit1: 0.3,
+    promotions: 0,
+    demotions: 9,
+    mean_rerank_ms: 10,
+    verdict: 'harmful',
+  }
+
+  it('returns null when no eval has been cached', () => {
+    expect(rerankerEvalAdvisory(dir, 'ms-marco-minilm-l6', 12)).toBeNull()
+  })
+
+  it('returns null for a beneficial/neutral verdict', () => {
+    saveRerankerEvalResult(dir, { ...harmful, verdict: 'neutral', delta_mrr: 0 })
+    expect(rerankerEvalAdvisory(dir, 'ms-marco-minilm-l6', 12)).toBeNull()
+  })
+
+  it('returns an advisory message for a harmful verdict — mentioning it stays enabled', () => {
+    saveRerankerEvalResult(dir, harmful)
+    const msg = rerankerEvalAdvisory(dir, 'ms-marco-minilm-l6', 12)
+    expect(msg).toBeTruthy()
+    expect(msg).toContain('net-negative')
+    expect(msg).toContain('ms-marco-minilm-l6')
+    // Advisory, not a kill switch: reranking stays on, the message says so.
+    expect(msg!.toLowerCase()).toContain('advisory')
+    expect(msg).toContain('plur_doctor')
+  })
+
+  it('flags staleness in the advisory when the cached verdict is old', () => {
+    saveRerankerEvalResult(dir, {
+      ...harmful,
+      evaluated_at: new Date(Date.now() - RERANKER_EVAL_STALENESS_MS - 1000).toISOString(),
+    })
+    const msg = rerankerEvalAdvisory(dir, 'ms-marco-minilm-l6', 12)
+    expect(msg).toBeTruthy()
+    expect(msg!.toLowerCase()).toContain('stale')
+  })
+
+  it('is per-reranker: a harmful bge verdict does not warn for the tiny tier', () => {
+    saveRerankerEvalResult(dir, { ...harmful, reranker: 'bge-reranker-v2-m3' })
+    expect(rerankerEvalAdvisory(dir, 'ms-marco-minilm-l6', 12)).toBeNull()
+  })
+})
+
+// ─── Plur integration ────────────────────────────────────────────────
+
+describe('Plur.rerankerSelfEval + advisory on the enable path (#451)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rerank-plur-'))
+    plur = new Plur({ path: dir })
+    for (const s of STATEMENTS) plur.learn(s, { scope: 'global' })
+    _resetRerankerCache()
+    resetRerankerStatus()
+  })
+  afterEach(() => {
+    delete process.env.PLUR_RERANKER
+    _resetRerankerCache()
+    resetRerankerStatus()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('runs the self-eval against the store and caches the verdict', async () => {
+    process.env.PLUR_RERANKER = 'ms-marco-minilm-l6'
+    _setCachedReranker('ms-marco-minilm-l6', { ...adversary, name: 'ms-marco-minilm-l6' })
+    const { result, cached } = await plur.rerankerSelfEval()
+    expect(cached).toBe(false)
+    expect(result.verdict).toBe('harmful')
+    expect(result.reranker).toBe('ms-marco-minilm-l6')
+    // Cached on disk, keyed by reranker name.
+    const disk = loadRerankerEvalCache(plur.status().storage_root)
+    expect(disk['ms-marco-minilm-l6']?.verdict).toBe('harmful')
+  })
+
+  it('returns the cached verdict on the second call; force re-runs', async () => {
+    process.env.PLUR_RERANKER = 'ms-marco-minilm-l6'
+    _setCachedReranker('ms-marco-minilm-l6', { ...adversary, name: 'ms-marco-minilm-l6' })
+    const first = await plur.rerankerSelfEval()
+    expect(first.cached).toBe(false)
+    const second = await plur.rerankerSelfEval()
+    expect(second.cached).toBe(true)
+    expect(second.result.evaluated_at).toBe(first.result.evaluated_at)
+    const forced = await plur.rerankerSelfEval({ force: true })
+    expect(forced.cached).toBe(false)
+  })
+
+  it('throws when no reranker is configured and none is passed', async () => {
+    delete process.env.PLUR_RERANKER
+    await expect(plur.rerankerSelfEval()).rejects.toThrow(/PLUR_RERANKER|reranker/i)
+  })
+
+  it('rerankerEvalStatus reads the cached verdict without running anything', async () => {
+    expect(plur.rerankerEvalStatus('ms-marco-minilm-l6')).toBeNull()
+    process.env.PLUR_RERANKER = 'ms-marco-minilm-l6'
+    _setCachedReranker('ms-marco-minilm-l6', { ...adversary, name: 'ms-marco-minilm-l6' })
+    await plur.rerankerSelfEval()
+    const status = plur.rerankerEvalStatus('ms-marco-minilm-l6')
+    expect(status).not.toBeNull()
+    expect(status!.result.verdict).toBe('harmful')
+    expect(status!.stale).toBe(false)
+  })
+
+  it('logs the harmful advisory ONCE when the env-configured reranker engages — and keeps reranking', async () => {
+    process.env.PLUR_RERANKER = 'ms-marco-minilm-l6'
+    _setCachedReranker('ms-marco-minilm-l6', { ...adversary, name: 'ms-marco-minilm-l6' })
+    await plur.rerankerSelfEval()
+
+    // Fresh instance simulates a new process picking up the cached verdict.
+    const fresh = new Plur({ path: dir })
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const first = await fresh.recallHybridWithMeta('staging deploy target cluster', { limit: 5 })
+      // NOT auto-disabled: the reranker still engaged.
+      expect(first.reranked).toBeGreaterThan(0)
+      const warnings = () => spy.mock.calls
+        .filter(c => String(c[0]).includes('plur:warning') && c.map(String).join(' ').includes('net-negative'))
+        .length
+      expect(warnings()).toBe(1)
+      // Second recall: advisory does not repeat.
+      await fresh.recallHybridWithMeta('staging deploy target cluster', { limit: 5 })
+      expect(warnings()).toBe(1)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('does not log an advisory when the cached verdict is not harmful', async () => {
+    process.env.PLUR_RERANKER = 'ms-marco-minilm-l6'
+    _setCachedReranker('ms-marco-minilm-l6', { ...oracle, name: 'ms-marco-minilm-l6' })
+    await plur.rerankerSelfEval()
+
+    const fresh = new Plur({ path: dir })
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await fresh.recallHybridWithMeta('staging deploy target cluster', { limit: 5 })
+      const warned = spy.mock.calls.some(c => c.map(String).join(' ').includes('net-negative'))
+      expect(warned).toBe(false)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -2,7 +2,7 @@ import { existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName } from '@plur-ai/core'
-import type { LlmFunction, MetaField, TensionStatus } from '@plur-ai/core'
+import type { LlmFunction, MetaField, TensionStatus, RerankerEvalResult } from '@plur-ai/core'
 import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
 
@@ -1082,6 +1082,7 @@ export function getToolDefinitions(): ToolDefinition[] {
         type: 'object',
         properties: {
           retry: { type: 'boolean', description: 'If true, reset cached embedder failure state and retry the model load before reporting' },
+          rerank_eval: { type: 'boolean', description: 'If true and a reranker is configured (PLUR_RERANKER), run the per-store self-eval gate (#451): probes synthesized from this store\'s own engrams compare rerank-on vs RRF-only ordering. Verdict is cached in the store and advisory — it never auto-disables reranking. Costs one cross-encoder pass per probe (~20 probes).' },
         },
       },
       handler: async (args, plur) => {
@@ -1195,6 +1196,61 @@ export function getToolDefinitions(): ToolDefinition[] {
             }
           }
           checks.push({ check: 'reranker available', ok: rerankerOk, detail: rerankerDetail })
+
+          // Per-store eval gate (#451, final task) — ADVISORY. Compares
+          // rerank-on vs RRF-only ordering on probes synthesized from this
+          // store's own engrams. A 'harmful' verdict fails this check and
+          // adds remediation, but never auto-disables reranking — the
+          // shipping-default decision stays with a human.
+          try {
+            let evalStatus: { result: RerankerEvalResult; stale: boolean } | null
+            let freshlyRun = false
+            if (args.rerank_eval === true) {
+              const run = await plur.rerankerSelfEval()
+              evalStatus = { result: run.result, stale: false }
+              freshlyRun = !run.cached
+            } else {
+              evalStatus = plur.rerankerEvalStatus(rerankerName)
+            }
+            if (!evalStatus) {
+              checks.push({
+                check: 'reranker per-store eval',
+                ok: true,
+                detail:
+                  'Not yet evaluated on this store — cross-encoders can be net-negative out-of-domain (#451). ' +
+                  'Run plur_doctor with rerank_eval:true for the advisory self-check before trusting reranked order.',
+              })
+            } else {
+              const r = evalStatus.result
+              const harmful = r.verdict === 'harmful'
+              const sign = r.delta_mrr >= 0 ? '+' : ''
+              const provenance = freshlyRun ? 'measured now' : `cached ${r.evaluated_at}`
+              const staleNote = evalStatus.stale ? ' [STALE — store changed since; re-run with rerank_eval:true]' : ''
+              checks.push({
+                check: 'reranker per-store eval',
+                ok: !harmful,
+                detail:
+                  `${r.verdict} on this store (${provenance}${staleNote}): ` +
+                  `ΔMRR ${sign}${r.delta_mrr.toFixed(3)} vs RRF-only over ${r.scored_probes} probes ` +
+                  `(hit@1 ${(r.rrf_hit1 * 100).toFixed(0)}%→${(r.rerank_hit1 * 100).toFixed(0)}%, ` +
+                  `${r.promotions} promoted / ${r.demotions} demoted, ~${r.mean_rerank_ms.toFixed(0)}ms/probe)`,
+              })
+              if (harmful) {
+                remediation.push(
+                  `Per-store self-eval measured reranker "${rerankerName}" as net-negative on THIS store ` +
+                  `(ΔMRR ${r.delta_mrr.toFixed(3)}; it demoted known-relevant engrams in ${r.demotions}/${r.scored_probes} probes). ` +
+                  `This gate is advisory — reranking remains enabled. Unset PLUR_RERANKER to opt out for this store, ` +
+                  `or re-run plur_doctor with rerank_eval:true after the store grows/changes.`,
+                )
+              }
+            }
+          } catch (err) {
+            checks.push({
+              check: 'reranker per-store eval',
+              ok: false,
+              detail: `self-eval failed: ${(err as Error).message}`,
+            })
+          }
         }
         const canaryStatuses = mcpCanary.status()
         for (const cs of canaryStatuses) {

--- a/packages/mcp/test/reranker-eval-gate.test.ts
+++ b/packages/mcp/test/reranker-eval-gate.test.ts
@@ -1,0 +1,168 @@
+/**
+ * plur_doctor per-store reranker eval gate — #451 (final task).
+ *
+ * The gate compares rerank-on vs RRF-only ordering on probes synthesized
+ * from the store's own engrams, caches the verdict per store, and surfaces
+ * it as an ADVISORY doctor check. It never auto-disables reranking.
+ *
+ * Stub rerankers are seeded into the adapter cache so no test touches a
+ * real model download.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, _setCachedReranker, _resetRerankerCache, resetRerankerStatus } from '@plur-ai/core'
+import type { RerankerAdapter } from '@plur-ai/core'
+import { getToolDefinitions } from '../src/tools.js'
+
+const TINY = 'ms-marco-minilm-l6' as const
+const TINY_MODEL_ID = 'Xenova/ms-marco-MiniLM-L-6-v2'
+
+const STATEMENTS = [
+  'The staging deploy target for the ingestion service is cluster-2 in Frankfurt',
+  'Karl prefers TypeScript strict mode enabled for every new package in the monorepo',
+  'The nightly benchmark harness runs LongMemEval fixtures against the hybrid search pipeline',
+  'Postgres connection pooling for the enterprise server uses pgbouncer in transaction mode',
+  'The Telegram bot forwards trading alerts to the meridian channel every morning',
+  'Grafana dashboards for the reranker latency live under the retrieval folder',
+  'The YAML store keeps engram truth while PGLite carries the derived vector index',
+  'OpenClaw sessions auto-inject engrams through the context engine assembler hook',
+  'The outbox queue retries failed remote writes on every session start event',
+  'BM25 tokenization lowercases statements and strips punctuation before scoring',
+  'Reciprocal rank fusion merges lexical and semantic result lists with constant sixty',
+  'The dedup pipeline hashes statement content before invoking the LLM judge',
+]
+
+/** Order-agreeing stub: scores by query-token overlap → source doc wins. */
+const oracle = (): RerankerAdapter => ({
+  name: TINY,
+  modelId: TINY_MODEL_ID,
+  async score(q, d) { return overlap(q, d) },
+  async scoreBatch(q, docs) { return docs.map(d => overlap(q, d)) },
+})
+
+function overlap(query: string, document: string): number {
+  const qs = new Set(query.toLowerCase().split(/\s+/).filter(Boolean))
+  let s = 0
+  for (const token of document.toLowerCase().split(/\s+/)) if (qs.has(token)) s += 1
+  return s
+}
+
+/** Order-inverting stub: demotes whatever RRF ranked first → harmful verdict. */
+const adversary = (): RerankerAdapter => ({
+  name: TINY,
+  modelId: TINY_MODEL_ID,
+  async score() { return 0 },
+  async scoreBatch(_q, docs) { return docs.map((_d, i) => i) },
+})
+
+describe('plur_doctor per-store reranker eval gate (#451)', () => {
+  let plur: Plur
+  let dir: string
+  let tools: ReturnType<typeof getToolDefinitions>
+
+  // #469: warm the cold ONNX embedder load once so individual tests measure
+  // logic, not model download/load time.
+  beforeAll(async () => {
+    const warmDir = mkdtempSync(join(tmpdir(), 'plur-evalgate-warm-'))
+    try {
+      const warm = new Plur({ path: warmDir })
+      warm.learn('embedder warm-up', { scope: 'global' })
+      await warm.recallHybrid('embedder warm-up')
+    } finally {
+      rmSync(warmDir, { recursive: true, force: true })
+    }
+  }, 120_000)
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-evalgate-'))
+    plur = new Plur({ path: dir })
+    for (const s of STATEMENTS) plur.learn(s, { scope: 'global' })
+    tools = getToolDefinitions()
+    process.env.PLUR_RERANKER = TINY
+    _resetRerankerCache()
+    resetRerankerStatus()
+  })
+  afterEach(() => {
+    delete process.env.PLUR_RERANKER
+    _resetRerankerCache()
+    resetRerankerStatus()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.find(t => t.name === name)
+    if (!tool) throw new Error(`Unknown tool: ${name}`)
+    return tool.handler(args, plur)
+  }
+
+  const gateCheck = (result: any) =>
+    result.checks.find((c: any) => c.check === 'reranker per-store eval')
+
+  it('reports "not yet evaluated" (ok, advisory) when no eval is cached', async () => {
+    _setCachedReranker(TINY, oracle())
+    const result = await callTool('plur_doctor') as any
+    const check = gateCheck(result)
+    expect(check).toBeDefined()
+    expect(check.ok).toBe(true)
+    expect(check.detail).toContain('rerank_eval')
+    expect(check.detail.toLowerCase()).toContain('not yet evaluated')
+  })
+
+  it('rerank_eval:true runs the self-eval and reports a non-harmful verdict as ok', async () => {
+    _setCachedReranker(TINY, oracle())
+    const result = await callTool('plur_doctor', { rerank_eval: true }) as any
+    const check = gateCheck(result)
+    expect(check).toBeDefined()
+    expect(check.ok).toBe(true)
+    expect(check.detail).toMatch(/beneficial|neutral/)
+    expect(check.detail).toContain('ΔMRR')
+  }, 60_000)
+
+  it('rerank_eval:true flags a harmful verdict loudly, with advisory remediation', async () => {
+    _setCachedReranker(TINY, adversary())
+    const result = await callTool('plur_doctor', { rerank_eval: true }) as any
+    const check = gateCheck(result)
+    expect(check).toBeDefined()
+    expect(check.ok).toBe(false)
+    expect(check.detail).toContain('harmful')
+    const remediation = result.remediation.join('\n')
+    expect(remediation).toContain('net-negative')
+    // Advisory, not auto-disable: the remediation must say reranking stays on.
+    expect(remediation.toLowerCase()).toContain('advisory')
+    expect(remediation).toContain('PLUR_RERANKER')
+  }, 60_000)
+
+  it('a cached harmful verdict surfaces on later doctor runs WITHOUT rerank_eval', async () => {
+    _setCachedReranker(TINY, adversary())
+    await callTool('plur_doctor', { rerank_eval: true })
+    // New doctor call, no flag: the cached verdict still shows.
+    const result = await callTool('plur_doctor') as any
+    const check = gateCheck(result)
+    expect(check).toBeDefined()
+    expect(check.ok).toBe(false)
+    expect(check.detail).toContain('harmful')
+    expect(check.detail).toContain('cached')
+  }, 60_000)
+
+  it('skips the gate check entirely when PLUR_RERANKER is off', async () => {
+    delete process.env.PLUR_RERANKER
+    const result = await callTool('plur_doctor') as any
+    expect(gateCheck(result)).toBeUndefined()
+  })
+
+  it('reports a failed self-eval as a failed check instead of throwing', async () => {
+    _setCachedReranker(TINY, {
+      name: TINY,
+      modelId: TINY_MODEL_ID,
+      async score() { throw new Error('model load failed') },
+      async scoreBatch() { throw new Error('model load failed') },
+    })
+    const result = await callTool('plur_doctor', { rerank_eval: true }) as any
+    const check = gateCheck(result)
+    expect(check).toBeDefined()
+    expect(check.ok).toBe(false)
+    expect(check.detail).toContain('model load failed')
+  }, 60_000)
+})


### PR DESCRIPTION
Refs #451 — the last open task (per-store eval gate before any default-ON reranker recommendation).

## What

Before `PLUR_RERANKER` is ever recommended as a default, each store gets a self-check proving the cross-encoder is **not actively harmful on its own domain** (cross-encoders can be net-negative out-of-domain — the motivating finding in #451).

- **`packages/core/src/reranker-eval.ts`** — `runRerankerSelfEval()`: sample the store's own engrams (seeded, deterministic), synthesize a keyword probe query from each statement (the source engram is the known-relevant document), retrieve the RRF top-K with reranker OFF, re-order the same pool with the cross-encoder, compare MRR / Hit@1 / promotions vs demotions. Verdict: `beneficial` / `neutral` / `harmful` / `insufficient-data` (ΔMRR ±0.05 thresholds, ≥5 scored probes required).
- **Cached per store** (`<store>/.reranker-eval.json`), staleness bound = 7 days **or** >20% engram-count drift — either invalidates the verdict.
- **Advisory, never silent auto-disable**: `plur_doctor` gains a `reranker per-store eval` check (pass `rerank_eval:true` for a fresh run; a cached `harmful` verdict surfaces on every later doctor run), and the reranker-enable path logs a **loud-once** warning when the cached verdict is harmful. Reranking stays enabled; the human decides.
- **CLI**: `plur rerank-eval [--reranker <name>] [--sample N] [--seed N] [--force]` — human-readable + `--json`, exits 1 on a harmful verdict so scripts can gate on it.

By construction the gate is conservative: probe queries are keyword extracts, so BM25 already ranks the source well — the gate has limited power to prove *benefit* (the #46 harness does that); its job is to prove **not-harmful**, which is exactly what an enable-gate needs.

## Relationship to #477

PR #477 (`feat/reranker-fit-check`) landed a lighter probe for the same task 5: score-distribution separability on same-domain vs cross-domain engram *pairs*. This PR measures the operational quantity directly — does reranking demote known-relevant documents in actual retrieval (rerank vs RRF ΔMRR) — and adds the per-store cache + staleness bound + enable-path advisory + CLI. The two touch the same files (`core/src/index.ts`, `mcp/src/tools.ts`) and will conflict textually; they answer the same question at different depths, so merging **one** of them is the right call. Comparison posted on #451 for the decision.

## Tests

- 30 new core tests (`reranker-eval.test.ts`) — query synthesis determinism, harmful/agreeing stub rerankers, cache roundtrip + staleness, advisory semantics, `Plur.rerankerSelfEval` + loud-once enable-path log. BM25-only + stub adapters: no model downloads.
- 6 new mcp tests (`reranker-eval-gate.test.ts`) — doctor check states: not-yet-evaluated, fresh ok, fresh harmful + remediation, cached harmful without `rerank_eval`, off-sentinel skip, failure surfaced as failed check.
- 5 new cli tests (`rerank-eval.test.ts`) — arg validation surface.
- Full suites on this branch (rebased on `7ce68aa`): **core 1782 passed / 31 skipped, mcp 178 passed, cli 243 passed / 4 skipped.**

## Gate results on a real store

Posted as a comment on #451 (run against the live `~/.plur` store, two runs for latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1