### PR TITLE
docs: labels/mentions are signals, not assignments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,11 @@ current scores. If your PR improves any of these, mention it in the PR descripti
   else, coordinate on the issue rather than opening a duplicate parallel fix.
   This binds automated runs too — self-assign or skip if already claimed. See
   `CONTRIBUTING.md`.
+- **Labels are signals, not assignments**: a label or an @-mention is triage/FYI
+  and never a work order — only assignment means someone is on it. Working on
+  it? Assign yourself. Want another party to do it? Assign it to *them* (don't
+  just label or @-mention). Handing off? Reassign. Unassigned = nobody is on it,
+  however many labels it carries.
 - TypeScript, Vitest, tsup, Zod for validation
 - No external API calls in core — search must work offline at zero cost
 - YAML for all persistent storage (not JSON, not SQLite for primary data)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,22 @@ pnpm --filter @plur-ai/core build
 
 7. **Green before merge.** `pnpm test` and `pnpm build` must pass.
 
+### Labels and @-mentions are signals, not assignments
+
+A label (`P0`, `enhancement`, `research`, …) *describes and prioritizes* an
+issue — it is triage and FYI, and never means anyone has committed to doing the
+work. @-mentioning someone in a comment informs them; it does not assign them.
+**Only assignment creates an expectation that the work will happen.**
+
+- **Working on it?** Assign it to yourself (see step 2).
+- **Want someone else to do it?** Assign it to *them* — don't just label the
+  issue or @-mention them and assume it will be picked up.
+- **Handing off work you were assigned?** Reassign it to the new owner and say
+  why, so the assignee always reflects who is actually on it.
+- **Unassigned means nobody is on it**, no matter how many labels it carries.
+
+This binds autonomous agents as much as people: a label is never a work order.
+
 ## Reviewing and merging
 
 Every change lands through a reviewed pull request — no direct pushes to


### PR DESCRIPTION
## Summary

Both `CONTRIBUTING.md` and `CLAUDE.md` already document the *claim-before-you-code* protocol well (self-assign, coordinate if already assigned, binds agents too). What neither stated is the distinction you need for the protocol to actually work:

**A label or an @-mention is triage/FYI — it is not a work order.** Only *assignment* creates an expectation that the work will happen.

This PR adds a short, explicit note to both guides covering:
- **Working on it?** Assign it to yourself.
- **Want someone else to do it?** Assign it to *them* — don't just label or @-mention and assume it will be picked up.
- **Handing off assigned work?** Reassign to the new owner (and say why).
- **Unassigned = nobody is on it**, no matter how many labels it carries.
- Explicitly binds autonomous agents: a label is never a work order.

Complements the CI enforcement already tracked in #593 (warn/auto-assign on PR-open) — this is the written norm that CI check will back.

## Changes
- `CONTRIBUTING.md` — new `### Labels and @-mentions are signals, not assignments` subsection under *Making a change*.
- `CLAUDE.md` — matching compact bullet under the *Claim before you code* convention.

Docs-only; no code, no tests affected.