### PR TITLE
ci(hermes): add Python 3.10–3.13 matrix CI (#539)

### DIFF
--- a/.github/workflows/hermes.yml
+++ b/.github/workflows/hermes.yml
@@ -1,0 +1,30 @@
+name: plur-hermes
+
+on:
+  push:
+    branches: [main]
+    paths: ['packages/hermes/**', '.github/workflows/hermes.yml']
+  pull_request:
+    branches: [main]
+    paths: ['packages/hermes/**', '.github/workflows/hermes.yml']
+
+  # manual matrix runs (crtahlin review, #541)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e packages/hermes pytest
+      - run: pytest packages/hermes -q


### PR DESCRIPTION
## What

Adds a dedicated CI workflow for `plur-hermes` — the first time its 143 tests will run in CI.

## Why

Closes #539. `plur-hermes` had zero CI coverage:
- No workflow referenced `packages/hermes/**`
- The package declared Python 3.10–3.13 classifiers but only one version was ever tested (3.11 in `python.yml`, which only covers `packages/python`)
- A regression (orphan process leak) reached production undetected

## What's in the workflow

- Triggers on `packages/hermes/**` and `.github/workflows/hermes.yml` changes
- Runs `pytest packages/hermes` on the full claimed matrix: 3.10 / 3.11 / 3.12 / 3.13
- No Node.js / pnpm needed — tests are stdlib-only (verified independently per #539)
- `fail-fast: false` to get the full signal across all Python versions

## Checklist

- [x] Workflow added at `.github/workflows/hermes.yml`
- [x] Matrix matches classifiers in `pyproject.toml` (3.10 / 3.11 / 3.12 / 3.13)
- [x] No external deps beyond `pytest` — tests are self-contained

🤖 heartbeat — cto role