### PR TITLE
fix(core): show commitment and confidence as distinct fields (#348)

### DIFF
--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -611,12 +611,15 @@ export function formatLayer3(engram: WireEngram): string {
   if (engram.rationale) lines.push(`  Rationale: ${engram.rationale}`)
   const meta: string[] = []
   if (engram.domain) meta.push(`Domain: ${engram.domain}`)
+  // #348: commitment (a decision-state ladder: exploring→leaning→decided→locked)
+  // and confidence (epistemic certainty, a float) are ORTHOGONAL. Previously
+  // commitment was rendered under the `Confidence:` label and the numeric score
+  // was discarded, so a shaky fact (confidence 0.12) marked `locked` read as
+  // maximally certain in the highest-authority directives block. Show both as
+  // distinct fields; never overwrite one with the other.
   const commitment = (engram as any).commitment as string | undefined
-  if (commitment) {
-    meta.push(`Confidence: ${commitment}`)
-  } else if (engram.confidence_score != null) {
-    meta.push(`Confidence: ${engram.confidence_score.toFixed(2)}`)
-  }
+  if (commitment) meta.push(`Commitment: ${commitment}`)
+  if (engram.confidence_score != null) meta.push(`Confidence: ${engram.confidence_score.toFixed(2)}`)
   if (engram.activation?.last_accessed) meta.push(`Last verified: ${engram.activation.last_accessed}`)
   if (meta.length > 0) lines.push(`  ${meta.join(' | ')}`)
   return lines.join('\n')

--- a/packages/core/test/inject.test.ts
+++ b/packages/core/test/inject.test.ts
@@ -216,35 +216,20 @@ describe('injection engine', () => {
       ...overrides,
     })
 
-    it('renders "Confidence: exploring" when commitment is exploring', () => {
-      const wire = makeWire({ commitment: 'exploring' })
-      const text = formatWithLayer([wire], 3)
-      expect(text).toContain('Confidence: exploring')
-      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
-    })
+    // #348: commitment and confidence are distinct fields. These used to assert
+    // `Confidence: <commitment>` with the numeric score HIDDEN — encoding the bug
+    // where a low-confidence engram read as maximally certain. Now both show.
+    for (const level of ['exploring', 'leaning', 'decided', 'locked'] as const) {
+      it(`renders "Commitment: ${level}" ALONGSIDE the confidence float`, () => {
+        const wire = makeWire({ commitment: level })
+        const text = formatWithLayer([wire], 3)
+        expect(text).toContain(`Commitment: ${level}`)
+        expect(text).toContain('Confidence: 0.73') // the number is NOT discarded
+        expect(text).not.toContain(`Confidence: ${level}`) // commitment never masquerades as confidence
+      })
+    }
 
-    it('renders "Confidence: leaning" when commitment is leaning', () => {
-      const wire = makeWire({ commitment: 'leaning' })
-      const text = formatWithLayer([wire], 3)
-      expect(text).toContain('Confidence: leaning')
-      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
-    })
-
-    it('renders "Confidence: decided" when commitment is decided', () => {
-      const wire = makeWire({ commitment: 'decided' })
-      const text = formatWithLayer([wire], 3)
-      expect(text).toContain('Confidence: decided')
-      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
-    })
-
-    it('renders "Confidence: locked" when commitment is locked', () => {
-      const wire = makeWire({ commitment: 'locked' })
-      const text = formatWithLayer([wire], 3)
-      expect(text).toContain('Confidence: locked')
-      expect(text).not.toMatch(/Confidence: 0\.\d{2}/)
-    })
-
-    it('renders the raw float when commitment is not set', () => {
+    it('renders only the float when commitment is not set', () => {
       const wire = makeWire()
       const text = formatWithLayer([wire], 3)
       expect(text).toContain('Confidence: 0.73')


### PR DESCRIPTION
## Problem

`formatLayer3` rendered the **commitment ladder** (`exploring`/`leaning`/`decided`/`locked`) under the `Confidence:` label and **discarded** the numeric `confidence_score`:

```ts
if (commitment) meta.push(`Confidence: ${commitment}`)          // ← masks the number
else if (confidence_score != null) meta.push(`Confidence: ${confidence_score.toFixed(2)}`)
```

So an engram with `confidence_score: 0.12` but `commitment: 'locked'` rendered as **`Confidence: locked`** in Layer 3 — the model's highest-authority directives block. A shaky fact read as maximally certain.

`commitment` (a decision-state ladder) and `confidence` (epistemic certainty) are **orthogonal**. Conflating them under one label loses real signal.

## Fix

Render both as distinct fields:

```
[ENG-…] Always deploy blue-green
  Commitment: locked | Confidence: 0.12
```

When commitment is absent, only `Confidence: <float>` shows, exactly as before.

## Tests

The four existing tests asserted `Confidence: <commitment>` **with the float hidden** (`not.toMatch(/Confidence: 0\.\d{2}/)`) — i.e. they **encoded the bug**. The test-honesty pass (#559) missed them because #348 was filed as a product-decision item, not a flagged bug. Rewritten to assert both fields render and commitment never masquerades as confidence. `@plur-ai/core` inject suite green (25/25).

Closes #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)