### PR TITLE
feat(core,mcp): plur_status domain + created_after date filters (#522)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3707,12 +3707,19 @@ Generate an improved version of the procedure that prevents this failure. Return
   }
 
   /** Return system health info. */
-  status(): StatusResult {
+  status(options?: { created_after?: string; domain?: string }): StatusResult {
     const engrams = this._loadAllEngrams()
     const episodes = queryTimeline(this.paths.episodes)
     const packs = listPacks(this.paths.packs)
 
-    const active = engrams.filter(e => e.status !== 'retired')
+    let active = engrams.filter(e => e.status !== 'retired')
+    if (options?.domain) {
+      active = active.filter(e => e.domain?.startsWith(options.domain!))
+    }
+    if (options?.created_after) {
+      const cutoff = options.created_after
+      active = active.filter(e => e.temporal?.learned_at && e.temporal.learned_at >= cutoff)
+    }
     const lockedCount = active.filter(e => (e as any).commitment === 'locked').length
     // #181 (audit #213 C2): tension_count counts UNRESOLVED persisted
     // tension records — the LLM-validated detector's output — instead of

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ import { computeContentHash } from './content-hash.js'
 import { loadTensions, saveTensions, generateTensionId, tensionPairKey, categorizeTension } from './tension-store.js'
 import type { TensionRecord, TensionStatus } from './schemas/tension.js'
 import type { TensionPair } from './tensions.js'
+import { engramDate } from './tensions.js'
 import { resolveValidity, buildTemporal } from './expiry.js'
 import { decodeJwtExpiry } from './jwt.js'
 import { RemoteStore } from './store/remote-store.js'
@@ -3718,7 +3719,7 @@ Generate an improved version of the procedure that prevents this failure. Return
     }
     if (options?.created_after) {
       const cutoff = options.created_after
-      active = active.filter(e => e.temporal?.learned_at && e.temporal.learned_at >= cutoff)
+      active = active.filter(e => { const d = engramDate(e); return d !== undefined && d >= cutoff })
     }
     const lockedCount = active.filter(e => (e as any).commitment === 'locked').length
     // #181 (audit #213 C2): tension_count counts UNRESOLVED persisted

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1335,14 +1335,20 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_status',
-      description: 'Return system health — running version, engram count, episode count, pack count, storage root',
+      description: 'Return system health — running version, engram count, episode count, pack count, storage root. Optionally filter engram counts by domain prefix and/or creation date.',
       annotations: { title: 'Status', readOnlyHint: true, idempotentHint: true },
       inputSchema: {
         type: 'object',
-        properties: {},
+        properties: {
+          domain: { type: 'string', description: 'Only count engrams whose domain starts with this prefix (e.g. "meridian")' },
+          created_after: { type: 'string', description: 'ISO-8601 date (YYYY-MM-DD). Only count engrams learned on or after this date.' },
+        },
       },
-      handler: async (_args, plur) => {
-        const status = plur.status()
+      handler: async (args, plur) => {
+        const status = plur.status({
+          domain: args.domain as string | undefined,
+          created_after: args.created_after as string | undefined,
+        })
         const versionCheck = getCachedUpdateCheck('@plur-ai/mcp')
         return {
           version: VERSION,

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -323,6 +323,24 @@ describe('MCP tools', () => {
     expect(result.version).toMatch(/^\d+\.\d+\.\d+/)
   })
 
+  it('plur_status filters engram count by domain', async () => {
+    await callTool('plur_learn', { statement: 'Meridian thing', scope: 'global', domain: 'meridian' })
+    await callTool('plur_learn', { statement: 'Other thing', scope: 'global', domain: 'other' })
+    const all = await callTool('plur_status', {}) as any
+    expect(all.engram_count).toBe(2)
+    const filtered = await callTool('plur_status', { domain: 'meridian' }) as any
+    expect(filtered.engram_count).toBe(1)
+  })
+
+  it('plur_status filters engram count by created_after', async () => {
+    await callTool('plur_learn', { statement: 'Status date test', scope: 'global' })
+    const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10)
+    const future = await callTool('plur_status', { created_after: tomorrow }) as any
+    expect(future.engram_count).toBe(0)
+    const past = await callTool('plur_status', { created_after: '2000-01-01' }) as any
+    expect(past.engram_count).toBe(1)
+  })
+
   // #452 — injection-provenance event/label counts feed #202's volume gate.
   it('plur_status surfaces injection event and label counts', async () => {
     const empty = await callTool('plur_status', {}) as any


### PR DESCRIPTION
## Summary

- Adds optional `domain` and `created_after` parameters to `plur_status` (closes #522)
- `domain` filters by prefix (e.g. `"meridian"` matches `meridian`, `meridian.projects`)
- `created_after` filters to engrams learned on or after an ISO date (`"YYYY-MM-DD"`)
- Both params are optional and combinable — no breaking change

## Motivation

KCR reviewers auditing a domain since a specific date were forced to receive 300+ engrams and grep manually. With this change, `{"domain": "meridian", "created_after": "2026-06-27"}` returns only what changed in that window.

## Implementation

**Core (`packages/core/src/index.ts`):** `status()` now accepts `options?: { domain?, created_after? }`. Filters `active` engrams before counting. `created_after` compares `temporal.learned_at` (always-set ISO string) with `>=` — correct for lexicographic ISO date ordering.

**MCP (`packages/mcp/src/tools.ts`):** `plur_status` `inputSchema.properties` now declares both params; handler forwards them to `plur.status()`.

**Tests (`packages/mcp/test/tools.test.ts`):** Two new tests — domain filter isolates engrams by domain prefix; `created_after` filter yields 0 for a future cutoff and 1 for a past cutoff.

## Test plan
- [ ] CI passes (Node 20/22/24 matrix)
- [ ] `plur_status { "domain": "meridian" }` returns only meridian engrams
- [ ] `plur_status { "created_after": "2026-06-27" }` returns engrams from that date onward
- [ ] `plur_status {}` (no params) still returns global counts — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)