### PR TITLE
feat(core): surface commitment tier in injected engram text (#348)

### DIFF
--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -588,7 +588,12 @@ export function formatLayer3(engram: WireEngram): string {
   if (engram.rationale) lines.push(`  Rationale: ${engram.rationale}`)
   const meta: string[] = []
   if (engram.domain) meta.push(`Domain: ${engram.domain}`)
-  if (engram.confidence_score != null) meta.push(`Confidence: ${engram.confidence_score.toFixed(2)}`)
+  const commitment = (engram as any).commitment as string | undefined
+  if (commitment) {
+    meta.push(`Confidence: ${commitment}`)
+  } else if (engram.confidence_score != null) {
+    meta.push(`Confidence: ${engram.confidence_score.toFixed(2)}`)
+  }
   if (engram.activation?.last_accessed) meta.push(`Last verified: ${engram.activation.last_accessed}`)
   if (meta.length > 0) lines.push(`  ${meta.join(' | ')}`)
   return lines.join('\n')

--- a/packages/core/test/inject.test.ts
+++ b/packages/core/test/inject.test.ts
@@ -206,6 +206,55 @@ describe('injection engine', () => {
     })
   })
 
+  // === formatLayer3 commitment tier rendering (SP1 Idea 6) ===
+
+  describe('formatLayer3 commitment rendering', () => {
+    const makeWire = (overrides: Partial<any> = {}): any => ({
+      id: 'ENG-2026-0704-001',
+      statement: 'Always deploy using blue-green strategy',
+      confidence_score: 0.73,
+      ...overrides,
+    })
+
+    it('renders "Confidence: exploring" when commitment is exploring', () => {
+      const wire = makeWire({ commitment: 'exploring' })
+      const text = formatWithLayer([wire], 3)
+      expect(text).toContain('Confidence: exploring')
+      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
+    })
+
+    it('renders "Confidence: leaning" when commitment is leaning', () => {
+      const wire = makeWire({ commitment: 'leaning' })
+      const text = formatWithLayer([wire], 3)
+      expect(text).toContain('Confidence: leaning')
+      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
+    })
+
+    it('renders "Confidence: decided" when commitment is decided', () => {
+      const wire = makeWire({ commitment: 'decided' })
+      const text = formatWithLayer([wire], 3)
+      expect(text).toContain('Confidence: decided')
+      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
+    })
+
+    it('renders "Confidence: locked" when commitment is locked', () => {
+      const wire = makeWire({ commitment: 'locked' })
+      const text = formatWithLayer([wire], 3)
+      expect(text).toContain('Confidence: locked')
+      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
+    })
+
+    it('renders the raw float when commitment is not set', () => {
+      const wire = makeWire()
+      const text = formatWithLayer([wire], 3)
+      expect(text).toContain('Confidence: 0.73')
+      expect(text).not.toContain('Confidence: exploring')
+      expect(text).not.toContain('Confidence: leaning')
+      expect(text).not.toContain('Confidence: decided')
+      expect(text).not.toContain('Confidence: locked')
+    })
+  })
+
   it('emotional weight boosts scoring for high-weight engrams', () => {
     const neutral = makeEngram({
       id: 'ENG-2026-0330-001',


### PR DESCRIPTION
## Summary

Replace the raw confidence float (`Confidence: 0.73`) in `formatLayer3` with the commitment tier label (`Confidence: decided`) when the engram's `commitment` field is set. Falls back to the raw float when `commitment` is unset.

**Why:** Raw floats aren't calibrated by consuming agents — they don't know if `0.73` is high or low. The commitment tier (`exploring | leaning | decided | locked`) is already used to weight injection scores but was invisible in rendered output. Surfacing it makes the epistemic state of each fact actionable.

## Changes

- `packages/core/src/inject.ts` — `formatLayer3`: read `commitment` field; if set, render `Confidence: <tier>`; otherwise fall back to `confidence_score.toFixed(2)`
- `packages/core/test/inject.test.ts` — 5 new tests covering all four commitment tiers + the float fallback

## Tests

All 5 new tests pass. No regressions in remaining inject tests.

Closes #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)