### PR TITLE
docs: surface orphaned developer docs, add no-AI-attribution rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ A reliability and hardening release: memory-quality, feedback, and security fixe
 - **Publish verification hardened** (#584): the `@next` smoke test now covers `core` (install + ESM import, catching the import-time crash class that bricked `cli@0.9.2`) and `mcp`, not just `cli` — the audited fixes live in `core`. PyPI publish now verifies the version is retrievable after upload and prints an explicit recovery path on failure (PyPI is immutable). The session-guard's unwritable-state-dir fail-open now leaves a stderr audit trail instead of a silent bypass.
 - The pre-release hardening pass for this release — the U+2028/U+2029 scope-metadata gap, multi-word historical-keyword matching, the `feedback()` `last_accessed` re-anchor, and the manifest-gate fix above — landed in (#579). The audit follow-ups (#581–#584) landed in (#585).
 
+## 0.13.0 (withdrawn — manifest-gate incident, #544)
+
+This release was pulled before reaching npm `latest`. The pre-publish manifest gate fired correctly, catching undeclared PRs in the release commit. No code change from 0.13.0 ever reached users; `latest` moved directly from 0.12.0 to 0.14.0. The gate now ships as a permanent pre-publish safeguard in `release.sh`.
+
 ## 0.12.0 (2026-07-09)
 
 Cursor IDE support (experimental/beta), plus a batch of queued core improvements: batch learning, supersedes chains, commitment tiers, reranker fit checks, session-end auto-close.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,11 +220,7 @@ This project lives inside a Datacore space. Session lifecycle commands are avail
 - `/standup` — generate/post standup from recent team journals
 - `/today` — daily briefing (incremental if already generated)
 
-| Key | Value |
-|-----|-------|
-| Space | `5-plur` |
-| Journal | `~/Data/5-plur/journal/YYYY-MM-DD.md` |
-| Org | `~/Data/5-plur/org/next_actions.org` |
+Journal and org paths are workspace-local — they vary per machine and are not tracked here.
 
 When `/wrap-up` runs, use the team journal schema: `## @contributor` narrative sections + `## Session Metadata` YAML block.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,9 +190,23 @@ current scores. If your PR improves any of these, mention it in the PR descripti
   however many labels it carries.
 - TypeScript, Vitest, tsup, Zod for validation
 - No external API calls in core — search must work offline at zero cost
-- YAML for all persistent storage (not JSON, not SQLite for primary data)
-- Tests in `packages/*/test/`, named `*.test.ts`
+- YAML for all persistent storage (not JSON; SQLite is an optional read cache via `PLUR_BACKEND=pglite`, never the source of truth)
+- Tests in `packages/*/test/`, named `*.test.ts`. Test-layer boundaries are documented in [`docs/test-pyramid.md`](docs/test-pyramid.md) — read it before adding a new test category.
 - Apache-2.0 license
+- **No AI attribution in commits or PRs.** Do not add `Co-Authored-By: Claude` / `🤖 Generated with ...` trailers, AI-tool badges, or any other AI-attribution markers to commit messages, PR descriptions, or issue comments. This applies to both human and automated contributors.
+
+## Developer docs
+
+Key docs that are not linked from the README but matter for contributors:
+
+| Doc | What it covers |
+|-----|---------------|
+| [`docs/test-pyramid.md`](docs/test-pyramid.md) | Unit / integration / smoke test boundaries — why there are no Docker integration tests |
+| [`docs/telemetry-design.md`](docs/telemetry-design.md) | Opt-in telemetry mechanism; relevant to the "no external calls in core" invariant |
+| [`docs/adr/ADR-0002-derived-state-provenance.md`](docs/adr/ADR-0002-derived-state-provenance.md) | Accepted decision: derived-state provenance for episodes |
+| [`docs/runbooks/store-consolidation.md`](docs/runbooks/store-consolidation.md) | The only procedure for a destructive store merge — read before merging stores |
+| [`docs/benchmarks/`](docs/benchmarks/) | Methodology notes and archived benchmark results |
+| [`ROADMAP.md`](ROADMAP.md) | Public roadmap — feature horizon and prioritization |
 
 ## Key files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ pnpm --filter @plur-ai/core build
 4. **Write tests.** Every change to behavior needs a test. Add unit tests in
    the affected package's `test/` directory (named `*.test.ts`). For changes to
    `RemoteStore`'s wire surface, extend the stub server in
-   `packages/core/test/helpers/stub-server.ts`.
+   `packages/core/test/helpers/stub-server.ts`. See [`docs/test-pyramid.md`](docs/test-pyramid.md)
+   for test-layer boundaries before adding a new test category.
 
 5. **Keep core offline and free.** Core must work with no external API calls —
    search runs locally at zero cost. Don't introduce a runtime network
@@ -105,9 +106,10 @@ plur-ai/plur#544) — don't work around it; declare the PRs.
 ## Conventions
 
 - TypeScript, Vitest, tsup, Zod for validation.
-- YAML for persistent storage (not JSON, not SQLite for primary data).
+- YAML for persistent storage (not JSON; SQLite is an optional read cache via `PLUR_BACKEND=pglite`, never source of truth).
 - Apache-2.0 licensed — by contributing you agree your contribution is
   licensed under the same terms.
+- **No AI attribution.** Do not add `Co-Authored-By: Claude` / `🤖 Generated with ...` trailers, AI-tool badges, or any other AI-attribution markers to commit messages, PR descriptions, or issue comments.
 
 ## Reporting bugs and requesting features
 


### PR DESCRIPTION
Fixes #620.

## Changes

**CHANGELOG.md**
- Added `## 0.13.0 (withdrawn — manifest-gate incident, #544)` stub to close the unexplained 0.12→0.14 gap.

**CLAUDE.md**
- New **Developer docs** table linking the six orphaned files: `docs/test-pyramid.md`, `docs/telemetry-design.md`, `docs/adr/ADR-0002-derived-state-provenance.md`, `docs/runbooks/store-consolidation.md`, `docs/benchmarks/`, `ROADMAP.md`.
- Conventions: qualified the SQLite line — it is an optional read cache (`PLUR_BACKEND=pglite`), not a blanket prohibition. Resolves the wording contradiction vs the README which documents SQLite support.
- Conventions: added explicit **no-AI-attribution** rule (no `Co-Authored-By: Claude` / `🤖 Generated with …` in commits, PRs, or comments).
- Testing: added link to `docs/test-pyramid.md` in the Conventions test bullet.

**CONTRIBUTING.md**
- Step 4 "Write tests" now links `docs/test-pyramid.md`.
- Conventions: same SQLite qualifier and no-AI-attribution rule as CLAUDE.md.

## Test plan
- [ ] Docs-only — no code changed, CI should pass without test changes
- [ ] Verify all linked files exist: `docs/test-pyramid.md`, `docs/telemetry-design.md`, `docs/adr/ADR-0002-derived-state-provenance.md`, `docs/runbooks/store-consolidation.md`