### PR TITLE
fix(python): bump npx CLI pin 0.10.1→0.13.0, document recall() semantic change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ PLUR now works inside Cursor — its own hook system (`sessionStart`, `preToolUs
 - **Commitment tier in injected text** (#348): `formatLayer3` shows the commitment label (`exploring`/`leaning`/`decided`/`locked`) instead of a raw confidence float when set.
 - **Per-store reranker fit check** (#451): `plur doctor` scores whether a cross-encoder reranker is actually helping on a given store's domain, since out-of-domain rerankers can produce inverted scores.
 - **`plur_session_end` wired to Claude Code's SessionEnd hook** (#217): memory lifecycle now auto-closes when a session ends, instead of depending on the agent remembering to call it.
-- Python SDK bumped to 0.10.0: `recall_hybrid()` added (hybrid BM25+embeddings); `recall()` changed to lexical-only (`--fast`); npx CLI pin bumped to 0.12.0. **Breaking**: `recall()` no longer does hybrid search — call `recall_hybrid()` for the previous behaviour.
+- Python SDK bumped to 0.10.0: `recall_hybrid()` added (hybrid BM25+embeddings); `recall()` changed to lexical-only (`--fast`); npx CLI pin bumped to 0.13.0. **Breaking**: `recall()` no longer does hybrid search — call `recall_hybrid()` for the previous behaviour.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ PLUR now works inside Cursor — its own hook system (`sessionStart`, `preToolUs
 - **Commitment tier in injected text** (#348): `formatLayer3` shows the commitment label (`exploring`/`leaning`/`decided`/`locked`) instead of a raw confidence float when set.
 - **Per-store reranker fit check** (#451): `plur doctor` scores whether a cross-encoder reranker is actually helping on a given store's domain, since out-of-domain rerankers can produce inverted scores.
 - **`plur_session_end` wired to Claude Code's SessionEnd hook** (#217): memory lifecycle now auto-closes when a session ends, instead of depending on the agent remembering to call it.
-- Python SDK bumped to 0.10.0 (`recall_hybrid`, npx pin fix).
+- Python SDK bumped to 0.10.0: `recall_hybrid()` added (hybrid BM25+embeddings); `recall()` changed to lexical-only (`--fast`); npx CLI pin bumped to 0.12.0. **Breaking**: `recall()` no longer does hybrid search — call `recall_hybrid()` for the previous behaviour.
 
 ### Fixed
 

--- a/packages/python/plur_ai/bridge.py
+++ b/packages/python/plur_ai/bridge.py
@@ -22,7 +22,7 @@ from typing import Any, Sequence
 
 # @plur-ai/cli pin for the npx fallback. Keep >= the published CLI that carries
 # the current scope-routing / leak-guard fixes; release tooling bumps this.
-_NPX_CLI_VERSION = "0.12.0"
+_NPX_CLI_VERSION = "0.13.0"
 _DEFAULT_TIMEOUT = 30
 
 

--- a/packages/python/plur_ai/bridge.py
+++ b/packages/python/plur_ai/bridge.py
@@ -22,7 +22,7 @@ from typing import Any, Sequence
 
 # @plur-ai/cli pin for the npx fallback. Keep >= the published CLI that carries
 # the current scope-routing / leak-guard fixes; release tooling bumps this.
-_NPX_CLI_VERSION = "0.10.1"
+_NPX_CLI_VERSION = "0.12.0"
 _DEFAULT_TIMEOUT = 30
 
 


### PR DESCRIPTION
## Summary

Post-merge audit of #495 (Python SDK v0.10.0) found two issues:

- **Stale npx pin** — `_NPX_CLI_VERSION` was set to `0.10.1` but `@plur-ai/cli` is at `0.12.0`. Users without a local `plur` binary fall back to `npx @plur-ai/cli@0.10.1`, missing self-watchdog (#504), RemoteStore timeout fixes, and Cursor IDE support shipped in 0.11.0–0.12.0.
- **Undocumented breaking change** — `recall()` changed from hybrid (0.9.x default) to lexical-only (`--fast`) in 0.10.0 without a CHANGELOG note.

## Changes

- `packages/python/plur_ai/bridge.py`: `_NPX_CLI_VERSION = "0.10.1"` → `"0.12.0"`
- `CHANGELOG.md`: expand the Python SDK 0.12.0 bullet to note the `recall()` semantic change as breaking and correct the pin version

## Test plan

- [x] `python3 -m pytest tests/ -q` → 4 passed
- [x] Audit findings posted to #495

Closes the publish-blocking finding from the #495 post-merge audit. Once this merges, `plur-ai` v0.10.0 can be published to PyPI with the correct pin (Gregor, needs PyPI auth as plur9).

🤖 heartbeat — cto.python-sdk-audit