### PR TITLE
docs: fix version-bump checklist + reconcile package inventory and test count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pnpm --filter @plur-ai/core build
 
 `scripts/release.sh` is the authoritative source. Two independent version tracks:
 
-**Standard release** (core / mcp / cli — always bumped together):
+**Standard release** (core / mcp / cli / hermes / python — always bumped together):
 
 1. `packages/core/package.json`
 2. `packages/mcp/package.json`
@@ -59,10 +59,12 @@ pnpm --filter @plur-ai/core build
 6. `packages/cli/src/index.ts` — `const VERSION`
 7. `packages/mcp/test/server.test.ts` — version assertions
 8. `packages/hermes/pyproject.toml`
-9. `packages/hermes/plur_hermes/skills/plur-memory.SKILL.md` — frontmatter `version:`
-10. `packages/hermes/plur_hermes/bridge.py` — `_NPX_CLI_VERSION`
-11. `packages/python/pyproject.toml`
-12. `packages/python/plur_ai/bridge.py` — `_NPX_CLI_VERSION`
+9. `packages/hermes/plugin.yaml` — top-level `version:` field
+10. `packages/hermes/plur_hermes/skills/plur-memory.SKILL.md` — frontmatter `version:`
+11. `packages/hermes/plur_hermes/bridge.py` — `_NPX_CLI_VERSION`
+12. `packages/python/pyproject.toml`
+13. `packages/python/plur_ai/bridge.py` — `_NPX_CLI_VERSION`
+14. `skills/plur-memory/SKILL.md` — frontmatter `version:` (standalone skills.sh copy)
 
 **Claw track** (independent — only bumped when `--claw <ver>` is passed to release.sh):
 
@@ -71,6 +73,11 @@ pnpm --filter @plur-ai/core build
 - `packages/claw/src/context-engine.ts` — `version:` in info object
 - `packages/claw/openclaw.plugin.json` — `version` field
 - `packages/claw/test/hello.test.ts` — version assertion
+
+**Langchain track** (independent — bumped separately when `plur-langchain` ships):
+
+- `packages/langchain/pyproject.toml`
+- `packages/langchain/plur_langchain/__init__.py` — `__version__`
 
 ## Publishing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,16 @@ Persistent memory for AI agents. An agent corrected on Monday remembers on Tuesd
 
 Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant, modeled on human memory (ACT-R activation). Storage is plain YAML on disk. Search is fully local: BM25 + BGE embeddings + Reciprocal Rank Fusion. Zero API calls, zero cloud.
 
-Three packages:
+Seven packages (four npm, three Python/PyPI):
 
 ```
-@plur-ai/core   — engram engine (learn, recall, inject, search, decay, sync)
-@plur-ai/mcp    — MCP server (Claude Code, Cursor, Windsurf)
-@plur-ai/claw   — OpenClaw ContextEngine plugin
+@plur-ai/core        — engram engine (learn, recall, inject, search, decay, sync)
+@plur-ai/mcp         — MCP server (Claude Code, Cursor, Windsurf)
+@plur-ai/claw        — OpenClaw ContextEngine plugin
+@plur-ai/cli         — CLI (plur learn / recall / inject / status)
+plur-hermes          — Hermes Agent plugin (Python, via CLI bridge)
+plur-ai              — Python SDK (LangChain, llama.cpp, scripts)
+plur-langchain       — LangChain BaseMemory + BaseChatMessageHistory adapter
 ```
 
 Core is the engine. MCP and Claw are thin wrappers — MCP exposes tools via Model Context Protocol, Claw hooks into OpenClaw's lifecycle (auto-inject on session start, auto-learn on corrections).
