### PR TITLE
fix(release): guard smoke-test command substitution under set -e (port bf00781)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -487,8 +487,11 @@ for pkg_check in "cli:$VERSION"; do
   pkg_name="${pkg_check%%:*}"
   pkg_ver="${pkg_check##*:}"
   echo -n "  npx -y @plur-ai/$pkg_name@$pkg_ver --version → "
-  smoke_out=$(npx -y "@plur-ai/$pkg_name@$pkg_ver" --version 2>&1)
-  smoke_exit=$?
+  # Guard the command substitution under `set -euo pipefail`: a transient
+  # npm-propagation failure would otherwise abort the whole release here instead
+  # of falling through to the smoke-fail handling below. (bf00781 — hit on both
+  # the 0.12.0 and 0.13.0 release attempts.)
+  smoke_out=$(npx -y "@plur-ai/$pkg_name@$pkg_ver" --version 2>&1) && smoke_exit=0 || smoke_exit=$?
   if [ "$smoke_exit" -eq 0 ] && echo "$smoke_out" | grep -q "$pkg_ver"; then
     echo "✓ ($smoke_out)"
   else


### PR DESCRIPTION
main's `release.sh` still had the **pre-bf00781 unguarded** smoke-test form:

```sh
smoke_out=$(npx -y "@plur-ai/$pkg_name@$pkg_ver" --version 2>&1)
smoke_exit=$?
```

Under `set -euo pipefail`, a transient npm-propagation failure in the command substitution **aborts the whole release before `$?` can be captured** — crashing instead of falling through to the smoke-fail handler. This hit **both the 0.12.0 and 0.13.0 release attempts**.

The fix (`smoke_out=$(...) && smoke_exit=0 || smoke_exit=$?`) was made in bf00781 but lived only on `fix-clean-0.11-base`. Porting it to `main` **before the 0.14.0 release** so we don't reproduce the crash.

Last release-tooling fix stranded on `fix-clean-0.11-base`; after this, that branch can be retired. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)