### PR TITLE
ops(release): manifest gate — abort on undeclared PRs before publish (#544)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,6 +14,33 @@ This repo publishes four npm packages from `packages/`:
 Publishing credentials (npm auth as `plur9`, the pending `NPM_TOKEN` repo secret, ClawHub OAuth)
 are documented in [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).
 
+## Manifest gate — the CHANGELOG must declare what ships (issue #544)
+
+`scripts/release.sh` runs a **manifest gate** (Step 3.6) before any irreversible
+step. It **aborts the release** if a *user-facing* PR merged since the last tag
+is **not declared** in this version's CHANGELOG section as `(#N)`. This exists
+because the 0.12.0/0.13.0 incident shipped 11 unreviewed PRs that no one had
+declared; the gate would have caught it.
+
+**What you must do before releasing:** ensure every user-facing PR that will ship
+appears in the `## <version>` section of `CHANGELOG.md` with its `(#N)` ref. If
+the gate aborts, it lists the missing PRs and your options.
+
+**What the gate skips:** PRs whose squash-commit subject uses a **non-user-facing
+conventional-commit type** — `chore`, `ci`, `docs`, `test`, `build`, `refactor`,
+`style`. These are curated out of the CHANGELOG by convention and are **not**
+required to be declared. Only `feat` / `fix` / `perf` (and any other type) must
+appear. So a `ci(hermes): …` or `chore(deps): …` PR ships silently; a
+`feat(core): …` or `fix(mcp): …` PR must be in the CHANGELOG or the release stops.
+
+**If the gate flags a PR that is genuinely not user-facing**, retitle its squash
+commit with the appropriate `chore`/`ci`/`docs`/etc. type so it is curated out —
+don't add noise to the CHANGELOG just to satisfy the gate.
+
+The gate is offline and deterministic (no GitHub API calls): it reads shipped PRs
+from `git log <last-tag>..HEAD` subjects and declared PRs from the CHANGELOG
+section, and compares the sets.
+
 ## Manual publish (one package)
 
 When `main` has a version bump that hasn't reached npm yet — e.g. `@plur-ai/claw@0.9.10` is on

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,6 +31,8 @@
 #   2.  Build all packages
 #   3.  Run tests
 #   3.5 Validate tweet length (abort if > 270 chars)
+#   3.6 Manifest gate: abort if a user-facing PR merged since the last tag is
+#       undeclared in the CHANGELOG (issue #544; see RELEASING.md)
 #   4.  Commit + tag + push
 #   5a. Publish npm to @next (canary)
 #   5b. Smoke test (npx by exact version, assert --version reports correctly)
@@ -336,6 +338,62 @@ if [ "$SKIP_TWEET" != true ]; then
   echo "$TWEET"
   echo ""
 fi
+
+# --- Step 3.6: Manifest gate (Part A -- issue #544) ---
+# Abort if a PR shipped since the last tag is undeclared in this version's
+# CHANGELOG section. Catches unintended shipping -- this gate would have stopped
+# the 0.12.0/0.13.0 rollback incident. Only USER-FACING PRs (feat/fix/perf) must
+# be declared; chore/ci/docs/test/build/refactor/style PRs are curated out of
+# the CHANGELOG by convention and are skipped here (documented in RELEASING.md).
+echo "--- Step 3.6: Manifest gate ---"
+MANIFEST_LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -z "$MANIFEST_LAST_TAG" ]; then
+  echo "  - No previous tag found -- skipping (first release)"
+else
+  # Anchor the version so a '.' is not a regex any-char; match "## X.Y.Z" and
+  # "## X.Y.Z (date)".
+  MANIFEST_CHANGELOG=$(awk -v v="$VERSION" '$0 ~ "^## "v"[ (]" || $0 == "## "v {p=1; next} /^## [0-9]/{if(p)exit} p' CHANGELOG.md)
+
+  # PRs shipped since the last tag, EXCLUDING non-user-facing conventional-commit
+  # types. Squash-merge subject format: "type(scope): subject (#N)".
+  #   sort -u (lexical): comm below compares lexically; numeric -n would disagree
+  #     on mixed-digit PR numbers and silently misfire.
+  #   || true: grep exits 1 on no match; under `set -euo pipefail` that would
+  #     abort the release instead of taking the empty-set path below.
+  SHIPPED_PRS=$(git log --format='%s' "${MANIFEST_LAST_TAG}..HEAD" \
+    | grep -vE '^(chore|ci|docs|test|build|refactor|style)(\(|:|!)' \
+    | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | sort -u || true)
+
+  DECLARED_PRS=$(printf '%s\n' "$MANIFEST_CHANGELOG" \
+    | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | sort -u || true)
+
+  if [ -z "$SHIPPED_PRS" ]; then
+    UNDECLARED_PRS=""
+  elif [ -z "$DECLARED_PRS" ]; then
+    UNDECLARED_PRS="$SHIPPED_PRS"
+  else
+    UNDECLARED_PRS=$(comm -23 <(printf '%s\n' "$SHIPPED_PRS") <(printf '%s\n' "$DECLARED_PRS"))
+  fi
+
+  if [ -n "$UNDECLARED_PRS" ]; then
+    echo ""
+    echo "FAIL Manifest gate: user-facing PR(s) on main since $MANIFEST_LAST_TAG but not in CHANGELOG $VERSION:"
+    echo "$UNDECLARED_PRS" | sed 's/^/    #/'
+    echo ""
+    echo "  Resolve -- pick one:"
+    echo "    1. Add each PR above to the '## $VERSION' section of CHANGELOG.md (they will ship)"
+    echo "    2. Cut the release from a commit that excludes them (issue #544 Part B)"
+    echo "    3. If a listed PR is genuinely non-user-facing, retitle its squash commit"
+    echo "       with a chore/ci/docs/etc. type so it is curated out (see RELEASING.md)"
+    echo ""
+    echo "  Prevents silent unintended shipping (0.12.0/0.13.0 postmortem). See issue #544."
+    exit 1
+  fi
+
+  SHIPPED_COUNT=$(printf '%s\n' "$SHIPPED_PRS" | grep -c '[0-9]' || echo "0")
+  echo "  OK: all ${SHIPPED_COUNT} user-facing PR(s) since $MANIFEST_LAST_TAG declared in CHANGELOG $VERSION"
+fi
+echo ""
 
 if [ "$DRY_RUN" = true ]; then
   echo "=== DRY RUN — stopping before publish ==="


