### PR TITLE
feat(core): temporal-aware tension detection — contradiction vs evolution (#240)

### DIFF
--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -29,6 +29,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   let derivedFrom: string | undefined
   let knowledgeAnchors: Array<{ path: string; relevance?: string; snippet?: string }> | undefined
   let dualCoding: { example?: string; analogy?: string } | undefined
+  // #240: engram IDs this statement intentionally replaces (comma-separated).
+  let supersedes: string[] | undefined
 
   // Parse a value as JSON, exiting 1 with a clear message on malformed input
   // (a bad --dual-coding/--knowledge-anchors should fail loudly, not silently
@@ -62,6 +64,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     else if (arg === '--dual-coding' && i + 1 < args.length) {
       dualCoding = parseJsonFlag('--dual-coding', args[++i]); i++
     }
+    else if (arg === '--supersedes' && i + 1 < args.length) {
+      supersedes = args[++i].split(',').map(t => t.trim()).filter(Boolean); i++
+    }
     else if (!statement) { statement = arg; i++ }
     else { i++ }
   }
@@ -76,7 +81,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (!statement) {
     exit(1, 'Usage: plur learn <statement> [--scope <scope>] [--type <type>] [--domain <domain>] ' +
       '[--source <s>] [--rationale <r>] [--tags a,b,c] [--visibility private|public|template] ' +
-      '[--abstract <id>] [--derived-from <id>] [--knowledge-anchors <json>] [--dual-coding <json>]')
+      '[--abstract <id>] [--derived-from <id>] [--knowledge-anchors <json>] [--dual-coding <json>] ' +
+      '[--supersedes id1,id2]')
   }
 
   // Build the context conditionally: when --scope is absent, OMIT the scope key
@@ -99,6 +105,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     ...(derivedFrom !== undefined ? { derived_from: derivedFrom } : {}),
     ...(knowledgeAnchors !== undefined ? { knowledge_anchors: knowledgeAnchors } : {}),
     ...(dualCoding !== undefined ? { dual_coding: dualCoding } : {}),
+    ...(supersedes !== undefined ? { supersedes } : {}),
   }
 
   // ALWAYS use learnRouted (not learn): learn() stamps _demoted but does NOT do

--- a/packages/cli/src/commands/tensions.ts
+++ b/packages/cli/src/commands/tensions.ts
@@ -43,6 +43,7 @@ function getLlmFunction(): LlmFunction | undefined {
  *   plur tensions --scan --min-confidence 0.8  # stricter threshold
  *   plur tensions --scan --max-pairs 100       # check more pairs
  *   plur tensions --scan --batch-size 1        # sequential single-pair judging (no batching)
+ *   plur tensions --scan --temporal-discount   # days-apart confidence discount (#240, default off)
  *   plur tensions --scan --model claude-haiku-... --llm-base-url ... --llm-api-key ...
  *   plur tensions                              # list legacy stored conflicts (usually empty)
  *   plur tensions --json                       # machine-readable output
@@ -54,6 +55,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   let minConfidence = 0.7
   let maxPairs = 50
   let batchSize = 5
+  // #240: undefined → fall back to config (tensions.temporal_discount)
+  let temporalDiscount: boolean | undefined
   let llmBaseUrl: string | undefined
   let llmApiKey: string | undefined
   let llmModel: string | undefined
@@ -67,6 +70,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     else if (arg === '--min-confidence' && i + 1 < args.length) { minConfidence = parseFloat(args[++i]); i++ }
     else if (arg === '--max-pairs' && i + 1 < args.length) { maxPairs = parseInt(args[++i], 10); i++ }
     else if (arg === '--batch-size' && i + 1 < args.length) { batchSize = parseInt(args[++i], 10); i++ }
+    else if (arg === '--temporal-discount') { temporalDiscount = true; i++ }
+    else if (arg === '--no-temporal-discount') { temporalDiscount = false; i++ }
     else if (arg === '--llm-base-url' && i + 1 < args.length) { llmBaseUrl = args[++i]; i++ }
     else if (arg === '--llm-api-key' && i + 1 < args.length) { llmApiKey = args[++i]; i++ }
     else if (arg === '--model' && i + 1 < args.length) { llmModel = args[++i]; i++ }
@@ -100,7 +105,18 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     }
 
     const { scanForTensions } = await import('@plur-ai/core')
-    const result = await scanForTensions(engrams, llm, { min_confidence: minConfidence, max_pairs: maxPairs, batch_size: batchSize })
+    // #240: config.yaml `tensions:` block supplies temporal defaults
+    // (temporal_domains, snapshot_pairs, temporal_discount); an explicit
+    // --temporal-discount / --no-temporal-discount flag overrides.
+    const tensionsConfig = plur.getTensionsConfig()
+    const result = await scanForTensions(engrams, llm, {
+      min_confidence: minConfidence,
+      max_pairs: maxPairs,
+      batch_size: batchSize,
+      temporal_domains: tensionsConfig.temporal_domains,
+      snapshot_pairs: tensionsConfig.snapshot_pairs,
+      temporal_discount: temporalDiscount ?? tensionsConfig.temporal_discount,
+    })
 
     if (shouldOutputJson(flags)) {
       outputJson({
@@ -111,6 +127,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
           engram_b: { id: t.id_b, statement: t.statement_b },
           confidence: t.confidence,
           reason: t.reason,
+          ...(t.days_apart !== undefined ? { days_apart: t.days_apart } : {}),
+          ...(t.raw_confidence !== undefined ? { raw_confidence: t.raw_confidence } : {}),
         })),
       })
       return
