### PR TITLE
feat(infra): north-star MAU metric — query.py --mau + daily timer (closes #542)

### DIFF
--- a/infra/heartbeat/deploy.sh
+++ b/infra/heartbeat/deploy.sh
@@ -13,16 +13,21 @@ DEPLOY_USER="${DEPLOY_USER:-$(whoami)}"
 : "${CERTBOT_EMAIL:?CERTBOT_EMAIL env var is required for Phase 2 (certbot TLS)}"
 
 echo "==> Installing backend"
-sudo mkdir -p /opt/plur-heartbeat /var/lib/plur-heartbeat
+sudo mkdir -p /opt/plur-heartbeat /var/lib/plur-heartbeat /var/lib/plur-metrics
 sudo cp "$SCRIPT_DIR/server.py" /opt/plur-heartbeat/server.py
 sudo cp "$SCRIPT_DIR/query.py" /opt/plur-heartbeat/query.py 2>/dev/null || true
-sudo chown -R "${DEPLOY_USER}:${DEPLOY_USER}" /opt/plur-heartbeat /var/lib/plur-heartbeat
+sudo chown -R "${DEPLOY_USER}:${DEPLOY_USER}" /opt/plur-heartbeat /var/lib/plur-heartbeat /var/lib/plur-metrics
 
-echo "==> Installing systemd unit"
+echo "==> Installing systemd units (heartbeat ingress + daily MAU timer)"
 sudo cp "$SCRIPT_DIR/plur-heartbeat.service" /etc/systemd/system/plur-heartbeat.service
+sudo cp "$SCRIPT_DIR/plur-metrics.service" /etc/systemd/system/plur-metrics.service
+sudo cp "$SCRIPT_DIR/plur-metrics.timer" /etc/systemd/system/plur-metrics.timer
+sudo sed -i "s/\${DEPLOY_USER:-gregor}/${DEPLOY_USER}/g" /etc/systemd/system/plur-metrics.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now plur-heartbeat
+sudo systemctl enable --now plur-metrics.timer
 sudo systemctl status plur-heartbeat --no-pager
+sudo systemctl status plur-metrics.timer --no-pager
 
 echo "==> Installing nginx config (Phase 1: HTTP)"
 sudo cp "$SCRIPT_DIR/nginx-heartbeat-http.conf" /etc/nginx/sites-available/heartbeat-http

--- a/infra/heartbeat/plur-metrics.service
+++ b/infra/heartbeat/plur-metrics.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=plur daily MAU metric aggregation
+After=network.target
+
+[Service]
+Type=oneshot
+User=${DEPLOY_USER:-gregor}
+Group=${DEPLOY_USER:-gregor}
+ExecStart=/usr/bin/python3 /opt/plur-heartbeat/query.py --mau --write
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=plur-metrics
+
+Environment=HEARTBEAT_DATA_DIR=/var/lib/plur-heartbeat
+Environment=METRICS_DIR=/var/lib/plur-metrics

--- a/infra/heartbeat/plur-metrics.timer
+++ b/infra/heartbeat/plur-metrics.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run plur MAU aggregation daily at 00:05 UTC
+
+[Timer]
+OnCalendar=*-*-* 00:05:00
+AccuracySec=1min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/heartbeat/query.py
+++ b/infra/heartbeat/query.py
@@ -8,6 +8,7 @@ Usage:
   python3 query.py --summary        # full summary stats
   python3 query.py --mau            # north-star MAU/WAU/DAU metric
   python3 query.py --mau --write    # same, but also persist to METRICS_DIR/YYYY-MM-DD.json
+                                   #   and update METRICS_DIR/metrics-latest.json pointer
 
 Data lives in /var/lib/plur-heartbeat/YYYY-MM-DD.jsonl (one record per flush).
 """
@@ -177,8 +178,10 @@ def main():
         result = mau_stats()
         if args.write:
             METRICS_DIR.mkdir(parents=True, exist_ok=True)
+            payload = json.dumps(result, indent=2) + "\n"
             out_path = METRICS_DIR / f"{result['date']}.json"
-            out_path.write_text(json.dumps(result, indent=2) + "\n")
+            out_path.write_text(payload)
+            (METRICS_DIR / "metrics-latest.json").write_text(payload)
         print(json.dumps(result, indent=2))
     elif args.summary:
         result = summary_stats(args.days)

--- a/infra/heartbeat/query.py
+++ b/infra/heartbeat/query.py
@@ -6,6 +6,8 @@ Usage:
   python3 query.py --days 14        # last N days
   python3 query.py --since 2026-07-01  # since a date
   python3 query.py --summary        # full summary stats
+  python3 query.py --mau            # north-star MAU/WAU/DAU metric
+  python3 query.py --mau --write    # same, but also persist to METRICS_DIR/YYYY-MM-DD.json
 
 Data lives in /var/lib/plur-heartbeat/YYYY-MM-DD.jsonl (one record per flush).
 """
@@ -18,6 +20,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 DATA_DIR = Path(os.environ.get("HEARTBEAT_DATA_DIR", "/var/lib/plur-heartbeat"))
+METRICS_DIR = Path(os.environ.get("METRICS_DIR", "/var/lib/plur-metrics"))
 
 
 def load_records(since: date, until: date) -> list[dict]:
@@ -121,23 +124,72 @@ def summary_stats(days: int = 30) -> dict:
     }
 
 
