### PR TITLE
fix(core,mcp): plur_learn_batch aligns results to inputs on partial failure (#281)

### DIFF
--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -313,7 +313,9 @@ export async function learnBatch(
     // against its input index and continue; the caller inspects `failures`.
     try {
       const result = await learnAsync(deps, statement, ctx)
-      results.push(result)
+      // Tag with the input position so a caller can map this result back to its
+      // input even though `results` is compacted (failed statements absent). #281
+      results.push({ ...result, input_index: i })
       const key = result.decision.toLowerCase()
       if (key === 'noop') stats.noops++
       else if (key === 'update') stats.updated++

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,6 +70,14 @@ export interface LearnAsyncResult {
   decision: DedupDecision
   existing_id?: string
   tensions?: string[]
+  /**
+   * Position of this result's statement in the original learnBatch input array
+   * (#281). `results` is compacted (failed statements are absent), so callers
+   * must NOT assume `results[i]` corresponds to `inputs[i]` — read `input_index`
+   * to map a result back to its input. Undefined for a single (non-batch)
+   * learnAsync call, where there is no input array to index into.
+   */
+  input_index?: number
 }
 
 /**

--- a/packages/core/test/batch.test.ts
+++ b/packages/core/test/batch.test.ts
@@ -100,31 +100,31 @@ describe('learnBatch: partial-failure isolation', () => {
     syncIndex: () => {},
   })
 
-  // #281 — a partial-failure batch must let a caller positionally map each INPUT
-  // to its engram. This test used to assert `res.results` has length 2, baking in
-  // the compaction that silently drops the failed slot: with [A, B(fails), C] the
-  // input-2 engram (C) collapses onto results[1], so `ids: results.map(...)`
-  // (mcp/src/tools.ts:596) emits C's id at position 1 — the #281 misalignment bug.
-  // Correct behaviour keeps C recoverable at input index 2.
-  // it.fails until the batch return aligns results to inputs; flip back to it() when it passes.
-  it.fails('a caller can positionally map each input to its engram even when a middle item fails (#281)', async () => {
+  // #281 — a partial-failure batch must let a caller map each INPUT to its
+  // engram. `results` is COMPACTED (failed statements absent), so before the fix
+  // `ids: results.map(...)` (mcp/src/tools.ts) shifted every id after a failure
+  // left and mis-attributed it. Fix: each result carries its `input_index`, so a
+  // caller reconstructs the input→engram mapping regardless of compaction.
+  it('a caller can map each input to its engram even when a middle item fails (#281)', async () => {
     const res = await learnBatch(makeDeps(), [
       { statement: 'good one' },       // input 0
       { statement: 'this will BOOM' }, // input 1 — fails
       { statement: 'good two' },       // input 2
     ])
 
-    // The failure side already carries the input index — that part works today.
+    // The failure side already carries the input index.
     expect(res.stats.added).toBe(2)
     expect(res.stats.failed).toBe(1)
     expect(res.failures).toHaveLength(1)
     expect(res.failures[0].index).toBe(1)
     expect(res.failures[0].statement).toBe('this will BOOM')
 
-    // The correct contract: C ('good two') stays at its input index (2), not
-    // shifted to 1 by compaction. Read index 2 directly so we don't assume the
-    // shape of whatever the fix puts in the failed slot at index 1.
-    expect(res.results[2]?.engram?.statement).toBe('good two')
+    // The fix: every successful result carries its input_index, so input 2 (C)
+    // is recoverable as input 2 — not shifted to results[1] by compaction.
+    const byInput = new Map(res.results.map(r => [r.input_index, r.engram.statement]))
+    expect(byInput.get(0)).toBe('good one')
+    expect(byInput.get(2)).toBe('good two')   // NOT mis-attributed to input 1
+    expect(byInput.has(1)).toBe(false)         // the failed input has no result
   })
 
   it('reports an all-failed batch without throwing', async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -526,9 +526,10 @@ function getAllToolDefinitions(): ToolDefinition[] {
         'Create many engrams in one call — the batch form of plur_learn. Accepts an array of engram objects and ' +
         'writes them sequentially through the SAME dedup + policy pipeline as plur_learn (content-hash NOOP → semantic ' +
         'recall → LLM ADD/UPDATE/MERGE decision). Dedup also applies WITHIN the batch: a statement duplicating an ' +
-        'earlier item in the same array resolves to NOOP against it. Returns the created/affected engram ids in input ' +
-        'order, the per-item decisions, aggregate stats, and any per-item failures — a single bad item does not abort ' +
-        'the batch. Use this when an orchestration fans out and wants to persist consolidated findings without N ' +
+        'earlier item in the same array resolves to NOOP against it. Returns `ids` aligned 1:1 with the input array ' +
+        '(ids[i] is the engram id for input i, or null if input i failed), the per-item decisions (each carrying its ' +
+        'input_index), aggregate stats, and any per-item failures (each with its input index) — a single bad item ' +
+        'does not abort the batch. Use this when an orchestration fans out and wants to persist consolidated findings without N ' +
         'separate calls. LLM dedup calls are capped (default 50, override with max_llm_calls) to bound bulk-import cost. ' +
         'Note: unlike plur_learn, batch items take the LOCAL learn path — remote-scope auto-routing (learnRouted) is ' +
         'not applied per item, so for shared/remote-store writes prefer plur_learn or pass an explicit local scope. ' +
@@ -592,9 +593,19 @@ function getAllToolDefinitions(): ToolDefinition[] {
         mcpCanary.signal('learn_activity')
         // Opt-in, content-free engagement counter (default-off; no statement text).
         recordTelemetry('learn')
+        // `ids` is aligned 1:1 with the INPUT array: ids[i] is the engram id for
+        // input i, or null if input i failed (see failures[]). Previously this
+        // was `results.map(r => r.engram.id)` — a COMPACTED array, so after a
+        // mid-batch failure every subsequent id shifted left and mis-attributed
+        // to the wrong input (#281). Build from input_index instead.
+        const ids: (string | null)[] = raw.map(() => null)
+        for (const r of results) {
+          if (r.input_index !== undefined) ids[r.input_index] = r.engram.id
+        }
         return {
-          ids: results.map((r) => r.engram.id),
+          ids,
           results: results.map((r) => ({
+            input_index: r.input_index,
             id: r.engram.id,
             statement: r.engram.statement,
             scope: r.engram.scope,


### PR DESCRIPTION
## Problem

`plur_learn_batch` returned `ids: results.map(r => r.engram.id)`, but `results` is **compacted** (failed statements are absent). So with inputs `[A, B(fails), C]`:

```
results = [A, C]
ids     = [idA, idC]   ← C's id at position 1, mis-attributed to input B
```

Every input after a failure shifts left. The tool description promised *"ids in input order,"* which the compaction silently broke — for the stated use case (an orchestration fanning out 50 findings, one mid-batch failure mis-attributes every subsequent id).

**Note:** the stored engrams were always correct — this is a *response-mapping* bug, not data corruption. (That's exactly why #281 stayed in the "keep + fix" bucket rather than being removed like batchDecay.)

## Fix — the proper 1:1 contract, not just "carry an index"

- `LearnAsyncResult` gains an optional `input_index`; the batch loop tags each success with its input position. `results` stays compacted (so the all-failed contract — length 0 — is unchanged), but every entry now knows where it came from.
- The MCP handler builds `ids` aligned **1:1 with the input array**: `ids[i]` is input `i`'s engram id, or `null` if input `i` failed. Each returned result item also carries `input_index`. Tool description updated to match.

```
inputs [A, B(fail), C]  →  ids = [idA, null, idC]   // C stays at index 2
```

## Verification

Flips the #281 `it.fails` (from #559) to a passing `it()`: a caller reconstructs input→engram from `input_index` regardless of compaction. Existing tests still pass (all-failed → length 0; 3-success → 3 dense ids; within-batch dedup NOOP). Full `@plur-ai/core` + `@plur-ai/mcp` green (137 files).

Closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)