### PR TITLE
docs: sync architecture/README docs with current code (closes #619)

### DIFF
--- a/packages/claw/ARCHITECTURE.md
+++ b/packages/claw/ARCHITECTURE.md
@@ -11,14 +11,16 @@ sibling MCP adapter see [`packages/mcp/ARCHITECTURE.md`](../mcp/ARCHITECTURE.md)
 
 ## The shape, in one paragraph
 
-OpenClaw exposes a `ContextEngine` lifecycle: `onSessionStart`, `onTurn`,
-`onSessionEnd`. Claw implements that interface, hooks each event into a
-`Plur` instance from `@plur-ai/core`. On session start it injects
-relevant engrams into the system prompt. On every assistant turn it
-runs the learner over the conversation looking for corrections /
-preferences / decisions. On session end it captures the episode and
-runs decay. There is no UI, no MCP transport, no user interaction — the
-entire memory layer is invisible.
+OpenClaw's `ContextEngine` protocol exposes lifecycle hooks: `assemble`
+(called before each prompt build to inject context), `ingest` (called
+per message for real-time correction detection), `compact` (called on
+context compaction to extract learnings), and `afterTurn` (called after
+every assistant response for batch learning + episode capture). Claw
+implements that interface via `PlurContextEngine`, registered with
+`api.registerContextEngine()`. It also installs two event hooks alongside
+— `before_prompt_build` and `agent_end` — for runtimes that use the event
+bus rather than the ContextEngine protocol. There is no UI, no MCP
+transport, no user interaction — the entire memory layer is invisible.
 
 ## Top-level layout
 
@@ -41,28 +43,51 @@ slot, version — OpenClaw reads this when discovering plugins.
 
 ## ContextEngine integration
 
-OpenClaw's `ContextEngine` interface (simplified):
+OpenClaw's `ContextEngine` interface (from `src/types.ts`):
 
 ```ts
 interface ContextEngine {
-  info(): { name, version, slot }
-  onSessionStart(session): Promise<{ inject?: string }>
-  onTurn(session, turn): Promise<{ inject?: string, capture?: any }>
-  onSessionEnd(session): Promise<void>
+  readonly info: ContextEngineInfo        // { id, name, version, ownsCompaction }
+  bootstrap?(params): Promise<BootstrapResult>   // optional: session init / scope setup
+  ingest(params): Promise<IngestResult>          // required: per-message processing
+  ingestBatch?(params): Promise<...>             // optional: batch ingest
+  afterTurn?(params): Promise<void>              // optional: post-turn learning + capture
+  assemble(params): Promise<AssembleResult>      // required: inject context before prompt build
+  compact(params): Promise<CompactResult>        // required: extract learnings on compaction
+  prepareSubagentSpawn?(params): Promise<...>    // optional: propagate scope to child session
+  onSubagentEnded?(params): Promise<void>        // optional: clean up child session state
+  dispose?(): Promise<void>                      // optional: clean up all session state
 }
 ```
 
-Claw's implementation in `context-engine.ts`:
+`PlurContextEngine` in `context-engine.ts` implements all required methods
+plus the optional ones:
 
-| Hook | What it does |
+| Method | What it does |
 |---|---|
-| `info()` | Returns `{ name: 'plur-claw', version, slot: 'memory' }` |
-| `onSessionStart` | Calls `plur.inject(task)` → builds system-prompt block via `assembler.ts` → returns `{ inject }` |
-| `onTurn` | Runs `learner.ts` over the user+assistant turn → if corrections detected, calls `plur.learn()` async (background) → optionally captures the turn as an episode |
-| `onSessionEnd` | Calls `plur.capture(summary)` |
+| `info` | Returns `{ id: 'plur-claw', name: 'PLUR Memory Engine', version, ownsCompaction: false }` |
+| `bootstrap` | Records session key for scope propagation to subagents |
+| `ingest` | Real-time correction detection per message — runs `learner.ts`; fires `plur.learnRouted()` async (fire-and-forget) when confidence ≥ 0.7 |
+| `assemble` | Injects relevant engrams before each prompt build via `plur.injectHybrid()` (BM25 + embeddings fallback to BM25-only) → `assembler.ts` formats the result |
+| `compact` | Extracts learnings from accumulated messages before context is dropped |
+| `afterTurn` | Primary learning pass: LLM self-report (🧠 I learned: section) + regex fallback; also captures episode summary |
+| `prepareSubagentSpawn` | Inherits parent scope for the child session |
+| `onSubagentEnded` | Cleans up child session scope and message state |
+| `dispose` | Clears all in-memory session maps |
 
-All operations are awaited from OpenClaw's perspective but the actual
-LLM-blocking work (learn, capture) is queued — `onTurn` returns fast.
+Learning and capture calls are fire-and-forget (`void promise.catch(...)`) —
+`ingest` and `afterTurn` return fast; slow remote stores don't stall the agent turn.
+
+### Parallel event hooks (legacy / redundancy path)
+
+The plugin also registers two event hooks via `api.on()` alongside the
+ContextEngine. These provide coverage for runtimes that use the event
+bus rather than the ContextEngine protocol:
+
+| Event | What it does |
+|---|---|
+| `before_prompt_build` | Injects engrams via `plur.inject()` (BM25 only — fast path) |
+| `agent_end` | Captures episode summary from the last assistant message |
 
 ## Assembler (`assembler.ts`)
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -48,6 +48,7 @@ src/
 │
 ├── storage.ts             # Legacy single-file YAML helpers (still used by tests)
 ├── storage-indexed.ts     # SQLite secondary index over engrams for fast load
+├── storage-pglite.ts      # PGLite (WebAssembly PostgreSQL) storage layer
 │
 ├── # — search layer —
 ├── fts.ts                 # In-memory BM25 over enriched engram text

--- a/packages/hermes/README.md
+++ b/packages/hermes/README.md
@@ -18,7 +18,7 @@ Once installed, PLUR runs invisibly in the background:
 - **Every response**: corrections and insights are captured automatically (via `post_llm_call` hook)
 - **Every session**: episodes are recorded to a timeline (via `on_session_end` hook)
 
-The agent also gets 16 tools it can call explicitly:
+The agent also gets 22 tools it can call explicitly:
 
 | Tool | What it does |
 |------|-------------|
@@ -34,10 +34,16 @@ The agent also gets 16 tools it can call explicitly:
 | `plur_sync` | Cross-device sync via git |
 | `plur_packs_list` | List installed knowledge packs |
 | `plur_packs_install` | Install a community knowledge pack |
+| `plur_packs_export` | Export a pack to a shareable file |
 | `plur_extract_meta` | Distill cross-domain principles from your memories |
 | `plur_meta_engrams` | List extracted meta-engrams |
 | `plur_meta_submit_analysis` | Continue multi-turn extraction |
 | `plur_validate_meta` | Test a principle against a new domain |
+| `plur_ingest` | Ingest a message into the memory pipeline |
+| `plur_promote` | Promote an engram to higher confidence |
+| `plur_similarity_search` | Embedding-based similarity search |
+| `plur_stores_add` | Register an additional engram store |
+| `plur_stores_list` | List all registered stores |
 
 ## How it works
 

--- a/packages/hermes/plugin.yaml
+++ b/packages/hermes/plugin.yaml
@@ -14,10 +14,16 @@ provides_tools:
   - plur_sync
   - plur_packs_list
   - plur_packs_install
+  - plur_packs_export
   - plur_extract_meta
   - plur_meta_submit_analysis
   - plur_meta_engrams
   - plur_validate_meta
+  - plur_ingest
+  - plur_promote
+  - plur_similarity_search
+  - plur_stores_add
+  - plur_stores_list
 provides_hooks:
   - pre_llm_call
   - post_llm_call

--- a/packages/mcp/ARCHITECTURE.md
+++ b/packages/mcp/ARCHITECTURE.md
@@ -75,18 +75,20 @@ Each tool is an object with:
 }
 ```
 
-Tool families (~20 tools total):
+Tool families (~40 tools total):
 
 | Family | Tools |
 |---|---|
 | Lifecycle | `plur_session_start`, `plur_session_end` |
 | Learning | `plur_learn`, `plur_learn_batch`, `plur_capture`, `plur_ingest`, `plur_extract_meta` |
 | Recall | `plur_recall`, `plur_recall_hybrid`, `plur_inject`, `plur_inject_hybrid`, `plur_similarity_search` |
+| Scopes | `plur_suggest_scope`, `plur_scopes_discover` |
 | Lifecycle (engram) | `plur_forget`, `plur_pin`, `plur_promote`, `plur_feedback`, `plur_history` |
 | Multi-store | `plur_stores_add`, `plur_stores_list` |
 | Packs | `plur_packs_install`, `plur_packs_list`, `plur_packs_export`, `plur_packs_discover`, `plur_packs_preview`, `plur_packs_uninstall` |
-| Diagnostics | `plur_status`, `plur_doctor`, `plur_profile`, `plur_timeline`, `plur_tensions`, `plur_meta_engrams` |
+| Diagnostics | `plur_status`, `plur_doctor`, `plur_profile`, `plur_timeline`, `plur_tensions`, `plur_tensions_purge`, `plur_meta_engrams` |
 | Sync / maintenance | `plur_sync`, `plur_sync_status`, `plur_validate_meta`, `plur_episode_to_engram`, `plur_report_failure` |
+| Admin dispatch | `plur_admin` (lean profile umbrella — bundles less-common tools for clients with tool-count limits) |
 
 When adding a new tool: define it in `tools.ts`, write the Zod schema
 (MCP clients use the schema to format args), add the test in

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -69,7 +69,8 @@ Runnable patterns in [`examples/`](examples/):
 | Method | Returns |
 |--------|---------|
 | `learn(statement, *, type, scope, domain, tags, source, rationale)` | the created engram (dict) |
-| `recall(query, *, limit)` | list of matching engrams |
+| `recall(query, *, limit)` | list of matching engrams (BM25) |
+| `recall_hybrid(query, *, limit)` | list of matching engrams (BM25 + embeddings) |
 | `inject(task, *, budget)` | `{directives, constraints, consider, count, tokens_used}` |
 | `status()` | `{engram_count, episode_count, storage_root, ...}` |
 


### PR DESCRIPTION
## What

Five doc files had drifted from the implementation. All fixes are docs-only — no code changes.

## Changes

| File | Fix |
|------|-----|
| `packages/claw/ARCHITECTURE.md` | Rewrote ContextEngine section — old `onSessionStart`/`onTurn`/`onSessionEnd` lifecycle doesn't exist; real interface is `ingest`/`assemble`/`compact`/`afterTurn` + parallel event hooks |
| `packages/hermes/README.md` + `plugin.yaml` | 16 → 22 tools; added 6 shipped-but-undocumented tools |
| `packages/mcp/ARCHITECTURE.md` | ~20 → ~40 tools; added Scopes family, `plur_tensions_purge`, `plur_admin` dispatch row |
| `packages/python/README.md` | Added `recall_hybrid` to API table |
| `packages/core/ARCHITECTURE.md` | Added `storage-pglite.ts` to `src/` tree (the largest storage file, completely absent) |

Closes #619.

🤖 heartbeat — cto.docs-sync