### PR TITLE
test: make the release gate trustworthy — fix three flaky-under-load suites

### DIFF
--- a/packages/core/test/adversarial/detector-fuzz.test.ts
+++ b/packages/core/test/adversarial/detector-fuzz.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll } from 'vitest'
 import { detectSensitive, detectSecrets, sensitivityCategory } from '../../src/secrets.js'
 
 /**
@@ -221,12 +221,27 @@ describe('detector-fuzz: sensitivityCategory routing', () => {
   })
 })
 
-describe('detector-fuzz: ReDoS bait timing (64KB, must stay sub-second)', () => {
-  // The round-2 fix comment claims the detectors are linear on the 64KB-capped
-  // scan input ("~0.3ms on 64KB", "the 64KB cap is cheap insurance, not a DoS
-  // fix"). A second-plus runtime on a 64KB input means a stored prompt-injection
-  // / DoS vector: detectSensitive runs on serialized engrams at the publish gate
-  // AND inside _guardSensitiveScope, so a slow input stalls every guard call.
+describe('detector-fuzz: ReDoS bait timing (64KB, must stay linear)', () => {
+  // What this guards: detectSensitive runs on serialized engrams at the publish
+  // gate AND inside _guardSensitiveScope, so catastrophic backtracking on an
+  // attacker-authored engram stalls every guard call — a stored DoS vector.
+  //
+  // ASSERT RATIO, NOT WALL-CLOCK. This used to assert `dt < 1000ms`, which
+  // measures the machine, not the regex: under a full parallel `vitest run`
+  // (BGE embedders + WASM Postgres saturating every core) a perfectly linear
+  // scan was observed at 1019ms and failed the build. That made the release
+  // gate unreliable — release.sh hard-aborts on any test failure — and the
+  // tempting workaround is to bypass the gate, which is how unreviewed code has
+  // shipped before.
+  //
+  // The signal we actually care about is *shape*: catastrophic backtracking is
+  // superlinear, so an adversarial input runs orders of magnitude slower than a
+  // benign string of the same length. Measured on an idle machine, every bait
+  // here sits at 1.0-1.4x a benign 64KB baseline (~20ms). The original #389 bug
+  // was 8-17s against milliseconds — thousands of times over. A 20x ceiling is
+  // therefore enormous headroom for a healthy detector while still catching any
+  // real blowup, and it holds on a loaded machine because the baseline is
+  // measured on that same machine, under that same load.
   const N = 65536
   const BAITS: [string, string][] = [
     ['colon run (no @)', ':'.repeat(N)],
@@ -238,13 +253,41 @@ describe('detector-fuzz: ReDoS bait timing (64KB, must stay sub-second)', () => 
     ['scheme bait http://aaa', 'http://' + 'a'.repeat(N)],
     ['at-run', 'a@'.repeat(N / 2)],
   ]
-  const BUDGET_MS = 1000
-  for (const [label, input] of BAITS) {
-    it(`${label} scans in < ${BUDGET_MS}ms`, () => {
+
+  // A benign string of the SAME length. Anything the detector does to this is
+  // the irreducible cost of walking 64KB on this machine right now.
+  const BENIGN = 'x'.repeat(N)
+  const RATIO_LIMIT = 20
+
+  // Best-of-k: we want the floor (the cost when the scheduler let us run), not
+  // an average polluted by preemption. A ReDoS blowup is present in every run,
+  // so taking the minimum cannot hide one.
+  const fastest = (input: string, k: number): number => {
+    let best = Infinity
+    for (let i = 0; i < k; i++) {
       const t0 = performance.now()
       detectSensitive(input)
-      const dt = performance.now() - t0
-      expect(dt, `ReDoS — 64KB '${label}' took ${dt.toFixed(0)}ms (budget ${BUDGET_MS}ms)`).toBeLessThan(BUDGET_MS)
+      best = Math.min(best, performance.now() - t0)
+    }
+    return best
+  }
+
+  let benignMs = 0
+  beforeAll(() => {
+    detectSensitive(BENIGN) // warm: first call pays regex compile + JIT
+    benignMs = Math.max(fastest(BENIGN, 5), 0.01) // floor guards against divide-by-zero
+  })
+
+  for (const [label, input] of BAITS) {
+    it(`${label} stays within ${RATIO_LIMIT}x a benign 64KB scan`, () => {
+      const dt = fastest(input, 3)
+      const ratio = dt / benignMs
+      expect(
+        ratio,
+        `ReDoS — 64KB '${label}' took ${dt.toFixed(1)}ms = ${ratio.toFixed(1)}x a benign ` +
+          `64KB scan (${benignMs.toFixed(1)}ms) on this machine. Superlinear blowup means ` +
+          `catastrophic backtracking, not a slow CPU.`,
+      ).toBeLessThan(RATIO_LIMIT)
     })
   }
 })

--- a/packages/core/test/packs.test.ts
+++ b/packages/core/test/packs.test.ts
@@ -491,17 +491,50 @@ describe('pack management', () => {
   // serializeForSecretScan returns unbounded JSON and EMAIL_RE/IP_RE run on it;
   // an attacker-authored engram with a long dotted run after `@` made EMAIL_RE
   // backtrack for 8-17s, hanging preview/install/export. The scan-input cap +
-  // bounded EMAIL_RE must keep it well under the 2s test budget.
+  // bounded EMAIL_RE must keep the adversarial export as cheap as a benign one.
+  //
+  // ASSERT RATIO, NOT WALL-CLOCK. This used to rely on a 2000ms vitest timeout,
+  // which measures the machine rather than the regex: under a full parallel run
+  // the *benign* path alone can exceed 2s, failing the build for a healthy
+  // detector and making the release gate unreliable (release.sh hard-aborts on
+  // any test failure). Comparing against a benign export of the same size on
+  // the same machine, under the same load, is load-independent — and the real
+  // bug was 8-17s versus milliseconds, so a 10x ceiling still catches it with
+  // room to spare.
   it('#389 adversarial-length engram does not hang the scan (ReDoS guard)', () => {
+    const payload = 'a.'.repeat(80_000)
     const evil = EngramSchema.parse({
       id: 'ENG-2026-0101-301',
-      statement: 'x@' + 'a.'.repeat(80_000) + '!',
+      statement: 'x@' + payload + '!', // the `@` is what made EMAIL_RE backtrack
       type: 'behavioral', scope: 'global', status: 'active', visibility: 'public',
     })
-    expect(() =>
-      exportPack([evil], join(dir, 'exp-redos'), { name: 'exp-redos', version: '1.0.0' }),
-    ).not.toThrow()
-  }, 2000)
+    // Same length, no `@` — so it cannot trigger the EMAIL_RE backtracking path.
+    const benign = EngramSchema.parse({
+      id: 'ENG-2026-0101-303',
+      statement: 'x_' + payload + '!',
+      type: 'behavioral', scope: 'global', status: 'active', visibility: 'public',
+    })
+
+    const timeExport = (e: typeof evil, name: string): number => {
+      const t0 = performance.now()
+      expect(() =>
+        exportPack([e], join(dir, name), { name, version: '1.0.0' }),
+      ).not.toThrow()
+      return performance.now() - t0
+    }
+
+    timeExport(benign, 'exp-warm') // warm: first export pays regex compile + JIT
+    const benignMs = Math.max(timeExport(benign, 'exp-benign'), 0.01)
+    const evilMs = timeExport(evil, 'exp-redos')
+
+    const ratio = evilMs / benignMs
+    expect(
+      ratio,
+      `ReDoS — adversarial export took ${evilMs.toFixed(1)}ms = ${ratio.toFixed(1)}x a ` +
+        `same-length benign export (${benignMs.toFixed(1)}ms). Superlinear blowup means ` +
+        `EMAIL_RE is backtracking again, not that the machine is slow.`,
+    ).toBeLessThan(10)
+  })
 
   // #389 review (blocker 2) / systemic packs gap: the export gate used
   // detectSecrets, which never scanned the infra family (public IPs, internal

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,8 +1,41 @@
 import { defineConfig } from 'vitest/config'
+
+// The PGLite suites are EXCLUDED here and run as a separate serial project
+// (see the root vitest.config.ts). They are not excluded from the test run —
+// only from the fully-parallel pool.
+//
+// Why: each PGLite suite boots a WASM Postgres *and* cold-loads the BGE
+// embedder. Vitest runs files in parallel across every core, so in a full-suite
+// run several start at once and starve each other, blow the 30s timeout, and
+// report as failures. That is contention, not a defect — the same four files
+// pass in isolation (40 passed, 1 skipped).
+//
+// It also made the release gate unreliable: release.sh hard-aborts on test
+// failures, so a legitimate release randomly could not ship, and the tempting
+// workaround (bypass the gate) is exactly how unreviewed code has shipped
+// before. Fixing the contention is what makes the gate trustworthy.
+//
+// Raising the timeout was already tried for this class of problem — the 5s
+// default went to 30s in #311 — and it regressed anyway. A third increase just
+// moves the goalpost.
+export const PGLITE_SUITES = [
+  'test/pglite-*.test.ts',
+  // Not named pglite, but PGLite-backed (it uses the same PGLITE_TIMEOUT) and
+  // fails in the same way under load.
+  'test/sync-index-error.test.ts',
+]
+
 // testTimeout raised from the 5s default: the BGE embedder (@huggingface/
 // transformers) cold-loads lazily on first use, and that one-time model init
 // can exceed 5s when several embedder-touching suites import in parallel under
 // `vitest run` — a slow-but-correct load, not a hang. The tight default caused
 // flaky CI timeouts (#311). hookTimeout matched so beforeAll/afterAll setup
 // that also triggers a cold load doesn't trip either.
-export default defineConfig({ test: { globals: true, testTimeout: 30000, hookTimeout: 30000 } })
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    exclude: ['**/node_modules/**', '**/dist/**', ...PGLITE_SUITES],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,9 +14,37 @@ import { defineConfig } from 'vitest/config'
 // `test.projects` is the current (non-deprecated) multi-project mechanism.
 // `test.exclude` also explicitly excludes .worktrees as a second, independent
 // safety net in case a future refactor reintroduces a broader project glob.
+// The `core-pglite` project exists to remove resource contention, not to
+// quarantine failures. Each PGLite suite boots a WASM Postgres and cold-loads
+// the BGE embedder; run in the fully-parallel pool alongside the other 107 core
+// files, several start at once, starve each other, and blow their 30s timeout —
+// reporting as failures despite passing in isolation. That made `release.sh`
+// (which hard-aborts on test failures) randomly unable to ship a legitimate
+// release. These four files now run serially, in their own pool, with headroom.
+// The other 107 core files stay fully parallel, so the suite stays fast.
 export default defineConfig({
   test: {
-    projects: ['packages/core', 'packages/mcp', 'packages/cli', 'packages/claw'],
+    projects: [
+      'packages/core', // excludes the PGLite suites — see packages/core/vitest.config.ts
+      'packages/mcp',
+      'packages/cli',
+      'packages/claw',
+      {
+        test: {
+          name: 'core-pglite',
+          root: 'packages/core',
+          globals: true,
+          include: ['test/pglite-*.test.ts', 'test/sync-index-error.test.ts'],
+          // The whole point: one file at a time, so no two WASM Postgres
+          // instances are booting concurrently.
+          fileParallelism: false,
+          // Generous, because serial execution means a slow run costs wall-clock
+          // rather than correctness. A timeout here should mean a real hang.
+          testTimeout: 120000,
+          hookTimeout: 120000,
+        },
+      },
+    ],
     exclude: ['**/node_modules/**', '**/dist/**', '**/.worktrees/**'],
   },
 })


### PR DESCRIPTION
## Why this matters

`release.sh` **hard-aborts on any test failure**. Flaky tests therefore mean a legitimate release randomly cannot ship — and the tempting workaround is to bypass the gate, which is how unreviewed code has shipped before. Observed run-to-run on the same commit: **11 → 1 → 4 → 3 failures, never the same set.**

Three distinct causes. **None of them is a real defect.**

## 1. PGLite contention (4 files)

Each PGLite suite boots a WASM Postgres *and* cold-loads the BGE embedder. Vitest runs files in parallel across every core, so several start at once, starve each other, and blow the 30s timeout — while **passing in isolation** (40 passed, 1 skipped).

Raising the timeout was already tried for exactly this class of problem (5s → 30s, #311) and regressed anyway. A third increase just moves the goalpost.

These four now run as a serial `core-pglite` project. The other 107 core files stay fully parallel — so the suite actually got **faster: ~288s → ~90s**.

Test count is unchanged (**2559 across 189 files**), so nothing was silently excluded — they run serially, not less.

## 2. ReDoS wall-clock budget (`detector-fuzz`)

Asserted `dt < 1000ms` on a 64KB scan. That **measures the machine, not the regex** — a perfectly linear scan was observed at **1019ms** under parallel load and failed the build.

Measured on an idle machine, there is **no ReDoS at all**:

```
benign 64KB baseline: 19.46ms
   23.84ms   1.2x benign   colon run (no @)
   27.53ms   1.4x benign   a: run
   19.76ms   1.0x benign   scheme bait http://aaa
```

Every bait runs at **1.0–1.4× a benign string of the same length**. The detectors are linear; the assertion was wrong, not the code.

It now asserts the **ratio against a benign baseline measured on the same machine, under the same load** — so it is load-independent. Catastrophic backtracking is superlinear *by definition*, so shape is the correct signal.

## 3. ReDoS 2s timeout (`packs`, #389)

Same defect — under load the **benign** path alone exceeds the 2000ms budget. Now compares the adversarial export against a same-length benign export (no `@`, so it can't hit the `EMAIL_RE` backtracking path).

## Both guards verified non-vacuous

Injecting a real polynomial backtracker (`/a*a*b/`) into `detectSensitive` turned a **1.9s suite into a >10 minute hang** — **>300×**, against guard limits of 20× and 10×. They fire. (Injection reverted; `secrets.ts` is untouched in this PR.)

Ratios are deliberately generous. The original #389 bug was **8–17s against milliseconds** — thousands of times over — so a healthy detector has enormous headroom while a real blowup is still caught.

## Scope

Test infrastructure only — 4 files. No `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)