### PR TITLE
fix(core): batchDecay no longer deletes engrams (P0 data loss)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3079,13 +3079,24 @@ export class Plur {
   batchDecay(options?: { contextScope?: string; lambda?: number; now?: Date }): BatchDecayResult {
     return withLock(this.paths.engrams, () => {
       const engrams = loadEngrams(this.paths.engrams)
-      const { result, modified } = applyBatchDecay(engrams, this.paths.root, options)
+      const { result } = applyBatchDecay(engrams, this.paths.root, options)
 
-      // Save modified engrams back (not the original unmodified list).
-      // Only primary store engrams are decayed — store/pack engrams are maintained
-      // by their respective store owners and are typically readonly.
-      if (result.transitions.length > 0) {
-        this._writeEngrams(this.paths.engrams, modified)
+      // Persist the FULL list, not the `modified` subset. applyBatchDecay mutates
+      // the decayed engrams IN PLACE inside `engrams`, so `engrams` already holds
+      // the new strengths for the ones that changed AND the untouched originals
+      // for everything else. Writing `modified` instead (the prior behaviour)
+      // overwrote the whole store with only the changed subset — silently
+      // DELETING every engram that was accessed today, scope-skipped, retired, or
+      // whose strength moved less than the 1e-10 threshold. loadEngrams returns
+      // all statuses (not just active), so the full list is safe to write back.
+      //
+      // Guard on `decayed`, not `transitions`: a decay that lowers strength
+      // without crossing a status boundary produces no transition, and the old
+      // `transitions.length > 0` guard discarded that legitimate decay entirely.
+      // (Only primary-store engrams are decayed; store/pack engrams are owned and
+      // maintained by their respective stores and are not loaded here.)
+      if (result.decayed > 0) {
+        this._writeEngrams(this.paths.engrams, engrams)
         this._syncIndex()
       }
 

--- a/packages/core/test/batch-decay.test.ts
+++ b/packages/core/test/batch-decay.test.ts
@@ -277,13 +277,12 @@ describe('Plur.batchDecay() wrapper — data preservation (#dataloss)', () => {
   // — the strength-CHANGED active engrams. Every other engram (accessed today,
   // scope-skipped, sub-threshold, or retired) is absent from `modified`, so
   // `_writeEngrams(paths.engrams, modified)` overwrites the whole store with that
-  // subset and DELETES them. Confirmed: 5 engrams in, 2 out. There is currently
-  // no test on the wrapper at all — applyBatchDecay's own unit tests never
-  // exercise the write-back. This asserts the CORRECT behaviour: batchDecay may
-  // change strengths but must never drop an engram.
-  // it.fails until the wrapper stops overwriting the store with `modified`;
-  // flip back to it() when it passes.
-  it.fails('preserves every engram; only decays strengths (#dataloss)', () => {
+  // subset and DELETED them. Confirmed at the time: 5 engrams in, 2 out. There
+  // was no test on the wrapper at all — applyBatchDecay's own unit tests never
+  // exercised the write-back. FIXED: the wrapper now writes the full in-place-
+  // mutated list. This asserts the invariant: batchDecay may change strengths
+  // but must never drop an engram.
+  it('preserves every engram; only decays strengths (#dataloss)', () => {
     const engramsPath = path.join(dir, 'engrams.yaml')
     const seed: Engram[] = [
       // Stale AND crosses a status boundary → guarantees transitions > 0, so the


### PR DESCRIPTION
**Stacked on #559** (the test-honesty pass). Retargets to `main` automatically when #559 merges.

## The bug — confirmed data loss

`plur.batchDecay()` backs the `plur_batch_decay` MCP tool — labelled `destructiveHint: false`, documented **"run weekly"** — and the CLI decay command. It **overwrote the entire engram store with only the subset whose strength changed.** Every engram accessed today, scope-skipped, retired, or whose strength moved less than the `1e-10` threshold was **silently deleted.**

Confirmed by execution:
```
BEFORE=5  decayed=3  AFTER=3   ← before the fix: 2 engrams destroyed
BEFORE=5  decayed=3  AFTER=5   ← after the fix: all survive, 3 decayed
```

This is the most severe bug found in the whole audit — and it is **not from the unreviewed batch.** It's pre-existing core, on a path users are told to run on a schedule.

## Root cause

`applyBatchDecay` mutates the decayed engrams **in place** inside the full `engrams` list, and *separately* returns `modified` — references to just the changed ones. The wrapper wrote `modified` (the subset) as the whole file.

## Fix

Write the full `engrams` list, which already carries the in-place strength updates. `loadEngrams` returns all statuses, so nothing is dropped.

Also: guard on `result.decayed > 0` instead of `result.transitions.length > 0`. A decay that lowered strength without crossing a status boundary produced no transition, so the old guard **discarded that legitimate decay entirely** — a second, quieter bug in the same three lines.

## Verification

This flips the `batch-decay` `it.fails` guard from #559 to a **normal passing test** — the test that proved "5 in, 2 out" now proves all 5 survive. That flip is the proof the fix is real, not asserted.

- New wrapper test: green.
- Independent probe: `BEFORE=5 decayed=3 AFTER=5`.
- Full `@plur-ai/core` suite: **122 files green**, no regressions.

Refs #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)