### PR TITLE
ops(release): smoke-test retry on propagation lag + website version pre-flight

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,8 +58,22 @@ packages**, not just `cli`:
   import-time crash class that bricked `cli@0.9.2` (`Dynamic require of "os" is not supported`,
   #64) — the audited fixes live in `core`, so promoting it unchecked was a real gap (#584).
 
-If any smoke check fails, `@next` is published but `@latest` is untouched; the script prints
-the `npm dist-tag rm … next` revert commands and aborts before promotion.
+Each smoke check **retries on npm-propagation lag** (up to 6 attempts, 8s apart): a package
+published to `@next` seconds earlier may not be visible to `npx` yet, returning `ETARGET`
+("no matching version") — which is not a real failure. Only that signature is retried; any
+other failure (crash, wrong version) fails fast. Without this, a propagation race aborts the
+whole release after `@next` is published — 0.14.0 hit exactly that and needed a manual
+promote → PyPI → GH release → website → tweet recovery.
+
+If a smoke check still fails after retries, `@next` is published but `@latest` is untouched;
+the script prints the `npm dist-tag rm … next` revert commands and aborts before promotion.
+
+**Website version pre-flight (Step 3.8).** Step 8 only *deploys* the website (rsync); it does
+not update content. The content bump (`softwareVersion` + `@plur-ai/cli@<version>` install
+commands in `index.html`, plus any `spec.html` feature changes) is a **manual pre-step**. Step
+3.8 aborts *before any publish* if `../website/index.html`'s `softwareVersion` ≠ `$VERSION`, so
+a forgotten site bump fails fast instead of silently shipping a stale site (ENG-2026-0422-052).
+Skipped when the website dir isn't present.
 
 **PyPI (Step 6) is immutable and has no canary.** A dropped or partial `twine upload` cannot be
 overwritten — only superseded by a new version — and it runs *after* npm `@latest` already moved,

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,9 +33,11 @@
 #   3.5 Validate tweet length (abort if > 270 chars)
 #   3.6 Manifest gate: abort if a user-facing PR merged since the last tag is
 #       undeclared in the CHANGELOG (issue #544; see RELEASING.md)
+#   3.7 Pre-flight: every target version must be publishable (not already taken)
+#   3.8 Website version pre-flight: index.html softwareVersion must == $VERSION
 #   4.  Commit + tag + push
 #   5a. Publish npm to @next (canary)
-#   5b. Smoke test (npx by exact version, assert --version reports correctly)
+#   5b. Smoke test (npx by exact version; retries on npm-propagation ETARGET)
 #   5c. Promote @next → @latest
 #   6.  Publish PyPI (hermes)
 #   7.  GitHub release
@@ -453,6 +455,27 @@ if [ "$PREFLIGHT_OK" != true ]; then
 fi
 echo ""
 
+# --- Step 3.8: Website version pre-flight (ENG-2026-0422-052) ---
+# The website CONTENT bump (softwareVersion + @plur-ai/cli install commands) is a
+# manual pre-step; Step 8 only DEPLOYS what's already in the repo. If the site
+# wasn't bumped to $VERSION, catch it HERE — before any irreversible publish —
+# rather than shipping a stale site and only warning post-deploy at Step 8.
+# Skipped when the website dir isn't present, same as Step 8.
+WEBSITE_PREFLIGHT_DIR="${WEBSITE_DIR:-$REPO_ROOT/../website}"
+if [ -f "$WEBSITE_PREFLIGHT_DIR/index.html" ]; then
+  echo "--- Step 3.8: Website version pre-flight ---"
+  SITE_VERSION=$(grep -Eo '"softwareVersion":[[:space:]]*"[0-9.]+"' "$WEBSITE_PREFLIGHT_DIR/index.html" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+  if [ "$SITE_VERSION" != "$VERSION" ]; then
+    echo "✗ Website not bumped: $WEBSITE_PREFLIGHT_DIR/index.html softwareVersion=${SITE_VERSION:-none}, expected $VERSION"
+    echo "  Update the website to $VERSION (softwareVersion + @plur-ai/cli@$VERSION install"
+    echo "  commands, plus any spec.html feature changes) and commit it before releasing."
+    echo "  Aborts BEFORE publish so a stale site can't ship. See ENG-2026-0422-052."
+    exit 1
+  fi
+  echo "  ✓ website index.html at softwareVersion=$VERSION"
+  echo ""
+fi
+
 # --- 4. Commit + tag + push ---
 echo "--- Step 4: Git ---"
 git add -A
@@ -499,16 +522,32 @@ for pkg_check in "cli:$VERSION" "mcp:$VERSION"; do
   pkg_name="${pkg_check%%:*}"
   pkg_ver="${pkg_check##*:}"
   echo -n "  npx -y @plur-ai/$pkg_name@$pkg_ver --version → "
-  # Guard the command substitution under `set -euo pipefail`: a transient
-  # npm-propagation failure would otherwise abort the whole release here instead
-  # of falling through to the smoke-fail handling below. (bf00781 — hit on both
-  # the 0.12.0 and 0.13.0 release attempts.)
-  smoke_out=$(npx -y "@plur-ai/$pkg_name@$pkg_ver" --version 2>&1) && smoke_exit=0 || smoke_exit=$?
-  if [ "$smoke_exit" -eq 0 ] && echo "$smoke_out" | grep -q "$pkg_ver"; then
+  # Guard the command substitution under `set -euo pipefail` (bf00781), AND retry
+  # on transient npm-propagation lag: a package published to @next seconds ago may
+  # not be visible to npx yet (ETARGET "no matching version"), which is NOT a real
+  # failure. Retrying only that signature — and failing fast on anything else —
+  # stops a propagation race from aborting the whole release (0.14.0 hit exactly
+  # this and needed a manual promote/PyPI/GH/site/tweet recovery).
+  smoke_ok_pkg=false
+  for attempt in 1 2 3 4 5 6; do
+    smoke_out=$(npx -y "@plur-ai/$pkg_name@$pkg_ver" --version 2>&1) && smoke_exit=0 || smoke_exit=$?
+    if [ "$smoke_exit" -eq 0 ] && echo "$smoke_out" | grep -q "$pkg_ver"; then
+      smoke_ok_pkg=true
+      break
+    fi
+    # Retry ONLY the transient propagation signature; any other failure is a real
+    # defect (crash, wrong version) — stop retrying and report it below.
+    if echo "$smoke_out" | grep -qiE 'ETARGET|No matching version|notarget'; then
+      [ "$attempt" -lt 6 ] && { echo -n "(propagating, retry $attempt) "; sleep 8; }
+      continue
+    fi
+    break
+  done
+  if [ "$smoke_ok_pkg" = true ]; then
     echo "✓ ($smoke_out)"
   else
     echo "✗"
-    echo "      Expected exit 0 + version $pkg_ver in output (exit=$smoke_exit): $smoke_out"
+    echo "      Expected exit 0 + version $pkg_ver in output after retries (exit=$smoke_exit): $smoke_out"
     SMOKE_OK=false
   fi
 done
@@ -518,7 +557,17 @@ done
 # Plur class is actually exported at the promoted version, before @latest moves.
 echo -n "  @plur-ai/core@$VERSION install + import → "
 core_exit=0
-npm install --no-save --no-audit --no-fund "@plur-ai/core@$VERSION" > /dev/null 2>&1 || core_exit=$?
+# Same propagation-retry as the --version checks above: the install can ETARGET
+# while @next is still propagating.
+for attempt in 1 2 3 4 5 6; do
+  core_install_out=$(npm install --no-save --no-audit --no-fund "@plur-ai/core@$VERSION" 2>&1) && core_exit=0 || core_exit=$?
+  [ "$core_exit" -eq 0 ] && break
+  if echo "$core_install_out" | grep -qiE 'ETARGET|No matching version|notarget'; then
+    [ "$attempt" -lt 6 ] && { echo -n "(propagating, retry $attempt) "; sleep 8; }
+    continue
+  fi
+  break
+done
 if [ "$core_exit" -eq 0 ]; then
   core_out=$(node --input-type=module -e "import('@plur-ai/core').then(m => process.exit(typeof m.Plur === 'function' ? 0 : 3)).catch(e => { console.error(e && e.message); process.exit(4) })" 2>&1) && core_exit=0 || core_exit=$?
 fi


### PR DESCRIPTION
Two release-robustness fixes prompted by the **0.14.0 release**, which aborted mid-publish on a transient npm-propagation race and needed a full manual recovery (promote → PyPI → GH release → website → tweet).

## 1. Smoke-test retry (Step 5b) — the root cause
The `@next` canary smoke test did a single `npx @plur-ai/<pkg>@<ver> --version`. A package published to `@next` seconds earlier can still be propagating and return `ETARGET` ("no matching version") — **not** a real failure. 0.14.0 hit exactly this: cli+mcp `--version` failed on timing, the smoke aborted, and `@latest` was left on 0.13.0 while everything else needed manual completion.

Now each check **retries up to 6× (8s apart), but only on the propagation signature** (`ETARGET`/`no matching version`/`notarget`); any other failure (crash, wrong version) still fails fast. The core install+import smoke gets the same retry.

## 2. Website version pre-flight (Step 3.8)
Step 8 only *deploys* the website (rsync); it never updates content. A forgotten `softwareVersion` bump would ship a stale site and only warn *after* deploy. Step 3.8 aborts **before any publish** if `../website/index.html`'s `softwareVersion` ≠ `$VERSION`. Skipped when the website dir is absent. (Per the convention that the website is updated every release.)

Step-order header + `RELEASING.md` updated to document both. `bash -n` clean.

Follows the 0.14.0 publish (npm/PyPI/GH/site/tweet all live at 0.14.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)