### PR TITLE
test: make the suite honest — stop tests from asserting bugs as correct

### DIFF
--- a/packages/claw/test/setup.test.ts
+++ b/packages/claw/test/setup.test.ts
@@ -34,7 +34,10 @@ describe('claw setup command', () => {
     expect(written.plugins.entries['plur-claw'].enabled).toBe(true)
     expect(written.plugins.entries['plur-claw'].config).toEqual({ auto_learn: true, auto_capture: true, injection_budget: 2000 })
     expect(written.plugins.slots.memory).toBe('plur-claw')
-    expect(written.plugins.allow).toEqual(['plur-claw'])
+    // NB: the `allow` seeding this used to assert is the #51 gating bug — its
+    // dedicated (inverted, it.fails) test lives below. On a truly empty config
+    // there are no other plugins to gate, so we simply don't assert on `allow`
+    // here rather than re-encode the buggy value.
     expect(written.mcp.servers.plur).toBeDefined()
     expect(written.mcp.servers.plur.command).toBe('npx')
   })
@@ -75,6 +78,24 @@ describe('claw setup command', () => {
     runSetup({ configPath: cfgPath })
     const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
     expect(written.plugins.entries['plur-claw'].hooks?.allowConversationAccess).toBe(true)
+  })
+
+  // MISSING coverage (#51 / D-4): setup.ts:103 force-sets allowConversationAccess
+  // true by spreading it AFTER the user's existing hooks, so it overrides a user
+  // who deliberately turned conversation access OFF. That's a plugin re-granting
+  // itself a privacy permission the user revoked. it.fails until setup honours an
+  // explicit false. (If the team decides force-true is intended, delete this.)
+  it.fails('does not re-grant allowConversationAccess when the user set it false (#51)', () => {
+    const prior = {
+      plugins: {
+        entries: { 'plur-claw': { enabled: true, hooks: { allowConversationAccess: false } } },
+        slots: { memory: 'plur-claw' },
+      },
+    }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+    runSetup({ configPath: cfgPath })
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    expect(written.plugins.entries['plur-claw'].hooks.allowConversationAccess).toBe(false)
   })
 
   it('preserves existing hooks when adding allowConversationAccess', () => {
@@ -148,11 +169,27 @@ describe('claw setup command', () => {
     expect(written.plugins.allow).toEqual(['other-plugin', 'plur-claw'])
   })
 
-  it('initializes plugins.allow to [plur-claw] on fresh install (allow is absent)', () => {
-    writeFileSync(cfgPath, '{}', 'utf8')
+  // WAS a BUG-ENCODING test: it asserted setup writes `allow: ['plur-claw']`
+  // when `allow` was absent. In OpenClaw an ABSENT allow means "allow ALL
+  // plugins"; writing a one-element list silently GATES OFF every other plugin
+  // the user has. This also directly contradicts the doctor test below
+  // ("absent allow = no gating (ok)"). See #51.
+  //
+  // Inverted to the correct behaviour (a fresh install with other plugins
+  // present must not gate them off), marked it.fails until setup.ts:132-136 is
+  // fixed. Uses a config WITH another plugin so the harm is actually asserted.
+  it.fails('does not gate off other plugins on fresh install when allow is absent (#51)', () => {
+    const prior = { plugins: { entries: { 'weather-plugin': { enabled: true }, 'git-plugin': { enabled: true } } } }
+    writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
     runSetup({ configPath: cfgPath })
     const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
-    expect(written.plugins.allow).toEqual(['plur-claw'])
+    const allow = written.plugins.allow
+    // Correct: either leave allow absent (allow-all), or include the plugins
+    // that were already enabled. Never a bare ['plur-claw'] that excludes them.
+    if (allow !== undefined) {
+      expect(allow).toContain('weather-plugin')
+      expect(allow).toContain('git-plugin')
+    }
   })
 
   it('does not modify plugins.allow when it is present but empty (honour explicit clear)', () => {
@@ -222,23 +259,34 @@ describe('claw setup command', () => {
   })
 
   describe('stale entry pruning (item 1 — manifest mismatch fix)', () => {
-    it('removes stale entries whose extension directory no longer exists', () => {
+    // WAS a BUG-ENCODING test: it asserted `entries['stale-plugin']` becomes
+    // undefined — i.e. it demanded that setup DELETE a third-party plugin's
+    // entire config entry (INCLUDING any API keys in its `config`) on the sole
+    // evidence that its extensions/<id> directory is absent. That directory is
+    // transiently absent during any install/upgrade, so this destroys a user's
+    // credentials for another vendor's plugin. See #51.
+    //
+    // Inverted to assert the CORRECT behaviour (foreign entry + its credentials
+    // survive) and marked it.fails because setup.ts:84-93 still prunes today.
+    // When #51 is fixed this test PASSES → it.fails fails → flip back to it().
+    it.fails('preserves a third-party entry (and its credentials) when its extension dir is absent (#51)', () => {
       const prior = {
         plugins: {
           entries: {
             'plur-claw': { enabled: true },
-            'stale-plugin': { enabled: true },
+            'weather-plugin': { enabled: true, config: { api_key: 'sk-SECRET-USER-KEY-123' } },
           },
           slots: { memory: 'plur-claw' },
           allow: ['plur-claw'],
         },
       }
       writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
-      // extensions/ dir exists (user has plugins set up) but stale-plugin/ does not
+      // extensions/ dir exists (user has plugins set up) but weather-plugin/ does not
       mkdirSync(join(dir, 'extensions'), { recursive: true })
       runSetup({ configPath: cfgPath, openclawHome: dir })
       const written = JSON.parse(readFileSync(cfgPath, 'utf8'))
-      expect(written.plugins.entries['stale-plugin']).toBeUndefined()
+      expect(written.plugins.entries['weather-plugin']).toBeDefined()
+      expect(written.plugins.entries['weather-plugin'].config.api_key).toBe('sk-SECRET-USER-KEY-123')
       expect(written.plugins.entries['plur-claw']).toBeDefined()
     })
 

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -139,6 +139,59 @@ describe('plur doctor', () => {
     expect(report.overall).toBe('ok')
   })
 
+  // Coverage gap: EVERY other test here runs `doctor --no-handshake`, so
+  // `overall` is computed with the live MCP handshake DISABLED and can never
+  // reflect a server that fails to start. Exercise the handshake ENABLED against
+  // a fake MCP shim that starts but never completes the JSON-RPC initialize — the
+  // handshake must fail and drive overall to 'fail'. Green today: overall gates on
+  // handshake.ok when not skipped (doctor.ts:569-570).
+  it('fails overall when the live handshake is enabled and the server never completes initialize', () => {
+    // buildMcpServerEntry() prefers the local shim at ~/.plur/bin/plur-mcp, so
+    // installing a fake one here makes doctor's handshake spawn OUR script.
+    const binDir = join(home, '.plur', 'bin')
+    mkdirSync(binDir, { recursive: true })
+    const shim = join(binDir, 'plur-mcp')
+    // Starts, waits long enough for doctor to write its init request (no EPIPE),
+    // then exits without ever responding → handshake resolves ok:false fast.
+    writeFileSync(shim, '#!/bin/sh\nsleep 0.5\nexit 0\n', { mode: 0o755 })
+    chmodSync(shim, 0o755)
+
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject' }] },
+        ],
+      },
+      mcpServers: {
+        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+      },
+    })
+
+    let stdout = ''
+    let status = 0
+    try {
+      stdout = execSync(`node ${CLI} doctor --json`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+        env: { ...process.env, HOME: home, USERPROFILE: home, PLUR_DISABLE_EMBEDDINGS: '1' },
+        cwd: home,
+      })
+    } catch (err: any) {
+      stdout = err.stdout?.toString() ?? ''
+      status = err.status ?? 1
+    }
+    const report = JSON.parse(stdout)
+
+    // hooks + MCP are both wired, so the handshake is the ONLY reason to fail.
+    expect(report.hooksInstalled).toBe(true)
+    expect(report.mcpRegistered).toBe(true)
+    expect(report.handshake.ok).toBe(false)
+    expect(report.handshake.error).toBeTruthy()
+    expect(report.handshake.error).not.toContain('skipped') // it actually ran
+    expect(report.overall).toBe('fail')
+    expect(status).toBe(1)
+  }, 40000)
+
   // ── Stale npx hook detection (#178) ─────────────────────────────────────
 
   it('detects stale npx hooks and recommends migration (#178)', () => {

--- a/packages/cli/test/hook-cursor-stop.test.ts
+++ b/packages/cli/test/hook-cursor-stop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
@@ -53,9 +53,21 @@ describe('hook-cursor-stop', () => {
     expect(third.followup_message).toContain('plur_learn')
   })
 
-  it('does not count or nudge on aborted/error stops', () => {
-    expect(stop('conv-stop-2', 'aborted').trim()).toBe('')
-    expect(stop('conv-stop-2', 'error').trim()).toBe('')
-    expect(stop('conv-stop-2', 'aborted').trim()).toBe('')
+  // Was VACUOUS: only asserted the output was empty, which proves "no nudge" but
+  // never "no count" — the aborted stops could have advanced the counter and the
+  // test would still pass. Now assert the COUNTER itself: two aborted/error stops
+  // followed by one completed stop must leave the counter at exactly 1 (a single
+  // appended byte), not 3. Counting is correct today (the status guard in
+  // hook-cursor-stop.ts returns before incrementCounter), so this is a green it().
+  it('does not count aborted/error stops toward the nudge cadence', () => {
+    const id = 'conv-stop-2'
+    // Aborted/error turns: no output AND must not touch the counter.
+    expect(stop(id, 'aborted').trim()).toBe('')
+    expect(stop(id, 'error').trim()).toBe('')
+    // First COMPLETED stop is counted as #1 (1 % 3 !== 0) → still no nudge.
+    expect(stop(id, 'completed').trim()).toBe('')
+    // Prove it: the stop-count file has advanced by exactly one, not three.
+    const counterFile = join(SESSIONS_DIR, `${id}.stopcount`)
+    expect(statSync(counterFile).size).toBe(1)
   })
 })

--- a/packages/cli/test/hook-inject-lock.test.ts
+++ b/packages/cli/test/hook-inject-lock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { spawnSync } from 'child_process'
@@ -66,21 +66,51 @@ describe('hook-inject concurrency guard (#519)', () => {
     expect(result.status).toBe(0)
   })
 
-  it('proceeds when the inject lock is stale', () => {
-    // Pre-create a lock that belongs to this pid (same as ppid in the spawned
-    // subprocess). With PLUR_LOCK_STALE_MS=-1 the staleness condition
-    // (Date.now() - mtime < -1) is always false, so the lock is always treated
-    // as stale. This avoids relying on utimesSync mtime precision, which can be
-    // unreliable on CI runners (observed silent no-op on Linux tmpfs variants).
+  // Was VACUOUS: it set PLUR_LOCK_STALE_MS='-1', which makes the staleness
+  // comparison (Date.now() - mtime < -1) always false — a tautology that never
+  // exercises the real mtime logic (any lock, fresh or old, is treated as stale).
+  // Now age a REAL lock: write it, then wait past a small, real staleness window
+  // so Date.now() - mtime genuinely exceeds it, and confirm injection proceeds.
+  // The sibling test above ("bails silently when a fresh inject lock exists")
+  // covers the fresh-within-window bail against the real comparison (default 55s
+  // window, fresh mtime), so together they exercise both sides of the branch.
+  it('proceeds when a real lock has aged past PLUR_LOCK_STALE_MS', async () => {
     const sessionDir = join(dir, 'tmp', 'plur-sessions')
     mkdirSync(sessionDir, { recursive: true })
     const lockPath = join(sessionDir, `${process.pid}.injecting`)
-    writeFileSync(lockPath, '')
+    writeFileSync(lockPath, '') // mtime = now
 
-    const result = runHook({ prompt: 'hello world' }, { PLUR_LOCK_STALE_MS: '-1' })
+    // Real wait, no utimesSync backdating: a 250ms sleep against a 50ms window
+    // guarantees Date.now() - mtime >= window by the time the hook stats it.
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    const result = runHook(
+      { prompt: 'hello world' },
+      { PLUR_LOCK_STALE_MS: '50', PLUR_DISABLE_EMBEDDINGS: '1' },
+    )
     // With an empty store the output is still a session-start header (0 engrams).
     expect(result.status).toBe(0)
     const parsed = JSON.parse(result.stdout) as { additionalContext?: string }
     expect(parsed.additionalContext).toContain('session started')
   }, 30_000)
+
+  // MISSING (fail-open contract, PROVEN): a hook MUST never throw or block the
+  // prompt. But hook-inject's mkdir/write of its state dir ($TMPDIR/plur-sessions)
+  // is not wrapped in try/catch, so an unwritable $TMPDIR makes the process EXIT 1
+  // and print {"error":...} to stdout (index.ts's top-level catch) — a hard
+  // failure on the hot path of every prompt. Correct behaviour: exit 0 and emit
+  // valid/empty output. it.fails until the state-dir I/O is made fail-open; flip
+  // to it() when green.
+  it.fails('never crashes the prompt when the state dir is unwritable', () => {
+    const roTmp = mkdtempSync(join(tmpdir(), 'plur-ro-tmp-'))
+    chmodSync(roTmp, 0o500) // r-x: owner cannot create plur-sessions inside
+    try {
+      const result = runHook({ prompt: 'hello world' }, { TMPDIR: roTmp })
+      expect(result.status).toBe(0) // fail-open: never a non-zero exit
+      expect(result.stdout).not.toContain('"error"')
+    } finally {
+      chmodSync(roTmp, 0o700)
+      rmSync(roTmp, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/cli/test/hook-learn-check.test.ts
+++ b/packages/cli/test/hook-learn-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { spawnSync } from 'child_process'
@@ -106,5 +106,30 @@ describe('hook-learn-check', () => {
       false, false, true, // 7,8,9
       false, false, true, // 10,11,12
     ])
+  })
+
+  // MISSING (fail-open contract, PROVEN): a Stop hook MUST never throw — it is on
+  // the hot path of every response. But counterPath()'s mkdir/appendFileSync of
+  // $TMPDIR/plur-sessions is not wrapped in try/catch, so an unwritable $TMPDIR
+  // makes the hook EXIT 1 and print {"error":...} to stdout (index.ts's top-level
+  // catch). Correct behaviour: exit 0 and emit valid/empty output. it.fails until
+  // the counter I/O is made fail-open; flip to it() when green.
+  it.fails('never crashes the response when the state dir is unwritable', () => {
+    const roTmp = mkdtempSync(join(tmpdir(), 'plur-ro-learn-'))
+    chmodSync(roTmp, 0o500) // r-x: owner cannot create plur-sessions inside
+    try {
+      const result = spawnSync('node', [CLI, 'hook-learn-check'], {
+        input: JSON.stringify({ cwd: home }),
+        encoding: 'utf-8',
+        timeout: 10000,
+        env: { ...process.env, HOME: home, USERPROFILE: home, TMPDIR: roTmp, CLAUDE_SESSION_ID: 'ro-learn' },
+        cwd: home,
+      })
+      expect(result.status ?? 1).toBe(0) // fail-open: never a non-zero exit
+      expect(result.stdout ?? '').not.toContain('"error"')
+    } finally {
+      chmodSync(roTmp, 0o700)
+      rmSync(roTmp, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/cli/test/hook-session-end.test.ts
+++ b/packages/cli/test/hook-session-end.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { spawnSync } from 'child_process'
@@ -116,7 +116,15 @@ describe('hook-session-end (#217 — SessionEnd auto-close)', () => {
     expect(readEpisodes()).not.toContain('auto-closed on SessionEnd')
   })
 
-  it('removes a corrupt checkpoint without crashing', () => {
+  // BUG-ENCODING (#217): the original test asserted that an unparseable
+  // checkpoint is DELETED (existsSync === false). That encodes a data-loss bug:
+  // writeCheckpoint (hook-learn-check.ts:96) is a plain, NON-atomic writeFileSync,
+  // so a concurrent reader that catches a mid-write PARTIAL read cannot tell it
+  // apart from genuine corruption — and this hook then permanently unlinks a LIVE
+  // session's checkpoint (hook-session-end.ts:97). Correct behaviour: unparseable
+  // content is RETAINED (or quarantined via rename), never silently destroyed.
+  // it.fails until the parse-failure branch stops unlinking; flip to it() when green.
+  it.fails('retains (does not delete) an unparseable checkpoint', () => {
     const sessionsDir = join(home, '.plur', 'sessions')
     mkdirSync(sessionsDir, { recursive: true })
     const cpPath = join(sessionsDir, 'end-test-session.checkpoint.json')
@@ -124,9 +132,36 @@ describe('hook-session-end (#217 — SessionEnd auto-close)', () => {
 
     const { status } = runSessionEnd({ session_id: 'end-test-session' })
     expect(status).toBe(0)
-    expect(existsSync(cpPath)).toBe(false)
-    // No episode from a corrupt checkpoint.
+    // A partial read of a live session's checkpoint is indistinguishable from
+    // corruption — it must not be destroyed on an unparse.
+    expect(existsSync(cpPath)).toBe(true)
+    // And nothing is captured from unparseable content.
     expect(readEpisodes()).not.toContain('auto-closed on SessionEnd')
+  })
+
+  // MISSING (data loss, #217): there was NO test where plur.capture() THROWS.
+  // hook-session-end.ts:128-142 swallows the throw with catch{} and then
+  // unlinkSync(checkpoint) UNCONDITIONALLY — so on a full disk (or any capture
+  // failure) the session's ONLY durable record is destroyed with nothing
+  // captured in its place. Correct behaviour: if capture fails, the checkpoint
+  // is RETAINED so the next session_start's deferred wrap-up (#216) can recover it.
+  // it.fails until the unlink is gated on capture success; flip to it() when green.
+  it.fails('retains the checkpoint when capture fails (#217)', () => {
+    const cpPath = writeCheckpoint('end-test-session')
+    const plurDir = join(home, '.plur')
+    // Make the plur root read-only so episode capture (atomicWrite → writeFileSync
+    // into this dir) fails, while the sessions/ subdir it contains stays writable
+    // so the unlink can still fire — this isolates "capture failed" from "couldn't
+    // unlink" and reproduces the full-disk data-loss path faithfully.
+    chmodSync(plurDir, 0o500)
+    try {
+      const { status } = runSessionEnd({ session_id: 'end-test-session', reason: 'clear' })
+      expect(status).toBe(0) // a SessionEnd hook must never fail the session
+      // The session's only durable record must survive a failed capture.
+      expect(existsSync(cpPath)).toBe(true)
+    } finally {
+      chmodSync(plurDir, 0o700)
+    }
   })
 
   it('silently passes through when plur is not configured', () => {

--- a/packages/cli/test/hook-session-guard.test.ts
+++ b/packages/cli/test/hook-session-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { spawnSync } from 'child_process'
@@ -82,6 +82,55 @@ describe('hook-session-guard', () => {
     for (let i = 0; i < 4; i++) {
       const result = runGuard({ session_id: 'deadlock-test', tool_name: 'Bash' })
       expect(result.stdout).not.toContain('deny')
+    }
+  })
+
+  // MISSING (security, PROVEN): the Cursor port sanitizes conversation_id via
+  // safeSessionKey and has a regression test (hook-cursor-guard.test.ts:116-131),
+  // but the Claude Code guard interpolates the RAW session_id straight into a
+  // filesystem path (hook-session-guard.ts:64-67, blockCountPath → writeFileSync).
+  // A `../`-laden session_id therefore writes the guard-count file OUTSIDE the
+  // sessions dir. Correct behaviour: a traversal id must NOT escape the state dir
+  // (and must not crash). it.fails until the CC guard sanitizes session_id like
+  // the Cursor port does; flip to it() when green.
+  it.fails('does not let a path-traversal session_id escape the sessions dir', () => {
+    mkdirSync(join(home, 'tmp'), { recursive: true })
+    // $TMPDIR is <home>/tmp, so the guard-count dir is <home>/tmp/plur-sessions.
+    // `../../PWNED` normalises out of both plur-sessions and tmp, landing the
+    // file directly in <home> — clean of the state dir entirely.
+    const escaped = join(home, 'PWNED.guard-count')
+    expect(existsSync(escaped)).toBe(false)
+
+    const result = runGuard({ session_id: '../../PWNED', tool_name: 'Bash' })
+    // The hook itself must survive a hostile id (no crash) — it still denies.
+    expect(result.stdout).toContain('deny')
+    // The sanitized id must keep the write inside the state dir, never in <home>.
+    expect(existsSync(escaped)).toBe(false)
+  })
+
+  // MISSING (fail-open contract, PROVEN): a PreToolUse guard MUST never throw.
+  // But incrementBlockCount's mkdir/write of $TMPDIR/plur-sessions is not wrapped
+  // in try/catch, so an unwritable $TMPDIR makes the guard EXIT 1 and print
+  // {"error":...} to stdout (index.ts's top-level catch) — which blocks the tool
+  // call it was meant to gate. Correct behaviour: exit 0 and emit valid/empty
+  // output (fail open). it.fails until the state-dir I/O is made fail-open; flip
+  // to it() when green.
+  it.fails('never crashes the tool call when the state dir is unwritable', () => {
+    const roTmp = mkdtempSync(join(tmpdir(), 'plur-ro-guard-'))
+    chmodSync(roTmp, 0o500) // r-x: owner cannot create plur-sessions inside
+    try {
+      const result = spawnSync('node', [CLI, 'hook-session-guard'], {
+        input: JSON.stringify({ session_id: 'ro-guard', tool_name: 'Bash' }),
+        encoding: 'utf-8',
+        timeout: 10000,
+        env: { ...process.env, HOME: home, USERPROFILE: home, TMPDIR: roTmp },
+        cwd: home,
+      })
+      expect(result.status ?? 1).toBe(0) // fail-open: never a non-zero exit
+      expect(result.stdout ?? '').not.toContain('"error"')
+    } finally {
+      chmodSync(roTmp, 0o700)
+      rmSync(roTmp, { recursive: true, force: true })
     }
   })
 

--- a/packages/cli/test/hook-session-mark.test.ts
+++ b/packages/cli/test/hook-session-mark.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { spawnSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+/**
+ * hook-session-mark is the PostToolUse sentinel-writer that lets
+ * hook-session-guard allow tools once plur_session_start has run. It
+ * interpolates the raw session_id into a filesystem path, so it shares the
+ * same path-traversal exposure the guard has — and had no test at all.
+ */
+describe('hook-session-mark', () => {
+  let home: string
+  let tmp: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-mark-test-'))
+    tmp = join(home, 'tmp')
+    mkdirSync(tmp, { recursive: true })
+    // Mark the project plur-configured so the hook doesn't silently no-op (#95).
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(
+      join(home, '.claude', 'settings.json'),
+      JSON.stringify({
+        mcpServers: {
+          plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        },
+      }),
+    )
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  function runMark(input: object): { stdout: string; status: number } {
+    const result = spawnSync('node', [CLI, 'hook-session-mark'], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 10000,
+      env: { ...process.env, HOME: home, USERPROFILE: home, TMPDIR: tmp },
+      cwd: home,
+    })
+    return { stdout: result.stdout ?? '', status: result.status ?? 1 }
+  }
+
+  it('writes the session sentinel for a well-formed session_id', () => {
+    const { status } = runMark({ session_id: 'good-123' })
+    expect(status).toBe(0)
+    expect(existsSync(join(tmp, 'plur-session-good-123'))).toBe(true)
+  })
+
+  // MISSING (security, PROVEN): like hook-session-guard, this hook interpolates
+  // the RAW session_id into a path (hook-session-mark.ts:50, join(tmpdir(),
+  // `plur-session-${sessionId}`) → writeFileSync). The Cursor port sanitizes with
+  // safeSessionKey and has a regression test (hook-cursor-guard.test.ts:116-131);
+  // this one does not. A `../`-laden session_id escapes $TMPDIR entirely. Correct
+  // behaviour: a traversal id must NOT write the sentinel outside the temp dir
+  // (and must not crash). it.fails until the CC hooks sanitize session_id like the
+  // Cursor port does; flip to it() when green.
+  it.fails('does not let a path-traversal session_id escape the temp dir', () => {
+    // $TMPDIR is <home>/tmp; `plur-session-` + `../../../PWNED` normalises up out
+    // of tmp, landing the sentinel directly in <home> — outside the temp dir.
+    const escaped = join(home, 'PWNED')
+    expect(existsSync(escaped)).toBe(false)
+
+    const { status } = runMark({ session_id: '../../../PWNED' })
+    expect(status).toBe(0) // hostile id must not crash the hook
+    // The sanitized id must keep the sentinel inside $TMPDIR, never in <home>.
+    expect(existsSync(escaped)).toBe(false)
+  })
+})

--- a/packages/core/test/batch-decay.test.ts
+++ b/packages/core/test/batch-decay.test.ts
@@ -4,6 +4,8 @@ import * as os from 'os'
 import * as path from 'path'
 import { applyBatchDecay, strengthToStatus } from '../src/decay.js'
 import { readHistory } from '../src/history.js'
+import { Plur } from '../src/index.js'
+import { loadEngrams, saveEngrams } from '../src/engrams.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 function tmpDir(): string {
@@ -257,5 +259,75 @@ describe('applyBatchDecay', () => {
     // 0 days since access = no decay applied (strength unchanged)
     expect(result.decayed).toBe(0)
     expect(modified.length).toBe(0)
+  })
+})
+
+describe('Plur.batchDecay() wrapper — data preservation (#dataloss)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-batchdecay-wrap-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  // The wrapper (index.ts:3079-3094) writes back only `applyBatchDecay(...).modified`
+  // — the strength-CHANGED active engrams. Every other engram (accessed today,
+  // scope-skipped, sub-threshold, or retired) is absent from `modified`, so
+  // `_writeEngrams(paths.engrams, modified)` overwrites the whole store with that
+  // subset and DELETES them. Confirmed: 5 engrams in, 2 out. There is currently
+  // no test on the wrapper at all — applyBatchDecay's own unit tests never
+  // exercise the write-back. This asserts the CORRECT behaviour: batchDecay may
+  // change strengths but must never drop an engram.
+  // it.fails until the wrapper stops overwriting the store with `modified`;
+  // flip back to it() when it passes.
+  it.fails('preserves every engram; only decays strengths (#dataloss)', () => {
+    const engramsPath = path.join(dir, 'engrams.yaml')
+    const seed: Engram[] = [
+      // Stale AND crosses a status boundary → guarantees transitions > 0, so the
+      // wrapper's buggy write actually fires.
+      makeEngram({
+        id: 'ENG-2026-0101-001',
+        activation: { retrieval_strength: 0.55, storage_strength: 1.0, frequency: 5, last_accessed: '2024-01-01' },
+      }),
+      makeEngram({
+        id: 'ENG-2026-0101-002',
+        activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 5, last_accessed: '2025-06-01' },
+      }),
+      // Accessed today (days === 0) → never enters `modified`.
+      makeEngram({
+        id: 'ENG-2026-0101-003',
+        activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 5, last_accessed: '2026-04-22' },
+      }),
+      // Scope-skipped → never enters `modified`.
+      makeEngram({
+        id: 'ENG-2026-0101-004',
+        scope: 'project:myapp',
+        activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 5, last_accessed: '2025-06-01' },
+      }),
+      // Retired → excluded from `active` → never enters `modified`.
+      makeEngram({
+        id: 'ENG-2026-0101-005',
+        status: 'retired',
+        activation: { retrieval_strength: 0.3, storage_strength: 1.0, frequency: 0, last_accessed: '2025-01-01' },
+      }),
+    ]
+    saveEngrams(engramsPath, seed)
+
+    const plur = new Plur({ path: dir })
+    plur.batchDecay({ contextScope: 'project:myapp', now: new Date('2026-04-22') })
+
+    // Reload the raw store: no engram may be deleted.
+    const survivors = loadEngrams(engramsPath)
+    expect(survivors).toHaveLength(5)
+    const ids = new Set(survivors.map(e => e.id))
+    expect(ids.has('ENG-2026-0101-003')).toBe(true) // accessed-today survives
+    expect(ids.has('ENG-2026-0101-004')).toBe(true) // scope-skipped survives
+    expect(ids.has('ENG-2026-0101-005')).toBe(true) // retired survives
+
+    // status() counts non-retired engrams — 4 of the 5 (retired excluded).
+    expect(new Plur({ path: dir }).status().engram_count).toBe(4)
   })
 })

--- a/packages/core/test/batch.test.ts
+++ b/packages/core/test/batch.test.ts
@@ -100,21 +100,31 @@ describe('learnBatch: partial-failure isolation', () => {
     syncIndex: () => {},
   })
 
-  it('captures the failing statement and still processes the rest', async () => {
+  // #281 — a partial-failure batch must let a caller positionally map each INPUT
+  // to its engram. This test used to assert `res.results` has length 2, baking in
+  // the compaction that silently drops the failed slot: with [A, B(fails), C] the
+  // input-2 engram (C) collapses onto results[1], so `ids: results.map(...)`
+  // (mcp/src/tools.ts:596) emits C's id at position 1 — the #281 misalignment bug.
+  // Correct behaviour keeps C recoverable at input index 2.
+  // it.fails until the batch return aligns results to inputs; flip back to it() when it passes.
+  it.fails('a caller can positionally map each input to its engram even when a middle item fails (#281)', async () => {
     const res = await learnBatch(makeDeps(), [
-      { statement: 'good one' },
-      { statement: 'this will BOOM' },
-      { statement: 'good two' },
+      { statement: 'good one' },       // input 0
+      { statement: 'this will BOOM' }, // input 1 — fails
+      { statement: 'good two' },       // input 2
     ])
 
-    expect(res.results).toHaveLength(2)   // both good statements succeeded
+    // The failure side already carries the input index — that part works today.
     expect(res.stats.added).toBe(2)
     expect(res.stats.failed).toBe(1)
-
     expect(res.failures).toHaveLength(1)
-    expect(res.failures[0].index).toBe(1) // original array index preserved
+    expect(res.failures[0].index).toBe(1)
     expect(res.failures[0].statement).toBe('this will BOOM')
-    expect(res.failures[0].error).toContain('simulated write failure')
+
+    // The correct contract: C ('good two') stays at its input index (2), not
+    // shifted to 1 by compaction. Read index 2 directly so we don't assume the
+    // shape of whatever the fix puts in the failed slot at index 1.
+    expect(res.results[2]?.engram?.statement).toBe('good two')
   })
 
   it('reports an all-failed batch without throwing', async () => {

--- a/packages/core/test/embedders.test.ts
+++ b/packages/core/test/embedders.test.ts
@@ -23,7 +23,7 @@
  * are gated behind PLUR_EMBEDDER_NETWORK_TESTS=1 so CI stays offline-safe.
  * Without the flag set, only metadata + factory routing are checked.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import {
   getEmbedder,
   EMBEDDER_NAMES,
@@ -76,8 +76,32 @@ describe('EmbedderAdapter factory — metadata contract', () => {
   }
 })
 
+/**
+ * Run the EmbeddingGemma adapter against a MOCKED transformers stack and return
+ * the exact strings the adapter hands to the tokenizer (prefix + text) for each
+ * embed call. Fully offline — no model download. Scoped via doMock + a
+ * re-import so the network-gated live-load suite below stays on real
+ * transformers (afterEach unmocks + resets the module registry).
+ */
+async function captureTokenizerInputs(
+  calls: Array<[text: string, role?: 'query' | 'passage']>,
+): Promise<string[]> {
+  vi.resetModules()
+  const inputs: string[] = []
+  vi.doMock('@huggingface/transformers', () => ({
+    AutoTokenizer: { from_pretrained: async () => (text: string) => { inputs.push(text); return {} } },
+    AutoModel: { from_pretrained: async () => async () => ({ sentence_embedding: { data: new Float32Array(768) } }) },
+  }))
+  const { makeEmbeddingGemmaAdapter: mk } = await import('../src/embedders/embedding-gemma.js')
+  const adapter = mk()
+  for (const [text, role] of calls) await adapter.embed(text, role)
+  return inputs
+}
+
 describe('EmbeddingGemma — role-aware prefix contract', () => {
   afterEach(() => {
+    vi.doUnmock('@huggingface/transformers')
+    vi.resetModules()
     _resetEmbeddingGemmaCache()
   })
 
@@ -86,25 +110,35 @@ describe('EmbeddingGemma — role-aware prefix contract', () => {
     expect(adapter.name).toBe('embedding-gemma@graph')
   })
 
-  it('embed() accepts an optional role parameter (query / passage / omitted)', () => {
-    // Structural check — no network call. We verify the adapter function
-    // accepts all role variants without TypeScript errors or runtime exceptions
-    // before the model is loaded (rejection comes from the async load, not the
-    // role parameter itself).
-    const adapter = makeEmbeddingGemmaAdapter()
-    // All three call shapes must be accepted by the type system:
-    const p1 = adapter.embed('test')           // omitted role → passage
-    const p2 = adapter.embed('test', 'passage') // explicit passage
-    const p3 = adapter.embed('test', 'query')   // explicit query
-    // Without a model loaded the promises will reject — that's expected.
-    // We just need them to not throw synchronously.
-    expect(p1).toBeInstanceOf(Promise)
-    expect(p2).toBeInstanceOf(Promise)
-    expect(p3).toBeInstanceOf(Promise)
-    // Suppress unhandled-rejection noise — we don't await these.
-    p1.catch(() => {})
-    p2.catch(() => {})
-    p3.catch(() => {})
+  it('prepends a DIFFERENT tokenizer input for query vs passage (role plumbing is live, not a no-op)', async () => {
+    // De-tautologized: the old test only asserted embed() returns a Promise —
+    // true even if the role plumbing were deleted. Here we capture what actually
+    // reaches the tokenizer and assert the two roles differ and that omitting
+    // the role defaults to passage.
+    const [q, p, omitted] = await captureTokenizerInputs([
+      ['memory engram lifecycle', 'query'],
+      ['memory engram lifecycle', 'passage'],
+      ['memory engram lifecycle'],
+    ])
+    expect(q).not.toBe(p)          // deleting the role prefix would make these identical
+    expect(omitted).toBe(p)        // omitted role → passage (documented default)
+    expect(q).toContain('memory engram lifecycle')
+    expect(p).toContain('memory engram lifecycle')
+  })
+
+  it.fails('uses the EmbeddingGemma model-card role prefixes, not the E5 convention (#483 E1)', async () => {
+    // The EmbeddingGemma model card requires 'task: search result | query: ' for
+    // queries and 'title: none | text: ' for documents. The adapter
+    // (embedding-gemma.ts:63) instead prepends the E5-convention 'query: ' /
+    // 'passage: ' — the WRONG prefixes for this model, producing off-space
+    // vectors that don't match any published EmbeddingGemma figure.
+    // it.fails until #483 swaps in the model-card prefixes; flip to it() when green.
+    const [q, p] = await captureTokenizerInputs([
+      ['the raw text', 'query'],
+      ['the raw text', 'passage'],
+    ])
+    expect(q).toBe('task: search result | query: the raw text')
+    expect(p).toBe('title: none | text: the raw text')
   })
 })
 

--- a/packages/core/test/fit-check.test.ts
+++ b/packages/core/test/fit-check.test.ts
@@ -38,16 +38,32 @@ function makeAdapter(opts: {
   }
 }
 
-/** Return a mock adapter where pos and neg pairs get different scores. */
-function makeSeparatingAdapter(posScore: number, negScore: number): RerankerAdapter {
-  return {
-    name: 'mock-sep',
-    modelId: 'mock/sep',
-    async score() { return posScore },
-    async scoreBatch(_q: string, docs: string[]) {
-      return docs.map(() => posScore)
-    },
-  }
+/** Token overlap between a (query, document) pair — the signal a healthy
+ *  relevance reranker rewards (same mechanism as reranker-eval.test.ts's oracle). */
+function overlap(query: string, document: string): number {
+  const qs = new Set(query.toLowerCase().split(/\s+/).filter(Boolean))
+  let s = 0
+  for (const token of document.toLowerCase().split(/\s+/)) if (qs.has(token)) s += 1
+  return s
+}
+
+/** A genuinely separating reranker: scores each (query, doc) pair by token
+ *  overlap, ranking relevant docs above irrelevant ones. Proven to separate in
+ *  reranker-eval.test.ts when fed real probe queries. */
+const oracle: RerankerAdapter = {
+  name: 'oracle',
+  modelId: 'fake://oracle',
+  async score(q, d) { return overlap(q, d) },
+  async scoreBatch(q, docs) { return docs.map(d => overlap(q, d)) },
+}
+
+/** A harmful reranker: INVERTS relevance (higher score for LESS overlap), so
+ *  cross-domain distractors outrank same-domain neighbours. */
+const inverter: RerankerAdapter = {
+  name: 'inverter',
+  modelId: 'fake://inverter',
+  async score(q, d) { return 10 - overlap(q, d) },
+  async scoreBatch(q, docs) { return docs.map(d => 10 - overlap(q, d)) },
 }
 
 function engrams(domains: Record<string, string[]>): FitCheckEngram[] {
@@ -66,42 +82,54 @@ describe('checkRerankerFit', () => {
     expect(result.separability).toBe(0)
   })
 
-  it('returns fit=true when model scores positive pairs higher', async () => {
+  it.fails('a genuinely separating reranker yields fit=true on real same-domain data (#451)', async () => {
+    // A healthy relevance reranker (oracle: scores by query/doc token overlap)
+    // SHOULD be judged a fit. But #451's metric feeds two DIFFERENT same-domain
+    // engrams as a (query, doc) "positive" pair — and real engrams within one
+    // domain are distinct facts that share few tokens, so even a healthy
+    // reranker scores them no higher than cross-domain negatives →
+    // separability ≈ 0 → fit=false. The correct expectation is fit=true.
+    // it.fails until #451 fixes positive-pair construction (synthesize a probe
+    // query from the doc, as reranker-eval does); flip to it() when green.
     const data = engrams({
       'plur.architecture': [
         'Engrams are stored as YAML on disk',
-        'Recall uses BM25 + embedding RRF fusion',
+        'Recall uses BM25 and embedding RRF fusion',
         'The reranker rescores top-K candidates',
-        'Session lifecycle: start → learn → end',
+        'Session lifecycle runs start then learn then end',
       ],
       'personal.preferences': [
-        'Always use pnpm, not npm',
+        'Always use pnpm never npm',
         'Prefer concise code without excessive comments',
         'Tests must pass before committing',
-        'Vitest is the test runner',
+        'Vitest is the configured test runner',
       ],
     })
-
-    // Build a separating adapter that returns high scores for all pairs —
-    // the multi-domain path will create real cross-domain negatives with
-    // the same model, so separability tests the pair construction logic.
-    // Use a real-signal adapter instead: pos=2, neg=-1.
-    const adapter: RerankerAdapter = {
-      name: 'mock-good',
-      modelId: 'mock',
-      async score() { return 2 },
-      async scoreBatch(_q, docs) {
-        return docs.map(() => 2)
-      },
-    }
-    const result = await checkRerankerFit(data, adapter)
-    // All pairs get uniform score → separability = 0 → threshold determines fit.
-    // This is expected: the mock can't actually separate, but the test verifies
-    // the arithmetic and n_pairs count.
+    const result = await checkRerankerFit(data, oracle)
     expect(result.n_pairs).toBeGreaterThan(0)
-    expect(result.reranker).toBe('mock-good')
-    expect(typeof result.separability).toBe('number')
-    expect(typeof result.computed_at).toBe('number')
+    expect(result.reranker).toBe('oracle')
+    expect(result.fit).toBe(true)
+  })
+
+  it('a relevance-inverting reranker is NOT a fit (fit=false)', async () => {
+    // Same-domain statements here SHARE tokens, so overlap genuinely separates
+    // same-domain neighbours (high) from cross-domain pairs (low). The inverter
+    // flips that ranking — cross-domain negatives outscore same-domain
+    // positives → separability < 0 → correctly judged not a fit.
+    const data = engrams({
+      'plur': [
+        'plur memory engine stores engrams',
+        'plur memory engine recalls engrams',
+      ],
+      'trading': [
+        'trading bot executes market orders',
+        'trading bot cancels market orders',
+      ],
+    })
+    const result = await checkRerankerFit(data, inverter)
+    expect(result.n_pairs).toBeGreaterThan(0)
+    expect(result.separability).toBeLessThan(0)
+    expect(result.fit).toBe(false)
   })
 
   it('reports separability ≈ 0 when model gives uniform scores (useless)', async () => {

--- a/packages/core/test/hybrid-rerank.test.ts
+++ b/packages/core/test/hybrid-rerank.test.ts
@@ -281,11 +281,6 @@ describe('Plur.recallHybrid with rerank=true (integration)', () => {
     expect(out.engrams[0].statement).toContain('Paris')
   })
 
-  // Belt-and-suspenders: silence unused-import warnings from vi.
-  it('vi mock surface stays available for future opt-in test rigs', () => {
-    expect(typeof vi.fn).toBe('function')
-  })
-
   // #341 — the tracker is reachable from the Plur instance (MCP consumes it
   // there) and resetReranker clears recorded failures for a doctor retry.
   it('Plur.rerankerStatus exposes the tracker; resetReranker clears it', () => {

--- a/packages/core/test/hybrid-search.test.ts
+++ b/packages/core/test/hybrid-search.test.ts
@@ -24,11 +24,13 @@ describe('hybrid search (BM25 + embeddings via RRF)', () => {
 
   afterEach(() => { rmSync(dir, { recursive: true }) })
 
-  it('returns results as a Promise', async () => {
-    const result = plur.recallHybrid('database')
-    expect(result).toBeInstanceOf(Promise)
-    const engrams = await result
-    expect(Array.isArray(engrams)).toBe(true)
+  it('resolves to relevance-ranked engrams — a keyword query top-ranks its match', async () => {
+    // Was a tautology (toBeInstanceOf(Promise) + Array.isArray, true for any
+    // async fn). The real contract: awaiting yields ranked engrams and the one
+    // strong keyword hit sorts to the top.
+    const results = await plur.recallHybrid('database')
+    expect(results.length).toBeGreaterThanOrEqual(1)
+    expect(results[0].statement).toContain('database')
   })
 
   it('finds engrams that match by keyword (BM25 strength)', async () => {
@@ -37,11 +39,19 @@ describe('hybrid search (BM25 + embeddings via RRF)', () => {
     expect(results[0].statement).toContain('PostgreSQL')
   })
 
-  it('returns empty for nonsense queries', async () => {
-    const results = await plur.recallHybrid('xyzzy plugh')
-    // May return results from embedding similarity (semantic match)
-    // but they should be low confidence — just check it doesn't crash
-    expect(Array.isArray(results)).toBe(true)
+  it('scores a genuine-nonsense query below a real keyword hit (miss signal)', async () => {
+    // "returns empty for nonsense" was never the contract — recallHybrid does
+    // not hard-filter, so a nonsense query still returns ranked engrams via
+    // embedding similarity. The real signal a caller thresholds on is topScore:
+    // a query with no keyword match cannot outscore a genuine keyword hit.
+    const hit = await plur.recallHybridWithMeta('PostgreSQL database')
+    const miss = await plur.recallHybridWithMeta('xyzzy plugh')
+    expect(hit.topScore).not.toBeNull()
+    if (miss.topScore === null) {
+      expect(miss.engrams).toHaveLength(0)
+    } else {
+      expect(miss.topScore as number).toBeLessThan(hit.topScore as number)
+    }
   })
 
   it('respects limit parameter', async () => {

--- a/packages/core/test/supersedes-inject.test.ts
+++ b/packages/core/test/supersedes-inject.test.ts
@@ -12,7 +12,13 @@ describe('supersedes chain — inject scoring (#481)', () => {
     ...overrides,
   })
 
-  it('under budget pressure without historical keywords, superseded engram is penalized and tip wins', () => {
+  // Both tests below list the superseded `older` FIRST in the input. Because the
+  // sort is stable and both engrams score equally on the query, the ONLY thing
+  // that can move `tip` ahead of `older` is the ×0.3 demotion penalty
+  // (inject.ts:460-467). The previous versions listed `tip` first and/or used a
+  // 5000-token budget where both fit, so stable-sort/order carried the assertion
+  // and deleting the penalty left them green. Here the penalty is load-bearing.
+  const makePair = () => {
     const tip = makeEngram({
       id: 'ENG-2026-0101-002',
       statement: 'deploy using canary strategy version 2',
@@ -31,57 +37,48 @@ describe('supersedes chain — inject scoring (#481)', () => {
         superseded_by: ['ENG-2026-0101-002'],
       },
     })
+    return { tip, older }
+  }
 
-    // Very tight budget — only one fits
+  const idsOf = (result: ReturnType<typeof selectAndSpread>) => [
+    ...result.directives.map(e => e.id),
+    ...result.constraints.map(e => e.id),
+    ...result.consider.map(e => e.id),
+  ]
+
+  it('under budget pressure without historical keywords, the penalty drops the superseded engram (older-first)', () => {
+    const { tip, older } = makePair()
+
+    // Tight budget admits exactly one engram. Input order [older, tip]: without
+    // the demotion penalty a stable sort keeps `older` first and it would win.
     const result = selectAndSpread(
       { prompt: 'deploy canary strategy', maxTokens: 80 },
-      [tip, older], []
+      [older, tip], []
     )
 
-    const ids = [
-      ...result.directives.map(e => e.id),
-      ...result.constraints.map(e => e.id),
-      ...result.consider.map(e => e.id),
-    ]
-    // Tip should be selected, older should be demoted out under tight budget
+    const ids = idsOf(result)
+    // The penalty re-ranks `tip` above `older`, so `tip` survives and the
+    // superseded `older` is dropped. This assertion fails if the penalty block
+    // is removed.
     expect(ids).toContain(tip.id)
     expect(ids).not.toContain(older.id)
   })
 
-  it('with historical keywords in prompt, superseded engrams are NOT penalized', () => {
-    const tip = makeEngram({
-      id: 'ENG-2026-0101-002',
-      statement: 'deploy using canary strategy version 2',
-      relations: {
-        broader: [], narrower: [], related: [], conflicts: [],
-        supersedes: ['ENG-2026-0101-001'],
-        superseded_by: [],
-      },
-    })
-    const older = makeEngram({
-      id: 'ENG-2026-0101-001',
-      statement: 'deploy using canary strategy version 1',
-      relations: {
-        broader: [], narrower: [], related: [], conflicts: [],
-        supersedes: [],
-        superseded_by: ['ENG-2026-0101-002'],
-      },
-    })
+  it('with a historical keyword the penalty is suppressed, so the superseded engram is retained (older-first)', () => {
+    const { tip, older } = makePair()
 
-    // With a generous budget, both should appear regardless of historical intent
+    // Same tight one-engram budget and same [older, tip] order. "previously" is
+    // a clean historical keyword (no substring collision, cf. #481) that
+    // suppresses the penalty, so the stable sort keeps `older` first and it
+    // survives while `tip` is dropped — the inverse of the test above.
     const result = selectAndSpread(
-      { prompt: 'what was the old deploy canary strategy previously', maxTokens: 5000 },
-      [tip, older], []
+      { prompt: 'deploy canary strategy previously', maxTokens: 80 },
+      [older, tip], []
     )
 
-    const ids = [
-      ...result.directives.map(e => e.id),
-      ...result.constraints.map(e => e.id),
-      ...result.consider.map(e => e.id),
-    ]
-    // With historical keywords, older should NOT be penalized — both should appear
-    expect(ids).toContain(tip.id)
+    const ids = idsOf(result)
     expect(ids).toContain(older.id)
+    expect(ids).not.toContain(tip.id)
   })
 
   it('engram with empty superseded_by is treated as tip — no penalty', () => {

--- a/packages/core/test/tensions.test.ts
+++ b/packages/core/test/tensions.test.ts
@@ -263,9 +263,35 @@ describe('subjectsOverlap — labeled 30-pair suite', () => {
     ['domain-generic', 'Always use pnpm for package management.', 'Always use npm for package management.'],
   ]
 
-  it('passes at least 27/30 pairs (90% recall — stemmed baseline)', () => {
+  // RECALL FLOOR ONLY. This asserts the stemmed pre-filter admits ≥27/30 known
+  // contradiction pairs — a recall measurement. It does NOT prove stemToken()
+  // helps: the assertion also passes with stemming deleted (the raw tokens of
+  // most pairs already overlap), and it is blind to false positives (precision).
+  // See the '#489' precision suite below for the complementary half.
+  it('recall floor: admits at least 27/30 labeled contradiction pairs', () => {
     const hits = CONTRADICTIONS.filter(([, a, b]) => subjectsOverlap(a, b))
     expect(hits.length).toBeGreaterThanOrEqual(27)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// subjectsOverlap — precision / false positives (#489)
+// The 30-pair suite above only measures recall. It cannot catch the inverse
+// failure: subject-DISJOINT statements wrongly flagged as overlapping. #489
+// proved stemToken() over-truncates — 'states' → 'stat' (via -es) and
+// 'station' → 'stat' (via -ion) collide on a meaningless 4-char stem, so two
+// unrelated statements pass the pre-filter and become a candidate contradiction
+// pair. That is a precision leak (wasted LLM judgements, phantom tensions).
+// ---------------------------------------------------------------------------
+
+describe('subjectsOverlap — precision / over-stemming false positives (#489)', () => {
+  it.fails('does NOT flag subject-disjoint pairs that collide only on an over-stemmed token', () => {
+    // 'states' and 'station' both stem to 'stat' → currently a false positive.
+    expect(subjectsOverlap('United states border policy', 'Station platform layout')).toBe(false)
+    // 'corners' and 'corn' both stem to 'corn' → currently a false positive.
+    expect(subjectsOverlap('Corners of the room', 'Corn futures rally')).toBe(false)
+    // Correct expectation is no-overlap for both; it.fails until #489 tightens
+    // stemToken() (e.g. min stem length / suffix guards). Flip to it() when green.
   })
 })
 

--- a/packages/hermes/test/test_bridge.py
+++ b/packages/hermes/test/test_bridge.py
@@ -67,6 +67,14 @@ class TestPlurBridge:
             with pytest.raises(PlurBridgeError, match="Engram not found"):
                 bridge.call("forget", ["ENG-999"])
 
+    # NOTE: the four timeout tests below (test_call_timeout_returns_safe_fallback,
+    # test_call_timeout_retries_then_falls_back, test_inject_graceful_fallback_on_timeout,
+    # and test_timeout_triggers_outer_retry_not_lock_retry) MOCK subprocess.run.
+    # They validate the return-value / retry-count contract on timeout, which is
+    # valid and worth keeping — but a mock never spawns a real process, so they
+    # CANNOT detect the process-group orphan/leak bug (grandchild reparented to
+    # PID 1 on timeout). That is covered by the real-process test in
+    # test_bridge_process_group.py, which must exist alongside these.
     def test_call_timeout_returns_safe_fallback(self):
         bridge = PlurBridge()
         bridge._binary = "/usr/local/bin/plur"
@@ -660,6 +668,8 @@ class TestLockRetry:
             # All three backoff delays consumed (jitter pinned to 0)
             assert [c[0][0] for c in mock_sleep.call_args_list] == [1.0, 2.0, 4.0]
 
+    # MOCKS subprocess.run: verifies retry routing/counts only, NOT the
+    # process-group orphan on timeout (see test_bridge_process_group.py).
     def test_timeout_triggers_outer_retry_not_lock_retry(self):
         """subprocess.TimeoutExpired is handled by the OUTER timeout-retry
         layer (Miles's, slow 5/15/30s, graceful degradation), NOT the INNER

--- a/packages/hermes/test/test_bridge_process_group.py
+++ b/packages/hermes/test/test_bridge_process_group.py
@@ -1,0 +1,104 @@
+"""Real-process orphan/leak test for the Hermes bridge timeout path.
+
+MISSING coverage (PROVEN class): ``PlurBridge._invoke_cli`` calls
+``subprocess.run(cmd, timeout=...)`` with an ``npx`` fallback and NO
+``start_new_session=True`` / ``os.killpg``. On timeout, ``subprocess.run``
+SIGKILLs only the *direct* child (e.g. ``npx``); any grandchild (e.g. the
+``node`` CLI process) is orphaned and reparented to PID 1 instead of being
+reaped. It keeps running forever.
+
+The four mocked timeout tests in ``test_bridge.py``
+(``test_call_timeout_returns_safe_fallback``,
+``test_call_timeout_retries_then_falls_back``,
+``test_inject_graceful_fallback_on_timeout``,
+``test_timeout_triggers_outer_retry_not_lock_retry``) patch ``subprocess.run``,
+so they verify the return-value / retry contract but CANNOT observe the orphan —
+a mock never spawns a real grandchild. This test spawns a genuine
+parent→grandchild tree and drives the real timeout path to detect the leak.
+
+The fix lands on branch ``fix-clean-0.11-base`` via PR #535 (process-group
+teardown); it is NOT on ``main``, so this is marked xfail(strict): it XPASSes
+(and forces the xfail to be removed) once the bridge kills the whole process
+group on timeout.
+"""
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+from plur_hermes.bridge import PlurBridge
+
+# Real parent: spawns a detached, long-lived grandchild, records its PID, then
+# blocks so the bridge's timeout fires while the parent is alive. Grandchild
+# stdio → /dev/null so it never holds the bridge's captured stdout pipe (which
+# would stall subprocess.run's post-kill communicate()).
+_PARENT_SRC = (
+    "import os, subprocess, sys, time\n"
+    "pidfile = sys.argv[1]\n"
+    "child = subprocess.Popen(\n"
+    "    [sys.executable, '-c', 'import time; time.sleep(600)'],\n"
+    "    stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,\n"
+    ")\n"
+    "with open(pidfile, 'w') as f:\n"
+    "    f.write(str(child.pid)); f.flush(); os.fsync(f.fileno())\n"
+    "time.sleep(600)\n"
+)
+
+
+def _is_reaped(pid: int) -> bool:
+    """True if pid is gone (killed with its group); False if it survived."""
+    try:
+        os.kill(pid, 0)
+        return False
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+
+
+def _force_kill(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group semantics")
+@pytest.mark.xfail(
+    strict=True,
+    reason="PlurBridge._invoke_cli uses subprocess.run(timeout=) without "
+    "start_new_session/os.killpg — on timeout the grandchild orphans to PID 1 "
+    "instead of being reaped with its process group. Fix is on "
+    "fix-clean-0.11-base (PR #535), not on main.",
+)
+def test_timeout_reaps_grandchild(tmp_path):
+    script = tmp_path / "parent.py"
+    pidfile = tmp_path / "gc.pid"
+    script.write_text(_PARENT_SRC)
+
+    bridge = PlurBridge()
+    # Build the command directly so _invoke_cli runs our real parent tree. This
+    # exercises the exact subprocess.run(timeout=) that leaks the grandchild.
+    cmd = [sys.executable, str(script), str(pidfile)]
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        bridge._invoke_cli(cmd, "status", timeout=2)
+
+    for _ in range(60):
+        if pidfile.exists():
+            break
+        time.sleep(0.05)
+    gc_pid = int(pidfile.read_text().strip())
+
+    try:
+        time.sleep(0.5)  # allow any process-group teardown to settle
+        assert _is_reaped(gc_pid), (
+            f"grandchild PID {gc_pid} survived the bridge timeout — it was "
+            f"orphaned/reparented to PID 1 instead of being killed with its "
+            f"process group (no start_new_session=True + os.killpg)"
+        )
+    finally:
+        _force_kill(gc_pid)  # never leak a real 600s sleeper

--- a/packages/mcp/test/e2e.test.ts
+++ b/packages/mcp/test/e2e.test.ts
@@ -57,25 +57,32 @@ describe('E2E: full learn-inject-feedback-recall lifecycle', () => {
     expect(resultB.directives).toContain('Vue')
   })
 
-  it('feedback loop improves injection', async () => {
-    const e1 = plur.learn('Use docker for deployment', { scope: 'global', type: 'procedural' })
-    const e2 = plur.learn('Use kubernetes for deployment', { scope: 'global', type: 'procedural' })
+  it('feedback loop improves injection ranking', async () => {
+    // Learn kubernetes FIRST so insertion order favours it. Positive feedback on
+    // docker + negative on kubernetes must then OVERCOME insertion order to rank
+    // docker ahead — proving feedback (not insertion order) drives ranking.
+    //
+    // The old test guarded on result.directives.indexOf('docker'/'kubernetes'),
+    // but these engrams land in the consider pool, so the directives STRING is
+    // empty and both indexOf calls returned -1 — the guard was always false and
+    // the ordering assertion never ran. Assert against injected_ids (the ordered
+    // id list inject() actually returns), unguarded.
+    const k8s = plur.learn('Use kubernetes for deployment', { scope: 'global', type: 'procedural' })
+    const docker = plur.learn('Use docker for deployment', { scope: 'global', type: 'procedural' })
 
-    // Positive feedback on e1
-    await plur.feedback(e1.id, 'positive')
-    await plur.feedback(e1.id, 'positive')
-    await plur.feedback(e1.id, 'positive')
-    // Negative feedback on e2
-    await plur.feedback(e2.id, 'negative')
-    await plur.feedback(e2.id, 'negative')
+    await plur.feedback(docker.id, 'positive')
+    await plur.feedback(docker.id, 'positive')
+    await plur.feedback(docker.id, 'positive')
+    await plur.feedback(k8s.id, 'negative')
+    await plur.feedback(k8s.id, 'negative')
 
-    // e1 should score higher and appear before e2 in formatted directives string
-    const result = plur.inject('deploy the application', { budget: 500 })
-    const dockerIdx = result.directives.indexOf('docker')
-    const k8sIdx = result.directives.indexOf('kubernetes')
-    if (dockerIdx >= 0 && k8sIdx >= 0) {
-      expect(dockerIdx).toBeLessThan(k8sIdx)
-    }
+    const result = plur.inject('deployment', { budget: 500 })
+    // Both engrams are injected for this task…
+    expect(result.injected_ids).toContain(docker.id)
+    expect(result.injected_ids).toContain(k8s.id)
+    // …and docker (positive feedback, learned SECOND) ranks ahead of kubernetes.
+    expect(result.injected_ids.indexOf(docker.id))
+      .toBeLessThan(result.injected_ids.indexOf(k8s.id))
   })
 
   it('ingest extracts and saves', () => {

--- a/packages/mcp/test/sp2-tools.test.ts
+++ b/packages/mcp/test/sp2-tools.test.ts
@@ -161,10 +161,13 @@ describe('SP2 MCP Tools', () => {
 
       expect(result.count).toBeGreaterThanOrEqual(1)
       const match = result.results.find((r: any) => r.statement?.includes('Port 3000'))
-      if (match?.episodes) {
-        expect(match.episodes.length).toBeGreaterThanOrEqual(1)
-        expect(match.episodes[0].id).toBe(episode.id)
-      }
+      // Unconditional: the old `if (match?.episodes)` guard let a regression
+      // (no matching result, or episodes silently dropped) pass. The engram was
+      // anchored to `episode`, so recall with include_episodes:true MUST surface it.
+      expect(match).toBeDefined()
+      expect(match.episodes).toBeDefined()
+      expect(match.episodes.length).toBeGreaterThanOrEqual(1)
+      expect(match.episodes[0].id).toBe(episode.id)
     })
   })
 })

--- a/packages/mcp/test/tensions.test.ts
+++ b/packages/mcp/test/tensions.test.ts
@@ -57,29 +57,59 @@ describe('plur_tensions tool', () => {
     expect(result.purge_hint).toBeUndefined()
   })
 
-  it('detects tensions between conflicting engrams', async () => {
-    const e1 = plur.learn('Always use tabs for indentation in TypeScript files')
-    const e2 = plur.learn('Always use spaces for indentation in TypeScript files')
+  it('scan detects a contradiction between conflicting engrams', async () => {
+    // The old test called plur_tensions in LIST mode (no scan), which returns
+    // only PERSISTED records — so count was ALWAYS 0 and the `if (count>0)`
+    // guard meant the pair-field assertions never ran. Detection happens in
+    // SCAN mode; mock the LLM judge (as the sibling scan tests do) and assert
+    // the detected pair, unguarded.
+    plur.learn('Always use tabs for indentation in TypeScript files')
+    plur.learn('Always use spaces for indentation in TypeScript files')
 
-    const result = await tensionsTool.handler({}, plur) as any
-    if (result.count > 0) {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'CONTRADICTS: yes\nCONFIDENCE: 0.9\nREASON: Tabs and spaces are mutually exclusive.' } }],
+      }),
+    }) as any
+    try {
+      const result = await tensionsTool.handler({
+        scan: true, llm_base_url: 'https://api.openai.com/v1', llm_api_key: 'test-key',
+      }, plur) as any
+      expect(result.count).toBeGreaterThan(0)
+      expect(result.tensions[0].tension_id).toMatch(/^T-/)
       expect(result.tensions[0].engram_a.id).toBeDefined()
       expect(result.tensions[0].engram_b.id).toBeDefined()
-      expect(result.tensions[0].detected_at).toBeDefined()
+      expect(result.tensions[0].confidence).toBeGreaterThanOrEqual(0.7)
+      expect(result.tensions[0].reason).toBeTruthy()
+    } finally {
+      globalThis.fetch = originalFetch
     }
   })
 
-  it('deduplicates conflict pairs', async () => {
+  it('list mode returns de-duplicated tension records', async () => {
+    // The old test ran LIST mode behind an `if (count>0)` guard that was always
+    // false (nothing was ever persisted), so the uniqueness assertion never ran
+    // — and it read t.engram_a.id, but list records expose engram_a as a bare id
+    // string. Here we SEED persisted records (same pair thrice, including a
+    // swapped-id ordering) and assert the pair collapses to one record, unguarded.
     const e1 = plur.learn('Use PostgreSQL for the database')
     const e2 = plur.learn('Use MySQL for the database instead of PostgreSQL')
-
-    const result = await tensionsTool.handler({}, plur) as any
-    if (result.count > 0) {
-      const pairKeys = result.tensions.map((t: any) =>
-        [t.engram_a.id, t.engram_b.id].sort().join(':')
-      )
-      expect(new Set(pairKeys).size).toBe(pairKeys.length)
+    const pair = {
+      id_a: e1.id, id_b: e2.id,
+      statement_a: e1.statement, statement_b: e2.statement,
+      confidence: 0.9, reason: 'Mutually exclusive database choices.',
     }
+    plur.recordTensions([pair])
+    plur.recordTensions([pair])
+    plur.recordTensions([{ ...pair, id_a: e2.id, id_b: e1.id }])
+
+    const result = await tensionsTool.handler({ status: 'all' }, plur) as any
+    const pairKeys = result.tensions.map((t: any) => [t.engram_a, t.engram_b].sort().join(':'))
+    expect(pairKeys.length).toBeGreaterThan(0)               // records actually persisted
+    expect(new Set(pairKeys).size).toBe(pairKeys.length)     // no duplicate pair
+    expect(pairKeys.length).toBe(1)                          // 3 recordings collapsed to 1
   })
 
   it('surfaces legacy conflict relations separately with a purge hint (#181)', async () => {

--- a/packages/python/tests/test_bridge_process_group.py
+++ b/packages/python/tests/test_bridge_process_group.py
@@ -1,0 +1,105 @@
+"""Real-process orphan/leak test for the plur-ai bridge timeout path.
+
+MISSING coverage (PROVEN class): ``bridge.run_json`` calls
+``subprocess.run(cmd, timeout=...)`` with an ``npx`` fallback and NO
+``start_new_session=True`` / ``os.killpg``. When the call times out,
+``subprocess.run`` SIGKILLs only the *direct* child (e.g. ``npx``); any
+grandchild it spawned (e.g. the ``node`` CLI process) is orphaned and reparented
+to PID 1 instead of being reaped. It keeps running, holding memory, forever.
+
+This test spawns a genuine parent→grandchild process tree (a real Python parent
+that spawns a long-sleeping grandchild and records its PID) and drives the
+bridge's actual timeout path. A MOCKED subprocess CANNOT detect this bug — only
+a real process tree can — which is why this test exists alongside the mocked
+timeout tests. The Hermes fix (PR #535) adds process-group teardown; the Python
+SDK has none yet, so this is marked xfail(strict): it XPASSes (and forces the
+xfail to be removed) once the bridge kills the whole process group on timeout.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import signal
+import sys
+import time
+
+import pytest
+
+from plur_ai.bridge import PlurError, run_json
+
+# A real parent that spawns a detached, long-lived grandchild and writes the
+# grandchild PID to a file, then blocks so the bridge's timeout fires while the
+# parent is still alive. stdio is sent to /dev/null so the grandchild never
+# holds the bridge's captured stdout pipe (which would otherwise stall
+# subprocess.run's post-kill communicate()).
+_PARENT_SRC = (
+    "import os, subprocess, sys, time\n"
+    "pidfile = sys.argv[1]\n"
+    "child = subprocess.Popen(\n"
+    "    [sys.executable, '-c', 'import time; time.sleep(600)'],\n"
+    "    stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,\n"
+    ")\n"
+    "with open(pidfile, 'w') as f:\n"
+    "    f.write(str(child.pid)); f.flush(); os.fsync(f.fileno())\n"
+    "time.sleep(600)\n"
+)
+
+
+def _is_reaped(pid: int) -> bool:
+    """True if pid is gone (killed with its group); False if it survived."""
+    try:
+        os.kill(pid, 0)
+        return False
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        # Exists but not ours — treat as alive (not reaped).
+        return False
+
+
+def _force_kill(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group semantics")
+@pytest.mark.xfail(
+    strict=True,
+    reason="bridge.run_json uses subprocess.run(timeout=) without "
+    "start_new_session/os.killpg — on timeout the grandchild orphans to PID 1 "
+    "instead of being reaped with its process group; fix mirrors PR #535",
+)
+def test_timeout_reaps_grandchild(tmp_path, monkeypatch):
+    script = tmp_path / "parent.py"
+    pidfile = tmp_path / "gc.pid"
+    script.write_text(_PARENT_SRC)
+
+    # Point the bridge at our real parent process via PLUR_CLI (shell-split);
+    # run_json appends its own args + "--json", which the parent ignores.
+    monkeypatch.setenv(
+        "PLUR_CLI",
+        f"{shlex.quote(sys.executable)} {shlex.quote(str(script))} {shlex.quote(str(pidfile))}",
+    )
+
+    # Drive the real timeout path — this must raise (hung CLI).
+    with pytest.raises(PlurError):
+        run_json(["status"], timeout=2)
+
+    # The parent wrote the grandchild PID before blocking.
+    for _ in range(60):
+        if pidfile.exists():
+            break
+        time.sleep(0.05)
+    gc_pid = int(pidfile.read_text().strip())
+
+    try:
+        time.sleep(0.5)  # allow any process-group teardown to settle
+        assert _is_reaped(gc_pid), (
+            f"grandchild PID {gc_pid} survived the bridge timeout — it was "
+            f"orphaned/reparented to PID 1 instead of being killed with its "
+            f"process group (no start_new_session=True + os.killpg)"
+        )
+    finally:
+        _force_kill(gc_pid)  # never leak a real 600s sleeper

--- a/packages/python/tests/test_client.py
+++ b/packages/python/tests/test_client.py
@@ -7,12 +7,15 @@ have ``plur`` on ``PATH``. The not-installed test runs everywhere.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import tempfile
+from pathlib import Path
 
 import pytest
 
-from plur_ai import Plur, PlurNotInstalledError
+from plur_ai import Plur, PlurError, PlurNotInstalledError
+from plur_ai.bridge import _NPX_CLI_VERSION
 
 
 def _cli_available() -> bool:
@@ -26,7 +29,14 @@ requires_cli = pytest.mark.skipif(
 
 
 @requires_cli
-def test_learn_recall_status_roundtrip():
+def test_learn_status_roundtrip():
+    # Was ``test_learn_recall_status_roundtrip``. The recall assertion that used
+    # to live here — ``recall("API style")`` finding "REST" — was VACUOUS: "API"
+    # lexically matches the seeded "api-service", so it passed under BM25-only or
+    # hybrid alike and proved nothing about which search leg ran. That check now
+    # lives, honestly, in ``test_recall_finds_semantic_match`` (a query with no
+    # lexical overlap). This test keeps only the learn + status legs, which are
+    # genuinely green.
     d = tempfile.mkdtemp(prefix="plur-pytest-")
     try:
         plur = Plur(path=d)
@@ -37,12 +47,63 @@ def test_learn_recall_status_roundtrip():
         )
         assert eng["id"].startswith("ENG-")
 
-        results = plur.recall("API style", limit=5)
-        assert any("REST" in r["statement"] for r in results)
-
         st = plur.status()
         assert st["engram_count"] >= 1
         assert st["storage_root"] == d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+# BUG-ENCODING (#495): recall() shells out with ``--fast`` (BM25-only) AND the
+# bridge raises PlurError on the CLI's exit-2 empty-result signal. Both faults
+# converge here: a purely-semantic query (no lexical/stem overlap with the
+# seeded engram) is unmatchable by BM25, so --fast returns zero results, the CLI
+# exits 2, and recall() raises instead of surfacing the semantically-relevant
+# engram. Verified live: `recall --fast "zero-downtime shipping approach"` on a
+# store holding the blue-green engram → {"results":[],"count":0} exit 2, whereas
+# hybrid returns the engram. This is the honest replacement for the old vacuous
+# lexical-overlap assertion. strict=True: when recall() is fixed to run hybrid
+# (and not raise on empty) this XPASSes and forces the xfail to be removed.
+@requires_cli
+@pytest.mark.xfail(
+    strict=True,
+    reason="recall() uses --fast (BM25-only) and raises on the resulting "
+    "exit-2 empty result — it cannot make a purely-semantic match; see #495",
+)
+def test_recall_finds_semantic_match():
+    d = tempfile.mkdtemp(prefix="plur-pytest-")
+    try:
+        plur = Plur(path=d)
+        plur.learn("deploy with blue-green never in-place", type="architectural")
+        # No lexical/stem overlap with the engram — only semantic/hybrid search
+        # can connect "zero-downtime shipping approach" to "blue-green deploy".
+        results = plur.recall("zero-downtime shipping approach", limit=5)
+        assert any("blue-green" in r["statement"] for r in results)
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+# BUG-ENCODING (#495): the CLI exits 2 on a zero-result recall (recall.ts:32)
+# and the bridge's run_json treats ANY nonzero exit as an error (bridge.py:78),
+# so a normal "no match" RAISES PlurError instead of returning []. Hermes already
+# handles exit 2 as an empty result (plur_hermes/bridge.py:320); the Python SDK
+# does not. strict=True: once bridge.py maps exit 2 → [] this XPASSes and forces
+# the xfail to be removed.
+@requires_cli
+@pytest.mark.xfail(
+    strict=True,
+    reason="recall() raises PlurError on the CLI's exit-2 empty-result signal "
+    "instead of returning []; see #495",
+)
+def test_recall_empty_returns_list():
+    d = tempfile.mkdtemp(prefix="plur-pytest-")
+    try:
+        plur = Plur(path=d)
+        plur.learn("deploy with blue-green never in-place", type="architectural")
+        # Nonsense query guaranteed to match nothing → CLI returns
+        # {"results":[],"count":0} with exit code 2.
+        results = plur.recall("zzzqqq nonexistent xyzzy vw-nomatch", limit=5)
+        assert results == []
     finally:
         shutil.rmtree(d, ignore_errors=True)
 
@@ -64,11 +125,18 @@ def test_inject_returns_sections():
 
 @requires_cli
 def test_recall_hybrid_returns_results():
+    # Honest hybrid test: the query shares NO lexical/stem overlap with the
+    # seeded engram, so only the embedding/hybrid leg can connect them. Under
+    # BM25-only this query returns zero results (verified: `recall --fast
+    # "zero-downtime shipping approach"` → exit 2, empty), so if embeddings were
+    # ever dropped from recall_hybrid this assertion would fail (or raise) —
+    # which is exactly what makes it non-vacuous. recall_hybrid() does NOT pass
+    # --fast, so it genuinely runs hybrid and this is green today.
     d = tempfile.mkdtemp(prefix="plur-pytest-")
     try:
         plur = Plur(path=d)
         plur.learn("deploy with blue-green never in-place", type="architectural")
-        results = plur.recall_hybrid("deployment strategy", limit=5)
+        results = plur.recall_hybrid("zero-downtime shipping approach", limit=5)
         assert isinstance(results, list)
         assert any("blue-green" in r["statement"] for r in results)
     finally:
@@ -82,3 +150,37 @@ def test_missing_cli_raises(monkeypatch):
 
     with pytest.raises(PlurNotInstalledError):
         run_json(["status"])
+
+
+def _major_minor(version: str) -> tuple[int, int]:
+    parts = version.split(".")
+    return (int(parts[0]), int(parts[1]))
+
+
+def test_npx_cli_version_pin_tracks_pyproject():
+    """Coupling guard for the npx-fallback CLI pin.
+
+    bridge.py's comment claims ``release tooling bumps this`` — but nothing in
+    this package enforces it (unlike hermes, which has
+    ``scripts/check_version_sync.py``). That comment is FALSE as written: the
+    pin is bumped by hand, if at all. This test is the only guard: the pinned
+    ``@plur-ai/cli`` must be on the SDK's own major line and at least as new
+    (major.minor) as the SDK package version — otherwise the npx fallback would
+    silently install a CLI predating this SDK, exactly the drift the comment
+    pretends is handled. (Code-fix TODO: correct the false comment in bridge.py.)
+    """
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    m = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE)
+    assert m, "could not find [project] version in pyproject.toml"
+    sdk_version = m.group(1)
+    sdk = _major_minor(sdk_version)
+    pin = _major_minor(_NPX_CLI_VERSION)
+
+    assert pin[0] == sdk[0], (
+        f"npx CLI pin {_NPX_CLI_VERSION} is on a different major line than the "
+        f"SDK {sdk_version} — the pin is stale or mismatched"
+    )
+    assert pin >= sdk, (
+        f"npx CLI pin {_NPX_CLI_VERSION} is older than the SDK's own version "
+        f"{sdk_version} — the fallback would install a CLI predating this SDK"
+    )


### PR DESCRIPTION
## Why

An audit found the test suite does not merely **miss** bugs — in many places it **asserts the buggy behaviour as correct**, so fixing a bug turns the suite red. That is why the 2026-07-11 automated review pass closed 7 issues without changing a line: **the suite was green because it was lying.**

A green suite was never evidence here. This PR removes the lies **before** any code is fixed, so the code-fix PRs that follow are verified against an honest baseline.

## The mechanism

A test that encodes a **known-live bug** is inverted to assert the **correct** behaviour and marked `it.fails()` (vitest) / `@pytest.mark.xfail(strict=True)` (pytest):

- While the bug exists → the correct assertion fails → the marker **passes** → suite green.
- The moment the code is fixed → the marker **fails loudly** → forces a flip back to a normal `it()` / removal of `xfail`.

So the correct behaviour is now **executable, tracked, and impossible to forget to verify**. Each code-fix PR flips exactly the markers it fixes — that's the proof it worked.

Every marker was confirmed to fail for the **right reason** (the real assertion, not an incidental setup throw). Example — the batchDecay data-loss test, run as a normal `it()`:

```
AssertionError: expected [ …(2) ] to have a length of 5 but got 2
```

## What changed

**Bug-encoding → inverted (it.fails / xfail):**
| Test asserted the bug… | Issue |
|---|---|
| claw setup DELETES a 3rd-party plugin's config incl. **API keys** | #51 |
| claw seeds `allow:[plur-claw]`, **gating off every other plugin** | #51 |
| claw overrides a user's explicit `allowConversationAccess:false` | #51 |
| batch results-compaction misaligns engram ids to inputs | #281 |
| hook-session-end deletes an unparseable/pending checkpoint | #217 |
| fit-check scores a **healthy reranker** as "poor fit" | #451 |
| embedders use E5 prefixes, not the model-card prefixes | #483 |
| tensions over-stem `states`/`station`/`stats`→`stat` (false positives) | #489 |
| python `recall()` **raises** on a zero-result query | #495 |

**Missing coverage added** (marked where the path is buggy today):
- **`batchDecay()` DATA LOSS** — no test existed; new test proves **5 engrams → 2** (the worst bug found; core, not batch, on a "run weekly" MCP path).
- `session_id` **path traversal** writes outside the state dir (guard + mark hooks).
- hook-session-end deletes the checkpoint after `capture()` throws (#217).
- hooks **not fail-open** — exit 1 on an unwritable state dir.
- doctor live-handshake path (was 100% `--no-handshake`).
- **real-process** subprocess-orphan tests for python + hermes bridges (the #535 fix + test live only on `fix-clean-0.11-base`, absent on `main`).

**Vacuous → rewritten to real green assertions:** supersedes penalty (was penalty-independent), hybrid-search tautologies, the mcp `if (count > 0) { … }` guards that never ran, hook-cursor-stop counting, hook-inject-lock staleness. **Deleted:** fit-check dead helper, `typeof vi.fn` tautology.

## Verification

Test-only. **Zero `src/` changes.**
- JS: `2612 passed | 15 expected-fail | 0 real failures | 0 xpass`
- python: `5 passed | 3 xfailed` · hermes: `143 passed | 1 xfailed`

## Next

Code-fix PRs follow in severity order (batchDecay data loss first). Each flips its `it.fails`/`xfail` markers to normal as the proof of fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)