### PR TITLE
infra: heartbeat ingress live on nightshift — H004 E3 / H005 E1 unblock (#132)

### DIFF
--- a/infra/heartbeat/deploy.sh
+++ b/infra/heartbeat/deploy.sh
@@ -1,25 +1,30 @@
 #!/usr/bin/env bash
-# deploy.sh — run on nightshift (gregor user, with sudo for systemd/nginx steps)
-# Nightshift is a personal server; runs as gregor, no separate service user needed.
-# Phase 1 (HTTP): works immediately via public IP (209.38.195.208:80)
-# Phase 2 (HTTPS): requires DNS A record heartbeat.plur-ai.org → 209.38.195.208
+# deploy.sh — run on the heartbeat server with sudo access
+# Required env vars:
+#   CERTBOT_EMAIL   — email address for Let's Encrypt registration
+# Optional env vars:
+#   DEPLOY_USER     — unix user that owns the heartbeat files (default: current user)
+# Phase 1 (HTTP): works immediately once port 80 is open on the server
+# Phase 2 (HTTPS): requires DNS A record heartbeat.plur-ai.org pointed at this server
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_USER="${DEPLOY_USER:-$(whoami)}"
+: "${CERTBOT_EMAIL:?CERTBOT_EMAIL env var is required for Phase 2 (certbot TLS)}"
 
 echo "==> Installing backend"
 sudo mkdir -p /opt/plur-heartbeat /var/lib/plur-heartbeat
 sudo cp "$SCRIPT_DIR/server.py" /opt/plur-heartbeat/server.py
 sudo cp "$SCRIPT_DIR/query.py" /opt/plur-heartbeat/query.py 2>/dev/null || true
-sudo chown -R gregor:gregor /opt/plur-heartbeat /var/lib/plur-heartbeat
+sudo chown -R "${DEPLOY_USER}:${DEPLOY_USER}" /opt/plur-heartbeat /var/lib/plur-heartbeat
 
 echo "==> Installing systemd unit"
-cp "$SCRIPT_DIR/plur-heartbeat.service" /etc/systemd/system/plur-heartbeat.service
-systemctl daemon-reload
-systemctl enable --now plur-heartbeat
-systemctl status plur-heartbeat --no-pager
+sudo cp "$SCRIPT_DIR/plur-heartbeat.service" /etc/systemd/system/plur-heartbeat.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now plur-heartbeat
+sudo systemctl status plur-heartbeat --no-pager
 
-echo "==> Installing nginx config (Phase 1: HTTP on public IP)"
+echo "==> Installing nginx config (Phase 1: HTTP)"
 sudo cp "$SCRIPT_DIR/nginx-heartbeat-http.conf" /etc/nginx/sites-available/heartbeat-http
 sudo ln -sf /etc/nginx/sites-available/heartbeat-http /etc/nginx/sites-enabled/heartbeat-http
 sudo cp "$SCRIPT_DIR/nginx-heartbeat.conf" /etc/nginx/sites-available/heartbeat.plur-ai.org
@@ -31,13 +36,13 @@ sudo ufw allow 80/tcp comment 'heartbeat-http'
 sudo nginx -t && sudo systemctl reload nginx
 
 echo ""
-echo "==> Phase 1 smoke test (HTTP via IP):"
-echo "    curl -sS -o /dev/null -w '%{http_code}' -X POST http://209.38.195.208/v1/heartbeat \\"
+echo "==> Phase 1 smoke test (HTTP — replace <server-ip> with this host's public IP):"
+echo "    curl -sS -o /dev/null -w '%{http_code}' -X POST http://<server-ip>/v1/heartbeat \\"
 echo "      -H 'Content-Type: application/json' \\"
 echo "      -d '{\"install_id\":\"00000000-0000-4000-8000-000000000000\",\"version\":\"0.12.0\",\"platform\":\"linux\",\"date\":\"\$(date +%Y-%m-%d)\",\"learn_count\":1,\"recall_count\":0,\"session_count\":1}'"
 echo ""
-echo "==> Phase 2 upgrade (after DNS A record heartbeat.plur-ai.org → 209.38.195.208 propagates):"
-echo "    certbot --nginx -d heartbeat.plur-ai.org --non-interactive --agree-tos -m gregor@datafund.io"
+echo "==> Phase 2 upgrade (after DNS A record heartbeat.plur-ai.org points at this server):"
+echo "    certbot --nginx -d heartbeat.plur-ai.org --non-interactive --agree-tos -m \"\${CERTBOT_EMAIL}\""
 echo "    sudo rm /etc/nginx/sites-enabled/heartbeat-http"
 echo "    sudo ln -sf /etc/nginx/sites-available/heartbeat.plur-ai.org /etc/nginx/sites-enabled/"
 echo "    sudo nginx -t && sudo systemctl reload nginx"

--- a/infra/heartbeat/deploy.sh
+++ b/infra/heartbeat/deploy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# deploy.sh — run on nightshift (gregor user, with sudo for systemd/nginx steps)
+# Nightshift is a personal server; runs as gregor, no separate service user needed.
+# Phase 1 (HTTP): works immediately via public IP (209.38.195.208:80)
+# Phase 2 (HTTPS): requires DNS A record heartbeat.plur-ai.org → 209.38.195.208
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> Installing backend"
+sudo mkdir -p /opt/plur-heartbeat /var/lib/plur-heartbeat
+sudo cp "$SCRIPT_DIR/server.py" /opt/plur-heartbeat/server.py
+sudo cp "$SCRIPT_DIR/query.py" /opt/plur-heartbeat/query.py 2>/dev/null || true
+sudo chown -R gregor:gregor /opt/plur-heartbeat /var/lib/plur-heartbeat
+
+echo "==> Installing systemd unit"
+cp "$SCRIPT_DIR/plur-heartbeat.service" /etc/systemd/system/plur-heartbeat.service
+systemctl daemon-reload
+systemctl enable --now plur-heartbeat
+systemctl status plur-heartbeat --no-pager
+
+echo "==> Installing nginx config (Phase 1: HTTP on public IP)"
+sudo cp "$SCRIPT_DIR/nginx-heartbeat-http.conf" /etc/nginx/sites-available/heartbeat-http
+sudo ln -sf /etc/nginx/sites-available/heartbeat-http /etc/nginx/sites-enabled/heartbeat-http
+sudo cp "$SCRIPT_DIR/nginx-heartbeat.conf" /etc/nginx/sites-available/heartbeat.plur-ai.org
+echo "    HTTP config enabled; HTTPS config installed but not enabled (needs DNS + certbot)"
+
+echo "==> Opening port 80"
+sudo ufw allow 80/tcp comment 'heartbeat-http'
+
+sudo nginx -t && sudo systemctl reload nginx
+
+echo ""
+echo "==> Phase 1 smoke test (HTTP via IP):"
+echo "    curl -sS -o /dev/null -w '%{http_code}' -X POST http://209.38.195.208/v1/heartbeat \\"
+echo "      -H 'Content-Type: application/json' \\"
+echo "      -d '{\"install_id\":\"00000000-0000-4000-8000-000000000000\",\"version\":\"0.12.0\",\"platform\":\"linux\",\"date\":\"\$(date +%Y-%m-%d)\",\"learn_count\":1,\"recall_count\":0,\"session_count\":1}'"
+echo ""
+echo "==> Phase 2 upgrade (after DNS A record heartbeat.plur-ai.org → 209.38.195.208 propagates):"
+echo "    certbot --nginx -d heartbeat.plur-ai.org --non-interactive --agree-tos -m gregor@datafund.io"
+echo "    sudo rm /etc/nginx/sites-enabled/heartbeat-http"
+echo "    sudo ln -sf /etc/nginx/sites-available/heartbeat.plur-ai.org /etc/nginx/sites-enabled/"
+echo "    sudo nginx -t && sudo systemctl reload nginx"
+echo "    # Also update client PLUR_TELEMETRY_ENDPOINT or let default heartbeat.plur-ai.org resolve"

--- a/infra/heartbeat/nginx-heartbeat-http.conf
+++ b/infra/heartbeat/nginx-heartbeat-http.conf
@@ -1,0 +1,38 @@
+# /etc/nginx/sites-available/heartbeat-http
+# Temporary HTTP-only endpoint — serves on public IP port 80
+# until DNS A record heartbeat.plur-ai.org → 209.38.195.208 propagates
+# and certbot TLS is obtained.
+# Activate: ln -s /etc/nginx/sites-available/heartbeat-http /etc/nginx/sites-enabled/
+# Remove once heartbeat.plur-ai.org HTTPS is live.
+
+limit_req_zone $binary_remote_addr zone=heartbeat_tmp:10m rate=60r/m;
+log_format heartbeat_privacy '$time_iso8601 "$request" $status $body_bytes_sent';
+
+server {
+    listen 80;
+    server_name 209.38.195.208 heartbeat.plur-ai.org;
+
+    # IP privacy: strip client address before it reaches backend or logs
+    access_log /var/log/nginx/heartbeat.access.log heartbeat_privacy;
+
+    limit_req zone=heartbeat_tmp burst=10 nodelay;
+
+    location /v1/heartbeat {
+        client_max_body_size 1k;
+        if ($request_method !~ ^(POST)$) { return 405; }
+
+        proxy_pass         http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+
+        # Strip all IP-identifying headers
+        proxy_set_header   X-Real-IP "";
+        proxy_set_header   X-Forwarded-For "";
+        proxy_set_header   X-Forwarded-Proto "";
+        proxy_set_header   Host $host;
+
+        proxy_read_timeout 10s;
+        proxy_connect_timeout 5s;
+    }
+
+    location / { return 404; }
+}

--- a/infra/heartbeat/nginx-heartbeat-http.conf
+++ b/infra/heartbeat/nginx-heartbeat-http.conf
@@ -1,7 +1,5 @@
 # /etc/nginx/sites-available/heartbeat-http
-# Temporary HTTP-only endpoint — serves on public IP port 80
-# until DNS A record heartbeat.plur-ai.org → 209.38.195.208 propagates
-# and certbot TLS is obtained.
+# Temporary HTTP-only endpoint — serves on port 80 until DNS propagates and certbot TLS is obtained.
 # Activate: ln -s /etc/nginx/sites-available/heartbeat-http /etc/nginx/sites-enabled/
 # Remove once heartbeat.plur-ai.org HTTPS is live.
 
@@ -10,7 +8,7 @@ log_format heartbeat_privacy '$time_iso8601 "$request" $status $body_bytes_sent'
 
 server {
     listen 80;
-    server_name 209.38.195.208 heartbeat.plur-ai.org;
+    server_name heartbeat.plur-ai.org;
 
     # IP privacy: strip client address before it reaches backend or logs
     access_log /var/log/nginx/heartbeat.access.log heartbeat_privacy;

--- a/infra/heartbeat/nginx-heartbeat.conf
+++ b/infra/heartbeat/nginx-heartbeat.conf
@@ -1,0 +1,52 @@
+# /etc/nginx/sites-available/heartbeat.plur-ai.org
+# Enable: ln -s /etc/nginx/sites-available/heartbeat.plur-ai.org /etc/nginx/sites-enabled/
+# Prereq: DNS A record heartbeat.plur-ai.org → 209.38.195.208 must propagate before certbot
+
+limit_req_zone $binary_remote_addr zone=heartbeat:10m rate=60r/m;
+# log_format must be in http context (not inside server {}); placed here so the
+# include from sites-enabled inherits it at the right scope level.
+log_format heartbeat_privacy '$time_iso8601 "$request" $status $body_bytes_sent';
+
+server {
+    listen 80;
+    server_name heartbeat.plur-ai.org;
+    # Let certbot ACME challenge through; redirect everything else
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {
+    listen 443 ssl;
+    server_name heartbeat.plur-ai.org;
+
+    # certbot will populate these after: certbot --nginx -d heartbeat.plur-ai.org
+    ssl_certificate     /etc/letsencrypt/live/heartbeat.plur-ai.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/heartbeat.plur-ai.org/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # IP privacy: strip client address before it ever reaches access log or backend
+    access_log /var/log/nginx/heartbeat.plur-ai.org.access.log heartbeat_privacy;
+
+    limit_req zone=heartbeat burst=10 nodelay;
+
+    location /v1/heartbeat {
+        limit_except POST { return 405; }
+
+        client_max_body_size 1k;
+
+        proxy_pass         http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+
+        # Strip all IP-identifying headers
+        proxy_set_header   X-Real-IP "";
+        proxy_set_header   X-Forwarded-For "";
+        proxy_set_header   X-Forwarded-Proto "";
+        proxy_set_header   Host $host;
+
+        proxy_read_timeout 10s;
+        proxy_connect_timeout 5s;
+    }
+
+    location / { return 404; }
+}

--- a/infra/heartbeat/nginx-heartbeat.conf
+++ b/infra/heartbeat/nginx-heartbeat.conf
@@ -1,6 +1,6 @@
 # /etc/nginx/sites-available/heartbeat.plur-ai.org
 # Enable: ln -s /etc/nginx/sites-available/heartbeat.plur-ai.org /etc/nginx/sites-enabled/
-# Prereq: DNS A record heartbeat.plur-ai.org → 209.38.195.208 must propagate before certbot
+# Prereq: DNS A record heartbeat.plur-ai.org must propagate before certbot
 
 limit_req_zone $binary_remote_addr zone=heartbeat:10m rate=60r/m;
 # log_format must be in http context (not inside server {}); placed here so the

--- a/infra/heartbeat/plur-heartbeat.service
+++ b/infra/heartbeat/plur-heartbeat.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=plur heartbeat ingress
+After=network.target
+
+[Service]
+Type=simple
+User=gregor
+Group=gregor
+ExecStart=/usr/bin/python3 /opt/plur-heartbeat/server.py
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=plur-heartbeat
+
+Environment=HEARTBEAT_DATA_DIR=/var/lib/plur-heartbeat
+Environment=HEARTBEAT_HOST=127.0.0.1
+Environment=HEARTBEAT_PORT=8001
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/heartbeat/query.py
+++ b/infra/heartbeat/query.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+plur heartbeat query tool
+Usage:
+  python3 query.py                  # weekly active count (last 7 days)
+  python3 query.py --days 14        # last N days
+  python3 query.py --since 2026-07-01  # since a date
+  python3 query.py --summary        # full summary stats
+
+Data lives in /var/lib/plur-heartbeat/YYYY-MM-DD.jsonl (one record per flush).
+"""
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+DATA_DIR = Path(os.environ.get("HEARTBEAT_DATA_DIR", "/var/lib/plur-heartbeat"))
+
+
+def load_records(since: date, until: date) -> list[dict]:
+    """Load all records from JSONL files in date range [since, until]."""
+    records = []
+    current = since
+    while current <= until:
+        path = DATA_DIR / f"{current.isoformat()}.jsonl"
+        if path.exists():
+            with open(path) as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        try:
+                            records.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            pass
+        current += timedelta(days=1)
+    return records
+
+
+def weekly_active_count(days: int = 7) -> dict:
+    """
+    Count distinct install_ids with any activity in the last N days.
+    This is the primary H004/H005 metric.
+    """
+    until = date.today()
+    since = until - timedelta(days=days - 1)
+    records = load_records(since, until)
+
+    active_installs = set()
+    for r in records:
+        iid = r.get("install_id")
+        if iid:
+            active_installs.add(iid)
+
+    return {
+        "window_days": days,
+        "since": since.isoformat(),
+        "until": until.isoformat(),
+        "weekly_active_count": len(active_installs),
+        "total_flushes": len(records),
+        "active_install_ids": sorted(active_installs),
+    }
+
+
+def summary_stats(days: int = 30) -> dict:
+    """Full summary: active installs, learn/recall rates, version distribution."""
+    until = date.today()
+    since = until - timedelta(days=days - 1)
+    records = load_records(since, until)
+
+    per_install = defaultdict(lambda: {
+        "learn_total": 0, "recall_total": 0, "session_total": 0,
+        "flush_count": 0, "dates": set(), "versions": set(),
+    })
+
+    for r in records:
+        iid = r.get("install_id", "unknown")
+        per_install[iid]["learn_total"] += r.get("learn_count", 0)
+        per_install[iid]["recall_total"] += r.get("recall_count", 0)
+        per_install[iid]["session_total"] += r.get("session_count", 0)
+        per_install[iid]["flush_count"] += 1
+        per_install[iid]["dates"].add(r.get("date", ""))
+        per_install[iid]["versions"].add(r.get("version", ""))
+
+    active = len(per_install)
+    total_learns = sum(v["learn_total"] for v in per_install.values())
+    total_recalls = sum(v["recall_total"] for v in per_install.values())
+
+    # H004 threshold check: >=5 learn AND >=10 recall per week
+    strong_signal = sum(
+        1 for v in per_install.values()
+        if v["learn_total"] >= 5 and v["recall_total"] >= 10
+    )
+    any_activity = sum(
+        1 for v in per_install.values()
+        if v["learn_total"] > 0 or v["recall_total"] > 0
+    )
+
+    strong_pct = (strong_signal / active * 100) if active > 0 else 0
+    any_pct = (any_activity / active * 100) if active > 0 else 0
+
+    return {
+        "window_days": days,
+        "since": since.isoformat(),
+        "until": until.isoformat(),
+        "total_opted_in_installs": active,
+        "total_flushes": len(records),
+        "total_learns": total_learns,
+        "total_recalls": total_recalls,
+        "strong_signal_installs": strong_signal,
+        "strong_signal_pct": round(strong_pct, 1),
+        "any_activity_installs": any_activity,
+        "any_activity_pct": round(any_pct, 1),
+        "h004_threshold_strong": ">=30% strong signal → PASS" if strong_pct >= 30 else f"{strong_pct:.1f}% < 30% → NOT YET",
+        "h004_threshold_mixed": ">=50% any activity → mixed signal" if any_pct >= 50 else f"{any_pct:.1f}% < 50%",
+        "h004_threshold_invalidation": "<20% any activity → INVALIDATED" if any_pct < 20 and active >= 30 else "not invalidated",
+        "sample_floor_met": active >= 30,
+        "sample_floor_note": f"{active}/30 required installs — {'FLOOR MET' if active >= 30 else 'below floor, no threshold calls yet'}",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="plur heartbeat query tool")
+    parser.add_argument("--days", type=int, default=7, help="Lookback window in days (default: 7)")
+    parser.add_argument("--since", help="Start date YYYY-MM-DD (overrides --days)")
+    parser.add_argument("--summary", action="store_true", help="Full summary with H004 threshold checks")
+    args = parser.parse_args()
+
+    if args.summary:
+        result = summary_stats(args.days)
+    else:
+        days = args.days
+        if args.since:
+            since = date.fromisoformat(args.since)
+            days = (date.today() - since).days + 1
+        result = weekly_active_count(days)
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/heartbeat/server.py
+++ b/infra/heartbeat/server.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+plur heartbeat ingress — listens on 127.0.0.1:8001
+Appends validated payloads to /var/lib/plur-heartbeat/YYYY-MM-DD.jsonl
+No external dependencies beyond stdlib.
+"""
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+DATA_DIR = Path(os.environ.get("HEARTBEAT_DATA_DIR", "/var/lib/plur-heartbeat"))
+BIND_HOST = os.environ.get("HEARTBEAT_HOST", "127.0.0.1")
+BIND_PORT = int(os.environ.get("HEARTBEAT_PORT", "8001"))
+MAX_BODY = 1024  # bytes
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-[\w.]+)?$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+PLATFORMS = {"linux", "darwin", "win32"}
+
+
+def validate(payload: dict) -> str | None:
+    """Return error string or None if valid."""
+    required = {"install_id", "version", "platform", "date", "learn_count", "recall_count", "session_count"}
+    missing = required - payload.keys()
+    if missing:
+        return f"missing fields: {', '.join(sorted(missing))}"
+    if not isinstance(payload["install_id"], str) or not UUID_RE.match(payload["install_id"]):
+        return "install_id must be UUID v4"
+    if not isinstance(payload["version"], str) or not VERSION_RE.match(payload["version"]):
+        return "version must match semver"
+    if payload["platform"] not in PLATFORMS:
+        return f"platform must be one of {PLATFORMS}"
+    if not isinstance(payload["date"], str) or not DATE_RE.match(payload["date"]):
+        return "date must be YYYY-MM-DD"
+    for field in ("learn_count", "recall_count", "session_count"):
+        if not isinstance(payload[field], int) or payload[field] < 0:
+            return f"{field} must be non-negative integer"
+    return None
+
+
+class HeartbeatHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        # Suppress default access log (contains client IP)
+        pass
+
+    def send_plain(self, code: int, body: str = ""):
+        encoded = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        if encoded:
+            self.wfile.write(encoded)
+
+    def do_POST(self):
+        if self.path != "/v1/heartbeat":
+            self.send_plain(404, "not found")
+            return
+
+        ct = self.headers.get("Content-Type", "")
+        if "application/json" not in ct:
+            self.send_plain(400, "Content-Type must be application/json")
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        if length > MAX_BODY:
+            self.send_plain(400, "payload too large")
+            return
+
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            self.send_plain(400, "invalid JSON")
+            return
+
+        if not isinstance(payload, dict):
+            self.send_plain(400, "payload must be a JSON object")
+            return
+
+        err = validate(payload)
+        if err:
+            self.send_plain(400, err)
+            return
+
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        out_path = DATA_DIR / f"{date_str}.jsonl"
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        line = json.dumps(payload, separators=(",", ":")) + "\n"
+        with open(out_path, "a") as f:
+            f.write(line)
+
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        self.send_plain(405, "method not allowed")
+
+    def do_HEAD(self):
+        self.send_plain(405, "method not allowed")
+
+
+def main():
+    server = HTTPServer((BIND_HOST, BIND_PORT), HeartbeatHandler)
+    print(f"plur-heartbeat listening on {BIND_HOST}:{BIND_PORT}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/heartbeat/server.py
+++ b/infra/heartbeat/server.py
@@ -11,6 +11,7 @@ import sys
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from typing import Optional
 
 DATA_DIR = Path(os.environ.get("HEARTBEAT_DATA_DIR", "/var/lib/plur-heartbeat"))
 BIND_HOST = os.environ.get("HEARTBEAT_HOST", "127.0.0.1")
@@ -26,7 +27,7 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 PLATFORMS = {"linux", "darwin", "win32"}
 
 
-def validate(payload: dict) -> str | None:
+def validate(payload: dict) -> Optional[str]:
     """Return error string or None if valid."""
     required = {"install_id", "version", "platform", "date", "learn_count", "recall_count", "session_count"}
     missing = required - payload.keys()

--- a/packages/claw/src/telemetry-flush.ts
+++ b/packages/claw/src/telemetry-flush.ts
@@ -50,7 +50,7 @@ export type FlushOpts = CountersOpts & {
   packageVersion?: string
 }
 
-const DEFAULT_ENDPOINT = 'https://plur.ai/v1/heartbeat'
+const DEFAULT_ENDPOINT = 'https://heartbeat.plur-ai.org/v1/heartbeat'
 const DEFAULT_TIMEOUT_MS = 5000
 
 function resolveEndpoint(opts: FlushOpts): string {


### PR DESCRIPTION
## Summary

- **Server deployed and live** on nightshift (209.38.195.208): `POST /v1/heartbeat` accepting counters-only opt-in payloads, storing to `/var/lib/plur-heartbeat/YYYY-MM-DD.jsonl`. Validated with smoke tests (204 responses, data confirmed written).
- **IP stripped at nginx** — heartbeat_privacy log format omits `$remote_addr`; no client IP reaches access logs or backend.
- **Client endpoint updated**: `DEFAULT_ENDPOINT` in `telemetry-flush.ts` corrected from `plur.ai` to `heartbeat.plur-ai.org`. All 129 claw tests pass.
- **Weekly-active query** at `/opt/plur-heartbeat/query.py` — `python3 query.py` returns distinct `install_id` count over last 7d; `--summary` adds H004 threshold checks.
- **Two-phase nginx deploy**: Phase 1 (HTTP on port 80, no DNS needed) is live now. Phase 2 (HTTPS via certbot) activates once DNS A record `heartbeat.plur-ai.org → 209.38.195.208` propagates.

## What was blocking this

PR #141 existed on the `infra/heartbeat-endpoint-132` branch but was never merged. The DNS record was never created so certbot couldn't run. This PR takes a pragmatic two-phase approach: serve on the public IP (port 80) immediately so opt-in clients can flush, then upgrade to HTTPS + domain once DNS propagates.

## Verification

```bash
# Smoke test (live now):
curl -sS -o /dev/null -w '%{http_code}' -X POST http://209.38.195.208/v1/heartbeat \
  -H 'Content-Type: application/json' \
  -d '{"install_id":"00000000-0000-4000-8000-000000000000","version":"0.12.0","platform":"linux","date":"2026-07-14","learn_count":1,"recall_count":0,"session_count":1}'
# expect: 204

# Weekly active count (on nightshift):
python3 /opt/plur-heartbeat/query.py --summary
```

## Phase 2 upgrade (requires human: DNS record)

```bash
# 1. Add DNS A record: heartbeat.plur-ai.org → 209.38.195.208
# 2. After propagation (~hours):
certbot --nginx -d heartbeat.plur-ai.org --non-interactive --agree-tos -m gregor@datafund.io
sudo rm /etc/nginx/sites-enabled/heartbeat-http
sudo ln -sf /etc/nginx/sites-available/heartbeat.plur-ai.org /etc/nginx/sites-enabled/
sudo nginx -t && sudo systemctl reload nginx
```

## H004 E3 / H005 readout timeline re-baseline

Ingress live: 2026-07-14. Re-baseline readout window: 2 weeks from first real opt-in heartbeat received (~2026-07-28). H004 threshold call requires ≥30 opted-in installs (sample floor).

**Note:** Client `PLUR_TELEMETRY_ENDPOINT` env var overrides the default endpoint for testing against the HTTP IP while DNS is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)