### PR TITLE
docs: update package README benchmarks to current multi-axis numbers

### DIFF
--- a/packages/claw/README.md
+++ b/packages/claw/README.md
@@ -122,11 +122,9 @@ Everything is stored as plain YAML in `~/.plur/`. Open it, read it, edit it. Ove
 
 ## Benchmark
 
-| Metric | Score |
-|--------|-------|
-| LongMemEval overall | **86.7%** |
-| A/B win rate vs no memory | 89% |
-| House rules accuracy | 100% |
+**Retrieval** (LongMemEval R@5): **76.7%** out-of-the-box · **97.0%** with openai-3-large embeddings
+
+**Agent task impact:** Haiku + PLUR outperforms Opus *without* memory at ~10× less cost. House rules: **12–0** across Haiku, Sonnet, Opus. A/B win rate: **89%**.
 
 [Full methodology →](https://plur.ai/benchmark.html)
 

--- a/packages/claw/clawhub/SKILL.md
+++ b/packages/claw/clawhub/SKILL.md
@@ -36,9 +36,9 @@ Correct something in OpenClaw — your Claude Code picks it up. Teach a pattern 
 
 ## Benchmarks
 
-- 97.0% R@5 on LongMemEval (N=500) — full methodology: https://plur.ai/benchmark.html
-- 89% agent task win rate — Haiku with PLUR outperformed Opus without it
-- 100% convention adherence (12–0 on house rules)
+- **Retrieval** (LongMemEval R@5): **76.7%** out-of-the-box · **97.0%** with openai-3-large embeddings — [full methodology](https://plur.ai/benchmark.html)
+- **Agent tasks**: 89% win rate — Haiku + PLUR outperforms Opus *without* memory
+- **House rules**: 12–0 across Haiku, Sonnet, Opus
 
 ## Open source. Local-first. Private. Free.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -112,12 +112,9 @@ Override the location with `PLUR_PATH` env var or `new Plur({ path: '...' })`.
 
 ## Benchmark
 
-| Metric | Score |
-|--------|-------|
-| LongMemEval overall | **86.7%** |
-| Hit@10 (retrieval) | 93.3% |
-| A/B win rate vs no memory | 89% |
-| House rules accuracy | 100% |
+**Retrieval** (LongMemEval R@5): **76.7%** out-of-the-box · **97.0%** with openai-3-large embeddings
+
+**Agent task impact:** Haiku + PLUR outperforms Opus *without* memory at ~10× less cost. House rules: **12–0** across Haiku, Sonnet, Opus. A/B win rate: **89%**.
 
 [Full methodology →](https://plur.ai/benchmark.html)
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -102,11 +102,9 @@ Default: `~/.plur/`. Everything is plain YAML — open it, read it, edit it.
 
 ## Benchmark
 
-| Metric | Score |
-|--------|-------|
-| LongMemEval overall | **86.7%** |
-| A/B win rate vs no memory | 89% |
-| House rules accuracy | 100% |
+**Retrieval** (LongMemEval R@5): **76.7%** out-of-the-box · **97.0%** with openai-3-large embeddings
+
+**Agent task impact:** Haiku + PLUR outperforms Opus *without* memory at ~10× less cost. House rules: **12–0** across Haiku, Sonnet, Opus. A/B win rate: **89%**.
 
 [Full methodology →](https://plur.ai/benchmark.html)
 


### PR DESCRIPTION
## Summary

- Replaces superseded v0.2.1 baseline (86.7% LongMemEval overall) in all three package READMEs (`@plur-ai/mcp`, `@plur-ai/claw`, `@plur-ai/core`) with current figures from the root README
- Current numbers: R@5 **76.7%** out-of-the-box · **97.0%** with openai-3-large embeddings · house rules **12–0** · A/B **89%**
- Docs-only change — no code, no tests

Closes #617.

## Test plan

- [ ] Spot-check npm pages after merge: mcp/claw/core benchmark sections match root README

🤖 Generated with [Claude Code](https://claude.com/claude-code)