### PR TITLE
fix(core): complete the EMBED_DIM contract — active-dim column sizing + storage-boundary enforcement (#335)

### DIFF
--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -122,6 +122,24 @@ export function resetEmbedder(): void {
   embedPipeline = null
 }
 
+/**
+ * Test-only: install a stub adapter as the active embedder so tests can
+ * exercise the embed()/activeEmbedderDim() contracts (#335) without a
+ * model load. Mirrors rerankers' `_setCachedReranker`. Production code
+ * never calls this; pair with `resetEmbedder()` in afterEach.
+ */
+export function _setCachedEmbedder(adapter: {
+  name: string
+  dim: number
+  modelId: string
+  embed(text: string): Promise<Float32Array>
+  embedBatch(texts: string[]): Promise<Float32Array[]>
+}): void {
+  embedPipeline = adapter
+  transformersUnavailable = false
+  lastLoadError = null
+}
+
 async function getEmbedder() {
   if (embeddingsDisabled) return null
   if (embedPipeline) return embedPipeline

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -375,6 +375,13 @@ export class Plur {
       // vector.precision (#223): unset = keep the store's existing column
       // type; 'halfvec' opts in to fp16 storage (lazy in-place migration).
       this.pgliteAdapter = new PGLiteAdapter(this.paths.engrams, this.paths.pglite, {
+        // #335: size the vector column from the ACTIVE embedder (PLUR_EMBEDDER),
+        // not the 384 default constant — bge-base/embedding-gemma are 768,
+        // openai-3-large is 3072. Metadata-only: adapters construct lazily,
+        // no model load happens here. Existing stores keep their on-disk
+        // column (ensureColumnPrecision reads reality); mismatches surface
+        // via the doctor dim-check + the upsert-time guard.
+        vectorDim: getEmbedder(resolveEmbedderName()).dim,
         precision: this.config.vector?.precision,
       })
       // Initial sync runs in the background — YAML is already authoritative,

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -137,6 +137,14 @@ export class PGLiteAdapter implements StorageAdapter {
    * and writes keep matching the on-disk column instead of erroring.
    */
   private activeVecType: 'vector' | 'halfvec' = 'vector'
+  /**
+   * ACTUAL dim of the embedding column after init (#335). For existing
+   * stores this is the on-disk column's dim, which may differ from the
+   * requested `vectorDim` — writes are enforced against reality, not the
+   * request. Null on the BYTEA fallback (no column constraint), where
+   * `vectorDim` is the enforcement contract instead.
+   */
+  private activeVecDim: number | null = null
   private db: any = null
   private initialized = false
   private hasVector = false
@@ -288,6 +296,9 @@ export class PGLiteAdapter implements StorageAdapter {
     const info = await this.readEmbeddingColumnInfo(db)
     if (!info) return // BYTEA fallback or exotic column — nothing to manage
     this.activeVecType = info.type
+    // #335: track the on-disk dim so writes are enforced against reality
+    // (existing stores keep their column; see upsertEmbedding).
+    this.activeVecDim = info.dim
     if (this.precision === undefined) return // keep-existing semantics
     const wantType = PRECISION_TYPE[this.precision]
     if (info.type === wantType) return
@@ -542,6 +553,20 @@ export class PGLiteAdapter implements StorageAdapter {
   async upsertEmbedding(engramId: string, vector: Float32Array): Promise<void> {
     return this.mutex.run(async () => {
       const db = await this.getDb()
+      // #335 storage-boundary contract: a wrong-shape vector must never be
+      // persisted. On the pgvector path this turns a cryptic pgvector error
+      // into a targeted one; on the BYTEA fallback (no column constraint)
+      // this is the ONLY guard — previously any length was silently stored
+      // and cosineSimilarity later returned garbage over min(a, b).
+      const expectedDim = this.activeVecDim ?? this.vectorDim
+      if (vector.length !== expectedDim) {
+        throw new Error(
+          `[pglite] Refusing to persist a ${vector.length}-dim embedding for "${engramId}": ` +
+          `this store's embedding ${this.hasVector ? 'column' : 'table'} is ${expectedDim}-dim (#335). ` +
+          `The active embedder (PLUR_EMBEDDER) and the indexed store must agree — ` +
+          `run 'plur sync --reembed --full' to rebuild the index at the active embedder's dim.`,
+        )
+      }
       if (this.hasVector) {
         // Cast to the column's actual type (#223): halfvec parses the same
         // "[...]" literal and rounds to fp16 on write.

--- a/packages/core/test/embed-dim-contract.test.ts
+++ b/packages/core/test/embed-dim-contract.test.ts
@@ -1,0 +1,239 @@
+/**
+ * EMBED_DIM contract — #335 (Sprint-0 integration C).
+ *
+ * The resolved design (option 2 + derived accessor, per the issue):
+ *   - `EMBED_DIM = 384` stays exported as the DEFAULT embedder's dim only —
+ *     a documented back-compat constant, pinned to `bge-small`.
+ *   - `activeEmbedderDim()` is the source of truth for the dim this install
+ *     actually produces (PLUR_EMBEDDER-dependent: 384 / 768 / 3072).
+ *   - `embed()` asserts every adapter output against the adapter's DECLARED
+ *     dim — a model/adapter disagreement throws instead of persisting
+ *     corrupt vectors.
+ *   - The storage boundary re-enforces dim-correctness: the PGLite vector
+ *     column is sized from the ACTIVE embedder (not the 384 constant), and
+ *     `upsertEmbedding` rejects wrong-shape vectors with a targeted error on
+ *     BOTH the pgvector and BYTEA paths (BYTEA previously persisted any
+ *     length silently — the exact #290-style silent drift #335 forbids).
+ *
+ * Cross-shape equivalence (ADR-0001): YAML stays the source of truth and the
+ * index is rebuildable at ANY supported shape — the same store roundtrips
+ * identically whether the vector column is 384 (bge-small, default),
+ * 768 (EmbeddingGemma / bge-base) or 3072 (openai-3-large).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import { Plur } from '../src/index.js'
+import {
+  EMBED_DIM,
+  activeEmbedderDim,
+  embed,
+  resetEmbedder,
+  _setCachedEmbedder,
+} from '../src/embeddings.js'
+import { getEmbedder, DEFAULT_EMBEDDER, _resetEmbedderCache } from '../src/embedders/index.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function mkEngram(id: string, statement: string): Engram {
+  return {
+    id,
+    statement,
+    type: 'behavioral',
+    scope: 'project:plur',
+    domain: 'plur.test',
+    status: 'active',
+    tags: [],
+    activation: {
+      retrieval_strength: 1.0,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-05-30',
+    },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+  } as unknown as Engram
+}
+
+function seedYaml(path: string, engrams: Engram[]): void {
+  writeFileSync(path, yaml.dump({ engrams }), 'utf8')
+}
+
+/** Deterministic unit vector of a given dim (varies by seed so cosine ranks are stable). */
+function vec(dim: number, seed: number): Float32Array {
+  const v = new Float32Array(dim)
+  for (let i = 0; i < dim; i++) v[i] = Math.sin(seed * 997 + i)
+  let norm = 0
+  for (let i = 0; i < dim; i++) norm += v[i] * v[i]
+  norm = Math.sqrt(norm)
+  for (let i = 0; i < dim; i++) v[i] /= norm
+  return v
+}
+
+const PGLITE_TIMEOUT = 60_000
+
+// ─── The exported constant: default-only, factory-derived reality ────
+
+describe('EMBED_DIM constant vs factory dims (#335)', () => {
+  it('EMBED_DIM equals the DEFAULT embedder dim (bge-small, 384) — and nothing else', () => {
+    expect(EMBED_DIM).toBe(384)
+    expect(getEmbedder(DEFAULT_EMBEDDER).dim).toBe(EMBED_DIM)
+    expect(DEFAULT_EMBEDDER).toBe('bge-small')
+  })
+
+  it('the three contract shapes: bge-small 384, embedding-gemma 768, openai-3-large 3072', () => {
+    expect(getEmbedder('bge-small').dim).toBe(384)
+    expect(getEmbedder('embedding-gemma').dim).toBe(768)
+    expect(getEmbedder('openai-3-large').dim).toBe(3072)
+  })
+})
+
+// ─── embed() output assertion + activeEmbedderDim ────────────────────
+
+describe('embed() asserts declared vs produced dim (#335 / #290)', () => {
+  afterEach(() => {
+    resetEmbedder()
+    _resetEmbedderCache()
+  })
+
+  it('returns the vector when the adapter honors its declared dim', async () => {
+    _setCachedEmbedder({
+      name: 'stub-768',
+      dim: 768,
+      modelId: 'stub',
+      embed: async () => vec(768, 1),
+      embedBatch: async (texts: string[]) => texts.map((_, i) => vec(768, i)),
+    })
+    const out = await embed('hello')
+    expect(out).not.toBeNull()
+    expect(out!.length).toBe(768)
+    expect(await activeEmbedderDim()).toBe(768)
+  })
+
+  it('THROWS (not null) when the adapter produces a different dim than declared', async () => {
+    _setCachedEmbedder({
+      name: 'stub-liar',
+      dim: 768,
+      modelId: 'stub',
+      embed: async () => vec(384, 1), // model disagrees with declaration
+      embedBatch: async (texts: string[]) => texts.map((_, i) => vec(384, i)),
+    })
+    await expect(embed('hello')).rejects.toThrow(/dimension mismatch/i)
+  })
+})
+
+// ─── Storage boundary: PGLite column sized + writes enforced ─────────
+
+describe.each([
+  { embedderName: 'bge-small', dim: 384 },
+  { embedderName: 'embedding-gemma', dim: 768 },
+  { embedderName: 'openai-3-large', dim: 3072 },
+])('PGLite cross-shape roundtrip at $dim d ($embedderName) — ADR-0001 (#335)', ({ dim }) => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-dim-contract-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'store.pglite')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it(`sizes the column to ${dim}, roundtrips vectors, rejects wrong shapes, and rebuilds from YAML`, async () => {
+    seedYaml(yamlPath, [mkEngram('ENG-A', 'alpha statement'), mkEngram('ENG-B', 'beta statement')])
+    const adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: dim })
+    try {
+      await adapter.reindex()
+
+      // Column is sized to the active shape (pgvector path only — BYTEA has no column dim).
+      const colDim = await adapter.getVectorColumnDim()
+      if (colDim !== null) expect(colDim).toBe(dim)
+
+      // Correct-shape writes roundtrip: nearest neighbor of A's vector is A.
+      await adapter.upsertEmbedding('ENG-A', vec(dim, 1))
+      await adapter.upsertEmbedding('ENG-B', vec(dim, 2))
+      const hits = await adapter.searchVector(vec(dim, 1), 2)
+      expect(hits.length).toBe(2)
+      expect(hits[0].engram.id).toBe('ENG-A')
+      expect(hits[0].score).toBeGreaterThan(0.99)
+
+      // Wrong-shape writes are REJECTED with a targeted error — on the
+      // pgvector path (clear message instead of a cryptic pgvector error)
+      // and on the BYTEA path (previously silently persisted). Assert OUR
+      // guard's message, not pgvector's, so the BYTEA-shared code path is
+      // what's proven.
+      await expect(adapter.upsertEmbedding('ENG-B', vec(dim + 8, 3)))
+        .rejects.toThrow(new RegExp(`Refusing to persist a ${dim + 8}-dim embedding.*${dim}-dim`, 's'))
+
+      // The rejected write must not have clobbered the good vector.
+      const stillGood = await adapter.searchVector(vec(dim, 2), 1)
+      expect(stillGood[0].engram.id).toBe('ENG-B')
+
+      // ADR-0001 rebuildability: reindex() drops + rebuilds rows from YAML
+      // at the same shape; engram rows survive, embeddings are rebuildable.
+      await adapter.reindex()
+      const all = await adapter.loadFiltered({})
+      expect(all.map(e => e.id).sort()).toEqual(['ENG-A', 'ENG-B'])
+      await adapter.upsertEmbedding('ENG-A', vec(dim, 1))
+      const postRebuild = await adapter.searchVector(vec(dim, 1), 1)
+      expect(postRebuild[0].engram.id).toBe('ENG-A')
+    } finally {
+      await adapter.close()
+    }
+  }, PGLITE_TIMEOUT)
+})
+
+// ─── Plur wires the ACTIVE embedder dim into the column ──────────────
+
+describe('Plur constructor sizes the PGLite column from the active embedder (#335)', () => {
+  let dir: string
+  const savedBackend = process.env.PLUR_BACKEND
+  const savedEmbedder = process.env.PLUR_EMBEDDER
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-dim-plur-'))
+    process.env.PLUR_BACKEND = 'pglite'
+  })
+
+  afterEach(() => {
+    if (savedBackend === undefined) delete process.env.PLUR_BACKEND
+    else process.env.PLUR_BACKEND = savedBackend
+    if (savedEmbedder === undefined) delete process.env.PLUR_EMBEDDER
+    else process.env.PLUR_EMBEDDER = savedEmbedder
+    _resetEmbedderCache()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('default install → 384 column (EMBED_DIM back-compat holds)', async () => {
+    delete process.env.PLUR_EMBEDDER
+    const plur = new Plur({ path: dir })
+    const adapter = (plur as any).pgliteAdapter as PGLiteAdapter
+    expect(adapter).toBeTruthy()
+    try {
+      await plur.waitForIndex()
+      const colDim = await adapter.getVectorColumnDim()
+      if (colDim !== null) expect(colDim).toBe(EMBED_DIM)
+    } finally {
+      await adapter.close()
+    }
+  }, PGLITE_TIMEOUT)
+
+  it('PLUR_EMBEDDER=bge-base → 768 column, NOT the 384 constant', async () => {
+    process.env.PLUR_EMBEDDER = 'bge-base'
+    const plur = new Plur({ path: dir })
+    const adapter = (plur as any).pgliteAdapter as PGLiteAdapter
+    expect(adapter).toBeTruthy()
+    try {
+      await plur.waitForIndex()
+      const colDim = await adapter.getVectorColumnDim()
+      if (colDim !== null) expect(colDim).toBe(768)
+    } finally {
+      await adapter.close()
+    }
+  }, PGLITE_TIMEOUT)
+})


### PR DESCRIPTION
Refs #335 (Sprint-0 integration C, part of #332).

## The decision

**Option 2 + derived accessor** — `EMBED_DIM = 384` stays exported strictly as *the default embedder's dim* (back-compat for #289/#290 consumers), and `activeEmbedderDim()` is the source of truth for what this install actually produces. Main already had the constant's documentation, the accessor, and the `embed()` declared-vs-produced assertion; **what it did not have is the wiring that makes variable dims actually work, or the storage boundary the issue calls for.** This PR completes both.

## Audit finding (the real bug)

The issue text assumed "the PGLite constructor in sub-B already reads `getEmbedder(resolveEmbedderName()).dim`" — on current main it does **not** (likely lost in the post-scrub re-land). `Plur`'s constructor built `PGLiteAdapter` without `vectorDim`, so a **fresh PGLite store under `PLUR_EMBEDDER=bge-base|embedding-gemma|openai-3-large` got a `vector(384)` column** and every 768/3072-dim upsert failed against pgvector; the auto-embed path then skipped everything.

## Changes

1. **Active-dim column sizing** — `Plur` passes `vectorDim: getEmbedder(resolveEmbedderName()).dim` to `PGLiteAdapter`. Metadata-only (adapters construct lazily; no model load, no API call). Existing stores keep their on-disk column: `ensureColumnPrecision` reads reality and mismatches surface via the existing doctor dim-check.
2. **Storage-boundary enforcement** — the adapter now tracks the on-disk column dim at init (`activeVecDim`) and `upsertEmbedding` **refuses wrong-shape vectors** with a targeted #335 error naming both dims and the `plur sync --reembed --full` remediation. On the pgvector path this converts a cryptic pgvector error; on the **BYTEA fallback it is the only guard** — previously any length was silently persisted, and `cosineSimilarity` later returned garbage over `min(a, b)` (the exact #290-style silent drift). The auto-embed path already skips dim mismatches and catches all errors, so `learn()` cannot crash on this.
3. **Test hook** — `_setCachedEmbedder` in `embeddings.ts` (mirrors rerankers' `_setCachedReranker`), enabling the first tests of the `embed()` dim assertion without a model download.

## Cross-shape equivalence tests (ADR-0001) — `embed-dim-contract.test.ts`, 9 tests

- The three contract shapes hold: `bge-small` 384 (= `EMBED_DIM`, = `DEFAULT_EMBEDDER`), `embedding-gemma` 768, `openai-3-large` 3072 — factory metadata, no model loads.
- `embed()` returns the vector when the adapter honors its declared dim; **throws** (never null / never persists) when the model disagrees with the declaration.
- Parameterized over 384/768/3072: PGLite column sized to the shape, identical-vector roundtrip via `searchVector` (score > 0.99), wrong-shape write rejected with **our** guard's message (not pgvector's), rejected write doesn't clobber good vectors, and `reindex()` rebuilds rows from YAML at the same shape (YAML-as-truth rebuildability invariant).
- `Plur` constructor sizing: default install → 384 column; `PLUR_EMBEDDER=bge-base` → 768 column.

## Tests

Full core suite on this branch: **1772 passed / 31 skipped / 0 failed**. mcp 172 passed, cli 238 passed (one flaky cli failure under load did not reproduce on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aLoB2xRrqrqtXuqpt2Cf1