### PR TITLE
docs: reconcile governance contradictions — test count, package inventory, publish recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Seven packages:
 @plur-ai/mcp        — MCP server (Claude Code, Cursor, Windsurf)
 @plur-ai/claw       — OpenClaw ContextEngine plugin
 @plur-ai/cli        — CLI: init, doctor, compact, admin
-@plur-ai/langchain  — LangChain / LCEL adapter
+plur-langchain      — LangChain / LCEL adapter (Python, PyPI)
 plur-hermes         — Hermes Agent plugin (Python, via CLI bridge)
 plur-ai             — Python SDK (learn/recall/inject for scripts and LangChain)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,19 @@ Persistent memory for AI agents. An agent corrected on Monday remembers on Tuesd
 
 Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant, modeled on human memory (ACT-R activation). Storage is plain YAML on disk. Search is fully local: BM25 + BGE embeddings + Reciprocal Rank Fusion. Zero API calls, zero cloud.
 
-Three packages:
+Seven packages:
 
 ```
-@plur-ai/core   — engram engine (learn, recall, inject, search, decay, sync)
-@plur-ai/mcp    — MCP server (Claude Code, Cursor, Windsurf)
-@plur-ai/claw   — OpenClaw ContextEngine plugin
+@plur-ai/core       — engram engine (learn, recall, inject, search, decay, sync)
+@plur-ai/mcp        — MCP server (Claude Code, Cursor, Windsurf)
+@plur-ai/claw       — OpenClaw ContextEngine plugin
+@plur-ai/cli        — CLI: init, doctor, compact, admin
+@plur-ai/langchain  — LangChain / LCEL adapter
+plur-hermes         — Hermes Agent plugin (Python, via CLI bridge)
+plur-ai             — Python SDK (learn/recall/inject for scripts and LangChain)
 ```
 
-Core is the engine. MCP and Claw are thin wrappers — MCP exposes tools via Model Context Protocol, Claw hooks into OpenClaw's lifecycle (auto-inject on session start, auto-learn on corrections).
+Core is the engine. MCP, Claw, and Langchain are adapters for their respective ecosystems. CLI is the install and ops tool. Hermes and the Python SDK bridge non-Node runtimes to the same engram store.
 
 ## Development
 
@@ -26,7 +30,7 @@ pnpm build
 pnpm test
 ```
 
-~1045 tests across ~120 files (117 Vitest + Python suites). All must pass before committing.
+~2250 tests across ~197 files. All must pass before committing.
 
 ## Package dependency
 
@@ -57,13 +61,7 @@ Nine places. Miss one and something breaks:
 
 ## Publishing
 
-Authenticate as `plur9`. Core first (it's the dependency):
-
-```
-pnpm --filter @plur-ai/core publish --access public --no-git-checks
-pnpm --filter @plur-ai/mcp publish --access public --no-git-checks
-pnpm --filter @plur-ai/claw publish --access public --no-git-checks
-```
+Follow the full publish procedure in [RELEASING.md](RELEASING.md). It covers all packages (core, mcp, claw, cli, hermes/PyPI, langchain) and the mandatory manifest gate that aborts the release if any user-facing PR is undeclared in the CHANGELOG. Do not drive a release from this file alone — RELEASING.md is the source of truth.
 
 ## Testing a change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,7 @@
 # Contributing to PLUR
 
 Thanks for helping build PLUR — persistent, composable memory for AI agents.
-This monorepo holds `@plur-ai/core` (the engine), `@plur-ai/mcp` (the MCP
-server), and `@plur-ai/claw` (the OpenClaw plugin). For the release process see
-[RELEASING.md](RELEASING.md); for agent/automation working rules see
-[CLAUDE.md](CLAUDE.md).
+This monorepo holds seven packages: `@plur-ai/core` (the engine), `@plur-ai/mcp`, `@plur-ai/claw`, `@plur-ai/cli`, `plur-langchain`, `plur-hermes`, and `plur-ai` (Python SDK). For the full package inventory see [CLAUDE.md](CLAUDE.md); for the release process see [RELEASING.md](RELEASING.md).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ While search is a core part of PLUR (finding the right engram to inject), the se
 | [`@plur-ai/core`](packages/core) | Engram engine — learn, recall, inject, search, decay |
 | [`@plur-ai/mcp`](packages/mcp) | MCP server for Claude Code, Cursor, Windsurf |
 | [`@plur-ai/claw`](packages/claw) | OpenClaw ContextEngine plugin |
+| [`@plur-ai/cli`](packages/cli) | CLI — init, doctor, compact, admin |
+| [`@plur-ai/langchain`](packages/langchain) | LangChain / LCEL adapter |
 | [`plur-hermes`](packages/hermes) | Hermes Agent plugin (Python, via CLI bridge) |
 | [`plur-ai`](packages/python) | Python SDK — learn/recall/inject for LangChain, llama.cpp, scripts |
 
@@ -313,6 +315,8 @@ While search is a core part of PLUR (finding the right engram to inject), the se
 
 @plur-ai/mcp          Wraps core as MCP tools
 @plur-ai/claw          OpenClaw ContextEngine hooks (assemble/compact/afterTurn)
+@plur-ai/cli           CLI: init, doctor, compact, admin
+@plur-ai/langchain     LangChain / LCEL adapter (wraps core)
 plur-hermes            Python plugin for Hermes Agent (auto inject/learn)
 plur-ai                Python SDK — direct learn/recall/inject for scripts and frameworks
 ```
