### PR TITLE
feat(core,mcp): session injection telemetry — per-pack activation tracking at session_end

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2503,6 +2503,25 @@ export class Plur {
       ...result.consider.map(e => e.id),
     ]
 
+    // Build per-pack injection counts for telemetry (session_end activation tracking).
+    // Uses the `pack` field that selectAndSpread stamps onto every WireEngram —
+    // null means the engram belongs to the user's personal store, not an installed pack.
+    const injected_packs: Record<string, number> | undefined = injected_ids.length > 0
+      ? (() => {
+          const allEngrams = [
+            ...result.directives,
+            ...result.constraints,
+            ...result.consider,
+          ]
+          const counts: Record<string, number> = {}
+          for (const e of allEngrams) {
+            const key = (e as any).pack ?? '__personal__'
+            counts[key] = (counts[key] ?? 0) + 1
+          }
+          return counts
+        })()
+      : undefined
+
     // #452: log a co_injection provenance event — which engrams fired
     // together for which query context. Data source for the co-fires-with
     // edges (#200/#201) and temporal-replay self-labeling (#202). Compact by
@@ -2537,6 +2556,7 @@ export class Plur {
       count,
       tokens_used: tokensUsed,
       injected_ids,
+      ...(injected_packs ? { injected_packs } : {}),
       ...(warnings.length > 0 ? { warnings } : {}),
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -160,6 +160,12 @@ export interface InjectionResult {
   tokens_used: number
   injected_ids: string[]
   /**
+   * Per-pack engram counts for this injection. Key is pack name or '__personal__'
+   * for engrams from the user's personal store. Used for session activation-rate
+   * telemetry at plur_session_end. Only present when at least one engram was injected.
+   */
+  injected_packs?: Record<string, number>
+  /**
    * Persisted-tension warnings (#181): present when an injected engram
    * participates in an unresolved tension (confirmed → either side injected;
    * detected → both sides injected together). Surface, don't adjudicate.

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -216,6 +216,59 @@ mcpCanary.expect({
   fix: 'Call plur_learn when corrected. If using hooks, verify they are installed.',
 })
 
+/**
+ * Session injection telemetry — tracks pack-level engram injection counts per
+ * session. Keyed by session_id → map of pack_name → engram count.
+ *
+ * Data source for the 25-80 sessions/month activation-rate assumption. Surface
+ * at plur_session_end so Michelle can validate with real data.
+ *
+ * The Map is process-scoped (one MCP server = one long-running process serving
+ * sequential sessions). Entries are cleaned up when session_end runs, so memory
+ * does not accumulate across sessions. A TTL guard caps memory if session_end
+ * is never called (hook crash, forced kill, etc.).
+ *
+ * Structure: session_id → { pack_name → injection_count, __total_injections → N }
+ * The __total_injections key counts how many inject calls happened (not engrams).
+ */
+interface SessionTelemetry {
+  pack_counts: Record<string, number>
+  /** Number of distinct inject calls (plur_session_start + plur_inject/hybrid). */
+  injection_calls: number
+  /** ISO timestamp of session_start — used for TTL cleanup. */
+  started_at: string
+}
+const _sessionTelemetry = new Map<string, SessionTelemetry>()
+
+/** TTL for unclosed sessions: 8 hours. Prevents unbounded memory if session_end is never called. */
+const SESSION_TTL_MS = 8 * 60 * 60 * 1000
+
+function _cleanExpiredSessions(): void {
+  const cutoff = Date.now() - SESSION_TTL_MS
+  for (const [id, state] of _sessionTelemetry) {
+    if (new Date(state.started_at).getTime() < cutoff) _sessionTelemetry.delete(id)
+  }
+}
+
+/**
+ * The session_id of the currently active session. Set by session_start, cleared
+ * by session_end. MCP sessions are sequential within a process, so a single
+ * module-level variable is safe. Used by plur_inject / plur_inject_hybrid to
+ * record telemetry without requiring callers to pass a session_id.
+ */
+let _activeSessionId: string | undefined
+
+/** Record pack counts from an InjectionResult into the active session's telemetry. */
+function _recordInjectionTelemetry(session_id: string | undefined, injected_packs: Record<string, number> | undefined): void {
+  if (!session_id || !injected_packs) return
+  const state = _sessionTelemetry.get(session_id)
+  if (!state) return
+  state.injection_calls++
+  for (const [pack, count] of Object.entries(injected_packs)) {
+    state.pack_counts[pack] = (state.pack_counts[pack] ?? 0) + count
+  }
+}
+
 export type ToolProfile = 'full' | 'cursor'
 
 // The day-to-day tools a Cursor user needs, plus every tool marked
@@ -714,6 +767,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           budget: args.budget as number | undefined,
           scope: args.scope as string | undefined,
         })
+        _recordInjectionTelemetry(_activeSessionId, result.injected_packs)
         return {
           directives: result.directives,
           consider: result.consider,
@@ -744,6 +798,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           budget: args.budget as number | undefined,
           scope: args.scope as string | undefined,
         })
