### PR TITLE
feat(core,mcp): plur_learn_batch — persist many engrams in one call (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Feature: `plur_learn_batch` — persist many engrams in one MCP call (#281)
+
+Saving knowledge was one engram per `plur_learn` call. When an orchestration fans out across agents and wants to record consolidated findings, the N-call overhead adds up. `plur_learn_batch` accepts an array of engram objects and writes them in a single call.
+
+- Writes go through the **same dedup + policy pipeline** as `plur_learn` (content-hash NOOP → semantic recall → LLM ADD/UPDATE/MERGE). Dedup also applies **within** the batch: a statement duplicating an earlier item in the same array resolves to NOOP against it.
+- Returns the created/affected engram ids in input order, per-item decisions, aggregate stats, and any per-item `failures`.
+- **Partial-failure isolation:** a single failing statement no longer aborts the batch — the rest are persisted and the failure is reported with its input index. `learnBatch`'s result gains a `failed` stat and a `failures[]` array (additive; existing fields unchanged).
+- LLM dedup calls stay bounded by `max_llm_calls` (default 50) to cap bulk-import cost.
+- Note: unlike `plur_learn`, batch items take the local learn path — remote-scope auto-routing (`learnRouted`) is not applied per item. For shared/remote-store writes prefer `plur_learn` or pass an explicit local scope.
+
 ## 0.11.0 (2026-07-06)
 
 Hooks that actually finish, tension lifecycle, migration importers.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ plur.sync('git@github.com:you/plur-memory.git')
 | Tool | What it does |
 |------|-------------|
 | `plur_learn` | Store a correction, preference, or convention |
+| `plur_learn_batch` | Store many engrams in one call (batch dedup + per-item failure isolation) |
 | `plur_recall_hybrid` | Retrieve relevant memories (BM25 + embeddings) |
 | `plur_inject_hybrid` | Select engrams for current task within token budget |
 | `plur_feedback` | Rate relevance (trains quality over time) |

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -10,7 +10,7 @@ import { logger } from './logger.js'
 import { withLock } from './sync.js'
 import type { Engram } from './schemas/engram.js'
 import type { SecretMatch } from './secrets.js'
-import type { LearnContext, LearnAsyncContext, LearnAsyncResult, LearnBatchResult, DedupDecision, LlmFunction } from './types.js'
+import type { LearnContext, LearnAsyncContext, LearnAsyncResult, LearnBatchResult, LearnBatchFailure, DedupDecision, LlmFunction } from './types.js'
 
 export interface LearnAsyncDeps {
   /** Content hash dedup against all engrams. Scope-aware: only matches same scope. */
@@ -279,13 +279,15 @@ export async function learnBatch(
   opts: LearnBatchOptions = {},
 ): Promise<LearnBatchResult> {
   const results: LearnAsyncResult[] = []
-  const stats = { added: 0, updated: 0, merged: 0, noops: 0 }
+  const failures: LearnBatchFailure[] = []
+  const stats = { added: 0, updated: 0, merged: 0, noops: 0, failed: 0 }
 
   const maxLlmCalls = opts.maxLlmCalls ?? 50
   let llmCallsUsed = 0
   let capWarned = false
 
-  for (const { statement, context } of statements) {
+  for (let i = 0; i < statements.length; i++) {
+    const { statement, context } = statements[i]
     // Resolve the LLM for this statement (per-statement override wins), then
     // gate it on the remaining budget. The wrapper increments the counter only
     // when learnAsync actually invokes the LLM (Step 4), so cheap short-circuits
@@ -305,14 +307,24 @@ export async function learnBatch(
     }
 
     const ctx: LearnAsyncContext = { ...context, llm: effectiveLlm }
-    const result = await learnAsync(deps, statement, ctx)
-    results.push(result)
-    const key = result.decision.toLowerCase()
-    if (key === 'noop') stats.noops++
-    else if (key === 'update') stats.updated++
-    else if (key === 'merge') stats.merged++
-    else stats.added++
+    // Partial-failure isolation (batch API, #281 item #3): one statement's
+    // failure must not abort the batch — an orchestrator persisting 50
+    // consolidated findings should keep the 49 that succeed. Capture the error
+    // against its input index and continue; the caller inspects `failures`.
+    try {
+      const result = await learnAsync(deps, statement, ctx)
+      results.push(result)
+      const key = result.decision.toLowerCase()
+      if (key === 'noop') stats.noops++
+      else if (key === 'update') stats.updated++
+      else if (key === 'merge') stats.merged++
+      else stats.added++
+    } catch (err) {
+      stats.failed++
+      failures.push({ index: i, statement, error: err instanceof Error ? err.message : String(err) })
+      logger.warning(`learnBatch: statement ${i} failed — ${err instanceof Error ? err.message : String(err)}`)
+    }
   }
 
-  return { results, stats }
+  return { results, stats, failures }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -72,9 +72,23 @@ export interface LearnAsyncResult {
   tensions?: string[]
 }
 
+/**
+ * A single statement that threw while being processed by learnBatch. Carrying
+ * the original array index lets callers correlate the failure back to their
+ * input; `results` only holds the statements that succeeded.
+ */
+export interface LearnBatchFailure {
+  index: number
+  statement: string
+  error: string
+}
+
 export interface LearnBatchResult {
+  /** Successful outcomes, in input order (excludes failed statements). */
   results: LearnAsyncResult[]
-  stats: { added: number; updated: number; merged: number; noops: number }
+  stats: { added: number; updated: number; merged: number; noops: number; failed: number }
+  /** Per-statement failures — a bad item does not abort the whole batch. */
+  failures: LearnBatchFailure[]
 }
 
 /**

--- a/packages/core/test/batch.test.ts
+++ b/packages/core/test/batch.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { learnBatch } from '../src/learn-async.js'
+import type { LearnAsyncDeps } from '../src/learn-async.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/**
+ * plur_learn_batch (batch API, #281 item #3): persist many engrams in one call,
+ * sharing the same dedup + policy pipeline as single learn. These tests cover
+ * the three behaviors the MCP tool relies on: batch write, dedup across the
+ * batch, and partial-failure isolation.
+ */
+
+describe('learnBatch: batch write', () => {
+  let plur: Plur
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-batch-'))
+    // Disable local embeddings so dedup uses the fast BM25 path — keeps the
+    // test deterministic and avoids one-time model warmup. Dedup logic itself
+    // stays enabled (this is exactly single-learn's policy path).
+    writeFileSync(join(dir, 'config.yaml'), 'embeddings:\n  enabled: false\n')
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('writes every novel statement and returns one id per success', async () => {
+    const res = await plur.learnBatch([
+      { statement: 'Deploy target is the nightshift server' },
+      { statement: 'Org files live under 0-personal/org' },
+      { statement: 'The weekly review runs on Sundays' },
+    ])
+
+    expect(res.results).toHaveLength(3)
+    expect(res.stats.added).toBe(3)
+    expect(res.stats.failed).toBe(0)
+    expect(res.failures).toEqual([])
+
+    const ids = res.results.map(r => r.engram.id)
+    expect(ids.every(id => typeof id === 'string' && id.length > 0)).toBe(true)
+    expect(new Set(ids).size).toBe(3) // ids are unique
+    // Every returned id is actually persisted and retrievable.
+    for (const id of ids) expect(plur.getById(id)).toBeTruthy()
+  })
+})
+
+describe('learnBatch: dedup within the batch', () => {
+  let plur: Plur
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-batch-dedup-'))
+    writeFileSync(join(dir, 'config.yaml'), 'embeddings:\n  enabled: false\n')
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('resolves a statement duplicating an earlier batch item to NOOP', async () => {
+    const res = await plur.learnBatch([
+      { statement: 'API responses use snake_case keys' },
+      { statement: 'The rate limit is 100 requests per minute' },
+      { statement: 'API responses use snake_case keys' }, // exact duplicate of item 0
+    ])
+
+    expect(res.results).toHaveLength(3)
+    expect(res.stats.added).toBe(2)
+    expect(res.stats.noops).toBe(1)
+    expect(res.stats.failed).toBe(0)
+
+    // The NOOP points back at the engram created for the first occurrence —
+    // dedup happened against the item persisted earlier in the same batch.
+    const noop = res.results.find(r => r.decision === 'NOOP')
+    expect(noop).toBeDefined()
+    expect(noop!.engram.id).toBe(res.results[0].engram.id)
+  })
+})
+
+describe('learnBatch: partial-failure isolation', () => {
+  // A fake deps whose write throws for one statement, so we can assert the
+  // batch keeps going and records the failure against its input index.
+  const makeDeps = (): LearnAsyncDeps => ({
+    hashDedup: () => null,
+    recallHybrid: async () => [],
+    recall: () => [],
+    learn: (statement: string) => {
+      if (statement.includes('BOOM')) throw new Error('simulated write failure')
+      return { id: 'ENG-2026-0101-777', statement } as unknown as Engram
+    },
+    getById: () => null,
+    engramsPath: '/tmp/plur-batch-fail-engrams.yaml',
+    rootPath: '/tmp/plur-batch-fail',
+    dedupConfig: { enabled: false }, // straight to deps.learn, no recall/LLM
+    isLlmAvailable: () => false,
+    recordLlmSuccess: () => {},
+    recordLlmFailure: () => {},
+    syncIndex: () => {},
+  })
+
+  it('captures the failing statement and still processes the rest', async () => {
+    const res = await learnBatch(makeDeps(), [
+      { statement: 'good one' },
+      { statement: 'this will BOOM' },
+      { statement: 'good two' },
+    ])
+
+    expect(res.results).toHaveLength(2)   // both good statements succeeded
+    expect(res.stats.added).toBe(2)
+    expect(res.stats.failed).toBe(1)
+
+    expect(res.failures).toHaveLength(1)
+    expect(res.failures[0].index).toBe(1) // original array index preserved
+    expect(res.failures[0].statement).toBe('this will BOOM')
+    expect(res.failures[0].error).toContain('simulated write failure')
+  })
+
+  it('reports an all-failed batch without throwing', async () => {
+    const res = await learnBatch(makeDeps(), [
+      { statement: 'BOOM one' },
+      { statement: 'BOOM two' },
+    ])
+
+    expect(res.results).toHaveLength(0)
+    expect(res.stats.added).toBe(0)
+    expect(res.stats.failed).toBe(2)
+    expect(res.failures.map(f => f.index)).toEqual([0, 1])
+  })
+})

--- a/packages/mcp/ARCHITECTURE.md
+++ b/packages/mcp/ARCHITECTURE.md
@@ -80,7 +80,7 @@ Tool families (~20 tools total):
 | Family | Tools |
 |---|---|
 | Lifecycle | `plur_session_start`, `plur_session_end` |
-| Learning | `plur_learn`, `plur_capture`, `plur_ingest`, `plur_extract_meta` |
+| Learning | `plur_learn`, `plur_learn_batch`, `plur_capture`, `plur_ingest`, `plur_extract_meta` |
 | Recall | `plur_recall`, `plur_recall_hybrid`, `plur_inject`, `plur_inject_hybrid`, `plur_similarity_search` |
 | Lifecycle (engram) | `plur_forget`, `plur_pin`, `plur_promote`, `plur_feedback`, `plur_history` |
 | Multi-store | `plur_stores_add`, `plur_stores_list` |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -52,6 +52,7 @@ Your agent gets these tools automatically:
 |------|-------------|
 | `plur_session_start` | Start a session — injects relevant engrams for your task |
 | `plur_learn` | Store a memory — correction, preference, convention, or decision |
+| `plur_learn_batch` | Store many memories in one call — same dedup + policy as `plur_learn`, with per-item failure isolation |
 | `plur_recall_hybrid` | **Best default** — BM25 + embeddings merged via RRF. Zero cost. |
 | `plur_recall` | Keyword search (BM25 only, instant) |
 | `plur_inject_hybrid` | Load relevant memories for the current task |

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -262,6 +262,96 @@ export function getToolDefinitions(): ToolDefinition[] {
     },
 
     {
+      name: 'plur_learn_batch',
+      description:
+        'Create many engrams in one call — the batch form of plur_learn. Accepts an array of engram objects and ' +
+        'writes them sequentially through the SAME dedup + policy pipeline as plur_learn (content-hash NOOP → semantic ' +
+        'recall → LLM ADD/UPDATE/MERGE decision). Dedup also applies WITHIN the batch: a statement duplicating an ' +
+        'earlier item in the same array resolves to NOOP against it. Returns the created/affected engram ids in input ' +
+        'order, the per-item decisions, aggregate stats, and any per-item failures — a single bad item does not abort ' +
+        'the batch. Use this when an orchestration fans out and wants to persist consolidated findings without N ' +
+        'separate calls. LLM dedup calls are capped (default 50, override with max_llm_calls) to bound bulk-import cost. ' +
+        'Note: unlike plur_learn, batch items take the LOCAL learn path — remote-scope auto-routing (learnRouted) is ' +
+        'not applied per item, so for shared/remote-store writes prefer plur_learn or pass an explicit local scope. ' +
+        'See plur-ai/plur#281.',
+      annotations: { title: 'Learn (batch)', destructiveHint: false, idempotentHint: false },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          engrams: {
+            type: 'array',
+            description: 'Engram objects to persist. Each requires `statement`; the other fields mirror plur_learn.',
+            items: {
+              type: 'object',
+              properties: {
+                statement: { type: 'string', description: 'The knowledge assertion to store' },
+                type: { type: 'string', enum: ['behavioral', 'terminological', 'procedural', 'architectural'], description: 'Category of the engram' },
+                scope: { type: 'string', description: 'Namespace, e.g. global, project:myapp' },
+                domain: { type: 'string', description: 'Domain tag, e.g. software.deployment' },
+                tags: { type: 'array', items: { type: 'string' }, description: 'Searchable keyword tags — contribute to BM25/embedding recall' },
+                rationale: { type: 'string', description: 'Why this knowledge matters — also enters the search corpus' },
+                source: { type: 'string', description: 'Origin of this knowledge (URL, conversation ref, etc.)' },
+                pinned: { type: 'boolean', description: 'Always-load flag. Use sparingly: meta-rules, safety conventions, core principles.' },
+                commitment: { type: 'string', enum: ['exploring', 'leaning', 'decided', 'locked'], description: 'How firmly the user has committed (default: leaning)' },
+                valid_from: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge becomes valid' },
+                valid_until: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge expires' },
+              },
+              required: ['statement'],
+            },
+          },
+          max_llm_calls: { type: 'number', description: 'Max LLM dedup calls across the whole batch (default 50). Once spent, remaining items use the cheap hash/cosine path. Pass a large number to opt out.' },
+        },
+        required: ['engrams'],
+      },
+      handler: async (args, plur) => {
+        const llm = getLlmFunction()
+        const raw = Array.isArray(args.engrams) ? (args.engrams as Array<Record<string, any>>) : []
+        if (raw.length === 0) {
+          return { ids: [], results: [], stats: { added: 0, updated: 0, merged: 0, noops: 0, failed: 0 }, failures: [], warning: 'No engrams provided — pass a non-empty `engrams` array.' }
+        }
+        const items = raw.map((e) => ({
+          statement: sanitizeStatement(e.statement as string),
+          context: {
+            type: e.type,
+            scope: e.scope as string | undefined,
+            domain: e.domain as string | undefined,
+            source: e.source as string | undefined,
+            tags: e.tags as string[] | undefined,
+            rationale: e.rationale as string | undefined,
+            commitment: e.commitment,
+            pinned: e.pinned as boolean | undefined,
+            valid_from: e.valid_from as string | undefined,
+            valid_until: e.valid_until as string | undefined,
+          },
+        }))
+        const maxLlmCalls = typeof args.max_llm_calls === 'number' ? args.max_llm_calls : undefined
+        const { results, stats, failures } = await plur.learnBatch(
+          items,
+          llm,
+          maxLlmCalls !== undefined ? { maxLlmCalls } : undefined,
+        )
+        mcpCanary.signal('learn_activity')
+        // Opt-in, content-free engagement counter (default-off; no statement text).
+        recordTelemetry('learn')
+        return {
+          ids: results.map((r) => r.engram.id),
+          results: results.map((r) => ({
+            id: r.engram.id,
+            statement: r.engram.statement,
+            scope: r.engram.scope,
+            type: r.engram.type,
+            decision: r.decision,
+            ...(r.existing_id ? { existing_id: r.existing_id } : {}),
+          })),
+          stats,
+          ...(failures.length > 0
+            ? { failures, warning: `${failures.length} of ${raw.length} engram(s) failed to persist; the rest were written.` }
+            : {}),
+        }
+      },
+    },
+
+    {
       name: 'plur_recall',
       description: 'Query engrams by BM25 keyword matching — use plur_recall_hybrid for semantic similarity. Note: a project-scope filter also returns personal-family engrams (local, global, user:*, agent:*); an explicit scope=global recall returns ALL personal-family engrams — wider than scope=global INJECT, which is targeted to the global namespace only.',
       annotations: { title: 'Recall (BM25)', readOnlyHint: true, idempotentHint: true },

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -62,6 +62,50 @@ describe('MCP tools', () => {
     expect(result.statement).toBe('Test learning')
   })
 
+  describe('plur_learn_batch', () => {
+    it('is registered as a tool', () => {
+      expect(tools.map(t => t.name)).toContain('plur_learn_batch')
+    })
+
+    it('writes an array of engrams and returns an id per input', async () => {
+      // Distinct, unrelated facts. We assert on persistence rather than the
+      // exact ADD/NOOP split, since the dedup decision depends on whether an
+      // LLM/embeddings are available in the test environment.
+      const result = await callTool('plur_learn_batch', {
+        engrams: [
+          { statement: 'The office WiFi password rotates every quarter', scope: 'global' },
+          { statement: 'Invoices are sent on the first Monday of the month', scope: 'global' },
+          { statement: 'The staging database is wiped every Friday night', scope: 'global' },
+        ],
+      }) as any
+      expect(result.ids).toHaveLength(3)
+      expect(result.ids.every((id: string) => /^ENG-/.test(id))).toBe(true)
+      expect(result.stats.failed).toBe(0)
+      expect(result.failures).toBeUndefined() // omitted when there are none
+      // every returned id is actually persisted
+      for (const id of result.ids) expect(plur.getById(id)).toBeTruthy()
+    })
+
+    it('dedupes a duplicate within the same batch to NOOP', async () => {
+      const result = await callTool('plur_learn_batch', {
+        engrams: [
+          { statement: 'Deploy uses git pull then restart', scope: 'global' },
+          { statement: 'Deploy uses git pull then restart', scope: 'global' },
+        ],
+      }) as any
+      expect(result.stats.added).toBe(1)
+      expect(result.stats.noops).toBe(1)
+      const noop = result.results.find((r: any) => r.decision === 'NOOP')
+      expect(noop.id).toBe(result.results[0].id)
+    })
+
+    it('returns an empty result for an empty array without throwing', async () => {
+      const result = await callTool('plur_learn_batch', { engrams: [] }) as any
+      expect(result.ids).toEqual([])
+      expect(result.warning).toMatch(/No engrams/)
+    })
+  })
+
   // #347 — temporal validity params on the write path.
   describe('plur_learn temporal validity (#347)', () => {
     it('accepts explicit valid_until and echoes it back', async () => {


### PR DESCRIPTION
## What

Adds `plur_learn_batch`, the batch form of `plur_learn`: one MCP call persists an array of engrams. Nice-to-have split from #281 item #3 — cuts the N-call overhead when an orchestration fans out across agents and wants to record consolidated findings.

## How it works

- **Same policy as single learn.** Each item runs the existing dedup pipeline (content-hash NOOP → semantic recall → LLM ADD/UPDATE/MERGE). Built on the existing `plur.learnBatch()` core method, which already bounds LLM dedup calls (`max_llm_calls`, default 50).
- **Dedup within the batch.** Statements are processed sequentially, so a later item duplicating an earlier one in the same array resolves to NOOP against it.
- **Returns** `ids` (in input order), per-item `results` (`{id, statement, scope, type, decision}`), aggregate `stats`, and `failures` when any occur.
- **Partial-failure isolation** (new in core `learnBatch`): a failing statement no longer aborts the batch. The rest persist; the failure is reported with its original input index. `LearnBatchResult` gains a `failed` stat and a `failures[]` array — additive, existing fields unchanged.

## Scope note

Unlike `plur_learn`, batch items take the **local** learn path — remote-scope auto-routing (`learnRouted`) is not applied per item. For shared/remote-store writes, prefer `plur_learn` or pass an explicit local scope. Called out in the tool description and CHANGELOG; a follow-up could add remote routing to the batch path if demand warrants.

## Tests

- `packages/core/test/batch.test.ts` (new): batch write + id/persistence, dedup-across-batch NOOP, partial-failure isolation, all-failed batch.
- `packages/mcp/test/tools.test.ts`: registration, array write, in-batch dedup, empty-array handling.
- Full core + mcp suites green locally: **2106 passed / 0 failed** (31 skipped).

## Docs

Root + `packages/mcp` README tool tables, `ARCHITECTURE.md` learning row, and a CHANGELOG **Unreleased** entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)