### PR TITLE
infra(heartbeat): parameterize User/Group via DEPLOY_USER (closes #597)

### DIFF
--- a/infra/heartbeat/deploy.sh
+++ b/infra/heartbeat/deploy.sh
@@ -19,7 +19,7 @@ sudo cp "$SCRIPT_DIR/query.py" /opt/plur-heartbeat/query.py 2>/dev/null || true
 sudo chown -R "${DEPLOY_USER}:${DEPLOY_USER}" /opt/plur-heartbeat /var/lib/plur-heartbeat
 
 echo "==> Installing systemd unit"
-sudo cp "$SCRIPT_DIR/plur-heartbeat.service" /etc/systemd/system/plur-heartbeat.service
+sed "s/__DEPLOY_USER__/${DEPLOY_USER}/g" "$SCRIPT_DIR/plur-heartbeat.service" | sudo tee /etc/systemd/system/plur-heartbeat.service > /dev/null
 sudo systemctl daemon-reload
 sudo systemctl enable --now plur-heartbeat
 sudo systemctl status plur-heartbeat --no-pager

--- a/infra/heartbeat/plur-heartbeat.service
+++ b/infra/heartbeat/plur-heartbeat.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-User=gregor
-Group=gregor
+User=__DEPLOY_USER__
+Group=__DEPLOY_USER__
 ExecStart=/usr/bin/python3 /opt/plur-heartbeat/server.py
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Summary

- Replace `User=gregor` / `Group=gregor` in `plur-heartbeat.service` with `__DEPLOY_USER__` placeholders
- `deploy.sh` already parameterizes ownership via `${DEPLOY_USER:-$(whoami)}`; the unit install step now uses the same variable via `sed` substitution before writing to `/etc/systemd/system/`

This makes the infra files operator-agnostic — no personal identifiers remain in the public repo.

## Test plan

- [ ] Dry-run: `sed "s/__DEPLOY_USER__/testuser/g" infra/heartbeat/plur-heartbeat.service` outputs `User=testuser` / `Group=testuser`
- [ ] Sweep: `grep -rn "gregor" infra/` returns empty

Closes #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)