### PR TITLE
docs: add CONTRIBUTING guide with claim-before-you-code workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,11 @@ current scores. If your PR improves any of these, mention it in the PR descripti
 
 ## Conventions
 
+- **Claim before you code**: before starting a GitHub issue, self-assign it
+  (`gh issue edit <n> --add-assignee @me`); if it is already assigned to someone
+  else, coordinate on the issue rather than opening a duplicate parallel fix.
+  This binds automated runs too — self-assign or skip if already claimed. See
+  `CONTRIBUTING.md`.
 - TypeScript, Vitest, tsup, Zod for validation
 - No external API calls in core — search must work offline at zero cost
 - YAML for all persistent storage (not JSON, not SQLite for primary data)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,58 @@
 # Contributing to PLUR
 
-Thanks for contributing. This file covers how changes get reviewed and
-merged. For the release process see [RELEASING.md](RELEASING.md); for
-agent/automation working rules see [CLAUDE.md](CLAUDE.md).
+Thanks for helping build PLUR — persistent, composable memory for AI agents.
+This monorepo holds `@plur-ai/core` (the engine), `@plur-ai/mcp` (the MCP
+server), and `@plur-ai/claw` (the OpenClaw plugin). For the release process see
+[RELEASING.md](RELEASING.md); for agent/automation working rules see
+[CLAUDE.md](CLAUDE.md).
+
+## Getting started
+
+pnpm workspace monorepo. From the repo root:
+
+```bash
+pnpm install
+pnpm build
+pnpm test
+```
+
+All tests must pass before you commit. `@plur-ai/claw` imports core's built
+`dist` (not source), so after changing core, rebuild it before running claw
+tests:
+
+```bash
+pnpm --filter @plur-ai/core build
+```
+
+## Making a change
+
+1. **Issue first.** Open or pick an issue that describes the change.
+
+2. **Claim it before you write any code.** Self-assign the issue
+   (`gh issue edit <n> --add-assignee @me`). If it is **already assigned to
+   someone else**, comment to coordinate before you start — do **not** open a
+   parallel fix. If you can't assign (no write access), comment "Starting on
+   this," and check for an existing such comment first. Assignment is the only
+   signal that stops two contributors landing the same fix. **This applies to
+   autonomous agents as much as to people**: an automated run must self-assign,
+   or skip the issue if it is already claimed by another party, before it
+   starts implementing.
+
+3. **Branch.** Use a descriptive name, e.g. `fix-sync-conflict` or
+   `feat-remote-store-retry`.
+
+4. **Write tests.** Every change to behavior needs a test. Add unit tests in
+   the affected package's `test/` directory (named `*.test.ts`). For changes to
+   `RemoteStore`'s wire surface, extend the stub server in
+   `packages/core/test/helpers/stub-server.ts`.
+
+5. **Keep core offline and free.** Core must work with no external API calls —
+   search runs locally at zero cost. Don't introduce a runtime network
+   dependency into `@plur-ai/core`.
+
+6. **Open a PR with the linked issue.** Keep commits to one logical change each.
+
+7. **Green before merge.** `pnpm test` and `pnpm build` must pass.
 
 ## Reviewing and merging
 
@@ -34,3 +84,15 @@ Every change lands through a reviewed pull request — no direct pushes to
 Release commits and tags follow [RELEASING.md](RELEASING.md). The release is
 guarded by a manifest gate that aborts on undeclared PRs before publish (see
 plur-ai/plur#544) — don't work around it; declare the PRs.
+
+## Conventions
+
+- TypeScript, Vitest, tsup, Zod for validation.
+- YAML for persistent storage (not JSON, not SQLite for primary data).
+- Apache-2.0 licensed — by contributing you agree your contribution is
+  licensed under the same terms.
+
+## Reporting bugs and requesting features
+
+Open an issue with a clear description and, for bugs, the smallest reproduction
+you can manage. Check open issues first to avoid duplicates.


### PR DESCRIPTION
## Why

The repo had no `CONTRIBUTING.md`, and nothing documented that a contributor should claim an issue before starting. That gap lets two contributors — or an autonomous agent and a person — implement the same fix in parallel, with no signal that work is already underway.

## What

- **CONTRIBUTING.md** (new) — getting started, and a "Making a change" workflow whose step 2 is: self-assign the issue before writing code; if already assigned to someone else, coordinate rather than open a parallel fix. Explicitly binds automated runs (self-assign or skip).
- **CLAUDE.md** — a matching "Claim before you code" convention so an agent session picks up the same rule automatically.

Kept generic (this is a public repo); the same convention is being added to the enterprise repo separately.