### PR TITLE
chore(test): replace a real org name in test fixtures with a generic placeholder

### DIFF
--- a/packages/core/test/expiry.test.ts
+++ b/packages/core/test/expiry.test.ts
@@ -38,7 +38,7 @@ describe('extractExpiry', () => {
   })
 
   it('parses bare "valid <date>" (offer shorthand)', () => {
-    const hit = extractExpiry('IGEA Enterprise offer, valid 31 May 2026')
+    const hit = extractExpiry('Acme Enterprise offer, valid 31 May 2026')
     expect(hit).not.toBeNull()
     expect(hit!.valid_until).toBe('2026-05-31')
   })

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -340,12 +340,12 @@ describe('Plur', () => {
     it('extraction round-trip: expiry phrase in statement → structured valid_until → hard-skipped after expiry', () => {
       // The observed #347 failure shape: statement says "valid 31 May 2026",
       // engram kept injecting past expiry because temporal.valid_until was empty.
-      const engram = plur.learn('IGEA Enterprise offer REV.002, valid 31 May 2026', { scope: 'global' })
+      const engram = plur.learn('Acme Enterprise offer REV.002, valid 31 May 2026', { scope: 'global' })
       expect(engram.temporal?.valid_until).toBe('2026-05-31')
       // Echo marker so the caller can confirm the parse (never silently guess).
       expect((engram as any).structured_data?._expiry_extracted).toMatchObject({ valid_until: '2026-05-31' })
       // 2026-05-31 is in the past relative to the test run → recall hard-skips it.
-      const results = plur.recall('IGEA Enterprise offer')
+      const results = plur.recall('Acme Enterprise offer')
       expect(results).toHaveLength(0)
     })
 


### PR DESCRIPTION
## What

Two test fixtures in `packages/core/test/` used a real third-party organization's name plus a specific commercial-offer string (revision + validity date) as literal test data. This is a public repository, so real third-party commercial detail should not appear in it.

## Change

Replaced the org name with a neutral `Acme` placeholder in:
- `packages/core/test/expiry.test.ts` — the "valid <date>" offer-shorthand case
- `packages/core/test/plur.test.ts` — the expiry-extraction round-trip case (learn + recall)

Dates and all assertions are unchanged (`2026-05-31` etc.), so the tests exercise exactly the same behavior. Pure fixture-string cleanup — no code or logic touched.

## Note

This scrubs the current tree only; the string remains in prior git history. Raising here so the fixture stops carrying it going forward.
