### PR TITLE
feat(mcp): packs install/list/uninstall CLI subcommands

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,10 +11,13 @@ const VERSION = '0.11.0'
 const HELP = `plur-mcp v${VERSION} — persistent memory for AI agents
 
 Usage:
-  plur-mcp              Start the MCP server (stdio transport)
-  plur-mcp init         Set up PLUR: storage + MCP config + hooks + CLAUDE.md
-  plur-mcp --help       Show this help message
-  plur-mcp --version    Show version
+  plur-mcp                           Start the MCP server (stdio transport)
+  plur-mcp init                      Set up PLUR: storage + MCP config + hooks + CLAUDE.md
+  plur-mcp packs install <path>      Install a knowledge pack from a local directory
+  plur-mcp packs list                List installed knowledge packs
+  plur-mcp packs uninstall <name>    Uninstall a knowledge pack by name
+  plur-mcp --help                    Show this help message
+  plur-mcp --version                 Show version
 
 Environment:
   PLUR_PATH             Storage location (default: ~/.plur/)
@@ -364,6 +367,61 @@ async function runInit() {
   }
 }
 
+// --- Packs subcommands ---
+
+async function runPacks(): Promise<void> {
+  const sub = process.argv[3]
+  const plurPath = process.env.PLUR_PATH ?? join(homedir(), '.plur')
+  const { Plur } = await import('@plur-ai/core')
+  const plur = new Plur({ path: plurPath })
+
+  if (sub === 'install') {
+    const source = process.argv[4]
+    if (!source) {
+      process.stderr.write('Usage: plur-mcp packs install <path>\n')
+      process.exit(1)
+    }
+    try {
+      const result = plur.installPack(source)
+      process.stdout.write(`Installed pack '${result.name}' (${result.installed} engrams)\n`)
+    } catch (err) {
+      process.stderr.write(`Error: ${(err as Error).message}\n`)
+      process.exit(1)
+    }
+  } else if (sub === 'list') {
+    const packs = plur.listPacks()
+    if (packs.length === 0) {
+      process.stdout.write('No packs installed.\n')
+    } else {
+      for (const pack of packs) {
+        const version = pack.manifest?.version ? ` v${pack.manifest.version}` : ''
+        process.stdout.write(`${pack.name}${version} (${pack.engram_count} engrams)\n`)
+      }
+    }
+  } else if (sub === 'uninstall') {
+    const name = process.argv[4]
+    if (!name) {
+      process.stderr.write('Usage: plur-mcp packs uninstall <name>\n')
+      process.exit(1)
+    }
+    try {
+      const result = plur.uninstallPack(name)
+      if (result.removed) {
+        process.stdout.write(`Uninstalled pack '${result.name}' (${result.engram_count} engrams removed)\n`)
+      } else {
+        process.stderr.write(`Pack '${name}' not found.\n`)
+        process.exit(1)
+      }
+    } catch (err) {
+      process.stderr.write(`Error: ${(err as Error).message}\n`)
+      process.exit(1)
+    }
+  } else {
+    process.stderr.write(`Unknown packs subcommand: ${sub ?? '(none)'}\nAvailable: install, list, uninstall\n`)
+    process.exit(1)
+  }
+}
+
 // --- Main execution ---
 
 const arg = process.argv[2]
@@ -380,6 +438,11 @@ if (arg === '--version' || arg === '-v') {
 
 if (arg === 'init') {
   await runInit()
+  process.exit(0)
+}
+
+if (arg === 'packs') {
+  await runPacks()
   process.exit(0)
 }
 


### PR DESCRIPTION
## What

Adds `packs install`, `packs list`, and `packs uninstall` subcommands to the `plur-mcp` CLI so users can manage knowledge packs without going through an AI agent tool call.

```bash
# Install a pack from a local directory
npx @plur-ai/mcp packs install ./my-typescript-pack

# List installed packs
npx @plur-ai/mcp packs list

# Remove a pack
npx @plur-ai/mcp packs uninstall my-typescript-pack
```

## Why

Content marketing (dev.to article + X thread drafted today) references `plur packs install <name>` as the pack install UX. Without this CLI command, developers who try it get `Unknown command: packs`. This unblocks publishing the exchange-layer explainer article.

Also useful in its own right: direct pack install via CLI is a reasonable DX expectation — users shouldn't need to open Claude just to install a local pack.

## Implementation

Single-file change to `packages/mcp/src/index.ts`:
- Added `runPacks()` function handling `install`, `list`, `uninstall` subcommands
- All three delegate to the same `plur.installPack()` / `plur.listPacks()` / `plur.uninstallPack()` core APIs already used by the MCP tools
- `install` runs the full security scan (inherited from core — secrets and prompt-injection blocked)
- Updated `HELP` string

## Notes

- `packs install <path>` takes a local directory path (registry-by-name is a follow-up once the marketplace is live)
- Builds cleanly, existing 193/201 mcp tests pass (8 login.test.ts failures are pre-existing, unrelated to this PR)

Closes #268 pre-publish gate (CLI accuracy) | Context: exchange-layer dev.to article at `1-tracks/comms/drafts/plur-exchange-layer-explainer-devto-2026-07-08.md`

🤖 heartbeat