### PR TITLE
feat(cli): wire SessionEnd hook — auto-close sessions via plur init (#475)

### DIFF
--- a/packages/cli/src/commands/hook-session-end-auto.ts
+++ b/packages/cli/src/commands/hook-session-end-auto.ts
@@ -1,0 +1,107 @@
+import { readSync, existsSync, readFileSync, unlinkSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir, homedir } from 'os'
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+
+/**
+ * plur hook-session-end-auto — SessionEnd hook that captures a session-end
+ * episode and cleans up checkpoints when Claude Code terminates a session.
+ *
+ * Called by Claude Code's SessionEnd hook (shipped in v1.0.85). Provides
+ * best-effort session lifecycle closure without requiring LLM access — no
+ * engram suggestions are generated (that requires model access), only the
+ * episode is captured and the checkpoint is cleaned up.
+ *
+ * Resume behavior: SessionEnd fires on true termination only, not on pause.
+ * A resumed session creates a new session_id on restart, so no special
+ * resume detection is needed here.
+ *
+ * Gaps this hook cannot cover (handled elsewhere):
+ *   - Hard kills (SIGKILL) — un-hookable; orphan recovery in hook-inject
+ *   - Non-Claude-Code transports — server-side timeout (enterprise#112)
+ *
+ * Input: JSON on stdin (Claude Code SessionEnd hook format)
+ *   { session_id?: string, transcript_path?: string, cwd?: string }
+ * Output: silent (exits 0)
+ */
+
+function readStdinSync(): Record<string, unknown> {
+  try {
+    const chunks: Buffer[] = []
+    const buf = Buffer.alloc(65536)
+    while (true) {
+      try {
+        const n = readSync(0, buf, 0, buf.length, null)
+        if (n === 0) break
+        chunks.push(Buffer.from(buf.subarray(0, n)))
+      } catch {
+        break
+      }
+    }
+    const raw = Buffer.concat(chunks).toString('utf8').trim()
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+function deriveSummary(transcriptPath: string | undefined, cwd: string | undefined): string {
+  const cwdPart = cwd ? ` in ${cwd.split('/').slice(-2).join('/')}` : ''
+  if (!transcriptPath) {
+    return `Session${cwdPart} ended automatically (no transcript available)`
+  }
+  try {
+    const content = readFileSync(transcriptPath, 'utf8')
+    const lines = content.trim().split('\n').filter(Boolean)
+    return `Session${cwdPart} ended automatically. ${lines.length} transcript entries.`
+  } catch {
+    return `Session${cwdPart} ended automatically`
+  }
+}
+
+function cleanupCheckpoint(sessionId: string | undefined): void {
+  try {
+    const plurDir = process.env.PLUR_PATH ?? join(homedir(), '.plur')
+    const sessionsDir = join(plurDir, 'sessions')
+    const keys = [sessionId, process.env.CLAUDE_SESSION_ID, String(process.ppid)]
+      .filter(Boolean)
+      .map(k => k!.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64))
+    for (const key of keys) {
+      const cp = join(sessionsDir, `${key}.checkpoint.json`)
+      if (existsSync(cp)) { unlinkSync(cp); break }
+    }
+  } catch { /* best-effort */ }
+}
+
+function cleanupSessionMarker(): void {
+  try {
+    const dir = join(tmpdir(), 'plur-sessions')
+    mkdirSync(dir, { recursive: true })
+    const marker = join(dir, `${process.ppid || 'unknown'}.marker`)
+    if (existsSync(marker)) unlinkSync(marker)
+  } catch { /* best-effort */ }
+}
+
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  if (!isPlurConfigured()) return
+
+  const input = readStdinSync()
+  const sessionId  = input.session_id     as string | undefined
+  const transcriptPath = input.transcript_path as string | undefined
+  const cwd        = input.cwd            as string | undefined
+
+  const summary = deriveSummary(transcriptPath, cwd)
+
+  const plur = createPlur(flags)
+
+  try {
+    plur.capture(summary, {
+      session_id: sessionId,
+      channel: 'session-end-hook',
+    })
+  } catch { /* best-effort — never block session termination */ }
+
+  cleanupCheckpoint(sessionId)
+  cleanupSessionMarker()
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -198,6 +198,14 @@ function buildEnforcementHooks(cmd: string): Record<string, HookEntry[]> {
       },
     ],
 
+    SessionEnd: [
+      {
+        hooks: [
+          { type: 'command', command: `${cmd} hook-session-end-auto`, timeout: 10 },
+        ],
+      },
+    ],
+
     PreToolUse: [
       // Session guard — blocks all tools until plur_session_start is called.
       // Must be first so it runs before any other PreToolUse hook.

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -174,8 +174,13 @@ describe('plur init', () => {
         readFileSync(join(project, '.claude', 'settings.json'), 'utf-8'),
       )
 
-      // Enforcement hooks (SessionStart, session-guard PreToolUse, session-mark PostToolUse) live globally
+      // Enforcement hooks (SessionStart, SessionEnd, session-guard PreToolUse, session-mark PostToolUse) live globally
       expect(globalSettings.hooks?.SessionStart).toBeDefined()
+      expect(globalSettings.hooks?.SessionEnd).toBeDefined()
+      const globalEnd = globalSettings.hooks?.SessionEnd?.find((h) =>
+        h.hooks.some((c) => c.command.includes('hook-session-end-auto')),
+      )
+      expect(globalEnd).toBeDefined()
       const globalGuard = globalSettings.hooks?.PreToolUse?.find((h) =>
         h.hooks.some((c) => c.command.includes('hook-session-guard')),
       )
@@ -191,6 +196,7 @@ describe('plur init', () => {
 
       // Enforcement hooks NOT duplicated at project
       expect(projectSettings.hooks?.SessionStart).toBeUndefined()
+      expect(projectSettings.hooks?.SessionEnd).toBeUndefined()
 
       // MCP server registered at project (the path that does work in this project)
       expect(projectSettings.mcpServers?.plur).toBeDefined()


### PR DESCRIPTION
## Summary

- `hook-session-end-auto` was implemented but never registered in `buildEnforcementHooks()`, so `plur init` never wired it into Claude Code's SessionEnd event
- Add `SessionEnd` entry alongside `SessionStart` so `plur init` registers the auto-close hook globally
- Init tests updated: assert `SessionEnd` lands in global settings and is NOT duplicated at project level

## What closes

Closes #475.

## Scope note

`hook-session-end-auto.ts` is included in this commit because it existed as an untracked file (implemented but not committed). The implementation was already complete — this PR just wires it and adds the test coverage for registration.

## Resume behavior

Already handled in the command (SessionEnd fires on true termination only; a resumed session gets a new session_id, so no special detection needed).

## Upgrade path

`plur init --global` (idempotent) on an existing install will add the `SessionEnd` hook without duplicating anything else. `plur doctor` will surface the gap on installs that haven't re-run init yet.