### PR TITLE
fix(core): drop no-op tension subject stemming (#489)

### DIFF
--- a/packages/core/src/tensions.ts
+++ b/packages/core/src/tensions.ts
@@ -252,29 +252,21 @@ export function domainSegmentsOverlap(a?: string, b?: string): boolean {
 }
 
 /**
- * Light suffix-stemming: maps plural/derivational variants onto a shared stem.
- * "errors"→"error", "deployments"→"deploy" (4-char minimum on result stem).
- * "bots" stays "bots" (stem "bot" would be 3 chars). Looser direction only.
- */
-export function stemToken(t: string): string {
-  for (const suf of ['ments', 'ment', 'ings', 'ing', 'ions', 'ion', 'ers', 'er', 'ies', 'es', 's']) {
-    if (t.length - suf.length >= 4 && t.endsWith(suf)) {
-      return t.slice(0, -suf.length)
-    }
-  }
-  return t
-}
-
-/**
  * Subject-predicate pre-filter: skip pairs whose subject noun phrases don't
  * overlap.
  *
  * Extracts "subject tokens" from each statement — longer content words
  * (>3 chars) from the first clause (up to the first verb-like boundary or
- * 10 tokens), then applies light suffix-stemming so that "bots"/"bot" and
- * "deployments"/"deployment" share the same stem. Two statements pass the
- * filter when they share at least one stemmed subject token, indicating they
- * are making assertions about the same entity.
+ * 10 tokens). Two statements pass the filter when they share at least one
+ * raw subject token, indicating they are making assertions about the same
+ * entity.
+ *
+ * Subject tokens are compared as raw lowercased, tokenized, stopword-filtered
+ * words — no suffix-stemming. An earlier stemming step (#489) was measurably a
+ * no-op on the labeled recall suite (29/30 with and without it) while it
+ * over-stemmed unrelated words onto shared 4-char stems ('states'/'station'/
+ * 'stats' all → 'stat'), colliding disjoint statements into false-positive
+ * candidate pairs. It was removed.
  *
  * This is a heuristic, not a true NLP parse. It captures the most common
  * pattern: "The plur CLI uses X" vs "The plur CLI uses Y" share "plur"
@@ -289,7 +281,7 @@ function extractSubjectTokens(s: string): Set<string> {
   // Take the first clause: split at first comma, semicolon, or after ~60 chars
   const clause = s.split(/[,;]|(?<=\w{3,})\s+(?:is|are|was|were|has|have|can|will|should|must|does|do)\s/)[0]
     .slice(0, 80)
-  return new Set(ftsTokenize(clause).filter(t => t.length > 3).slice(0, 10).map(stemToken))
+  return new Set(ftsTokenize(clause).filter(t => t.length > 3).slice(0, 10))
 }
 
 function setsIntersect(a: Set<string>, b: Set<string>): boolean {

--- a/packages/core/test/tensions.test.ts
+++ b/packages/core/test/tensions.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   scopesOverlap,
   domainSegmentsOverlap,
-  stemToken,
   subjectsOverlap,
   statementOverlap,
   getCandidatePairs,
@@ -149,14 +148,18 @@ describe('subjectsOverlap', () => {
     )).toBe(true)
   })
 
-  it('plural/singular subject token → overlap via stemming', () => {
+  it('plural/singular statements → overlap via shared subject word', () => {
+    // Overlap comes from the shared raw token 'deployment', not from stemming
+    // 'bots'/'bot' together (stemming was removed in #489).
     expect(subjectsOverlap(
       'Deployment bots are rate-limited to 5 per hour.',
       'Deployment bot is rate-limited to 10 per hour.',
     )).toBe(true)
   })
 
-  it('plural/singular with -ments suffix → overlap via stemming', () => {
+  it('related statements → overlap via shared subject word', () => {
+    // Overlap comes from the shared raw token 'environment', not from stemming
+    // 'variables'/'variable' together (stemming was removed in #489).
     expect(subjectsOverlap(
       'Environment variables are sourced from .env file.',
       'Environment variable sourcing is handled by dotenv.',
@@ -165,68 +168,11 @@ describe('subjectsOverlap', () => {
 })
 
 // ---------------------------------------------------------------------------
-// stemToken
-// ---------------------------------------------------------------------------
-
-describe('stemToken', () => {
-  it('strips -s suffix when stem >= 4 chars', () => {
-    expect(stemToken('errors')).toBe('error')
-    expect(stemToken('bots')).toBe('bots') // stem "bot" = 3 chars → NOT stripped
-  })
-
-  it('strips -es suffix', () => {
-    expect(stemToken('batches')).toBe('batch')
-  })
-
-  it('strips -ies suffix', () => {
-    expect(stemToken('deployies')).toBe('deploy')
-  })
-
-  it('strips -ment suffix', () => {
-    expect(stemToken('deployment')).toBe('deploy')
-  })
-
-  it('strips -ments suffix', () => {
-    expect(stemToken('deployments')).toBe('deploy')
-  })
-
-  it('strips -ing suffix', () => {
-    expect(stemToken('processing')).toBe('process')
-  })
-
-  it('strips -ings suffix', () => {
-    expect(stemToken('settings')).toBe('sett')  // 8-4=4 chars → stripped to 'sett'
-    expect(stemToken('greetings')).toBe('greet') // 9-4=5 chars → 'greet'
-  })
-
-  it('strips -ion suffix', () => {
-    expect(stemToken('validation')).toBe('validat')
-  })
-
-  it('strips -er suffix', () => {
-    expect(stemToken('builder')).toBe('build')
-  })
-
-  it('does not strip when stem would be < 4 chars', () => {
-    expect(stemToken('bees')).toBe('bees')  // stem "be" = 2 chars
-    expect(stemToken('ones')).toBe('ones')  // stem "on" = 2 chars
-    expect(stemToken('runs')).toBe('runs')  // stem "run" = 3 chars
-  })
-
-  it('returns unchanged for tokens with no matching suffix', () => {
-    expect(stemToken('plur')).toBe('plur')
-    expect(stemToken('search')).toBe('search')
-  })
-
-  it('strips longest matching suffix first', () => {
-    expect(stemToken('deployments')).toBe('deploy')
-  })
-})
-
-// ---------------------------------------------------------------------------
 // subjectsOverlap — labeled 30-pair contradiction suite
-// Source: #489 measurement. Stemmed filter gets 27/30 (90% recall).
-// Any regression below 27 must be explained and explicitly accepted.
+// Source: #489 measurement. The raw (unstemmed) filter admits 29/30. The
+// earlier suffix-stemming step also scored 29/30 here — zero pairs changed —
+// so it was removed (#489). Any regression below the 27 floor must be
+// explained and explicitly accepted.
 // ---------------------------------------------------------------------------
 
 describe('subjectsOverlap — labeled 30-pair suite', () => {
@@ -263,11 +209,12 @@ describe('subjectsOverlap — labeled 30-pair suite', () => {
     ['domain-generic', 'Always use pnpm for package management.', 'Always use npm for package management.'],
   ]
 
-  // RECALL FLOOR ONLY. This asserts the stemmed pre-filter admits ≥27/30 known
-  // contradiction pairs — a recall measurement. It does NOT prove stemToken()
-  // helps: the assertion also passes with stemming deleted (the raw tokens of
-  // most pairs already overlap), and it is blind to false positives (precision).
-  // See the '#489' precision suite below for the complementary half.
+  // RECALL FLOOR ONLY. This asserts the (raw, unstemmed) pre-filter admits
+  // ≥27/30 known contradiction pairs — a recall measurement; it currently
+  // admits 29/30. This floor is why suffix-stemming was safe to remove (#489):
+  // the raw tokens of most pairs already overlap, so stemming scored the same
+  // 29/30 without helping. The floor is blind to false positives (precision) —
+  // see the '#489' precision suite below for the complementary half.
   it('recall floor: admits at least 27/30 labeled contradiction pairs', () => {
     const hits = CONTRADICTIONS.filter(([, a, b]) => subjectsOverlap(a, b))
     expect(hits.length).toBeGreaterThanOrEqual(27)
@@ -278,20 +225,23 @@ describe('subjectsOverlap — labeled 30-pair suite', () => {
 // subjectsOverlap — precision / false positives (#489)
 // The 30-pair suite above only measures recall. It cannot catch the inverse
 // failure: subject-DISJOINT statements wrongly flagged as overlapping. #489
-// proved stemToken() over-truncates — 'states' → 'stat' (via -es) and
-// 'station' → 'stat' (via -ion) collide on a meaningless 4-char stem, so two
-// unrelated statements pass the pre-filter and become a candidate contradiction
-// pair. That is a precision leak (wasted LLM judgements, phantom tensions).
+// proved the old stemToken() over-truncated — 'states' → 'stat' (via -es) and
+// 'station' → 'stat' (via -ion) collided on a meaningless 4-char stem, so two
+// unrelated statements passed the pre-filter and became a candidate
+// contradiction pair (a precision leak: wasted LLM judgements, phantom
+// tensions). Removing stemming closes that leak — these pairs now stay disjoint.
 // ---------------------------------------------------------------------------
 
 describe('subjectsOverlap — precision / over-stemming false positives (#489)', () => {
-  it.fails('does NOT flag subject-disjoint pairs that collide only on an over-stemmed token', () => {
-    // 'states' and 'station' both stem to 'stat' → currently a false positive.
+  it('does NOT flag subject-disjoint pairs that would have collided on an over-stemmed token', () => {
+    // Under the old suffix-stemming, 'states'→'stat' (via -es) and
+    // 'station'→'stat' (via -ion) collided on a meaningless 4-char stem, so
+    // these disjoint statements passed the pre-filter. #489 removed stemming;
+    // the raw tokens 'states' and 'station' no longer match → no overlap.
     expect(subjectsOverlap('United states border policy', 'Station platform layout')).toBe(false)
-    // 'corners' and 'corn' both stem to 'corn' → currently a false positive.
+    // Likewise 'corners'→'corn' and 'corn' both collapsed to 'corn' under
+    // stemming; raw 'corners' and 'corn' are distinct → no overlap.
     expect(subjectsOverlap('Corners of the room', 'Corn futures rally')).toBe(false)
-    // Correct expectation is no-overlap for both; it.fails until #489 tightens
-    // stemToken() (e.g. min stem length / suffix guards). Flip to it() when green.
   })
 })
 


### PR DESCRIPTION
Removes the #489 suffix-stemming from the tension (contradiction) subject pre-filter. It did **nothing measurable** and introduced **false positives**.

## Evidence
- On the commit's own 30-pair recall suite it changed **zero** pairs: 29/30 with stemming, 29/30 without.
- `stemToken` over-stemmed unrelated words onto shared 4-char stems: `states` / `station` / `stats` all → `stat`, so subject-disjoint statements ("United states border policy" vs "Station platform layout") collided into false-positive candidate pairs.

The "77%→90% recall" claim was already withdrawn (#558).

## Change
Remove `stemToken` (and its export). Subject overlap now compares raw lowercased, tokenized, stopword-filtered tokens — the rest of the pre-filter (clause split, verb boundary, 10-token cap, set intersection) is untouched.

## Tests
- The #559 precision `it.fails` (over-stem collisions must NOT overlap) flips to a passing `it()`.
- The `stemToken` unit tests are deleted (the function is gone).
- The 27/30 recall floor still holds **unstemmed at 29/30** — threshold not weakened.
- Full `@plur-ai/core` suite green (120 files).

Closes #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)