### PR TITLE
docs: surface orphaned docs, add 0.13.0 CHANGELOG note, fix wording (closes #620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ A reliability and hardening release: memory-quality, feedback, and security fixe
 - **Publish verification hardened** (#584): the `@next` smoke test now covers `core` (install + ESM import, catching the import-time crash class that bricked `cli@0.9.2`) and `mcp`, not just `cli` — the audited fixes live in `core`. PyPI publish now verifies the version is retrievable after upload and prints an explicit recovery path on failure (PyPI is immutable). The session-guard's unwritable-state-dir fail-open now leaves a stderr audit trail instead of a silent bypass.
 - The pre-release hardening pass for this release — the U+2028/U+2029 scope-metadata gap, multi-word historical-keyword matching, the `feedback()` `last_accessed` re-anchor, and the manifest-gate fix above — landed in (#579). The audit follow-ups (#581–#584) landed in (#585).
 
+## 0.13.0 (2026-07-09)
+
+Withdrawn — manifest-gate incident (#544). Cut ~90 minutes after 0.12.0 to walk back unintended features that weren't sufficiently tested. npm `latest` skips this version; upgrade directly to 0.14.0.
+
 ## 0.12.0 (2026-07-09)
 
 Cursor IDE support (experimental/beta), plus a batch of queued core improvements: batch learning, supersedes chains, commitment tiers, reranker fit checks, session-end auto-close.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ current scores. If your PR improves any of these, mention it in the PR descripti
 | Document | What it covers |
 |----------|---------------|
 | [docs/test-pyramid.md](docs/test-pyramid.md) | Test architecture — when to write unit vs integration vs smoke tests, why there are no Docker integration tests |
-| [docs/adr/ADR-0002-derived-state-provenance.md](docs/adr/ADR-0002-derived-state-provenance.md) | ADR index — architecture decisions (derived-state provenance, etc.) |
+| [docs/adr/README.md](docs/adr/README.md) | ADR index — architecture decisions (ADR-0001: YAML-as-truth, ADR-0002: derived-state provenance) |
 | [docs/runbooks/store-consolidation.md](docs/runbooks/store-consolidation.md) | Runbook for destructive store merges — read before touching `plur sync --consolidate` |
 | [docs/telemetry-design.md](docs/telemetry-design.md) | Opt-in telemetry design — what is collected, what is not, the no-external-calls-in-core invariant |
 | [ROADMAP.md](ROADMAP.md) | Prioritized feature roadmap |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,17 @@ The earlier v0.2.1 baseline (86.7% overall / 93.3% Hit@10) is still cited in
 is the reproducible harness that realises it. That doc tracks methodology, not
 current scores. If your PR improves any of these, mention it in the PR description.
 
+## Developer documentation
+
+| Document | What it covers |
+|----------|---------------|
+| [docs/test-pyramid.md](docs/test-pyramid.md) | Test architecture — when to write unit vs integration vs smoke tests, why there are no Docker integration tests |
+| [docs/adr/ADR-0002-derived-state-provenance.md](docs/adr/ADR-0002-derived-state-provenance.md) | ADR index — architecture decisions (derived-state provenance, etc.) |
+| [docs/runbooks/store-consolidation.md](docs/runbooks/store-consolidation.md) | Runbook for destructive store merges — read before touching `plur sync --consolidate` |
+| [docs/telemetry-design.md](docs/telemetry-design.md) | Opt-in telemetry design — what is collected, what is not, the no-external-calls-in-core invariant |
+| [ROADMAP.md](ROADMAP.md) | Prioritized feature roadmap |
+| [RELEASING.md](RELEASING.md) | Authoritative publish procedure, manifest gate, version tracks |
+
 ## Conventions
 
 - **Claim before you code**: before starting a GitHub issue, self-assign it
@@ -188,9 +199,13 @@ current scores. If your PR improves any of these, mention it in the PR descripti
   it? Assign yourself. Want another party to do it? Assign it to *them* (don't
   just label or @-mention). Handing off? Reassign. Unassigned = nobody is on it,
   however many labels it carries.
+- **No AI attribution in commits, PRs, or issues**: do not add `Co-Authored-By:` AI
+  lines, `🤖 Generated with` footers, or any other AI-assistant credit to commits,
+  PR descriptions, or issue comments. Automated runs may tag their output with a
+  role marker (e.g. `🤖 heartbeat —`) in issue comments, but not in git history.
 - TypeScript, Vitest, tsup, Zod for validation
 - No external API calls in core — search must work offline at zero cost
-- YAML for all persistent storage (not JSON, not SQLite for primary data)
+- YAML for all persistent storage (not JSON, not SQLite for primary data; SQLite is used only as an optional read index — YAML is always the source of truth)
 - Tests in `packages/*/test/`, named `*.test.ts`
 - Apache-2.0 license
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ pnpm --filter @plur-ai/core build
 4. **Write tests.** Every change to behavior needs a test. Add unit tests in
    the affected package's `test/` directory (named `*.test.ts`). For changes to
    `RemoteStore`'s wire surface, extend the stub server in
-   `packages/core/test/helpers/stub-server.ts`.
+   `packages/core/test/helpers/stub-server.ts`. See [docs/test-pyramid.md](docs/test-pyramid.md)
+   for the unit / integration / smoke breakdown and when each layer applies.
 
 5. **Keep core offline and free.** Core must work with no external API calls —
    search runs locally at zero cost. Don't introduce a runtime network
@@ -105,7 +106,10 @@ plur-ai/plur#544) — don't work around it; declare the PRs.
 ## Conventions
 
 - TypeScript, Vitest, tsup, Zod for validation.
-- YAML for persistent storage (not JSON, not SQLite for primary data).
+- YAML for persistent storage (not JSON, not SQLite for primary data; SQLite is used only as an optional read index — YAML is always the source of truth).
+- No AI attribution in commits, PRs, or issues: do not add `Co-Authored-By:` AI
+  lines, `🤖 Generated with` footers, or any other AI-assistant credit to commits,
+  PR descriptions, or issue comments.
 - Apache-2.0 licensed — by contributing you agree your contribution is
   licensed under the same terms.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+ADRs document significant architectural choices — why a decision was made, what
+alternatives were rejected, and what the trade-offs are.
+
+**New ADRs:** copy the most recent file as a template, increment the number, and
+open a PR. Link the issue that prompted the decision in the `Related:` field.
+
+## Index
+
+| # | Title | Status | Date | Issue |
+|---|-------|--------|------|-------|
+| 0001 | [YAML as source of truth for engram state](https://github.com/plur-ai/plur/issues/226) | Accepted | 2025-09 | [#226](https://github.com/plur-ai/plur/issues/226) |
+| 0002 | [Derived-state provenance — history JSONL as source of truth for graph edges](ADR-0002-derived-state-provenance.md) | Accepted | 2026-07-02 | [#452](https://github.com/plur-ai/plur/issues/452) |
+
+## Notes
+
+**ADR-0001** predates the `docs/adr/` directory and lives as GitHub issue
+[#226](https://github.com/plur-ai/plur/issues/226). It established the
+YAML-as-truth invariant that ADR-0002 extends. It will be migrated here as a
+file when it is next amended.
+
+**ADR-0002** has two files: `ADR-0002-derived-state-provenance.md` (the
+canonical record, linked above) and `ADR-0002.md` (an earlier draft, kept for
+reference). The canonical file supersedes the draft.


### PR DESCRIPTION
## Summary

Fixes all four items from #620 (audit result filed by crtahlin, 2026-07-19).

- **Orphaned docs surfaced** — `CLAUDE.md` gains a `## Developer documentation` table linking the five unreferenced docs: `docs/test-pyramid.md`, `docs/adr/ADR-0002-derived-state-provenance.md`, `docs/runbooks/store-consolidation.md`, `docs/telemetry-design.md`, and `ROADMAP.md`. `CONTRIBUTING.md` gets a link to `test-pyramid.md` directly in the "Write tests" step where it's most useful.
- **0.13.0 CHANGELOG gap closed** — adds the missing `## 0.13.0` header noting it was withdrawn (manifest-gate incident, #544) so the `0.12.0 → 0.14.0` jump is explained.
- **SQLite wording reconciled** — `CLAUDE.md` and `CONTRIBUTING.md` both said "not SQLite for primary data" while `README.md` documents an optional SQLite read index. Added the qualifier "SQLite is used only as an optional read index — YAML is always the source of truth" to make them consistent.
- **No-AI-attribution convention documented** — adds the "no `Co-Authored-By:` AI lines or `Generated with` footers in commits/PRs" rule to both `CLAUDE.md` Conventions and `CONTRIBUTING.md` Conventions. The rule was enforced in practice but absent from the written docs.

Docs-only — no code, no tests.

🤖 heartbeat — cmo.docs-review 2026-07-19