### PR TITLE
feat(python): bump plur-ai to 0.10.0 — add recall_hybrid, fix npx CLI pin (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Security-hardening release, independently audited.
 - Pack & sync locked down
 - Private-by-default scopes
 - Independently re-audited (Črt)
+- **Python SDK (`plur-ai`)**: bumped to 0.10.0 — adds `recall_hybrid()` (BM25 + embeddings + RRF), pins npx fallback to CLI 0.10.1
 
 PLUR's engram leak guard, scope isolation, pack/sync distribution, and remote-store trust boundaries were hardened across three internal audit rounds **and an independent adversarial re-audit by Črt** — the Blocker and the full High confidentiality cluster fixed and re-verified, plus every Medium/Low finding. Also lands per-engram scope routing, **private-by-default** visibility, and read-side personal-scope visibility on all three read paths. No breaking API changes; the behavior changes are noted per entry below.
 

--- a/packages/python/plur_ai/__init__.py
+++ b/packages/python/plur_ai/__init__.py
@@ -16,5 +16,5 @@ from __future__ import annotations
 from .bridge import PlurError, PlurNotInstalledError
 from .client import Plur
 
-__version__ = "0.9.13"
+__version__ = "0.10.0"
 __all__ = ["Plur", "PlurError", "PlurNotInstalledError", "__version__"]

--- a/packages/python/plur_ai/bridge.py
+++ b/packages/python/plur_ai/bridge.py
@@ -22,7 +22,7 @@ from typing import Any, Sequence
 
 # @plur-ai/cli pin for the npx fallback. Keep >= the published CLI that carries
 # the current scope-routing / leak-guard fixes; release tooling bumps this.
-_NPX_CLI_VERSION = "0.9.12"
+_NPX_CLI_VERSION = "0.10.1"
 _DEFAULT_TIMEOUT = 30
 
 

--- a/packages/python/plur_ai/client.py
+++ b/packages/python/plur_ai/client.py
@@ -64,11 +64,27 @@ class Plur:
         return self._run(args) or {}
 
     def recall(self, query: str, *, limit: int | None = None) -> list[dict]:
-        """Search engrams. Returns the list of matching engrams (most relevant first)."""
-        args = ["recall", query]
+        """Fast lexical-only search. Returns engrams most relevant first.
+
+        Use :meth:`recall_hybrid` for better quality at the cost of a slightly
+        longer first call while the embedder model loads.
+        """
+        args = ["recall", "--fast", query]
         if limit is not None:
             args += ["--limit", str(limit)]
         res = self._run(args) or {}
+        return res.get("results", [])
+
+    def recall_hybrid(self, query: str, *, limit: int | None = None) -> list[dict]:
+        """Hybrid search (BM25 + embeddings + RRF). Returns engrams most relevant first.
+
+        Requires ``@plur-ai/cli`` >= 0.10.0. The first call may be slower while the
+        BGE embedder model loads; subsequent calls are fast.
+        """
+        args = ["recall", query]
+        if limit is not None:
+            args += ["--limit", str(limit)]
+        res = self._run(args, timeout=max(self.timeout, 30)) or {}
         return res.get("results", [])
 
     def inject(self, task: str, *, budget: int | None = None) -> dict:

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plur-ai"
-version = "0.9.13"
+version = "0.10.0"
 description = "Local-first shared memory for AI agents — Python SDK over the @plur-ai/cli"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/python/tests/test_client.py
+++ b/packages/python/tests/test_client.py
@@ -62,6 +62,19 @@ def test_inject_returns_sections():
         shutil.rmtree(d, ignore_errors=True)
 
 
+@requires_cli
+def test_recall_hybrid_returns_results():
+    d = tempfile.mkdtemp(prefix="plur-pytest-")
+    try:
+        plur = Plur(path=d)
+        plur.learn("deploy with blue-green never in-place", type="architectural")
+        results = plur.recall_hybrid("deployment strategy", limit=5)
+        assert isinstance(results, list)
+        assert any("blue-green" in r["statement"] for r in results)
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_missing_cli_raises(monkeypatch):
     monkeypatch.delenv("PLUR_CLI", raising=False)
     monkeypatch.setattr("plur_ai.bridge.shutil.which", lambda _name: None)


### PR DESCRIPTION
## Summary

- Add `recall_hybrid()` method (BM25 + embeddings + RRF) matching `plur_recall_hybrid` in the MCP server — the key 0.10.x quality improvement
- Clarify `recall()` as lexical-only (`--fast`) — distinct semantics instead of both methods silently doing the same thing
- Bump `_NPX_CLI_VERSION` from 0.9.12 → 0.10.1 — the stale pin served Python npx users a 9-minor-version-old CLI, missing hybrid search and security fixes
- Bump SDK version 0.9.13 → 0.10.0 in `pyproject.toml` and `__init__.py`
- Add `test_recall_hybrid_returns_results` test

## Why

Found during CMO docs-review cadence 2026-07-04. The Python SDK was functionally stale: no hybrid recall method and the npx CLI pin at 0.9.12 gave users a significantly outdated binary.

## Test plan

- [ ] `cd packages/python && python -m pytest tests/ -v` — all tests pass including new `test_recall_hybrid_returns_results`
- [ ] `pip install -e packages/python && python -c "from plur_ai import Plur; help(Plur.recall_hybrid)"` — method visible

## Publish note (after merge)

```
cd packages/python
pip install build twine
python -m build
twine upload dist/*  # needs PyPI auth as plur9
```

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)