### PR TITLE
chore(hermes): add missing PyPI project metadata

### DIFF
--- a/packages/hermes/pyproject.toml
+++ b/packages/hermes/pyproject.toml
@@ -5,13 +5,45 @@ description = "PLUR persistent memory plugin for Hermes Agent"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
-authors = [{name = "plur-ai"}]
+authors = [{name = "PLUR", email = "info@plur.ai"}]
 keywords = ["hermes", "agent", "memory", "plur", "engram"]
+
+# Zero runtime dependencies, declared explicitly rather than omitted: the
+# plugin is stdlib-only by design and reaches PLUR through the `plur` CLI, so
+# it never pulls a dependency tree into the host agent's environment. An empty
+# list states that as a contract; an absent key would just look like an
+# oversight.
+dependencies = []
+
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
 ]
+# No "License ::" classifier: `license` above is an SPDX expression (PEP 639),
+# and setting both is mutually exclusive. No "Typing :: Typed" either — there
+# is no py.typed marker in this package, so it would be a false claim.
+
+# Without these, the PyPI page has no link back to the source. That is not
+# cosmetic: the Hermes integration lives inside the monorepo (packages/hermes)
+# while the OmniGent one is a standalone repo, so "there is probably a
+# plur-hermes repo" is a natural and wrong guess. `directory` points pip and
+# PyPI at the right subtree.
+[project.urls]
+Homepage = "https://plur.ai"
+Repository = "https://github.com/plur-ai/plur"
+Issues = "https://github.com/plur-ai/plur/issues"
+Changelog = "https://github.com/plur-ai/plur/blob/main/CHANGELOG.md"
+Source = "https://github.com/plur-ai/plur/tree/main/packages/hermes"
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
 
 [project.entry-points."hermes_agent.plugins"]
 plur = "plur_hermes"


### PR DESCRIPTION
Closes #537.

## Problem

`plur-hermes` on PyPI has **no `home_page` and no `project_urls`** — the published package contains no link back to its source. Install it and you cannot find the repo, file an issue, or read the changelog from the package page.

That is especially confusing here because the Hermes integration lives **inside the monorepo** (`packages/hermes`) while `omnigent-plur` is a **standalone repo** — so "there's probably a `plur-hermes` repo" is a natural and wrong inference. It took an org listing plus a PyPI/pyproject cross-check to answer "where does this live?". The `directory`-scoped `Source` URL now answers it from the package itself.

The npm siblings already carry this metadata (`packages/core/package.json` has `repository` + `directory`, `homepage`, `license`, `author`); the Python package was the odd one out.

## Changes

- `[project.urls]` — Homepage, Repository, Issues, Changelog, Source
- `authors` — add email, matching npm (`PLUR <info@plur.ai>`)
- `classifiers` — Python 3.10–3.13 (matching `requires-python`), OS Independent
- `dependencies = []` — the plugin is **stdlib-only by design** (verified by AST-walking every import) and reaches PLUR through the `plur` CLI, so it never pulls a dependency tree into the host agent's environment. An empty list states that as a contract; an absent key just looks like an oversight.
- `optional-dependencies.test = pytest`

## Deliberately NOT added — both would be wrong

- **No `License ::` classifier.** `license = "Apache-2.0"` is already an SPDX expression (PEP 639); setting both is mutually exclusive and build backends reject it.
- **No `Typing :: Typed`.** There is no `py.typed` marker in the package, so it would be a false claim.

## Verification

Built the wheel and read the **rendered** `METADATA` rather than trusting the TOML:

```
License-Expression  Apache-2.0
Author-email        PLUR <info@plur.ai>
Project-URL         Homepage, https://plur.ai
Project-URL         Repository, https://github.com/plur-ai/plur
Project-URL         Issues, https://github.com/plur-ai/plur/issues
Project-URL         Changelog, https://github.com/plur-ai/plur/blob/main/CHANGELOG.md
Project-URL         Source, https://github.com/plur-ai/plur/tree/main/packages/hermes
Requires-Dist       (none — zero runtime deps)
```

`twine check` **PASSED**. 143 tests pass.

## Out of scope, flagged in #537

`requires-python = ">=3.10"` but CI only tests **3.11**. We claim 3.10/3.12/3.13 support without testing any of them — worth either widening the CI matrix or narrowing `requires-python`, but that is a testing change, not packaging metadata.

Base is `fix-clean-0.11-base`, consistent with #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)