### PR TITLE
docs(claw): correct ClawHub benchmark — 97.0% not 97.6% (gbrain's number)

### DIFF
--- a/packages/claw/clawhub/SKILL.md
+++ b/packages/claw/clawhub/SKILL.md
@@ -36,7 +36,7 @@ Correct something in OpenClaw — your Claude Code picks it up. Teach a pattern 
 
 ## Benchmarks
 
-- 97.6% R@5 on LongMemEval (N=500) — full methodology: https://plur.ai/benchmark.html
+- 97.0% R@5 on LongMemEval (N=500) — full methodology: https://plur.ai/benchmark.html
 - 89% agent task win rate — Haiku with PLUR outperformed Opus without it
 - 100% convention adherence (12–0 on house rules)
 


### PR DESCRIPTION
## What

Correct the benchmark figure in the ClawHub skill listing (`packages/claw/clawhub/SKILL.md`): **97.6% → 97.0%**.

## Why

97.6% is gbrain's published figure, which plur-bench#4 reproduced as a *harness validation* (positive control to prove equivalence). It was never PLUR's result.

PLUR's actual N=500 result: **97.0% R@5** (openai-3-large, hybrid, chunk) — from plur-bench#4's closing comment and the per-category table in README.md.

This is a companion fix to #558, which makes the same correction in README.md and CHANGELOG.md. 97.0% is a strong number — we don't need to borrow a competitor's.

## Urgency

ClawHub publish is scheduled **2026-07-17**. This must merge before that date.

## Changes

- `packages/claw/clawhub/SKILL.md`: `97.6%` → `97.0%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)