### PR TITLE
fix(cli): install injection hooks async; BM25-only for sync event hooks

### DIFF
--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -367,29 +367,24 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const plur = createPlur(flags)
     const label = `[PLUR Memory — ${event}]`
 
-    try {
-      const result = await plur.injectHybrid(task, { budget: 3000 })
-      if (result.count > 0) {
-        const parts: string[] = []
-        if (result.directives) parts.push(result.directives)
-        if (result.constraints) parts.push(result.constraints)
-        if (result.consider) parts.push(result.consider)
-        const output = { additionalContext: `${label} ${result.count} engrams\n\n${parts.join('\n')}` }
-        process.stdout.write(JSON.stringify(output))
-        return
-      }
-    } catch {
-      // Fall back to BM25
-      const result = plur.inject(task, { budget: 3000 })
-      if (result.count > 0) {
-        const parts: string[] = []
-        if (result.directives) parts.push(result.directives)
-        if (result.constraints) parts.push(result.constraints)
-        if (result.consider) parts.push(result.consider)
-        const output = { additionalContext: `${label} ${result.count} engrams\n\n${parts.join('\n')}` }
-        process.stdout.write(JSON.stringify(output))
-        return
-      }
+    // BM25-only, deliberately. Event hooks are SYNC — their whole point is
+    // context arriving BEFORE the tool runs — and they're installed with a
+    // 10s timeout. Hybrid search needs the BGE embedder, which costs ~20s
+    // to load in a cold CLI process once the store is a few thousand
+    // engrams: the hook got killed at the timeout on EVERY invocation,
+    // burning CPU and injecting nothing. BM25 completes in a few seconds,
+    // and event task strings ("skill: X", "agent: Y") are short keyword-ish
+    // queries where BM25 holds its own against embeddings anyway. The main
+    // first-message injection keeps full hybrid — it runs async with room
+    // to breathe.
+    const result = plur.inject(task, { budget: 3000 })
+    if (result.count > 0) {
+      const parts: string[] = []
+      if (result.directives) parts.push(result.directives)
+      if (result.constraints) parts.push(result.constraints)
+      if (result.consider) parts.push(result.consider)
+      const output = { additionalContext: `${label} ${result.count} engrams\n\n${parts.join('\n')}` }
+      process.stdout.write(JSON.stringify(output))
     }
     return
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -54,6 +54,7 @@ interface HookEntry {
     type: string
     command: string
     timeout?: number
+    async?: boolean
   }>
 }
 
@@ -228,10 +229,18 @@ function buildInjectionHooks(cmd: string): Record<string, HookEntry[]> {
   return {
     // First message: inject engrams based on the prompt.
     // Subsequent messages: periodic reminder to call plur_learn (~1ms skip).
+    //
+    // async: the cold-start CLI loads the BGE embedder for hybrid injection —
+    // ~20s+ once the store grows past a few thousand engrams. A sync hook
+    // would block every first prompt that long (or get killed at the timeout
+    // and inject nothing, which is how this was failing for real users).
+    // Async lets the prompt proceed immediately; the injected context arrives
+    // as soon as the search completes. 90s is a generous ceiling, not a
+    // target — typical completion is well under half that.
     UserPromptSubmit: [
       {
         hooks: [
-          { type: 'command', command: `${cmd} hook-inject`, timeout: 15 },
+          { type: 'command', command: `${cmd} hook-inject`, timeout: 90, async: true },
         ],
       },
     ],
@@ -241,7 +250,7 @@ function buildInjectionHooks(cmd: string): Record<string, HookEntry[]> {
       {
         matcher: 'auto|manual',
         hooks: [
-          { type: 'command', command: `${cmd} hook-inject --rehydrate`, timeout: 15 },
+          { type: 'command', command: `${cmd} hook-inject --rehydrate`, timeout: 90, async: true },
         ],
       },
     ],

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -7,7 +7,7 @@ import { execSync } from 'child_process'
 const CLI = join(__dirname, '..', 'dist', 'index.js')
 
 interface Settings {
-  hooks?: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>>
+  hooks?: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; timeout?: number; async?: boolean }> }>>
   mcpServers?: Record<string, { command: string; args: string[] }>
 }
 
@@ -51,6 +51,31 @@ describe('plur init', () => {
     // MCP server registered
     expect(settings.mcpServers).toBeDefined()
     expect(settings.mcpServers?.plur).toBeDefined()
+  })
+
+  it('installs injection hooks async with a 90s ceiling; event hooks stay sync', () => {
+    runInit()
+    const settings = readSettings()
+
+    // The cold-start embedder load (~20s on stores past a few thousand
+    // engrams) killed sync injection hooks at their old 15s timeout —
+    // users got a timeout error and no injection. Async + 90s is the fix.
+    const injectHook = settings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]
+    expect(injectHook?.command).toContain('hook-inject')
+    expect(injectHook?.async).toBe(true)
+    expect(injectHook?.timeout).toBe(90)
+
+    const rehydrateHook = settings.hooks?.PostCompact?.[0]?.hooks?.[0]
+    expect(rehydrateHook?.command).toContain('--rehydrate')
+    expect(rehydrateHook?.async).toBe(true)
+    expect(rehydrateHook?.timeout).toBe(90)
+
+    // Event hooks must deliver context BEFORE the tool runs — async would
+    // defeat them. They fit their sync 10s window because hook-inject uses
+    // BM25-only (no embedder load) for the --event path.
+    const planModeEntry = settings.hooks?.PreToolUse?.find((e) => e.matcher === 'EnterPlanMode')
+    expect(planModeEntry?.hooks?.[0]?.async).toBeUndefined()
+    expect(planModeEntry?.hooks?.[0]?.timeout).toBe(10)
   })
 
   it('writes per-engram scope-selection guidance into CLAUDE.md (#296)', () => {


### PR DESCRIPTION
## Problem

Once a store grows past a few thousand engrams, the CLI cold-start pays ~20s to load the BGE embedder for hybrid injection. The hook config `plur init` installs (sync, `timeout: 15`) means every user eventually hits:

```
UserPromptSubmit hook timed out after 15s — output discarded. Raise the hook's "timeout" to allow more time.
```

on **every first prompt** — full cold-start CPU cost paid, zero engrams injected. Separately, the `--event` hooks (plan_mode/skill/agent/subagent, sync `timeout: 10`) run `injectHybrid` unconditionally, which can never finish cold — they were being killed at timeout on every single invocation, for every user with a non-trivial store.

Found while debugging exactly this error recurring on a 4,290-engram store (timeout raised 15→30→90 and it still fired — the fix isn't a bigger number).

## Fix

1. **`init.ts`** — UserPromptSubmit `hook-inject` and PostCompact `--rehydrate` install with `async: true` + `timeout: 90`. The prompt proceeds immediately; injected context arrives when search completes. Since init strips-and-reinstalls plur hooks, **re-running `plur init` after upgrading migrates existing installs**.

2. **`hook-inject.ts`** — the `--event` path drops `injectHybrid` and goes straight to BM25. Event hooks must stay sync (their context has to arrive *before* the tool runs), so they must actually fit their 10s window. Measured: **0.74s** against a 4,290-engram store, returning 9 relevant engrams — versus killed-at-10s-with-nothing before. Event task strings ("skill: X", "agent: Y") are short keyword queries where BM25 holds its own; first-message injection keeps full hybrid, now with async room to breathe.

## Testing

- New test: fresh `plur init` installs async/90 injection hooks, sync/10 event hooks
- Full monorepo suite: 2,494 passed / 0 failed
- Manual timing of the real built CLI against the real 4k store (0.74s event path, ~22s async main path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)