### PR DESCRIPTION
## Summary

- Adds step 3.6 to `scripts/release.sh`: before commit/tag/push, compare PRs in `git log` since the last tag against PRs declared in the `CHANGELOG.md` section for the new version
- Aborts with a clear action list (add to CHANGELOG, or cut from a cherry-picked commit) if any shipped PR is undeclared
- Runs before all irreversible steps — the entire git/npm/PyPI/GitHub/tweet chain is still revertable when the gate fires
- Would have stopped the 0.12.0/0.13.0 rollback incident

Implements Part A of issue #544. Part B (release-PR model) is left for a follow-up decision.

## How it works

```
git log --format='%s' v0.12.0..HEAD | grep -oE '\(#[0-9]+\)'  → shipped PRs
awk ... CHANGELOG.md | grep -oE '\(#[0-9]+\)'                  → declared PRs
comm -23 <shipped> <declared>                                   → undeclared PRs → abort
```

Against the current main (since v0.12.0): detects PRs #516, #519, #521, #539 as undeclared — exactly right, since none of these appear in a `## 0.13.0` CHANGELOG section yet.

## Test plan

- [ ] `./scripts/release.sh 0.13.0 --dry-run --skip-tweet` — should abort at step 3.6 listing PRs since v0.12.0 as undeclared (no `## 0.13.0` section in CHANGELOG yet)
- [ ] Add a `## 0.13.0` section to CHANGELOG.md declaring those PRs, re-run — should pass the gate
- [ ] Verify no regressions: existing steps 3.5 (tweet), 3.7 (preflight), 4 (git) are unchanged

Closes #544 (Part A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)