### PR TITLE
feat(hermes): TTL on the bridge dedup cache — in-process half of #120

### DIFF
--- a/packages/hermes/plur_hermes/bridge.py
+++ b/packages/hermes/plur_hermes/bridge.py
@@ -28,6 +28,24 @@ logger = logging.getLogger("plur_hermes.bridge")
 _NPX_CLI_VERSION = "0.10.0"
 
 _DEFAULT_DEDUP_CACHE_SIZE = 256
+# TTL (seconds) on dedup-cache entries — the in-process half of #120.
+#
+# The #119 LRU cache made repeat learn() calls skip the CLI subprocess
+# (sub-ms vs ~4s), but entries lived for the whole process lifetime. In a
+# long-lived Hermes process spanning many logical sessions that means a
+# `forget` (or edit) from another session is never observed: the bridge keeps
+# serving `deduplicated: true` with a dangling engram id forever. The TTL
+# bounds that staleness — every entry is revalidated against the store via the
+# recall path once its deadline passes. Deadlines are anchored at WRITE time
+# (reads never extend them), so even a continuously-hit statement revalidates
+# every _DEFAULT_DEDUP_CACHE_TTL seconds.
+#
+# 300s balances subprocess amortization (~4s per revalidation, so amortized
+# overhead is well under the 50ms/call AC at any realistic call rate) against
+# cross-session visibility lag. ttl <= 0 disables expiry (pre-#120 behavior).
+# The true cross-session COLD path (< 50ms with no in-process hit) needs the
+# `plur serve` daemon and remains open on #120.
+_DEFAULT_DEDUP_CACHE_TTL = 300.0
 _DEFAULT_TIMEOUT = 30
 _DEFAULT_INJECT_TIMEOUT = 5
 _DEFAULT_RETRIES = 3
@@ -138,11 +156,23 @@ class PlurBridge:
     """Manages subprocess calls to the plur CLI."""
 
     def __init__(self, plur_path: str | None = None,
-                 dedup_cache_size: int = _DEFAULT_DEDUP_CACHE_SIZE):
+                 dedup_cache_size: int = _DEFAULT_DEDUP_CACHE_SIZE,
+                 dedup_cache_ttl: float | None = None):
         self._binary: str | None = None
         self._plur_path = plur_path or os.environ.get("PLUR_PATH")
         self._dedup_cache_size = max(0, dedup_cache_size)
-        self._dedup_cache: "OrderedDict[str, dict]" = OrderedDict()
+        # TTL resolution: explicit arg > PLUR_BRIDGE_DEDUP_TTL env > default.
+        # ttl <= 0 means entries never expire (pre-#120 infinite lifetime).
+        if dedup_cache_ttl is None:
+            try:
+                dedup_cache_ttl = float(
+                    os.environ.get("PLUR_BRIDGE_DEDUP_TTL", str(_DEFAULT_DEDUP_CACHE_TTL)))
+            except ValueError:
+                dedup_cache_ttl = _DEFAULT_DEDUP_CACHE_TTL
+        self._dedup_cache_ttl = dedup_cache_ttl
+        # Values are (entry, expires_at) pairs; expires_at is a time.monotonic()
+        # deadline, or None when TTL is disabled.
+        self._dedup_cache: "OrderedDict[str, tuple[dict, float | None]]" = OrderedDict()
         self._timeout = int(os.environ.get("PLUR_BRIDGE_TIMEOUT", str(_DEFAULT_TIMEOUT)))
         self._inject_timeout = int(os.environ.get("PLUR_BRIDGE_INJECT_TIMEOUT", str(_DEFAULT_INJECT_TIMEOUT)))
         self._retry_enabled = os.environ.get("PLUR_BRIDGE_RETRY", "true").lower() != "false"
@@ -152,17 +182,27 @@ class PlurBridge:
             return None
         if normalized not in self._dedup_cache:
             return None
+        entry, expires_at = self._dedup_cache[normalized]
+        # Reads never refresh the deadline — the staleness bound is anchored
+        # at write time so hot statements still revalidate every TTL seconds.
+        if expires_at is not None and time.monotonic() >= expires_at:
+            del self._dedup_cache[normalized]
+            return None
         self._dedup_cache.move_to_end(normalized)
-        return self._dedup_cache[normalized]
+        return entry
 
     def _cache_put(self, normalized: str, value: dict) -> None:
         if self._dedup_cache_size == 0 or not normalized:
             return
+        expires_at = (
+            time.monotonic() + self._dedup_cache_ttl
+            if self._dedup_cache_ttl > 0 else None
+        )
         if normalized in self._dedup_cache:
             self._dedup_cache.move_to_end(normalized)