+        _recordInjectionTelemetry(_activeSessionId, result.injected_packs)
         return {
           directives: result.directives,
           consider: result.consider,
@@ -1652,6 +1707,17 @@ function getAllToolDefinitions(): ToolDefinition[] {
         const task = args.task as string
         const tags = args.tags as string[] | undefined
 
+        // Initialize session telemetry — tracks per-pack injection counts for
+        // activation-rate validation (target: 25-80 sessions/month per user).
+        // TTL cleanup runs here to evict any unclosed sessions from prior starts.
+        _cleanExpiredSessions()
+        _activeSessionId = session_id
+        _sessionTelemetry.set(session_id, {
+          pack_counts: {},
+          injection_calls: 0,
+          started_at: new Date().toISOString(),
+        })
+
         // Auto-discovery happens in Plur constructor — no manual call needed.
 
         // Flush outbox — retry pending remote writes (issue #26)
@@ -1719,6 +1785,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
             scope: tags?.length ? `tags:${tags.join(',')}` : undefined,
             session_id, // stamped on the co_injection provenance event (#452)
           })
+          _recordInjectionTelemetry(session_id, result.injected_packs)
           if (result.count > 0) {
             const lines: string[] = []
             if (result.directives) lines.push('## DIRECTIVES\n', result.directives)
@@ -1732,6 +1799,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
             scope: tags?.length ? `tags:${tags.join(',')}` : undefined,
             session_id,
           })
+          _recordInjectionTelemetry(session_id, result.injected_packs)
           if (result.count > 0) {
             const lines: string[] = []
             if (result.directives) lines.push('## DIRECTIVES\n', result.directives)
@@ -1962,6 +2030,22 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           channel: 'mcp',
         })
 
+        // Collect injection telemetry before cleanup
+        const telemetry = session_id ? _sessionTelemetry.get(session_id) : undefined
+        const injection_summary = telemetry && telemetry.injection_calls > 0
+          ? {
+              pack_counts: { ...telemetry.pack_counts },
+              total_injections: telemetry.injection_calls,
+              session_duration_ms: Date.now() - new Date(telemetry.started_at).getTime(),
+            }
+          : undefined
+
+        // Clean up session telemetry
+        if (session_id) {
+          _sessionTelemetry.delete(session_id)
+          if (_activeSessionId === session_id) _activeSessionId = undefined
+        }
+
         // Clean up session checkpoint (#215) — session ended cleanly
         try {
           const plurDir = process.env.PLUR_PATH ?? join(homedir(), '.plur')
@@ -1982,6 +2066,7 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           engrams_created,
           episode_id: episode.id,
           total_engrams: status.engram_count,
+          ...(injection_summary ? { injection_summary } : {}),
           hint: engrams_created === 0
             ? 'No engrams captured this session. If any corrections, preferences, or patterns came up, consider calling plur_learn before ending.'
             : undefined,

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -116,6 +116,122 @@ describe('Session & store tools', () => {
     })).rejects.toThrow(/must be a string or \{statement/)
   })
 
