### PR TITLE
feat(scopes): consume server-authoritative scope metadata (#345 D2 client)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -275,6 +275,13 @@ export interface RemoteScopeDiscovery {
   registered: string[]
   /** Authorized minus registered — the scopes a user could still add. */
   unregistered: string[]
+  /**
+   * Server-authoritative scope metadata (#345 D2) for the authorized scopes,
+   * when the remote serves it via `/api/v1/me` (`scope_metadata`). Each entry
+   * is a validated {@link ScopeMetadata}. Empty when the server is older /
+   * declares no metadata — discovery still works, just without descriptions.
+   */
+  metadata: ScopeMetadata[]
   /** Present when `ok` is false. */
   error?: string
 }
@@ -4535,11 +4542,14 @@ Generate an improved version of the procedure that prevents this failure. Return
           authorized: me.scopes,
           registered,
           unregistered: me.scopes.filter(s => !registeredSet.has(s)),
+          // #345 D2: server-authoritative metadata for the authorized scopes,
+          // already validated in RemoteStore.me(). Empty for older servers.
+          metadata: me.scope_metadata ?? [],
         }
       } catch (err) {
         return {
           url, ok: false,
-          authorized: [], registered, unregistered: [],
+          authorized: [], registered, unregistered: [], metadata: [],
           error: err instanceof Error ? err.message : String(err),
         }
       }

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import type { Engram } from '../schemas/engram.js'
 import type { EngramStore } from './types.js'
 import { logger } from '../logger.js'
+import { ScopeMetadataSchema, type ScopeMetadata } from '../schemas/scope-metadata.js'
 
 /**
  * Lenient validation for semi-trusted remote rows (security audit 2026-06-10,
@@ -105,17 +106,14 @@ export class RemoteStore implements EngramStore {
    *
    * Throws on a non-2xx response (caller decides whether to swallow per URL).
    */