@@ -126,7 +144,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     }
 
     for (const t of result.tensions) {
-      outputText(`── TENSION (confidence: ${t.confidence.toFixed(2)}) ──`)
+      const tempNote = t.days_apart !== undefined ? `, ${t.days_apart} day${t.days_apart === 1 ? '' : 's'} apart` : ''
+      const rawNote = t.raw_confidence !== undefined ? `, raw: ${t.raw_confidence.toFixed(2)}` : ''
+      outputText(`── TENSION (confidence: ${t.confidence.toFixed(2)}${rawNote}${tempNote}) ──`)
       outputText(`  A [${t.id_a}]: ${t.statement_a}`)
       outputText(`  B [${t.id_b}]: ${t.statement_b}`)
       outputText(`  Reason: ${t.reason}`)

--- a/packages/cli/test/tensions.test.ts
+++ b/packages/cli/test/tensions.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync, execFile } from 'child_process'
+import { promisify } from 'util'
+import { createServer, type Server } from 'http'
+import { Plur } from '@plur-ai/core'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+/**
+ * Stub OpenAI-compatible chat-completions server. Always answers
+ * "CONTRADICTS: yes / 0.9" per pair so tests can observe the temporal
+ * gates (#240): whether a pair reached the judge at all, and whether the
+ * confidence was discounted afterwards.
+ */
+let server: Server
+let baseUrl: string
+const promptsSeen: string[] = []
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', c => chunks.push(c))
+    req.on('end', () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString())
+      const prompt: string = body.messages[0].content
+      promptsSeen.push(prompt)
+      const n = (prompt.match(/PAIR \d+/g) ?? []).length
+      const content = n > 0
+        ? Array.from({ length: n }, (_, i) => `PAIR_${i + 1}: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.`).join('\n')
+        : 'CONTRADICTS: yes\nCONFIDENCE: 0.9\nREASON: Opposite.'
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ choices: [{ message: { content } }] }))
+    })
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const addr = server.address() as { port: number }
+  baseUrl = `http://127.0.0.1:${addr.port}/v1`
+})
+
+afterAll(() => new Promise<void>(resolve => server.close(() => resolve())))
+
+describe('plur tensions --scan temporal gates (#240)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-cli-tensions-'))
+    promptsSeen.length = 0
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  // NOTE: must be async — the stub LLM server lives in this same process, so a
+  // synchronous execSync would block the event loop and the server could never
+  // answer the child's request (the child would hang until timeout).
+  const execFileAsync = promisify(execFile)
+  async function run(args: string): Promise<string> {
+    const { stdout } = await execFileAsync('node', [CLI, ...args.split(' '), '--path', dir, '--json'], {
+      encoding: 'utf-8',
+      timeout: 20000,
+    })
+    return stdout.trim()
+  }
+
+  /** Two contradicting engrams recorded ~a month apart (learned_at back-dated). */
+  function seedPair(domain?: string): void {
+    const plur = new Plur({ path: dir })
+    const a = plur.learn('hormuz strait ceasefire holding, passage regulated', domain ? { domain } : undefined)
+    const b = plur.learn('hormuz strait ceasefire collapsed, passage closed', domain ? { domain } : undefined)
+    for (const [id, learnedAt] of [[a.id, '2026-04-07'], [b.id, '2026-05-05']] as const) {
+      const stored = plur.getById(id)!
+      plur.updateEngram({ ...stored, temporal: { ...stored.temporal, learned_at: learnedAt } })
+    }
+  }
+
+  it('reports days_apart and passes recorded dates to the judge', async () => {
+    seedPair()
+    const out = JSON.parse(await run(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(out.pairs_checked).toBe(1)
+    expect(out.count).toBe(1)
+    expect(out.tensions[0].days_apart).toBe(28)
+    expect(out.tensions[0].confidence).toBeCloseTo(0.9)
+    expect(promptsSeen.join('\n')).toContain('2026-04-07')
+    expect(promptsSeen.join('\n')).toContain('2026-05-05')
+  })
+
+  it('config tensions.temporal_domains skips snapshot pairs before the judge', async () => {
+    writeFileSync(join(dir, 'config.yaml'), 'tensions:\n  temporal_domains:\n    - war-analysis\n')
+    seedPair('war-analysis')
+    const out = JSON.parse(await run(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(out.pairs_checked).toBe(0)
+    expect(out.count).toBe(0)
+    expect(promptsSeen).toHaveLength(0)
+  })
+
+  it('--temporal-discount multiplies confidence by the days-apart ladder', async () => {
+    seedPair()
+    const out = JSON.parse(await run(`tensions --scan --temporal-discount --min-confidence 0.2 --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(out.count).toBe(1)
+    // 28 days apart → ×0.3 → 0.27
+    expect(out.tensions[0].confidence).toBeCloseTo(0.27)
+    expect(out.tensions[0].raw_confidence).toBeCloseTo(0.9)
+  })
+
+  it('--no-temporal-discount overrides config temporal_discount: true', async () => {
+    writeFileSync(join(dir, 'config.yaml'), 'tensions:\n  temporal_discount: true\n')
+    seedPair()
+    const out = JSON.parse(await run(`tensions --scan --no-temporal-discount --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(out.count).toBe(1)
+    expect(out.tensions[0].confidence).toBeCloseTo(0.9)
+    expect(out.tensions[0].raw_confidence).toBeUndefined()
+  })
+})
+
+describe('plur learn --supersedes (#240)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-cli-supersedes-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  function run(args: string): string {
+    return execSync(`node ${CLI} ${args} --path ${dir} --json`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    }).trim()
+  }
+
+  it('writes the forward edge on the new engram and the reverse edge on the target', () => {
+    const oldE = JSON.parse(run('learn "plur cli version is 0.3.0"'))
+    const newE = JSON.parse(run(`learn "plur cli version is 0.8.2" --supersedes ${oldE.id}`))
+
+    const plur = new Plur({ path: dir })
+    expect(plur.getById(newE.id)?.relations?.supersedes).toEqual([oldE.id])
+    expect(plur.getById(oldE.id)?.relations?.superseded_by).toEqual([newE.id])
+  })
+
+  it('supersedes-linked pair is not scanned as a tension candidate', () => {
+    const oldE = JSON.parse(run('learn "plur cli version is 0.3.0"'))
+    JSON.parse(run(`learn "plur cli version is 0.8.2" --supersedes ${oldE.id}`))
+
+    // Scan finds zero candidates, so the (blocked-event-loop) stub server is
+    // never contacted — safe to run synchronously.
+    const out = JSON.parse(run(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(out.pairs_checked).toBe(0)
+    expect(out.count).toBe(0)
+  })
+})

--- a/packages/core/src/importers/engine.ts
+++ b/packages/core/src/importers/engine.ts
@@ -210,6 +210,9 @@ function applyImportMetadata(engram: Engram, record: ImportRecord, conflictIds: 
       narrower: engram.relations?.narrower ?? [],
       related: engram.relations?.related ?? [],
       conflicts: [...new Set([...(engram.relations?.conflicts ?? []), ...conflictIds])],
+      // #240: preserve intentional-update edges when merging conflict ids
+      supersedes: engram.relations?.supersedes ?? [],
+      superseded_by: engram.relations?.superseded_by ?? [],
     }
     changed = true
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,7 +115,7 @@ export type { RerankerAdapter } from './rerankers/types.js'
 export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus } from './sync.js'
 export { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'
-export { scanForTensions, getCandidatePairs, scopesOverlap, domainSegmentsOverlap, subjectsOverlap, statementOverlap, buildContradictionPrompt, parseContradictionResponse, buildBatchContradictionPrompt, parseBatchContradictionResponse, type ContradictionVerdict, type TensionPair, type TensionScanResult } from './tensions.js'
+export { scanForTensions, getCandidatePairs, scopesOverlap, domainSegmentsOverlap, subjectsOverlap, statementOverlap, buildContradictionPrompt, parseContradictionResponse, buildBatchContradictionPrompt, parseBatchContradictionResponse, engramDate, daysApart, inTemporalDomain, temporalDiscountFactor, SNAPSHOT_CONFIDENCE_CAP, type ContradictionVerdict, type TensionPair, type TensionScanResult, type TensionScanOptions, type TemporalGateOptions, type JudgeStatement } from './tensions.js'
 // Migration importers (issue #441) — `plur import --from <source> --path <file>`.
 export {
   importFrom, runImport, getImportSource, listImportSources, IMPORT_SOURCES,
@@ -1400,13 +1400,24 @@ export class Plur {
         summary: autoSummary(statement, undefined),
         engram_version: 1,
         episode_ids: episodeIds ?? [],
-        relations: conflictIds.length > 0 ? {
+        relations: (conflictIds.length > 0 || (context?.supersedes?.length ?? 0) > 0) ? {
           broader: [],
           narrower: [],
           related: [],
           conflicts: conflictIds,
+          supersedes: context?.supersedes ?? [],
+          superseded_by: [],
         } : undefined,
         pinned: context?.pinned === true ? true : undefined,
+      }
+
+      // #240: supersedes is a graph edge, not a temporality enum — write the
+      // reverse superseded_by edge on each target found in the local primary
+      // store (best-effort; targets living in other stores are not patched).
+      // The tension scanner skips supersedes-linked pairs: an intentional
+      // update is not a contradiction.
+      if (context?.supersedes?.length) {
+        this._writeSupersededByEdges(engrams, context.supersedes, id)
       }
 
       // Stamp the extraction marker (#347) so the plur_learn MCP response can
@@ -1750,6 +1761,13 @@ export class Plur {
       summary: autoSummary(statement, undefined),
       engram_version: 1,
       episode_ids: context?.session_episode_id ? [context.session_episode_id] : [],
+      // #240: forward supersedes edge travels with the remote-routed shape.
+      // The reverse superseded_by edge on remote targets is NOT patched
+      // (best-effort — see LearnContext.supersedes docs).
+      relations: (context?.supersedes?.length ?? 0) > 0 ? {
+        broader: [], narrower: [], related: [], conflicts: [],
+        supersedes: context!.supersedes!, superseded_by: [],
+      } : undefined,
       pinned: context?.pinned === true ? true : undefined,
     }
     // Echo marker for extracted expiry (#347) — mirrors the learn() stamping
@@ -3581,6 +3599,40 @@ Generate an improved version of the procedure that prevents this failure. Return
       outbox_count: this.outboxCount(),
       history_events: countInjectionEvents(this.paths.root),
       ...(this._lastIndexError ? { index_error: this._lastIndexError } : {}),
+    }
+  }
+
+  /**
+   * Resolved tension-scan defaults from config (#240). Consumers (MCP
+   * plur_tensions, CLI) merge explicit args over these.
+   */
+  getTensionsConfig(): { temporal_domains: string[]; snapshot_pairs: 'skip' | 'floor'; temporal_discount: boolean } {
+    const t = this.config.tensions ?? {}
+    return {
+      temporal_domains: t.temporal_domains ?? [],
+      snapshot_pairs: t.snapshot_pairs ?? 'skip',
+      temporal_discount: t.temporal_discount ?? false,
+    }
+  }
+
+  /**
+   * Write the reverse `relations.superseded_by` edge on each supersede
+   * target present in the (already-loaded, lock-held) local engram list
+   * (#240). Unknown targets are skipped silently — the forward edge on the
+   * new engram still records the intent. Mutates in place; the caller's
+   * subsequent _writeEngrams persists the change.
+   */
+  private _writeSupersededByEdges(engrams: Engram[], targetIds: string[], newId: string): void {
+    for (const targetId of targetIds) {
+      const target = engrams.find(e => e.id === targetId)
+      if (!target) continue
+      target.relations = target.relations ?? {
+        broader: [], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: [],
+      }
+      target.relations.superseded_by = target.relations.superseded_by ?? []
+      if (!target.relations.superseded_by.includes(newId)) {
+        target.relations.superseded_by.push(newId)
+      }
     }
   }
 

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -657,6 +657,11 @@ export function exportPack(
         ...cleaned.relations,
         conflicts: [],
         related: [],
+        // #240: supersedes edges are store-internal cross-refs too — a stale
+        // edge in a foreign store could falsely suppress tension detection
+        // between unrelated engrams on ID collision.
+        supersedes: [],
+        superseded_by: [],
       }
     }
     // Strip associations (co-access edges are store-specific)

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -143,6 +143,29 @@ export const ScopeRoutingConfigSchema = z.object({
 
 export type ScopeRoutingConfig = z.infer<typeof ScopeRoutingConfigSchema>
 
+/**
+ * Tension-scan configuration (#240) — temporal-aware contradiction detection.
+ *
+ * `temporal_domains` (Layer 2) declares domains whose engrams are
+ * point-in-time snapshots by default (e.g. war-analysis, markets). A
+ * snapshot-vs-snapshot pair recorded on different days is an event log, not
+ * a contradiction — the scanner skips it (`snapshot_pairs: 'skip'`, default)
+ * or judges it with confidence capped at 0.1 (`'floor'`). Retroactive: no
+ * engram re-tagging needed.
+ *
+ * `temporal_discount` (Layer 3 multiplier) additionally multiplies judge
+ * confidence by a days-apart ladder (same day ×1.0 … 15+ days ×0.3).
+ * OFF by default: the dated judge prompt is the default mechanism, and a
+ * blanket multiplier can bury genuine corrections made weeks apart.
+ */
+export const TensionsConfigSchema = z.object({
+  temporal_domains: z.array(z.string()).default([]),
+  snapshot_pairs: z.enum(['skip', 'floor']).default('skip'),
+  temporal_discount: z.boolean().default(false),
+}).partial()
+
+export type TensionsConfigYaml = z.infer<typeof TensionsConfigSchema>
+
 export const PlurConfigSchema = z.object({
   auto_learn: z.boolean().default(true),
   auto_capture: z.boolean().default(true),
@@ -156,6 +179,8 @@ export const PlurConfigSchema = z.object({
     co_access: z.boolean().default(true),
   }).default({}),
   dedup: DedupConfigSchema.default({}),
+  /** Temporal-aware tension scan tuning (#240). See {@link TensionsConfigSchema}. */
+  tensions: TensionsConfigSchema.default({}),
   /**
    * Expiry handling at injection time (#347). `hard` (default) skips any
    * engram whose `temporal.valid_until` is in the past. `soft` keeps

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -43,6 +43,11 @@ export const RelationsSchema = z.object({
   narrower: z.array(z.string()).default([]),
   related: z.array(z.string()).default([]),
   conflicts: z.array(z.string()).default([]),
+  /** IDs of engrams this one intentionally replaces (#240). An intentional
+   *  update is not a tension — the scanner skips supersedes-linked pairs. */
+  supersedes: z.array(z.string()).default([]),
+  /** Reverse edge of `supersedes` (#240) — IDs of engrams that replace this one. */
+  superseded_by: z.array(z.string()).default([]),
 }).describe('Typed graph edges between engram IDs.')
 
 export const ProvenanceSchema = z.object({

--- a/packages/core/src/tensions.ts
+++ b/packages/core/src/tensions.ts
@@ -9,6 +9,10 @@ export interface TensionPair {
   statement_b: string
   confidence: number
   reason: string
+  /** Calendar days between the two engrams' recorded dates, when derivable (#240). */
+  days_apart?: number
+  /** Judge confidence before the temporal discount / snapshot floor (#240). Present only when adjusted. */
+  raw_confidence?: number
 }
 
 export interface TensionScanResult {
@@ -17,21 +21,102 @@ export interface TensionScanResult {
   tensions: TensionPair[]
 }
 
+/** A statement handed to the judge — `date` is its recorded date (#240). */
+export interface JudgeStatement {
+  id: string
+  statement: string
+  /** ISO date (YYYY-MM-DD) the statement was recorded. Optional — prompts stay unchanged without it. */
+  date?: string
+}
+
+/**
+ * Resolve the recorded date of an engram (#240 Layer 3 prompt half).
+ *
+ * Prefers `temporal.learned_at`; falls back to the date embedded in the
+ * canonical id forms `ENG-YYYY-MMDD-NNN`, `ENG-{PREFIX}-YYYY-MMDD-NNN`, and
+ * the server-assigned `ENG-YYYY-MM-DD-NNN`. Returns undefined when no date
+ * is derivable — callers must degrade gracefully.
+ */
+export function engramDate(e: Engram): string | undefined {
+  const learned = e.temporal?.learned_at
+  if (learned && /^\d{4}-\d{2}-\d{2}/.test(learned)) return learned.slice(0, 10)
+  const m = e.id.match(/(\d{4})-(\d{2})-?(\d{2})(?=-|$)/)
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`
+  return undefined
+}
+
+/** Absolute whole-day distance between two ISO dates (UTC, calendar days). */
+export function daysApart(a: string, b: string): number {
+  const ms = Math.abs(Date.parse(`${a}T00:00:00Z`) - Date.parse(`${b}T00:00:00Z`))
+  return Math.round(ms / 86_400_000)
+}
+
+/**
+ * Does a dotted domain fall under any configured temporal (snapshot) domain
+ * (#240 Layer 2)? Matches the exact domain or a dotted sub-domain —
+ * `war-analysis.hormuz` matches config entry `war-analysis`, but
+ * `war-analysis-2` does not.
+ */
+export function inTemporalDomain(domain: string | undefined, temporalDomains: readonly string[]): boolean {
+  if (!domain || temporalDomains.length === 0) return false
+  return temporalDomains.some(td => domain === td || domain.startsWith(`${td}.`))
+}
+
+/**
+ * Timestamp-aware confidence multiplier (#240 Layer 3 — OPT-IN, off by
+ * default). The ladder follows the issue: pairs recorded further apart are
+ * more likely temporal evolution than contradiction. Kept opt-in because a
+ * blanket multiplier can bury genuine standing-fact corrections that happen
+ * weeks apart — the dated judge prompt is the default mechanism.
+ */
+export function temporalDiscountFactor(days: number): number {
+  if (days <= 0) return 1.0
+  if (days <= 3) return 0.8
+  if (days <= 14) return 0.5
+  return 0.3
+}
+
+/** Confidence cap for snapshot-vs-snapshot pairs in `snapshot_pairs: 'floor'` mode (#240). */
+export const SNAPSHOT_CONFIDENCE_CAP = 0.1
+
+/** Temporal gating options shared by getCandidatePairs and scanForTensions (#240). */
+export interface TemporalGateOptions {
+  /** Domains whose engrams are point-in-time snapshots by default (Layer 2). */
+  temporal_domains?: string[]
+  /**
+   * Handling of snapshot-vs-snapshot pairs recorded on different days:
+   * 'skip' (default) drops them before the judge; 'floor' judges them but
+   * caps confidence at SNAPSHOT_CONFIDENCE_CAP.
+   */
+  snapshot_pairs?: 'skip' | 'floor'
+  /** ISO date treated as "today" for expired-validity gating. Defaults to the current date. */
+  now?: string
+}
+
+function temporalGuidance(dateA: string, dateB: string): string {
+  const days = daysApart(dateA, dateB)
+  const apart = days === 0 ? 'on the same day' : `${days} day${days === 1 ? '' : 's'} apart`
+  return `The statements were recorded ${apart} (A: ${dateA}, B: ${dateB}). Consider whether the difference reflects a genuine contradiction about the same claim, or temporal evolution of a changing situation — statements that were each true when recorded, describing how events unfolded over time, do NOT contradict.`
+}
+
 export function buildContradictionPrompt(
-  a: { id: string; statement: string },
-  b: { id: string; statement: string },
+  a: JudgeStatement,
+  b: JudgeStatement,
 ): string {
+  const bothDated = Boolean(a.date && b.date)
+  const label = (s: JudgeStatement, name: string) =>
+    `STATEMENT ${name} [${s.id}]${bothDated ? ` (recorded ${s.date})` : ''}:`
   return `You are a memory consistency checker. Determine whether these two statements CONTRADICT each other.
 
-STATEMENT A [${a.id}]:
+${label(a, 'A')}
 "${a.statement}"
 
-STATEMENT B [${b.id}]:
+${label(b, 'B')}
 "${b.statement}"
 
 Two statements CONTRADICT when one asserts X is true and the other asserts X is false, different, or mutually exclusive.
 Do NOT flag as contradictions: different topics in the same domain, complementary facts, or unrelated statements that happen to share keywords.
-
+${bothDated ? `${temporalGuidance(a.date!, b.date!)}\n` : ''}
 Respond in this EXACT format:
 CONTRADICTS: yes|no
 CONFIDENCE: 0.0-1.0
@@ -61,27 +146,40 @@ export function parseContradictionResponse(response: string): ContradictionVerdi
  *
  * Keeps the same contradiction definition and guardrails as the single-pair
  * prompt; each pair is numbered and the model answers one line per pair.
+ * Dated pairs (#240) are annotated with their recorded dates and days-apart
+ * distance so the judge can distinguish contradiction from evolution.
  */
 export function buildBatchContradictionPrompt(
-  pairs: Array<[{ id: string; statement: string }, { id: string; statement: string }]>,
+  pairs: Array<[JudgeStatement, JudgeStatement]>,
 ): string {
+  const anyDated = pairs.some(([a, b]) => a.date && b.date)
   const blocks = pairs
-    .map(
-      ([a, b], i) => `PAIR ${i + 1}:
-A [${a.id}]: "${a.statement}"
-B [${b.id}]: "${b.statement}"`,
-    )
+    .map(([a, b], i) => {
+      const bothDated = Boolean(a.date && b.date)
+      const apart = bothDated ? daysApart(a.date!, b.date!) : undefined
+      const header = bothDated
+        ? `PAIR ${i + 1} (recorded ${apart === 0 ? 'on the same day' : `${apart} day${apart === 1 ? '' : 's'} apart`}):`
+        : `PAIR ${i + 1}:`
+      const dateTag = (s: JudgeStatement) => (bothDated ? ` (${s.date})` : '')
+      return `${header}
+A [${a.id}]${dateTag(a)}: "${a.statement}"
+B [${b.id}]${dateTag(b)}: "${b.statement}"`
+    })
     .join('\n\n')
 
   const formatLines = pairs
     .map((_, i) => `PAIR_${i + 1}: CONTRADICTS: yes|no | CONFIDENCE: 0.0-1.0 | REASON: <one sentence>`)
     .join('\n')
 
+  const temporalNote = anyDated
+    ? '\nFor dated pairs, consider whether the difference reflects a genuine contradiction about the same claim, or temporal evolution of a changing situation — statements that were each true when recorded, describing how events unfolded over time, do NOT contradict.'
+    : ''
+
   return `You are a memory consistency checker. For each numbered pair of statements below, determine whether the two statements CONTRADICT each other.
 
 Two statements CONTRADICT when one asserts X is true and the other asserts X is false, different, or mutually exclusive.
 Do NOT flag as contradictions: different topics in the same domain, complementary facts, or unrelated statements that happen to share keywords.
-Judge each pair independently.
+Judge each pair independently.${temporalNote}
 
 ${blocks}
 
@@ -204,6 +302,42 @@ export function statementOverlap(a: string, b: string): number {
 }
 
 /**
+ * True when the pair is linked by an intentional-update edge (#240):
+ * `relations.supersedes` / `relations.superseded_by` in either direction.
+ * An intentional update is not a tension — the newer engram is MEANT to
+ * replace the older one.
+ */
+function supersedesLinked(a: Engram, b: Engram): boolean {
+  return Boolean(
+    a.relations?.supersedes?.includes(b.id) ||
+    a.relations?.superseded_by?.includes(b.id) ||
+    b.relations?.supersedes?.includes(a.id) ||
+    b.relations?.superseded_by?.includes(a.id),
+  )
+}
+
+/** True when the engram's validity window has closed (`temporal.valid_until` before `now`). */
+function validityExpired(e: Engram, now: string): boolean {
+  const until = e.temporal?.valid_until
+  return Boolean(until && until < now)
+}
+
+/**
+ * True when BOTH engrams are point-in-time snapshots (their domains fall in
+ * a configured temporal domain) recorded on different days — an event log,
+ * not a contradiction (#240 Layer 2). Same-day snapshot pairs stay in: two
+ * reports of the same day ARE a likely correction. Pairs whose dates cannot
+ * be derived also stay in (conservative — let the judge see them).
+ */
+function isSnapshotPair(a: Engram, b: Engram, temporalDomains: readonly string[]): boolean {
+  if (!inTemporalDomain(a.domain, temporalDomains) || !inTemporalDomain(b.domain, temporalDomains)) return false
+  const dateA = engramDate(a)
+  const dateB = engramDate(b)
+  if (!dateA || !dateB) return false
+  return dateA !== dateB
+}
+
+/**
  * Build candidate pairs for the LLM contradiction scan.
  *
  * Three-stage pipeline (cheapest first):
@@ -214,17 +348,36 @@ export function statementOverlap(a: string, b: string): number {
  * Already-known conflicts (relations.conflicts) are skipped to avoid
  * re-evaluating the same pair.
  *
+ * Temporal gates (#240):
+ *   - Supersedes-linked pairs are skipped in both directions — an
+ *     intentional update is not a tension.
+ *   - Pairs where either side's validity window has closed
+ *     (`temporal.valid_until` in the past) are skipped — an expired engram
+ *     is no longer a peer claim about CURRENT truth, so lining it up
+ *     against a newer claim manufactures a false tension.
+ *   - Snapshot-vs-snapshot pairs (both domains in `temporal_domains`)
+ *     recorded on different days are skipped by default — they are an
+ *     event log, not a contradiction. `snapshot_pairs: 'floor'` keeps them
+ *     for the judge (scanForTensions caps their confidence instead).
+ *
  * Surviving pairs are ranked by descending shared-token overlap (#180) so
  * that the pairs most likely to be genuine contradictions are judged first
  * when the caller applies a max_pairs cap. Ties keep insertion order
  * (stable sort).
  */
-export function getCandidatePairs(engrams: Engram[]): Array<[Engram, Engram]> {
+export function getCandidatePairs(
+  engrams: Engram[],
+  options?: TemporalGateOptions,
+): Array<[Engram, Engram]> {
   const active = engrams.filter(e => e.status === 'active')
+  const temporalDomains = options?.temporal_domains ?? []
+  const snapshotMode = options?.snapshot_pairs ?? 'skip'
+  const now = options?.now ?? new Date().toISOString().slice(0, 10)
 
   // Tokenize each engram once instead of once per pair (O(n) vs O(n²) passes).
   const subjectTokens = active.map(e => extractSubjectTokens(e.statement))
   const statementTokens = active.map(e => new Set(ftsTokenize(e.statement)))
+  const expired = active.map(e => validityExpired(e, now))
 
   const scored: Array<{ pair: [Engram, Engram]; overlap: number }> = []
 
@@ -242,6 +395,17 @@ export function getCandidatePairs(engrams: Engram[]): Array<[Engram, Engram]> {
       // Skip already-known conflict pairs
       if (a.relations?.conflicts?.includes(b.id)) continue
 
+      // #240: intentional updates are not tensions
+      if (supersedesLinked(a, b)) continue
+
+      // #240: an engram whose validity window has closed is not a peer
+      // claim about current truth — don't line it up against anything.
+      if (expired[i] || expired[j]) continue
+
+      // #240 Layer 2: snapshot-vs-snapshot at different timestamps is an
+      // event log, not a contradiction.
+      if (snapshotMode === 'skip' && isSnapshotPair(a, b, temporalDomains)) continue
+
       // Stage 3: subject-predicate pre-filter
       if (!setsIntersect(subjectTokens[i], subjectTokens[j])) continue
 
@@ -257,6 +421,19 @@ export function getCandidatePairs(engrams: Engram[]): Array<[Engram, Engram]> {
   return scored.map(s => s.pair)
 }
 
+/** Options for scanForTensions. Temporal gates/adjustments are #240. */
+export interface TensionScanOptions extends TemporalGateOptions {
+  min_confidence?: number
+  max_pairs?: number
+  batch_size?: number
+  /**
+   * Timestamp-aware confidence discount (#240 Layer 3 multiplier).
+   * OFF by default — the dated judge prompt is the default mechanism; the
+   * blanket multiplier can bury genuine corrections that happen weeks apart.
+   */
+  temporal_discount?: boolean
+}
+
 /**
  * Scan engrams for contradictions with an LLM judge.
  *
@@ -268,25 +445,37 @@ export function getCandidatePairs(engrams: Engram[]): Array<[Engram, Engram]> {
  * missing or unparseable falls back to an individual single-pair call;
  * a pair is never counted as a contradiction without an explicit verdict.
  * Set batch_size to 1 for the original sequential single-pair behavior.
+ *
+ * Temporal behavior (#240): each judged statement carries its recorded date
+ * (engramDate) so the judge can tell evolution from contradiction. With
+ * `temporal_discount: true`, verdict confidence is additionally multiplied
+ * by temporalDiscountFactor(days_apart). Snapshot-vs-snapshot pairs are
+ * skipped by getCandidatePairs (default) or confidence-capped at
+ * SNAPSHOT_CONFIDENCE_CAP in `snapshot_pairs: 'floor'` mode.
  */
 export async function scanForTensions(
   engrams: Engram[],
   llm: LlmFunction,
-  options?: { min_confidence?: number; max_pairs?: number; batch_size?: number },
+  options?: TensionScanOptions,
 ): Promise<TensionScanResult> {
   const minConfidence = options?.min_confidence ?? 0.7
   const maxPairs = options?.max_pairs ?? 50
   const rawBatchSize = options?.batch_size ?? 5
   const batchSize = Number.isFinite(rawBatchSize) ? Math.max(1, Math.floor(rawBatchSize)) : 5
+  const temporalDomains = options?.temporal_domains ?? []
+  const discountEnabled = options?.temporal_discount === true
 
-  const candidates = getCandidatePairs(engrams).slice(0, maxPairs)
+  const candidates = getCandidatePairs(engrams, options).slice(0, maxPairs)
   const tensions: TensionPair[] = []
 
+  const toJudgeStatement = (e: Engram): JudgeStatement => ({
+    id: e.id,
+    statement: e.statement,
+    date: engramDate(e),
+  })
+
   const judgeSingle = async (a: Engram, b: Engram): Promise<ContradictionVerdict | null> => {
-    const prompt = buildContradictionPrompt(
-      { id: a.id, statement: a.statement },
-      { id: b.id, statement: b.statement },
-    )
+    const prompt = buildContradictionPrompt(toJudgeStatement(a), toJudgeStatement(b))
     try {
       return parseContradictionResponse(await llm(prompt))
     } catch {
@@ -303,10 +492,7 @@ export async function scanForTensions(
       verdicts = [await judgeSingle(batch[0][0], batch[0][1])]
     } else {
       const prompt = buildBatchContradictionPrompt(
-        batch.map(([a, b]) => [
-          { id: a.id, statement: a.statement },
-          { id: b.id, statement: b.statement },
-        ]),
+        batch.map(([a, b]) => [toJudgeStatement(a), toJudgeStatement(b)]),
       )
       try {
         verdicts = parseBatchContradictionResponse(await llm(prompt), batch.length)
@@ -326,14 +512,31 @@ export async function scanForTensions(
       const verdict = verdicts[i]
       if (!verdict) continue
       const [a, b] = batch[i]
-      if (verdict.is_contradiction && verdict.confidence >= minConfidence) {
+
+      const dateA = engramDate(a)
+      const dateB = engramDate(b)
+      const days = dateA && dateB ? daysApart(dateA, dateB) : undefined
+
+      // #240: temporal adjustments — snapshot floor first, then the
+      // opt-in days-apart discount.
+      let confidence = verdict.confidence
+      if (isSnapshotPair(a, b, temporalDomains)) {
+        // Only reachable in 'floor' mode ('skip' drops these at candidate stage)
+        confidence = Math.min(confidence, SNAPSHOT_CONFIDENCE_CAP)
+      } else if (discountEnabled && days !== undefined) {
+        confidence = confidence * temporalDiscountFactor(days)
+      }
+
+      if (verdict.is_contradiction && confidence >= minConfidence) {
         tensions.push({
           id_a: a.id,
           id_b: b.id,
           statement_a: a.statement,
           statement_b: b.statement,
-          confidence: verdict.confidence,
+          confidence,
           reason: verdict.reason,
+          ...(days !== undefined ? { days_apart: days } : {}),
+          ...(confidence !== verdict.confidence ? { raw_confidence: verdict.confidence } : {}),
         })
       }
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,15 @@ export interface LearnContext {
    * is echoed back via `structured_data._expiry_extracted`, never guessed.
    */
   valid_until?: string
+  /**
+   * IDs of engrams this one intentionally replaces (#240). Writes
+   * `relations.supersedes` on the new engram and the reverse
+   * `relations.superseded_by` edge on each target found in the local
+   * primary store (best-effort -- remote-store targets are not patched).
+   * Supersedes-linked pairs are skipped by the tension scanner: an
+   * intentional update is not a contradiction.
+   */
+  supersedes?: string[]
 }
 
 /** Extended context for async learn with LLM dedup. */

--- a/packages/core/test/supersedes.test.ts
+++ b/packages/core/test/supersedes.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { getCandidatePairs, scanForTensions } from '../src/tensions.js'
+
+/**
+ * #240 item 3: `supersedes` is a RELATION (graph edge), not a temporality
+ * enum value. `learn(statement, { supersedes: [ids] })` writes
+ * `relations.supersedes` on the new engram and the reverse
+ * `relations.superseded_by` edge on each (local) target. The tension
+ * scanner skips supersedes-linked pairs — an intentional update is not a
+ * contradiction.
+ */
+describe('learn with supersedes (#240)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-supersedes-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('writes relations.supersedes on the new engram', () => {
+    const oldE = plur.learn('plur cli version is 0.3.0')
+    const newE = plur.learn('plur cli version is 0.8.2', { supersedes: [oldE.id] })
+    expect(newE.relations?.supersedes).toEqual([oldE.id])
+  })
+
+  it('writes the reverse superseded_by edge on the target engram', () => {
+    const oldE = plur.learn('plur cli version is 0.3.0')
+    const newE = plur.learn('plur cli version is 0.8.2', { supersedes: [oldE.id] })
+    const reloaded = plur.getById(oldE.id)
+    expect(reloaded?.relations?.superseded_by).toEqual([newE.id])
+  })
+
+  it('supports multiple superseded targets', () => {
+    const a = plur.learn('war analysis uses 5 agents')
+    const b = plur.learn('war analysis uses 7 agents')
+    const c = plur.learn('war analysis uses 9 agents', { supersedes: [a.id, b.id] })
+    expect(c.relations?.supersedes?.sort()).toEqual([a.id, b.id].sort())
+    expect(plur.getById(a.id)?.relations?.superseded_by).toEqual([c.id])
+    expect(plur.getById(b.id)?.relations?.superseded_by).toEqual([c.id])
+  })
+
+  it('ignores unknown target ids without failing the write', () => {
+    const e = plur.learn('plur cli version is 0.8.2', { supersedes: ['ENG-0000-0000-999'] })
+    expect(e.id).toMatch(/^ENG-/)
+    expect(e.relations?.supersedes).toEqual(['ENG-0000-0000-999'])
+  })
+
+  it('does not duplicate the reverse edge when superseded twice', () => {
+    const oldE = plur.learn('plur cli version is 0.3.0')
+    const newE = plur.learn('plur cli version is 0.8.2', { supersedes: [oldE.id] })
+    // re-learn with a different statement superseding the same target
+    const newer = plur.learn('plur cli version is 0.9.0', { supersedes: [oldE.id] })
+    const reloaded = plur.getById(oldE.id)
+    expect(reloaded?.relations?.superseded_by?.sort()).toEqual([newE.id, newer.id].sort())
+    expect(new Set(reloaded?.relations?.superseded_by).size).toBe(reloaded?.relations?.superseded_by?.length)
+  })
+
+  it('preserves existing relations on the target when adding the reverse edge', () => {
+    const oldE = plur.learn('plur cli version is 0.3.0')
+    const stored = plur.getById(oldE.id)!
+    plur.updateEngram({
+      ...stored,
+      relations: { broader: ['B1'], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: [] },
+    })
+    const newE = plur.learn('plur cli version is 0.8.2', { supersedes: [oldE.id] })
+    const reloaded = plur.getById(oldE.id)
+    expect(reloaded?.relations?.broader).toEqual(['B1'])
+    expect(reloaded?.relations?.superseded_by).toEqual([newE.id])
+  })
+
+  it('supersedes-linked pairs are skipped by the tension scanner end-to-end', async () => {
+    const oldE = plur.learn('plur cli version is 0.3.0')
+    plur.learn('plur cli version is 0.8.2', { supersedes: [oldE.id] })
+    const engrams = plur.list()
+    expect(getCandidatePairs(engrams)).toHaveLength(0)
+    const llm = vi.fn(async () => 'CONTRADICTS: yes\nCONFIDENCE: 1.0\nREASON: Versions differ.')
+    const result = await scanForTensions(engrams, llm)
+    expect(result.pairs_checked).toBe(0)
+    expect(llm).not.toHaveBeenCalled()
+  })
+
+  it('round-trips supersedes relations through YAML persistence', () => {
+    const oldE = plur.learn('plur cli version is 0.3.0')
+    const newE = plur.learn('plur cli version is 0.8.2', { supersedes: [oldE.id] })
+    // Fresh instance re-reads from disk
+    const plur2 = new Plur({ path: dir })
+    expect(plur2.getById(newE.id)?.relations?.supersedes).toEqual([oldE.id])
+    expect(plur2.getById(oldE.id)?.relations?.superseded_by).toEqual([newE.id])
+  })
+})

--- a/packages/core/test/tensions-e2e.test.ts
+++ b/packages/core/test/tensions-e2e.test.ts
@@ -19,9 +19,10 @@ function newDir(): string {
 /** Mock LLM that detects contradictions when both statements mention the same subject. */
 function makeMockLlm(): LlmFunction {
   return async (prompt: string): Promise<string> => {
-    // Extract the two statements from the prompt
-    const stmtA = prompt.match(/STATEMENT A \[.*?\]:\s*"([^"]+)"/)?.[1] ?? ''
-    const stmtB = prompt.match(/STATEMENT B \[.*?\]:\s*"([^"]+)"/)?.[1] ?? ''
+    // Extract the two statements from the prompt. The label may carry a
+    // "(recorded YYYY-MM-DD)" annotation when dates are derivable (#240).
+    const stmtA = prompt.match(/STATEMENT A \[.*?\][^:]*:\s*"([^"]+)"/)?.[1] ?? ''
+    const stmtB = prompt.match(/STATEMENT B \[.*?\][^:]*:\s*"([^"]+)"/)?.[1] ?? ''
 
     // Simple heuristic: if both mention a shared keyword and make different assertions, flag it
     const wordsA = new Set(stmtA.toLowerCase().split(/\W+/).filter(w => w.length > 4))

--- a/packages/core/test/tensions-temporal.test.ts
+++ b/packages/core/test/tensions-temporal.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  engramDate,
+  daysApart,
+  inTemporalDomain,
+  temporalDiscountFactor,
+  getCandidatePairs,
+  buildContradictionPrompt,
+  buildBatchContradictionPrompt,
+  scanForTensions,
+} from '../src/tensions.js'
+import type { Engram } from '../src/schemas/engram.js'
+import { PlurConfigSchema } from '../src/schemas/config.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEngram(overrides: Partial<Engram> & { id: string; statement: string }): Engram {
+  return {
+    version: 2,
+    status: 'active',
+    consolidated: false,
+    type: 'behavioral',
+    scope: 'global',
+    visibility: 'private',
+    activation: {
+      retrieval_strength: 0.7,
+      storage_strength: 1,
+      frequency: 0,
+      last_accessed: '2026-05-16',
+    },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [],
+    associations: [],
+    derivation_count: 1,
+    tags: [],
+    content_hash: overrides.id,
+    commitment: 'leaning',
+    engram_version: 1,
+    episode_ids: [],
+    polarity: null,
+    ...overrides,
+  } as Engram
+}
+
+const NO_VERDICT = 'CONTRADICTS: no | CONFIDENCE: 0.1 | REASON: Fine.'
+const batchNoLlm = vi.fn(async (prompt: string) => {
+  const n = (prompt.match(/PAIR \d+/g) ?? []).length
+  if (n === 0) return 'CONTRADICTS: no\nCONFIDENCE: 0.1\nREASON: Fine.'
+  return Array.from({ length: n }, (_, i) => `PAIR_${i + 1}: ${NO_VERDICT}`).join('\n')
+})
+
+// ---------------------------------------------------------------------------
+// engramDate (#240 Layer 3 prompt half)
+// ---------------------------------------------------------------------------
+
+describe('engramDate', () => {
+  it('uses temporal.learned_at when present', () => {
+    const e = makeEngram({
+      id: 'ENG-2026-0101-001',
+      statement: 'x',
+      temporal: { learned_at: '2026-04-07T10:00:00Z' },
+    })
+    expect(engramDate(e)).toBe('2026-04-07')
+  })
+
+  it('falls back to the date embedded in a canonical ENG-YYYY-MMDD-NNN id', () => {
+    const e = makeEngram({ id: 'ENG-2026-0519-052', statement: 'x' })
+    expect(engramDate(e)).toBe('2026-05-19')
+  })
+
+  it('parses store-namespaced ids ENG-PREFIX-YYYY-MMDD-NNN', () => {
+    const e = makeEngram({ id: 'ENG-TEAM-2026-0413-002', statement: 'x' })
+    expect(engramDate(e)).toBe('2026-04-13')
+  })
+
+  it('parses server-assigned ids ENG-YYYY-MM-DD-NNN', () => {
+    const e = makeEngram({ id: 'ENG-2026-05-06-007', statement: 'x' })
+    expect(engramDate(e)).toBe('2026-05-06')
+  })
+
+  it('returns undefined when no date is derivable', () => {
+    const e = makeEngram({ id: 'ENG-custom-id', statement: 'x' })
+    expect(engramDate(e)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// daysApart
+// ---------------------------------------------------------------------------
+
+describe('daysApart', () => {
+  it('returns 0 for the same day', () => {
+    expect(daysApart('2026-04-07', '2026-04-07')).toBe(0)
+  })
+
+  it('returns the absolute difference in days', () => {
+    expect(daysApart('2026-04-07', '2026-04-13')).toBe(6)
+    expect(daysApart('2026-04-13', '2026-04-07')).toBe(6)
+  })
+
+  it('spans month boundaries', () => {
+    expect(daysApart('2026-04-28', '2026-05-05')).toBe(7)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// inTemporalDomain (#240 Layer 2)
+// ---------------------------------------------------------------------------
+
+describe('inTemporalDomain', () => {
+  it('matches an exact domain', () => {
+    expect(inTemporalDomain('war-analysis', ['war-analysis'])).toBe(true)
+  })
+
+  it('matches dotted sub-domains of a configured domain', () => {
+    expect(inTemporalDomain('war-analysis.hormuz', ['war-analysis'])).toBe(true)
+  })
+
+  it('does not match a different domain', () => {
+    expect(inTemporalDomain('plur.core', ['war-analysis'])).toBe(false)
+  })
+
+  it('does not match a domain that merely shares a prefix string', () => {
+    expect(inTemporalDomain('war-analysis-2', ['war-analysis'])).toBe(false)
+  })
+
+  it('returns false for missing domain or empty config', () => {
+    expect(inTemporalDomain(undefined, ['war-analysis'])).toBe(false)
+    expect(inTemporalDomain('war-analysis', [])).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// temporalDiscountFactor (#240 Layer 3 multiplier — opt-in)
+// ---------------------------------------------------------------------------
+
+describe('temporalDiscountFactor', () => {
+  it('same day → 1.0 (likely real contradiction)', () => {
+    expect(temporalDiscountFactor(0)).toBe(1.0)
+  })
+
+  it('1-3 days apart → 0.8', () => {
+    expect(temporalDiscountFactor(1)).toBe(0.8)
+    expect(temporalDiscountFactor(3)).toBe(0.8)
+  })
+
+  it('4-14 days apart → 0.5', () => {
+    expect(temporalDiscountFactor(4)).toBe(0.5)
+    expect(temporalDiscountFactor(14)).toBe(0.5)
+  })
+
+  it('15+ days apart → 0.3', () => {
+    expect(temporalDiscountFactor(15)).toBe(0.3)
+    expect(temporalDiscountFactor(60)).toBe(0.3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCandidatePairs — snapshot-domain gate (#240 Layer 2)
+// ---------------------------------------------------------------------------
+
+describe('getCandidatePairs snapshot-domain gate (#240)', () => {
+  const ceasefireA = () => makeEngram({
+    id: 'ENG-2026-0407-001',
+    statement: 'Iran ceasefire agreed April 7, Hormuz regulated passage',
+    domain: 'war-analysis',
+  })
+  const ceasefireB = () => makeEngram({
+    id: 'ENG-2026-0413-002',
+    statement: 'Iran ceasefire collapsed, Hormuz passage closed again',
+    domain: 'war-analysis',
+  })
+
+  it('skips snapshot-vs-snapshot pairs recorded on different days', () => {
+    const pairs = getCandidatePairs([ceasefireA(), ceasefireB()], {
+      temporal_domains: ['war-analysis'],
+    })
+    expect(pairs).toHaveLength(0)
+  })
+
+  it('keeps snapshot-vs-snapshot pairs recorded the same day (likely a correction)', () => {
+    const a = ceasefireA()
+    const b = ceasefireB()
+    b.id = 'ENG-2026-0407-002' // same day as a
+    const pairs = getCandidatePairs([a, b], { temporal_domains: ['war-analysis'] })
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('keeps mixed snapshot/standing pairs', () => {
+    const a = ceasefireA()
+    const b = ceasefireB()
+    b.domain = undefined // standing engram with no domain — not a snapshot
+    const pairs = getCandidatePairs([a, b], { temporal_domains: ['war-analysis'] })
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('is inert when no temporal domains are configured (default)', () => {
+    const pairs = getCandidatePairs([ceasefireA(), ceasefireB()])
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('keeps snapshot pairs when snapshot_pairs=floor (judged, then confidence-capped)', () => {
+    const pairs = getCandidatePairs([ceasefireA(), ceasefireB()], {
+      temporal_domains: ['war-analysis'],
+      snapshot_pairs: 'floor',
+    })
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('does not skip when dates cannot be derived for both sides', () => {
+    const a = ceasefireA()
+    const b = ceasefireB()
+    a.id = 'ENG-no-date-a'
+    b.id = 'ENG-no-date-b'
+    const pairs = getCandidatePairs([a, b], { temporal_domains: ['war-analysis'] })
+    expect(pairs).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCandidatePairs — supersedes edge gate (#240 item 3)
+// ---------------------------------------------------------------------------
+
+describe('getCandidatePairs supersedes gate (#240)', () => {
+  it('skips pairs linked by relations.supersedes', () => {
+    const oldE = makeEngram({ id: 'E1', statement: 'plur cli version is 0.3.0' })
+    const newE = makeEngram({
+      id: 'E2',
+      statement: 'plur cli version is 0.8.2',
+      relations: { broader: [], narrower: [], related: [], conflicts: [], supersedes: ['E1'], superseded_by: [] },
+    })
+    expect(getCandidatePairs([oldE, newE])).toHaveLength(0)
+  })
+
+  it('skips pairs linked by relations.superseded_by', () => {
+    const oldE = makeEngram({
+      id: 'E1',
+      statement: 'plur cli version is 0.3.0',
+      relations: { broader: [], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: ['E2'] },
+    })
+    const newE = makeEngram({ id: 'E2', statement: 'plur cli version is 0.8.2' })
+    expect(getCandidatePairs([oldE, newE])).toHaveLength(0)
+  })
+
+  it('keeps unlinked pairs', () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur cli version is 0.3.0' })
+    const b = makeEngram({ id: 'E2', statement: 'plur cli version is 0.8.2' })
+    expect(getCandidatePairs([a, b])).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCandidatePairs — expired validity gate (#240 / #347 real fields)
+// ---------------------------------------------------------------------------
+
+describe('getCandidatePairs expired-validity gate (#240)', () => {
+  it('skips pairs where one side has a closed valid_until in the past', () => {
+    const expired = makeEngram({
+      id: 'E1',
+      statement: 'Iran ceasefire holds in the hormuz strait',
+      temporal: { learned_at: '2026-04-07', valid_until: '2026-04-22' },
+    })
+    const current = makeEngram({
+      id: 'E2',
+      statement: 'Iran ceasefire collapsed in the hormuz strait',
+      temporal: { learned_at: '2026-05-05' },
+    })
+    const pairs = getCandidatePairs([expired, current], { now: '2026-07-02' })
+    expect(pairs).toHaveLength(0)
+  })
+
+  it('keeps pairs whose valid_until is still in the future', () => {
+    const a = makeEngram({
+      id: 'E1',
+      statement: 'plur discount code CONF20 works',
+      temporal: { learned_at: '2026-06-01', valid_until: '2099-12-31' },
+    })
+    const b = makeEngram({
+      id: 'E2',
+      statement: 'plur discount code CONF20 is invalid',
+      temporal: { learned_at: '2026-06-02' },
+    })
+    const pairs = getCandidatePairs([a, b], { now: '2026-07-02' })
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('keeps pairs with no validity windows', () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur uses yaml' })
+    const b = makeEngram({ id: 'E2', statement: 'plur uses json' })
+    expect(getCandidatePairs([a, b], { now: '2026-07-02' })).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Prompt dates (#240 Layer 3 prompt half)
+// ---------------------------------------------------------------------------
+
+describe('buildContradictionPrompt with dates', () => {
+  it('includes both dates and the days-apart evolution nudge', () => {
+    const prompt = buildContradictionPrompt(
+      { id: 'E1', statement: 'Ceasefire agreed.', date: '2026-04-07' },
+      { id: 'E2', statement: 'Ceasefire collapsed.', date: '2026-04-13' },
+    )
+    expect(prompt).toContain('2026-04-07')
+    expect(prompt).toContain('2026-04-13')
+    expect(prompt).toContain('6 days apart')
+    expect(prompt).toMatch(/temporal evolution/i)
+  })
+
+  it('stays byte-identical to the legacy prompt when no dates are passed', () => {
+    const prompt = buildContradictionPrompt(
+      { id: 'E1', statement: 'A' },
+      { id: 'E2', statement: 'B' },
+    )
+    expect(prompt).not.toMatch(/days apart/i)
+    expect(prompt).not.toMatch(/recorded/i)
+    expect(prompt).toContain('CONTRADICTS: yes|no')
+  })
+
+  it('omits the nudge when only one side has a date', () => {
+    const prompt = buildContradictionPrompt(
+      { id: 'E1', statement: 'A', date: '2026-04-07' },
+      { id: 'E2', statement: 'B' },
+    )
+    expect(prompt).not.toMatch(/days apart/i)
+  })
+})
+
+describe('buildBatchContradictionPrompt with dates', () => {
+  it('annotates each dated pair and includes the evolution guidance', () => {
+    const prompt = buildBatchContradictionPrompt([
+      [
+        { id: 'E1', statement: 'Ceasefire agreed.', date: '2026-04-07' },
+        { id: 'E2', statement: 'Ceasefire collapsed.', date: '2026-04-13' },
+      ],
+      [
+        { id: 'E3', statement: 'Y is red.' },
+        { id: 'E4', statement: 'Y is blue.' },
+      ],
+    ])
+    expect(prompt).toContain('2026-04-07')
+    expect(prompt).toContain('2026-04-13')
+    expect(prompt).toContain('6 days apart')
+    expect(prompt).toMatch(/temporal evolution/i)
+  })
+
+  it('has no temporal guidance when no pair is dated', () => {
+    const prompt = buildBatchContradictionPrompt([
+      [{ id: 'E1', statement: 'A' }, { id: 'E2', statement: 'B' }],
+    ])
+    expect(prompt).not.toMatch(/days apart/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TensionsConfig schema (#240 Layer 2 config home)
+// ---------------------------------------------------------------------------
+
+describe('tensions config block (#240)', () => {
+  it('parses temporal_domains and snapshot_pairs', () => {
+    const parsed = PlurConfigSchema.parse({
+      tensions: {
+        temporal_domains: ['war-analysis', 'geopolitics', 'markets'],
+        snapshot_pairs: 'floor',
+        temporal_discount: true,
+      },
+    })
+    expect(parsed.tensions?.temporal_domains).toEqual(['war-analysis', 'geopolitics', 'markets'])
+    expect(parsed.tensions?.snapshot_pairs).toBe('floor')
+    expect(parsed.tensions?.temporal_discount).toBe(true)
+  })
+
+  it('defaults: no temporal domains, skip behavior, discount off', () => {
+    const parsed = PlurConfigSchema.parse({ tensions: {} })
+    expect(parsed.tensions?.temporal_domains ?? []).toEqual([])
+    expect(parsed.tensions?.snapshot_pairs ?? 'skip').toBe('skip')
+    expect(parsed.tensions?.temporal_discount ?? false).toBe(false)
+  })
+
+  it('config without a tensions block still parses (backward compat)', () => {
+    const parsed = PlurConfigSchema.parse({ auto_learn: true })
+    expect(parsed.auto_learn).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scanForTensions temporal integration (#240)
+// ---------------------------------------------------------------------------
+
+describe('scanForTensions temporal integration (#240)', () => {
+  it('feeds engram dates into the judge prompt', async () => {
+    const a = makeEngram({
+      id: 'ENG-2026-0407-001',
+      statement: 'plur ceasefire status is holding',
+      temporal: { learned_at: '2026-04-07' },
+    })
+    const b = makeEngram({
+      id: 'ENG-2026-0413-002',
+      statement: 'plur ceasefire status is collapsed',
+      temporal: { learned_at: '2026-04-13' },
+    })
+    const prompts: string[] = []
+    const llm = vi.fn(async (p: string) => {
+      prompts.push(p)
+      return `PAIR_1: ${NO_VERDICT}`
+    })
+    await scanForTensions([a, b], llm)
+    expect(prompts.join('\n')).toContain('2026-04-07')
+    expect(prompts.join('\n')).toContain('2026-04-13')
+  })
+
+  it('skips snapshot-domain pairs entirely (no LLM call)', async () => {
+    const a = makeEngram({ id: 'ENG-2026-0407-001', statement: 'hormuz strait passage regulated', domain: 'war-analysis' })
+    const b = makeEngram({ id: 'ENG-2026-0505-001', statement: 'hormuz strait passage closed', domain: 'war-analysis' })
+    const llm = vi.fn(async () => NO_VERDICT)
+    const result = await scanForTensions([a, b], llm, { temporal_domains: ['war-analysis'] })
+    expect(result.pairs_checked).toBe(0)
+    expect(llm).not.toHaveBeenCalled()
+  })
+
+  it('floor mode caps snapshot-pair confidence at 0.1', async () => {
+    const a = makeEngram({ id: 'ENG-2026-0407-001', statement: 'hormuz strait passage regulated', domain: 'war-analysis' })
+    const b = makeEngram({ id: 'ENG-2026-0505-001', statement: 'hormuz strait passage closed', domain: 'war-analysis' })
+    const llm = vi.fn(async () => 'PAIR_1: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.')
+    const result = await scanForTensions([a, b], llm, {
+      temporal_domains: ['war-analysis'],
+      snapshot_pairs: 'floor',
+      min_confidence: 0.05,
+    })
+    expect(result.pairs_checked).toBe(1)
+    expect(result.new_tensions).toBe(1)
+    expect(result.tensions[0].confidence).toBeCloseTo(0.1)
+    // suppressed under the default 0.7 threshold
+    const suppressed = await scanForTensions([a, b], llm, {
+      temporal_domains: ['war-analysis'],
+      snapshot_pairs: 'floor',
+    })
+    expect(suppressed.new_tensions).toBe(0)
+  })
+
+  it('temporal discount is OFF by default — far-apart standing contradictions surface at raw confidence', async () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur uses tabs for indentation', temporal: { learned_at: '2026-04-01' } })
+    const b = makeEngram({ id: 'E2', statement: 'plur uses spaces for indentation', temporal: { learned_at: '2026-06-01' } })
+    const llm = vi.fn(async () => 'PAIR_1: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.')
+    const result = await scanForTensions([a, b], llm)
+    expect(result.new_tensions).toBe(1)
+    expect(result.tensions[0].confidence).toBeCloseTo(0.9)
+  })
+
+  it('temporal discount ON multiplies confidence by the ladder factor', async () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur uses tabs for indentation', temporal: { learned_at: '2026-04-01' } })
+    const b = makeEngram({ id: 'E2', statement: 'plur uses spaces for indentation', temporal: { learned_at: '2026-06-01' } })
+    const llm = vi.fn(async () => 'PAIR_1: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.')
+    const result = await scanForTensions([a, b], llm, { temporal_discount: true, min_confidence: 0.2 })
+    expect(result.new_tensions).toBe(1)
+    // 61 days apart → 0.3 factor → 0.27
+    expect(result.tensions[0].confidence).toBeCloseTo(0.27)
+    expect(result.tensions[0].raw_confidence).toBeCloseTo(0.9)
+
+    // Under the default 0.7 threshold the discounted pair is suppressed
+    const suppressed = await scanForTensions([a, b], llm, { temporal_discount: true })
+    expect(suppressed.new_tensions).toBe(0)
+  })
+
+  it('temporal discount leaves same-day pairs untouched', async () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur uses tabs for indentation', temporal: { learned_at: '2026-04-01' } })
+    const b = makeEngram({ id: 'E2', statement: 'plur uses spaces for indentation', temporal: { learned_at: '2026-04-01' } })
+    const llm = vi.fn(async () => 'PAIR_1: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.')
+    const result = await scanForTensions([a, b], llm, { temporal_discount: true })
+    expect(result.new_tensions).toBe(1)
+    expect(result.tensions[0].confidence).toBeCloseTo(0.9)
+  })
+
+  it('reports days_apart on detected tensions when derivable', async () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur uses tabs for indentation', temporal: { learned_at: '2026-04-07' } })
+    const b = makeEngram({ id: 'E2', statement: 'plur uses spaces for indentation', temporal: { learned_at: '2026-04-13' } })
+    const llm = vi.fn(async () => 'PAIR_1: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.')
+    const result = await scanForTensions([a, b], llm)
+    expect(result.tensions[0].days_apart).toBe(6)
+  })
+
+  it('single-pair mode (batch_size 1) also gets dates', async () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur uses tabs for indentation', temporal: { learned_at: '2026-04-07' } })
+    const b = makeEngram({ id: 'E2', statement: 'plur uses spaces for indentation', temporal: { learned_at: '2026-04-13' } })
+    const prompts: string[] = []
+    const llm = vi.fn(async (p: string) => {
+      prompts.push(p)
+      return 'CONTRADICTS: no\nCONFIDENCE: 0.1\nREASON: Fine.'
+    })
+    await scanForTensions([a, b], llm, { batch_size: 1 })
+    expect(prompts[0]).toContain('2026-04-07')
+    expect(prompts[0]).toContain('6 days apart')
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -143,6 +143,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           locked_reason: { type: 'string', description: 'Why this engram is locked (only meaningful when commitment=locked)' },
           valid_from: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge becomes valid — inject/recall skip the engram before this date (#347)' },
           valid_until: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge expires — inject/recall skip the engram after this date. Set this for any time-bound fact (offers, deadlines, temporary endpoints). When omitted, an explicit expiry phrase in the statement ("valid until 31 May 2026") is auto-parsed and echoed back (#347)' },
+          supersedes: { type: 'array', items: { type: 'string' }, description: 'Engram IDs this statement intentionally replaces (#240). Writes relations.supersedes on the new engram and the reverse superseded_by edge on each local target. Supersedes-linked pairs are skipped by tension scans — an intentional update is not a contradiction. Use when updating a standing fact (new version, changed rule) rather than contradicting it.' },
         },
         required: ['statement'],
       },
@@ -166,6 +167,7 @@ export function getToolDefinitions(): ToolDefinition[] {
           pinned: args.pinned as boolean | undefined,
           valid_from: args.valid_from as string | undefined,
           valid_until: args.valid_until as string | undefined,
+          supersedes: args.supersedes as string[] | undefined,
           llm,
         }
         // Route through learnRouted FIRST so remote-scope writes get
@@ -1773,6 +1775,7 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           min_confidence: { type: 'number', description: 'Minimum confidence threshold for scan mode (0–1, default: 0.7)' },
           max_pairs: { type: 'number', description: 'Maximum candidate pairs to evaluate in scan mode (default: 50)' },
           batch_size: { type: 'number', description: 'Pairs judged per LLM call in scan mode (default: 5). Set to 1 for sequential single-pair judging.' },
+          temporal_discount: { type: 'boolean', description: 'Multiply judge confidence by a days-apart ladder (same day x1.0 ... 15+ days x0.3) in scan mode (#240). Overrides the config default (tensions.temporal_discount, off by default). The judge prompt already carries recorded dates; enable this only when date-aware judging alone leaves too many temporal-evolution false positives.' },
         },
       },
       handler: async (args, plur) => {
@@ -1794,10 +1797,16 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
             }
           }
 
+          // #240: config supplies the temporal defaults (tensions: block in
+          // config.yaml); an explicit temporal_discount arg overrides.
+          const tensionsConfig = plur.getTensionsConfig()
           const result = await scanForTensions(engrams, llm, {
             min_confidence: args.min_confidence as number | undefined,
             max_pairs: args.max_pairs as number | undefined,
             batch_size: args.batch_size as number | undefined,
+            temporal_domains: tensionsConfig.temporal_domains,
+            snapshot_pairs: tensionsConfig.snapshot_pairs,
+            temporal_discount: (args.temporal_discount as boolean | undefined) ?? tensionsConfig.temporal_discount,
           })
 
           return {
@@ -1808,6 +1817,8 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
               engram_b: { id: t.id_b, statement: t.statement_b },
               confidence: t.confidence,
               reason: t.reason,
+              ...(t.days_apart !== undefined ? { days_apart: t.days_apart } : {}),
+              ...(t.raw_confidence !== undefined ? { raw_confidence: t.raw_confidence } : {}),
             })),
           }
         }

--- a/packages/mcp/test/tensions.test.ts
+++ b/packages/mcp/test/tensions.test.ts
@@ -271,6 +271,175 @@ describe('plur_tensions scan mode', () => {
   })
 })
 
+describe('plur_tensions temporal config wiring (#240)', () => {
+  let dir: string
+  let originalFetch: typeof globalThis.fetch
+  const tools = getToolDefinitions()
+  const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-tensions-temporal-'))
+    originalFetch = globalThis.fetch
+    delete (process.env as any).OPENAI_API_KEY
+    delete (process.env as any).OPENROUTER_API_KEY
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** Learn two contradicting snapshot engrams recorded on different days. */
+  function seedSnapshotPair(plur: Plur): void {
+    const a = plur.learn('hormuz strait ceasefire holding, passage regulated', { domain: 'war-analysis' })
+    const b = plur.learn('hormuz strait ceasefire collapsed, passage closed', { domain: 'war-analysis' })
+    for (const [id, learnedAt] of [[a.id, '2026-04-07'], [b.id, '2026-05-05']] as const) {
+      const stored = plur.getById(id)!
+      plur.updateEngram({ ...stored, temporal: { ...stored.temporal, learned_at: learnedAt } })
+    }
+  }
+
+  const yesLlm = () => vi.fn().mockImplementation(async (_url: any, init: any) => {
+    const prompt: string = JSON.parse(init.body).messages[0].content
+    const n = (prompt.match(/PAIR \d+/g) ?? []).length
+    const content = n > 0
+      ? Array.from({ length: n }, (_, i) => `PAIR_${i + 1}: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.`).join('\n')
+      : 'CONTRADICTS: yes\nCONFIDENCE: 0.9\nREASON: Opposite.'
+    return { ok: true, json: async () => ({ choices: [{ message: { content } }] }) }
+  })
+
+  it('config tensions.temporal_domains skips snapshot pairs in scan mode', async () => {
+    fs.writeFileSync(path.join(dir, 'config.yaml'), 'tensions:\n  temporal_domains:\n    - war-analysis\n')
+    const plur = new Plur({ path: dir })
+    seedSnapshotPair(plur)
+
+    const fetchMock = yesLlm()
+    globalThis.fetch = fetchMock as any
+
+    const result = await tensionsTool.handler({
+      scan: true, llm_base_url: 'https://api.openai.com/v1', llm_api_key: 'k',
+    }, plur) as any
+
+    expect(result.pairs_checked).toBe(0)
+    expect(result.count).toBe(0)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('without the config the same pair is judged (dates still reach the prompt)', async () => {
+    const plur = new Plur({ path: dir })
+    seedSnapshotPair(plur)
+
+    const prompts: string[] = []
+    const fetchMock = vi.fn().mockImplementation(async (_url: any, init: any) => {
+      const prompt: string = JSON.parse(init.body).messages[0].content
+      prompts.push(prompt)
+      const n = (prompt.match(/PAIR \d+/g) ?? []).length
+      const content = Array.from({ length: Math.max(n, 1) }, (_, i) => `PAIR_${i + 1}: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.`).join('\n')
+      return { ok: true, json: async () => ({ choices: [{ message: { content } }] }) }
+    })
+    globalThis.fetch = fetchMock as any
+
+    const result = await tensionsTool.handler({
+      scan: true, llm_base_url: 'https://api.openai.com/v1', llm_api_key: 'k',
+    }, plur) as any
+
+    expect(result.pairs_checked).toBe(1)
+    expect(result.count).toBe(1)
+    expect(prompts.join('\n')).toContain('2026-04-07')
+    expect(prompts.join('\n')).toContain('2026-05-05')
+    expect(result.tensions[0].days_apart).toBe(28)
+  })
+
+  it('temporal_discount arg discounts confidence and reports raw_confidence', async () => {
+    const plur = new Plur({ path: dir })
+    seedSnapshotPair(plur)
+
+    globalThis.fetch = yesLlm() as any
+
+    const result = await tensionsTool.handler({
+      scan: true, llm_base_url: 'https://api.openai.com/v1', llm_api_key: 'k',
+      temporal_discount: true, min_confidence: 0.2,
+    }, plur) as any
+
+    expect(result.count).toBe(1)
+    // 28 days apart → 0.3 factor → 0.27
+    expect(result.tensions[0].confidence).toBeCloseTo(0.27)
+    expect(result.tensions[0].raw_confidence).toBeCloseTo(0.9)
+  })
+
+  it('config tensions.temporal_discount=true applies without an explicit arg', async () => {
+    fs.writeFileSync(path.join(dir, 'config.yaml'), 'tensions:\n  temporal_discount: true\n')
+    const plur = new Plur({ path: dir })
+    seedSnapshotPair(plur)
+
+    globalThis.fetch = yesLlm() as any
+
+    const result = await tensionsTool.handler({
+      scan: true, llm_base_url: 'https://api.openai.com/v1', llm_api_key: 'k',
+      min_confidence: 0.2,
+    }, plur) as any
+
+    expect(result.count).toBe(1)
+    expect(result.tensions[0].confidence).toBeCloseTo(0.27)
+  })
+})
+
+describe('plur_learn supersedes (#240)', () => {
+  let dir: string
+  let plur: Plur
+  const tools = getToolDefinitions()
+  const learnTool = tools.find(t => t.name === 'plur_learn')!
+  const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-learn-supersedes-'))
+    plur = new Plur({ path: dir })
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('declares supersedes as an array param', () => {
+    const schema = learnTool.inputSchema as any
+    expect(schema.properties.supersedes).toBeDefined()
+    expect(schema.properties.supersedes.type).toBe('array')
+  })
+
+  it('writes the forward edge on the new engram and the reverse edge on the target', async () => {
+    const oldE = await learnTool.handler({ statement: 'plur cli version is 0.3.0', scope: 'global' }, plur) as any
+    const newE = await learnTool.handler({
+      statement: 'plur cli version is 0.8.2', scope: 'global', supersedes: [oldE.id],
+    }, plur) as any
+
+    expect(plur.getById(newE.id)?.relations?.supersedes).toEqual([oldE.id])
+    expect(plur.getById(oldE.id)?.relations?.superseded_by).toEqual([newE.id])
+  })
+
+  it('supersedes-linked pair no longer surfaces as a scan candidate', async () => {
+    const oldE = await learnTool.handler({ statement: 'plur cli version is 0.3.0', scope: 'global' }, plur) as any
+    await learnTool.handler({
+      statement: 'plur cli version is 0.8.2', scope: 'global', supersedes: [oldE.id],
+    }, plur) as any
+
+    const originalFetch = globalThis.fetch
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'CONTRADICTS: yes\nCONFIDENCE: 1.0\nREASON: Versions differ.' } }] }),
+    })
+    globalThis.fetch = fetchMock as any
+    try {
+      const result = await tensionsTool.handler({
+        scan: true, llm_base_url: 'https://api.openai.com/v1', llm_api_key: 'k',
+      }, plur) as any
+      expect(result.pairs_checked).toBe(0)
+      expect(fetchMock).not.toHaveBeenCalled()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
 describe('plur_tensions_purge tool', () => {
   let dir: string
   let plur: Plur

--- a/spec/engram.schema.json
+++ b/spec/engram.schema.json
@@ -222,6 +222,20 @@
             "type": "string"
           },
           "default": []
+        },
+        "supersedes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "superseded_by": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Closes #240

Implements temporal-aware tension detection along the lines @plur9 recommended in the issue thread: Layer 2 (domain defaults) as the primary mechanism, the Layer 3 prompt half by default, the Layer 3 multiplier as an opt-in tunable, and `supersedes` as a **relation (graph edge), not a temporality enum**.

## What changed

### Layer 2 — domain-level temporal defaults (`tensions:` config block)

```yaml
# config.yaml
tensions:
  temporal_domains:        # domains whose engrams are point-in-time snapshots
    - war-analysis
    - geopolitics
    - markets
  snapshot_pairs: skip     # skip (default) | floor
  temporal_discount: false # Layer 3 multiplier, OFF by default
```

- A snapshot-vs-snapshot pair (both domains under a `temporal_domains` entry, dotted sub-domains included) recorded on **different days** is an event log, not a contradiction — `getCandidatePairs` drops it before the judge (`skip`) or the scanner caps its confidence at 0.1 (`floor`).
- Same-day snapshot pairs stay in: two reports of the same day ARE a likely correction.
- Retroactive: no re-tagging of existing engrams. Zero config → zero behavior change.

### Layer 3 prompt half — dated judge prompts (default ON)

- Every judged statement now carries its recorded date (`temporal.learned_at`, falling back to the date embedded in `ENG-YYYY-MMDD-NNN` / `ENG-{PREFIX}-YYYY-MMDD-NNN` / `ENG-YYYY-MM-DD-NNN` ids).
- Single-pair and batch prompts annotate both dates plus days-apart, with the evolution-vs-contradiction nudge. Prompts without derivable dates are byte-identical to before.
- Detected tensions report `days_apart`.

### Layer 3 multiplier — opt-in `temporal_discount`

- The `1.0 / 0.8 / 0.5 / 0.3` days-apart ladder multiplies judge confidence, **off by default** (config `tensions.temporal_discount`, CLI `--temporal-discount` / `--no-temporal-discount`, MCP `temporal_discount` arg). Kept opt-in per the review comment: a blanket multiplier can bury genuine standing-fact corrections made weeks apart. Discounted tensions report `raw_confidence` alongside the adjusted value.

### `supersedes` as a relation + `plur_learn` param

- `relations.supersedes[]` / `relations.superseded_by[]` edges (mirroring `relations.conflicts[]`), settable via `plur_learn` MCP tool (`supersedes: [ids]`), the `Plur.learn`/`learnRouted` context, and CLI `plur learn --supersedes id1,id2`.
- Learn writes the forward edge on the new engram and best-effort reverse edges on local targets (persisted under the same store lock; unknown/remote targets keep the forward edge only).
- The scanner skips supersedes-linked pairs in both directions — an intentional update is not a tension.
- Pack export strips `supersedes`/`superseded_by` alongside `conflicts`/`related` (store-internal cross-refs; a stale edge in a foreign store could falsely suppress detection on ID collision).

### Expired-validity gate (uses the existing #347 fields)

- A pair where either side's `temporal.valid_until` has passed is skipped — an expired engram is no longer a peer claim about *current* truth, so lining it up against a newer claim manufactures a false tension. This is the "PLUR already owns (b) machinery" point from the issue thread, wired in.

### Wiring

- MCP `plur_tensions` scan mode merges the `tensions:` config defaults; explicit `temporal_discount` arg overrides. Output includes `days_apart` / `raw_confidence` when present.
- CLI `plur tensions --scan` same merge + flags; text output shows days-apart and raw confidence.
- `spec/engram.schema.json` regenerated (drift gate green).

## Deliberately NOT in this PR (scope guard from the issue thread)

- **No `temporality` enum on the engram schema** — Layer 2 domain defaults cover the population; the per-engram marker can be added later as `temporal.kind` if measurement shows the long tail matters.
- **Inject/recall/decay supersedes behavior** (injection priority, `[superseded by …]` recall annotations, faster decay) — split to follow-up issue #481 as recommended.

## Tests

- `packages/core/test/tensions-temporal.test.ts` — 45 new tests: date resolution, days-apart, domain matching, discount ladder, snapshot/supersedes/expired candidate gates, dated prompts (byte-identical without dates), config schema, scan integration incl. floor mode and discount on/off.
- `packages/core/test/supersedes.test.ts` — 8 new tests: forward/reverse edges, multi-target, unknown targets, idempotent reverse edge, relation preservation, YAML round-trip, scanner skip end-to-end.
- `packages/mcp/test/tensions.test.ts` — 7 new tests: config wiring through the tool, discount arg + config default, `plur_learn supersedes` param, scan skip.
- `packages/cli/test/tensions.test.ts` — 6 new tests: config-driven skip, `--temporal-discount`/`--no-temporal-discount` override semantics, `--supersedes` flag, days-apart reporting (stub OpenAI-compatible server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