@@ -26,7 +30,7 @@ pnpm build
 pnpm test
 ```
 
-~1045 tests across ~120 files (117 Vitest + Python suites). All must pass before committing.
+~3500 tests across ~200 files (Vitest + Python suites). All must pass before committing.
 
 ## Package dependency
 
@@ -70,13 +74,16 @@ pnpm --filter @plur-ai/core build
 
 ## Publishing
 
-Authenticate as `plur9`. Core first (it's the dependency):
+See [RELEASING.md](RELEASING.md) for the authoritative publish procedure (including the manifest gate that runs before any irreversible step). Quick reference for npm packages — authenticate as `plur9` first, publish core before dependents:
 
 ```
 pnpm --filter @plur-ai/core publish --access public --no-git-checks
 pnpm --filter @plur-ai/mcp publish --access public --no-git-checks
 pnpm --filter @plur-ai/claw publish --access public --no-git-checks
+pnpm --filter @plur-ai/cli publish --access public --no-git-checks
 ```
+
+Python packages (`plur-hermes`, `plur-ai`, `plur-langchain`) ship via PyPI — see RELEASING.md for the build/twine workflow.
 
 ## Testing a change
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,17 +43,30 @@ pnpm --filter @plur-ai/core build
 
 ## Version bumps
 
-Nine places. Miss one and something breaks:
+`scripts/release.sh` is the authoritative source. Two independent version tracks:
+
+**Standard release** (core / mcp / cli — always bumped together):
 
 1. `packages/core/package.json`
 2. `packages/mcp/package.json`
-3. `packages/mcp/src/version.ts` — `VERSION` (shared by server.ts and tools.ts)
-4. `packages/mcp/src/index.ts` — `const VERSION` (CLI)
-5. `packages/claw/package.json`
-6. `packages/claw/src/index.ts` — `version:` in plugin object
-7. `packages/claw/src/context-engine.ts` — `version:` in info object
-8. `packages/claw/openclaw.plugin.json` — `version` field
-9. `packages/claw/test/hello.test.ts` + `packages/mcp/test/server.test.ts` — version assertions
+3. `packages/cli/package.json`
+4. `packages/mcp/src/version.ts` — `export const VERSION`
+5. `packages/mcp/src/index.ts` — `const VERSION`
+6. `packages/cli/src/index.ts` — `const VERSION`
+7. `packages/mcp/test/server.test.ts` — version assertions
+8. `packages/hermes/pyproject.toml`
+9. `packages/hermes/plur_hermes/skills/plur-memory.SKILL.md` — frontmatter `version:`
+10. `packages/hermes/plur_hermes/bridge.py` — `_NPX_CLI_VERSION`
+11. `packages/python/pyproject.toml`
+12. `packages/python/plur_ai/bridge.py` — `_NPX_CLI_VERSION`
+
+**Claw track** (independent — only bumped when `--claw <ver>` is passed to release.sh):
+
+- `packages/claw/package.json`
+- `packages/claw/src/index.ts` — `version:` in plugin object
+- `packages/claw/src/context-engine.ts` — `version:` in info object
+- `packages/claw/openclaw.plugin.json` — `version` field
+- `packages/claw/test/hello.test.ts` — version assertion
 
 ## Publishing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing to PLUR
 
 Thanks for helping build PLUR — persistent, composable memory for AI agents.
-This monorepo holds `@plur-ai/core` (the engine), `@plur-ai/mcp` (the MCP
-server), and `@plur-ai/claw` (the OpenClaw plugin). For the release process see
-[RELEASING.md](RELEASING.md); for agent/automation working rules see
-[CLAUDE.md](CLAUDE.md).
+This monorepo holds seven packages: `@plur-ai/core` (the engine), `@plur-ai/mcp`
+(the MCP server), `@plur-ai/claw` (the OpenClaw plugin), `@plur-ai/cli` (the CLI),
+`plur-hermes` (Hermes Agent plugin), `plur-ai` (Python SDK), and `plur-langchain`
+(LangChain adapter). For the release process see [RELEASING.md](RELEASING.md); for
+agent/automation working rules see [CLAUDE.md](CLAUDE.md).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -292,8 +292,10 @@ While search is a core part of PLUR (finding the right engram to inject), the se
 | [`@plur-ai/core`](packages/core) | Engram engine — learn, recall, inject, search, decay |
 | [`@plur-ai/mcp`](packages/mcp) | MCP server for Claude Code, Cursor, Windsurf |
 | [`@plur-ai/claw`](packages/claw) | OpenClaw ContextEngine plugin |
+| [`@plur-ai/cli`](packages/cli) | CLI — plur learn / recall / inject / status |
 | [`plur-hermes`](packages/hermes) | Hermes Agent plugin (Python, via CLI bridge) |
 | [`plur-ai`](packages/python) | Python SDK — learn/recall/inject for LangChain, llama.cpp, scripts |
+| [`plur-langchain`](packages/langchain) | LangChain BaseMemory + BaseChatMessageHistory adapter |
 
 ## Architecture
 
@@ -346,7 +348,7 @@ cd plur
 pnpm install && pnpm build && pnpm test
 ```
 