-  async me(): Promise<{ username: string; org_id: string; role: string; scopes: string[] }> {
+  async me(): Promise<{ username: string; org_id: string; role: string; scopes: string[]; scope_metadata: ScopeMetadata[] }> {
     const r = await fetch(`${this.apiBase}/me`, { headers: this.headers() })
     if (!r.ok) {
       const text = await r.text().catch(() => '')
       throw new Error(`Remote /me failed: ${r.status} ${text}`)
     }
-    const body = await r.json().catch(() => ({})) as Partial<{ username: string; org_id: string; role: string; scopes: unknown[] }>
-    return {
-      username: body.username ?? '',
-      org_id:   body.org_id ?? '',
-      role:     body.role ?? '',
+    const body = await r.json().catch(() => ({})) as Partial<{ username: string; org_id: string; role: string; scopes: unknown[]; scope_metadata: unknown[] }>
+    const scopes = Array.isArray(body.scopes)
       // Validate every /me scope to a safe grammar at the trust boundary:
       //  - #427: a non-string element would later throw in isSharedScope's
       //    `scope.startsWith(...)` BEFORE the per-scope try/catch — drop non-strings.
@@ -123,8 +121,26 @@ export class RemoteStore implements EngramStore {
       //    agent's directive surface); a name carrying newlines/control chars is a
       //    prompt-injection channel — require `[\w:./-]+` (allows group:org/team,
       //    user:*, etc.) so nothing malformed enters from a hostile/MITM remote.
-      scopes:   Array.isArray(body.scopes)
-        ? body.scopes.filter((s): s is string => typeof s === 'string' && /^[\w:./-]+$/.test(s))
+      ? body.scopes.filter((s): s is string => typeof s === 'string' && /^[\w:./-]+$/.test(s))
+      : []
+    return {
+      username: body.username ?? '',
+      org_id:   body.org_id ?? '',
+      role:     body.role ?? '',
+      scopes,
+      // #345 D2: self-describing scope metadata served by the enterprise
+      // `scopes` table. Validate each entry through the SAME ScopeMetadataSchema
+      // the local config path uses — a hostile/old remote can send anything, so
+      // drop entries that don't parse (and any whose `scope` isn't in the
+      // authorized set, so a remote can't smuggle metadata for an unrelated
+      // scope into discovery). Absent/empty → [] (older servers).
+      scope_metadata: Array.isArray(body.scope_metadata)
+        ? body.scope_metadata.flatMap((m) => {
+            const parsed = ScopeMetadataSchema.safeParse(m)
+            if (!parsed.success) return []
+            if (!scopes.includes(parsed.data.scope)) return []
+            return [parsed.data]
+          })
         : [],
     }
   }

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -65,7 +65,9 @@ export class StubServer {
   private port = 0
   // Identity returned by GET /api/v1/me (#292). Defaults to a single-scope
   // user; override per-test with setMe() to simulate multi-team authorization.
-  private me: { username: string; org_id: string; role: string; scopes: string[] } = {
+  // #345 D2: scope_metadata is optional and defaults to absent so older-server
+  // behavior is the default; setMe({ scope_metadata }) opts a test into it.
+  private me: { username: string; org_id: string; role: string; scopes: string[]; scope_metadata?: unknown[] } = {
     username: 'testuser', org_id: 'test-org', role: 'developer', scopes: ['group:test'],
   }
   /** When set, POST /engrams returns this as the assigned id instead of a valid
@@ -78,8 +80,10 @@ export class StubServer {
 
   constructor(private readonly validToken: string) {}
 
-  /** Override the GET /api/v1/me response (authorized scope set, identity). */
-  setMe(me: Partial<{ username: string; org_id: string; role: string; scopes: string[] }>): void {
+  /** Override the GET /api/v1/me response (authorized scope set, identity).
+   *  #345 D2: pass `scope_metadata` to simulate a server that serves
+   *  self-describing scope metadata. */
+  setMe(me: Partial<{ username: string; org_id: string; role: string; scopes: string[]; scope_metadata: unknown[] }>): void {
     this.me = { ...this.me, ...me }
   }
 

--- a/packages/core/test/scope-discovery.test.ts
+++ b/packages/core/test/scope-discovery.test.ts
@@ -123,6 +123,63 @@ describe('Plur.discoverRemoteScopes()', () => {
     expect(discoveries[0].registered.sort()).toEqual(['group:plur/plur-ai/comms', 'group:plur/plur-ai/engineering'])
     expect(discoveries[0].unregistered.sort()).toEqual(['group:plur/plur-ai', 'group:plur/plur-ai/research'])
   })
+
+  // --- #345 D2: server-authoritative scope metadata ---
+
+  it('metadata is [] when the server serves none (backward-compat)', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.metadata).toEqual([])
+  })
+
+  it('surfaces validated scope_metadata for authorized scopes', async () => {
+    server.setMe({
+      scope_metadata: [
+        { scope: 'group:plur/plur-ai/engineering', description: 'Eng knowledge', covers: ['ci', 'deploy'] },
+        { scope: 'group:plur/plur-ai/comms', description: 'Comms', covers: [] },
+      ],
+    })
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.metadata).toHaveLength(2)
+    const eng = d.metadata.find(m => m.scope === 'group:plur/plur-ai/engineering')
+    expect(eng?.description).toBe('Eng knowledge')
+    expect(eng?.covers).toEqual(['ci', 'deploy'])
+  })
+
+  it('drops metadata whose scope is not in the authorized set (anti-smuggle)', async () => {
+    server.setMe({
+      scope_metadata: [
+        { scope: 'group:plur/plur-ai/engineering', description: 'ok', covers: [] },
+        { scope: 'group:evil/unrelated', description: 'smuggled', covers: [] },
+      ],
+    })
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.metadata.map(m => m.scope)).toEqual(['group:plur/plur-ai/engineering'])
+  })
+
+  it('drops structurally-invalid metadata entries without failing discovery', async () => {
+    server.setMe({
+      scope_metadata: [
+        { description: 'no scope field' },          // missing required `scope`
+        'not even an object',
+        { scope: 'group:plur/plur-ai/comms', description: 'valid', covers: [] },
+      ],
+    })
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.ok).toBe(true)
+    expect(d.metadata.map(m => m.scope)).toEqual(['group:plur/plur-ai/comms'])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1775,11 +1775,32 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
         if (discoveries.length === 0) {
           return { discovered: [], note: 'No remote stores configured. Register one scope first with plur_stores_add, then discover the rest.' }
         }
+        // #345 D2: surface the server-authoritative description/covers per scope
+        // so an agent can pick the right scope from discovery alone (instead of
+        // guessing from the bare scope name). Each authorized scope is annotated
+        // with its metadata when the server returned any; `registered` flags
+        // whether it's already in local config.
+        const enrich = (d: typeof discoveries[number]) => {
+          if (!d.ok) return d
+          const byScope = new Map(d.metadata.map(m => [m.scope, m]))
+          const registeredSet = new Set(d.registered)
+          const scopes = d.authorized.map(scope => {
+            const m = byScope.get(scope)
+            return {
+              scope,
+              registered: registeredSet.has(scope),
+              ...(m?.description ? { description: m.description } : {}),
+              ...(m && m.covers.length ? { covers: m.covers } : {}),
+            }
+          })
+          return { ...d, scopes }
+        }
+        const discovered = discoveries.map(enrich)
         if (!register) {
-          return { discovered: discoveries }
+          return { discovered }
         }
         const registered = await plur.registerDiscoveredScopes({ url })
-        return { discovered: discoveries, registered }
+        return { discovered, registered }
       },
     },
 

--- a/packages/mcp/test/e2e-remote.test.ts
+++ b/packages/mcp/test/e2e-remote.test.ts
@@ -279,6 +279,34 @@ describe('MCP plur_scopes_discover', () => {
     expect(remoteScopes).not.toContain('team:e2e-other')
   })
 
+  it('surfaces per-scope description/covers from server metadata (#345 D2)', async () => {
+    stub.setMe({
+      username: 'crtahlin',
+      scopes: [REMOTE_SCOPE, 'team:e2e-other'],
+      scope_metadata: [
+        { scope: REMOTE_SCOPE, description: 'Primary team scope', covers: ['alpha', 'beta'] },
+        { scope: 'team:e2e-other', description: 'Other team', covers: [] },
+      ],
+    })
+    const { client } = await makeClient(dir)
+
+    const raw = await client.callTool({ name: 'plur_scopes_discover', arguments: {} })
+    const { discovered } = callResult(raw) as any
+    expect(discovered).toHaveLength(1)
+
+    const scopes = discovered[0].scopes as Array<any>
+    const primary = scopes.find(s => s.scope === REMOTE_SCOPE)
+    expect(primary.registered).toBe(true)
+    expect(primary.description).toBe('Primary team scope')
+    expect(primary.covers).toEqual(['alpha', 'beta'])
+
+    const other = scopes.find(s => s.scope === 'team:e2e-other')
+    expect(other.registered).toBe(false)
+    expect(other.description).toBe('Other team')
+    // covers omitted when empty
+    expect(other.covers).toBeUndefined()
+  })
+
   it('register:true registers every authorized scope under the one URL', async () => {
     stub.setMe({ username: 'crtahlin', scopes: [REMOTE_SCOPE, 'team:e2e-other', 'team:e2e-third'] })
     const { client } = await makeClient(dir)


### PR DESCRIPTION
## Summary

Client half of #345 D2 — parse the self-describing scope metadata the enterprise server now serves so scope selection can use server covers instead of local-only config.

- **`RemoteStore.me()`**: parse + validate optional `scope_metadata` from `/api/v1/me` through the SAME `ScopeMetadataSchema` the local config uses; drop entries that don't parse or whose scope isn't in the authorized set (anti-smuggle). Absent → `[]` (older servers — backward-compat)
- **`RemoteScopeDiscovery`**: gains `metadata: ScopeMetadata[]`; `discoverRemoteScopes` populates it
- **`plur_scopes_discover`**: surface per-scope description/covers in an agent-friendly `scopes[]` shape (scope, registered, description?, covers?)
- **Tests**: 4 new core discovery tests (parse, anti-smuggle, invalid-drop, backward-compat) + 1 MCP tool test; stub servers gain `scope_metadata` support

## Test plan

- [ ] `pnpm test` — all 5 new tests pass alongside existing suite
- [ ] `pnpm build` — clean build

## Part of

Closes #345 D2 (client side). Companion server PR: plur-ai/enterprise feat/345-d2-enterprise-scopes-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)