+def mau_stats() -> dict:
+    """
+    North-star metric: monthly_active_mcp_connections.
+    Single pass over 30d of records; computes MAU/WAU/DAU from distinct install_ids.
+    Output written to METRICS_DIR/YYYY-MM-DD.json when --write is used.
+    """
+    today = date.today()
+    since_30d = today - timedelta(days=29)
+    records = load_records(since_30d, today)
+
+    since_7d = today - timedelta(days=6)
+    since_1d = today
+
+    ids_30d: set[str] = set()
+    ids_7d: set[str] = set()
+    ids_1d: set[str] = set()
+
+    for r in records:
+        iid = r.get("install_id")
+        if not iid:
+            continue
+        try:
+            record_date = date.fromisoformat(r.get("date", ""))
+        except ValueError:
+            continue
+        ids_30d.add(iid)
+        if record_date >= since_7d:
+            ids_7d.add(iid)
+        if record_date >= since_1d:
+            ids_1d.add(iid)
+
+    return {
+        "date": today.isoformat(),
+        "mau_30d": len(ids_30d),
+        "wau_7d": len(ids_7d),
+        "dau_1d": len(ids_1d),
+        "total_flushes_30d": len(records),
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="plur heartbeat query tool")
     parser.add_argument("--days", type=int, default=7, help="Lookback window in days (default: 7)")
     parser.add_argument("--since", help="Start date YYYY-MM-DD (overrides --days)")
     parser.add_argument("--summary", action="store_true", help="Full summary with H004 threshold checks")
+    parser.add_argument("--mau", action="store_true", help="North-star MAU/WAU/DAU metric")
+    parser.add_argument("--write", action="store_true", help="With --mau: persist output to METRICS_DIR/YYYY-MM-DD.json")
     args = parser.parse_args()
 
-    if args.summary:
+    if args.mau:
+        result = mau_stats()
+        if args.write:
+            METRICS_DIR.mkdir(parents=True, exist_ok=True)
+            out_path = METRICS_DIR / f"{result['date']}.json"
+            out_path.write_text(json.dumps(result, indent=2) + "\n")
+        print(json.dumps(result, indent=2))
+    elif args.summary:
         result = summary_stats(args.days)
+        print(json.dumps(result, indent=2))
     else:
         days = args.days
         if args.since:
             since = date.fromisoformat(args.since)
             days = (date.today() - since).days + 1
         result = weekly_active_count(days)
-
-    print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

PLUR has no way to measure growth. `monthly_active_mcp_connections` is the north-star metric (#542) and it is not instrumented — distribution decisions are made on gut, not signal.

## What this adds

**`query.py --mau`** — compute `mau_30d` / `wau_7d` / `dau_1d` from the heartbeat JSONL log in a single 30-day pass:

```json
{
  "date": "2026-07-16",
  "mau_30d": 12,
  "wau_7d": 8,
  "dau_1d": 3,
  "total_flushes_30d": 41
}
```

**`--mau --write`** — also persists to `METRICS_DIR/YYYY-MM-DD.json` (default `/var/lib/plur-metrics/`).

**`plur-metrics.timer`** — systemd timer that fires daily at 00:05 UTC, running `query.py --mau --write` via the one-shot `plur-metrics.service`. `Persistent=true` ensures a missed run catches up on next boot.

**`deploy.sh`** — updated to create `/var/lib/plur-metrics/`, install and enable the timer alongside the existing `plur-heartbeat` service.

## Acceptance

- [x] `mau_30d` = distinct `install_id` values with any event in the last 30d
- [x] `wau_7d` / `dau_1d` computed in the same pass (no extra disk reads)
- [x] JSON written to `METRICS_DIR/YYYY-MM-DD.json` when `--write` is used
- [x] Daily timer at 00:05 UTC; `Persistent=true` catches missed runs
- [x] `deploy.sh` installs everything in one pass

## Post-deploy

```bash
systemctl status plur-metrics.timer
python3 /opt/plur-heartbeat/query.py --mau
cat /var/lib/plur-metrics/$(date +%Y-%m-%d).json
```

The heartbeat `ops.metrics-check` cadence can read the file directly once the timer has fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)