### PR TITLE
fix(cli): SessionEnd hook stops destroying the session checkpoint + path traversal (#217)

### DIFF
--- a/packages/cli/src/commands/hook-learn-check.ts
+++ b/packages/cli/src/commands/hook-learn-check.ts
@@ -1,4 +1,4 @@
-import { readSync, readFileSync, writeFileSync, mkdirSync, existsSync, appendFileSync, statSync } from 'fs'
+import { readSync, readFileSync, writeFileSync, mkdirSync, existsSync, appendFileSync, statSync, renameSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { tmpdir, homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
@@ -93,7 +93,20 @@ function writeCheckpoint(count: number, cwd: string): void {
     observation_file: `${dateStr}.jsonl`,
   }
 
-  writeFileSync(path, JSON.stringify(checkpoint, null, 2) + '\n')
+  // Atomic write: temp file + rename, so a concurrent reader (hook-session-end,
+  // the deferred wrap-up in hook-inject) never observes a mid-write PARTIAL
+  // file. A plain writeFileSync here made a partial read indistinguishable from
+  // genuine corruption, which hook-session-end then used to justify DESTROYING
+  // a live session's only durable record (#217). renameSync is atomic on POSIX
+  // when src and dst are on the same filesystem (they share this dir).
+  const tmpPath = `${path}.${process.pid}.tmp`
+  writeFileSync(tmpPath, JSON.stringify(checkpoint, null, 2) + '\n')
+  try {
+    renameSync(tmpPath, path)
+  } catch (err) {
+    try { unlinkSync(tmpPath) } catch { /* best-effort temp cleanup */ }
+    throw err
+  }
 }
 
 function readStdinRaw(): string {

--- a/packages/cli/src/commands/hook-session-end.ts
+++ b/packages/cli/src/commands/hook-session-end.ts
@@ -93,8 +93,15 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
         checkpointPath = cp
         break
       } catch {
-        // Corrupt checkpoint — remove it and stop.
-        try { unlinkSync(cp) } catch {}
+        // Unparseable checkpoint — RETAIN it, never destroy it (#217). With
+        // hook-learn-check's writeCheckpoint now atomic (temp-file + rename),
+        // a concurrent reader can no longer catch a mid-write PARTIAL read, so
+        // this branch is reached only on genuine on-disk corruption. Even then,
+        // a checkpoint is a session's only durable record: unlinking it (the
+        // old behaviour) was silent data loss, and a partial read of a LIVE
+        // session's checkpoint was indistinguishable from corruption. Leave it
+        // in place and stop — the next session_start's deferred wrap-up (#216)
+        // can still find it, and nothing is captured from unparseable content.
         return
       }
     }
@@ -125,6 +132,7 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     `${durationStr ? `, ${durationStr}` : ''}` +
     `${project ? `, ${project}` : ''}.`
 
+  let captured = false
   try {
     const plur = createPlur(flags)
     plur.capture(summary, {
@@ -133,13 +141,28 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       session_id: checkpoint.session_id || payload.session_id,
       tags: ['session-end', 'auto-close'],
     })
-  } catch {
+    captured = true
+  } catch (err) {
     // Capture is best-effort — never let a SessionEnd hook fail the session.
+    // But do NOT delete the checkpoint below when it fails: the checkpoint is
+    // the session's only durable record, and on a full disk (or any capture
+    // failure) unlinking it unconditionally was silent data loss (#217).
+    // Retaining it lets the next session_start's deferred wrap-up (#216)
+    // recover the session. Advisory stderr only — SessionEnd output is not
+    // surfaced to the user.
+    process.stderr.write(
+      `[plur] hook-session-end: capture failed, retaining checkpoint for recovery: ` +
+      `${(err as Error)?.message ?? String(err)}\n`,
+    )
   }
 
-  // Clean up the checkpoint so the next session_start's deferred wrap-up does
-  // not double-report this session (#216).
-  try { unlinkSync(checkpointPath) } catch {}
+  // Clean up the checkpoint ONLY after a successful capture, so the session's
+  // durable record survives a failed capture (#217). On success this also
+  // prevents the next session_start's deferred wrap-up from double-reporting
+  // this session (#216).
+  if (captured) {
+    try { unlinkSync(checkpointPath) } catch {}
+  }
 
   // Ensure the sessions dir still exists for subsequent sessions (defensive —
   // capture may create the plur root lazily).

--- a/packages/cli/src/commands/hook-session-guard.ts
+++ b/packages/cli/src/commands/hook-session-guard.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { type GlobalFlags } from '../plur.js'
 import { isPlurConfigured } from '../lib/plur-configured.js'
+import { safeSessionKey } from '../lib/session-key.js'
 
 /**
  * plur hook-session-guard — PreToolUse hook that blocks all tools until
@@ -57,14 +58,19 @@ function readStdinRaw(): string {
   }
 }
 
+// Both path builders sanitize session_id via safeSessionKey (shared with the
+// Cursor port) before interpolating it. A hostile id like `../../PWNED` would
+// otherwise escape the state dir and write the sentinel/guard-count file
+// wherever it points (path traversal). hook-session-mark sanitizes the same
+// way, so a well-formed session still matches its sentinel.
 function sentinelPath(sessionId: string): string {
-  return join(tmpdir(), `plur-session-${sessionId}`)
+  return join(tmpdir(), `plur-session-${safeSessionKey(sessionId)}`)
 }
 
 function blockCountPath(sessionId: string): string {
   const dir = join(tmpdir(), 'plur-sessions')
   mkdirSync(dir, { recursive: true })
-  return join(dir, `${sessionId}.guard-count`)
+  return join(dir, `${safeSessionKey(sessionId)}.guard-count`)
 }
 
 function incrementBlockCount(sessionId: string): number {

--- a/packages/cli/src/commands/hook-session-mark.ts
+++ b/packages/cli/src/commands/hook-session-mark.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { type GlobalFlags } from '../plur.js'
 import { isPlurConfigured } from '../lib/plur-configured.js'
+import { safeSessionKey } from '../lib/session-key.js'
 
 /**
  * plur hook-session-mark — PostToolUse hook on mcp__plur__plur_session_start.
@@ -47,7 +48,10 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
   const sessionId = data.session_id ?? ''
   if (!sessionId) return
 
-  const sentinel = join(tmpdir(), `plur-session-${sessionId}`)
+  // Sanitize before interpolating into a path (shared with hook-session-guard,
+  // which reads this same sentinel): a `../`-laden session_id would otherwise
+  // escape $TMPDIR and write the sentinel wherever it points (path traversal).
+  const sentinel = join(tmpdir(), `plur-session-${safeSessionKey(sessionId)}`)
   try {
     writeFileSync(sentinel, '')
   } catch {

--- a/packages/cli/src/lib/cursor-hook-io.ts
+++ b/packages/cli/src/lib/cursor-hook-io.ts
@@ -2,6 +2,7 @@ import { readSync, mkdirSync, writeFileSync, appendFileSync, statSync, readdirSy
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
 import { cursorContextRulePath } from '../mcp-config.js'
+import { safeSessionKey } from './session-key.js'
 
 /**
  * Shared stdin-reading and sentinel-path helpers for the four hook-cursor-*
@@ -92,23 +93,6 @@ export function cursorConversationId(input: Record<string, unknown>): string {
     )
   }
   return id
-}
-
-/**
- * Filesystem-safe token derived from a raw conversation id. Cursor's hook
- * payload schema is documented as beta/unconfirmed (see cursorConversationId
- * above) — nothing guarantees the value is safe to interpolate directly into
- * a path. Replacing anything outside [A-Za-z0-9_-] closes both path
- * traversal (`../`, `/`) and OS-invalid characters (`:`, `|`, null bytes)
- * while leaving well-formed real ids (UUIDs, which are already in this safe
- * set) untouched (audit fix — evaluator review, 2026-07-08: previously used
- * unsanitized in every path below, so a malformed id could throw ENOENT/
- * EINVAL and, combined with every hook's `failClosed: false`, silently and
- * permanently disable that conversation's guard/injection/reminders).
- */
-function safeSessionKey(conversationId: string): string {
-  const safe = conversationId.replace(/[^A-Za-z0-9_-]/g, '_')
-  return safe || 'unknown'
 }
 
 /**

--- a/packages/cli/src/lib/session-key.ts
+++ b/packages/cli/src/lib/session-key.ts
@@ -1,0 +1,20 @@
+/**
+ * Filesystem-safe token derived from a raw session/conversation id.
+ *
+ * Hook payloads (Claude Code `session_id`, Cursor `conversation_id`) are not
+ * guaranteed safe to interpolate directly into a path — a `../`-laden or
+ * OS-invalid id can escape the sessions/temp dir (path traversal) or throw
+ * ENOENT/EINVAL. Replacing anything outside [A-Za-z0-9_-] closes both path
+ * traversal (`../`, `/`) and OS-invalid characters (`:`, `|`, null bytes) while
+ * leaving well-formed real ids (UUIDs, which are already in this safe set)
+ * untouched.
+ *
+ * Shared by the Cursor hooks (cursor-hook-io.ts) and the Claude Code session
+ * hooks (hook-session-guard.ts, hook-session-mark.ts) so every hook that turns
+ * an id into a path sanitizes it identically — a guard and its sentinel-writer
+ * must agree on the key, or a well-formed session would stop matching.
+ */
+export function safeSessionKey(conversationId: string): string {
+  const safe = conversationId.replace(/[^A-Za-z0-9_-]/g, '_')
+  return safe || 'unknown'
+}

--- a/packages/cli/test/hook-session-end.test.ts
+++ b/packages/cli/test/hook-session-end.test.ts
@@ -124,7 +124,7 @@ describe('hook-session-end (#217 — SessionEnd auto-close)', () => {
   // session's checkpoint (hook-session-end.ts:97). Correct behaviour: unparseable
   // content is RETAINED (or quarantined via rename), never silently destroyed.
   // it.fails until the parse-failure branch stops unlinking; flip to it() when green.
-  it.fails('retains (does not delete) an unparseable checkpoint', () => {
+  it('retains (does not delete) an unparseable checkpoint', () => {
     const sessionsDir = join(home, '.plur', 'sessions')
     mkdirSync(sessionsDir, { recursive: true })
     const cpPath = join(sessionsDir, 'end-test-session.checkpoint.json')
@@ -146,7 +146,7 @@ describe('hook-session-end (#217 — SessionEnd auto-close)', () => {
   // captured in its place. Correct behaviour: if capture fails, the checkpoint
   // is RETAINED so the next session_start's deferred wrap-up (#216) can recover it.
   // it.fails until the unlink is gated on capture success; flip to it() when green.
-  it.fails('retains the checkpoint when capture fails (#217)', () => {
+  it('retains the checkpoint when capture fails (#217)', () => {
     const cpPath = writeCheckpoint('end-test-session')
     const plurDir = join(home, '.plur')
     // Make the plur root read-only so episode capture (atomicWrite → writeFileSync

--- a/packages/cli/test/hook-session-guard.test.ts
+++ b/packages/cli/test/hook-session-guard.test.ts
@@ -93,7 +93,7 @@ describe('hook-session-guard', () => {
   // sessions dir. Correct behaviour: a traversal id must NOT escape the state dir
   // (and must not crash). it.fails until the CC guard sanitizes session_id like
   // the Cursor port does; flip to it() when green.
-  it.fails('does not let a path-traversal session_id escape the sessions dir', () => {
+  it('does not let a path-traversal session_id escape the sessions dir', () => {
     mkdirSync(join(home, 'tmp'), { recursive: true })
     // $TMPDIR is <home>/tmp, so the guard-count dir is <home>/tmp/plur-sessions.
     // `../../PWNED` normalises out of both plur-sessions and tmp, landing the

--- a/packages/cli/test/hook-session-mark.test.ts
+++ b/packages/cli/test/hook-session-mark.test.ts
@@ -61,7 +61,7 @@ describe('hook-session-mark', () => {
   // behaviour: a traversal id must NOT write the sentinel outside the temp dir
   // (and must not crash). it.fails until the CC hooks sanitize session_id like the
   // Cursor port does; flip to it() when green.
-  it.fails('does not let a path-traversal session_id escape the temp dir', () => {
+  it('does not let a path-traversal session_id escape the temp dir', () => {
     // $TMPDIR is <home>/tmp; `plur-session-` + `../../../PWNED` normalises up out
     // of tmp, landing the sentinel directly in <home> — outside the temp dir.
     const escaped = join(home, 'PWNED')


### PR DESCRIPTION
Two Claude Code session-hook bugs — one data loss, one security. Both flip `it.fails` markers from the #559 honesty pass to passing `it()`.

## #217 — checkpoint destroyed on the failure path (data loss)

`hook-session-end` did `try { plur.capture(summary) } catch {}` then `unlinkSync(checkpoint)` **unconditionally**. On a full disk the capture throws, is swallowed, and the checkpoint — the session's only durable record — is deleted anyway. Separately, the "corrupt checkpoint" branch **deleted** an unparseable checkpoint, which destroys a *live* session's checkpoint when a concurrent reader catches a mid-write partial.

**Fix:**
- Track a `captured` flag; only `unlinkSync` **after** `capture()` succeeds. A failed capture keeps the checkpoint (and logs to stderr) so the next session's deferred wrap-up (#216) can recover it.
- The unparseable branch **retains** the checkpoint in place instead of deleting it.
- `writeCheckpoint` (`hook-learn-check.ts`) is now **atomic** (temp file + `renameSync`), so a reader never sees a partial write as "corrupt" — the parse-failure branch is now only reachable on genuine on-disk corruption, which is left in place.

## Path traversal via `session_id` (security)

`session_id` was interpolated raw into file paths, so `../../../PWNED` wrote **outside** the sessions/temp dir. The Cursor hooks already sanitized with `safeSessionKey`; the Claude Code hooks didn't.

**Fix:** factored `safeSessionKey` (replaces anything outside `[A-Za-z0-9_-]` with `_`) into a shared `lib/session-key.ts`, used by the Cursor hooks **and** `hook-session-guard` + `hook-session-mark`. `../../PWNED` → `______PWNED`, stays inside the dir; well-formed UUIDs are untouched, so a guard and its sentinel-writer still agree on the key.

## Verification

`@plur-ai/cli`: **42 files / 320 tests pass** (`--no-file-parallelism`; the default-parallel run hits unrelated 5s spawn-timeouts on this machine — CPU contention, never assertion failures). The 4 relevant markers flipped; the traversal marker was spot-checked failing pre-fix for the right reason (wrote `<home>/PWNED.guard-count`). The H-4 fail-open marker is deliberately left as `it.fails` (separate fix).

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)