### PR TITLE
feat(core): deterministic lexical query rewriting for hybrid recall (#224 remainder)

### DIFF
--- a/packages/core/src/hybrid-search.ts
+++ b/packages/core/src/hybrid-search.ts
@@ -1,6 +1,7 @@
 import type { Engram } from './schemas/engram.js'
 import { searchEngrams } from './fts.js'
 import { embeddingSearch, embedderStatus } from './embeddings.js'
+import { rewriteLexicalQuery, isQueryRewriteDisabled } from './intent/rewrite.js'
 import { logger } from './logger.js'
 import type { RerankerAdapter } from './rerankers/types.js'
 import { isRerankerOff, recordRerankerEngaged, recordRerankerFailure, hfCacheDirName } from './rerankers/index.js'
@@ -145,8 +146,14 @@ export async function hybridSearchWithMeta(
   const bm25Limit = Math.min(engrams.length, exhaustive ? effectiveLimit * 5 : effectiveLimit * 3)
   const embLimit = Math.min(engrams.length, exhaustive ? effectiveLimit * 3 : effectiveLimit * 2)
 
+  // #224 remainder: the LEXICAL leg gets the deterministically rewritten
+  // query (interrogative scaffolding + relative-temporal anchors stripped).
+  // The embedding leg and the reranker keep the original natural-language
+  // query — those models are trained on questions; BM25 is not.
+  const lexicalQuery = isQueryRewriteDisabled() ? query : rewriteLexicalQuery(query)
+
   const [bm25Results, embResults] = await Promise.all([
-    Promise.resolve(searchEngrams(engrams, query, bm25Limit)),
+    Promise.resolve(searchEngrams(engrams, lexicalQuery, bm25Limit)),
     embeddingSearch(engrams, query, embLimit, storagePath),
   ])
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,7 @@ import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as p
 import { getReranker, resolveRerankerName, isRerankerOff, rerankerStatus, resetRerankerStatus, _resetRerankerCache, type RerankerAdapter, type RerankerRuntimeStatus } from './rerankers/index.js'
 import { _resetBgeRerankerCache } from './rerankers/bge-reranker-v2-m3.js'
 import { _resetMsMarcoMiniLmCache } from './rerankers/ms-marco-minilm-l6.js'
-import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, isEntityDomain, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
+import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, isEntityDomain, rewriteLexicalQuery, isQueryRewriteDisabled, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
 import { getEmbedder, resolveEmbedderName } from './embedders/index.js'
 import { emitMissSignal } from './telemetry-miss-signal.js'
 import { embedderStatus, resetEmbedder, setEmbeddingsEnabled, type EmbedderStatus } from './embeddings.js'
@@ -1983,7 +1983,11 @@ export class Plur {
       return hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
     }
     const bm25Limit = Math.min(filtered.length, wantReranker ? Math.max(limit * 3, 50) : limit * 3)
-    const bm25Results = searchEngrams(filtered, query, bm25Limit)
+    // #224 remainder: the lexical leg gets the deterministic rewrite, same
+    // as the YAML-path hybridSearchWithMeta. Vector leg + reranker keep the
+    // original query.
+    const lexicalQuery = isQueryRewriteDisabled() ? query : rewriteLexicalQuery(query)
+    const bm25Results = searchEngrams(filtered, lexicalQuery, bm25Limit)
     const merged = pgliteRrfMerge([bm25Results, pgHits])
     const reranked = await applyReranker(merged, query, rerank)
     const mode: HybridSearchResult['mode'] = status.disabled ? 'bm25-only' : 'hybrid'

--- a/packages/core/src/intent/index.ts
+++ b/packages/core/src/intent/index.ts
@@ -4,3 +4,4 @@ export { routeForIntent, isIntentRoutingDisabled, isEntityDomain } from './route
 export type { IntentRoutingProfile } from './route.js'
 export { applyIntentRouting } from './apply.js'
 export type { ApplyIntentOptions } from './apply.js'
+export { rewriteLexicalQuery, isQueryRewriteDisabled } from './rewrite.js'

--- a/packages/core/src/intent/rewrite.ts
+++ b/packages/core/src/intent/rewrite.ts
@@ -1,0 +1,152 @@
+/**
+ * Deterministic intent-aware query rewriting — #224 (remainder).
+ *
+ * The classifier + per-intent ranking profiles landed earlier ("intent
+ * routing"); this module is the rewriting layer the issue is named after:
+ * a deterministic (regex/lexicon, no LLM, no I/O) transform of the query
+ * text that feeds the LEXICAL (BM25) leg of hybrid recall.
+ *
+ * Only the BM25 leg gets the rewritten query. The embedding leg and the
+ * cross-encoder reranker keep the original natural-language query —
+ * embedding/cross-encoder models are trained on questions; BM25 is not.
+ *
+ * Why scaffolding hurts BM25 here: `ftsScore` uses substring matching
+ * (`t.includes(qt) || qt.includes(t)`), so interrogative tokens are not
+ * inert — "what" matches "whatsapp", "how" matches "showed" — and every
+ * scaffold token that substring-matches anything consumes IDF budget and
+ * pulls in distractors.
+ *
+ * Rules (all deterministic):
+ *   1. Question-shaped queries (trailing "?" or leading interrogative) get
+ *      interrogative scaffolding stripped: what/which/who/where/when/why/
+ *      how/whose/whom + the auxiliaries did/does/do. Role words like
+ *      "user" and "assistant" are content-bearing in a memory store and
+ *      are NEVER stripped.
+ *   2. Temporal-intent queries additionally drop RELATIVE temporal phrases
+ *      ("yesterday", "last week", "three days ago", "recently") — they
+ *      cannot lexically match stored statements; the temporal ranking
+ *      profile (recency boost) is the mechanism that handles them.
+ *      Absolute anchors (ISO dates, "Apr 15") are KEPT — engram temporal
+ *      fields are part of the BM25 search text and match them literally.
+ *
+ * Safety contract (graceful degradation, mirroring the classifier):
+ *   - the final rewrite must keep >= MIN_CONTENT_TOKENS content tokens,
+ *     otherwise the ORIGINAL query is returned unchanged;
+ *   - non-question queries pass through untouched by rule 1;
+ *   - PLUR_QUERY_REWRITE=off disables the feature entirely (checked by
+ *     callers via {@link isQueryRewriteDisabled}).
+ */
+import { classifyQuery, type QueryIntent } from './classifier.js'
+import { ftsTokenize } from '../fts.js'
+
+/** Final rewrites keeping fewer content tokens than this revert to the original. */
+const MIN_CONTENT_TOKENS = 2
+
+/** Interrogative words — question-shape signal AND strip targets. */
+const INTERROGATIVES = new Set([
+  'what', 'whats', 'which', 'who', 'whos', 'whose', 'whom',
+  'where', 'wheres', 'when', 'whens', 'why', 'how', 'hows',
+])
+
+/**
+ * Auxiliaries stripped only inside question-shaped queries. Deliberately
+ * short: `do`/`did`/`does` are the ones the fts stopword list does NOT
+ * already drop. Content-ish verbs (say, mention, remember) are kept.
+ */
+const QUESTION_AUXILIARIES = new Set(['do', 'did', 'does'])
+
+/**
+ * Relative temporal phrases — removed for temporal-intent queries.
+ * Mirrors the classifier's TEMPORAL_PATTERNS minus the absolute anchors
+ * (iso-date, month-day), which are kept because engram temporal fields
+ * are part of the BM25 search text.
+ */
+const RELATIVE_TEMPORAL_PATTERNS: RegExp[] = [
+  /\byesterday\b/gi,
+  /\btoday\b/gi,
+  /\btomorrow\b/gi,
+  /\b(?:just\s+|right\s+)now\b/gi,
+  /\bthis (?:morning|afternoon|evening|night|week|month|year|quarter)\b/gi,
+  /\blast (?:week|month|year|quarter|night|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi,
+  /\bnext (?:week|month|year|quarter)\b/gi,
+  /\b(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|few|several) (?:days?|weeks?|months?|years?|hours?|minutes?) ago\b/gi,
+  /\brecent(?:ly)?\b/gi,
+  /\blately\b/gi,
+]
+
+/** True when PLUR_QUERY_REWRITE opts the feature off. Default: enabled. */
+export function isQueryRewriteDisabled(): boolean {
+  const v = process.env.PLUR_QUERY_REWRITE
+  if (!v) return false
+  const lower = v.toLowerCase()
+  return lower === 'off' || v === '0' || lower === 'false'
+}
+
+/** Lowercased alphanumeric core of a whitespace token ("What's" -> "whats"). */
+function tokenCore(word: string): string {
+  return word.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+/** True when the query reads as a question: trailing "?" or leading interrogative. */
+function isQuestionShaped(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.endsWith('?')) return true
+  const first = tokenCore(trimmed.split(/\s+/)[0] ?? '')
+  return INTERROGATIVES.has(first)
+}
+
+/** Rule 1: drop interrogative scaffolding + "?" from a question-shaped query. */
+function stripScaffolding(query: string): string {
+  const kept = query
+    .split(/\s+/)
+    .filter(w => {
+      const core = tokenCore(w)
+      if (core.length === 0) return false
+      return !INTERROGATIVES.has(core) && !QUESTION_AUXILIARIES.has(core)
+    })
+    .map(w => w.replace(/\?/g, ''))
+    .filter(w => w.length > 0)
+  return kept.join(' ').trim()
+}
+
+/** Rule 2: drop relative temporal phrases (absolute anchors are untouched). */
+function stripRelativeTemporal(query: string): string {
+  let out = query
+  for (const re of RELATIVE_TEMPORAL_PATTERNS) {
+    out = out.replace(re, ' ')
+  }
+  return out.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Rewrite a query for the LEXICAL (BM25) leg of hybrid recall.
+ *
+ * Deterministic and synchronous — safe on the hot path (< 1ms). When the
+ * rewrite would leave fewer than {@link MIN_CONTENT_TOKENS} content tokens
+ * (per `ftsTokenize`), the ORIGINAL query is returned unchanged: a thin
+ * query is left alone rather than gutted.
+ *
+ * @param query  The user's query, verbatim.
+ * @param intent Optional pre-computed intent (avoids re-classifying when the
+ *               caller already ran `classifyQuery`). Auto-classifies when
+ *               omitted.
+ */
+export function rewriteLexicalQuery(query: string, intent?: QueryIntent): string {
+  const original = query ?? ''
+  if (original.trim().length === 0) return original
+
+  let out = original
+  if (isQuestionShaped(out)) {
+    out = stripScaffolding(out)
+  }
+
+  const resolvedIntent: QueryIntent = intent ?? classifyQuery(original).intent
+  if (resolvedIntent === 'temporal') {
+    out = stripRelativeTemporal(out)
+  }
+
+  if (out === original) return original
+  // Global guard: never return a rewrite too thin to retrieve on.
+  if (ftsTokenize(out).length < MIN_CONTENT_TOKENS) return original
+  return out
+}

--- a/packages/core/test/intent-rewrite.test.ts
+++ b/packages/core/test/intent-rewrite.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Deterministic intent-aware query rewriting — #224 (remainder).
+ *
+ * The intent classifier + per-intent ranking profiles landed earlier; what
+ * was still missing from #224 is the REWRITING itself: a deterministic
+ * (no-LLM) transform of the query text feeding the lexical (BM25) leg of
+ * hybrid recall. The embedding leg and the reranker keep the original
+ * natural-language query — embedding models are trained on questions;
+ * BM25 is not.
+ *
+ * Why this matters mechanically: `ftsScore` uses substring matching
+ * (`t.includes(qt) || qt.includes(t)`), so interrogative scaffolding
+ * tokens like "what" / "who" / "how" are not inert — "what" matches
+ * "whatsapp", "how" matches "showed" — and they consume IDF budget.
+ *
+ * Safety contract (graceful degradation, mirroring the classifier):
+ *   - only question-shaped queries are touched;
+ *   - the rewrite must leave >= 2 content tokens or the original query is
+ *     returned unchanged;
+ *   - PLUR_QUERY_REWRITE=off disables the whole feature.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { rewriteLexicalQuery, isQueryRewriteDisabled } from '../src/intent/rewrite.js'
+import { classifyQuery } from '../src/intent/classifier.js'
+import { hybridSearchWithMeta } from '../src/hybrid-search.js'
+import { searchEngrams } from '../src/fts.js'
+import { setEmbeddingsEnabled } from '../src/embeddings.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+// ─── rewriteLexicalQuery: interrogative scaffolding ──────────────────
+
+describe('rewriteLexicalQuery — interrogative scaffolding (#224)', () => {
+  it('strips question scaffolding from a question-shaped query', () => {
+    const out = rewriteLexicalQuery('What car does the user drive?')
+    expect(out).not.toMatch(/\bwhat\b/i)
+    expect(out).not.toMatch(/\bdoes\b/i)
+    expect(out).not.toMatch(/\?/)
+    // Content words survive, in original order.
+    expect(out).toMatch(/car .*user .*drive/i)
+  })
+
+  it('strips scaffolding for queries starting with an interrogative even without "?"', () => {
+    const out = rewriteLexicalQuery('where is the production database hosted')
+    expect(out).not.toMatch(/\bwhere\b/i)
+    expect(out).toMatch(/production database hosted/i)
+  })
+
+  it('strips mid-query auxiliaries (did/does) in question-shaped queries', () => {
+    const out = rewriteLexicalQuery('What Redis client library did the assistant recommend?')
+    expect(out).not.toMatch(/\bdid\b/i)
+    // "assistant" is content-bearing in a memory store — never stripped.
+    expect(out).toMatch(/\bassistant\b/i)
+    expect(out).toMatch(/redis client library/i)
+  })
+
+  it('leaves non-question queries untouched', () => {
+    const q = 'staging deploy target for the ingestion service'
+    expect(rewriteLexicalQuery(q)).toBe(q)
+  })
+
+  it('does not strip interrogative words inside a non-question statement', () => {
+    const q = 'notes explaining how the deploy pipeline works'
+    expect(rewriteLexicalQuery(q)).toBe(q)
+  })
+
+  it('returns the original when stripping would leave < 2 content tokens', () => {
+    // "Who is Karl?" -> stripping leaves only "Karl" -> too weak, keep original.
+    const q = 'Who is Karl?'
+    expect(rewriteLexicalQuery(q)).toBe(q)
+  })
+
+  it('is deterministic', () => {
+    const q = 'What database does the user prefer?'
+    expect(rewriteLexicalQuery(q)).toBe(rewriteLexicalQuery(q))
+  })
+})
+
+// ─── rewriteLexicalQuery: temporal anchors ───────────────────────────
+
+describe('rewriteLexicalQuery — temporal anchors (#224)', () => {
+  it('drops relative temporal phrases for temporal-intent queries', () => {
+    const q = 'What did I say about the deployment target last week?'
+    expect(classifyQuery(q).intent).toBe('temporal')
+    const out = rewriteLexicalQuery(q, 'temporal')
+    expect(out).not.toMatch(/last week/i)
+    expect(out).toMatch(/deployment target/i)
+  })
+
+  it('drops "N days ago" style anchors', () => {
+    const out = rewriteLexicalQuery('Which config value changed three days ago?', 'temporal')
+    expect(out).not.toMatch(/three days ago/i)
+    expect(out).toMatch(/config value changed/i)
+  })
+
+  it('KEEPS ISO dates — they literally match engram temporal fields', () => {
+    const out = rewriteLexicalQuery('What happened on 2026-04-15 with the migration?', 'temporal')
+    expect(out).toContain('2026-04-15')
+    expect(out).toMatch(/migration/i)
+  })
+
+  it('does not strip temporal words when intent is not temporal', () => {
+    // Explicit non-temporal override: "yesterday" survives.
+    const out = rewriteLexicalQuery('the yesterday report archive format', 'general')
+    expect(out).toMatch(/yesterday/i)
+  })
+
+  it('auto-classifies when no intent is passed', () => {
+    const out = rewriteLexicalQuery('What did the standup cover yesterday about the release?')
+    expect(out).not.toMatch(/\byesterday\b/i)
+    expect(out).toMatch(/standup cover/i)
+  })
+
+  it('returns the original when temporal stripping would gut the query', () => {
+    const q = 'what happened yesterday?'
+    // scaffold-strip removes "what"; "happened" stays but "yesterday" removal
+    // would leave a single content token -> keep the stronger form.
+    const out = rewriteLexicalQuery(q, 'temporal')
+    expect(out).toBe(q)
+  })
+})
+
+// ─── env kill-switch ─────────────────────────────────────────────────
+
+describe('isQueryRewriteDisabled (#224)', () => {
+  const saved = process.env.PLUR_QUERY_REWRITE
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PLUR_QUERY_REWRITE
+    else process.env.PLUR_QUERY_REWRITE = saved
+  })
+
+  it('is enabled by default', () => {
+    delete process.env.PLUR_QUERY_REWRITE
+    expect(isQueryRewriteDisabled()).toBe(false)
+  })
+
+  it.each(['off', 'OFF', '0', 'false'])('is disabled for PLUR_QUERY_REWRITE=%s', v => {
+    process.env.PLUR_QUERY_REWRITE = v
+    expect(isQueryRewriteDisabled()).toBe(true)
+  })
+})
+
+// ─── wiring: hybrid lexical leg uses the rewritten query ─────────────
+
+function mkEngram(id: string, statement: string): Engram {
+  const now = new Date().toISOString()
+  return {
+    id,
+    version: 1,
+    status: 'active',
+    statement,
+    type: 'behavioral',
+    scope: 'global',
+    tags: [],
+    confidence: { band: 'medium' },
+    activation: { strength: 0.5, last_accessed: now, access_count: 0 },
+    temporal: { learned_at: now },
+    provenance: { created_by: 'test', session_id: 'test' },
+  } as unknown as Engram
+}
+
+describe('hybrid lexical leg wiring (#224)', () => {
+  beforeAll(() => setEmbeddingsEnabled(false, 'intent-rewrite wiring tests run BM25-only'))
+  afterAll(() => setEmbeddingsEnabled(true))
+
+  const savedEnv = process.env.PLUR_QUERY_REWRITE
+  beforeEach(() => { delete process.env.PLUR_QUERY_REWRITE })
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.PLUR_QUERY_REWRITE
+    else process.env.PLUR_QUERY_REWRITE = savedEnv
+  })
+
+  // "what" substring-matches "whatsapp" in ftsScore — the scaffold token is
+  // NOT inert. A corpus with a whatsapp distractor demonstrates the wiring.
+  const corpus: Engram[] = [
+    mkEngram('e1', 'WhatsApp backup notes'),
+    mkEngram('e2', 'the nightly rsync job syncs address contacts for the team'),
+    mkEngram('e3', 'grafana dashboards live under the retrieval folder'),
+    mkEngram('e4', 'postgres pooling uses pgbouncer in transaction mode'),
+    mkEngram('e5', 'the telegram bot forwards trading alerts every morning'),
+  ]
+  const query = 'What syncs the contacts?'
+
+  it('the rewrite changes BM25 results on a scaffold-sensitive corpus', () => {
+    const raw = searchEngrams(corpus, query, 5).map(e => e.id)
+    const rewritten = searchEngrams(corpus, rewriteLexicalQuery(query), 5).map(e => e.id)
+    expect(raw).toContain('e1') // distractor pulled in by "what"~"whatsapp"
+    expect(rewritten).not.toContain('e1')
+  })
+
+  it('hybridSearchWithMeta feeds the REWRITTEN query to the BM25 leg', async () => {
+    const result = await hybridSearchWithMeta(corpus, query, 5)
+    const expected = searchEngrams(corpus, rewriteLexicalQuery(query), 15).slice(0, 5).map(e => e.id)
+    expect(result.engrams.map(e => e.id)).toEqual(expected)
+    expect(result.mode).toBe('bm25-only')
+  })
+
+  it('PLUR_QUERY_REWRITE=off restores the original behavior', async () => {
+    process.env.PLUR_QUERY_REWRITE = 'off'
+    const result = await hybridSearchWithMeta(corpus, query, 5)
+    const expected = searchEngrams(corpus, query, 15).slice(0, 5).map(e => e.id)
+    expect(result.engrams.map(e => e.id)).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Refs #224.

## What (audit-first)

#224's intent **classifier + per-intent ranking profiles** are already on main (`packages/core/src/intent/{classifier,route,apply}.ts`, wired into recall). What was still missing is the layer the issue is *named* after: **deterministic query rewriting**. This PR adds it, scoped to the lexical (BM25) leg only.

- **`packages/core/src/intent/rewrite.ts`** — `rewriteLexicalQuery(query, intent?)`: regex/lexicon, no LLM, no I/O, synchronous (sub-ms, well inside the issue's <5ms p95 budget).
  - **Rule 1 — interrogative scaffolding**: question-shaped queries (trailing `?` or leading interrogative) lose `what/which/who/whose/whom/where/when/why/how` + `do/did/does`. These tokens are not inert in our BM25: `ftsScore` matches substrings, so "what" matches "whatsapp", "how" matches "showed" — scaffold tokens pull in distractors and consume IDF budget. Role words (`user`, `assistant`) are content-bearing in a memory store and are never stripped.
  - **Rule 2 — relative temporal anchors** (temporal-intent queries only): "yesterday", "last week", "three days ago", "recently" are dropped — they cannot lexically match stored statements; the existing recency-boost profile is the mechanism that handles them. **Absolute anchors are kept** (ISO dates, month-day): engram temporal fields are part of the BM25 search text and match them literally.
  - **Safety**: a rewrite keeping <2 content tokens reverts to the original query; non-questions pass through; `PLUR_QUERY_REWRITE=off` disables the feature (graceful degradation, mirroring the classifier's contract).
- Wired at **both** hybrid BM25 call sites: YAML `hybridSearchWithMeta` and the PGLite hybrid leg. The embedding leg and the cross-encoder reranker keep the original natural-language query — those models are trained on questions; BM25 is not.

## Benchmark gate (#46 harness, fixture n=30, shipping config: `bge-small` + hybrid + rerank off, seed 1337, commit `5e9b75f`)

Before = `PLUR_QUERY_REWRITE=off` (bit-identical to pre-PR behavior), after = default ON. Two runs per config; **quality metrics were bit-identical across runs** of each config.

| Config | R@5 | R@1 | Acc | ss_assistant MRR | temporal MRR | multi_session MRR | p50 / p95 (run1) | (run2) |
|---|---|---|---|---|---|---|---|---|
| rewrite OFF | 80.0% | 50.0% | 80.0% | 0.600 | 0.520 | 0.470 | 218 / 331 ms | 143 / 271 ms |
| **rewrite ON** | 80.0% | **53.3%** | 80.0% | **0.700** | **0.522** | **0.489** | 237 / 472 ms | 178 / 248 ms |

- **ΔR@1 +3.3pp, ΔMRR positive in 3/6 categories, zero regressions in any metric or category.** R@5 and accuracy unchanged.
- Latency deltas are load noise: loadavg was 100–253 throughout (agent fleet active); treat latencies as upper bounds. The rewrite itself is a synchronous string transform.
- Baseline note: main's fixture baseline has drifted up since the #451 measurements (76.7% → 80.0% R@5 on `357f1ec` → `5e9b75f`); the comparison above is same-commit, same-instrument, env-toggled only.

Honest read: this is a **modest, free win** — it does not move R@5 on this fixture (the fused embedding leg already recovers most scaffold noise); the delta is concentrated exactly where the mechanism predicts: rank-1 precision on question-shaped lookups.

## Tests

- 21 new tests (`intent-rewrite.test.ts`): scaffold rules, temporal rules (ISO-date preservation), min-content guard, kill switch, plus wiring proofs — a scaffold-sensitive corpus where "what"~"whatsapp" substring noise changes BM25 results, asserting `hybridSearchWithMeta` feeds the rewritten query to the BM25 leg and `PLUR_QUERY_REWRITE=off` restores original behavior.
- Retrieval-adjacent suites (fts, hybrid-search, hybrid-rerank, intent-classifier, intent-routing, pglite-recall-wiring, search-orchestrator, similarity-search, agentic-search, enriched-search): **116 passed**.
- Full core suite on this branch: 1780/1784 passed; the 4 failures are the known load-flake families (packs ReDoS 2s wall-clock budget, pglite-* / sync-index-error 30s timeouts) on a loadavg-250 machine — all timeout-shaped, none in the rewrite path; isolated reruns reproduce them without this diff's involvement. mcp 172 + cli 238 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1