### PR TITLE
fix(core): EmbeddingGemma uses model-card role prefixes, not E5 (#483)

### DIFF
--- a/packages/core/src/embedders/embedding-gemma.ts
+++ b/packages/core/src/embedders/embedding-gemma.ts
@@ -14,13 +14,15 @@
  * sentence_embedding and were in a different space from all published figures.
  *
  * Fix (#483): load the model via AutoModel (not the feature-extraction pipeline)
- * and read sentence_embedding directly. The adapter name is 'embedding-gemma@graph'
+ * and read sentence_embedding directly. The adapter name is 'embedding-gemma@graph-mcprefix'
  * (not 'embedding-gemma') so any caches built with wrong-space vectors are
  * automatically detected as a name mismatch and rebuilt by embeddings.ts.
  *
- * Role prefixes: EmbeddingGemma is trained with asymmetric prefixes per the
- * model card — "query: " for search queries, "passage: " for stored text.
- * Callers pass role='query' for search; omitting role defaults to 'passage'.
+ * Role prefixes: EmbeddingGemma is trained with asymmetric prefixes per its
+ * model card — "task: search result | query: " for search queries and
+ * "title: none | text: " for stored documents. (The earlier "query: "/"passage: "
+ * pair was the E5 convention, NOT EmbeddingGemma's — #483.) Callers pass
+ * role='query' for search; omitting role defaults to the document prefix.
  *
  * Disk cost: q8 weights ~ 300 MB. We use q8 to match published EmbeddingGemma
  * benchmark numbers and keep first-run download manageable.
@@ -60,7 +62,7 @@ export function _resetEmbeddingGemmaCache(): void {
 
 export function makeEmbeddingGemmaAdapter(): EmbedderAdapter {
   async function embedOne(text: string, role?: EmbedRole): Promise<Float32Array> {
-    const prefix = role === 'query' ? 'query: ' : 'passage: '
+    const prefix = role === 'query' ? 'task: search result | query: ' : 'title: none | text: '
     const { tokenizer, model } = await load()
     const inputs = await tokenizer(prefix + text, { padding: true, truncation: true })
     const outputs = await model(inputs)
@@ -73,9 +75,12 @@ export function makeEmbeddingGemmaAdapter(): EmbedderAdapter {
   }
 
   return {
-    // '@graph' suffix distinguishes from old JS-side pooled vectors — embeddings.ts
-    // detects the name change and auto-invalidates any cached wrong-space data.
-    name: 'embedding-gemma@graph',
+    // Suffix is a cache-space marker: embeddings.ts detects a name change and
+    // auto-invalidates any cached vectors built in a different space. '@graph'
+    // marked the switch off JS-side pooling; '-mcprefix' marks the #483 switch to
+    // the model-card role prefixes (old "query:"/"passage:" vectors are a
+    // different space and must be rebuilt).
+    name: 'embedding-gemma@graph-mcprefix',
     dim: DIM,
     modelId: EMBEDDING_GEMMA_MODEL_ID,
     embed: embedOne,

--- a/packages/core/src/embedders/index.ts
+++ b/packages/core/src/embedders/index.ts
@@ -5,9 +5,9 @@
  * One uniform interface (`EmbedderAdapter`) across the candidate models:
  *
  *   - minilm            sentence-transformers/all-MiniLM-L6-v2     (384d, 22M)
- *   - bge-small         BAAI/bge-small-en-v1.5                     (384d, 33M)
+ *   - bge-small         BAAI/bge-small-en-v1.5                     (384d, 33M)  — DEFAULT
  *   - bge-base          BAAI/bge-base-en-v1.5                      (768d, 110M)
- *   - embedding-gemma   google/EmbeddingGemma-300M (ONNX community) (768d, 300M) — DEFAULT
+ *   - embedding-gemma   google/EmbeddingGemma-300M (ONNX community) (768d, 300M) — opt-in
  *   - openai-3-large    OpenAI text-embedding-3-large              (3072d, API)  — opt-in
  *
  * Pick one via PLUR_EMBEDDER env var or programmatically via `getEmbedder()`.
@@ -21,11 +21,11 @@
  *   - storage-pglite.ts reads adapter.dim to size its vector(N) column
  *   - embeddings.ts routes through the active adapter
  *
- * PR 5 default switch: bake-off (docs/benchmarks/embedder-bake-off-2026-05.md)
- * showed EmbeddingGemma matches BGE-small on R@5 with the best Accuracy at
- * N=5/category and Apache-2.0 license. The default flipped from bge-small to
- * embedding-gemma. If Phase C (N=500) inverts the ordering it's a one-line
- * revert here.
+ * Default embedder: bge-small. A PR-5 flip to embedding-gemma was REVERTED by
+ * the iter-1 audit (the bake-off was only N=5/category — too small to justify
+ * the switch), so embedding-gemma is opt-in pending a Phase C N=500 result. See
+ * DEFAULT_EMBEDDER below for the full rationale — that constant is authoritative;
+ * do not infer the default from this header.
  */
 import { logger } from '../logger.js'
 import { makeMiniLMAdapter } from './minilm.js'

--- a/packages/core/test/embedders.test.ts
+++ b/packages/core/test/embedders.test.ts
@@ -36,14 +36,14 @@ const NETWORK = process.env.PLUR_EMBEDDER_NETWORK_TESTS === '1'
 
 /** Expected metadata per adapter — checked even when the network is offline.
  *  adapterName overrides the expected `.name` when the adapter name differs from the factory key
- *  (e.g. 'embedding-gemma' factory key → 'embedding-gemma@graph' adapter name for cache busting). */
+ *  (e.g. 'embedding-gemma' factory key → 'embedding-gemma@graph-mcprefix' adapter name for cache busting). */
 const EXPECTED: Record<EmbedderName, { dim: number; modelId: string; adapterName?: string }> = {
   'minilm': { dim: 384, modelId: 'Xenova/all-MiniLM-L6-v2' },
   'bge-small': { dim: 384, modelId: 'Xenova/bge-small-en-v1.5' },
   'bge-base': { dim: 768, modelId: 'Xenova/bge-base-en-v1.5' },
-  // adapter.name is 'embedding-gemma@graph' — the @graph suffix busts caches
+  // adapter.name is 'embedding-gemma@graph-mcprefix' — the @graph suffix busts caches
   // that hold wrong-space vectors from the old JS-side mean pooling (#483).
-  'embedding-gemma': { dim: 768, modelId: 'onnx-community/embeddinggemma-300m-ONNX', adapterName: 'embedding-gemma@graph' },
+  'embedding-gemma': { dim: 768, modelId: 'onnx-community/embeddinggemma-300m-ONNX', adapterName: 'embedding-gemma@graph-mcprefix' },
   'openai-3-large': { dim: 3072, modelId: 'text-embedding-3-large' },
 }
 
@@ -107,7 +107,7 @@ describe('EmbeddingGemma — role-aware prefix contract', () => {
 
   it('adapter name includes @graph cache-bust suffix', () => {
     const adapter = makeEmbeddingGemmaAdapter()
-    expect(adapter.name).toBe('embedding-gemma@graph')
+    expect(adapter.name).toBe('embedding-gemma@graph-mcprefix')
   })
 
   it('prepends a DIFFERENT tokenizer input for query vs passage (role plumbing is live, not a no-op)', async () => {
@@ -126,7 +126,7 @@ describe('EmbeddingGemma — role-aware prefix contract', () => {
     expect(p).toContain('memory engram lifecycle')
   })
 
-  it.fails('uses the EmbeddingGemma model-card role prefixes, not the E5 convention (#483 E1)', async () => {
+  it('uses the EmbeddingGemma model-card role prefixes, not the E5 convention (#483 E1)', async () => {
     // The EmbeddingGemma model card requires 'task: search result | query: ' for
     // queries and 'title: none | text: ' for documents. The adapter
     // (embedding-gemma.ts:63) instead prepends the E5-convention 'query: ' /


### PR DESCRIPTION
The adapter prepended **E5's** role prefixes — `'query: '` / `'passage: '` — while a code comment *and* the original commit message both falsely cited *"the model card."* EmbeddingGemma's model card actually requires:

| role | required prefix |
|---|---|
| query | `task: search result \| query: ` |
| document | `title: none \| text: ` |

Every engram was embedded with an out-of-distribution prefix, so retrieval quality was degraded relative to the intended stack and MTEB comparability (the whole point of the adapter) was not achieved.

The **pooling** half of #483 (reading `sentence_embedding` from the ONNX graph instead of JS-side mean-pooling) was genuinely fixed already and is untouched here.

## Fix

- **`embedding-gemma.ts`:** correct the prefixes and the comment that mis-cited the card. Bump the adapter's cache-space name `@graph` → `@graph-mcprefix` so `embeddings.ts` auto-invalidates any vectors built with the old E5 prefixes (they're a different space and must be rebuilt).
- **`embedders/index.ts`:** fix the **stale file header** that claimed `embedding-gemma` is the **DEFAULT** and *"the default flipped from bge-small."* It isn't — the flip was reverted (iter-1 audit), `DEFAULT_EMBEDDER` is `'bge-small'`, and Gemma is opt-in. The authoritative `DEFAULT_EMBEDDER` doc already said so; only the header lied.

## Verification

Flips the #483-E1 `it.fails` (from #559) to a passing `it()` asserting the exact model-card prefix strings; updated the two adapter-name assertions to the new cache name. Full `@plur-ai/core` suite green (120 files).

**Blast radius:** Gemma is **opt-in** (`PLUR_EMBEDDER=embedding-gemma`), so this degraded only users who explicitly selected it — but it must be correct before any future default flip lands.

Closes #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)