### PR TITLE
docs(changelog): tweet-shape 0.14.0 lead + declare plur login (#532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The clean re-release of the queued batch that 0.12.0 shipped unreviewed and 0.13
 
 ### Added
 
+- **`plur login` — enterprise OAuth device flow** (#532): authenticate against an enterprise server (`plur login https://plur.datafund.io`) via the RFC 8628 device-authorization grant, writing the token to `~/.plur/config.json` (mode `0600`) and hot-reloading a running MCP server over SIGUSR1 (reload-marker file on Windows). The command was fully implemented but never registered in the CLI dispatcher (closes #300); it now is. Hardened through a dedicated security review (#551): the browser launcher uses `spawn` with an argument array (no shell) and validates the URL scheme, closing a command-injection vector from a server-controlled `verification_uri`; `http://` is rejected for any non-localhost host so tokens never travel in plaintext.
 - **`plur compact` + `plur_compact`** (#580): explicitly reclaim disk space from retired engrams, exposed as both a CLI command and an MCP tool. With batchDecay gone (#563), this is the deliberate, logged maintenance op for shrinking the store — retired rows previously had no user-facing removal path.
 - **Session injection telemetry** (#536): per-pack activation tracking logged at `session_end` for offline relevance analysis.
 - **`plur_status` domain + `created_after` filters** (#522, #524).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.14.0 (2026-07-15)
 
+Clean re-release — 11 held-back features re-audited & fixed.
+
+- batchDecay removed
+- scope injection hardening
+- feedback() decay bug fixed
+- multi-evaluator re-audit
+
 The clean re-release of the queued batch that 0.12.0 shipped unreviewed and 0.13.0 then pulled back. Every held-back feature was individually re-audited this cycle through a multi-evaluator review (correctness, risk, edge-case, and code-correctness passes), fixed where the audit found a real defect, and locked behind a test that fails if the bug comes back. The riskiest piece — batchDecay — was removed outright rather than patched. npm `latest` moves 0.13.0 → 0.14.0; 0.12.0 remains deprecated.
 
 ### Changed


### PR DESCRIPTION
Final CHANGELOG prep so `release.sh 0.14.0` runs clean end-to-end. Two commits:

1. **Tweet-shape the 0.14.0 lead** — the section produced a 2597-char auto-tweet (release.sh `generate_tweet` reads the first non-bullet line + first 4 bullets), tripping the Step 3.5 length gate. Now leads with a short headline + 4 TL;DR bullets; detailed prose + `###` sections unchanged below. **Preview: 268/270.**
2. **Declare `plur login` (#532)** — #532 (enterprise OAuth device flow, closes #300) merged to main after the 0.14.0 section was written, so the manifest gate flagged it undeclared. Added to the Added section with a clean `(#532)` trailer.

**Audited #532 before declaring** (it's security-sensitive — OAuth, token storage, browser launch):
- Browser launcher uses `spawn` + argv (no shell) and validates the URL scheme → command-injection vector from a server-controlled `verification_uri` is closed.
- `http://` rejected for any non-localhost host → tokens never travel plaintext.
- Token file written `0600`. Went through a dedicated security review (#551). login tests: **29 passed / 1 skipped**.

**Definitive verification** — full `release.sh 0.14.0 --dry-run` on this branch: version-sync ✓, **Tweet 268/270 ✓**, **Manifest gate: all 34 PRs declared ✓**, stops before publish.

Prep for the 0.14.0 publish. Crt's audit (#588) cleared. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)