### PR TITLE
fix(core): add per-process salt to prevent cross-process ID collisions (closes #600)

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -77,16 +77,28 @@ export function readHistoryForEngram(root: string, engramId: string): HistoryEve
   return events
 }
 
+// Per-process salt — generated once at module load, never reused across processes.
+// Two processes that both call generateEventId/generateInjectionId in the same
+// millisecond will differ unless they happen to draw the same 2-char base36 value
+// (~1/1296 probability), which is far better than the deterministic collision
+// guaranteed by the counter-only format (#596 left this gap, closed here).
+// Note: the counter suffix widens past 4 chars once _seq exceeds 36^4 (1,679,616
+// calls); IDs remain unique and monotonic, but the fixed-width invariant breaks.
+// At typical session rates this takes years; for safety the salt segment makes
+// even a width-collision identifiable across processes.
+const _PROC_SALT = Math.random().toString(36).slice(2, 4).padEnd(2, '0')
+
 let _evtSeq = 0
 let _injSeq = 0
 
 /**
  * Generate a unique event ID for history entries.
- * Uses a per-process counter combined with timestamp to guarantee uniqueness
- * even when called in rapid succession within the same millisecond.
+ * Combines a per-process monotonic counter (intra-process uniqueness from #596)
+ * with a one-time per-process salt (cross-process uniqueness, closes #600).
+ * Format: EVT-<ms>-<counter>-<salt>
  */
 export function generateEventId(): string {
-  return `EVT-${Date.now()}-${(_evtSeq++).toString(36).padStart(4, '0')}`
+  return `EVT-${Date.now()}-${(_evtSeq++).toString(36).padStart(4, '0')}-${_PROC_SALT}`
 }
 
 // --- Injection provenance (#452) ---
@@ -110,11 +122,12 @@ export function generateEventId(): string {
 
 /**
  * Generate a unique injection ID for co_injection events.
- * Uses a per-process counter combined with timestamp to guarantee uniqueness
- * even when called in rapid succession within the same millisecond.
+ * Combines a per-process monotonic counter (intra-process uniqueness from #596)
+ * with a one-time per-process salt (cross-process uniqueness, closes #600).
+ * Format: INJ-<ms>-<counter>-<salt>
  */
 export function generateInjectionId(): string {
-  return `INJ-${Date.now()}-${(_injSeq++).toString(36).padStart(4, '0')}`
+  return `INJ-${Date.now()}-${(_injSeq++).toString(36).padStart(4, '0')}-${_PROC_SALT}`
 }
 
 /**

--- a/packages/core/test/co-injection-logging.test.ts
+++ b/packages/core/test/co-injection-logging.test.ts
@@ -44,7 +44,7 @@ describe('co-injection helpers (#452)', () => {
 
   describe('generateInjectionId', () => {
     it('uses the INJ- prefix', () => {
-      expect(generateInjectionId()).toMatch(/^INJ-\d+-[a-z0-9]{4}$/)
+      expect(generateInjectionId()).toMatch(/^INJ-\d+-[a-z0-9]{4,}-[a-z0-9]{2}$/)
     })
 
     it('generates unique ids', () => {


### PR DESCRIPTION
## Problem

#596 replaced `Math.random()` suffixes with per-process monotonic counters (`_evtSeq`, `_injSeq`), eliminating intra-process same-millisecond collisions. However it introduced a **deterministic** cross-process collision: two processes each generating their first ID in the same millisecond both produce `…-<ts>-0000`.

This matters because the persistent MCP server and hook-spawned CLI processes can call `generateInjectionId()` concurrently, and a collision mis-attributes an `injection_outcome` feedback label to the wrong `co_injection` event — degrading self-labeling quality.

## Fix

Compute a one-time 2-char base36 salt at module load (`_PROC_SALT = Math.random().toString(36).slice(2,4)`) and append it as a fourth dash-separated segment.

- Cross-process collision: 1.0 (deterministic) → ~1/1296 (~0.077%)
- Intra-process deterministic guarantee from #596 fully preserved
- Format: `INJ-<ms>-<counter>-<salt>` (was `INJ-<ms>-<counter>`)

## Changes

- `packages/core/src/history.ts` — add `_PROC_SALT`, update both generators, document format + overflow
- `packages/core/test/co-injection-logging.test.ts` — update format regex to match new shape

## Test

All 33 tests in the affected test files pass (`co-injection-logging.test.ts`, `sp2-history-evolution.test.ts`).

## Checklist

- [x] Injection/event IDs unique across concurrent processes generating in same ms
- [x] Intra-process deterministic uniqueness from #596 preserved
- [x] Format documented (comment + updated test regex)
- [x] Overflow past 36⁴ documented in comment

🤖 heartbeat