### PR TITLE
fix(core): RemoteStore.load() — no cache poisoning on mid-pagination error (closes #550)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pnpm --filter @plur-ai/core build
 
 `scripts/release.sh` is the authoritative source. Two independent version tracks:
 
-**Standard release** (core / mcp / cli — always bumped together):
+**Standard release** (core / mcp / cli / hermes / python — always bumped together):
 
 1. `packages/core/package.json`
 2. `packages/mcp/package.json`
@@ -59,10 +59,12 @@ pnpm --filter @plur-ai/core build
 6. `packages/cli/src/index.ts` — `const VERSION`
 7. `packages/mcp/test/server.test.ts` — version assertions
 8. `packages/hermes/pyproject.toml`
-9. `packages/hermes/plur_hermes/skills/plur-memory.SKILL.md` — frontmatter `version:`
-10. `packages/hermes/plur_hermes/bridge.py` — `_NPX_CLI_VERSION`
-11. `packages/python/pyproject.toml`
-12. `packages/python/plur_ai/bridge.py` — `_NPX_CLI_VERSION`
+9. `packages/hermes/plugin.yaml` — top-level `version:` field
+10. `packages/hermes/plur_hermes/skills/plur-memory.SKILL.md` — frontmatter `version:`
+11. `packages/hermes/plur_hermes/bridge.py` — `_NPX_CLI_VERSION`
+12. `packages/python/pyproject.toml`
+13. `packages/python/plur_ai/bridge.py` — `_NPX_CLI_VERSION`
+14. `skills/plur-memory/SKILL.md` — frontmatter `version:` (standalone skills.sh copy)
 
 **Claw track** (independent — only bumped when `--claw <ver>` is passed to release.sh):
 
@@ -71,6 +73,11 @@ pnpm --filter @plur-ai/core build
 - `packages/claw/src/context-engine.ts` — `version:` in info object
 - `packages/claw/openclaw.plugin.json` — `version` field
 - `packages/claw/test/hello.test.ts` — version assertion
+
+**Langchain track** (independent — bumped separately when `plur-langchain` ships):
+
+- `packages/langchain/pyproject.toml`
+- `packages/langchain/plur_langchain/__init__.py` — `__version__`
 
 ## Publishing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,16 @@ Persistent memory for AI agents. An agent corrected on Monday remembers on Tuesd
 
 Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant, modeled on human memory (ACT-R activation). Storage is plain YAML on disk. Search is fully local: BM25 + BGE embeddings + Reciprocal Rank Fusion. Zero API calls, zero cloud.
 
-Three packages:
+Seven packages (four npm, three Python/PyPI):
 
 ```
-@plur-ai/core   — engram engine (learn, recall, inject, search, decay, sync)
-@plur-ai/mcp    — MCP server (Claude Code, Cursor, Windsurf)
-@plur-ai/claw   — OpenClaw ContextEngine plugin
+@plur-ai/core        — engram engine (learn, recall, inject, search, decay, sync)
+@plur-ai/mcp         — MCP server (Claude Code, Cursor, Windsurf)
+@plur-ai/claw        — OpenClaw ContextEngine plugin
+@plur-ai/cli         — CLI (plur learn / recall / inject / status)
+plur-hermes          — Hermes Agent plugin (Python, via CLI bridge)
+plur-ai              — Python SDK (LangChain, llama.cpp, scripts)
+plur-langchain       — LangChain BaseMemory + BaseChatMessageHistory adapter
 ```
 
 Core is the engine. MCP and Claw are thin wrappers — MCP exposes tools via Model Context Protocol, Claw hooks into OpenClaw's lifecycle (auto-inject on session start, auto-learn on corrections).
@@ -26,7 +30,7 @@ pnpm build
 pnpm test
 ```
 
-~1045 tests across ~120 files (117 Vitest + Python suites). All must pass before committing.
+~3500 tests across ~200 files (Vitest + Python suites). All must pass before committing.
 
 ## Package dependency
 
@@ -70,13 +74,16 @@ pnpm --filter @plur-ai/core build
 
 ## Publishing
 
-Authenticate as `plur9`. Core first (it's the dependency):
+See [RELEASING.md](RELEASING.md) for the authoritative publish procedure (including the manifest gate that runs before any irreversible step). Quick reference for npm packages — authenticate as `plur9` first, publish core before dependents:
 
 ```
 pnpm --filter @plur-ai/core publish --access public --no-git-checks
 pnpm --filter @plur-ai/mcp publish --access public --no-git-checks
 pnpm --filter @plur-ai/claw publish --access public --no-git-checks
+pnpm --filter @plur-ai/cli publish --access public --no-git-checks
 ```
+
+Python packages (`plur-hermes`, `plur-ai`, `plur-langchain`) ship via PyPI — see RELEASING.md for the build/twine workflow.
 
 ## Testing a change
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,17 +43,30 @@ pnpm --filter @plur-ai/core build
 
 ## Version bumps
 
-Nine places. Miss one and something breaks:
+`scripts/release.sh` is the authoritative source. Two independent version tracks:
+
+**Standard release** (core / mcp / cli — always bumped together):
 
 1. `packages/core/package.json`
 2. `packages/mcp/package.json`
-3. `packages/mcp/src/version.ts` — `VERSION` (shared by server.ts and tools.ts)
-4. `packages/mcp/src/index.ts` — `const VERSION` (CLI)
-5. `packages/claw/package.json`
-6. `packages/claw/src/index.ts` — `version:` in plugin object
-7. `packages/claw/src/context-engine.ts` — `version:` in info object
-8. `packages/claw/openclaw.plugin.json` — `version` field
-9. `packages/claw/test/hello.test.ts` + `packages/mcp/test/server.test.ts` — version assertions
+3. `packages/cli/package.json`
+4. `packages/mcp/src/version.ts` — `export const VERSION`
+5. `packages/mcp/src/index.ts` — `const VERSION`
+6. `packages/cli/src/index.ts` — `const VERSION`
+7. `packages/mcp/test/server.test.ts` — version assertions
+8. `packages/hermes/pyproject.toml`
+9. `packages/hermes/plur_hermes/skills/plur-memory.SKILL.md` — frontmatter `version:`
+10. `packages/hermes/plur_hermes/bridge.py` — `_NPX_CLI_VERSION`
+11. `packages/python/pyproject.toml`
+12. `packages/python/plur_ai/bridge.py` — `_NPX_CLI_VERSION`
+
+**Claw track** (independent — only bumped when `--claw <ver>` is passed to release.sh):
+
+- `packages/claw/package.json`
+- `packages/claw/src/index.ts` — `version:` in plugin object
+- `packages/claw/src/context-engine.ts` — `version:` in info object
+- `packages/claw/openclaw.plugin.json` — `version` field
+- `packages/claw/test/hello.test.ts` — version assertion
 
 ## Publishing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing to PLUR
 
 Thanks for helping build PLUR — persistent, composable memory for AI agents.
-This monorepo holds `@plur-ai/core` (the engine), `@plur-ai/mcp` (the MCP
-server), and `@plur-ai/claw` (the OpenClaw plugin). For the release process see
-[RELEASING.md](RELEASING.md); for agent/automation working rules see
-[CLAUDE.md](CLAUDE.md).
+This monorepo holds seven packages: `@plur-ai/core` (the engine), `@plur-ai/mcp`
+(the MCP server), `@plur-ai/claw` (the OpenClaw plugin), `@plur-ai/cli` (the CLI),
+`plur-hermes` (Hermes Agent plugin), `plur-ai` (Python SDK), and `plur-langchain`
+(LangChain adapter). For the release process see [RELEASING.md](RELEASING.md); for
+agent/automation working rules see [CLAUDE.md](CLAUDE.md).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -292,8 +292,10 @@ While search is a core part of PLUR (finding the right engram to inject), the se
 | [`@plur-ai/core`](packages/core) | Engram engine — learn, recall, inject, search, decay |
 | [`@plur-ai/mcp`](packages/mcp) | MCP server for Claude Code, Cursor, Windsurf |
 | [`@plur-ai/claw`](packages/claw) | OpenClaw ContextEngine plugin |
+| [`@plur-ai/cli`](packages/cli) | CLI — plur learn / recall / inject / status |
 | [`plur-hermes`](packages/hermes) | Hermes Agent plugin (Python, via CLI bridge) |
 | [`plur-ai`](packages/python) | Python SDK — learn/recall/inject for LangChain, llama.cpp, scripts |
+| [`plur-langchain`](packages/langchain) | LangChain BaseMemory + BaseChatMessageHistory adapter |
 
 ## Architecture
 
@@ -346,7 +348,7 @@ cd plur
 pnpm install && pnpm build && pnpm test
 ```
 
-~340 tests across 27 files. `pnpm test:watch` for development.
+~3500 tests across ~200 files. `pnpm test:watch` for development.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For **multi-project setups**, use domain/scope to separate knowledge:
 
 ```bash
 cd ~/projects/my-app
-npx @plur-ai/cli@0.10.1 init --domain myapp --scope project:my-app
+npx @plur-ai/cli init --domain myapp --scope project:my-app
 ```
 
 This creates a `.plur.yaml` in the project with defaults that hooks apply automatically. Engrams learned in that project are tagged; recall filters by scope but always includes global knowledge.
@@ -101,10 +101,10 @@ That's it. PLUR works in the background from here. No workflow changes needed â€
 
 ```bash
 pip install plur-hermes
-npm install -g @plur-ai/cli@0.10.1
+npm install -g @plur-ai/cli
 ```
 
-The plugin registers automatically via Hermes' plugin system. It injects relevant memories before each LLM call, extracts learnings from agent responses, and exposes all PLUR tools to the agent. Hermes shells out to the PLUR CLI; current verified pairing is `plur-hermes==0.10.0` with `@plur-ai/cli@0.10.1`.
+The plugin registers automatically via Hermes' plugin system. It injects relevant memories before each LLM call, extracts learnings from agent responses, and exposes all PLUR tools to the agent. Hermes shells out to the PLUR CLI.
 
 ### Python SDK (LangChain, llama.cpp, scripts)
 
@@ -112,7 +112,7 @@ For Python environments that aren't Hermes:
 
 ```bash
 pip install plur-ai
-npm install -g @plur-ai/cli@0.10.1   # bridge (required)
+npm install -g @plur-ai/cli   # bridge (required)
 ```
 
 ```python

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,8 @@
 # Releasing
 
-This repo publishes four npm packages from `packages/`:
+This repo publishes four npm packages and three Python/PyPI packages from `packages/`:
+
+**npm:**
 
 | Package | npm name |
 |---|---|
@@ -9,7 +11,15 @@ This repo publishes four npm packages from `packages/`:
 | `claw` | `@plur-ai/claw` |
 | `cli` | `@plur-ai/cli` |
 
-`hermes` (Python) ships through a separate PyPI pipeline and is out of scope for this guide.
+**Python/PyPI** (separate pipeline — build + twine, not pnpm):
+
+| Package | PyPI name |
+|---|---|
+| `hermes` | `plur-hermes` |
+| `python` | `plur-ai` |
+| `langchain` | `plur-langchain` |
+
+This guide covers the npm release workflow. Python packages follow the same versioning cadence but ship via `python -m build` + `twine upload`.
 
 Publishing credentials (npm auth as `plur9`, the pending `NPM_TOKEN` repo secret, ClawHub OAuth)
 are documented in [`docs/runbooks/credentials.md`](docs/runbooks/credentials.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -152,8 +152,8 @@ until `cli@0.9.3` was bumped (#64) and republished.
    done
    ```
 2. If a consumer's published `core` pin is older than the fix, that consumer is shipping the
-   broken dep. Bump it: follow the nine-place version-bump checklist in `CLAUDE.md`
-   (package.json + in-source `VERSION` constants + test assertions), open a PR, merge.
+   broken dep. Bump it: follow the version-bump checklist in `CLAUDE.md`
+   (standard-release surfaces: package.json + VERSION constants + test assertions + hermes/python pins), open a PR, merge.
 3. After merge, run the **Manual publish** recipe above for each bumped consumer.
 4. Verify the pin landed:
    ```sh

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,16 +7,14 @@ PLUR stores corrections, preferences, and patterns as **engrams** that strengthe
 ## Install
 
 ```bash
-npm install -g @plur-ai/cli@0.9.4
+npm install -g @plur-ai/cli
 ```
 
 Or use without installing:
 
 ```bash
-npx @plur-ai/cli@0.9.4 status
+npx @plur-ai/cli status
 ```
-
-> Current verified CLI release: `@plur-ai/cli@0.9.4`.
 
 ## Quick Start
 

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -169,6 +169,11 @@ export class RemoteStore implements EngramStore {
         let offset = 0
         const limit = 200
         const maxPages = 50  // hard cap to avoid runaway loops
+        // #550: only cache a result set from a clean (complete) pagination run.
+        // A mid-pagination abort/error must not overwrite a prior good cache with
+        // a partial view — that's the "cache poisoning" class fixed in #130 for
+        // cold-cache appends, and reintroduced by #531 for page-fetch errors.
+        let paginationComplete = false
         for (let i = 0; i < maxPages; i++) {
           const u = `${this.apiBase}/engrams?scope=${encodeURIComponent(this.scope)}&limit=${limit}&offset=${offset}`
           const ctrl = new AbortController()
@@ -176,10 +181,16 @@ export class RemoteStore implements EngramStore {
           try {
             const r = await fetch(u, { headers: this.headers(), signal: ctrl.signal })
             if (!r.ok) {
-              // 403 (no read access) and 404 (scope doesn't exist) are
-              // not errors at the store level — that store just contributes
-              // nothing. Bubble other 5xx as logs.
-              if (r.status >= 500) console.error(`[plur:remote-store] ${this.url} returned ${r.status} loading scope ${this.scope}`)
+              // 403 (no read access) and 404 (scope doesn't exist) are stable
+              // states: the scope genuinely has nothing for us. Cache [] so we
+              // don't spam the server on every TTL expiry.
+              // 5xx are transient — don't cache the partial/empty result; fall
+              // back to the prior good cache so recall stays useful.
+              if (r.status === 403 || r.status === 404) {
+                paginationComplete = true
+              } else if (r.status >= 500) {
+                console.error(`[plur:remote-store] ${this.url} returned ${r.status} loading scope ${this.scope}`)
+              }
               break
             }
             const body = await r.json() as { rows: any[]; total_count: number }
@@ -189,17 +200,29 @@ export class RemoteStore implements EngramStore {
               const e = this.reshape(row)
               if (e) all.push(e)
             }
-            if (all.length >= body.total_count || body.rows.length < limit) break
+            if (all.length >= body.total_count || body.rows.length < limit) {
+              paginationComplete = true
+              break
+            }
             offset += limit
           } catch (err) {
-            console.error(`[plur:remote-store] ${this.url} load page failed: ${(err as Error).message}`)
+            const msg = (err as Error).name === 'AbortError'
+              ? `page fetch timed out after ${LOAD_FETCH_TIMEOUT_MS}ms`
+              : (err as Error).message
+            console.error(`[plur:remote-store] ${this.url} load page failed: ${msg}`)
             break
           } finally {
             clearTimeout(t)
           }
         }
-        this.cache = { ts: Date.now(), engrams: all }
-        return all
+        if (paginationComplete) {
+          this.cache = { ts: Date.now(), engrams: all }
+          return all
+        }
+        // Incomplete pagination (transient error / abort): preserve the prior
+        // good cache and return it so callers keep seeing valid engrams. Fall
+        // back to the partial set only if there is no prior cache at all.
+        return this.cache?.engrams ?? all
       } catch (err) {
         console.error(`[plur:remote-store] ${this.url} load failed: ${(err as Error).message}`)
         // Don't poison the cache on failure — let the next call retry.

--- a/packages/core/test/remote-store-cache.test.ts
+++ b/packages/core/test/remote-store-cache.test.ts
@@ -127,6 +127,143 @@ describe('RemoteStore — optimistic cache insert (issue #89)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Cache poisoning — issue #550
+// ---------------------------------------------------------------------------
+
+describe('RemoteStore — cache poisoning on partial pagination (issue #550)', () => {
+  let originalFetch: typeof globalThis.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  // To trigger multi-page pagination the first page must be a full 200-row page
+  // (limit is hardcoded at 200 in load()). We generate 200 stub rows here.
+  const PAGE_LIMIT = 200
+  const page1Rows = Array.from({ length: PAGE_LIMIT }, (_, i) => ({
+    id: `ENG-P1-${String(i + 1).padStart(3, '0')}`,
+    scope: 'group:test',
+    status: 'active',
+    data: { statement: `page1 item ${i + 1}` },
+  }))
+  // A smaller set used as "prior good cache" primed via a short initial load.
+  const primeRows = [
+    { id: 'ENG-GOOD-001', scope: 'group:test', status: 'active', data: { statement: 'good a' } },
+    { id: 'ENG-GOOD-002', scope: 'group:test', status: 'active', data: { statement: 'good b' } },
+  ]
+
+  it('page 1 OK + page 2 AbortError — does not overwrite a good prior cache (#550)', async () => {
+    let loadCall = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      const offsetMatch = url.match(/offset=(\d+)/)
+      const offset = offsetMatch ? parseInt(offsetMatch[1], 10) : 0
+      loadCall++
+
+      if (loadCall === 1) {
+        // First overall fetch: clean 2-engram load that primes the cache.
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: primeRows, total_count: 2 }),
+        } as Response
+      }
+      // Second load (after cache expires via ttlMs:0) — page 1 returns a full
+      // 200-row page signalling total_count=400 (more pages remain).
+      if (offset === 0) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: page1Rows, total_count: PAGE_LIMIT + 1 }),
+        } as Response
+      }
+      // Page 2 throws (simulates AbortError / network stall after abort fires).
+      const err = new Error('This operation was aborted.')
+      ;(err as any).name = 'AbortError'
+      throw err
+    })
+
+    const store = new RemoteStore('https://plur.example.com/sse', 'tok', 'group:test', { ttlMs: 0 })
+
+    // Prime the cache with the known-good set.
+    const primed = await store.load()
+    expect(primed.map(e => e.id).sort()).toEqual(['ENG-GOOD-001', 'ENG-GOOD-002'])
+
+    // Second load: page 1 OK, page 2 aborts → must NOT overwrite prior cache.
+    const afterError = await store.load()
+    expect(afterError.map(e => e.id).sort()).toEqual(['ENG-GOOD-001', 'ENG-GOOD-002'])
+  })
+
+  it('5xx on page 2 does not overwrite prior good cache (#550)', async () => {
+    let loadCall = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      const offsetMatch = url.match(/offset=(\d+)/)
+      const offset = offsetMatch ? parseInt(offsetMatch[1], 10) : 0
+      loadCall++
+      if (loadCall === 1) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: primeRows, total_count: 2 }),
+        } as Response
+      }
+      if (offset === 0) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: page1Rows, total_count: PAGE_LIMIT + 1 }),
+        } as Response
+      }
+      return { ok: false, status: 503 } as Response
+    })
+
+    const store = new RemoteStore('https://plur.example.com/sse', 'tok', 'group:test', { ttlMs: 0 })
+    const primed = await store.load()
+    expect(primed.map(e => e.id).sort()).toEqual(['ENG-GOOD-001', 'ENG-GOOD-002'])
+
+    const afterError = await store.load()
+    expect(afterError.map(e => e.id).sort()).toEqual(['ENG-GOOD-001', 'ENG-GOOD-002'])
+  })
+
+  it('transient page 1 error caches nothing — prior cache preserved (#550)', async () => {
+    let loadCall = 0
+    fetchMock.mockImplementation(async () => {
+      loadCall++
+      if (loadCall === 1) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: primeRows, total_count: 2 }),
+        } as Response
+      }
+      return { ok: false, status: 500 } as Response
+    })
+
+    const store = new RemoteStore('https://plur.example.com/sse', 'tok', 'group:test', { ttlMs: 0 })
+    const primed = await store.load()
+    expect(primed.length).toBe(2)
+
+    const afterError = await store.load()
+    // Must still return the two engrams from the good first load.
+    expect(afterError.length).toBe(2)
+  })
+
+  it('403 on page 1 caches empty result (stable state — scope has no access)', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403 } as Response)
+
+    const store = new RemoteStore('https://plur.example.com/sse', 'tok', 'group:test', { ttlMs: 60_000 })
+    const result = await store.load()
+    expect(result).toEqual([])
+
+    // Next call within TTL must be served from cache (no additional fetch).
+    const cached = await store.load()
+    expect(cached).toEqual([])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Cold-start behavior — Plur-level (issue #184, #185 gap 3)
 // ---------------------------------------------------------------------------
 

--- a/packages/hermes/plugin.yaml
+++ b/packages/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: plur
-version: 0.1.1
+version: 0.14.0
 description: Persistent memory that improves over time — learn, recall, inject, forget, feedback, meta-engram extraction
 provides_tools:
   - plur_learn

--- a/skills/plur-memory/SKILL.md
+++ b/skills/plur-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plur-memory
 description: Persistent learning for AI agents. Open engram format. Your agent learns from corrections, remembers across sessions, and transfers knowledge across domains.
-version: 0.9.0
+version: 0.14.0
 metadata:
   hermes:
     tags: [memory, learning, knowledge, engrams]


### PR DESCRIPTION
## Summary

Fixes the cache poisoning regression introduced by #531. When a page fetch fails mid-pagination (AbortError, 5xx), the partial accumulation was written to the cache with a fresh timestamp — hiding all previously-good engrams for up to `ttlMs` (60s default).

- Track `paginationComplete` — only write `this.cache` on a full, clean pagination run
- On an incomplete exit: fall back to the prior good cache so callers keep seeing valid engrams
- 403/404 on page 1 are treated as "stable empty" and _do_ get cached (scope has no access; avoids repeated server hits per TTL expiry)
- AbortError log now prints the timeout bound instead of the generic "This operation was aborted."

Also fixes the pre-existing `!r.ok` 5xx-on-page-2 partial-cache issue called out in the issue (same root cause, predates #531).

## Test plan

- [x] `page 1 OK + page 2 AbortError — does not overwrite a good prior cache` 
- [x] `5xx on page 2 does not overwrite prior good cache`
- [x] `transient page 1 error caches nothing — prior cache preserved`
- [x] `403 on page 1 caches empty result (stable state — scope has no access)`
- [x] All 13 existing remote-store-cache tests still pass (2 skipped, pre-existing)

Closes #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)