### PR TITLE
ci(hermes): also run on the branch that actually ships

### DIFF
--- a/.github/workflows/hermes.yml
+++ b/.github/workflows/hermes.yml
@@ -12,9 +12,15 @@ name: plur-hermes
 
 on:
   push:
-    branches: [main]
+    # NOT `branches: [main]`. Releases are currently cut from
+    # fix-clean-0.11-base, not main, so a main-only trigger would skip CI on
+    # the branch that actually ships. The existing workflows do gate on main,
+    # which is why #535 and #538 merged with zero checks reported.
+    branches: [main, 'fix-clean-*', 'release/*']
     paths: ['packages/hermes/**', '.github/workflows/hermes.yml']
   pull_request:
+    # Deliberately no `branches:` filter — run on PRs into ANY base, so a PR
+    # targeting the release branch cannot merge unverified.
     paths: ['packages/hermes/**', '.github/workflows/hermes.yml']
 
 permissions:


### PR DESCRIPTION
Follow-up to #540 — this commit was authored but **missed the merge**, so the workflow landed with the defect still in it.

## Problem

The `push` trigger says `branches: [main]`. But releases are cut from `fix-clean-0.11-base`, not `main` — so CI would skip pushes to **the branch that actually ships**.

This is the same defect that let #535 and #538 merge with **zero checks reported**: every pre-existing workflow gates on `branches: [main]`, and both PRs targeted the release branch.

```
$ gh pr checks 535
no checks reported on the 'fix/hermes-bridge-orphan' branch
```

## Change

- `push`: `[main, 'fix-clean-*', 'release/*']` — cover the release line, not just `main`.
- `pull_request`: **deliberately no `branches:` filter**, so a PR into *any* base runs the matrix and cannot merge unverified. (This is why #540's own checks ran at all.)

CI-only. No runtime or packaging impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)