### PR TITLE
fix(cli): hooks fail open when the state dir is unwritable (H-4)

### DIFF
--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -199,7 +199,10 @@ async function tryRemoteInject(
 
 function sessionDir(): string {
   const dir = join(tmpdir(), 'plur-sessions')
-  mkdirSync(dir, { recursive: true })
+  // Fail-open: an unwritable $TMPDIR (read-only tmpfs, full disk) must never
+  // crash the prompt. Swallow the mkdir error and return the path anyway —
+  // downstream state-dir writes are individually wrapped and degrade to no-ops.
+  try { mkdirSync(dir, { recursive: true }) } catch { /* fail-open */ }
   return dir
 }
 
@@ -245,7 +248,9 @@ function isReminderDue(): boolean {
 }
 
 function touchReminder(): void {
-  writeFileSync(lastReminderPath(), String(Date.now()))
+  // Fail-open: a state-dir write failing (unwritable $TMPDIR) must never crash
+  // the prompt. The reminder timer is best-effort bookkeeping.
+  try { writeFileSync(lastReminderPath(), String(Date.now())) } catch { /* fail-open */ }
 }
 
 function extractEventTask(input: Record<string, unknown>, event: string): string {
@@ -457,9 +462,11 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (!task) {
       task = 'general session'
     }
-    // Auto session start: generate session ID and save with task
+    // Auto session start: generate session ID and save with task.
+    // Fail-open: if the state dir is unwritable, skip the marker (the session
+    // header is read back defensively below) rather than crash the prompt.
     const sessionId = randomUUID()
-    writeFileSync(marker, JSON.stringify({ task, sessionId }))
+    try { writeFileSync(marker, JSON.stringify({ task, sessionId })) } catch { /* fail-open */ }
     touchReminder() // Reset reminder timer on first message
   }
 

--- a/packages/cli/src/commands/hook-learn-check.ts
+++ b/packages/cli/src/commands/hook-learn-check.ts
@@ -147,9 +147,18 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
     if (data.cwd) cwd = data.cwd
   } catch { /* use process.cwd fallback */ }
 
-  // Increment persistent counter (atomic append — see incrementCounter's docstring)
-  const cPath = counterPath()
-  const count = incrementCounter(cPath)
+  // Increment persistent counter (atomic append — see incrementCounter's docstring).
+  // Fail-open: if the state dir is unwritable (read-only $TMPDIR, full disk),
+  // a Stop hook MUST NOT crash the response — pass the payload through untouched.
+  // counterPath() creates the dir and incrementCounter() appends; either can
+  // throw on an unwritable filesystem, so wrap both.
+  let count: number
+  try {
+    count = incrementCounter(counterPath())
+  } catch {
+    process.stdout.write(raw)
+    return
+  }
 
   // Write session checkpoint periodically (#215)
   if (count % CHECKPOINT_INTERVAL === 0) {

--- a/packages/cli/src/commands/hook-session-guard.ts
+++ b/packages/cli/src/commands/hook-session-guard.ts
@@ -112,7 +112,17 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
   // Deadlock prevention (#199): if we've blocked too many times without a
   // session starting, the MCP server likely failed to load. Stop blocking
   // to prevent permanent deadlock.
-  const blockCount = incrementBlockCount(sessionId)
+  //
+  // Fail-open: incrementBlockCount creates the state dir and writes the counter;
+  // on an unwritable $TMPDIR (read-only tmpfs, full disk) either can throw. A
+  // PreToolUse guard MUST NEVER crash the tool call it gates — allow through,
+  // the same outcome as the deadlock fallback below.
+  let blockCount: number
+  try {
+    blockCount = incrementBlockCount(sessionId)
+  } catch {
+    return
+  }
   if (blockCount > MAX_BLOCKS_BEFORE_FALLBACK) {
     process.stderr.write(
       `[plur] session guard: allowing tools after ${MAX_BLOCKS_BEFORE_FALLBACK} nudge(s) ` +

--- a/packages/cli/test/hook-inject-lock.test.ts
+++ b/packages/cli/test/hook-inject-lock.test.ts
@@ -101,7 +101,7 @@ describe('hook-inject concurrency guard (#519)', () => {
   // failure on the hot path of every prompt. Correct behaviour: exit 0 and emit
   // valid/empty output. it.fails until the state-dir I/O is made fail-open; flip
   // to it() when green.
-  it.fails('never crashes the prompt when the state dir is unwritable', () => {
+  it('never crashes the prompt when the state dir is unwritable', () => {
     const roTmp = mkdtempSync(join(tmpdir(), 'plur-ro-tmp-'))
     chmodSync(roTmp, 0o500) // r-x: owner cannot create plur-sessions inside
     try {

--- a/packages/cli/test/hook-learn-check.test.ts
+++ b/packages/cli/test/hook-learn-check.test.ts
@@ -114,7 +114,7 @@ describe('hook-learn-check', () => {
   // makes the hook EXIT 1 and print {"error":...} to stdout (index.ts's top-level
   // catch). Correct behaviour: exit 0 and emit valid/empty output. it.fails until
   // the counter I/O is made fail-open; flip to it() when green.
-  it.fails('never crashes the response when the state dir is unwritable', () => {
+  it('never crashes the response when the state dir is unwritable', () => {
     const roTmp = mkdtempSync(join(tmpdir(), 'plur-ro-learn-'))
     chmodSync(roTmp, 0o500) // r-x: owner cannot create plur-sessions inside
     try {

--- a/packages/cli/test/hook-session-guard.test.ts
+++ b/packages/cli/test/hook-session-guard.test.ts
@@ -115,7 +115,7 @@ describe('hook-session-guard', () => {
   // call it was meant to gate. Correct behaviour: exit 0 and emit valid/empty
   // output (fail open). it.fails until the state-dir I/O is made fail-open; flip
   // to it() when green.
-  it.fails('never crashes the tool call when the state dir is unwritable', () => {
+  it('never crashes the tool call when the state dir is unwritable', () => {
     const roTmp = mkdtempSync(join(tmpdir(), 'plur-ro-guard-'))
     chmodSync(roTmp, 0o500) // r-x: owner cannot create plur-sessions inside
     try {


### PR DESCRIPTION
PLUR's Claude Code hooks are **fail-open by contract** — a hook must never crash the user's prompt, response, or tool call. But when `$TMPDIR` is unwritable (read-only tmpfs, full disk), three hooks let an `mkdir`/`writeFileSync`/`appendFileSync` EACCES bubble up to `index.ts`'s top-level catch, which **exits 1 and prints `{"error":...}` to stdout** — hard-failing the hot path.

## Fix

Each hook's own state-dir I/O is now wrapped so any filesystem error **fails open** — exit 0 with the hook's normal empty output:
- `hook-inject` (session dir mkdir, reminder write, marker write) → pass-through
- `hook-learn-check` (counter mkdir + append) → pass stdin through
- `hook-session-guard` (block-count write) → allow the tool through

Behavior when the state dir **is** writable is unchanged — only the failure path differs.

## Verification

Flips the three `it.fails` markers from #559 to passing `it()`. `@plur-ai/cli`: **42 files / 323 tests pass** (`--no-file-parallelism`; the default-parallel run hits unrelated 5s spawn-timeouts under load). Pre-fix spot-check against a read-only `$TMPDIR` confirmed the old behavior — `EXIT_CODE=1`, `{"error":"EACCES: permission denied, mkdir ...plur-sessions"}` on stdout.

This clears the last deferred hook markers from the test-honesty pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)