### PR TITLE
fix(core): async UPDATE/MERGE increments engram_version not version (#484)

### DIFF
--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -117,7 +117,7 @@ function executeDedupDecision(
             const updated = { ...engrams[idx] } as any
             updated.statement = statement
             updated.content_hash = computeContentHash(statement)
-            updated.version = (updated.version ?? 1) + 1
+            updated.engram_version = (updated.engram_version ?? 1) + 1
             updated.activation.last_accessed = new Date().toISOString().slice(0, 10)
             if (context?.tags) updated.tags = [...new Set([...updated.tags, ...context.tags])]
             // Leak guard (#353): a dedup UPDATE can introduce sensitive content
@@ -150,7 +150,7 @@ function executeDedupDecision(
             const merged = { ...engrams[idx] } as any
             merged.statement = `${merged.statement} ${statement}`
             merged.content_hash = computeContentHash(merged.statement)
-            merged.version = (merged.version ?? 1) + 1
+            merged.engram_version = (merged.engram_version ?? 1) + 1
             merged.activation.last_accessed = new Date().toISOString().slice(0, 10)
             if (context?.tags) merged.tags = [...new Set([...merged.tags, ...context.tags])]
             if (0.7 > merged.activation.retrieval_strength) merged.activation.retrieval_strength = 0.7

--- a/packages/core/test/learn-async-scope.test.ts
+++ b/packages/core/test/learn-async-scope.test.ts
@@ -113,6 +113,47 @@ describe('learnAsync scope-aware LLM dedup (issue #359)', () => {
   })
 })
 
+// #484: async UPDATE/MERGE must increment `engram_version` (content-evolution
+// counter used by previous_version chains), not `version` (schema-shape field).
+describe('learnAsync UPDATE/MERGE increment engram_version not version (#484)', () => {
+  let dir: string
+  let engramsPath: string
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }) })
+
+  function depsWithFile(candidates: Engram[]): LearnAsyncDeps {
+    dir = mkdtempSync(join(tmpdir(), 'plur-484-'))
+    engramsPath = join(dir, 'engrams.yaml')
+    saveEngrams(engramsPath, candidates)
+    return { ...makeDeps(candidates), engramsPath, rootPath: dir }
+  }
+
+  it('UPDATE increments engram_version and leaves version untouched', async () => {
+    const seed = { ...globalCandidate, id: 'ENG-2026-0101-484a', scope: 'global', engram_version: 3, version: 2 } as unknown as Engram
+    const deps = depsWithFile([seed])
+    const llm = vi.fn().mockResolvedValue('DECISION: UPDATE\nTARGET: ENG-2026-0101-484a\nREASON: same topic')
+
+    const result = await learnAsync(deps, 'updated statement', { llm })
+
+    expect(result.decision).toBe('UPDATE')
+    const persisted = loadEngrams(engramsPath).find(e => e.id === 'ENG-2026-0101-484a') as any
+    expect(persisted.engram_version).toBe(4)   // incremented
+    expect(persisted.version).toBe(2)           // schema-shape, untouched
+  })
+
+  it('MERGE increments engram_version and leaves version untouched', async () => {
+    const seed = { ...globalCandidate, id: 'ENG-2026-0101-484b', scope: 'global', engram_version: 2, version: 2 } as unknown as Engram
+    const deps = depsWithFile([seed])
+    const llm = vi.fn().mockResolvedValue('DECISION: MERGE\nTARGET: ENG-2026-0101-484b\nREASON: complementary')
+
+    const result = await learnAsync(deps, 'extra clause', { llm })
+
+    expect(result.decision).toBe('MERGE')
+    const persisted = loadEngrams(engramsPath).find(e => e.id === 'ENG-2026-0101-484b') as any
+    expect(persisted.engram_version).toBe(3)   // incremented
+    expect(persisted.version).toBe(2)           // schema-shape, untouched
+  })
+})
+
 // #409: a dedup UPDATE/MERGE unions context.tags into the engram, but the demote
 // scan only looked at the statement — a secret in a merged TAG reached the shared
 // store unguarded. The demote now scans statement + tags.


### PR DESCRIPTION
## Summary

- `executeDedupDecision` UPDATE and MERGE paths in `learn-async.ts` were incrementing `version` (the schema-shape generation counter) instead of `engram_version` (the content-evolution counter that backs previous_version lineage chains)
- The sync UPDATE path in `index.ts` has always used `engram_version` correctly — this was an asymmetry introduced when the async path was split into its own file
- Two regression tests added: assert `engram_version` increments and `version` stays untouched for both UPDATE and MERGE decisions

## Test plan

- [x] `packages/core/test/learn-async-scope.test.ts` — 7 tests pass (5 existing + 2 new #484 regression tests)
- [x] New tests confirm `engram_version` increments from N to N+1 and `version` (schema-shape field) is not touched

Fixes #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)