### PR TITLE
ops(release): draft v0.15.0 CHANGELOG + add infra to manifest gate skip list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.15.0 (upcoming)
+
+Performance + expansion — lean MCP surface by default, new LangChain adapter, three core stability fixes.
+
+- **74% fewer tool tokens per turn** (lean profile now default)
+- new `plur-langchain` Python package
+- three core ID-uniqueness and cache-safety fixes
+
+### Changed
+
+- **Lean tool profile is now the default** (#625): the MCP server exposes 11 tools (down from 40) to every consumer — Claude Code, Cursor, Windsurf, OpenClaw, Hermes, and nightshift agents alike. Per-turn tool-schema overhead drops ~74% (~2K vs ~9K tokens). All 40 tools remain reachable via `plur_admin { action: "<tool>", args: {...} }`. Restore the full surface with `PLUR_TOOL_PROFILE=full`. **Consumers that depend on all 40 tools being available by default must either call via `plur_admin` or set `PLUR_TOOL_PROFILE=full`.**
+
+### Added
+
+- **`plur-langchain` adapter** (#529): new Python package providing a LangChain `BaseMemory` + `BaseChatMessageHistory` adapter. Install with `pip install plur-langchain`. Chains and LCEL pipelines now get persistent engram memory with zero extra wiring.
+
+### Fixed
+
+- **`generateInjectionId` / `generateEventId` cross-process uniqueness** (#596): IDs are now unique across processes started within the same millisecond. Replaced `Date.now() + 4-char random suffix` with a per-process counter — eliminates the ~0.07% birthday-collision chance per 50-call batch and removes the intermittent `expected 49 to be 50` flake in co-injection tests.
+- **`RemoteStore.load()` — no cache poisoning on mid-pagination error** (#550): a network or server error mid-way through a paginated remote load no longer overwrites the local cache with partial data. The local cache is only updated after a complete, successful load.
+- **PID salt for cross-process ID uniqueness** (#600): ID generation now includes the process ID as a salt, preventing collisions between sibling processes (e.g. parallel nightshift agents) that start in the same millisecond.
+
 ## 0.14.0 (2026-07-15)
 
 A hardening release — 24 issues closed.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,7 +54,8 @@ section, and compares the sets.
 The gate parses PR numbers from the trailing `(#N)` on each squash-commit subject,
 including multi-issue trailers like `(#521, #247)`. Non-user-facing conventional
 types are curated out — the standard `chore`/`ci`/`docs`/`test`/`build`/`refactor`/
-`style` plus this repo's internal `ops` (release tooling) and `cmo` (marketing copy).
+`style` plus this repo's internal `ops` (release tooling), `cmo` (marketing copy),
+and `infra` (server-side infrastructure — heartbeat, ingress, telemetry server).
 
 ## Publish verification (npm smoke + PyPI verify)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -372,7 +372,8 @@ else
   #     ignores bare in-prose refs like "refs #535" (not paren-wrapped) so a
   #     cross-repo issue mention is never mistaken for a shipped PR.
   #   Skip list also curates out this repo's internal non-user-facing types
-  #     'ops' (release tooling) and 'cmo' (marketing copy) alongside the standard
+  #     'ops' (release tooling), 'cmo' (marketing copy), and 'infra' (server-side
+  #     infrastructure — heartbeat, ingress, telemetry server) alongside the standard
   #     conventional set — same "not in the user CHANGELOG" convention.
   #   sort -u (lexical): comm below compares lexically; numeric -n would disagree
   #     on mixed-digit PR numbers and silently misfire.
@@ -380,7 +381,7 @@ else
   #     abort the release instead of taking the empty-set path below.
   PR_TRAILER='\(#[0-9]+(,[[:space:]]*#[0-9]+)*\)'
   SHIPPED_PRS=$(git log --format='%s' "${MANIFEST_LAST_TAG}..HEAD" \
-    | grep -vE '^(chore|ci|docs|test|build|refactor|style|ops|cmo)(\(|:|!)' \
+    | grep -vE '^(chore|ci|docs|test|build|refactor|style|ops|cmo|infra)(\(|:|!)' \
     | grep -oE "$PR_TRAILER" | grep -oE '[0-9]+' | sort -u || true)
 
   DECLARED_PRS=$(printf '%s\n' "$MANIFEST_CHANGELOG" \


### PR DESCRIPTION
## Summary

- Drafts the `## 0.15.0 (upcoming)` CHANGELOG section covering all user-facing changes since v0.14.0
- Adds `infra` to the manifest gate skip list (`scripts/release.sh` + `RELEASING.md`) so server-side heartbeat/ingress commits don't block the release

## What ships in 0.15.0

**Changed:**
- Lean tool profile is now the default (#625) — 11 tools vs 40, ~74% fewer tokens/turn. Breaking for consumers that depend on all 40 tools being exposed by default; use `plur_admin` or `PLUR_TOOL_PROFILE=full`.

**Added:**
- `plur-langchain` LangChain + LCEL adapter (#529)

**Fixed:**
- `generateInjectionId`/`generateEventId` cross-process uniqueness (#596)
- `RemoteStore.load()` — no cache poisoning on mid-pagination error (#550)
- PID salt for cross-process ID uniqueness (#600)

## Manifest gate fix

`infra:` commits (heartbeat server harden + ingress live) were being flagged as undeclared user-facing PRs because `infra` wasn't in the exempt type list. These are server-side ops, not npm package changes — same rationale as `ops:` (release tooling) already being exempt.

## Test plan

- [ ] `scripts/release.sh 0.15.0 --dry-run` passes manifest gate clean
- [ ] CHANGELOG 0.15.0 section renders correctly for tweet generation (`--preview-tweet`)

🤖 heartbeat — cto.release-check 2026-07-19