### PR TITLE
fix(core): EmbeddingGemma — use sentence_embedding graph output + role prefixes (#483)

### DIFF
--- a/packages/core/src/embedders/embedding-gemma.ts
+++ b/packages/core/src/embedders/embedding-gemma.ts
@@ -5,35 +5,84 @@
  * on disk with int8/q8 quantisation. Apache 2.0.
  *
  * Model id: onnx-community/embeddinggemma-300m-ONNX — the community ONNX
- * conversion that ships with text/embed pipeline metadata. Recent
- * @huggingface/transformers releases (3.x) handle the gemma3_text model_type
- * via the feature-extraction pipeline. Pooling for EmbeddingGemma is the
- * "last token" / mean of the prompt+content tokens; we use mean here as the
- * pipeline's `mean` pooling matches the encoder semantics for this model.
+ * conversion. The ONNX graph ships two outputs: last_hidden_state [B,T,768]
+ * and sentence_embedding [B,768]. The sentence_embedding output is the
+ * complete official stack: mean pooling + Dense(768→3072) + Dense(3072→768)
+ * + L2 normalisation (from the sentence-transformers modules.json). The old
+ * adapter fed last_hidden_state through a JS-side mean pooling, skipping the
+ * two Dense projection layers — the resulting vectors had cos ≈ −0.003 against
+ * sentence_embedding and were in a different space from all published figures.
  *
- * Disk cost (FYI): q8 weights ~ 300 MB, fp32 ~ 1.2 GB. We prefer q8 here so
- * the bake-off lines up with the published EmbeddingGemma benchmarks (which
- * report numbers at q8) and so first-time download stays within reach on
- * laptop bandwidth.
+ * Fix (#483): load the model via AutoModel (not the feature-extraction pipeline)
+ * and read sentence_embedding directly. The adapter name is 'embedding-gemma@graph'
+ * (not 'embedding-gemma') so any caches built with wrong-space vectors are
+ * automatically detected as a name mismatch and rebuilt by embeddings.ts.
  *
- * If a future @huggingface/transformers version drops gemma3_text support
- * the adapter still loads — the lazy import will throw a descriptive error
- * at first embed() call rather than at module import time.
+ * Role prefixes: EmbeddingGemma is trained with asymmetric prefixes per the
+ * model card — "query: " for search queries, "passage: " for stored text.
+ * Callers pass role='query' for search; omitting role defaults to 'passage'.
+ *
+ * Disk cost: q8 weights ~ 300 MB. We use q8 to match published EmbeddingGemma
+ * benchmark numbers and keep first-run download manageable.
  */
-import { makeTransformersAdapter } from './transformers-base.js'
-import type { EmbedderAdapter } from './types.js'
+import type { EmbedderAdapter, EmbedRole } from './types.js'
 
 export const EMBEDDING_GEMMA_MODEL_ID = 'onnx-community/embeddinggemma-300m-ONNX'
+const DIM = 768
+
+// Minimal callable shapes for the transformers.js tokenizer and model.
+// We extract `sentence_embedding` from the ONNX graph directly — the pipeline
+// API only surfaces `last_hidden_state` after JS-side pooling, which skips
+// the two Dense post-pooling layers that are part of EmbeddingGemma's stack.
+type Tok = (text: string, opts: { padding: boolean; truncation: boolean }) => Promise<unknown>
+type Mdl = (inputs: unknown) => Promise<{ sentence_embedding: { data: Float32Array | number[] } }>
+
+let loaded: Promise<{ tokenizer: Tok; model: Mdl }> | null = null
+
+async function load(): Promise<{ tokenizer: Tok; model: Mdl }> {
+  if (!loaded) {
+    loaded = (async () => {
+      // Xet transfer protocol silently truncates ONNX files (#340). Disable it.
+      process.env.HF_HUB_DISABLE_XET ??= '1'
+      const { AutoTokenizer, AutoModel } = await import('@huggingface/transformers')
+      const tokenizer = (await AutoTokenizer.from_pretrained(EMBEDDING_GEMMA_MODEL_ID)) as unknown as Tok
+      const model = (await AutoModel.from_pretrained(EMBEDDING_GEMMA_MODEL_ID, { dtype: 'q8' })) as unknown as Mdl
+      return { tokenizer, model }
+    })()
+  }
+  return loaded
+}
+
+/** Reset the model + tokenizer cache. Test-only. */
+export function _resetEmbeddingGemmaCache(): void {
+  loaded = null
+}
 
 export function makeEmbeddingGemmaAdapter(): EmbedderAdapter {
-  return makeTransformersAdapter({
-    name: 'embedding-gemma',
-    dim: 768,
+  async function embedOne(text: string, role?: EmbedRole): Promise<Float32Array> {
+    const prefix = role === 'query' ? 'query: ' : 'passage: '
+    const { tokenizer, model } = await load()
+    const inputs = await tokenizer(prefix + text, { padding: true, truncation: true })
+    const outputs = await model(inputs)
+    const raw = outputs.sentence_embedding.data
+    const arr = raw instanceof Float32Array ? raw : new Float32Array(raw)
+    if (arr.length !== DIM) {
+      throw new Error(`EmbeddingGemma: expected ${DIM}-dim sentence_embedding, got ${arr.length}`)
+    }
+    return arr
+  }
+
+  return {
+    // '@graph' suffix distinguishes from old JS-side pooled vectors — embeddings.ts
+    // detects the name change and auto-invalidates any cached wrong-space data.
+    name: 'embedding-gemma@graph',
+    dim: DIM,
     modelId: EMBEDDING_GEMMA_MODEL_ID,
-    pooling: 'mean',
-    normalize: true,
-    // q8 picked to match the published EmbeddingGemma benchmark numbers and
-    // keep the first-run download manageable (~300MB instead of ~1.2GB).
-    dtype: 'q8',
-  })
+    embed: embedOne,
+    async embedBatch(texts: string[]): Promise<Float32Array[]> {
+      const out: Float32Array[] = []
+      for (const t of texts) out.push(await embedOne(t))
+      return out
+    },
+  }
 }

--- a/packages/core/src/embedders/index.ts
+++ b/packages/core/src/embedders/index.ts
@@ -35,7 +35,7 @@ import { makeEmbeddingGemmaAdapter } from './embedding-gemma.js'
 import { makeOpenAI3LargeAdapter } from './openai.js'
 import type { EmbedderAdapter } from './types.js'
 
-export type { EmbedderAdapter } from './types.js'
+export type { EmbedderAdapter, EmbedRole } from './types.js'
 
 /** All embedder names supported by the factory. Drives benchmark CLI parsing. */
 export const EMBEDDER_NAMES = [

--- a/packages/core/src/embedders/types.ts
+++ b/packages/core/src/embedders/types.ts
@@ -14,6 +14,13 @@
  * Adapters must be stateless w.r.t. caller — repeated embed("foo") calls
  * produce identical output once the model is loaded.
  */
+
+/** Asymmetric embedding role — models that use role-aware prefixes (e.g. EmbeddingGemma)
+ *  produce different vector spaces for queries vs passages. Pass 'query' when embedding
+ *  a search term and 'passage' (or omit) when embedding stored text. Adapters that
+ *  don't support role prefixes (BGE, MiniLM) silently ignore this field. */
+export type EmbedRole = 'query' | 'passage'
+
 export interface EmbedderAdapter {
   /** Short name used by --embedder and PLUR_EMBEDDER. */
   readonly name: string
@@ -22,7 +29,7 @@ export interface EmbedderAdapter {
   /** Hugging Face model id (or local path) the adapter loads. */
   readonly modelId: string
   /** Embed a single text. Loads the model on first call. */
-  embed(text: string): Promise<Float32Array>
+  embed(text: string, role?: EmbedRole): Promise<Float32Array>
   /** Embed N texts. Output order matches input order. */
   embedBatch(texts: string[]): Promise<Float32Array[]>
 }

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -1,4 +1,5 @@
 import type { Engram } from './schemas/engram.js'
+import type { EmbedRole } from './embedders/types.js'
 import { engramSearchText } from './fts.js'
 import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
@@ -146,8 +147,10 @@ async function getEmbedder() {
   }
 }
 
-/** Generate embedding for a text string. Returns the active embedder's native dim, or null if unavailable. */
-export async function embed(text: string): Promise<Float32Array | null> {
+/** Generate embedding for a text string. Returns the active embedder's native dim, or null if unavailable.
+ *  Pass role='query' when embedding search terms; omit or pass 'passage' for stored engram text.
+ *  Adapters that support asymmetric prefixes (EmbeddingGemma) use this to pick the correct space. */
+export async function embed(text: string, role?: EmbedRole): Promise<Float32Array | null> {
   const embedder = await getEmbedder()
   if (!embedder) return null
   // When the cached value is an EmbedderAdapter (PR 4 path) it has an .embed
@@ -156,7 +159,7 @@ export async function embed(text: string): Promise<Float32Array | null> {
   if (typeof embedder.embed === 'function') {
     let vector: Float32Array | null
     try {
-      vector = await embedder.embed(text)
+      vector = await embedder.embed(text, role)
     } catch (err) {
       transformersUnavailable = true
       lastLoadError = err instanceof Error ? err.message : String(err)
@@ -321,7 +324,7 @@ export async function embeddingSearch(
   const cache = loadCache(cachePath, activeMeta)
 
   // Embed the query
-  const queryEmbedding = await embed(query)
+  const queryEmbedding = await embed(query, 'query')
   if (!queryEmbedding) {
     // Embeddings unavailable — return empty (caller should fall back to BM25)
     return []
@@ -389,7 +392,7 @@ export async function embeddingSearchWithScores(
   const cache = loadCache(cachePath, activeMeta)
 
   // Embed the query
-  const queryEmbedding = await embed(query)
+  const queryEmbedding = await embed(query, 'query')
   if (!queryEmbedding) {
     // Embeddings unavailable — return empty (caller should fall back to BM25)
     return []

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1981,7 +1981,7 @@ export class Plur {
       return { engrams: [], mode: 'hybrid', embedderError: null, topScore: null, reranked: 0 }
     }
     const { embed } = await import('./embeddings.js')
-    const queryVec = await embed(query)
+    const queryVec = await embed(query, 'query')
     const status = embedderStatus()
     if (!queryVec) {
       return hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
@@ -2016,7 +2016,7 @@ export class Plur {
   private async _pgliteSemanticRecall(query: string, limit: number, filtered: Engram[]): Promise<Engram[]> {
     if (!this.pgliteAdapter) return []
     const { embed } = await import('./embeddings.js')
-    const queryVec = await embed(query)
+    const queryVec = await embed(query, 'query')
     if (!queryVec) {
       return embeddingSearch(filtered, query, limit, this.paths.root)
     }
@@ -2252,7 +2252,7 @@ export class Plur {
       let results: SimilarityResult[] = []
       if (this.pgliteAdapter) {
         const { embed } = await import('./embeddings.js')
-        const queryVec = await embed(task)
+        const queryVec = await embed(task, 'query')
         if (queryVec) {
           try {
             const hits = await this.pgliteAdapter.searchVector(queryVec, engrams.length)

--- a/packages/core/test/embedders.test.ts
+++ b/packages/core/test/embedders.test.ts
@@ -8,7 +8,7 @@
  *     readonly name: string
  *     readonly dim: number
  *     readonly modelId: string
- *     embed(text: string): Promise<Float32Array>
+ *     embed(text: string, role?: EmbedRole): Promise<Float32Array>
  *     embedBatch(texts: string[]): Promise<Float32Array[]>
  *   }
  *
@@ -23,22 +23,27 @@
  * are gated behind PLUR_EMBEDDER_NETWORK_TESTS=1 so CI stays offline-safe.
  * Without the flag set, only metadata + factory routing are checked.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
   getEmbedder,
   EMBEDDER_NAMES,
   type EmbedderAdapter,
   type EmbedderName,
 } from '../src/embedders/index.js'
+import { makeEmbeddingGemmaAdapter, _resetEmbeddingGemmaCache } from '../src/embedders/embedding-gemma.js'
 
 const NETWORK = process.env.PLUR_EMBEDDER_NETWORK_TESTS === '1'
 
-/** Expected metadata per adapter — checked even when the network is offline. */
-const EXPECTED: Record<EmbedderName, { dim: number; modelId: string }> = {
+/** Expected metadata per adapter — checked even when the network is offline.
+ *  adapterName overrides the expected `.name` when the adapter name differs from the factory key
+ *  (e.g. 'embedding-gemma' factory key → 'embedding-gemma@graph' adapter name for cache busting). */
+const EXPECTED: Record<EmbedderName, { dim: number; modelId: string; adapterName?: string }> = {
   'minilm': { dim: 384, modelId: 'Xenova/all-MiniLM-L6-v2' },
   'bge-small': { dim: 384, modelId: 'Xenova/bge-small-en-v1.5' },
   'bge-base': { dim: 768, modelId: 'Xenova/bge-base-en-v1.5' },
-  'embedding-gemma': { dim: 768, modelId: 'onnx-community/embeddinggemma-300m-ONNX' },
+  // adapter.name is 'embedding-gemma@graph' — the @graph suffix busts caches
+  // that hold wrong-space vectors from the old JS-side mean pooling (#483).
+  'embedding-gemma': { dim: 768, modelId: 'onnx-community/embeddinggemma-300m-ONNX', adapterName: 'embedding-gemma@graph' },
   'openai-3-large': { dim: 3072, modelId: 'text-embedding-3-large' },
 }
 
@@ -57,7 +62,7 @@ describe('EmbedderAdapter factory — metadata contract', () => {
     describe(`adapter "${name}"`, () => {
       it('reports the expected name, dim, and modelId', () => {
         const adapter = getEmbedder(name)
-        expect(adapter.name).toBe(name)
+        expect(adapter.name).toBe(EXPECTED[name].adapterName ?? name)
         expect(adapter.dim).toBe(EXPECTED[name].dim)
         expect(adapter.modelId).toBe(EXPECTED[name].modelId)
       })
@@ -69,6 +74,38 @@ describe('EmbedderAdapter factory — metadata contract', () => {
       })
     })
   }
+})
+
+describe('EmbeddingGemma — role-aware prefix contract', () => {
+  afterEach(() => {
+    _resetEmbeddingGemmaCache()
+  })
+
+  it('adapter name includes @graph cache-bust suffix', () => {
+    const adapter = makeEmbeddingGemmaAdapter()
+    expect(adapter.name).toBe('embedding-gemma@graph')
+  })
+
+  it('embed() accepts an optional role parameter (query / passage / omitted)', () => {
+    // Structural check — no network call. We verify the adapter function
+    // accepts all role variants without TypeScript errors or runtime exceptions
+    // before the model is loaded (rejection comes from the async load, not the
+    // role parameter itself).
+    const adapter = makeEmbeddingGemmaAdapter()
+    // All three call shapes must be accepted by the type system:
+    const p1 = adapter.embed('test')           // omitted role → passage
+    const p2 = adapter.embed('test', 'passage') // explicit passage
+    const p3 = adapter.embed('test', 'query')   // explicit query
+    // Without a model loaded the promises will reject — that's expected.
+    // We just need them to not throw synchronously.
+    expect(p1).toBeInstanceOf(Promise)
+    expect(p2).toBeInstanceOf(Promise)
+    expect(p3).toBeInstanceOf(Promise)
+    // Suppress unhandled-rejection noise — we don't await these.
+    p1.catch(() => {})
+    p2.catch(() => {})
+    p3.catch(() => {})
+  })
 })
 
 describe.skipIf(!NETWORK)('EmbedderAdapter — live model loads (PLUR_EMBEDDER_NETWORK_TESTS=1)', () => {
@@ -121,4 +158,15 @@ describe.skipIf(!NETWORK)('EmbedderAdapter — live model loads (PLUR_EMBEDDER_N
       expect(cos).toBeGreaterThan(0.99)
     }, LIVE_TIMEOUT)
   }
+
+  it('"embedding-gemma" query vs passage embeddings differ', async () => {
+    const adapter = getEmbedder('embedding-gemma')
+    const text = 'memory engram about session lifecycle'
+    const queryVec = await adapter.embed(text, 'query')
+    const passageVec = await adapter.embed(text, 'passage')
+    // Vectors should differ because of role prefixes
+    let diff = 0
+    for (let i = 0; i < queryVec.length; i++) diff += Math.abs(queryVec[i] - passageVec[i])
+    expect(diff).toBeGreaterThan(0.01)
+  }, LIVE_TIMEOUT)
 })


### PR DESCRIPTION
Fixes #483.

## Problem

The old adapter mean-pooled `last_hidden_state` in JavaScript, skipping the model's two Dense post-pooling layers that are part of EmbeddingGemma's official stack. The resulting vectors had **cos ≈ −0.003** against the ONNX graph's own `sentence_embedding` output — they were in a completely different space from all published benchmark figures.

## Fix

- **`embedding-gemma.ts`** — rewritten: loads via `AutoModel` (not the feature-extraction pipeline), reads `sentence_embedding` directly from the ONNX graph. Role-aware prefixes added per model card: `'query: '` for search, `'passage: '` for stored text. Module-level lazy-load cache with `_resetEmbeddingGemmaCache()` test helper.
- **`types.ts`** — adds `EmbedRole = 'query' | 'passage'`; `embed()` signature accepts optional `role?` parameter.
- **`embedders/index.ts`** — re-exports `EmbedRole`.
- **`embeddings.ts`** — threads `role` through to the adapter; passes `'query'` in `embeddingSearch` / `embeddingSearchWithScores`.
- **`core/index.ts`** — passes `'query'` in `recall_hybrid` embed call.

## Cache invalidation

The adapter `name` is now `'embedding-gemma@graph'` (was `'embedding-gemma'`). `embeddings.ts` checks the cache header's stored embedder name on every load — a name mismatch triggers an automatic re-embed of the entire store. No manual migration needed.

## Tests

- 2 new offline tests: `@graph` suffix assertion, role parameter accepted without throwing.
- 1 new live test (gated behind `PLUR_EMBEDDER_NETWORK_TESTS=1`): query vs passage embeddings differ when the model is loaded.
- All metadata contract tests pass with the `adapterName` override in `EXPECTED`.

## Relationship to #219 Phase C

Per the issue: "prerequisite for any #219 Phase C N=500 run." Corrected pooling already repairs R@1 (46.7 ties baseline at same R@5) — re-run the fixture eval on this branch before merging to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)