### PR TITLE
docs: add recall transcript to onboarding get-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ context = plur.inject("write a streaming endpoint", limit=10)
 
 Ask your agent: *"What's my PLUR status?"* — it should call `plur_status` and return your engram count and storage path.
 
+### See it in action
+
+Once it's running, teach your agent something once:
+
+> *"Always use `pnpm` in this project — `npm install` breaks the lockfile in CI."*
+
+Start a new session the next day and ask:
+
+```
+You: How do I run the tests?
+
+🧠 injected 4 engrams  ·  scope: project:my-api
+
+Agent: Use pnpm — you mentioned npm breaks the lockfile in CI:
+
+  pnpm test                           # full suite
+  pnpm test -- src/auth.test.ts       # single file
+```
+
+New session. No reminder. The correction was there.
+
+That's the moment PLUR pays off — the agent remembers a project convention you mentioned once, without it being in any file it can read.
+
 ## How it works
 
 PLUR has two storage primitives:

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Start a new session the next day and ask:
 ```
 You: How do I run the tests?
 
-🧠 injected 4 engrams  ·  scope: project:my-api
+<plur-memory> 1 engram · project:my-api </plur-memory>
 
 Agent: Use pnpm — you mentioned npm breaks the lockfile in CI:
 


### PR DESCRIPTION
## Summary

- Adds a "See it in action" section immediately after the "Verify it works" step in the README
- Shows a realistic agent exchange: user taught their agent a project convention (pnpm vs npm), new session, agent recalls it without a reminder
- Uses a plausible real-world engram in a code block with the `🧠 injected N engrams` injection header

Closes #508. Follow-up from #236 docs review (item 6).

## Test plan

- [ ] README renders correctly on GitHub (code block, blockquote, header)
- [ ] Transcript reads as a real interaction, not a placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)