### PR TITLE
fix(cli,core): self-watchdog + RemoteStore timeout prevent orphan hook processes (#504)

### DIFF
--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -344,10 +344,23 @@ function processDeferredWrapups(): string | null {
   return `[PLUR] ${notices.join(' ')}\nConsider running plur_session_end with engram_suggestions when this session ends.`
 }
 
+// Self-watchdog ceiling for hook-inject. Hooks are fail-open — a silent
+// exit after the ceiling is always better than an immortal orphan process
+// when a background RemoteStore.load() hangs on a degraded network (#504).
+// Defaults to 55 s (within the 90 s harness timeout); override via env.
+// The timer is unref()ed so a normal clean exit isn't delayed.
+const HOOK_CEILING_MS = parseInt(process.env.PLUR_HOOK_CEILING_MS ?? '', 10) || 55_000
+
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // Silent pass-through for projects without plur configured (#247).
   // Lets hooks be installed globally without affecting non-plur projects.
   if (!isPlurConfigured()) return
+
+  // Watchdog: guarantee this process exits even if a background network call
+  // hangs (#504). Installed after isPlurConfigured() so it only fires for
+  // sessions that actually do work. unref() prevents it from delaying clean exit.
+  const watchdog = setTimeout(() => process.exit(0), HOOK_CEILING_MS)
+  watchdog.unref()
 
   const isRehydrate = args.includes('--rehydrate')
   const eventIdx = args.indexOf('--event')

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -46,6 +46,12 @@ const RemoteRowSchema = z.object({
  * — the upstream merge sees "no engrams from this store right now"
  * rather than blowing up. Callers learn about the problem via logs.
  */
+// Timeout for each page fetch inside load(). Background loads are not on
+// the hot path — a degraded network that never delivers headers must still
+// eventually unblock the caller (#504). 30 s is generous for a healthy
+// server while still keeping the process mortal on a blackholed route.
+const LOAD_FETCH_TIMEOUT_MS = 30_000
+
 export class RemoteStore implements EngramStore {
   private cache: { ts: number; engrams: Engram[] } | null = null
   private inFlight: Promise<Engram[]> | null = null
@@ -149,7 +155,9 @@ export class RemoteStore implements EngramStore {
         const maxPages = 50  // hard cap to avoid runaway loops
         for (let i = 0; i < maxPages; i++) {
           const u = `${this.apiBase}/engrams?scope=${encodeURIComponent(this.scope)}&limit=${limit}&offset=${offset}`
-          const r = await fetch(u, { headers: this.headers() })
+          const ctrl = new AbortController()
+          const t = setTimeout(() => ctrl.abort(), LOAD_FETCH_TIMEOUT_MS)
+          const r = await fetch(u, { headers: this.headers(), signal: ctrl.signal }).finally(() => clearTimeout(t))
           if (!r.ok) {
             // 403 (no read access) and 404 (scope doesn't exist) are
             // not errors at the store level — that store just contributes


### PR DESCRIPTION
## Summary

Fixes #504 — two compounding failure modes on degraded networks that caused 24 immortal `hook-inject` orphan processes to accumulate in ~40 minutes on a real degraded-VPN session (17.4 GB swap used).

**Fix 1 — Self-watchdog in `hook-inject` (primary)**
- Added `setTimeout(() => process.exit(0), HOOK_CEILING_MS).unref()` at `run()` entry (after `isPlurConfigured()` check)
- Default ceiling: 55 s (within the 90 s harness timeout); configurable via `PLUR_HOOK_CEILING_MS`
- `.unref()` ensures clean exits aren't delayed; the timer only fires if the process would otherwise hang forever
- Covers all code paths: event injection, reminder, and main injection

**Fix 2 — AbortController timeout on `RemoteStore.load()` (defense-in-depth)**
- Each page `fetch()` inside `load()` now has a 30 s `AbortController` timeout (`LOAD_FETCH_TIMEOUT_MS`)
- `AbortError` propagates to `load()`'s outer `catch`, which returns cached engrams or `[]` — fail-open, no cache poisoning
- Mirrors the `REMOTE_TIMEOUT_MS` discipline already in `tryRemoteInject()`

## Root cause (from issue)

1. `_loadRemoteCached()` fires `void driver.load()` as a background Promise — this `fetch()` had no deadline. On a half-open network it hangs indefinitely, keeping the Node.js event loop alive.
2. When the harness kills the parent hook process, the `node .../bin/plur hook-inject` child survives, reparented to PID 1. Orphans accumulate per prompt.

## Test plan

- [ ] `hook-inject` exits cleanly on non-plur projects (hook-noop.test.ts — unaffected: watchdog installed after `isPlurConfigured()` early return)
- [ ] Multi-store recall still works (multi-store.test.ts — RemoteStore local-cache path unchanged)
- [ ] Simulate blackholed network: `pfctl drop` to remote store host, verify hook-inject process dies within 55 s instead of hanging for 39+ min
- [ ] `PLUR_HOOK_CEILING_MS=5000 node .../plur hook-inject` exits within 5 s on a stalled remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)