-            self._dedup_cache[normalized] = value
+            self._dedup_cache[normalized] = (value, expires_at)
             return
-        self._dedup_cache[normalized] = value
+        self._dedup_cache[normalized] = (value, expires_at)
         while len(self._dedup_cache) > self._dedup_cache_size:
             self._dedup_cache.popitem(last=False)
 

--- a/packages/hermes/test/test_bridge.py
+++ b/packages/hermes/test/test_bridge.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+import time
 import pytest
 from unittest.mock import patch, MagicMock
 from plur_hermes.bridge import PlurBridge, PlurBridgeError, PlurLockError, PlurNotFoundError
@@ -919,3 +920,184 @@ class TestLockRetry:
         from plur_hermes.bridge import _extract_cli_error_message
         result = _extract_cli_error_message("stderr msg", '[{"error": "bad"}]')
         assert result == "stderr msg"
+
+
+class TestDedupTtlCache:
+    """Issue #120 (in-process half) — TTL on the dedup cache.
+
+    The #119 v2 LRU cache made in-session repeat learn() calls skip the
+    subprocess entirely, but entries lived for the whole process lifetime.
+    In a long-lived Hermes process spanning many logical sessions that means
+    a `forget` (or edit) from another session is never observed: the bridge
+    keeps serving `deduplicated: true` with a dangling engram id forever.
+
+    The TTL bounds that staleness: cache hits stay sub-millisecond (repeat
+    statements << the 50 ms AC), and every entry is revalidated against the
+    store via the recall path after `dedup_cache_ttl` seconds. The deadline
+    is anchored at WRITE time — reads never extend it — so even a hot
+    statement revalidates every TTL seconds.
+
+    The true cross-session cold path (< 50 ms with NO in-process cache hit)
+    needs the `plur serve` daemon and stays open on #120.
+    """
+
+    @staticmethod
+    def _mock_json(payload: dict) -> MagicMock:
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = json.dumps(payload)
+        m.stderr = ""
+        return m
+
+    def _learned_bridge(self, ttl: float, statement: str = "Prefer pnpm over npm",
+                        engram_id: str = "ENG-120") -> PlurBridge:
+        """Bridge with `statement` already learned (cache warm), subprocess mocked."""
+        bridge = PlurBridge(dedup_cache_ttl=ttl)
+        bridge._binary = "/usr/local/bin/plur"
+        empty_recall = self._mock_json({"results": [], "count": 0})
+        learn_ok = self._mock_json({"id": engram_id, "statement": statement})
+        with patch("subprocess.run", side_effect=[empty_recall, learn_ok]):
+            r = bridge.learn(statement)
+            assert r["id"] == engram_id
+        return bridge
+
+    def test_cache_hit_within_ttl_skips_subprocess(self):
+        bridge = self._learned_bridge(ttl=60.0)
+        with patch("subprocess.run") as mock_run:
+            r = bridge.learn("Prefer pnpm over npm")
+            assert r == {"id": "ENG-120", "statement": "Prefer pnpm over npm",
+                         "deduplicated": True}
+            assert mock_run.call_count == 0
+
+    def test_cache_entry_expires_after_ttl_and_revalidates(self):
+        bridge = self._learned_bridge(ttl=0.05)
+        time.sleep(0.15)
+        # Entry expired → bridge must revalidate via recall. Store still has
+        # the engram, so the result is a dedup hit sourced from the store.
+        recall_hit = self._mock_json({
+            "results": [{"id": "ENG-120", "statement": "Prefer pnpm over npm"}],
+        })
+        with patch("subprocess.run", side_effect=[recall_hit]) as mock_run:
+            r = bridge.learn("Prefer pnpm over npm")
+            assert r == {"id": "ENG-120", "statement": "Prefer pnpm over npm",
+                         "deduplicated": True}
+            assert mock_run.call_count == 1  # exactly one recall, no insert
+
+    def test_revalidation_rearms_ttl(self):
+        bridge = self._learned_bridge(ttl=0.05)
+        time.sleep(0.15)
+        recall_hit = self._mock_json({
+            "results": [{"id": "ENG-120", "statement": "Prefer pnpm over npm"}],
+        })
+        with patch("subprocess.run", side_effect=[recall_hit]):
+            bridge.learn("Prefer pnpm over npm")
+        # Revalidation re-armed the entry — next call is a pure cache hit.
+        with patch("subprocess.run") as mock_run:
+            r = bridge.learn("Prefer pnpm over npm")
+            assert r["deduplicated"] is True
+            assert mock_run.call_count == 0
+
+    def test_stale_entry_dropped_when_store_changed(self):
+        """Cross-session correctness: engram forgotten elsewhere → after TTL
+        the bridge must NOT serve the dangling id; it re-learns."""
+        bridge = self._learned_bridge(ttl=0.05)
+        time.sleep(0.15)
+        empty_recall = self._mock_json({"results": [], "count": 0})
+        relearn = self._mock_json({"id": "ENG-121", "statement": "Prefer pnpm over npm"})
+        with patch("subprocess.run", side_effect=[empty_recall, relearn]) as mock_run:
+            r = bridge.learn("Prefer pnpm over npm")
+            assert r["id"] == "ENG-121"
+            assert "deduplicated" not in r
+            assert mock_run.call_count == 2  # recall miss + insert
+
+    def test_read_does_not_extend_deadline(self):
+        """Staleness bound is write-anchored: hot statements still revalidate
+        every TTL seconds even when hit continuously."""
+        bridge = self._learned_bridge(ttl=0.3)
+        time.sleep(0.15)
+        with patch("subprocess.run") as mock_run:
+            assert bridge.learn("Prefer pnpm over npm")["deduplicated"] is True
+            assert mock_run.call_count == 0  # mid-TTL hit
+        time.sleep(0.25)  # now past the original write deadline
+        recall_hit = self._mock_json({
+            "results": [{"id": "ENG-120", "statement": "Prefer pnpm over npm"}],
+        })
+        with patch("subprocess.run", side_effect=[recall_hit]) as mock_run:
+            assert bridge.learn("Prefer pnpm over npm")["deduplicated"] is True
+            assert mock_run.call_count == 1  # the mid-TTL hit did not re-arm
+
+    def test_ttl_zero_disables_expiry(self):
+        """ttl <= 0 restores the pre-TTL infinite-lifetime behavior."""
+        bridge = self._learned_bridge(ttl=0)
+        time.sleep(0.1)
+        with patch("subprocess.run") as mock_run:
+            r = bridge.learn("Prefer pnpm over npm")
+            assert r["deduplicated"] is True
+            assert mock_run.call_count == 0
+
+    def test_ttl_env_override(self, monkeypatch):
+        monkeypatch.setenv("PLUR_BRIDGE_DEDUP_TTL", "123.5")
+        bridge = PlurBridge()
+        assert bridge._dedup_cache_ttl == 123.5
+
+    def test_ttl_constructor_beats_env(self, monkeypatch):
+        monkeypatch.setenv("PLUR_BRIDGE_DEDUP_TTL", "123.5")
+        bridge = PlurBridge(dedup_cache_ttl=7.0)
+        assert bridge._dedup_cache_ttl == 7.0
+
+    def test_force_learn_rearms_expired_entry(self):
+        """force=True bypasses cache reads but its result re-populates the
+        cache with a fresh deadline (same contract as #119, now with TTL)."""
+        bridge = self._learned_bridge(ttl=0.05)
+        time.sleep(0.15)
+        forced = self._mock_json({"id": "ENG-122", "statement": "Prefer pnpm over npm"})
+        with patch("subprocess.run", side_effect=[forced]) as mock_run:
+            r = bridge.learn("Prefer pnpm over npm", force=True)
+            assert r["id"] == "ENG-122"
+            assert mock_run.call_count == 1  # no recall on force
+        with patch("subprocess.run") as mock_run:
+            r = bridge.learn("Prefer pnpm over npm")
+            assert r == {"id": "ENG-122", "statement": "Prefer pnpm over npm",
+                         "deduplicated": True}
+            assert mock_run.call_count == 0
+
+    def test_lru_eviction_still_works_with_ttl(self):
+        bridge = PlurBridge(dedup_cache_size=2, dedup_cache_ttl=60.0)
+        bridge._binary = "/usr/local/bin/plur"
+        empty = self._mock_json({"results": [], "count": 0})
+        for i, stmt in enumerate(("eng-a", "eng-b", "eng-c")):
+            learn_ok = self._mock_json({"id": f"ENG-{i}", "statement": stmt})
+            with patch("subprocess.run", side_effect=[empty, learn_ok]):
+                bridge.learn(stmt)
+        assert "eng-a" not in bridge._dedup_cache
+        assert "eng-b" in bridge._dedup_cache
+        assert "eng-c" in bridge._dedup_cache
+
+    def test_benchmark_repeat_learn_median_under_50ms(self, capsys):
+        """Micro-benchmark for the #120 in-process AC reading: repeat learn()
+        of a statement already in cache must complete in < 50 ms median.
+
+        subprocess.run is patched to fail loudly, so the timed loop measures
+        the true production cache-hit path — which by construction performs
+        zero subprocess work. Numbers are printed for the PR body.
+        """
+        bridge = self._learned_bridge(ttl=300.0)
+        n = 1000
+        samples: list[float] = []
+        with patch("subprocess.run",
+                   side_effect=AssertionError("subprocess on cache-hit path")):
+            for _ in range(n):
+                t0 = time.perf_counter()
+                r = bridge.learn("Prefer pnpm over npm")
+                samples.append(time.perf_counter() - t0)
+                assert r["deduplicated"] is True
+        samples.sort()
+        median = samples[n // 2]
+        p95 = samples[int(n * 0.95)]
+        worst = samples[-1]
+        with capsys.disabled():
+            print(f"\n[bench #120] repeat learn() cache hit, n={n}: "
+                  f"median={median * 1000:.4f}ms p95={p95 * 1000:.4f}ms "
+                  f"max={worst * 1000:.4f}ms")
+        assert median < 0.050, f"median {median * 1000:.3f}ms >= 50ms"
+        assert p95 < 0.050, f"p95 {p95 * 1000:.3f}ms >= 50ms"


### PR DESCRIPTION
## Summary

Implements the **in-process option** of #120: a TTL on `PlurBridge`'s dedup cache so cross-session staleness is bounded while repeat-statement dedup stays far under the 50 ms target. The **daemon half (`plur serve`) stays open on #120** — the true cross-session *cold* path (statement in store, no in-process cache hit, < 50 ms) is architecturally unreachable while the bridge shells out `Hermes → PlurBridge → CLI subprocess → @plur-ai/core` (~600 ms node cold-start + ~2.7 s store load per call, per the #119 benchmark).

## Problem

The #119 v2 LRU cache made in-session repeat `learn()` calls skip the subprocess entirely, but entries lived for the whole process lifetime. In a long-lived Hermes process spanning many logical sessions, a `forget` (or edit) from another session was never observed — the bridge kept serving `deduplicated: true` with a dangling engram id forever.

## Changes (`packages/hermes/plur_hermes/bridge.py`)

- Dedup-cache entries now carry a `time.monotonic()` deadline: `(entry, expires_at)` tuples in the same LRU `OrderedDict`.
- **Expired entries are dropped on read** and revalidated against the store via the existing recall path (`_find_duplicate`); a hit re-arms the entry, a miss falls through to a fresh CLI `learn`.
- **Write-anchored deadlines**: reads never extend the TTL, so even a continuously-hit statement revalidates every TTL seconds — the staleness bound is hard.
- Config: `dedup_cache_ttl` constructor arg > `PLUR_BRIDGE_DEDUP_TTL` env > **300 s default**. `ttl <= 0` disables expiry (pre-#120 behavior). Malformed env falls back to the default.
- LRU sizing/eviction, normalization (trim + casefold), the `force=True` contract, and all failure fall-throughs are unchanged.

## Benchmark (repeat-statement path, n=1000)

`test_benchmark_repeat_learn_median_under_50ms` times production `learn()` calls on the cache-hit path with `subprocess.run` patched to fail loudly (proving zero subprocess work) and asserts median and p95 < 50 ms:

| metric | latency |
|---|---|
| median | **0.0004 ms** |
| p95 | 0.0010 ms |
| max | 0.0221 ms |

Amortized revalidation cost: one ~4 s recall per statement per 300 s window — well under 50 ms/call at any realistic call rate.

## #120 acceptance criteria status

- [x] Repeat `learn()` (in-process hit) « 50 ms median — benchmarked above
- [x] Stale-entry correctness: after TTL, a store-side `forget` is observed (`test_stale_entry_dropped_when_store_changed`)
- [ ] Cross-session **cold** path < 50 ms — needs the `plur serve` daemon; **not in this PR**, tracked on #120
- [ ] Daemon cold-start bounding + daemon-unavailable fallback — daemon half, stays open

## Tests

11 new tests in `packages/hermes/test/test_bridge.py` (`TestDedupTtlCache`): hit-within-TTL, expiry + revalidation, re-arm after revalidation, stale-entry drop on store change, write-anchored deadline (read does not extend), `ttl<=0` opt-out, env override + ctor precedence, `force=True` re-arm, LRU eviction under TTL, and the micro-benchmark.

Full hermes suite: **143 passed, 0 failed** (was 132).

Refs #120 — the daemon half (`plur serve`, cold-path < 50 ms) remains open.

Refs #119, #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1