### PR TITLE
docs: remove machine-local paths from Datacore Space Context (closes #621)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,11 +220,7 @@ This project lives inside a Datacore space. Session lifecycle commands are avail
 - `/standup` — generate/post standup from recent team journals
 - `/today` — daily briefing (incremental if already generated)
 
-| Key | Value |
-|-----|-------|
-| Space | `5-plur` |
-| Journal | `~/Data/5-plur/journal/YYYY-MM-DD.md` |
-| Org | `~/Data/5-plur/org/next_actions.org` |
+Journal and org paths are workspace-local — they vary per machine and are not tracked here.
 
 When `/wrap-up` runs, use the team journal schema: `## @contributor` narrative sections + `## Session Metadata` YAML block.
 


### PR DESCRIPTION
## Summary

Fixes #621 (audit result filed by crtahlin, 2026-07-19).

`CLAUDE.md` lines 220–227 hardcoded machine-specific workspace paths:

```
| Space | `5-plur` |
| Journal | `~/Data/5-plur/journal/YYYY-MM-DD.md` |
| Org | `~/Data/5-plur/org/next_actions.org` |
```

These are wrong on any machine other than the original author's (`5-plur` vs `3-plur` locally; `~/Data/...` is a personal layout). They carry no information useful to contributors or CI.

**Fix:** replace the three-row path table with a single generic line noting that journal/org paths are workspace-local and not tracked in the repo.

Docs-only — no code, no tests.

🤖 heartbeat — ops.issue-triage — 2026-07-19