-~340 tests across 27 files. `pnpm test:watch` for development.
+~3500 tests across ~200 files. `pnpm test:watch` for development.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For **multi-project setups**, use domain/scope to separate knowledge:
 
 ```bash
 cd ~/projects/my-app
-npx @plur-ai/cli@0.10.1 init --domain myapp --scope project:my-app
+npx @plur-ai/cli init --domain myapp --scope project:my-app
 ```
 
 This creates a `.plur.yaml` in the project with defaults that hooks apply automatically. Engrams learned in that project are tagged; recall filters by scope but always includes global knowledge.
@@ -101,10 +101,10 @@ That's it. PLUR works in the background from here. No workflow changes needed â€
 
 ```bash
 pip install plur-hermes
-npm install -g @plur-ai/cli@0.10.1
+npm install -g @plur-ai/cli
 ```
 
-The plugin registers automatically via Hermes' plugin system. It injects relevant memories before each LLM call, extracts learnings from agent responses, and exposes all PLUR tools to the agent. Hermes shells out to the PLUR CLI; current verified pairing is `plur-hermes==0.10.0` with `@plur-ai/cli@0.10.1`.
+The plugin registers automatically via Hermes' plugin system. It injects relevant memories before each LLM call, extracts learnings from agent responses, and exposes all PLUR tools to the agent. Hermes shells out to the PLUR CLI.
 
 ### Python SDK (LangChain, llama.cpp, scripts)
 
@@ -112,7 +112,7 @@ For Python environments that aren't Hermes:
 
 ```bash
 pip install plur-ai
-npm install -g @plur-ai/cli@0.10.1   # bridge (required)
+npm install -g @plur-ai/cli   # bridge (required)
 ```
 
 ```python

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,8 @@
 # Releasing
 
-This repo publishes four npm packages from `packages/`:
+This repo publishes four npm packages and three Python/PyPI packages from `packages/`:
+
+**npm:**
 
 | Package | npm name |
 |---|---|
@@ -9,7 +11,15 @@ This repo publishes four npm packages from `packages/`:
 | `claw` | `@plur-ai/claw` |
 | `cli` | `@plur-ai/cli` |
 
-`hermes` (Python) ships through a separate PyPI pipeline and is out of scope for this guide.
+**Python/PyPI** (separate pipeline — build + twine, not pnpm):
+
+| Package | PyPI name |
+|---|---|
+| `hermes` | `plur-hermes` |
+| `python` | `plur-ai` |
+| `langchain` | `plur-langchain` |
+
+This guide covers the npm release workflow. Python packages follow the same versioning cadence but ship via `python -m build` + `twine upload`.
 
 Publishing credentials (npm auth as `plur9`, the pending `NPM_TOKEN` repo secret, ClawHub OAuth)
 are documented in [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -152,8 +152,8 @@ until `cli@0.9.3` was bumped (#64) and republished.
    done
    ```
 2. If a consumer's published `core` pin is older than the fix, that consumer is shipping the
-   broken dep. Bump it: follow the nine-place version-bump checklist in `CLAUDE.md`
-   (package.json + in-source `VERSION` constants + test assertions), open a PR, merge.
+   broken dep. Bump it: follow the version-bump checklist in `CLAUDE.md`
+   (standard-release surfaces: package.json + VERSION constants + test assertions + hermes/python pins), open a PR, merge.
 3. After merge, run the **Manual publish** recipe above for each bumped consumer.
 4. Verify the pin landed:
    ```sh

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,16 +7,14 @@ PLUR stores corrections, preferences, and patterns as **engrams** that strengthe
 ## Install
 
 ```bash
