### PR TITLE
fix(core): extend AbortController coverage to r.json() body read in RemoteStore.load()

### DIFF
--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -173,23 +173,30 @@ export class RemoteStore implements EngramStore {
           const u = `${this.apiBase}/engrams?scope=${encodeURIComponent(this.scope)}&limit=${limit}&offset=${offset}`
           const ctrl = new AbortController()
           const t = setTimeout(() => ctrl.abort(), LOAD_FETCH_TIMEOUT_MS)
-          const r = await fetch(u, { headers: this.headers(), signal: ctrl.signal }).finally(() => clearTimeout(t))
-          if (!r.ok) {
-            // 403 (no read access) and 404 (scope doesn't exist) are
-            // not errors at the store level — that store just contributes
-            // nothing. Bubble other 5xx as logs.
-            if (r.status >= 500) console.error(`[plur:remote-store] ${this.url} returned ${r.status} loading scope ${this.scope}`)
+          try {
+            const r = await fetch(u, { headers: this.headers(), signal: ctrl.signal })
+            if (!r.ok) {
+              // 403 (no read access) and 404 (scope doesn't exist) are
+              // not errors at the store level — that store just contributes
+              // nothing. Bubble other 5xx as logs.
+              if (r.status >= 500) console.error(`[plur:remote-store] ${this.url} returned ${r.status} loading scope ${this.scope}`)
+              break
+            }
+            const body = await r.json() as { rows: any[]; total_count: number }
+            // Server returns DB rows shaped {id, scope, status, data, created_at, updated_at}
+            // — the engram contents live in row.data. Reshape + validate; drop malformed.
+            for (const row of body.rows) {
+              const e = this.reshape(row)
+              if (e) all.push(e)
+            }
+            if (all.length >= body.total_count || body.rows.length < limit) break
+            offset += limit
+          } catch (err) {
+            console.error(`[plur:remote-store] ${this.url} load page failed: ${(err as Error).message}`)
             break
+          } finally {
+            clearTimeout(t)
           }
-          const body = await r.json() as { rows: any[]; total_count: number }
-          // Server returns DB rows shaped {id, scope, status, data, created_at, updated_at}
-          // — the engram contents live in row.data. Reshape + validate; drop malformed.
-          for (const row of body.rows) {
-            const e = this.reshape(row)
-            if (e) all.push(e)
-          }
-          if (all.length >= body.total_count || body.rows.length < limit) break
-          offset += limit
         }
         this.cache = { ts: Date.now(), engrams: all }
         return all


### PR DESCRIPTION
## Summary

Fixes #525.

`clearTimeout` was firing inside `.finally()` on the `fetch()` promise, which resolves when response **headers** arrive. The body read (`r.json()`) ran outside the abort deadline — a server returning headers quickly but stalling the body could hang `load()` until the 55 s process watchdog killed it.

**Fix:** wrap each per-page `fetch` + `r.json()` in a `try/catch/finally` with `clearTimeout` in the `finally`. This matches the correct pattern already used in `tryRemoteInject()` (hook-inject.ts). AbortErrors from stalled body reads now log a per-page message and `break` the pagination loop cleanly.

## Before / After

**Before** — abort deadline clears on headers; body read is unprotected:
```ts
const r = await fetch(u, { ..., signal: ctrl.signal }).finally(() => clearTimeout(t))
const body = await r.json()  // ← no deadline
```

**After** — abort deadline covers headers + body:
```ts
try {
  const r = await fetch(u, { ..., signal: ctrl.signal })
  const body = await r.json()  // ← still under deadline
  ...
} catch (err) {
  console.error(`[plur:remote-store] ${this.url} load page failed: ${(err as Error).message}`)
  break
} finally {
  clearTimeout(t)  // ← fires after both fetch and body read
}
```

## Priority

P3 per #525 — 55 s process watchdog catches the hang at process level; no user-visible regression from the gap. This is a correctness cleanup only.

🤖 heartbeat — 2026-07-12