### PR TITLE
fix(core): hasHistoricalIntent matches word boundaries, not substrings (#481)

### DIFF
--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -184,9 +184,20 @@ export function flattenRelations(engram: Engram): Association[] {
 
 const HISTORICAL_KEYWORDS = ['before', 'was', 'prior', 'used to', 'previously', 'old', 'earlier', 'history', 'historical', 'legacy']
 
+// Match keywords on WORD BOUNDARIES, not substrings (#481). Substring matching
+// false-positived on common words: 'prior' ⊂ "priority"/"prioritize",
+// 'old' ⊂ "hold"/"threshold"/"placeholder", 'was' ⊂ "wasm". A false positive
+// SUPPRESSES the ×0.3 penalty on superseded engrams, injecting stale memory
+// instead of the current tip. \b sits at every space↔word transition, so
+// multi-word phrases like "used to" match correctly with a boundary at each end.
+const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const HISTORICAL_KEYWORD_PATTERNS = HISTORICAL_KEYWORDS.map(
+  kw => new RegExp(`\\b${escapeRegExp(kw)}\\b`),
+)
+
 function hasHistoricalIntent(prompt: string): boolean {
   const lower = prompt.toLowerCase()
-  return HISTORICAL_KEYWORDS.some(kw => lower.includes(kw))
+  return HISTORICAL_KEYWORD_PATTERNS.some(re => re.test(lower))
 }
 
 function isSupersededEngram(engram: ScoredEngram): boolean {

--- a/packages/core/test/supersedes-inject.test.ts
+++ b/packages/core/test/supersedes-inject.test.ts
@@ -104,4 +104,44 @@ describe('supersedes chain — inject scoring (#481)', () => {
     ]
     expect(ids).toContain(tip.id)
   })
+
+  // --- Word-boundary matching for historical intent (#481) ---
+  // hasHistoricalIntent used SUBSTRING matching, so common words false-positived
+  // as "historical" and suppressed the ×0.3 penalty, injecting the STALE
+  // superseded engram instead of the current tip. 'prior' ⊂ "priority",
+  // 'old' ⊂ "threshold", 'was' ⊂ "wasm". These must NOT count as historical.
+
+  it('a prompt containing "priority" (substring "prior") is NOT historical — penalty applies, tip wins (#481)', () => {
+    const { tip, older } = makePair()
+
+    // "priority" contains the substring "prior" but is not a historical keyword.
+    // Pre-fix: substring match treats this as historical, suppresses the penalty,
+    // and the stable [older, tip] sort keeps the STALE `older` — the bug.
+    // Post-fix: word-boundary match => non-historical => penalty demotes `tip`
+    // above `older`, so the current `tip` survives and `older` is dropped.
+    const result = selectAndSpread(
+      { prompt: 'deploy canary strategy priority', maxTokens: 80 },
+      [older, tip], []
+    )
+
+    const ids = idsOf(result)
+    expect(ids).toContain(tip.id)
+    expect(ids).not.toContain(older.id)
+  })
+
+  it('a genuinely historical prompt ("used to") IS historical — penalty suppressed, superseded retained (#481)', () => {
+    const { tip, older } = makePair()
+
+    // Multi-word keyword "used to" still matches as a phrase under word-boundary
+    // logic. Historical intent suppresses the penalty, so the stable [older, tip]
+    // sort keeps `older` and it survives while `tip` is dropped.
+    const result = selectAndSpread(
+      { prompt: 'the canary deploy strategy we used to prefer', maxTokens: 80 },
+      [older, tip], []
+    )
+
+    const ids = idsOf(result)
+    expect(ids).toContain(older.id)
+    expect(ids).not.toContain(tip.id)
+  })
 })


### PR DESCRIPTION
`hasHistoricalIntent` matched historical keywords as **substrings**, so common words false-positived:

- `'prior'` ⊂ "priority" / "prioritize"
- `'old'` ⊂ "hold" / "threshold" / "placeholder"
- `'was'` ⊂ "wasm"

A `true` return **suppresses the ×0.3 penalty on superseded engrams**, so a prompt like *"deploy canary rollout production gradual priority"* injects the **stale** superseded engram instead of the current tip. Proven by execution.

## Fix

Compile each keyword to a `\b<escaped>\b` regex (metachars escaped) and test the prompt against each. `\b` sits at every space↔word transition, so whole-word matching is enforced while multi-word phrases like `"used to"` still match.

## Tests

Two tests added to `supersedes-inject.test.ts` (modeled on the load-bearing `[older, tip]` / tight-budget setup):
- a `"priority"` prompt is correctly **non-historical** → penalty applies, current tip wins, stale `older` dropped — **verified failing on pre-fix code**;
- a genuine `"used to"` prompt stays **historical** → penalty suppressed, superseded engram retained (positive control).

Full `@plur-ai/core` suite green (120 files; one unrelated LLM-dedup flake confirmed transient).

Closes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)