### PR TITLE
feat(cli,mcp): wire plur_session_end to Claude Code SessionEnd hook (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ One command sets up everything — storage, MCP config, and Claude Code hooks:
 npx @plur-ai/mcp init
 ```
 
-This creates `~/.plur/` for storage, adds PLUR to your `.mcp.json`, and installs Claude Code hooks for automatic engram injection. PLUR is installed **globally** — one MCP server, one store, available in every project. You only run init once.
+This creates `~/.plur/` for storage, adds PLUR to your `.mcp.json`, and installs Claude Code hooks for automatic engram injection. The hooks also **auto-close the memory lifecycle**: a `SessionEnd` hook captures a closing episode and cleans up session state when a conversation ends, so memory closes cleanly even if the agent forgets to call `plur_session_end`. PLUR is installed **globally** — one MCP server, one store, available in every project. You only run init once.
 
 For **multi-project setups**, use domain/scope to separate knowledge:
 

--- a/packages/cli/src/commands/hook-session-end.ts
+++ b/packages/cli/src/commands/hook-session-end.ts
@@ -1,0 +1,147 @@
+import { readSync, readFileSync, existsSync, unlinkSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { type GlobalFlags } from '../plur.js'
+import { createPlur } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+
+/**
+ * plur hook-session-end — Claude Code SessionEnd hook (shipped v1.0.85).
+ *
+ * Auto-closes the PLUR memory lifecycle when a session ends, instead of
+ * relying on the agent remembering to call plur_session_end (#217).
+ *
+ * How it relates to the rest of the lifecycle:
+ * - hook-learn-check writes periodic session checkpoints (#215).
+ * - plur_session_end (agent-called) is the primary close: it creates engrams
+ *   from LLM-reviewed suggestions, captures an episode, AND unlinks the
+ *   checkpoint.
+ * - If the agent never calls plur_session_end, the checkpoint is left behind.
+ *   Previously the ONLY recovery was hook-inject's deferred wrap-up (#216) on
+ *   the NEXT session_start, which emits a transient notice but captures no
+ *   durable episode.
+ *
+ * This hook closes that gap: fired by Claude Code at the moment the session
+ * ends, it captures a durable closing episode from the checkpoint metadata and
+ * cleans up the checkpoint — at the right time, with the right cwd. It cannot
+ * produce LLM-quality engram suggestions (no model runs in a shell hook), so it
+ * is a conservative safety net, not a replacement for plur_session_end.
+ *
+ * If the checkpoint is absent, plur_session_end already ran (clean close) or
+ * the session was too short to checkpoint — either way there is nothing to do.
+ *
+ * Input: JSON on stdin (Claude Code SessionEnd hook format: session_id, cwd,
+ *        reason). Never blocks; SessionEnd output is advisory.
+ */
+
+function sessionKeys(payloadSessionId?: string): string[] {
+  // Mirror plur_session_end's key resolution (tools.ts): payload session_id
+  // first, then CLAUDE_SESSION_ID, then ppid — sanitized the same way as
+  // hook-learn-check writes them.
+  return [payloadSessionId, process.env.CLAUDE_SESSION_ID, String(process.ppid)]
+    .filter(Boolean)
+    .map(k => k!.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64))
+    .filter(Boolean)
+}
+
+function plurPath(flags: GlobalFlags): string {
+  return flags.path ?? process.env.PLUR_PATH ?? join(homedir(), '.plur')
+}
+
+function readStdinRaw(): string {
+  try {
+    const chunks: Buffer[] = []
+    const buf = Buffer.alloc(65536)
+    while (true) {
+      try {
+        const n = readSync(0, buf, 0, buf.length, null)
+        if (n === 0) break
+        chunks.push(Buffer.from(buf.subarray(0, n)))
+      } catch {
+        break
+      }
+    }
+    return Buffer.concat(chunks).toString('utf8')
+  } catch {
+    return ''
+  }
+}
+
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  // Silent pass-through for projects without plur configured (#247) — lets the
+  // hook be installed globally without touching unrelated projects.
+  if (!isPlurConfigured()) return
+
+  const raw = readStdinRaw()
+  let payload: { session_id?: string; cwd?: string; reason?: string } = {}
+  try {
+    payload = JSON.parse(raw)
+  } catch { /* fall back to env-derived keys */ }
+
+  const sessionsDir = join(plurPath(flags), 'sessions')
+  if (!existsSync(sessionsDir)) return
+
+  // Locate this session's checkpoint. Presence means plur_session_end did NOT
+  // run (it unlinks the checkpoint), so we auto-close.
+  let checkpointPath: string | null = null
+  let checkpoint: any = null
+  for (const key of sessionKeys(payload.session_id)) {
+    const cp = join(sessionsDir, `${key}.checkpoint.json`)
+    if (existsSync(cp)) {
+      try {
+        checkpoint = JSON.parse(readFileSync(cp, 'utf8'))
+        checkpointPath = cp
+        break
+      } catch {
+        // Corrupt checkpoint — remove it and stop.
+        try { unlinkSync(cp) } catch {}
+        return
+      }
+    }
+  }
+
+  // No checkpoint → clean close already happened, or session too short. Nothing
+  // to close.
+  if (!checkpointPath || !checkpoint) return
+
+  // Build a conservative, metadata-only summary — the same information the
+  // deferred wrap-up (#216) reports, but captured as a durable episode.
+  const started = checkpoint.started_at ? new Date(checkpoint.started_at) : null
+  const ended = checkpoint.last_checkpoint ? new Date(checkpoint.last_checkpoint) : null
+  let durationStr = ''
+  if (started && ended && !isNaN(started.getTime()) && !isNaN(ended.getTime())) {
+    const durationMin = Math.max(0, Math.round((ended.getTime() - started.getTime()) / 60000))
+    durationStr = durationMin >= 60
+      ? `${Math.floor(durationMin / 60)}h ${durationMin % 60}m`
+      : `${durationMin}m`
+  }
+  const cwd = payload.cwd || checkpoint.cwd || ''
+  const project = cwd ? cwd.split('/').slice(-2).join('/') : ''
+  const reason = payload.reason ? ` (reason: ${payload.reason})` : ''
+
+  const summary =
+    `Session auto-closed on SessionEnd${reason} without an explicit plur_session_end. ` +
+    `${checkpoint.stop_count ?? 0} responses` +
+    `${durationStr ? `, ${durationStr}` : ''}` +
+    `${project ? `, ${project}` : ''}.`
+
+  try {
+    const plur = createPlur(flags)
+    plur.capture(summary, {
+      channel: 'hook',
+      agent: 'claude-code',
+      session_id: checkpoint.session_id || payload.session_id,
+      tags: ['session-end', 'auto-close'],
+    })
+  } catch {
+    // Capture is best-effort — never let a SessionEnd hook fail the session.
+  }
+
+  // Clean up the checkpoint so the next session_start's deferred wrap-up does
+  // not double-report this session (#216).
+  try { unlinkSync(checkpointPath) } catch {}
+
+  // Ensure the sessions dir still exists for subsequent sessions (defensive —
+  // capture may create the plur root lazily).
+  try { mkdirSync(sessionsDir, { recursive: true }) } catch {}
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -198,6 +198,17 @@ function buildEnforcementHooks(cmd: string): Record<string, HookEntry[]> {
       },
     ],
 
+    // Auto-close the memory lifecycle when the session ends (Claude Code
+    // SessionEnd, shipped v1.0.85). Captures a closing episode and cleans up
+    // the checkpoint even if the agent forgot to call plur_session_end (#217).
+    SessionEnd: [
+      {
+        hooks: [
+          { type: 'command', command: `${cmd} hook-session-end`, timeout: 5 },
+        ],
+      },
+    ],
+
     PreToolUse: [
       // Session guard — blocks all tools until plur_session_start is called.
       // Must be first so it runs before any other PreToolUse hook.
@@ -337,7 +348,7 @@ A PreToolUse guard enforces that \`plur_session_start\` is called at the beginni
 2. **Learn**: When corrected or discovering something new, call \`plur_learn\` immediately
 3. **Recall**: Before answering factual questions, call \`plur_recall_hybrid\` — check memory first
 4. **Feedback**: Rate injected engrams with \`plur_feedback\` (positive/negative) — trains relevance
-5. **End**: Call \`plur_session_end\` with summary + engram_suggestions
+5. **End**: Call \`plur_session_end\` with summary + engram_suggestions — a SessionEnd hook auto-closes the lifecycle if you forget, but calling it yourself captures higher-quality learnings
 
 Do not ask permission to use these tools — they are your memory system.
 
@@ -607,8 +618,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   outputText(`MCP server (plur): ${mcpStatus}`)
   outputText(`  command: ${entry.command} ${entry.args.join(' ')}`)
   outputText('')
-  outputText(`Enforcement hooks (3, always global): ${enforcementHooksStatus}`)
+  outputText(`Enforcement hooks (4, always global): ${enforcementHooksStatus}`)
   outputText('  SessionStart      — enforce plur_session_start before any work')
+  outputText('  SessionEnd        — auto-close memory lifecycle (captures closing episode)')
   outputText('  PreToolUse        — session guard (blocks tools until session started)')
   outputText('  PostToolUse       — session sentinel (marks session as started)')
   outputText('')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,6 +55,7 @@ Commands:
   hook-observe            (internal) Hook handler for observation capture
   hook-learn-check        (internal) Hook handler for learning reflection
   hook-session-guard      (internal) Hook handler for session enforcement
+  hook-session-end        (internal) SessionEnd hook — auto-close memory lifecycle
   hook-session-mark       (internal) Hook handler for session sentinel
   hook-session-remind     (internal) Hook handler for session start reminder
   hook-correction-detect  (internal) UserPromptSubmit hook — detect corrections
@@ -103,6 +104,7 @@ const COMMANDS: Record<string, string> = {
   'hook-observe': './commands/hook-observe.js',
   'hook-learn-check': './commands/hook-learn-check.js',
   'hook-session-guard': './commands/hook-session-guard.js',
+  'hook-session-end': './commands/hook-session-end.js',
   'hook-session-mark': './commands/hook-session-mark.js',
   'hook-session-remind': './commands/hook-session-remind.js',
   'hook-correction-detect': './commands/hook-correction-detect.js',

--- a/packages/cli/test/hook-session-end.test.ts
+++ b/packages/cli/test/hook-session-end.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { spawnSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+/**
+ * Integration tests for the SessionEnd hook (#217).
+ *
+ * Confirms the hook fires end-to-end: given a session checkpoint left behind by
+ * a session that never called plur_session_end, `plur hook-session-end`
+ * captures a durable closing episode and cleans up the checkpoint.
+ */
+describe('hook-session-end (#217 — SessionEnd auto-close)', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-session-end-test-'))
+    // A plur config so isPlurConfigured() does not short-circuit the hook.
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(
+      join(home, '.claude', 'settings.json'),
+      JSON.stringify({
+        mcpServers: {
+          plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        },
+      }),
+    )
+    mkdirSync(join(home, 'tmp'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  function writeCheckpoint(sessionId: string, overrides: Record<string, unknown> = {}): string {
+    const sessionsDir = join(home, '.plur', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const now = Date.now()
+    const path = join(sessionsDir, `${sessionId}.checkpoint.json`)
+    writeFileSync(
+      path,
+      JSON.stringify({
+        session_id: sessionId,
+        started_at: new Date(now - 90 * 60000).toISOString(),
+        last_checkpoint: new Date(now - 1 * 60000).toISOString(),
+        stop_count: 30,
+        cwd: '/Users/test/project',
+        observation_file: '2026-07-04.jsonl',
+        ...overrides,
+      }),
+    )
+    return path
+  }
+
+  function runSessionEnd(
+    input: object,
+    env?: Record<string, string>,
+  ): { stdout: string; stderr: string; status: number | null } {
+    const result = spawnSync('node', [CLI, 'hook-session-end'], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 15000,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        TMPDIR: join(home, 'tmp'),
+        PLUR_PATH: join(home, '.plur'),
+        CLAUDE_SESSION_ID: 'end-test-session',
+        ...env,
+      },
+      cwd: home,
+    })
+    return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status }
+  }
+
+  function readEpisodes(): string {
+    const path = join(home, '.plur', 'episodes.yaml')
+    return existsSync(path) ? readFileSync(path, 'utf-8') : ''
+  }
+
+  it('captures a closing episode and cleans up the checkpoint', () => {
+    const cpPath = writeCheckpoint('end-test-session')
+
+    const { status } = runSessionEnd({ session_id: 'end-test-session', cwd: '/Users/test/project', reason: 'clear' })
+    expect(status).toBe(0)
+
+    // Checkpoint removed — lifecycle closed.
+    expect(existsSync(cpPath)).toBe(false)
+
+    // A durable episode was captured with the auto-close marker.
+    const episodes = readEpisodes()
+    expect(episodes).toContain('auto-closed on SessionEnd')
+    expect(episodes).toContain('auto-close')
+    // Metadata is carried through (stop count).
+    expect(episodes).toContain('30 responses')
+  })
+
+  it('resolves the checkpoint from CLAUDE_SESSION_ID when payload omits session_id', () => {
+    const cpPath = writeCheckpoint('end-test-session')
+
+    // No session_id in the SessionEnd payload — falls back to CLAUDE_SESSION_ID.
+    const { status } = runSessionEnd({ reason: 'other' })
+    expect(status).toBe(0)
+    expect(existsSync(cpPath)).toBe(false)
+    expect(readEpisodes()).toContain('auto-closed on SessionEnd')
+  })
+
+  it('is a no-op when no checkpoint exists (clean close already happened)', () => {
+    const { status } = runSessionEnd({ session_id: 'end-test-session', reason: 'clear' })
+    expect(status).toBe(0)
+    // No episode captured — nothing to close.
+    expect(readEpisodes()).not.toContain('auto-closed on SessionEnd')
+  })
+
+  it('removes a corrupt checkpoint without crashing', () => {
+    const sessionsDir = join(home, '.plur', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const cpPath = join(sessionsDir, 'end-test-session.checkpoint.json')
+    writeFileSync(cpPath, '{ not valid json')
+
+    const { status } = runSessionEnd({ session_id: 'end-test-session' })
+    expect(status).toBe(0)
+    expect(existsSync(cpPath)).toBe(false)
+    // No episode from a corrupt checkpoint.
+    expect(readEpisodes()).not.toContain('auto-closed on SessionEnd')
+  })
+
+  it('silently passes through when plur is not configured', () => {
+    // Remove the plur config so isPlurConfigured() is false.
+    rmSync(join(home, '.claude', 'settings.json'))
+    const cpPath = writeCheckpoint('end-test-session')
+
+    const { status } = runSessionEnd({ session_id: 'end-test-session' })
+    expect(status).toBe(0)
+    // Checkpoint untouched — the hook did nothing in an unconfigured project.
+    expect(existsSync(cpPath)).toBe(true)
+    expect(readEpisodes()).not.toContain('auto-closed on SessionEnd')
+  })
+
+  it('does not double-capture when run twice for the same session', () => {
+    writeCheckpoint('end-test-session')
+
+    runSessionEnd({ session_id: 'end-test-session', reason: 'clear' })
+    const afterFirst = readEpisodes()
+    const firstCount = (afterFirst.match(/auto-closed on SessionEnd/g) ?? []).length
+    expect(firstCount).toBe(1)
+
+    // Second SessionEnd (e.g. the mcp-scaffolded hook also firing) finds no
+    // checkpoint and captures nothing further.
+    runSessionEnd({ session_id: 'end-test-session', reason: 'clear' })
+    const afterSecond = readEpisodes()
+    const secondCount = (afterSecond.match(/auto-closed on SessionEnd/g) ?? []).length
+    expect(secondCount).toBe(1)
+  })
+})

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -174,12 +174,20 @@ describe('plur init', () => {
         readFileSync(join(project, '.claude', 'settings.json'), 'utf-8'),
       )
 
-      // Enforcement hooks (SessionStart, session-guard PreToolUse, session-mark PostToolUse) live globally
+      // Enforcement hooks (SessionStart, SessionEnd, session-guard PreToolUse, session-mark PostToolUse) live globally
       expect(globalSettings.hooks?.SessionStart).toBeDefined()
       const globalGuard = globalSettings.hooks?.PreToolUse?.find((h) =>
         h.hooks.some((c) => c.command.includes('hook-session-guard')),
       )
       expect(globalGuard).toBeDefined()
+
+      // SessionEnd hook auto-closes the memory lifecycle (#217)
+      const globalSessionEnd = globalSettings.hooks?.SessionEnd?.find((h) =>
+        h.hooks.some((c) => c.command.includes('hook-session-end')),
+      )
+      expect(globalSessionEnd).toBeDefined()
+      // ...and is NOT duplicated at project scope
+      expect(projectSettings.hooks?.SessionEnd).toBeUndefined()
       const globalMark = globalSettings.hooks?.PostToolUse?.find((h) =>
         h.hooks.some((c) => c.command.includes('hook-session-mark')),
       )

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -107,6 +107,12 @@ const PLUR_HOOKS: Record<string, HookEntry[]> = {
     matcher: 'auto|manual',
     hooks: [{ type: 'command', command: `${CLI} hook-inject --rehydrate`, timeout: 15 }],
   }],
+  // Auto-close the memory lifecycle at session end (Claude Code SessionEnd,
+  // shipped v1.0.85) — captures a closing episode and cleans up the session
+  // checkpoint even if the agent forgot to call plur_session_end (#217).
+  SessionEnd: [{
+    hooks: [{ type: 'command', command: `${CLI} hook-session-end`, timeout: 5 }],
+  }],
   // --- Contextual injection ---
   PreToolUse: [
     { matcher: 'EnterPlanMode', hooks: [{ type: 'command', command: `${CLI} hook-inject --event plan_mode`, timeout: 10 }] },
@@ -158,7 +164,7 @@ Hooks inject engrams automatically on every first message — you do not need to
 2. **Learn**: When corrected or discovering something new, call \`plur_learn\` immediately
 3. **Recall**: Before answering factual questions, call \`plur_recall_hybrid\` — check memory first
 4. **Feedback**: Rate injected engrams with \`plur_feedback\` (positive/negative) — trains relevance
-5. **End**: Call \`plur_session_end\` with summary + engram_suggestions
+5. **End**: Call \`plur_session_end\` with summary + engram_suggestions — a SessionEnd hook auto-closes the lifecycle if you forget, but calling it yourself captures higher-quality learnings
 
 Do not ask permission to use these tools — they are your memory system.
 


### PR DESCRIPTION
## Summary

Claude Code shipped the **SessionEnd** hook in v1.0.85. This wires it up so PLUR's memory lifecycle **auto-closes** when a session ends, instead of depending on the agent remembering to call `plur_session_end`. Follow-up to #217, opened before upstream shipped the hook.

## What it does

A new internal CLI command `plur hook-session-end` runs on Claude Code's `SessionEnd` event:

1. Silent pass-through if plur isn't configured in the project (#247).
2. Locates this session's checkpoint (written by `hook-learn-check`, #215). **Its presence means `plur_session_end` was never called** — the tool unlinks the checkpoint on a clean close.
3. Captures a durable **closing episode** from the checkpoint metadata (duration, response count, cwd, end reason), tagged `session-end` / `auto-close`.
4. Cleans up the checkpoint so the next `session_start`'s deferred wrap-up (#216) doesn't double-report it.

This closes a real gap: previously, a session that forgot to wrap up left an orphaned checkpoint that the **next** `session_start` would only mention in a transient notice (#216) — no durable record. Now the close happens at the right time, with the right cwd, and produces an episode.

Conservative by design: no LLM runs in a shell hook, so this is a **safety net**, not a replacement for an explicit `plur_session_end` with `engram_suggestions` (which still produces higher-quality learnings).

## Changes

- **`packages/cli/src/commands/hook-session-end.ts`** — new SessionEnd hook command.
- **`packages/cli/src/index.ts`** — register `hook-session-end` in the command dispatcher + help.
- **`packages/cli/src/commands/init.ts`** — `plur init` scaffolds `SessionEnd` into the global enforcement hooks; updated init summary output.
- **`packages/mcp/src/index.ts`** — `@plur-ai/mcp init` scaffolds `SessionEnd` into `PLUR_HOOKS`; installed-CLAUDE.md note.
- **`README.md`** — documents the auto-close behavior.
- **Tests** — `hook-session-end.test.ts` (6 cases: captures episode + cleans checkpoint, CLAUDE_SESSION_ID fallback, no-op without checkpoint, corrupt-checkpoint handling, unconfigured pass-through, no double-capture) + `init.test.ts` now asserts `SessionEnd` is scaffolded globally and not duplicated at project scope.

## Verification

- `@plur-ai/cli` — 260 passed (32 files), incl. the 6 new SessionEnd cases and the augmented init test.
- `@plur-ai/mcp` — 193 passed (16 files); `PLUR_HOOKS` change breaks nothing.

## Notes on scope

The task brief referenced `packages/claw/src/hooks.ts` and `@plur-ai/claw`, but Claude Code hooks are not scaffolded by `claw` (that's the OpenClaw ContextEngine plugin). The Claude Code hook wiring lives in `@plur-ai/mcp` (`PLUR_HOOKS`) and `@plur-ai/cli` (`init` + the `hook-*` handlers), so the SessionEnd hook is implemented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)