@@ -346,7 +350,7 @@ cd plur
 pnpm install && pnpm build && pnpm test
 ```
 
-~340 tests across 27 files. `pnpm test:watch` for development.
+~2250 tests across ~197 files. `pnpm test:watch` for development.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ While search is a core part of PLUR (finding the right engram to inject), the se
 | [`@plur-ai/mcp`](packages/mcp) | MCP server for Claude Code, Cursor, Windsurf |
 | [`@plur-ai/claw`](packages/claw) | OpenClaw ContextEngine plugin |
 | [`@plur-ai/cli`](packages/cli) | CLI — init, doctor, compact, admin |
-| [`@plur-ai/langchain`](packages/langchain) | LangChain / LCEL adapter |
+| [`plur-langchain`](packages/langchain) | LangChain / LCEL adapter (Python, PyPI) |
 | [`plur-hermes`](packages/hermes) | Hermes Agent plugin (Python, via CLI bridge) |
 | [`plur-ai`](packages/python) | Python SDK — learn/recall/inject for LangChain, llama.cpp, scripts |
 
@@ -316,7 +316,7 @@ While search is a core part of PLUR (finding the right engram to inject), the se
 @plur-ai/mcp          Wraps core as MCP tools
 @plur-ai/claw          OpenClaw ContextEngine hooks (assemble/compact/afterTurn)
 @plur-ai/cli           CLI: init, doctor, compact, admin
-@plur-ai/langchain     LangChain / LCEL adapter (wraps core)
+plur-langchain         LangChain / LCEL adapter (Python, PyPI)
 plur-hermes            Python plugin for Hermes Agent (auto inject/learn)
 plur-ai                Python SDK — direct learn/recall/inject for scripts and frameworks
 ```


### PR DESCRIPTION
Closes #616.

## Summary

Three governance-doc contradictions fixed, all docs-only:

- **Test count**: README said ~340/27 files, CLAUDE said ~1045/120 files. Actual (verified via `git ls-tree | grep test | xargs grep -c`) is ~2250 tests across ~197 files. Both updated.
- **Package inventory**: CLAUDE.md said "Three packages" (core/mcp/claw); README listed five; RELEASING.md listed four. Now consistently lists all seven: core, mcp, claw, cli, langchain, hermes, python.
- **Publish recipe**: CLAUDE.md carried an incomplete publish snippet (skipped cli, hermes, python, langchain, and the manifest gate). Now defers to RELEASING.md as the single source of truth.

## What was NOT changed

- Version-bump checklist ("Nine places") — that's a separate decision (#615, requires first deciding whether claw is intentionally on its own version track).
- No code or test changes.

🤖 heartbeat — docs.governance-fix — 2026-07-17