### PR TITLE
feat(core): tension lifecycle — persistence, confirm/dismiss/resolve, injection warnings (#181)

### DIFF
--- a/packages/cli/src/commands/tensions.ts
+++ b/packages/cli/src/commands/tensions.ts
@@ -34,10 +34,13 @@ function getLlmFunction(): LlmFunction | undefined {
 }
 
 /**
- * plur tensions — scan for or list engram contradictions.
+ * plur tensions — scan for contradictions, manage the tension lifecycle (#181).
  *
  * Usage:
- *   plur tensions --scan                       # live LLM scan (requires API key)
+ *   plur tensions                              # list persisted tensions (unresolved)
+ *   plur tensions --status all                 # include dismissed/resolved
+ *   plur tensions --scan                       # LLM scan; NEW detections are persisted
+ *   plur tensions --scan --no-persist          # dry-run scan (no records, no suppress-list)
  *   plur tensions --scan --scope project:plur  # narrow to one scope
  *   plur tensions --scan --domain plur.core    # narrow to one domain
  *   plur tensions --scan --min-confidence 0.8  # stricter threshold
@@ -45,11 +48,14 @@ function getLlmFunction(): LlmFunction | undefined {
  *   plur tensions --scan --batch-size 1        # sequential single-pair judging (no batching)
  *   plur tensions --scan --temporal-discount   # days-apart confidence discount (#240, default off)
  *   plur tensions --scan --model claude-haiku-... --llm-base-url ... --llm-api-key ...
- *   plur tensions                              # list legacy stored conflicts (usually empty)
+ *   plur tensions confirm T-2026-0703-001      # mark a detection as a real conflict
+ *   plur tensions dismiss T-2026-0703-001      # false positive — suppress the pair
+ *   plur tensions resolve T-2026-0703-001 --winner ENG-...   # keep winner, retire loser
  *   plur tensions --json                       # machine-readable output
  */
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   let scan = false
+  let persist = true
   let scope: string | undefined
   let domain: string | undefined
   let minConfidence = 0.7
@@ -57,6 +63,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   let batchSize = 5
   // #240: undefined → fall back to config (tensions.temporal_discount)
   let temporalDiscount: boolean | undefined
+  let statusFilter: string | undefined
+  let action: 'confirm' | 'dismiss' | 'resolve' | undefined
+  let tensionId: string | undefined
+  let winner: string | undefined
   let llmBaseUrl: string | undefined
   let llmApiKey: string | undefined
   let llmModel: string | undefined
@@ -65,6 +75,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   while (i < args.length) {
     const arg = args[i]
     if (arg === '--scan') { scan = true; i++ }
+    else if (arg === '--no-persist') { persist = false; i++ }
     else if (arg === '--scope' && i + 1 < args.length) { scope = args[++i]; i++ }
     else if (arg === '--domain' && i + 1 < args.length) { domain = args[++i]; i++ }
     else if (arg === '--min-confidence' && i + 1 < args.length) { minConfidence = parseFloat(args[++i]); i++ }
@@ -72,13 +83,52 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     else if (arg === '--batch-size' && i + 1 < args.length) { batchSize = parseInt(args[++i], 10); i++ }
     else if (arg === '--temporal-discount') { temporalDiscount = true; i++ }
     else if (arg === '--no-temporal-discount') { temporalDiscount = false; i++ }
+    else if (arg === '--status' && i + 1 < args.length) { statusFilter = args[++i]; i++ }
+    else if (arg === '--winner' && i + 1 < args.length) { winner = args[++i]; i++ }
     else if (arg === '--llm-base-url' && i + 1 < args.length) { llmBaseUrl = args[++i]; i++ }
     else if (arg === '--llm-api-key' && i + 1 < args.length) { llmApiKey = args[++i]; i++ }
     else if (arg === '--model' && i + 1 < args.length) { llmModel = args[++i]; i++ }
+    else if ((arg === 'confirm' || arg === 'dismiss' || arg === 'resolve') && !action) { action = arg; i++ }
+    else if (action && !tensionId && arg.startsWith('T-')) { tensionId = arg; i++ }
     else { i++ }
   }
 
   const plur = createPlur(flags, { readonly: true })
+
+  // --- Lifecycle actions (#181) ---
+  if (action) {
+    if (!tensionId) {
+      exit(1, `Usage: plur tensions ${action} <T-YYYY-MMDD-NNN>${action === 'resolve' ? ' --winner <engram-id>' : ''}`)
+      return
+    }
+    try {
+      if (action === 'confirm') {
+        const record = plur.confirmTension(tensionId)
+        if (shouldOutputJson(flags)) { outputJson({ record }) } else {
+          outputText(`Confirmed ${record.id} as a real conflict.`)
+          outputText(`Resolve it with: plur tensions resolve ${record.id} --winner <engram-id>`)
+        }
+      } else if (action === 'dismiss') {
+        const record = plur.dismissTension(tensionId)
+        if (shouldOutputJson(flags)) { outputJson({ record }) } else {
+          outputText(`Dismissed ${record.id} — the pair is suppressed from future scans.`)
+        }
+      } else {
+        if (!winner) {
+          exit(1, `Usage: plur tensions resolve ${tensionId} --winner <engram-id>`)
+          return
+        }
+        const { record, retired_id } = plur.resolveTension(tensionId, winner)
+        if (shouldOutputJson(flags)) { outputJson({ record, retired: retired_id }) } else {
+          outputText(`Resolved ${record.id}: ${winner} wins, ${retired_id} retired.`)
+        }
+      }
+    } catch (err) {
+      exit(1, `Error: ${(err as Error).message}`)
+    }
+    return
+  }
+
   const engrams = plur.list({ scope, domain })
 
   if (scan) {
@@ -109,6 +159,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     // (temporal_domains, snapshot_pairs, temporal_discount); an explicit
     // --temporal-discount / --no-temporal-discount flag overrides.
     const tensionsConfig = plur.getTensionsConfig()
+    // #181: recorded pairs are excluded (suppress-list) and new detections
+    // persisted, unless --no-persist (dry run).
     const result = await scanForTensions(engrams, llm, {
       min_confidence: minConfidence,
       max_pairs: maxPairs,
@@ -116,13 +168,17 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       temporal_domains: tensionsConfig.temporal_domains,
       snapshot_pairs: tensionsConfig.snapshot_pairs,
       temporal_discount: temporalDiscount ?? tensionsConfig.temporal_discount,
+      ...(persist ? { exclude_pairs: new Set(plur.suppressedTensionPairKeys()) } : {}),
     })
+    const persisted = persist && result.tensions.length > 0 ? plur.recordTensions(result.tensions) : undefined
 
     if (shouldOutputJson(flags)) {
       outputJson({
         pairs_checked: result.pairs_checked,
         count: result.new_tensions,
-        tensions: result.tensions.map(t => ({
+        ...(persisted ? { persisted_new: persisted.new_count } : {}),
+        tensions: result.tensions.map((t, idx) => ({
+          ...(persisted ? { tension_id: persisted.records[idx].id, category: persisted.records[idx].category } : {}),
           engram_a: { id: t.id_a, statement: t.statement_a },
           engram_b: { id: t.id_b, statement: t.statement_b },
           confidence: t.confidence,
@@ -136,6 +192,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
 
     outputText(`Checked: ${result.pairs_checked} candidate pairs`)
     outputText(`Found:   ${result.new_tensions} tension${result.new_tensions === 1 ? '' : 's'} (confidence >= ${minConfidence})`)
+    if (persisted) outputText(`Persisted: ${persisted.new_count} new record${persisted.new_count === 1 ? '' : 's'}`)
     outputText('')
 
     if (result.tensions.length === 0) {
@@ -143,29 +200,35 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       return
     }
 
-    for (const t of result.tensions) {
+    result.tensions.forEach((t, idx) => {
+      const rid = persisted ? ` ${persisted.records[idx].id} (${persisted.records[idx].category})` : ''
       const tempNote = t.days_apart !== undefined ? `, ${t.days_apart} day${t.days_apart === 1 ? '' : 's'} apart` : ''
       const rawNote = t.raw_confidence !== undefined ? `, raw: ${t.raw_confidence.toFixed(2)}` : ''
-      outputText(`── TENSION (confidence: ${t.confidence.toFixed(2)}${rawNote}${tempNote}) ──`)
+      outputText(`── TENSION${rid} (confidence: ${t.confidence.toFixed(2)}${rawNote}${tempNote}) ──`)
       outputText(`  A [${t.id_a}]: ${t.statement_a}`)
       outputText(`  B [${t.id_b}]: ${t.statement_b}`)
       outputText(`  Reason: ${t.reason}`)
       outputText('')
-    }
+    })
 
     outputText('Next steps:')
-    outputText('  Resolve: determine which statement is correct, retire the other via plur forget <id>')
-    outputText('  Dismiss: if not a real conflict, both statements can coexist')
+    outputText('  plur tensions confirm <T-id>                       # real conflict')
+    outputText('  plur tensions dismiss <T-id>                       # false positive, suppress')
+    outputText('  plur tensions resolve <T-id> --winner <engram-id>  # keep winner, retire loser')
     return
   }
 
-  // Non-scan mode: list any legacy stored conflict relations (usually empty after auto-purge)
-  const tensions: Array<{
+  // --- List mode (#181): persisted tension records ---
+  const records = statusFilter === 'all'
+    ? plur.listTensions()
+    : plur.listTensions({ status: statusFilter ? [statusFilter as any] : ['detected', 'confirmed'] })
+
+  // Legacy relations.conflicts pairs (unvalidated importer heuristics) shown separately.
+  const legacy: Array<{
     engram_a: { id: string; statement: string }
     engram_b: { id: string; statement: string }
     detected_at: string
   }> = []
-
   const seen = new Set<string>()
   for (const engram of engrams) {
     if (!engram.relations?.conflicts?.length) continue
@@ -175,7 +238,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       seen.add(pairKey)
       const other = engrams.find(e => e.id === conflictId)
       if (!other) continue
-      tensions.push({
+      legacy.push({
         engram_a: { id: engram.id, statement: engram.statement },
         engram_b: { id: other.id, statement: other.statement },
         detected_at: engram.activation.last_accessed,
@@ -184,21 +247,36 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   }
 
   if (shouldOutputJson(flags)) {
-    outputJson({ tensions, count: tensions.length })
+    outputJson({ tensions: records, count: records.length, ...(legacy.length > 0 ? { legacy_conflicts: legacy } : {}) })
     return
   }
 
-  if (tensions.length === 0) {
-    outputText('No stored tensions. Run `plur tensions --scan` to detect live contradictions.')
+  if (records.length === 0 && legacy.length === 0) {
+    outputText('No persisted tensions. Run `plur tensions --scan` to detect contradictions.')
     return
   }
 
-  outputText(`Stored tensions: ${tensions.length}`)
-  outputText('')
-  for (const t of tensions) {
-    outputText(`  A [${t.engram_a.id}]: ${t.engram_a.statement}`)
-    outputText(`  B [${t.engram_b.id}]: ${t.engram_b.statement}`)
-    outputText(`  Detected: ${t.detected_at}`)
+  if (records.length > 0) {
+    outputText(`Tensions: ${records.length}`)
     outputText('')
+    for (const r of records) {
+      outputText(`── ${r.id} [${r.status}, ${r.category}] (confidence: ${r.confidence.toFixed(2)}) ──`)
+      outputText(`  A [${r.engram_a}]: ${r.statement_a}`)
+      outputText(`  B [${r.engram_b}]: ${r.statement_b}`)
+      outputText(`  Reason: ${r.reason}`)
+      if (r.status === 'resolved') outputText(`  Resolved: ${r.resolved_by} won (${r.resolved_at})`)
+      outputText('')
+    }
+  }
+
+  if (legacy.length > 0) {
+    outputText(`Legacy conflict refs (unvalidated heuristics): ${legacy.length}`)
+    outputText('  Run `plur tensions --scan` to judge them, or purge via the plur_tensions_purge MCP tool.')
+    outputText('')
+    for (const t of legacy) {
+      outputText(`  A [${t.engram_a.id}]: ${t.engram_a.statement}`)
+      outputText(`  B [${t.engram_b.id}]: ${t.engram_b.statement}`)
+      outputText('')
+    }
   }
 }

--- a/packages/cli/test/tensions-lifecycle.test.ts
+++ b/packages/cli/test/tensions-lifecycle.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync, execFile } from 'child_process'
+import { promisify } from 'util'
+import { createServer, type Server } from 'http'
+import { Plur } from '@plur-ai/core'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+/**
+ * plur tensions lifecycle CLI (#181): scan persistence, suppress-list,
+ * confirm/dismiss/resolve subcommands.
+ *
+ * Stub OpenAI-compatible server answers CONTRADICTS: yes / 0.9 per pair.
+ * Scan-tests must use the async runner — the stub lives in this process, so
+ * a blocking execSync would starve its event loop.
+ */
+let server: Server
+let baseUrl: string
+let llmCalls = 0
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', c => chunks.push(c))
+    req.on('end', () => {
+      llmCalls++
+      const prompt: string = JSON.parse(Buffer.concat(chunks).toString()).messages[0].content
+      const n = (prompt.match(/PAIR \d+/g) ?? []).length
+      const content = n > 0
+        ? Array.from({ length: n }, (_, i) => `PAIR_${i + 1}: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite.`).join('\n')
+        : 'CONTRADICTS: yes\nCONFIDENCE: 0.9\nREASON: Opposite.'
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ choices: [{ message: { content } }] }))
+    })
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}/v1`
+})
+
+afterAll(() => new Promise<void>(resolve => server.close(() => resolve())))
+
+describe('plur tensions lifecycle (#181)', () => {
+  let dir: string
+  const execFileAsync = promisify(execFile)
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-cli-tension-lc-'))
+    llmCalls = 0
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  async function runAsync(args: string): Promise<string> {
+    const { stdout } = await execFileAsync('node', [CLI, ...args.split(' '), '--path', dir, '--json'], {
+      encoding: 'utf-8', timeout: 20000,
+    })
+    return stdout.trim()
+  }
+
+  function run(args: string): string {
+    return execSync(`node ${CLI} ${args} --path ${dir} --json`, { encoding: 'utf-8', timeout: 10000 }).trim()
+  }
+
+  function seed(): { aId: string; bId: string } {
+    const a = JSON.parse(run('learn "plur cli version is 0.3.0"'))
+    const b = JSON.parse(run('learn "plur cli version is 0.8.2"'))
+    return { aId: a.id, bId: b.id }
+  }
+
+  it('scan persists records; second scan is suppressed', async () => {
+    seed()
+    const first = JSON.parse(await runAsync(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(first.count).toBe(1)
+    expect(first.persisted_new).toBe(1)
+    expect(first.tensions[0].tension_id).toMatch(/^T-/)
+    expect(existsSync(join(dir, 'tensions.yaml'))).toBe(true)
+
+    const callsAfterFirst = llmCalls
+    const second = JSON.parse(await runAsync(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(second.pairs_checked).toBe(0)
+    expect(llmCalls).toBe(callsAfterFirst)
+  })
+
+  it('--no-persist scans without recording', async () => {
+    seed()
+    const out = JSON.parse(await runAsync(`tensions --scan --no-persist --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(out.count).toBe(1)
+    expect(out.persisted_new).toBeUndefined()
+    const list = JSON.parse(run('tensions'))
+    expect(list.count).toBe(0)
+  })
+
+  it('list shows persisted records; --status filters', async () => {
+    seed()
+    const scan = JSON.parse(await runAsync(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    const id = scan.tensions[0].tension_id
+
+    const list = JSON.parse(run('tensions'))
+    expect(list.count).toBe(1)
+    expect(list.tensions[0].id).toBe(id)
+    expect(list.tensions[0].status).toBe('detected')
+
+    run(`tensions dismiss ${id}`)
+    expect(JSON.parse(run('tensions')).count).toBe(0)
+    expect(JSON.parse(run('tensions --status all')).count).toBe(1)
+    expect(JSON.parse(run('tensions --status dismissed')).count).toBe(1)
+  })
+
+  it('confirm then resolve retires the loser', async () => {
+    const { aId, bId } = seed()
+    const scan = JSON.parse(await runAsync(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    const id = scan.tensions[0].tension_id
+
+    const confirmed = JSON.parse(run(`tensions confirm ${id}`))
+    expect(confirmed.record.status).toBe('confirmed')
+
+    const resolved = JSON.parse(run(`tensions resolve ${id} --winner ${bId}`))
+    expect(resolved.record.status).toBe('resolved')
+    expect(resolved.record.resolved_by).toBe(bId)
+    expect(resolved.retired).toBe(aId)
+
+    const plur = new Plur({ path: dir })
+    expect(plur.getById(aId)?.status).toBe('retired')
+    expect(plur.getById(bId)?.status).toBe('active')
+  })
+
+  it('resolve without --winner exits 1', async () => {
+    seed()
+    const scan = JSON.parse(await runAsync(`tensions --scan --llm-base-url ${baseUrl} --llm-api-key k`))
+    expect(() => run(`tensions resolve ${scan.tensions[0].tension_id}`)).toThrow()
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,9 @@ import type { ScopeMetadata, SensitivityCategory } from './schemas/scope-metadat
 import { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
 import { appendHistory, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, type InjectionEventCounts } from './history.js'
 import { computeContentHash } from './content-hash.js'
+import { loadTensions, saveTensions, generateTensionId, tensionPairKey, categorizeTension } from './tension-store.js'
+import type { TensionRecord, TensionStatus } from './schemas/tension.js'
+import type { TensionPair } from './tensions.js'
 import { resolveValidity, buildTemporal } from './expiry.js'
 import { decodeJwtExpiry } from './jwt.js'
 import { RemoteStore } from './store/remote-store.js'
@@ -115,7 +118,10 @@ export type { RerankerAdapter } from './rerankers/types.js'
 export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus } from './sync.js'
 export { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'
-export { scanForTensions, getCandidatePairs, scopesOverlap, domainSegmentsOverlap, subjectsOverlap, statementOverlap, buildContradictionPrompt, parseContradictionResponse, buildBatchContradictionPrompt, parseBatchContradictionResponse, engramDate, daysApart, inTemporalDomain, temporalDiscountFactor, SNAPSHOT_CONFIDENCE_CAP, type ContradictionVerdict, type TensionPair, type TensionScanResult, type TensionScanOptions, type TemporalGateOptions, type JudgeStatement } from './tensions.js'
+export { scanForTensions, getCandidatePairs, scopesOverlap, domainSegmentsOverlap, subjectsOverlap, statementOverlap, buildContradictionPrompt, parseContradictionResponse, buildBatchContradictionPrompt, parseBatchContradictionResponse, engramDate, daysApart, inTemporalDomain, temporalDiscountFactor, SNAPSHOT_CONFIDENCE_CAP, type ContradictionVerdict, type TensionPair, type TensionScanResult, type TensionScanOptions, type TemporalGateOptions, type CandidatePairOptions, type JudgeStatement } from './tensions.js'
+// Tension lifecycle persistence (#181)
+export { loadTensions, saveTensions, generateTensionId, tensionPairKey, categorizeTension } from './tension-store.js'
+export { TensionRecordSchema, TensionStatusSchema, TensionCategorySchema, type TensionRecord, type TensionStatus, type TensionCategory } from './schemas/tension.js'
 // Migration importers (issue #441) — `plur import --from <source> --path <file>`.
 export {
   importFrom, runImport, getImportSource, listImportSources, IMPORT_SOURCES,
@@ -745,6 +751,11 @@ export class Plur {
     // unsafe cast.
     const sourceEntry = this._buildSourceEntry(scope, context)
     const lockTimestamp = new Date().toISOString()
+    // #181 (audit #213 item 3): an engram in an unresolved persisted tension
+    // must not escalate INTO 'locked' — contradicted knowledge freezing at
+    // the top of the commitment ladder is exactly the failure #213 feared.
+    // Escalation caps at 'decided' until the tension is resolved/dismissed.
+    const lockBlockedByTension = this.hasUnresolvedTension(hit.id)
     const applyMutation = (e: Engram, source: typeof sourceEntry, lockedAt: string): number => {
       const newRecurrence = ((e as any).recurrence_count ?? 0) + 1
       ;(e as any).recurrence_count = newRecurrence
@@ -763,8 +774,11 @@ export class Plur {
             : e.commitment === 'leaning'
               ? 'decided'
               : e.commitment === 'decided'
-                ? 'locked'
+                ? (lockBlockedByTension ? 'decided' : 'locked')
                 : (e.commitment ?? 'leaning')
+          if (lockBlockedByTension && e.commitment === 'decided') {
+            logger.info(`[plur:tensions] lock escalation blocked for ${e.id} — unresolved tension (#181)`)
+          }
           if (e.commitment === 'locked' && !e.locked_at) {
             e.locked_at = lockedAt
             e.locked_reason = `Auto-locked: cross-scope recurrence detected (${newRecurrence}x)`
@@ -2391,6 +2405,10 @@ export class Plur {
       } catch { /* best-effort */ }
     }
 
+    // #181: surface persisted tensions touching this injection — flag,
+    // don't adjudicate (audit #213 item 4).
+    const warnings = this._tensionWarningsFor(injected_ids)
+
     return {
       directives: directivesStr,
       constraints: constraintsStr,
@@ -2398,6 +2416,7 @@ export class Plur {
       count,
       tokens_used: tokensUsed,
       injected_ids,
+      ...(warnings.length > 0 ? { warnings } : {}),
     }
   }
 
@@ -3574,13 +3593,11 @@ Generate an improved version of the procedure that prevents this failure. Return
 
     const active = engrams.filter(e => e.status !== 'retired')
     const lockedCount = active.filter(e => (e as any).commitment === 'locked').length
-    const tensionPairs = new Set<string>()
-    for (const e of active) {
-      if (!e.relations?.conflicts?.length) continue
-      for (const cid of e.relations.conflicts) {
-        tensionPairs.add([e.id, cid].sort().join(':'))
-      }
-    }
+    // #181 (audit #213 C2): tension_count counts UNRESOLVED persisted
+    // tension records — the LLM-validated detector's output — instead of
+    // relations.conflicts, which post-#138 holds only unvalidated importer
+    // heuristics (or nothing, post-purge).
+    const unresolvedTensions = this.listTensions({ status: ['detected', 'confirmed'] }).length
 
     // Count engrams with version > 1 (SP2 Idea 8)
     const versionedCount = engrams.filter(e => {
@@ -3595,11 +3612,256 @@ Generate an improved version of the procedure that prevents this failure. Return
       storage_root: this.paths.root,
       config: this.config,
       locked_count: lockedCount,
-      tension_count: tensionPairs.size,
+      tension_count: unresolvedTensions,
       versioned_engram_count: versionedCount,
       outbox_count: this.outboxCount(),
       history_events: countInjectionEvents(this.paths.root),
       ...(this._lastIndexError ? { index_error: this._lastIndexError } : {}),
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Tension lifecycle (#181) — persistence, confirm/dismiss/resolve.
+  // ------------------------------------------------------------------
+
+  /** List persisted tension records, optionally filtered by status. */
+  listTensions(filter?: { status?: TensionStatus[] }): TensionRecord[] {
+    const records = loadTensions(this.paths.tensions)
+    if (!filter?.status?.length) return records
+    const wanted = new Set(filter.status)
+    return records.filter(r => wanted.has(r.status))
+  }
+
+  /**
+   * Canonical pair keys of every recorded tension — the scan exclusion set
+   * (#181). Any recorded pair is excluded from future scans regardless of
+   * status: dismissed/resolved pairs are suppressed, detected/confirmed
+   * pairs are already adjudicated and must not re-pay the LLM judge.
+   */
+  suppressedTensionPairKeys(): string[] {
+    return loadTensions(this.paths.tensions).map(r => tensionPairKey(r.engram_a, r.engram_b))
+  }
+
+  /**
+   * Persist fresh scan detections as tension records (#181). Pairs already
+   * recorded (any status) are returned as-is and counted in existing_count —
+   * a scan can never duplicate or resurrect a record. New records get a
+   * T-YYYY-MMDD-NNN id, a v1 category (categorizeTension), status
+   * 'detected', and emit the `contradiction_detected` history event (the
+   * event type existed since SP2 with zero emitters — audit #213 C5).
+   */
+  recordTensions(pairs: TensionPair[]): { records: TensionRecord[]; new_count: number; existing_count: number } {
+    if (pairs.length === 0) return { records: [], new_count: 0, existing_count: 0 }
+    const engramById = new Map(this._loadAllEngrams().map(e => [e.id, e]))
+    return withLock(this.paths.tensions, () => {
+      const all = loadTensions(this.paths.tensions)
+      const byKey = new Map(all.map(r => [tensionPairKey(r.engram_a, r.engram_b), r]))
+      const out: TensionRecord[] = []
+      let newCount = 0
+      let existingCount = 0
+      const nowIso = new Date().toISOString()
+      for (const pair of pairs) {
+        const key = tensionPairKey(pair.id_a, pair.id_b)
+        const prior = byKey.get(key)
+        if (prior) {
+          existingCount++
+          out.push(prior)
+          continue
+        }
+        const record: TensionRecord = {
+          id: generateTensionId(all),
+          engram_a: pair.id_a,
+          engram_b: pair.id_b,
+          statement_a: pair.statement_a,
+          statement_b: pair.statement_b,
+          confidence: pair.confidence,
+          reason: pair.reason,
+          detected_at: nowIso,
+          status: 'detected',
+          resolved_by: null,
+          resolved_at: null,
+          category: categorizeTension(
+            pair.statement_a, pair.statement_b,
+            engramById.get(pair.id_a), engramById.get(pair.id_b),
+          ),
+        }
+        all.push(record)
+        byKey.set(key, record)
+        out.push(record)
+        newCount++
+        try {
+          appendHistory(this.paths.root, {
+            event: 'contradiction_detected',
+            engram_id: pair.id_a,
+            timestamp: nowIso,
+            data: {
+              tension_id: record.id,
+              engram_b: pair.id_b,
+              confidence: pair.confidence,
+              reason: pair.reason,
+              category: record.category,
+            },
+          })
+        } catch { /* best-effort — history failure must not lose the record */ }
+      }
+      if (newCount > 0) saveTensions(this.paths.tensions, all)
+      return { records: out, new_count: newCount, existing_count: existingCount }
+    })
+  }
+
+  /** Locked mutation of a single tension record by id. */
+  private _mutateTension(id: string, mutate: (r: TensionRecord) => void): TensionRecord {
+    return withLock(this.paths.tensions, () => {
+      const all = loadTensions(this.paths.tensions)
+      const record = all.find(r => r.id === id)
+      if (!record) throw new Error(`Tension ${id} not found`)
+      mutate(record)
+      saveTensions(this.paths.tensions, all)
+      return record
+    })
+  }
+
+  /** Mark a detected tension as a real conflict (detected → confirmed). */
+  confirmTension(id: string): TensionRecord {
+    return this._mutateTension(id, r => {
+      if (r.status === 'resolved') throw new Error(`Tension ${id} is already resolved`)
+      if (r.status === 'dismissed') throw new Error(`Tension ${id} is dismissed — re-scan cannot resurrect it; delete tensions.yaml entry manually if truly needed`)
+      r.status = 'confirmed'
+    })
+  }
+
+  /**
+   * Dismiss a tension as a false positive (detected|confirmed → dismissed).
+   * The pair stays in the scan exclusion set, so it is never re-flagged.
+   */
+  dismissTension(id: string): TensionRecord {
+    return this._mutateTension(id, r => {
+      if (r.status === 'resolved') throw new Error(`Tension ${id} is already resolved`)
+      r.status = 'dismissed'
+    })
+  }
+
+  /**
+   * Resolve a tension by picking the winning engram: the loser is retired
+   * outright (decisive — NOT reference-count-decremented like forget(), see
+   * audit #213 §2), the record becomes status 'resolved' with resolved_by /
+   * resolved_at set.
+   */
+  resolveTension(id: string, winnerId: string): { record: TensionRecord; retired_id: string } {
+    const existing = this.listTensions().find(r => r.id === id)
+    if (!existing) throw new Error(`Tension ${id} not found`)
+    if (existing.status === 'resolved') throw new Error(`Tension ${id} is already resolved`)
+    if (existing.status === 'dismissed') throw new Error(`Tension ${id} is dismissed`)
+    if (winnerId !== existing.engram_a && winnerId !== existing.engram_b) {
+      throw new Error(`Winner ${winnerId} is not part of tension ${id} (${existing.engram_a} vs ${existing.engram_b})`)
+    }
+    const loserId = winnerId === existing.engram_a ? existing.engram_b : existing.engram_a
+    // Retire the loser FIRST — if retirement fails, the record stays
+    // unresolved and the operation can be retried.
+    const retired = this._retireEngramForResolution(loserId, `tension ${id} resolved in favor of ${winnerId}`)
+    if (!retired) throw new Error(`Cannot retire losing engram ${loserId} (not found in a writable local store)`)
+    const record = this._mutateTension(id, r => {
+      r.status = 'resolved'
+      r.resolved_by = winnerId
+      r.resolved_at = new Date().toISOString()
+    })
+    return { record, retired_id: loserId }
+  }
+
+  /**
+   * Unconditional retirement for tension resolution. Unlike forget(), does
+   * NOT decrement reference_count — the user explicitly adjudicated this
+   * engram as the losing side, so a multiply-learned loser must still die
+   * (audit #213 §2: "a user who resolved a tension by forgetting the loser
+   * may find it still active").
+   */
+  private _retireEngramForResolution(id: string, reason: string): boolean {
+    const stamp = (engram: Engram): void => {
+      engram.status = 'retired'
+      if (!engram.rationale) engram.rationale = `Retired: ${reason}`
+    }
+    const foundInPrimary = withLock(this.paths.engrams, () => {
+      const engrams = loadEngrams(this.paths.engrams)
+      const engram = engrams.find(e => e.id === id)
+      if (!engram) return false
+      stamp(engram)
+      this._writeEngrams(this.paths.engrams, engrams)
+      this._syncIndex()
+      appendHistory(this.paths.root, {
+        event: 'engram_retired',
+        engram_id: id,
+        timestamp: new Date().toISOString(),
+        data: { reason },
+      })
+      return true
+    })
+    if (foundInPrimary) return true
+
+    // Secondary local stores (namespaced ids) — mirrors forget()'s branch.
+    const storeInfo = this._findEngramStore(id)
+    if (storeInfo && storeInfo.path !== this.paths.engrams) {
+      if (storeInfo.readonly) throw new Error('Cannot retire engram from readonly store')
+      const storeEngrams = loadEngrams(storeInfo.path)
+      const engram = storeEngrams.find(e => e.id === storeInfo.originalId)
+      if (engram) {
+        stamp(engram)
+        this._writeEngrams(storeInfo.path, storeEngrams)
+        this._syncIndex()
+        appendHistory(this.paths.root, {
+          event: 'engram_retired',
+          engram_id: id,
+          timestamp: new Date().toISOString(),
+          data: { reason },
+        })
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * True when the engram participates in an unresolved (detected|confirmed)
+   * persisted tension. Gates commitment escalation into 'locked' (#181,
+   * audit #213 item 3): contradicted knowledge must not lock.
+   */
+  hasUnresolvedTension(engramId: string): boolean {
+    try {
+      return loadTensions(this.paths.tensions).some(r =>
+        (r.status === 'detected' || r.status === 'confirmed')
+        && (r.engram_a === engramId || r.engram_b === engramId))
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Injection warnings for persisted tensions (#181, audit #213 item 4 —
+   * surface, don't adjudicate):
+   * - confirmed tension: warn when EITHER side injects (the user vouched
+   *   for the conflict being real; relying on one side blind is a hazard);
+   * - detected tension: warn only when BOTH sides inject together.
+   */
+  private _tensionWarningsFor(injectedIds: string[]): string[] {
+    if (injectedIds.length === 0) return []
+    try {
+      const unresolved = loadTensions(this.paths.tensions)
+        .filter(r => r.status === 'detected' || r.status === 'confirmed')
+      if (unresolved.length === 0) return []
+      const injected = new Set(injectedIds)
+      const clip = (t: string) => (t.length > 80 ? `${t.slice(0, 77)}...` : t)
+      const warnings: string[] = []
+      for (const r of unresolved) {
+        const aIn = injected.has(r.engram_a)
+        const bIn = injected.has(r.engram_b)
+        const fires = r.status === 'confirmed' ? (aIn || bIn) : (aIn && bIn)
+        if (!fires) continue
+        warnings.push(
+          `Tension ${r.id} (${r.status}, ${r.category}): "${clip(r.statement_a)}" [${r.engram_a}] contradicts "${clip(r.statement_b)}" [${r.engram_b}]. Consider resolving before relying on either.`,
+        )
+      }
+      return warnings
+    } catch {
+      return [] // best-effort — a tension-store problem must never break injection
     }
   }
 

--- a/packages/core/src/schemas/tension.ts
+++ b/packages/core/src/schemas/tension.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod'
+
+/**
+ * Tension record — the persisted output of a contradiction scan (#181).
+ *
+ * Phase 1 (#172) detection returned scan results to the caller and dropped
+ * them: every scan re-paid the LLM calls, false positives were re-flagged
+ * forever, and "resolved" had no representation (see the #213 audit,
+ * findings C2/C5). A TensionRecord is the durable representation: one
+ * record per engram pair, carried through the lifecycle
+ *
+ *   detected → confirmed → resolved   (real conflict, winner picked)
+ *   detected → dismissed              (false positive, pair suppressed)
+ *
+ * Records live in `tensions.yaml` next to `engrams.yaml`. Any recorded
+ * pair — whatever its status — is excluded from future scans, so
+ * dismissals act as a suppress-list and detections are never re-judged.
+ */
+export const TensionStatusSchema = z.enum(['detected', 'confirmed', 'dismissed', 'resolved'])
+export type TensionStatus = z.infer<typeof TensionStatusSchema>
+
+/**
+ * v1 category heuristic (deterministic, assigned at record time):
+ * - `superseded`: a statement carries an explicit "(not X)" correction marker
+ * - `temporal`: both engrams have derivable recorded dates ≥1 day apart —
+ *   likely evolution of a changing situation rather than a wrong value
+ * - `factual`: everything else (same-day or undatable pairs)
+ *
+ * Advisory only — resolution never branches on category; the user picks the
+ * action. A judge-assisted categorization can replace this later without a
+ * schema change.
+ */
+export const TensionCategorySchema = z.enum(['factual', 'temporal', 'superseded'])
+export type TensionCategory = z.infer<typeof TensionCategorySchema>
+
+export const TensionRecordSchema = z.object({
+  /** T-YYYY-MMDD-NNN, numbered per detection day. */
+  id: z.string(),
+  engram_a: z.string(),
+  engram_b: z.string(),
+  /** Statement snapshots at detection time — engrams may be edited or retired later. */
+  statement_a: z.string(),
+  statement_b: z.string(),
+  /** Judge confidence at detection. */
+  confidence: z.number().min(0).max(1),
+  reason: z.string(),
+  detected_at: z.string(),
+  status: TensionStatusSchema.default('detected'),
+  /** Winning engram id once resolved, else null. */
+  resolved_by: z.string().nullable().default(null),
+  resolved_at: z.string().nullable().default(null),
+  category: TensionCategorySchema.default('factual'),
+})
+
+export type TensionRecord = z.infer<typeof TensionRecordSchema>

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -6,6 +6,8 @@ export interface PlurPaths {
   root: string
   engrams: string
   episodes: string
+  /** Persisted tension records (#181). */
+  tensions: string
   candidates: string
   packs: string
   exchange: string
@@ -28,6 +30,7 @@ export function detectPlurStorage(explicitPath?: string): PlurPaths {
     root,
     engrams: join(root, 'engrams.yaml'),
     episodes: join(root, 'episodes.yaml'),
+    tensions: join(root, 'tensions.yaml'),
     candidates: join(root, 'candidates.yaml'),
     packs: packsDir,
     exchange: join(root, 'exchange'),

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -42,7 +42,7 @@ exchange/
  * derived files (engrams.db, store.pglite/, exchange/) can NEVER ride along into a
  * synced repo, regardless of how the user's gitignore is (mis)configured. (#380, #384)
  */
-const SYNC_PATHS = ['engrams.yaml', 'episodes.yaml', 'candidates.yaml', 'packs', '.gitignore'] as const
+const SYNC_PATHS = ['engrams.yaml', 'episodes.yaml', 'candidates.yaml', 'tensions.yaml', 'packs', '.gitignore'] as const
 
 /**
  * Secret-bearing files that must never be tracked. Untracked on every sync, so a

--- a/packages/core/src/tension-store.ts
+++ b/packages/core/src/tension-store.ts
@@ -1,0 +1,93 @@
+/**
+ * Tension persistence (#181) — load/save tension records and the pure
+ * helpers around them (pair keys, ids, categorization).
+ *
+ * Storage mirrors episodes.ts: a YAML array in `tensions.yaml` at the store
+ * root, written atomically. Mutations go through the Plur class, which holds
+ * the file lock; this module stays pure I/O + helpers.
+ */
+import { existsSync, readFileSync } from 'fs'
+import yaml from 'js-yaml'
+import { atomicWrite } from './sync.js'
+import { TensionRecordSchema, type TensionRecord, type TensionCategory } from './schemas/tension.js'
+import type { Engram } from './schemas/engram.js'
+
+/** Canonical unordered pair key: sorted ids joined by ':'. */
+export function tensionPairKey(idA: string, idB: string): string {
+  return [idA, idB].sort().join(':')
+}
+
+export function loadTensions(path: string): TensionRecord[] {
+  if (!existsSync(path)) return []
+  try {
+    const raw = yaml.load(readFileSync(path, 'utf8'))
+    if (!Array.isArray(raw)) return []
+    const records: TensionRecord[] = []
+    for (const entry of raw) {
+      const parsed = TensionRecordSchema.safeParse(entry)
+      if (parsed.success) records.push(parsed.data)
+      // Malformed entries are skipped, not fatal — same posture as episodes.
+    }
+    return records
+  } catch {
+    return []
+  }
+}
+
+export function saveTensions(path: string, records: TensionRecord[]): void {
+  atomicWrite(path, yaml.dump(records, { lineWidth: 120, noRefs: true }))
+}
+
+/**
+ * Next tension id for `now`: T-YYYY-MMDD-NNN, NNN numbered per detection day
+ * across the existing records.
+ */
+export function generateTensionId(existing: TensionRecord[], now: Date = new Date()): string {
+  const iso = now.toISOString().slice(0, 10)
+  const day = iso.replace(/-/g, '').slice(0, 8) // YYYYMMDD
+  const prefix = `T-${day.slice(0, 4)}-${day.slice(4, 8)}-`
+  let max = 0
+  for (const r of existing) {
+    if (!r.id.startsWith(prefix)) continue
+    const n = parseInt(r.id.slice(prefix.length), 10)
+    if (Number.isFinite(n) && n > max) max = n
+  }
+  return `${prefix}${String(max + 1).padStart(3, '0')}`
+}
+
+/** Explicit correction marker — "use 9 agents (not 5)". */
+const SUPERSEDED_PATTERN = /\(\s*not\s+[^)]+\)/i
+
+/**
+ * Recorded date of an engram: `temporal.learned_at`, falling back to the
+ * date embedded in canonical ids (ENG-YYYY-MMDD-NNN, ENG-PREFIX-YYYY-MMDD-NNN,
+ * server-assigned ENG-YYYY-MM-DD-NNN). Undefined when underivable.
+ */
+function recordedDate(e: Engram): string | undefined {
+  const learned = e.temporal?.learned_at
+  if (learned && /^\d{4}-\d{2}-\d{2}/.test(learned)) return learned.slice(0, 10)
+  const m = e.id.match(/(\d{4})-(\d{2})-?(\d{2})(?=-|$)/)
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`
+  return undefined
+}
+
+/**
+ * v1 deterministic category heuristic (#181). See TensionCategorySchema for
+ * the contract; advisory only — resolution never branches on category.
+ */
+export function categorizeTension(
+  statementA: string,
+  statementB: string,
+  engramA?: Engram,
+  engramB?: Engram,
+): TensionCategory {
+  if (SUPERSEDED_PATTERN.test(statementA) || SUPERSEDED_PATTERN.test(statementB)) {
+    return 'superseded'
+  }
+  if (engramA && engramB) {
+    const dateA = recordedDate(engramA)
+    const dateB = recordedDate(engramB)
+    if (dateA && dateB && dateA !== dateB) return 'temporal'
+  }
+  return 'factual'
+}

--- a/packages/core/src/tensions.ts
+++ b/packages/core/src/tensions.ts
@@ -345,8 +345,10 @@ function isSnapshotPair(a: Engram, b: Engram, temporalDomains: readonly string[]
  *   2. Domain filter    — skip pairs whose domain hierarchies don't touch
  *   3. Subject overlap  — skip pairs whose subject noun phrases don't overlap
  *
- * Already-known conflicts (relations.conflicts) are skipped to avoid
- * re-evaluating the same pair.
+ * Pairs already adjudicated in the tension store are skipped via
+ * options.exclude_pairs (#181). relations.conflicts does NOT exempt a pair:
+ * importer-written conflict edges are heuristic suspects awaiting an LLM
+ * verdict (audit #213 C1).
  *
  * Temporal gates (#240):
  *   - Supersedes-linked pairs are skipped in both directions — an
@@ -365,14 +367,25 @@ function isSnapshotPair(a: Engram, b: Engram, temporalDomains: readonly string[]
  * when the caller applies a max_pairs cap. Ties keep insertion order
  * (stable sort).
  */
+export interface CandidatePairOptions {
+  /**
+   * Canonical pair keys (sorted ids joined by ':') to exclude — the persisted
+   * tension records (#181). Any recorded pair, whatever its status, is
+   * skipped: dismissed records act as a suppress-list, detected/confirmed
+   * records are already adjudicated and must not re-pay the judge.
+   */
+  exclude_pairs?: ReadonlySet<string>
+}
+
 export function getCandidatePairs(
   engrams: Engram[],
-  options?: TemporalGateOptions,
+  options?: TemporalGateOptions & CandidatePairOptions,
 ): Array<[Engram, Engram]> {
   const active = engrams.filter(e => e.status === 'active')
   const temporalDomains = options?.temporal_domains ?? []
   const snapshotMode = options?.snapshot_pairs ?? 'skip'
   const now = options?.now ?? new Date().toISOString().slice(0, 10)
+  const excludePairs = options?.exclude_pairs
 
   // Tokenize each engram once instead of once per pair (O(n) vs O(n²) passes).
   const subjectTokens = active.map(e => extractSubjectTokens(e.statement))
@@ -392,8 +405,12 @@ export function getCandidatePairs(
       // Stage 2: domain segment filter
       if (!domainSegmentsOverlap(a.domain, b.domain)) continue
 
-      // Skip already-known conflict pairs
-      if (a.relations?.conflicts?.includes(b.id)) continue
+      // Skip pairs already adjudicated in the tension store (#181). This
+      // REPLACES the old relations.conflicts skip (audit #213 C1): the
+      // importer writes heuristic conflict suspects precisely so the scan
+      // can confirm them with an LLM, so a conflicts edge must not exempt
+      // a pair from judging — only a persisted record does.
+      if (excludePairs && excludePairs.has([a.id, b.id].sort().join(':'))) continue
 
       // #240: intentional updates are not tensions
       if (supersedesLinked(a, b)) continue
@@ -421,8 +438,8 @@ export function getCandidatePairs(
   return scored.map(s => s.pair)
 }
 
-/** Options for scanForTensions. Temporal gates/adjustments are #240. */
-export interface TensionScanOptions extends TemporalGateOptions {
+/** Options for scanForTensions. Temporal gates/adjustments are #240; pair exclusion is #181. */
+export interface TensionScanOptions extends TemporalGateOptions, CandidatePairOptions {
   min_confidence?: number
   max_pairs?: number
   batch_size?: number

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -145,6 +145,12 @@ export interface InjectionResult {
   count: number
   tokens_used: number
   injected_ids: string[]
+  /**
+   * Persisted-tension warnings (#181): present when an injected engram
+   * participates in an unresolved tension (confirmed → either side injected;
+   * detected → both sides injected together). Surface, don't adjudicate.
+   */
+  warnings?: string[]
 }
 
 export interface CaptureContext {

--- a/packages/core/test/tension-lifecycle.test.ts
+++ b/packages/core/test/tension-lifecycle.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { getCandidatePairs, scanForTensions, type TensionPair } from '../src/tensions.js'
+import { generateTensionId, tensionPairKey, categorizeTension } from '../src/tension-store.js'
+import { readHistory } from '../src/history.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/**
+ * Tension lifecycle (#181): persistence, suppress-list, confirm/dismiss/
+ * resolve, injection warnings, lock-escalation gate. Directly implements the
+ * must-have items 1–4 of the #213 audit.
+ */
+
+function pairOf(a: { id: string; statement: string }, b: { id: string; statement: string }, extra?: Partial<TensionPair>): TensionPair {
+  return {
+    id_a: a.id,
+    id_b: b.id,
+    statement_a: a.statement,
+    statement_b: b.statement,
+    confidence: 0.9,
+    reason: 'Mutually exclusive claims.',
+    ...extra,
+  }
+}
+
+describe('tension persistence (#181)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-tension-lc-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('recordTensions persists records to tensions.yaml and survives a fresh instance', () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    const { records, new_count } = plur.recordTensions([pairOf(a, b)])
+
+    expect(new_count).toBe(1)
+    expect(records[0].id).toMatch(/^T-\d{4}-\d{4}-\d{3}$/)
+    expect(records[0].status).toBe('detected')
+    expect(existsSync(join(dir, 'tensions.yaml'))).toBe(true)
+
+    const plur2 = new Plur({ path: dir })
+    const reloaded = plur2.listTensions()
+    expect(reloaded).toHaveLength(1)
+    expect(reloaded[0].id).toBe(records[0].id)
+    expect(reloaded[0].statement_a).toBe(a.statement)
+  })
+
+  it('does not duplicate an already-recorded pair (either direction)', () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    const first = plur.recordTensions([pairOf(a, b)])
+    expect(first.new_count).toBe(1)
+
+    // Same pair again — and reversed
+    const again = plur.recordTensions([pairOf(a, b), pairOf(b, a)])
+    expect(again.new_count).toBe(0)
+    expect(again.existing_count).toBe(2)
+    expect(plur.listTensions()).toHaveLength(1)
+  })
+
+  it('emits the contradiction_detected history event on new records (audit C5)', () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    plur.recordTensions([pairOf(a, b)])
+
+    const month = new Date().toISOString().slice(0, 7)
+    const events = readHistory(dir, month).filter(e => e.event === 'contradiction_detected')
+    expect(events).toHaveLength(1)
+    expect(events[0].engram_id).toBe(a.id)
+    expect((events[0].data as any).engram_b).toBe(b.id)
+    expect((events[0].data as any).tension_id).toMatch(/^T-/)
+  })
+
+  it('status().tension_count counts unresolved persisted records (audit C2)', () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    expect(plur.status().tension_count).toBe(0)
+
+    const { records } = plur.recordTensions([pairOf(a, b)])
+    expect(plur.status().tension_count).toBe(1)
+
+    plur.dismissTension(records[0].id)
+    expect(plur.status().tension_count).toBe(0)
+  })
+
+  it('listTensions filters by status', () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    const c = plur.learn('plur uses yaml storage')
+    const d = plur.learn('plur uses json storage')
+    const { records } = plur.recordTensions([pairOf(a, b), pairOf(c, d)])
+    plur.dismissTension(records[1].id)
+
+    expect(plur.listTensions({ status: ['detected'] })).toHaveLength(1)
+    expect(plur.listTensions({ status: ['dismissed'] })).toHaveLength(1)
+    expect(plur.listTensions()).toHaveLength(2)
+  })
+})
+
+describe('tension id + category helpers (#181)', () => {
+  it('generateTensionId numbers per day', () => {
+    const now = new Date('2026-07-03T10:00:00Z')
+    expect(generateTensionId([], now)).toBe('T-2026-0703-001')
+    const existing = [
+      { id: 'T-2026-0703-002' }, { id: 'T-2026-0702-009' },
+    ] as any
+    expect(generateTensionId(existing, now)).toBe('T-2026-0703-003')
+  })
+
+  it('tensionPairKey is order-independent', () => {
+    expect(tensionPairKey('B', 'A')).toBe(tensionPairKey('A', 'B'))
+  })
+
+  it('categorize: "(not X)" pattern → superseded', () => {
+    expect(categorizeTension('war analysis uses 9 agents (not 5)', 'war analysis uses 5 agents')).toBe('superseded')
+  })
+
+  it('categorize: different recorded dates → temporal', () => {
+    const a = { id: 'ENG-2026-0407-001', temporal: { learned_at: '2026-04-07' } } as unknown as Engram
+    const b = { id: 'ENG-2026-0413-002', temporal: { learned_at: '2026-04-13' } } as unknown as Engram
+    expect(categorizeTension('ceasefire holds', 'ceasefire collapsed', a, b)).toBe('temporal')
+  })
+
+  it('categorize: same-day or undatable → factual', () => {
+    const a = { id: 'ENG-2026-0407-001' } as unknown as Engram
+    const b = { id: 'ENG-2026-0407-002' } as unknown as Engram
+    expect(categorizeTension('cli is v1', 'cli is v2', a, b)).toBe('factual')
+    expect(categorizeTension('cli is v1', 'cli is v2')).toBe('factual')
+  })
+})
+
+describe('scan suppression via recorded pairs (#181)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-tension-sup-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('recorded pairs are excluded from future scans (no LLM call)', async () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    plur.recordTensions([pairOf(a, b)])
+
+    const llm = vi.fn(async () => 'CONTRADICTS: yes\nCONFIDENCE: 1.0\nREASON: versions differ.')
+    const result = await scanForTensions(plur.list(), llm, {
+      exclude_pairs: new Set(plur.suppressedTensionPairKeys()),
+    })
+    expect(result.pairs_checked).toBe(0)
+    expect(llm).not.toHaveBeenCalled()
+  })
+
+  it('dismissed pairs stay suppressed', async () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    const { records } = plur.recordTensions([pairOf(a, b)])
+    plur.dismissTension(records[0].id)
+
+    expect(plur.suppressedTensionPairKeys()).toContain(tensionPairKey(a.id, b.id))
+  })
+
+  it('relations.conflicts no longer exempts a pair from judging (audit C1)', () => {
+    // Importer-written conflict suspects must reach the LLM judge.
+    const mk = (id: string, statement: string, conflicts: string[] = []): Engram => ({
+      id, statement,
+      version: 2, status: 'active', consolidated: false, type: 'behavioral',
+      scope: 'global', visibility: 'private',
+      activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-07-01' },
+      feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+      knowledge_anchors: [], associations: [], derivation_count: 1, tags: [],
+      content_hash: id, commitment: 'leaning', engram_version: 1, episode_ids: [], polarity: null,
+      ...(conflicts.length > 0 ? { relations: { broader: [], narrower: [], related: [], conflicts } } : {}),
+    } as unknown as Engram)
+
+    const a = mk('E1', 'plur search uses BM25.', ['E2'])
+    const b = mk('E2', 'plur search uses embeddings.')
+    expect(getCandidatePairs([a, b])).toHaveLength(1)
+
+    // …but a recorded pair IS excluded:
+    expect(getCandidatePairs([a, b], { exclude_pairs: new Set([tensionPairKey('E1', 'E2')]) })).toHaveLength(0)
+  })
+})
+
+describe('confirm / dismiss / resolve (#181)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-tension-res-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  function seed(): { id: string; a: Engram; b: Engram } {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    const { records } = plur.recordTensions([pairOf(a, b)])
+    return { id: records[0].id, a: a as Engram, b: b as Engram }
+  }
+
+  it('confirm marks a detected tension confirmed', () => {
+    const { id } = seed()
+    const record = plur.confirmTension(id)
+    expect(record.status).toBe('confirmed')
+    expect(plur.listTensions({ status: ['confirmed'] })).toHaveLength(1)
+  })
+
+  it('dismiss works from detected and confirmed', () => {
+    const { id } = seed()
+    plur.confirmTension(id)
+    const record = plur.dismissTension(id)
+    expect(record.status).toBe('dismissed')
+  })
+
+  it('resolve picks a winner, retires the loser, stamps the record', () => {
+    const { id, a, b } = seed()
+    const { record, retired_id } = plur.resolveTension(id, b.id)
+
+    expect(record.status).toBe('resolved')
+    expect(record.resolved_by).toBe(b.id)
+    expect(record.resolved_at).toBeTruthy()
+    expect(retired_id).toBe(a.id)
+
+    const loser = new Plur({ path: dir }).getById(a.id)
+    expect(loser?.status).toBe('retired')
+    expect(loser?.rationale).toContain(id)
+    // Winner untouched
+    expect(plur.getById(b.id)?.status).toBe('active')
+  })
+
+  it('resolve retires a multiply-learned loser outright (no reference-count games)', () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    plur.learn('plur cli version is 0.3.0', { scope: 'project:other' }) // bump reference_count
+    const b = plur.learn('plur cli version is 0.8.2')
+    const { records } = plur.recordTensions([pairOf(plur.getById(a.id)!, b)])
+
+    plur.resolveTension(records[0].id, b.id)
+    expect(plur.getById(a.id)?.status).toBe('retired')
+  })
+
+  it('resolve rejects a winner outside the pair', () => {
+    const { id } = seed()
+    const c = plur.learn('unrelated statement about storage')
+    expect(() => plur.resolveTension(id, c.id)).toThrow(/not part of tension/)
+  })
+
+  it('terminal states are enforced', () => {
+    const { id, b } = seed()
+    plur.resolveTension(id, b.id)
+    expect(() => plur.confirmTension(id)).toThrow(/already resolved/)
+    expect(() => plur.dismissTension(id)).toThrow(/already resolved/)
+    expect(() => plur.resolveTension(id, b.id)).toThrow(/already resolved/)
+  })
+
+  it('unknown tension ids throw', () => {
+    expect(() => plur.confirmTension('T-0000-0000-001')).toThrow(/not found/)
+  })
+})
+
+describe('injection warnings (#181, audit item 4)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-tension-inj-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('confirmed tension warns when either side injects', () => {
+    // pinned → bypasses the relevance gate, so injection is deterministic
+    const a = plur.learn('use tabs for indentation in this repo', { pinned: true })
+    const b = plur.learn('completely unrelated fact about databases')
+    const { records } = plur.recordTensions([pairOf(a, b)])
+    plur.confirmTension(records[0].id)
+
+    const result = plur.inject('anything at all')
+    expect(result.injected_ids).toContain(a.id)
+    expect(result.warnings).toBeDefined()
+    expect(result.warnings![0]).toContain(records[0].id)
+    expect(result.warnings![0]).toMatch(/contradicts/)
+  })
+
+  it('detected tension warns only when BOTH sides inject', () => {
+    const a = plur.learn('use tabs for indentation in this repo', { pinned: true })
+    const b = plur.learn('completely unrelated fact about databases')
+    plur.recordTensions([pairOf(a, b)])
+
+    const oneSide = plur.inject('anything at all')
+    expect(oneSide.injected_ids).toContain(a.id)
+    expect(oneSide.warnings).toBeUndefined()
+
+    // Pin the other side too — now both inject and the warning fires
+    const bStored = plur.getById(b.id)!
+    plur.updateEngram({ ...bStored, pinned: true } as Engram)
+    const bothSides = plur.inject('anything at all')
+    expect(bothSides.injected_ids).toEqual(expect.arrayContaining([a.id, b.id]))
+    expect(bothSides.warnings).toBeDefined()
+    expect(bothSides.warnings![0]).toMatch(/Tension T-/)
+  })
+
+  it('resolved and dismissed tensions never warn', () => {
+    const a = plur.learn('use tabs for indentation in this repo', { pinned: true })
+    const b = plur.learn('use spaces for indentation in this repo', { pinned: true })
+    const { records } = plur.recordTensions([pairOf(a, b)])
+    plur.dismissTension(records[0].id)
+
+    const result = plur.inject('anything at all')
+    expect(result.warnings).toBeUndefined()
+  })
+})
+
+describe('lock-escalation gate (#181, audit item 3)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-tension-lock-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  const STMT = 'deploy platform is fly.io for all services'
+
+  /** Drive cross-scope recurrence to the point where the NEXT hit would lock. */
+  function escalateToDecided(): Engram {
+    plur.learn(STMT, { scope: 'project:a' })            // create (leaning)
+    plur.learn(STMT, { scope: 'project:b' })            // recurrence 1 — no escalation
+    const e = plur.learn(STMT, { scope: 'project:c' })  // recurrence 2 — leaning → decided
+    expect((plur.getById(e.id) as any).commitment).toBe('decided')
+    return e as Engram
+  }
+
+  it('without a tension, the next cross-scope hit locks (baseline #176 behavior)', () => {
+    const e = escalateToDecided()
+    plur.learn(STMT, { scope: 'project:d' })            // recurrence 3 — decided → locked
+    expect((plur.getById(e.id) as any).commitment).toBe('locked')
+  })
+
+  it('an unresolved tension blocks the decided → locked step', () => {
+    const e = escalateToDecided()
+    const rival = plur.learn('deploy platform is render.com for all services')
+    plur.recordTensions([pairOf(plur.getById(e.id)!, rival)])
+
+    plur.learn(STMT, { scope: 'project:d' })            // recurrence 3 — capped
+    expect((plur.getById(e.id) as any).commitment).toBe('decided')
+  })
+
+  it('resolving the tension re-opens the path to locked', () => {
+    const e = escalateToDecided()
+    const rival = plur.learn('deploy platform is render.com for all services')
+    const { records } = plur.recordTensions([pairOf(plur.getById(e.id)!, rival)])
+
+    plur.learn(STMT, { scope: 'project:d' })            // blocked
+    expect((plur.getById(e.id) as any).commitment).toBe('decided')
+
+    plur.resolveTension(records[0].id, e.id)            // engram wins
+    plur.learn(STMT, { scope: 'project:e' })            // next hit locks
+    expect((plur.getById(e.id) as any).commitment).toBe('locked')
+  })
+})

--- a/packages/core/test/tensions.test.ts
+++ b/packages/core/test/tensions.test.ts
@@ -189,7 +189,7 @@ describe('getCandidatePairs', () => {
     expect(pairs).toHaveLength(0)
   })
 
-  it('skips already-known conflict pairs', () => {
+  it('relations.conflicts does NOT exempt a pair — importer suspects must be judged (#181, audit C1)', () => {
     const a = makeEngram({
       id: 'E1',
       statement: 'plur search uses BM25.',
@@ -198,6 +198,13 @@ describe('getCandidatePairs', () => {
     })
     const b = makeEngram({ id: 'E2', statement: 'plur search uses embeddings.', scope: 'global' })
     const pairs = getCandidatePairs([a, b])
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('skips pairs recorded in the tension store (exclude_pairs, #181)', () => {
+    const a = makeEngram({ id: 'E1', statement: 'plur search uses BM25.', scope: 'global' })
+    const b = makeEngram({ id: 'E2', statement: 'plur search uses embeddings.', scope: 'global' })
+    const pairs = getCandidatePairs([a, b], { exclude_pairs: new Set(['E1:E2']) })
     expect(pairs).toHaveLength(0)
   })
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -2,7 +2,7 @@ import { existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName } from '@plur-ai/core'
-import type { LlmFunction, MetaField } from '@plur-ai/core'
+import type { LlmFunction, MetaField, TensionStatus } from '@plur-ai/core'
 import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
 
@@ -418,6 +418,8 @@ export function getToolDefinitions(): ToolDefinition[] {
           count: result.count,
           tokens_used: result.tokens_used,
           injected_ids: result.injected_ids,
+          // #181: unresolved-tension warnings — flag contradicted context
+          ...(result.warnings ? { warnings: result.warnings } : {}),
         }
       },
     },
@@ -447,6 +449,8 @@ export function getToolDefinitions(): ToolDefinition[] {
           tokens_used: result.tokens_used,
           injected_ids: result.injected_ids,
           mode: 'hybrid',
+          // #181: unresolved-tension warnings — flag contradicted context
+          ...(result.warnings ? { warnings: result.warnings } : {}),
         }
       },
     },
@@ -1761,14 +1765,19 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
 
     {
       name: 'plur_tensions',
-      description: 'List or scan for engram pairs that have conflicting knowledge. Without scan mode, shows previously detected conflicts. With scan:true, runs an active LLM-powered contradiction scan and returns only high-confidence tensions.',
-      annotations: { title: 'Tensions', readOnlyHint: true, idempotentHint: true },
+      description: 'Tension lifecycle (#181). Default: list persisted tension records (unresolved first). scan:true runs an LLM contradiction scan, persists NEW detections as records, and skips already-recorded pairs. Lifecycle actions: action:"confirm" (real conflict), action:"dismiss" (false positive — pair suppressed from future scans), action:"resolve" + winner:<engram_id> (loser engram retired). Scan requires OPENAI_API_KEY or OPENROUTER_API_KEY env var, or explicit llm_base_url + llm_api_key args.',
+      annotations: { title: 'Tensions', readOnlyHint: false, idempotentHint: true },
       inputSchema: {
         type: 'object',
         properties: {
           scope: { type: 'string', description: 'Filter by scope' },
           domain: { type: 'string', description: 'Filter by domain prefix' },
-          scan: { type: 'boolean', description: 'Run an active contradiction scan using an LLM judge. Requires OPENAI_API_KEY or OPENROUTER_API_KEY env var, or explicit llm_base_url + llm_api_key args.' },
+          scan: { type: 'boolean', description: 'Run an active contradiction scan using an LLM judge. New detections are persisted as tension records; recorded pairs (any status) are skipped. Requires OPENAI_API_KEY or OPENROUTER_API_KEY env var, or explicit llm_base_url + llm_api_key args.' },
+          persist: { type: 'boolean', description: 'Persist scan detections as tension records (default true). Set false for a dry-run scan that also ignores the recorded-pair suppress list.' },
+          action: { type: 'string', enum: ['confirm', 'dismiss', 'resolve'], description: 'Lifecycle action on a persisted tension record (requires id). confirm: mark real. dismiss: false positive, suppress the pair. resolve: pick winner (requires winner), the losing engram is retired.' },
+          id: { type: 'string', description: 'Tension record id (T-YYYY-MMDD-NNN) for action mode' },
+          winner: { type: 'string', description: 'Engram id that wins the tension (action:"resolve" only). The other engram is retired.' },
+          status: { type: 'string', enum: ['detected', 'confirmed', 'dismissed', 'resolved', 'all'], description: 'List-mode status filter. Default: unresolved records (detected + confirmed).' },
           llm_base_url: { type: 'string', description: 'OpenAI-compatible API base URL for scan mode (e.g. https://api.openai.com/v1)' },
           llm_api_key: { type: 'string', description: 'API key for the LLM (scan mode)' },
           llm_model: { type: 'string', description: 'Model name for scan mode (default: gpt-4o-mini)' },
@@ -1779,6 +1788,27 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
         },
       },
       handler: async (args, plur) => {
+        // --- Lifecycle actions (#181) ---
+        if (args.action) {
+          const id = args.id as string | undefined
+          if (!id) throw new Error(`action:"${args.action}" requires id (tension record id, e.g. T-2026-0703-001)`)
+          if (args.action === 'confirm') {
+            const record = plur.confirmTension(id)
+            return { record, message: `Tension ${id} confirmed as a real conflict. Resolve it with action:"resolve" + winner:<engram_id>.` }
+          }
+          if (args.action === 'dismiss') {
+            const record = plur.dismissTension(id)
+            return { record, message: `Tension ${id} dismissed — the pair is suppressed from future scans.` }
+          }
+          if (args.action === 'resolve') {
+            const winner = args.winner as string | undefined
+            if (!winner) throw new Error('action:"resolve" requires winner (the engram id to keep)')
+            const { record, retired_id } = plur.resolveTension(id, winner)
+            return { record, retired: retired_id, message: `Tension ${id} resolved: ${winner} wins, ${retired_id} retired.` }
+          }
+          throw new Error(`Unknown action: ${args.action}. Use confirm, dismiss, or resolve.`)
+        }
+
         const engrams = plur.list({
           scope: args.scope as string | undefined,
           domain: args.domain as string | undefined,
@@ -1800,6 +1830,10 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           // #240: config supplies the temporal defaults (tensions: block in
           // config.yaml); an explicit temporal_discount arg overrides.
           const tensionsConfig = plur.getTensionsConfig()
+          // #181: recorded pairs (any status) are excluded — dismissals are
+          // suppressed, prior detections are not re-judged. persist:false is
+          // a dry run: no records written AND no suppress-list applied.
+          const persist = args.persist !== false
           const result = await scanForTensions(engrams, llm, {
             min_confidence: args.min_confidence as number | undefined,
             max_pairs: args.max_pairs as number | undefined,
@@ -1807,12 +1841,18 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
             temporal_domains: tensionsConfig.temporal_domains,
             snapshot_pairs: tensionsConfig.snapshot_pairs,
             temporal_discount: (args.temporal_discount as boolean | undefined) ?? tensionsConfig.temporal_discount,
+            ...(persist ? { exclude_pairs: new Set(plur.suppressedTensionPairKeys()) } : {}),
           })
+          const persisted = persist && result.tensions.length > 0
+            ? plur.recordTensions(result.tensions)
+            : undefined
 
           return {
             pairs_checked: result.pairs_checked,
             count: result.new_tensions,
-            tensions: result.tensions.map(t => ({
+            ...(persisted ? { persisted_new: persisted.new_count } : {}),
+            tensions: result.tensions.map((t, i) => ({
+              ...(persisted ? { tension_id: persisted.records[i].id, category: persisted.records[i].category, status: persisted.records[i].status } : {}),
               engram_a: { id: t.id_a, statement: t.statement_a },
               engram_b: { id: t.id_b, statement: t.statement_b },
               confidence: t.confidence,
@@ -1820,44 +1860,53 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
               ...(t.days_apart !== undefined ? { days_apart: t.days_apart } : {}),
               ...(t.raw_confidence !== undefined ? { raw_confidence: t.raw_confidence } : {}),
             })),
+            ...(persisted && persisted.new_count > 0
+              ? { next_steps: 'Review each tension: action:"confirm" (real), action:"dismiss" (false positive), or action:"resolve" + winner:<engram_id> (retire the loser).' }
+              : {}),
           }
         }
 
-        // Legacy mode: read from relations.conflicts (kept for backward compat;
-        // returns empty for stores that have been through purgeTensions).
-        const tensions: Array<{
+        // --- List mode (#181): persisted tension records ---
+        const statusArg = args.status as TensionStatus | 'all' | undefined
+        const records = statusArg === 'all'
+          ? plur.listTensions()
+          : plur.listTensions({ status: statusArg ? [statusArg] : ['detected', 'confirmed'] })
+
+        // Legacy relations.conflicts pairs (unvalidated importer heuristics or
+        // pre-#138 residue) are surfaced separately with the purge hint.
+        const legacy: Array<{
           engram_a: { id: string; statement: string; type: string }
           engram_b: { id: string; statement: string; type: string }
           detected_at: string
-          purge_hint?: string
         }> = []
-
         const seen = new Set<string>()
-
         for (const engram of engrams) {
           if (!engram.relations?.conflicts?.length) continue
           for (const conflictId of engram.relations.conflicts) {
             const pairKey = [engram.id, conflictId].sort().join(':')
             if (seen.has(pairKey)) continue
             seen.add(pairKey)
-
             const other = engrams.find(e => e.id === conflictId)
             if (!other) continue
-
-            tensions.push({
+            legacy.push({
               engram_a: { id: engram.id, statement: engram.statement, type: engram.type },
               engram_b: { id: other.id, statement: other.statement, type: other.type },
               detected_at: engram.activation.last_accessed,
-              purge_hint: 'These conflicts are from the legacy detection system. Run plur_tensions_purge to clear them, then use scan:true for active contradiction detection.',
             })
           }
         }
 
-        const purge_hint = tensions.length > 0
-          ? 'These are legacy conflict relations. Run plur_tensions_purge to clear them.'
-          : undefined
-
-        return { tensions, count: tensions.length, ...(purge_hint ? { purge_hint } : {}) }
+        return {
+          tensions: records,
+          count: records.length,
+          ...(legacy.length > 0 ? {
+            legacy_conflicts: legacy,
+            purge_hint: 'legacy_conflicts are unvalidated relations.conflicts refs (importer heuristics or pre-#138 residue) — run scan:true to judge them, or plur_tensions_purge to clear them.',
+          } : {}),
+          ...(records.length === 0 && legacy.length === 0
+            ? { hint: 'No persisted tensions. Run scan:true to detect contradictions.' }
+            : {}),
+        }
       },
     },
 

--- a/packages/mcp/test/tensions-lifecycle.test.ts
+++ b/packages/mcp/test/tensions-lifecycle.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { Plur } from '@plur-ai/core'
+import { getToolDefinitions } from '../src/tools.js'
+
+/**
+ * plur_tensions lifecycle wiring (#181): scan persistence + suppress-list,
+ * confirm/dismiss/resolve actions, injection warnings through the MCP
+ * surface.
+ */
+describe('plur_tensions lifecycle (#181)', () => {
+  let dir: string
+  let plur: Plur
+  let originalFetch: typeof globalThis.fetch
+  const tools = getToolDefinitions()
+  const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
+  const injectTool = tools.find(t => t.name === 'plur_inject')!
+
+  const LLM_ARGS = { llm_base_url: 'https://api.openai.com/v1', llm_api_key: 'test-key' }
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-tensions-lc-'))
+    plur = new Plur({ path: dir })
+    originalFetch = globalThis.fetch
+    delete (process.env as any).OPENAI_API_KEY
+    delete (process.env as any).OPENROUTER_API_KEY
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  function mockYesLlm() {
+    const fetchMock = vi.fn().mockImplementation(async (_url: any, init: any) => {
+      const prompt: string = JSON.parse(init.body).messages[0].content
+      const n = (prompt.match(/PAIR \d+/g) ?? []).length
+      const content = n > 0
+        ? Array.from({ length: n }, (_, i) => `PAIR_${i + 1}: CONTRADICTS: yes | CONFIDENCE: 0.9 | REASON: Opposite claims.`).join('\n')
+        : 'CONTRADICTS: yes\nCONFIDENCE: 0.9\nREASON: Opposite claims.'
+      return { ok: true, json: async () => ({ choices: [{ message: { content } }] }) }
+    })
+    globalThis.fetch = fetchMock as any
+    return fetchMock
+  }
+
+  it('scan persists new detections as tension records', async () => {
+    plur.learn('plur cli version is 0.3.0')
+    plur.learn('plur cli version is 0.8.2')
+    mockYesLlm()
+
+    const result = await tensionsTool.handler({ scan: true, ...LLM_ARGS }, plur) as any
+    expect(result.count).toBe(1)
+    expect(result.persisted_new).toBe(1)
+    expect(result.tensions[0].tension_id).toMatch(/^T-/)
+    expect(result.tensions[0].category).toBeDefined()
+    expect(result.next_steps).toContain('confirm')
+
+    // Records visible in list mode
+    const list = await tensionsTool.handler({}, plur) as any
+    expect(list.count).toBe(1)
+    expect(list.tensions[0].id).toBe(result.tensions[0].tension_id)
+    expect(list.tensions[0].status).toBe('detected')
+  })
+
+  it('a second scan skips the recorded pair (no LLM calls)', async () => {
+    plur.learn('plur cli version is 0.3.0')
+    plur.learn('plur cli version is 0.8.2')
+    mockYesLlm()
+    await tensionsTool.handler({ scan: true, ...LLM_ARGS }, plur)
+
+    const fetchMock = mockYesLlm()
+    const second = await tensionsTool.handler({ scan: true, ...LLM_ARGS }, plur) as any
+    expect(second.pairs_checked).toBe(0)
+    expect(second.count).toBe(0)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('persist:false is a dry run — nothing recorded, suppress-list ignored', async () => {
+    plur.learn('plur cli version is 0.3.0')
+    plur.learn('plur cli version is 0.8.2')
+    mockYesLlm()
+
+    const result = await tensionsTool.handler({ scan: true, persist: false, ...LLM_ARGS }, plur) as any
+    expect(result.count).toBe(1)
+    expect(result.persisted_new).toBeUndefined()
+    expect(plur.listTensions()).toHaveLength(0)
+  })
+
+  it('confirm action marks the record confirmed', async () => {
+    plur.learn('plur cli version is 0.3.0')
+    plur.learn('plur cli version is 0.8.2')
+    mockYesLlm()
+    const scan = await tensionsTool.handler({ scan: true, ...LLM_ARGS }, plur) as any
+    const id = scan.tensions[0].tension_id
+
+    const result = await tensionsTool.handler({ action: 'confirm', id }, plur) as any
+    expect(result.record.status).toBe('confirmed')
+    expect(result.message).toContain(id)
+  })
+
+  it('dismiss action suppresses the pair', async () => {
+    plur.learn('plur cli version is 0.3.0')
+    plur.learn('plur cli version is 0.8.2')
+    mockYesLlm()
+    const scan = await tensionsTool.handler({ scan: true, ...LLM_ARGS }, plur) as any
+
+    const result = await tensionsTool.handler({ action: 'dismiss', id: scan.tensions[0].tension_id }, plur) as any
+    expect(result.record.status).toBe('dismissed')
+
+    // Dismissed records leave the default list view but stay under status:all
+    const list = await tensionsTool.handler({}, plur) as any
+    expect(list.count).toBe(0)
+    const all = await tensionsTool.handler({ status: 'all' }, plur) as any
+    expect(all.count).toBe(1)
+  })
+
+  it('resolve action retires the losing engram', async () => {
+    const a = plur.learn('plur cli version is 0.3.0')
+    const b = plur.learn('plur cli version is 0.8.2')
+    mockYesLlm()
+    const scan = await tensionsTool.handler({ scan: true, ...LLM_ARGS }, plur) as any
+    const id = scan.tensions[0].tension_id
+
+    const result = await tensionsTool.handler({ action: 'resolve', id, winner: b.id }, plur) as any
+    expect(result.record.status).toBe('resolved')
+    expect(result.record.resolved_by).toBe(b.id)
+    expect(result.retired).toBe(a.id)
+    expect(plur.getById(a.id)?.status).toBe('retired')
+    expect(plur.getById(b.id)?.status).toBe('active')
+  })
+
+  it('resolve without winner and unknown actions fail loudly', async () => {
+    await expect(tensionsTool.handler({ action: 'resolve', id: 'T-0000-0000-001' }, plur)).rejects.toThrow(/winner/)
+    await expect(tensionsTool.handler({ action: 'confirm' }, plur)).rejects.toThrow(/requires id/)
+  })
+
+  it('plur_inject surfaces tension warnings for confirmed tensions', async () => {
+    const a = plur.learn('use tabs for indentation everywhere', { pinned: true })
+    const b = plur.learn('completely unrelated database fact')
+    const { records } = plur.recordTensions([{
+      id_a: a.id, id_b: b.id,
+      statement_a: a.statement, statement_b: b.statement,
+      confidence: 0.9, reason: 'Opposite.',
+    }])
+    plur.confirmTension(records[0].id)
+
+    const result = await injectTool.handler({ task: 'anything' }, plur) as any
+    expect(result.warnings).toBeDefined()
+    expect(result.warnings[0]).toContain(records[0].id)
+  })
+})

--- a/packages/mcp/test/tensions.test.ts
+++ b/packages/mcp/test/tensions.test.ts
@@ -82,13 +82,15 @@ describe('plur_tensions tool', () => {
     }
   })
 
-  it('includes purge_hint when legacy conflict relations exist', async () => {
+  it('surfaces legacy conflict relations separately with a purge hint (#181)', async () => {
     const e1 = plur.learn('Always use PostgreSQL')
     const e2 = plur.learn('Always use MySQL')
     injectLegacyConflict(plur, e1.id, e2.id)
 
     const result = await tensionsTool.handler({}, plur) as any
-    expect(result.count).toBe(1)
+    // legacy relations.conflicts refs are NOT persisted tension records
+    expect(result.count).toBe(0)
+    expect(result.legacy_conflicts).toHaveLength(1)
     expect(result.purge_hint).toBeDefined()
     expect(result.purge_hint).toContain('plur_tensions_purge')
   })
@@ -462,7 +464,7 @@ describe('plur_tensions_purge tool', () => {
     injectLegacyConflict(plur, e1.id, e2.id)
 
     const before = await tensionsTool.handler({}, plur) as any
-    expect(before.count).toBe(1)
+    expect(before.legacy_conflicts).toHaveLength(1)
 
     const purgeResult = await purgeTool.handler({}, plur) as any
     expect(purgeResult.purged_conflict_refs).toBe(1)
@@ -470,7 +472,7 @@ describe('plur_tensions_purge tool', () => {
     expect(purgeResult.message).toContain('1')
 
     const after = await tensionsTool.handler({}, plur) as any
-    expect(after.count).toBe(0)
+    expect(after.legacy_conflicts).toBeUndefined()
     expect(after.purge_hint).toBeUndefined()
   })
 


### PR DESCRIPTION
Closes #181

Tension detection Phase 3: persisted lifecycle. Scan verdicts stop being ephemeral — they become durable records with a confirm/dismiss/resolve workflow, a suppress-list, injection warnings, and a lock-escalation gate. Directly implements the four must-have items of the [#213 audit](https://github.com/plur-ai/plur/issues/213#issuecomment-4873884508) (C1, C2, C5, items 3–4).

## Audit-first

`plur_tensions` / `plur_tensions_purge` already existed; per the tracker, only the remainder was built. What existed vs what this adds:

| Surface | Before | Now |
|---|---|---|
| Scan verdicts | returned to caller, dropped (every scan re-pays LLM calls) | persisted as `TensionRecord`s in `tensions.yaml`, `contradiction_detected` history event emitted (type existed since SP2 with **zero emitters** — audit C5) |
| False positives | re-flagged forever | `dismiss` → pair suppressed from all future scans |
| Real conflicts | no representation | `confirm` → surfaces as `warnings` in inject results |
| Resolution | manual `plur_forget` (reference-counted — a multiply-learned loser survives, audit §2) | `resolve --winner` → loser retired **outright**, record stamped `resolved_by`/`resolved_at` |
| `tension_count` in status | counted unvalidated `relations.conflicts` heuristics (audit C2: "measures the wrong detector") | counts unresolved persisted records |
| Importer conflict suspects | written "for the scan to confirm" but the scan **skipped** known-conflict pairs — the one class of pairs flagged for judging was the one class never judged (audit C1) | the `relations.conflicts` skip is dropped; suspects get judged; suppression comes from records instead |
| #176 lock escalation | contradicted engrams marched to `locked` with no tension check (audit item 3; 162 locked / 0 persisted conflicts on the real store) | cross-scope recurrence caps at `decided` while the engram has an unresolved persisted tension; resolving/dismissing re-opens the path |

## Design

**Record schema** (`schemas/tension.ts`, stored in `tensions.yaml` next to `engrams.yaml`, added to the sync allowlist):

```yaml
- id: T-2026-0703-001            # numbered per detection day
  engram_a: ENG-...              # + statement snapshots (engrams may be edited/retired later)
  engram_b: ENG-...
  confidence: 0.9
  reason: "A says JSON files, B says single YAML"
  detected_at: 2026-07-03T...
  status: detected               # detected | confirmed | dismissed | resolved
  resolved_by: null              # winner engram id
  resolved_at: null
  category: factual              # factual | temporal | superseded
```

**Lifecycle** — `detected → confirmed → resolved` / `detected|confirmed → dismissed`; terminal states enforced. Any recorded pair (whatever its status) is excluded from future scans: dismissals are the suppress-list, detections/confirmations are already adjudicated and never re-pay the judge.

**Categories (v1, deterministic):** `superseded` on an explicit "(not X)" correction marker; `temporal` when both engrams carry derivable recorded dates ≥1 day apart; else `factual`. Advisory only — resolution never branches on category — and documented as replaceable by judge-assisted categorization without a schema change.

**Injection integration** (audit item 4 — *surface, don't adjudicate*): `InjectionResult.warnings` when a confirmed tension has **either** side injected, or a detected tension has **both** sides injected together. Passed through `plur_inject` / `plur_inject_hybrid`. Best-effort: a tension-store problem can never break injection.

**Surface:**
- MCP `plur_tensions`: `scan:true` persists new detections (`persist:false` = dry run), `action:"confirm"|"dismiss"|"resolve"` + `id` (+ `winner`), `status` list filter. Legacy `relations.conflicts` refs are surfaced separately as `legacy_conflicts` with a purge hint.
- CLI: `plur tensions` (list), `--scan [--no-persist]`, `confirm <T-id>`, `dismiss <T-id>`, `resolve <T-id> --winner <engram-id>`, `--status all|detected|...`.

## Deliberately out of scope

- Auto-resolve without confirmation (Phase 4, per issue) and cross-store detection (enterprise).
- #115 correction-detection hookup (auto-create superseded tensions from Hermes corrections) — belongs with #115.
- Proactive tension surfacing in `plur_session_start` (audit §5) — injection warnings cover the agent-facing path; session surfacing is a UX decision worth its own slice.
- Audit C6 (dead `conflictIds` in `learn()`) — that region is touched by #482 (in review); cleaning it here would manufacture a conflict.
- Audit C7 (feedback commitment asymmetry) and C8 (`engram_version` lineage) — unrelated to tension lifecycle.
- Note: audit item 3 also names `feedback()` commitment promotion, but that ladder caps at `decided` by construction (exploring→leaning→decided, never locked), so only the cross-scope recurrence path needed the gate.

## Tests (39 new)

- `packages/core/test/tension-lifecycle.test.ts` — 26: persistence + reload, pair dedupe (both directions), history events, tension_count, id/category helpers, scan suppression, C1 (conflicts edge no longer exempts), confirm/dismiss/resolve incl. terminal-state and bad-winner errors, decisive retirement of a multiply-learned loser, injection warnings (confirmed-either / detected-both / resolved-never), lock gate (baseline locks, tension blocks, resolution re-opens).
- `packages/mcp/test/tensions-lifecycle.test.ts` — 8: scan persistence, second-scan suppression (zero LLM calls), dry run, actions, inject warnings via MCP.
- `packages/cli/test/tensions-lifecycle.test.ts` — 5: scan→persist→suppress round-trip, `--no-persist`, list/status filters, confirm+resolve retiring the loser, usage errors.
- 3 existing tests updated to the new contract (legacy conflicts under `legacy_conflicts`; C1 skip reversal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
