### PR TITLE
fix: 0.14.0 audit follow-ups (#580-#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,16 @@ The clean re-release of the queued batch that 0.12.0 shipped unreviewed and 0.13
 - **Process-group orphan kill ported to the hermes bridge** (#575): the `plur-hermes` bridge now kills the whole process group on timeout (`start_new_session` + `killpg`), so a timed-out `npx @plur-ai/cli` can't orphan a runaway `node` grandchild.
 - **Hooks fail open on an unwritable state dir** (#574): the session-guard, learn-check, and inject-lock hooks now proceed instead of crashing the prompt or tool call when their state directory isn't writable.
 - **Assorted hook/remote robustness**: per-session concurrency lock for hook-inject (#519), AbortController coverage extended to the `RemoteStore.load()` body read (#531), and `isPlurConfigured` checks the home directory only when the working directory is under home (#521, #247).
+- **`plur doctor` flags stale PGLite + embedding-gemma vectors** (#581): the companion diagnostic to the #483 caveat above — when the PGLite backend runs the opt-in `embedding-gemma` (whose vectors that backend does not auto-rebuild), doctor advises a one-time `plur sync --reembed --full`. Advisory only; it never fails the overall check.
+- **claw warns non-destructively on orphaned OpenClaw config entries** (#583): #51 removed the destructive prune that deleted third-party plugin config — including embedded API keys — whenever a plugin dir was transiently absent during install. `plur doctor` now *warns* about genuinely-orphaned entries (PLUR's own and third-party) without ever deleting, restoring detection without the data-loss.
+
+### Changed (cleanup)
+
+- **Removed dead `strengthToStatus`** (#582): unused since batchDecay's removal, and its label vocabulary never matched the persisted `status` enum. The `dormant`/`candidate` enum values are retained (legacy/reserved) for backward-compatibility with stores written before #563 — removing them would reject existing data.
 
 ### Added
 
+- **`plur compact` + `plur_compact`** (#580): explicitly reclaim disk space from retired engrams, exposed as both a CLI command and an MCP tool. With batchDecay gone (#563), this is the deliberate, logged maintenance op for shrinking the store — retired rows previously had no user-facing removal path.
 - **Session injection telemetry** (#536): per-pack activation tracking logged at `session_end` for offline relevance analysis.
 - **`plur_status` domain + `created_after` filters** (#522, #524).
 - **packs install/list/uninstall CLI subcommands** (#513), and the claw `before_prompt_build` migration with sharpened ClawHub positioning (#516).
@@ -34,7 +41,8 @@ The clean re-release of the queued batch that 0.12.0 shipped unreviewed and 0.13
 ### Release tooling
 
 - The manifest gate (`release.sh`) now recognizes multi-issue commit trailers like `(#521, #247)` — the old extraction silently dropped every number in a comma trailer — and curates out this repo's internal `ops`/`cmo` commit types alongside the standard non-user-facing set. The canary smoke-test command substitution is also guarded under `set -e` (#578).
-- The pre-release hardening pass for this release — the U+2028/U+2029 scope-metadata gap, multi-word historical-keyword matching, the `feedback()` `last_accessed` re-anchor, and the manifest-gate fix above — landed in (#579).
+- **Publish verification hardened** (#584): the `@next` smoke test now covers `core` (install + ESM import, catching the import-time crash class that bricked `cli@0.9.2`) and `mcp`, not just `cli` — the audited fixes live in `core`. PyPI publish now verifies the version is retrievable after upload and prints an explicit recovery path on failure (PyPI is immutable). The session-guard's unwritable-state-dir fail-open now leaves a stderr audit trail instead of a silent bypass.
+- The pre-release hardening pass for this release — the U+2028/U+2029 scope-metadata gap, multi-word historical-keyword matching, the `feedback()` `last_accessed` re-anchor, and the manifest-gate fix above — landed in (#579). The audit follow-ups (#580–#584) landed in (#585).
 
 ## 0.12.0 (2026-07-09)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,6 +41,34 @@ The gate is offline and deterministic (no GitHub API calls): it reads shipped PR
 from `git log <last-tag>..HEAD` subjects and declared PRs from the CHANGELOG
 section, and compares the sets.
 
+The gate parses PR numbers from the trailing `(#N)` on each squash-commit subject,
+including multi-issue trailers like `(#521, #247)`. Non-user-facing conventional
+types are curated out — the standard `chore`/`ci`/`docs`/`test`/`build`/`refactor`/
+`style` plus this repo's internal `ops` (release tooling) and `cmo` (marketing copy).
+
+## Publish verification (npm smoke + PyPI verify)
+
+`scripts/release.sh` publishes npm to the `@next` dist-tag first, smoke-tests, then
+promotes to `@latest` (Step 5). The smoke test (Step 5b) covers **all three promoted
+packages**, not just `cli`:
+
+- `cli` and `mcp` are checked via `npx -y @plur-ai/<pkg>@<version> --version` (both ship a bin).
+- `core` has no bin, so it is checked by installing the exact `@next` version and importing
+  the ESM entry, asserting the `Plur` export loads at the expected version. This catches the
+  import-time crash class that bricked `cli@0.9.2` (`Dynamic require of "os" is not supported`,
+  #64) — the audited fixes live in `core`, so promoting it unchecked was a real gap (#584).
+
+If any smoke check fails, `@next` is published but `@latest` is untouched; the script prints
+the `npm dist-tag rm … next` revert commands and aborts before promotion.
+
+**PyPI (Step 6) is immutable and has no canary.** A dropped or partial `twine upload` cannot be
+overwritten — only superseded by a new version — and it runs *after* npm `@latest` already moved,
+so a silent miss leaves a half-published release. The script now verifies `plur-hermes==<version>`
+is retrievable from PyPI after upload (with retries for propagation lag) and, if it can't confirm,
+prints the recovery path: check the project history (usually just lag), re-run `twine upload`, or —
+if the filename is already registered from a partial upload — bump to the next patch, because the
+version is burned and cannot be reused.
+
 ## Manual publish (one package)
 
 When `main` has a version bump that hasn't reached npm yet — e.g. `@plur-ai/claw@0.9.10` is on

--- a/packages/claw/src/setup.ts
+++ b/packages/claw/src/setup.ts
@@ -178,10 +178,11 @@ export type SetupStep =
   | 'plugin_enabled'
   | 'slot_selected'
   | 'allow_gated'
+  | 'orphaned_entries'
   | 'reload_required'
   | 'runtime_registered'
   | 'telemetry_optin'
-export type SetupStatus = 'ok' | 'skip' | 'fail' | 'pending'
+export type SetupStatus = 'ok' | 'skip' | 'fail' | 'pending' | 'warn'
 export type SetupReport = {
   path: string
   steps: { step: SetupStep; status: SetupStatus; detail?: string }[]
@@ -211,6 +212,72 @@ function runtimeRegistrationStep(openclawHome?: string): { step: SetupStep; stat
     step: 'runtime_registered',
     status: 'pending',
     detail: 'run `openclaw plugins install @plur-ai/claw` then restart OpenClaw',
+  }
+}
+
+// Non-destructive replacement for the removed #51 / D-2 prune. That prune
+// DELETED any plugins.entries[<id>] whose extensions/<id> directory was absent —
+// destroying third-party config INCLUDING embedded API keys. Its fatal flaw was
+// the false positive: extensions/<id> is transiently absent during any
+// install/upgrade, and the prune ran unattended from postinstall (via
+// mergeEnable), i.e. exactly in that window. #566 removed it entirely, leaving no
+// detection at all — genuinely-orphaned entries (and their credentials) now
+// linger forever (#583).
+//
+// This restores DETECTION without the danger, by inverting all three risk axes:
+//   1. NON-DESTRUCTIVE: it only warns. It never deletes or mutates config.
+//   2. USER-INVOKED, NOT AUTOMATIC: it runs only inside runDoctor (the `doctor`
+//      command a user runs deliberately), never from the postinstall setup path
+//      that fires mid-install. This structurally avoids the prune's timing bug.
+//   3. CONSERVATIVE GATE + HONEST MESSAGE: if the extensions/ dir itself is
+//      absent we cannot distinguish "no plugins installed" from "tree not yet
+//      populated mid-install", so we stay silent (skip). When we do warn, the
+//      message states plainly that it is advisory, may be a false positive during
+//      an in-progress upgrade, and that the user — not claw — must remove anything.
+// It intentionally includes plur-claw's OWN entry (unlike the old prune, which
+// skipped it): a lingering plur-claw entry with no extension is equally orphaned.
+function orphanedEntriesStep(
+  cfg: OpenclawConfig,
+  configPath: string,
+  openclawHome?: string,
+): { step: SetupStep; status: SetupStatus; detail?: string } {
+  const plugins = (cfg.plugins && typeof cfg.plugins === 'object' && !Array.isArray(cfg.plugins)
+    ? cfg.plugins
+    : {}) as NonNullable<OpenclawConfig['plugins']>
+  const entries =
+    plugins.entries && typeof plugins.entries === 'object' && !Array.isArray(plugins.entries)
+      ? plugins.entries
+      : {}
+
+  const home = openclawHome ?? resolveOpenclawHome()
+  const extensionsDir = join(home, 'extensions')
+
+  // Conservative gate: an absent extensions/ dir is ambiguous (fresh install with
+  // no plugins yet, OR a partially-populated tree mid-install). Either way we
+  // cannot reliably tell orphaned from transiently-absent, so say nothing.
+  if (!existsSync(extensionsDir)) {
+    return {
+      step: 'orphaned_entries',
+      status: 'skip',
+      detail: `extensions dir absent (${extensionsDir}) — cannot assess orphaned entries`,
+    }
+  }
+
+  const orphaned = Object.keys(entries).filter((id) => !existsSync(join(extensionsDir, id)))
+  if (orphaned.length === 0) {
+    return { step: 'orphaned_entries', status: 'ok', detail: 'every plugins.entries id has a backing extension' }
+  }
+
+  const noun = orphaned.length === 1 ? 'entry has' : 'entries have'
+  return {
+    step: 'orphaned_entries',
+    status: 'warn',
+    detail:
+      `${orphaned.length} plugins.entries ${noun} no backing extension: ${orphaned.join(', ')}. ` +
+      `ADVISORY ONLY — nothing was changed. This may be a genuinely-orphaned entry (the plugin was ` +
+      `uninstalled but its config, including any embedded API keys, still lingers), OR a false positive if ` +
+      `the extension is transiently absent during an in-progress install/upgrade. claw never deletes foreign ` +
+      `config; if you have confirmed the plugin is uninstalled, remove the entry by hand from ${configPath}.`,
   }
 }
 
@@ -288,7 +355,7 @@ export function runSetup(opts: { configPath?: string; openclawHome?: string } = 
 
 export function formatReport(r: SetupReport): string {
   const symbol = (s: SetupStatus) =>
-    s === 'ok' ? '✓' : s === 'skip' ? '·' : s === 'pending' ? '…' : '✗'
+    s === 'ok' ? '✓' : s === 'skip' ? '·' : s === 'pending' ? '…' : s === 'warn' ? '⚠' : '✗'
   const lines = [`PLUR setup → ${r.path}`]
   for (const s of r.steps) {
     const tag = s.step.replace(/_/g, ' ')
@@ -411,6 +478,9 @@ export function runDoctor(
     // allow is undefined (no gating) or plur-claw is already listed — ok.
     report.steps.push({ step: 'allow_gated', status: 'ok' })
   }
+
+  // #583: non-destructively flag config entries with no backing extension.
+  report.steps.push(orphanedEntriesStep(cfg, path, opts.openclawHome))
 
   tailPending()
   return report

--- a/packages/claw/test/setup.test.ts
+++ b/packages/claw/test/setup.test.ts
@@ -409,6 +409,7 @@ describe('claw doctor command', () => {
       'plugin_enabled',
       'slot_selected',
       'allow_gated',
+      'orphaned_entries',
       'reload_required',
       'runtime_registered',
       'telemetry_optin',
@@ -535,6 +536,88 @@ describe('claw doctor command', () => {
       expect(step.status).toBe('fail')
       expect(step.detail).toContain('plur-claw')
       expect(step.detail).toContain('npx @plur-ai/claw setup')
+    })
+  })
+
+  // #583: the removed #51 / D-2 prune DELETED any plugins.entries[<id>] whose
+  // extensions/<id> dir was absent, destroying third-party config (and API keys)
+  // during the transient absence of a normal install/upgrade. These tests prove
+  // the replacement DETECTS the same orphan condition WITHOUT ever mutating the
+  // config, does not fire for a present plugin, and stays silent (never warns,
+  // never fails) during a simulated whole-tree transient absence.
+  describe('orphaned_entries step (#583 — non-destructive replacement for #51 prune)', () => {
+    it('warns (does NOT delete) a genuinely-orphaned third-party entry and its API key', () => {
+      const prior = {
+        plugins: {
+          entries: {
+            'plur-claw': { enabled: true },
+            'weather-plugin': { enabled: true, config: { api_key: 'sk-SECRET-USER-KEY-123' } },
+          },
+          slots: { memory: 'plur-claw' },
+        },
+      }
+      const raw = JSON.stringify(prior)
+      writeFileSync(cfgPath, raw, 'utf8')
+      // extensions/ exists and plur-claw is installed, but weather-plugin is not:
+      // a genuine, stable orphan — not a transient whole-tree absence.
+      mkdirSync(join(dir, 'extensions', 'plur-claw'), { recursive: true })
+      const r = runDoctor({ configPath: cfgPath, openclawHome: dir })
+      const step = r.steps.find((s) => s.step === 'orphaned_entries')!
+      expect(step.status).toBe('warn')
+      expect(step.detail).toContain('weather-plugin')
+      expect(step.detail).toContain('ADVISORY ONLY')
+      // Non-destructive: doctor must not rewrite the config, and warn must not fail.
+      expect(readFileSync(cfgPath, 'utf8')).toBe(raw)
+      expect(r.steps.some((s) => s.status === 'fail')).toBe(false)
+    })
+
+    it('flags plur-claw itself when its own entry is orphaned', () => {
+      const prior = {
+        plugins: { entries: { 'plur-claw': { enabled: true } }, slots: { memory: 'plur-claw' } },
+      }
+      writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+      // extensions/ exists (some other plugin present) but plur-claw's own dir is gone.
+      mkdirSync(join(dir, 'extensions', 'other-plugin'), { recursive: true })
+      const r = runDoctor({ configPath: cfgPath, openclawHome: dir })
+      const step = r.steps.find((s) => s.step === 'orphaned_entries')!
+      expect(step.status).toBe('warn')
+      expect(step.detail).toContain('plur-claw')
+    })
+
+    it('does NOT warn when every entry has a backing extension (present plugin)', () => {
+      const prior = {
+        plugins: {
+          entries: { 'plur-claw': { enabled: true }, 'active-plugin': { enabled: true } },
+          slots: { memory: 'plur-claw' },
+        },
+      }
+      writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+      mkdirSync(join(dir, 'extensions', 'plur-claw'), { recursive: true })
+      mkdirSync(join(dir, 'extensions', 'active-plugin'), { recursive: true })
+      const r = runDoctor({ configPath: cfgPath, openclawHome: dir })
+      const step = r.steps.find((s) => s.step === 'orphaned_entries')!
+      expect(step.status).toBe('ok')
+    })
+
+    it('stays silent (skip, never warn) during a simulated transient whole-tree absence', () => {
+      // The exact false-positive that made the removed prune destructive: mid
+      // install/upgrade the extensions/ tree is not yet populated. With the dir
+      // absent we cannot tell orphaned from transient, so we must NOT warn.
+      const prior = {
+        plugins: {
+          entries: {
+            'plur-claw': { enabled: true },
+            'weather-plugin': { enabled: true, config: { api_key: 'sk-SECRET' } },
+          },
+          slots: { memory: 'plur-claw' },
+        },
+      }
+      writeFileSync(cfgPath, JSON.stringify(prior), 'utf8')
+      // Note: dir/extensions is intentionally NOT created.
+      const r = runDoctor({ configPath: cfgPath, openclawHome: dir })
+      const step = r.steps.find((s) => s.step === 'orphaned_entries')!
+      expect(step.status).toBe('skip')
+      expect(step.detail).toContain('cannot assess')
     })
   })
 })

--- a/packages/cli/src/commands/compact.ts
+++ b/packages/cli/src/commands/compact.ts
@@ -1,0 +1,24 @@
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { shouldOutputJson, outputJson, outputText } from '../output.js'
+
+/**
+ * `plur compact` — physically remove retired engrams from the local store and
+ * reclaim the YAML file space they occupy. A thin wrapper over core's
+ * compact(): plur_forget only marks an engram status:retired (the row stays on
+ * disk), so without an explicit compaction the store grows unbounded. This is
+ * the user-invoked, logged maintenance op that shrinks it. Only retired
+ * engrams are removed; active engrams are never touched. (#580)
+ */
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  const plur = createPlur(flags)
+  const result = plur.compact() // { removed, remaining }
+
+  if (shouldOutputJson(flags)) {
+    outputJson(result)
+  } else if (result.removed === 0) {
+    outputText(`No retired engrams to remove — store unchanged (${result.remaining} active).`)
+  } else {
+    const s = result.removed === 1 ? '' : 's'
+    outputText(`Compacted store: removed ${result.removed} retired engram${s}, ${result.remaining} remaining.`)
+  }
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -83,6 +83,16 @@ interface DoctorReport {
    */
   cursorProjectDetected: boolean
   cursorWired: boolean
+  /**
+   * PGLite backend running the opt-in embedding-gemma embedder (#581). #483
+   * corrected embedding-gemma's role prefixes and bumped the JSON embedding
+   * cache name so the SQLite/flat-file path auto-rebuilds — but the PGLite
+   * backend keys its `engram_embeddings` table on vector DIMENSION only (768d,
+   * unchanged by #483), so it silently keeps serving vectors computed under the
+   * old prefix. Advisory only: it recommends a one-time `plur sync --reembed
+   * --full` and never fails the overall check.
+   */
+  pgliteGemmaReembedNeeded: boolean
   overall: 'ok' | 'fail'
 }
 
@@ -569,10 +579,17 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     const overall: 'ok' | 'fail' =
       hooksInstalled && mcpRegistered && (skipHandshake || handshake.ok) && (!cursorProjectDetected || cursorWired)
         ? 'ok' : 'fail'
+    // #581: PGLite + embedding-gemma both opt-in via env (PLUR_BACKEND=pglite,
+    // PLUR_EMBEDDER=embedding-gemma) — the documented activation for each. When
+    // both are set, #483's prefix fix did not auto-rebuild the PGLite vectors
+    // (dimension-keyed cache), so flag a one-time re-embed.
+    const pgliteGemmaReembedNeeded =
+      process.env.PLUR_BACKEND === 'pglite' && process.env.PLUR_EMBEDDER === 'embedding-gemma'
+
     return {
       configs, hooksInstalled, mcpRegistered, datacoreCollision, staleNpxHooks, staleNpxMcp,
       hookShim, mcpShim, handshake, cursorHandshake, embedder,
-      cursorProjectDetected, cursorWired, overall,
+      cursorProjectDetected, cursorWired, pgliteGemmaReembedNeeded, overall,
     }
   })
 }
@@ -645,6 +662,16 @@ function printText(report: DoctorReport): void {
     outputText('   This is the same bug class as #178 (which fixed hooks). Symptom: Claude Code')
     outputText('   sessions silently lose PLUR memory after a new @plur-ai/mcp publish.')
     outputText('   Fix: run `plur init` to migrate to the local MCP binary (no npx, no race).')
+  }
+
+  if (report.pgliteGemmaReembedNeeded) {
+    outputText('')
+    outputText('⚠  PGLite backend + embedding-gemma: stored vectors may be stale (#483).')
+    outputText('   embedding-gemma\'s role prefixes were corrected in 0.14.0 (#483), but the PGLite')
+    outputText('   backend keys its embedding cache on vector dimension (unchanged at 768d), so it')
+    outputText('   does NOT auto-rebuild — recall keeps serving the old (wrong-prefix) embedding')
+    outputText('   space silently. The SQLite/flat-file backend auto-rebuilds; PGLite cannot.')
+    outputText('   Fix: run `plur sync --reembed --full` once to rebuild the vectors.')
   }
 
   outputText('')

--- a/packages/cli/src/commands/hook-session-guard.ts
+++ b/packages/cli/src/commands/hook-session-guard.ts
@@ -121,6 +121,15 @@ export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
   try {
     blockCount = incrementBlockCount(sessionId)
   } catch {
+    // Fail open on an unwritable state dir — but leave an audit trail. A silent
+    // return here is a bypass of the session guard with no signal; write the
+    // same advisory the deadlock fallback below does, for parity with the other
+    // fail-open hooks (hook-inject, hook-learn-check) so the bypass is
+    // observable rather than invisible.
+    process.stderr.write(
+      '[plur] session guard: state dir not writable — allowing tools through ' +
+      '(fail-open). Memory injection is best-effort; run `plur doctor` to diagnose.\n',
+    )
     return
   }
   if (blockCount > MAX_BLOCKS_BEFORE_FALLBACK) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ Commands:
   inject <task>           Get relevant engrams for a task
   list                    List all engrams
   forget <id>             Retire an engram
+  compact                 Remove retired engrams and reclaim store space
   ingest <content>        Extract and save engrams from content
   import                  Import memories from another system (issue #441)
                           --from <generic|gp-engram|mem0> --path <input-file>
@@ -84,6 +85,7 @@ const COMMANDS: Record<string, string> = {
   inject: './commands/inject.js',
   list: './commands/list.js',
   forget: './commands/forget.js',
+  compact: './commands/compact.js',
   feedback: './commands/feedback.js',
   capture: './commands/capture.js',
   timeline: './commands/timeline.js',

--- a/packages/cli/test/compact.test.ts
+++ b/packages/cli/test/compact.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('plur compact', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-cli-test-')) })
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  function run(args: string): string {
+    return execSync(`node ${CLI} ${args} --path ${dir} --json`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    }).trim()
+  }
+
+  function learn(statement: string): string {
+    const output = execSync(`node ${CLI} learn "${statement}" --path ${dir} --json`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    }).trim()
+    return JSON.parse(output).id as string
+  }
+
+  it('removes retired engrams and reports removed/remaining', () => {
+    const id = learn('engram to be compacted away')
+    learn('engram that stays active')
+    // forget retires the first engram (status:retired) but leaves the row on disk
+    execSync(`node ${CLI} forget ${id} --path ${dir} --json`, { encoding: 'utf-8', timeout: 10000 })
+
+    const output = JSON.parse(run('compact'))
+    expect(output.removed).toBe(1)
+    expect(output.remaining).toBe(1)
+
+    // idempotent: a second compact finds nothing left to remove
+    const again = JSON.parse(run('compact'))
+    expect(again.removed).toBe(0)
+    expect(again.remaining).toBe(1)
+  })
+
+  it('reports zero removed on a store with no retired engrams', () => {
+    learn('only active engram here')
+    const output = JSON.parse(run('compact'))
+    expect(output.removed).toBe(0)
+    expect(output.remaining).toBe(1)
+  })
+
+  it('handles an empty store without error', () => {
+    const output = JSON.parse(run('compact'))
+    expect(output.removed).toBe(0)
+    expect(output.remaining).toBe(0)
+  })
+
+  it('prints a human-readable summary in text mode', async () => {
+    const id = learn('doomed engram')
+    execSync(`node ${CLI} forget ${id} --path ${dir} --json`, { encoding: 'utf-8', timeout: 10000 })
+
+    // Text mode requires a TTY or an explicit json:false — run in-process.
+    const writes: string[] = []
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk))
+      return true
+    }) as never)
+    try {
+      const { run: runCompact } = await import('../src/commands/compact.js')
+      await runCompact([], { path: dir, json: false })
+    } finally {
+      spy.mockRestore()
+    }
+    const out = writes.join('')
+    expect(out).toContain('removed 1 retired engram')
+    expect(out).toContain('0 remaining')
+  })
+})

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -47,6 +47,37 @@ describe('plur doctor', () => {
     expect(report.mcpRegistered).toBe(false)
   })
 
+  it('warns to re-embed only on PGLite + embedding-gemma (#581)', () => {
+    // Explicit non-triggering values in the negative cases so the assertion is
+    // robust against an ambient PLUR_BACKEND/PLUR_EMBEDDER in the test shell.
+    // doctor emits JSON in a non-TTY pipe (execSync), so assert on the report
+    // field, which the printText advisory is gated on 1:1. Explicit
+    // non-triggering values in the negatives keep the assertion robust against
+    // an ambient PLUR_BACKEND/PLUR_EMBEDDER in the test shell.
+    const flag = (over: Record<string, string>): boolean => {
+      let out = ''
+      try {
+        out = execSync(`node ${CLI} doctor --no-handshake --json`, {
+          encoding: 'utf-8', timeout: 15000, cwd: home,
+          // Skip the embedder model probe — this test only checks env-derived
+          // backend/embedder detection, and 4 spawns × a cold model load blows
+          // the vitest timeout.
+          env: { ...process.env, HOME: home, USERPROFILE: home, PLUR_DISABLE_EMBEDDINGS: '1', ...over },
+        })
+      } catch (err: any) { out = err.stdout?.toString() ?? '' } // doctor exits 1 on empty env
+      const report = JSON.parse(out)
+      // Advisory only: it must never flip the overall verdict on its own.
+      expect(report.overall).toBe('fail') // empty env fails regardless of this flag
+      return report.pgliteGemmaReembedNeeded
+    }
+
+    // Both opt-ins set → advisory fires; any other combination stays silent.
+    expect(flag({ PLUR_BACKEND: 'pglite', PLUR_EMBEDDER: 'embedding-gemma' })).toBe(true)
+    expect(flag({ PLUR_BACKEND: 'pglite', PLUR_EMBEDDER: 'bge-small' })).toBe(false)
+    expect(flag({ PLUR_BACKEND: 'sqlite', PLUR_EMBEDDER: 'embedding-gemma' })).toBe(false)
+    expect(flag({ PLUR_BACKEND: 'sqlite', PLUR_EMBEDDER: 'bge-small' })).toBe(false)
+  }, 30000)
+
   it('reports ok when both hooks and plur MCP are present', () => {
     writeGlobalSettings({
       hooks: {

--- a/packages/cli/test/hook-session-guard.test.ts
+++ b/packages/cli/test/hook-session-guard.test.ts
@@ -128,6 +128,8 @@ describe('hook-session-guard', () => {
       })
       expect(result.status ?? 1).toBe(0) // fail-open: never a non-zero exit
       expect(result.stdout ?? '').not.toContain('"error"')
+      // The fail-open must leave an audit trail, not silently bypass the guard (#584).
+      expect(result.stderr ?? '').toContain('plur doctor')
     } finally {
       chmodSync(roTmp, 0o700)
       rmSync(roTmp, { recursive: true, force: true })

--- a/packages/core/src/decay.ts
+++ b/packages/core/src/decay.ts
@@ -94,11 +94,3 @@ export function confidenceDecay(
   return Math.max(CONFIDENCE_DECAY_FLOOR, decayed)
 }
 
-/** Map retrieval strength to a human-readable status label. */
-export function strengthToStatus(strength: number): string {
-  if (strength > 0.5) return 'active'
-  if (strength > 0.3) return 'fading'
-  if (strength > 0.1) return 'dormant'
-  return 'retirement_candidate'
-}
-

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,7 +80,6 @@ export { recallAuto, type AutoSearchResult, type SearchStrategy } from './search
 export { generateProfile, getProfileForInjection, loadProfileCache, saveProfileCache, markProfileDirty, profileNeedsRegeneration, type ProfileCache } from './profile.js'
 export { formatLayer1, formatLayer2, formatLayer3, formatWithLayer, assignLayer, type InjectionLayer } from './inject.js'
 export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, type HistoryEvent, type InjectionEventCounts } from './history.js'
-export { strengthToStatus } from './decay.js'
 export { computeContentHash, normalizeStatement } from './content-hash.js'
 export { parseDedupResponse, buildDedupPrompt, buildBatchDedupPrompt } from './dedup.js'
 export { runMigrations, rollbackMigrations, getSchemaVersion, setSchemaVersion, ALL_MIGRATIONS, CURRENT_SCHEMA_VERSION, type Migration, type MigrationResult } from './migrations/index.js'

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -254,7 +254,14 @@ export const EngramSchema = z.object({
     .describe('Unique identifier. Class prefix ENG (concrete engram), ABS (abstraction), or META (meta-engram). Canonical concrete form: ENG-YYYY-MMDD-NNN; store-namespaced form: ENG-{PREFIX}-YYYY-MMDD-NNN.'),
   version: z.number().int().min(1).default(2)
     .describe('Schema-shape generation of this engram object (currently 2). Distinct from engram_version, which tracks content evolution.'),
-  status: z.enum(['active', 'dormant', 'retired', 'candidate']).describe('Lifecycle state.'),
+  // 'active' and 'retired' are the two states any current code path assigns
+  // (retire via forget/dedup/supersede). 'dormant' and 'candidate' are NOT
+  // assigned by any code today: 'dormant' was only ever set by the batchDecay
+  // pass removed in #563 (decay is now a read-time property, not a materialized
+  // status), and 'candidate' is reserved. They are kept in the enum so stores
+  // written before #563 that persisted status:'dormant' still load, and so the
+  // status filter accepts them; do not remove without a data migration.
+  status: z.enum(['active', 'dormant', 'retired', 'candidate']).describe('Lifecycle state. Assigned values today are active/retired; dormant/candidate are legacy/reserved (see note above).'),
   consolidated: z.boolean().default(false)
     .describe('Whether this engram has been through consolidation (sleep-like batch reprocessing).'),
   type: z.enum(['behavioral', 'terminological', 'procedural', 'architectural'])

--- a/packages/core/test/decay.test.ts
+++ b/packages/core/test/decay.test.ts
@@ -1,24 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { decayedStrength, daysSince, shouldInject, reactivate, strengthToStatus } from '../src/decay.js'
-
-// Moved here from the deleted batch-decay.test.ts when batchDecay was removed
-// (2026-07-14). strengthToStatus is part of the read-time decay model and is
-// retained; the batch-decay materialization job that also lived here is gone.
-describe('strengthToStatus', () => {
-  it('maps strength ranges to correct statuses', () => {
-    expect(strengthToStatus(0.8)).toBe('active')
-    expect(strengthToStatus(0.51)).toBe('active')
-    expect(strengthToStatus(0.5)).toBe('fading')
-    expect(strengthToStatus(0.4)).toBe('fading')
-    expect(strengthToStatus(0.31)).toBe('fading')
-    expect(strengthToStatus(0.3)).toBe('dormant')
-    expect(strengthToStatus(0.2)).toBe('dormant')
-    expect(strengthToStatus(0.11)).toBe('dormant')
-    expect(strengthToStatus(0.1)).toBe('retirement_candidate')
-    expect(strengthToStatus(0.05)).toBe('retirement_candidate')
-    expect(strengthToStatus(0.0)).toBe('retirement_candidate')
-  })
-})
+import { decayedStrength, daysSince, shouldInject, reactivate } from '../src/decay.js'
 
 describe('decay as deprioritization', () => {
   it('decays retrieval strength over time', () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -304,6 +304,7 @@ export const CURSOR_CORE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'plur_doctor',
   'plur_packs_uninstall',
   'plur_tensions_purge',
+  'plur_compact',
 ])
 
 function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
@@ -2426,6 +2427,28 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
           purged_conflict_refs: result.purged_count,
           engrams_modified: result.engrams_modified,
           message: `Purged ${result.purged_count} conflict references from ${result.engrams_modified} engrams.`,
+        }
+      },
+    },
+
+    {
+      name: 'plur_compact',
+      description:
+        'Physically remove retired engrams from the local store and reclaim the YAML file space ' +
+        'they occupy. plur_forget only marks an engram status:retired — the row stays on disk, so ' +
+        'without an explicit compaction the store grows unbounded. This is the user-invoked, logged ' +
+        'maintenance op that shrinks it. Only retired engrams are removed; active engrams are never ' +
+        'touched. Irreversible.',
+      annotations: { title: 'Compact store', destructiveHint: true, idempotentHint: true },
+      inputSchema: { type: 'object', properties: {} },
+      handler: async (_args, plur) => {
+        const result = plur.compact()
+        return {
+          removed: result.removed,
+          remaining: result.remaining,
+          message: result.removed === 0
+            ? `No retired engrams to remove — store unchanged (${result.remaining} active).`
+            : `Removed ${result.removed} retired engram${result.removed === 1 ? '' : 's'}; ${result.remaining} remaining.`,
         }
       },
     },

--- a/packages/mcp/test/tool-profile.test.ts
+++ b/packages/mcp/test/tool-profile.test.ts
@@ -19,11 +19,11 @@ describe('tool profiles', () => {
 
   it('cursor profile stays at or under 12 tools and includes plur_admin', () => {
     const cursor = getToolDefinitions('cursor')
-    // 8 day-to-day tools + plur_packs_uninstall/plur_tensions_purge (kept as
-    // direct top-level tools, not wrapped in plur_admin, so their
-    // destructiveHint annotation stays visible to clients — audit fix,
-    // evaluator review 2026-07-08) + plur_admin = 11, still far under
-    // Cursor's ~40-tool-per-workspace cap.
+    // 8 day-to-day tools + plur_packs_uninstall/plur_tensions_purge/plur_compact
+    // (destructive maintenance tools kept as direct top-level tools, not wrapped
+    // in plur_admin, so their destructiveHint annotation stays visible to
+    // clients — audit fix, evaluator review 2026-07-08; plur_compact added #580)
+    // + plur_admin = 12, still far under Cursor's ~40-tool-per-workspace cap.
     expect(cursor.length).toBeLessThanOrEqual(12)
     const names = cursor.map(t => t.name)
     expect(names).toContain('plur_session_start')
@@ -32,6 +32,7 @@ describe('tool profiles', () => {
     expect(names).toContain('plur_admin')
     expect(names).toContain('plur_packs_uninstall')
     expect(names).toContain('plur_tensions_purge')
+    expect(names).toContain('plur_compact')
     expect(names).not.toContain('plur_packs_install')
   })
 
@@ -61,12 +62,14 @@ describe('tool profiles', () => {
     // Audit fix (evaluator review, 2026-07-08): destructive tools must keep
     // their real annotation once they're direct top-level tools again —
     // this is the whole point of pulling them out of plur_admin's dispatch.
-    it('exposes destructiveHint on plur_packs_uninstall and plur_tensions_purge directly', async () => {
+    it('exposes destructiveHint on plur_packs_uninstall, plur_tensions_purge and plur_compact directly', async () => {
       const { tools } = await client.listTools()
       const uninstall = tools.find((t) => t.name === 'plur_packs_uninstall')
       const purge = tools.find((t) => t.name === 'plur_tensions_purge')
+      const compact = tools.find((t) => t.name === 'plur_compact')
       expect(uninstall?.annotations?.destructiveHint).toBe(true)
       expect(purge?.annotations?.destructiveHint).toBe(true)
+      expect(compact?.annotations?.destructiveHint).toBe(true)
     })
 
     it('dispatches plur_status through plur_admin', async () => {

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -104,6 +104,39 @@ describe('MCP tools', () => {
       expect(result.ids).toEqual([])
       expect(result.warning).toMatch(/No engrams/)
     })
+
+    it('aligns ids to inputs with null in the failed slot, through the MCP handler (#281)', async () => {
+      // The core learnBatch partial-failure path is covered in core/test/batch.test.ts.
+      // This exercises the MCP GLUE that the core test cannot reach: the handler
+      // rebuilds `ids` 1:1 with the input array from each result's input_index. A
+      // COMPACTED results array (failed item absent) must NOT shift ids left — the
+      // failed slot must be null. Stub learnBatch so the failure is deterministic.
+      const original = plur.learnBatch.bind(plur)
+      ;(plur as any).learnBatch = async () => ({
+        results: [
+          { input_index: 0, engram: { id: 'ENG-2026-0101-001', statement: 'good one', scope: 'global', type: 'behavioral' }, decision: 'ADD' },
+          { input_index: 2, engram: { id: 'ENG-2026-0101-003', statement: 'good two', scope: 'global', type: 'behavioral' }, decision: 'ADD' },
+        ],
+        stats: { added: 2, updated: 0, merged: 0, noops: 0, failed: 1 },
+        failures: [{ index: 1, statement: 'this one fails', error: 'simulated write failure' }],
+      })
+      try {
+        const result = await callTool('plur_learn_batch', {
+          engrams: [
+            { statement: 'good one', scope: 'global' },
+            { statement: 'this one fails', scope: 'global' },
+            { statement: 'good two', scope: 'global' },
+          ],
+        }) as any
+        // 1:1 with input (length 3, not compacted to 2); failed middle slot is null.
+        expect(result.ids).toEqual(['ENG-2026-0101-001', null, 'ENG-2026-0101-003'])
+        expect(result.stats.failed).toBe(1)
+        expect(result.failures).toHaveLength(1)
+        expect(result.failures[0].index).toBe(1)
+      } finally {
+        ;(plur as any).learnBatch = original
+      }
+    })
   })
 
   // #347 — temporal validity params on the write path.

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -54,12 +54,45 @@ describe('MCP tools', () => {
     expect(names).toContain('plur_packs_install')
     expect(names).toContain('plur_packs_list')
     expect(names).toContain('plur_status')
+    expect(names).toContain('plur_compact')
   })
 
   it('plur_learn creates an engram', async () => {
     const result = await callTool('plur_learn', { statement: 'Test learning', scope: 'global' }) as any
     expect(result.id).toMatch(/^ENG-/)
     expect(result.statement).toBe('Test learning')
+  })
+
+  describe('plur_compact (#580)', () => {
+    it('is registered as a destructive maintenance tool', () => {
+      const tool = tools.find(t => t.name === 'plur_compact')
+      expect(tool).toBeDefined()
+      expect(tool!.annotations?.destructiveHint).toBe(true)
+    })
+
+    it('physically removes retired engrams and reports removed/remaining', async () => {
+      const doomed = await callTool('plur_learn', { statement: 'compact me away', scope: 'global' }) as any
+      await callTool('plur_learn', { statement: 'keep me active', scope: 'global' })
+      await callTool('plur_forget', { id: doomed.id }) // status:retired, row still on disk
+
+      const result = await callTool('plur_compact') as any
+      expect(result.removed).toBe(1)
+      expect(result.remaining).toBe(1)
+      expect(result.message).toContain('Removed 1 retired engram')
+
+      // idempotent: nothing left to remove on a second pass
+      const again = await callTool('plur_compact') as any
+      expect(again.removed).toBe(0)
+      expect(again.remaining).toBe(1)
+    })
+
+    it('reports zero removed when there is nothing to compact', async () => {
+      await callTool('plur_learn', { statement: 'only active engram', scope: 'global' })
+      const result = await callTool('plur_compact') as any
+      expect(result.removed).toBe(0)
+      expect(result.remaining).toBe(1)
+      expect(result.message).toContain('No retired engrams')
+    })
   })
 
   describe('plur_learn_batch', () => {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -493,7 +493,10 @@ echo "--- Step 5b: Smoke test from @next ---"
 SMOKE_DIR=$(mktemp -d)
 pushd "$SMOKE_DIR" > /dev/null
 SMOKE_OK=true
-for pkg_check in "cli:$VERSION"; do
+# CLI-shaped packages ship a `--version` bin (cli → `plur`, mcp → `plur-mcp`).
+# Both are promoted to @latest, so both are smoke-tested — #584: previously only
+# cli was checked, yet the audited fixes live in core (pulled in transitively).
+for pkg_check in "cli:$VERSION" "mcp:$VERSION"; do
   pkg_name="${pkg_check%%:*}"
   pkg_ver="${pkg_check##*:}"
   echo -n "  npx -y @plur-ai/$pkg_name@$pkg_ver --version → "
@@ -510,6 +513,24 @@ for pkg_check in "cli:$VERSION"; do
     SMOKE_OK=false
   fi
 done
+# core has no bin — smoke it by installing the exact @next version and importing
+# the ESM entry (#584). This catches the import-time crash class that bricked
+# cli@0.9.2 ("Dynamic require of \"os\" is not supported", #64) and confirms the
+# Plur class is actually exported at the promoted version, before @latest moves.
+echo -n "  @plur-ai/core@$VERSION install + import → "
+core_exit=0
+npm install --no-save --no-audit --no-fund "@plur-ai/core@$VERSION" > /dev/null 2>&1 || core_exit=$?
+if [ "$core_exit" -eq 0 ]; then
+  core_out=$(node --input-type=module -e "import('@plur-ai/core').then(m => process.exit(typeof m.Plur === 'function' ? 0 : 3)).catch(e => { console.error(e && e.message); process.exit(4) })" 2>&1) && core_exit=0 || core_exit=$?
+fi
+core_inst=$(node -p "require('$SMOKE_DIR/node_modules/@plur-ai/core/package.json').version" 2>/dev/null || echo "?")
+if [ "$core_exit" -eq 0 ] && [ "$core_inst" = "$VERSION" ]; then
+  echo "✓ (core@$core_inst, Plur export present)"
+else
+  echo "✗"
+  echo "      Expected core@$VERSION to import with a Plur export (exit=$core_exit, installed=$core_inst): ${core_out:-}"
+  SMOKE_OK=false
+fi
 popd > /dev/null
 rm -rf "$SMOKE_DIR"
 if [ "$SMOKE_OK" != true ]; then
@@ -548,6 +569,36 @@ cd packages/hermes
 rm -rf dist/
 python3 -m build 2>&1 | tail -1
 TWINE_USERNAME=__token__ TWINE_PASSWORD="$PYPI_TOKEN_PLUR_HERMES" python3 -m twine upload dist/* 2>&1 | tail -1
+
+# Post-publish verification (#584). PyPI is IMMUTABLE — a dropped or partial
+# upload can't be overwritten, only superseded by a new version — and this step
+# runs AFTER npm @latest already moved, so a silent PyPI miss = a half-published
+# release. Verify the version is actually retrievable (retry for propagation lag),
+# and if not, print the exact recovery path rather than exiting 0 as if done.
+echo -n "  Verifying plur-hermes==$VERSION on PyPI... "
+pypi_ok=false
+for _attempt in 1 2 3 4 5; do
+  if curl -sf "https://pypi.org/pypi/plur-hermes/$VERSION/json" > /dev/null 2>&1; then
+    pypi_ok=true; break
+  fi
+  sleep 6
+done
+if [ "$pypi_ok" = true ]; then
+  echo "✓"
+else
+  echo "✗ not visible after retries"
+  echo ""
+  echo "  ⚠ plur-hermes==$VERSION did not verify on PyPI. npm @latest is ALREADY"
+  echo "    promoted, so this is a half-published release — resolve before announcing."
+  echo "    PyPI is immutable: you CANNOT re-upload the same version+filename. Recovery:"
+  echo "      1. Check https://pypi.org/project/plur-hermes/#history — if $VERSION is"
+  echo "         listed, this was propagation lag; no action needed."
+  echo "      2. If absent, retry the upload: (cd packages/hermes && \\"
+  echo "         TWINE_USERNAME=__token__ TWINE_PASSWORD=\$PYPI_TOKEN_PLUR_HERMES \\"
+  echo "         python3 -m twine upload dist/*)"
+  echo "      3. If the filename is locked (a partial upload registered it), the version"
+  echo "         is burned — bump to the next patch and re-release; it cannot be reused."
+fi
 cd "$REPO_ROOT"
 echo ""
 

--- a/spec/engram.schema.json
+++ b/spec/engram.schema.json
@@ -24,7 +24,7 @@
         "retired",
         "candidate"
       ],
-      "description": "Lifecycle state."
+      "description": "Lifecycle state. Assigned values today are active/retired; dormant/candidate are legacy/reserved (see note above)."
     },
     "consolidated": {
       "type": "boolean",


### PR DESCRIPTION
## 0.14.0 audit follow-ups (#580–#584)

Addresses **all** remaining non-blocking findings from the five-evaluator pre-release audit — the ones #579 deferred to tickets. **Stacked on #579** (base is `release-prep/0.14.0`); merge #579 first, or merge this after and I'll rebase onto `main`.

| Fix | Issue | What |
|---|---|---|
| `feat(cli,mcp)` compact | #580 | `plur compact` CLI + `plur_compact` MCP tool — the explicit, logged store-shrink op that replaces batchDecay's implicit cleanup. Retired rows had no user-facing removal path after #563. |
| `fix(cli)` doctor | #581 | `plur doctor` advises a one-time `plur sync --reembed --full` when PGLite runs `embedding-gemma`, whose vectors #483 can't auto-rebuild. Advisory only. |
| `refactor(core)` cleanup | #582 | Remove dead `strengthToStatus` (zero callers post-#563, vocab never matched the enum). Keep `dormant`/`candidate` enum values (legacy/reserved) — removing them would reject pre-#563 data. |
| `fix(claw)` orphans | #583 | Non-destructive `plur doctor` warning for genuinely-orphaned OpenClaw config entries — restores the detection #51 removed with its destructive prune, without ever deleting. |
| `fix(cli,release)` hardening | #584 | hook-session-guard fail-open now leaves a stderr audit trail; MCP-layer partial-failure test for `plur_learn_batch`'s `ids` alignment; smoke test extended to core+mcp; PyPI post-publish verify + documented recovery. |

### Verification

- Full workspace suite green: **2,626 passed / 0 failed** (integration of all five fixes + the cherry-picked agent work).
- New/updated tests: LS/PS payload cases (#582 spec regen kept #315 green), `plur compact` CLI+MCP, doctor pglite+gemma detection, claw orphan detection (4 cases incl. transient-absence safety), `plur_learn_batch` MCP `ids`-alignment, hook-guard fail-open advisory.
- Operational check (Taleb T4): confirmed **no scheduled `plur batch-decay`** anywhere in the datacore/nightshift config — #563's removal breaks no automation. The only reference is a docstring in an unscheduled `decay_and_review.py` helper.

### Notes

- #583's warning is advisory and, by design, could surface a spurious line if `doctor` runs at the exact moment a plugin dir is transiently absent mid-upgrade — it never deletes, so this is harmless; a fully reliable orphan signal would require OpenClaw's own manifest, which this repo can't see.
- #581 detects the pglite+gemma combo via env (`PLUR_BACKEND`/`PLUR_EMBEDDER`), the documented activation for each.