-npm install -g @plur-ai/cli@0.9.4
+npm install -g @plur-ai/cli
 ```
 
 Or use without installing:
 
 ```bash
-npx @plur-ai/cli@0.9.4 status
+npx @plur-ai/cli status
 ```
-
-> Current verified CLI release: `@plur-ai/cli@0.9.4`.
 
 ## Quick Start
 

--- a/packages/hermes/plugin.yaml
+++ b/packages/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: plur
-version: 0.1.1
+version: 0.14.0
 description: Persistent memory that improves over time — learn, recall, inject, forget, feedback, meta-engram extraction
 provides_tools:
   - plur_learn

--- a/skills/plur-memory/SKILL.md
+++ b/skills/plur-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plur-memory
 description: Persistent learning for AI agents. Open engram format. Your agent learns from corrections, remembers across sessions, and transfers knowledge across domains.
-version: 0.9.0
+version: 0.14.0
 metadata:
   hermes:
     tags: [memory, learning, knowledge, engrams]


### PR DESCRIPTION
Closes #615.
Closes #616.
Closes #618.

## Summary

Three related audit findings from the 2026-07 codebase/docs consistency audit:

### #615 — Version-bump checklist stale (first commit)

- **Missing surfaces**: `cli`, `hermes`, and `python` are bumped on every standard release by `scripts/release.sh`, but the checklist omitted them entirely.
- **Misleading claw placement**: All five claw surfaces were listed alongside core/mcp surfaces with no indication that claw is on an **independent version track** — only bumped when `--claw <ver>` is explicitly passed to `release.sh`. This is why claw is at `0.10.0` while core/mcp/cli are at `0.14.0`: that's correct and intentional.
- Renamed "Nine places" → two explicit subsections: **Standard release** (12 surfaces) and **Claw track** (5 surfaces).

### #616 — Governance docs contradict on test count, package inventory, and publish recipe (second commit)

- **Package inventory**: CLAUDE.md said "Three packages", CONTRIBUTING.md listed only core/mcp/claw, README had five, RELEASING.md said "four npm". Actual is seven (four npm + three Python/PyPI including `plur-langchain` from #529). All docs now agree.
- **Test count**: CLAUDE.md ~1045/~120, README ~340/27, actual ~3500/~200. Both updated.
- **Publish recipe**: CLAUDE.md's Publishing section was narrower than RELEASING.md (missing `@plur-ai/cli` and all Python packages), so an agent following CLAUDE.md alone would ship an incomplete release. Section now defers to RELEASING.md as source of truth and lists all four npm packages.

### #618 — README install commands pin stale versions (fourth commit)

- Root `README.md` and `packages/cli/README.md` had install commands pinned to `@plur-ai/cli@0.9.4` / `@0.10.1` (4–5 minors behind current `0.14.0`).
- Dropped all pins — install commands now use `@plur-ai/cli` without a version, which resolves to `@latest` and is self-maintaining going forward.

## What changed

- `CLAUDE.md`: package list (3→7), test count (~1045/~120 → ~3500/~200), Publishing section (defer to RELEASING.md + add missing packages)
- `README.md`: test count (~340/27 → ~3500/~200), Packages table (5→7 rows, add `@plur-ai/cli` and `plur-langchain`), install pins dropped
- `CONTRIBUTING.md`: package list (core/mcp/claw → all seven)
- `RELEASING.md`: "four npm packages" → four npm + three Python/PyPI, with a separate table
- `packages/cli/README.md`: stale `@0.9.4` pins dropped, "Current verified CLI release" line removed
- `packages/hermes/plugin.yaml`, `skills/plur-memory/SKILL.md`: version corrected (third commit)

Docs-only. No version bumps, no code changes.

🤖 heartbeat — docs.governance-reconcile — 2026-07-17