### PR TITLE
docs: surface orphaned docs + no-AI-attribution convention (part of #620)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ Python packages (`plur-hermes`, `plur-ai`, `plur-langchain`) ship via PyPI — s
 
 ### Unit tests
 
+The test architecture (unit / integration / smoke tiers and the rationale for no Docker-based integration tests) is documented in [docs/test-pyramid.md](docs/test-pyramid.md).
+
 ```
 pnpm test                                    # all packages
 pnpm test -- packages/core/test/sync.test.ts # specific file
@@ -190,9 +192,10 @@ current scores. If your PR improves any of these, mention it in the PR descripti
   however many labels it carries.
 - TypeScript, Vitest, tsup, Zod for validation
 - No external API calls in core — search must work offline at zero cost
-- YAML for all persistent storage (not JSON, not SQLite for primary data)
+- YAML for all persistent storage (not JSON, not SQLite — SQLite is permitted only as an optional read-cache index, never as source of truth)
 - Tests in `packages/*/test/`, named `*.test.ts`
 - Apache-2.0 license
+- **No AI attribution in commits, PRs, or issues** — do not add `Co-Authored-By: Claude ...`, `🤖 Generated with Claude Code`, or similar AI-attribution footers. They add noise and conflict with the project's human-attribution standard.
 
 ## Key files
 
@@ -210,6 +213,17 @@ current scores. If your PR improves any of these, mention it in the PR descripti
 | `packages/mcp/src/tools.ts` | All MCP tool definitions |
 | `packages/claw/src/assembler.ts` | Context assembly for OpenClaw |
 | `packages/claw/src/learner.ts` | Auto-extraction of learnings from conversation |
+
+## Documentation index
+
+| Document | What it covers |
+|----------|---------------|
+| [ROADMAP.md](ROADMAP.md) | Feature roadmap and milestone targets |
+| [docs/test-pyramid.md](docs/test-pyramid.md) | Test architecture — unit / integration / smoke tiers; why there are no Docker integration tests |
+| [docs/adr/ADR-0002-derived-state-provenance.md](docs/adr/ADR-0002-derived-state-provenance.md) | ADR: derived-state provenance for episodes |
+| [docs/runbooks/store-consolidation.md](docs/runbooks/store-consolidation.md) | Runbook: destructive store merge procedure |
+| [docs/telemetry-design.md](docs/telemetry-design.md) | Opt-in telemetry mechanism; "no external calls in core" invariant explained |
+| [docs/benchmarks/](docs/benchmarks/) | Historical benchmark results (current scores are in plur-bench) |
 
 ## Datacore Space Context
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,9 @@ pnpm --filter @plur-ai/core build
 4. **Write tests.** Every change to behavior needs a test. Add unit tests in
    the affected package's `test/` directory (named `*.test.ts`). For changes to
    `RemoteStore`'s wire surface, extend the stub server in
-   `packages/core/test/helpers/stub-server.ts`.
+   `packages/core/test/helpers/stub-server.ts`. See
+   [docs/test-pyramid.md](docs/test-pyramid.md) for the test architecture and
+   the rationale for each tier.
 
 5. **Keep core offline and free.** Core must work with no external API calls —
    search runs locally at zero cost. Don't introduce a runtime network
@@ -105,9 +107,14 @@ plur-ai/plur#544) — don't work around it; declare the PRs.
 ## Conventions
 
 - TypeScript, Vitest, tsup, Zod for validation.
-- YAML for persistent storage (not JSON, not SQLite for primary data).
+- YAML for persistent storage (not JSON, not SQLite — SQLite is permitted only
+  as an optional read-cache index, never as source of truth).
 - Apache-2.0 licensed — by contributing you agree your contribution is
   licensed under the same terms.
+- **No AI attribution in commits, PRs, or issues.** Do not add
+  `Co-Authored-By: Claude ...`, `🤖 Generated with Claude Code`, or similar
+  AI-attribution footers. They conflict with the project's human-attribution
+  standard and add noise to the git history.
 
 ## Reporting bugs and requesting features
 


### PR DESCRIPTION
## Summary

Addresses the remaining items from #620 not covered by #630 (CHANGELOG entry):

- **Surfaced orphaned docs** — adds a Documentation index table in `CLAUDE.md` linking to `ROADMAP.md`, `docs/test-pyramid.md`, `docs/adr/ADR-0002-derived-state-provenance.md`, `docs/runbooks/store-consolidation.md`, `docs/telemetry-design.md`, and `docs/benchmarks/`. Also links `docs/test-pyramid.md` directly from the testing section in `CLAUDE.md` and from step 4 in `CONTRIBUTING.md`.
- **Qualified YAML/SQLite wording** — both files now say "SQLite is permitted only as an optional read-cache index, never as source of truth", resolving the apparent contradiction with the README's optional SQLite read index.
- **No-AI-attribution convention** — added to Conventions in both `CLAUDE.md` and `CONTRIBUTING.md`: no `Co-Authored-By: Claude ...` or `🤖 Generated with Claude Code` footers in commits, PRs, or issues.

Note: the `## 0.13.0` CHANGELOG entry is handled by the companion PR #630.

## Test plan

- [ ] Docs-only — no code changes
- [ ] Verify links resolve to existing files in the repo
- [ ] Confirm wording in both files is consistent