### PR TITLE
docs: update benchmark table with shipping-config numbers (#451 task 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,18 +140,19 @@ result JSONs are no longer committed here (#336). Local benchmark runs still
 write to `benchmark/results/` (gitignored). A/B figures are the README's
 published run.
 
-Cadence standard: `npx tsx benchmark/run.ts --rerank on` (fixture corpus, hybrid+reranker, n=30).
+Cadence standard: `npx tsx benchmark/run.ts --rerank on` (fixture corpus, hybrid+bge-reranker, n=30).
 
 | Metric | Score | Config |
 |--------|-------|--------|
-| LongMemEval Hit@5 (hybrid+rerank, n=30) | **90.0%** | reranker on |
-| LongMemEval Hit@5 (hybrid, n=30) | 76.7% | reranker off |
-| temporal_reasoning R@5 | **100%** | reranker on |
-| temporal_reasoning R@5 | 60% | reranker off |
+| LongMemEval Hit@5 (hybrid, n=30) | 76.7% | reranker off — **shipping default** |
+| LongMemEval Hit@5 (hybrid + ms-marco, n=30) | 83.3% | ms-marco-minilm-l6 — recommended opt-in |
+| LongMemEval Hit@5 (hybrid + bge-reranker, n=30) | **90.0%** | bge-reranker-v2-m3 — max quality |
+| temporal_reasoning R@5 | 60% / 80% / **100%** | off / ms-marco / bge |
+| multi_session_reasoning R@5 | 40% / 60% / 60% | off / ms-marco / bge |
 | A/B win rate (31W/4L) | 89% | |
 | House rules | 12–0 | |
 
-**Latency with reranker:** p50≈3s, p95≈10s, peak RSS≈2GB. Acceptable for agentic use; not suitable for latency-sensitive interactive paths.
+**Reranker latency (fixture, loaded machine — idle machine will be lower):** ms-marco p50≈245ms; bge-reranker p50≈5s, p95≈10s, peak RSS≈2GB. ms-marco is production-viable; bge is suitable for offline/batch only. Set via `PLUR_RERANKER=ms-marco-minilm-l6` or `PLUR_RERANKER=bge-reranker-v2-m3`.
 
 The earlier v0.2.1 baseline (86.7% overall / 93.3% Hit@10) is still cited in
 `docs/benchmarks/phase2-methodology.md` as the self-calibration target for the

--- a/README.md
+++ b/README.md
@@ -19,9 +19,19 @@ PLUR is memory, not just retrieval — so we measure it on more than one axis.
 
 **Retrieval recall** — LongMemEval (R@5, chunk granularity):
 
+*Shipping config (BGE-small embeddings, n=30 fixture):*
+
 | Stack | R@5 | Notes |
 |-------|-----|-------|
-| **PLUR hybrid + reranker** | **97.6%** | fully local cross-encoder — no API |
+| PLUR default (hybrid, no reranker) | 76.7% | out-of-the-box — no model downloads |
+| **+ ms-marco-minilm-l6 reranker** | **83.3%** | recommended opt-in — `PLUR_RERANKER=ms-marco-minilm-l6`, p50≈245ms |
+| + bge-reranker-v2-m3 (max quality) | 90.0% | fully local cross-encoder — p50≈5s on CPU |
+
+*Full LongMemEval-S corpus (N=500, openai-3-large embeddings):*
+
+| Stack | R@5 | Notes |
+|-------|-----|-------|
+| PLUR hybrid + bge-reranker-v2-m3 | 97.6% | max quality — not production-suitable on CPU |
 | PLUR hybrid (openai-3-large embeddings) | 97.0% | optional cloud embedder |
 | PLUR BM25 only | 92.2% | no embedder — fully airgapped |
 


### PR DESCRIPTION
Closes task 4 of #451 (the last open checkbox).

## Problem

The published benchmark table showed **97.6% R@5** as the headline figure — measured in the full LongMemEval-S harness with bge-reranker-v2-m3 + openai-3-large embeddings. Users installing PLUR with defaults get **76.7% R@5** (no reranker, BGE-small). That gap was never disclosed in the README.

## Changes

**README:** Split the retrieval table into two clearly-labelled sections:

*Shipping config (BGE-small, n=30 fixture):*
- PLUR default (no reranker): **76.7%**
- + ms-marco-minilm-l6 (recommended opt-in): **83.3%**
- + bge-reranker-v2-m3 (max quality): 90.0%

*Full LongMemEval-S corpus (N=500, openai-3-large):*
- + bge-reranker-v2-m3: 97.6% (relabelled, marked not production-suitable on CPU)
- openai-3-large: 97.0%
- BM25 only: 92.2%

**CLAUDE.md:** Expand the internal n=30 table to three reranker tiers with per-category breakdown (temporal, multi-session) and corrected latency note — ms-marco is production-viable (p50≈245ms); bge is offline/batch only.

## Prerequisite

PR #479 (per-store reranker eval gate, task 5 of #451) — merged 2026-07-03.

## Measurement provenance

Numbers from #451 comment: fixture corpus (n=30), BGE-small embeddings, commit `357f1ec`, macOS/CPU Apple Silicon. R@5 figures are deterministic across load; latency figures were taken under high load (loadavg 55–165) and noted as upper bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)