+  // ── Session injection telemetry ──────────────────────────────────────────────
+  //
+  // session_start records engram injections per-pack into an in-process Map so
+  // session_end can surface them as injection_summary. Validates the 25-80
+  // sessions/month activation-rate assumption in hypotheses.yaml (H003).
+
+  describe('session injection telemetry', () => {
+    it('session_end returns injection_summary when engrams were injected', async () => {
+      // Seed an engram so session_start injects something
+      plur.learn('Always use semicolons in TypeScript', { scope: 'global' })
+
+      const startResult = await callTool('plur_session_start', { task: 'write TypeScript code' }) as any
+      const session_id = startResult.session_id
+      expect(session_id).toBeDefined()
+
+      const endResult = await callTool('plur_session_end', {
+        summary: 'Wrote TypeScript',
+        session_id,
+        engram_suggestions: [],
+      }) as any
+
+      expect(endResult.injection_summary).toBeDefined()
+      expect(endResult.injection_summary.total_injections).toBeGreaterThan(0)
+      expect(endResult.injection_summary.pack_counts).toBeDefined()
+      // Personal engrams (no pack) show up as __personal__
+      expect(endResult.injection_summary.pack_counts.__personal__).toBeGreaterThan(0)
+      // session_duration_ms must be a non-negative number
+      expect(typeof endResult.injection_summary.session_duration_ms).toBe('number')
+      expect(endResult.injection_summary.session_duration_ms).toBeGreaterThanOrEqual(0)
+    })
+
+    it('injection_summary.session_duration_ms reflects elapsed wall-clock time', async () => {
+      plur.learn('Timing test engram', { scope: 'global' })
+
+      const before = Date.now()
+      const startResult = await callTool('plur_session_start', { task: 'timing test' }) as any
+      const session_id = startResult.session_id
+
+      const endResult = await callTool('plur_session_end', {
+        summary: 'Timing session done',
+        session_id,
+        engram_suggestions: [],
+      }) as any
+      const after = Date.now()
+
+      expect(endResult.injection_summary).toBeDefined()
+      const { session_duration_ms } = endResult.injection_summary
+      // Duration must be a non-negative number bounded by actual wall time
+      expect(session_duration_ms).toBeGreaterThanOrEqual(0)
+      expect(session_duration_ms).toBeLessThanOrEqual(after - before)
+    })
+
+    it('session_end returns no injection_summary when no engrams exist', async () => {
+      // No engrams → session_start injects nothing
+      const startResult = await callTool('plur_session_start', { task: 'fresh store task' }) as any
+      const session_id = startResult.session_id
+
+      const endResult = await callTool('plur_session_end', {
+        summary: 'Nothing injected',
+        session_id,
+        engram_suggestions: [],
+      }) as any
+
+      expect(endResult.injection_summary).toBeUndefined()
+    })
+
+    it('standalone plur_inject calls accumulate into the session telemetry', async () => {
+      plur.learn('Use pnpm for package management', { scope: 'global' })
+
+      const startResult = await callTool('plur_session_start', { task: 'tooling check' }) as any
+      const session_id = startResult.session_id
+
+      // Make an additional standalone inject call
+      await callTool('plur_inject', { task: 'pnpm install' })
+
+      const endResult = await callTool('plur_session_end', {
+        summary: 'Ran pnpm',
+        session_id,
+        engram_suggestions: [],
+      }) as any
+
+      // At least 2 injection calls: one from session_start, one from plur_inject
+      expect(endResult.injection_summary).toBeDefined()
+      expect(endResult.injection_summary.total_injections).toBeGreaterThanOrEqual(2)
+    })
+
+    it('session telemetry is cleared after session_end — no cross-session bleed', async () => {
+      plur.learn('Test engram', { scope: 'global' })
+
+      const startA = await callTool('plur_session_start', { task: 'task A' }) as any
+      const session_id_A = startA.session_id
+
+      const endA = await callTool('plur_session_end', {
+        summary: 'Session A done',
+        session_id: session_id_A,
+        engram_suggestions: [],
+      }) as any
+      const injectionsA = endA.injection_summary?.total_injections ?? 0
+
+      // Session B starts fresh — its total_injections should equal A's (same engram,
+      // same one inject call from session_start), NOT 2× A's.
+      const startB = await callTool('plur_session_start', { task: 'task B' }) as any
+      const session_id_B = startB.session_id
+      expect(session_id_B).not.toBe(session_id_A)
+
+      const endB = await callTool('plur_session_end', {
+        summary: 'Session B done',
+        session_id: session_id_B,
+        engram_suggestions: [],
+      }) as any
+      const injectionsB = endB.injection_summary?.total_injections ?? 0
+
+      expect(injectionsB).toBe(injectionsA)
+    })
+  })
+
   it('plur_stores_add registers a store in config', async () => {
     const storePath = join(dir, 'extra-store', 'engrams.yaml')
     const storeDir = join(dir, 'extra-store')


### PR DESCRIPTION
## Summary

- Adds `injection_summary` field to `plur_session_end` response: `pack_counts` (engrams per pack), `total_injections` (distinct inject calls), `session_duration_ms`
- Populates `injected_packs` on `InjectionResult` in core — uses the `pack` field that `selectAndSpread` stamps on every `WireEngram`; `__personal__` key for user-owned engrams
- Process-scoped `_sessionTelemetry` Map in MCP with 8h TTL guard for unclosed sessions
- `_recordInjectionTelemetry` wired into `plur_session_start`, `plur_inject`, and `plur_inject_hybrid`

## Motivation

Validates the 25-80 sessions/month activation-rate assumption for H003/H005. With real per-pack injection data from `plur_session_end`, Michelle can compute actual activation rates and compare against the hypothesis baseline.

## Implementation notes

**No duplicate counting:** `plur_session_start` tries `injectHybrid` first and falls back to `inject` in a try/catch — only one path fires per session start. Standalone `plur_inject` / `plur_inject_hybrid` calls each record once via their own handlers.

**TTL guard:** `_cleanExpiredSessions()` runs at session_start. Sessions older than 8h are evicted to prevent unbounded memory if `session_end` is never called (hook crash, forced kill).

**Non-breaking:** `injection_summary` is optional — omitted when no engrams were injected. `injected_packs` on `InjectionResult` is optional and conditional on `injected_ids.length > 0`.

**Note on `injected_packs` in types.ts:** PR #534 (flip DEFAULT_RERANKER) also adds `injected_packs?: Record<string, number>` to `InjectionResult` without JSDoc. This PR includes the full JSDoc. Merge order: either works — trivial rebase if #534 lands first.

## Test plan

- [x] `session_end` returns `injection_summary` when engrams were injected
- [x] `injection_summary.session_duration_ms` reflects elapsed wall-clock time
- [x] `session_end` returns no `injection_summary` when no engrams exist
- [x] Standalone `plur_inject` calls accumulate into session telemetry
- [x] Session telemetry is cleared after `session_end` — no cross-session bleed
- [x] All 25 session tests pass

Closes: recovered from stash on `feat/451-flip-default-reranker` (nightshift 2026-07-12) + cleaned by heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)