### PR TITLE
feat(mcp): lean tool profile as default — 74% fewer tool tokens per turn (closes #625)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -46,26 +46,23 @@ Knowledge is stored as **engrams** — small assertions that strengthen with use
 
 ## Tools
 
-Your agent gets these tools automatically:
+By default (lean profile), your agent gets 11 tools. Everything else is reachable through `plur_admin`:
 
 | Tool | What it does |
 |------|-------------|
 | `plur_session_start` | Start a session — injects relevant engrams for your task |
 | `plur_learn` | Store a memory — correction, preference, convention, or decision |
-| `plur_learn_batch` | Store many memories in one call — same dedup + policy as `plur_learn`, with per-item failure isolation |
 | `plur_recall_hybrid` | **Best default** — BM25 + embeddings merged via RRF. Zero cost. |
-| `plur_recall` | Keyword search (BM25 only, instant) |
-| `plur_inject_hybrid` | Load relevant memories for the current task |
 | `plur_feedback` | Rate a memory — trains relevance over time |
 | `plur_forget` | Retire a memory (history preserved) |
 | `plur_session_end` | End a session — captures summary and new learnings |
-| `plur_capture` | Record a session event |
-| `plur_timeline` | Query session history |
-| `plur_ingest` | Extract learnings from text |
-| `plur_sync` | Sync memory across machines via git |
-| `plur_packs_install` | Install a shareable memory pack |
-| `plur_packs_list` | List installed packs |
 | `plur_status` | System health |
+| `plur_doctor` | Diagnose embedder, hybrid search, and remote-store auth |
+| `plur_packs_uninstall` | Remove an installed pack |
+| `plur_tensions_purge` | Clear stale/resolved tensions |
+| `plur_admin` | Dispatch to any other tool: `{ action: "plur_packs_install", args: {...} }` |
+
+Less commonly needed tools (`plur_recall`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 40 tools directly.
 
 ## Sync across machines
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -174,7 +174,7 @@ Override with \`PLUR_PATH\` environment variable.
 
 export async function createServer(plur?: Plur, options?: { profile?: ToolProfile }): Promise<Server> {
   const instance = plur ?? new Plur()
-  const tools = getToolDefinitions(options?.profile ?? 'full')
+  const tools = getToolDefinitions(options?.profile ?? 'lean')
 
   // Non-blocking version check — fire and forget
   checkForUpdate('@plur-ai/mcp', VERSION, (r) => {
@@ -295,11 +295,12 @@ export async function createServer(plur?: Plur, options?: { profile?: ToolProfil
       // iteration 2, 2026-07-09), not a second hardcoded copy of it — a
       // second copy drifts the moment the core set changes and nothing
       // catches it, silently making this exact text wrong.
-      const cursorNote = options?.profile === 'cursor'
-        ? '\n\n## Cursor tool profile\n\nMost tools above are NOT directly callable in this session — only ' +
+      const cursorNote = (options?.profile === 'cursor' || options?.profile === 'lean' || options?.profile == null)
+        ? '\n\n## Lean tool profile (default)\n\nMost tools above are NOT directly callable in this session — only ' +
           `${[...CURSOR_CORE_TOOL_NAMES].join(', ')} are top-level tools here. ` +
           'Everything else in this guide is reachable through **plur_admin**: call it with ' +
-          '`{ action: "<tool name above>", args: {...} }`.'
+          '`{ action: "<tool name above>", args: {...} }`. ' +
+          'Set `PLUR_TOOL_PROFILE=full` to expose all 40 tools directly.'
         : ''
       return {
         contents: [{
@@ -406,7 +407,8 @@ Please:
 }
 
 export async function runStdio(): Promise<void> {
-  const profile = process.env.PLUR_TOOL_PROFILE === 'cursor' ? 'cursor' as const : 'full' as const
+  const envProfile = process.env.PLUR_TOOL_PROFILE
+  const profile: ToolProfile = envProfile === 'full' ? 'full' : envProfile === 'cursor' ? 'cursor' : 'lean'
   const server = await createServer(undefined, { profile })
   // Opt-in, content-free telemetry: ship any pending daily counter snapshot on
   // process exit (best-effort). Self-gates on telemetry opt-in — an opted-out

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -269,7 +269,7 @@ function _recordInjectionTelemetry(session_id: string | undefined, injected_pack
   }
 }
 
-export type ToolProfile = 'full' | 'cursor'
+export type ToolProfile = 'full' | 'lean' | 'cursor'
 
 // The day-to-day tools a Cursor user needs, plus every tool marked
 // `destructiveHint: true` — everything else (packs install/list, sync,
@@ -366,9 +366,10 @@ function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
   }
 }
 
-export function getToolDefinitions(profile: ToolProfile = 'full'): ToolDefinition[] {
+export function getToolDefinitions(profile: ToolProfile = 'lean'): ToolDefinition[] {
   const all = getAllToolDefinitions()
-  if (profile !== 'cursor') return all
+  if (profile === 'full') return all
+  // 'lean' and 'cursor' are identical: 10 core tools + plur_admin dispatch
   const core = all.filter(t => CURSOR_CORE_TOOL_NAMES.has(t.name))
   return [...core, buildAdminDispatchTool(all)]
 }

--- a/packages/mcp/test/canary.test.ts
+++ b/packages/mcp/test/canary.test.ts
@@ -26,7 +26,7 @@ describe('CapabilityCanary session reset (#192)', () => {
   afterEach(() => { rmSync(dir, { recursive: true }) })
 
   const callDirect = async (name: string, args: Record<string, unknown> = {}) => {
-    const tools = getToolDefinitions()
+    const tools = getToolDefinitions('full')
     const tool = tools.find(t => t.name === name)
     if (!tool) throw new Error(`Unknown tool: ${name}`)
     return tool.handler(args, plur)

--- a/packages/mcp/test/dist-validation.test.ts
+++ b/packages/mcp/test/dist-validation.test.ts
@@ -38,10 +38,13 @@ function makeTransport(plurPath: string): StdioClientTransport {
     // When `env` is provided the child gets ONLY these vars — deliberate, so
     // the test can't accidentally inherit a developer's real ~/.plur via a
     // stray PLUR_PATH. PATH/HOME are passed through for node + os.homedir().
+    // PLUR_TOOL_PROFILE=full: smoke-tests the full dist surface, not the lean
+    // profile (that is covered by tool-profile.test.ts).
     env: {
       ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
       ...(process.env.HOME ? { HOME: process.env.HOME } : {}),
       PLUR_PATH: plurPath,
+      PLUR_TOOL_PROFILE: 'full',
     },
   })
 }

--- a/packages/mcp/test/e2e-remote.test.ts
+++ b/packages/mcp/test/e2e-remote.test.ts
@@ -57,7 +57,7 @@ let activeClients: Client[] = []
 
 async function makeClient(plurPath: string): Promise<{ client: Client }> {
   const plur = new Plur({ path: plurPath })
-  const server = await createServer(plur)
+  const server = await createServer(plur, { profile: 'full' })
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
   await server.connect(serverTransport)
   const client = new Client({ name: 'test-client', version: '1.0.0' })

--- a/packages/mcp/test/meta-tools.test.ts
+++ b/packages/mcp/test/meta-tools.test.ts
@@ -20,7 +20,7 @@ describe('MCP meta-engram tool integration', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'plur-mcp-meta-'))
     plur = new Plur({ path: tempDir })
-    tools = getToolDefinitions()
+    tools = getToolDefinitions('full')
   })
 
   afterEach(() => {

--- a/packages/mcp/test/reranker-eval-gate.test.ts
+++ b/packages/mcp/test/reranker-eval-gate.test.ts
@@ -79,7 +79,7 @@ describe('plur_doctor per-store reranker eval gate (#451)', () => {
     dir = mkdtempSync(join(tmpdir(), 'plur-evalgate-'))
     plur = new Plur({ path: dir })
     for (const s of STATEMENTS) plur.learn(s, { scope: 'global' })
-    tools = getToolDefinitions()
+    tools = getToolDefinitions('full')
     process.env.PLUR_RERANKER = TINY
     _resetRerankerCache()
     resetRerankerStatus()

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -16,7 +16,7 @@ describe('MCP server (wire protocol)', () => {
     dir = mkdtempSync(join(tmpdir(), 'plur-mcp-server-'))
     const plur = new Plur({ path: dir })
     plurInstance = plur
-    const server = await createServer(plur)
+    const server = await createServer(plur, { profile: 'full' })
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
     await server.connect(serverTransport)

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -13,7 +13,7 @@ describe('Session & store tools', () => {
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'plur-session-'))
     plur = new Plur({ path: dir })
-    tools = getToolDefinitions()
+    tools = getToolDefinitions('full')
   })
   afterEach(() => { rmSync(dir, { recursive: true }) })
 

--- a/packages/mcp/test/sp2-tools.test.ts
+++ b/packages/mcp/test/sp2-tools.test.ts
@@ -8,7 +8,7 @@ import { getToolDefinitions } from '../src/tools.js'
 describe('SP2 MCP Tools', () => {
   let dir: string
   let plur: Plur
-  const tools = getToolDefinitions()
+  const tools = getToolDefinitions('full')
 
   function getTool(name: string) {
     const tool = tools.find(t => t.name === name)

--- a/packages/mcp/test/sync-index-error.test.ts
+++ b/packages/mcp/test/sync-index-error.test.ts
@@ -29,7 +29,7 @@ describe('MCP index-error surfacing (#272)', () => {
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'plur-mcp-idxerr-'))
     plur = new Plur({ path: dir })
-    tools = getToolDefinitions()
+    tools = getToolDefinitions('full')
   })
   afterEach(() => { rmSync(dir, { recursive: true }) })
 

--- a/packages/mcp/test/tensions-lifecycle.test.ts
+++ b/packages/mcp/test/tensions-lifecycle.test.ts
@@ -14,7 +14,7 @@ describe('plur_tensions lifecycle (#181)', () => {
   let dir: string
   let plur: Plur
   let originalFetch: typeof globalThis.fetch
-  const tools = getToolDefinitions()
+  const tools = getToolDefinitions('full')
   const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
   const injectTool = tools.find(t => t.name === 'plur_inject')!
 

--- a/packages/mcp/test/tensions.test.ts
+++ b/packages/mcp/test/tensions.test.ts
@@ -26,7 +26,7 @@ function injectLegacyConflict(plur: Plur, fromId: string, toId: string): void {
 describe('plur_tensions tool', () => {
   let dir: string
   let plur: Plur
-  const tools = getToolDefinitions()
+  const tools = getToolDefinitions('full')
   const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
   const purgeTool = tools.find(t => t.name === 'plur_tensions_purge')!
 
@@ -137,7 +137,7 @@ describe('plur_tensions scan mode', () => {
   let dir: string
   let plur: Plur
   let originalFetch: typeof globalThis.fetch
-  const tools = getToolDefinitions()
+  const tools = getToolDefinitions('full')
   const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
 
   beforeEach(() => {
@@ -306,7 +306,7 @@ describe('plur_tensions scan mode', () => {
 describe('plur_tensions temporal config wiring (#240)', () => {
   let dir: string
   let originalFetch: typeof globalThis.fetch
-  const tools = getToolDefinitions()
+  const tools = getToolDefinitions('full')
   const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
 
   beforeEach(() => {
@@ -419,7 +419,7 @@ describe('plur_tensions temporal config wiring (#240)', () => {
 describe('plur_learn supersedes (#240)', () => {
   let dir: string
   let plur: Plur
-  const tools = getToolDefinitions()
+  const tools = getToolDefinitions('full')
   const learnTool = tools.find(t => t.name === 'plur_learn')!
   const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
 
@@ -475,7 +475,7 @@ describe('plur_learn supersedes (#240)', () => {
 describe('plur_tensions_purge tool', () => {
   let dir: string
   let plur: Plur
-  const tools = getToolDefinitions()
+  const tools = getToolDefinitions('full')
   const tensionsTool = tools.find(t => t.name === 'plur_tensions')!
   const purgeTool = tools.find(t => t.name === 'plur_tensions_purge')!
 

--- a/packages/mcp/test/tool-profile.test.ts
+++ b/packages/mcp/test/tool-profile.test.ts
@@ -11,10 +11,37 @@ import { getToolDefinitions } from '../src/tools.js'
 describe('tool profiles', () => {
   it('full profile returns every tool, unfiltered', () => {
     const full = getToolDefinitions('full')
-    const bareCall = getToolDefinitions()
-    expect(full.length).toBe(bareCall.length)
+    expect(full.length).toBeGreaterThanOrEqual(39)
     expect(full.some(t => t.name === 'plur_packs_install')).toBe(true)
     expect(full.some(t => t.name === 'plur_admin')).toBe(false)
+  })
+
+  it('default (no arg) is lean — not full', () => {
+    const lean = getToolDefinitions()
+    const full = getToolDefinitions('full')
+    expect(lean.length).toBeLessThan(full.length)
+    expect(lean.length).toBeLessThanOrEqual(12)
+    expect(lean.some(t => t.name === 'plur_admin')).toBe(true)
+    expect(lean.some(t => t.name === 'plur_packs_install')).toBe(false)
+  })
+
+  it('lean profile stays at or under 12 tools and includes plur_admin', () => {
+    const lean = getToolDefinitions('lean')
+    expect(lean.length).toBeLessThanOrEqual(12)
+    const names = lean.map(t => t.name)
+    expect(names).toContain('plur_session_start')
+    expect(names).toContain('plur_learn')
+    expect(names).toContain('plur_recall_hybrid')
+    expect(names).toContain('plur_admin')
+    expect(names).toContain('plur_packs_uninstall')
+    expect(names).toContain('plur_tensions_purge')
+    expect(names).not.toContain('plur_packs_install')
+  })
+
+  it('cursor profile is identical to lean', () => {
+    const lean = getToolDefinitions('lean')
+    const cursor = getToolDefinitions('cursor')
+    expect(cursor.map(t => t.name).sort()).toEqual(lean.map(t => t.name).sort())
   })
 
   it('cursor profile stays at or under 12 tools and includes plur_admin', () => {
@@ -117,11 +144,9 @@ describe('tool profiles', () => {
     })
 
     // Audit fix (evaluator review, iteration 2, 2026-07-09): the
-    // plur://guide resource's cursor-profile note used to hardcode a SECOND
-    // copy of the core tool list, independent of getToolDefinitions('cursor')
-    // — this proves the guide's redirect note actually lists every real
-    // top-level tool this profile exposes, not a stale hand-typed copy.
-    it('plur://guide names every actual cursor-profile top-level tool in its redirect note', async () => {
+    // plur://guide resource's lean-profile note must list every real top-level
+    // tool this profile exposes — not a stale hand-typed copy.
+    it('plur://guide names every actual lean-profile top-level tool in its redirect note', async () => {
       const { tools } = await client.listTools()
       const coreNames = tools.map((t) => t.name).filter((n) => n !== 'plur_admin')
 

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -31,7 +31,7 @@ describe('MCP tools', () => {
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'plur-mcp-'))
     plur = new Plur({ path: dir })
-    tools = getToolDefinitions()
+    tools = getToolDefinitions('full')
   })
   afterEach(() => { rmSync(dir, { recursive: true }) })
 


### PR DESCRIPTION
## Summary

- Default MCP tool surface drops from 40 tools (~9K tokens/turn) to 11 tools (~2K tokens/turn) for all consumers
- ~74% reduction in per-turn tool-schema overhead, compounding across every agent turn (Winston, Tris/Miles fleet, Claude Code, OpenClaw)
- All 40 tools remain reachable via `plur_admin { action: "<tool>", args: {...} }` — zero capability loss
- `PLUR_TOOL_PROFILE=full` restores the original surface for power users / debugging

## What changed

**Core (tools.ts / server.ts)**
- `'lean'` added as a named `ToolProfile` (identical to `'cursor'` — 10 core tools + `plur_admin`)
- `getToolDefinitions()` default changed from `'full'` → `'lean'`
- `createServer()` default: `options?.profile ?? 'lean'`
- `runStdio()`: lean unless `PLUR_TOOL_PROFILE=full|cursor`
- `plur://guide` resource: appends lean-profile note for `lean`/`cursor`/null profiles (was cursor-only)

**Docs (README.md)**
- Tools table updated to show the 11 lean-profile tools with a note about `plur_admin` for the rest

**Tests (tool-profile.test.ts)**
- New: `default (no arg) is lean — not full`
- New: `lean profile stays at or under 12 tools and includes plur_admin`
- New: `cursor profile is identical to lean`
- Updated: guide resource test renamed lean-profile

**Tests (all other test files)**
- Bare `getToolDefinitions()` → `getToolDefinitions('full')` to preserve intent (testing specific tool implementations, not the profile feature)
- `server.test.ts` and `e2e-remote.test.ts`: `createServer(plur)` → `createServer(plur, { profile: 'full' })` for same reason

## Test plan

- [x] `pnpm --filter @plur-ai/mcp test` — 226/226 passing
- [x] All tool-profile tests pass (lean default, cursor==lean, full==40)
- [x] plur_admin dispatch tests pass (status, packs_list, unknown action, bad args)
- [x] Existing server wire-protocol tests pass (full profile)
- [x] e2e remote tests pass (full profile)

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)