### PR TITLE
docs: withdraw two unsubstantiated benchmark claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ PLUR now works inside Cursor — its own hook system (`sessionStart`, `preToolUs
 ### Fixed
 
 - **Orphaned hook processes on degraded networks** (#504): `hook-inject` had no process-level ceiling and `RemoteStore.load()` made unbounded fetch calls — together these could accumulate dozens of orphaned processes and gigabytes of swap on a flaky connection. Added a self-watchdog (55s default ceiling) and a 30s fetch timeout with fail-open (cached engrams or `[]`, no cache poisoning).
-- **Tension subject filter** (#489): suffix-stemming in the contradiction pre-filter raises recall 77%→90%.
+- **Tension subject filter** (#489): suffix-stemming in the contradiction pre-filter. (The "77%→90% recall" figure originally published here was withdrawn on 2026-07-14 — re-running the commit's own 30-pair suite gives 29/30 both with and without stemming, changing the outcome on zero pairs. The number was never reproducible. See #489.)
 - **`hook-learn-check`'s Stop-hook counter** made atomic (append-only, not read-increment-write) — the same race class found and fixed in the new Cursor hooks during their audit.
 - Three OpenClaw (`@plur-ai/claw`) UX fixes: stale plugin-manifest pruning, `plugins.allow` seeding on fresh installs, `runtime_registered` verified via an actual filesystem check instead of a hardcoded placeholder.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ PLUR is memory, not just retrieval — so we measure it on more than one axis.
 
 | Stack | R@5 | Notes |
 |-------|-----|-------|
-| PLUR hybrid + bge-reranker-v2-m3 | 97.6% | max quality — not production-suitable on CPU |
 | PLUR hybrid (openai-3-large embeddings) | 97.0% | optional cloud embedder |
 | PLUR BM25 only | 92.2% | no embedder — fully airgapped |
 


### PR DESCRIPTION
Both numbers were published as fact. Neither is reproducible.

## 1. README: the 97.6% row is gbrain's number, not ours

`README.md` printed, under an **N=500** header:

| Stack | R@5 |
|---|---|
| ~~PLUR hybrid + bge-reranker-v2-m3~~ | ~~97.6%~~ |

**97.6% is gbrain's published figure.** plur-bench **#4** is literally titled *"Parity #2: validate harness equivalence — **reproduce gbrain ~97.6%** with openai-3-large @ chunk granularity"*. We reproduced it as a **positive control**, to prove our harness is equivalent to theirs. It was never a PLUR result.

The row was also internally incoherent — it sat under a header reading *"openai-3-large embeddings"* while attributing the score to a **bge reranker**, a stack that was never run at N=500.

**Our real N=500 result is the row directly below it, and it's genuine:**

| | R@1 | R@5 | R@10 |
|---|---|---|---|
| PLUR (openai-3-large, hybrid, chunk) | 89.2% | **97.0%** | 98.8% |

That's from plur-bench#4's closing comment, and the per-category table further down this same README matches it exactly. **97.0% is a strong number. We don't need to borrow a competitor's.**

## 2. CHANGELOG: the #489 "77%→90%" figure does not reproduce

The 0.12.0 entry claimed suffix-stemming *"raises recall 77%→90%"*.

Re-running **the commit's own 30-pair labelled suite**, both ways:

| | result |
|---|---|
| stemmed | **29/30** |
| unstemmed | **29/30** |
| pairs where stemming changed the outcome | **0** |

The stemmer changes the verdict on **zero** pairs — because in every pair both statements already share identical literal subject tokens, and stemming applied symmetrically cannot alter the intersection. Neither published number (23/30 → 27/30) matches the suite that shipped alongside it.

The guard test (`expect(hits.length).toBeGreaterThanOrEqual(27)`) passes at 29 — and **would still pass with `stemToken()` deleted entirely**.

I **withdrew** the figure rather than deleting the line, so the correction stays visible to anyone who read the original.

## Not addressed here

The underlying #489 feature itself (does nothing measurable, introduces real false matches like `stats`/`states`/`station` → `stat`) is a separate call — tracked in the batch review, not fixed in this docs-only PR.

Refs #489, plur-ai/plur-bench#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)