### PR TITLE
fix(core): guarantee generateInjectionId/generateEventId uniqueness

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -77,13 +77,16 @@ export function readHistoryForEngram(root: string, engramId: string): HistoryEve
   return events
 }
 
+let _evtSeq = 0
+let _injSeq = 0
+
 /**
  * Generate a unique event ID for history entries.
+ * Uses a per-process counter combined with timestamp to guarantee uniqueness
+ * even when called in rapid succession within the same millisecond.
  */
 export function generateEventId(): string {
-  const ts = Date.now()
-  const rand = Math.random().toString(36).slice(2, 6)
-  return `EVT-${ts}-${rand}`
+  return `EVT-${Date.now()}-${(_evtSeq++).toString(36).padStart(4, '0')}`
 }
 
 // --- Injection provenance (#452) ---
@@ -107,11 +110,11 @@ export function generateEventId(): string {
 
 /**
  * Generate a unique injection ID for co_injection events.
+ * Uses a per-process counter combined with timestamp to guarantee uniqueness
+ * even when called in rapid succession within the same millisecond.
  */
 export function generateInjectionId(): string {
-  const ts = Date.now()
-  const rand = Math.random().toString(36).slice(2, 6)
-  return `INJ-${ts}-${rand}`
+  return `INJ-${Date.now()}-${(_injSeq++).toString(36).padStart(4, '0')}`
 }
 
 /**


### PR DESCRIPTION
## Problem

`generateInjectionId()` and `generateEventId()` used `Date.now()` (ms precision) plus a 4-character base-36 random suffix. When many IDs are generated in rapid succession within the same millisecond, uniqueness depends entirely on the 4-char suffix (36⁴ = 1,679,616 possibilities). Birthday collision probability for 50 samples is ~0.07% — rare but real.

This surfaced as an intermittent CI failure on PR #592 (Node 20, docs-only changes):
```
AssertionError: expected 49 to be 50
❯ test/co-injection-logging.test.ts:52:24
```

## Fix

Replace the random suffix with a per-process monotonic counter (`_evtSeq`, `_injSeq`). The ID format is unchanged — `INJ-<ts>-<4-char base36>` — so the existing test regex `[a-z0-9]{4}` still passes. Counter produces `0000`, `0001`, ..., `zzzz` (up to 1.68M unique IDs per process lifetime, unreachable in practice).

## Verified

- `co-injection-logging.test.ts`: 23 passed (was 1 flaky fail at ~0.07% rate)
- Generated 50 IDs in tight loop: `unique: 50` every time
- Regex `^INJ-\d+-[a-z0-9]{4}$` still matches

Closes the flake exposed in #592's CI run. Also fixes `generateEventId()` for consistency — same pattern, same potential issue.