### PR TITLE
chore(release): 0.15.0 CHANGELOG prep — declare all shipped PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 0.15.0 (upcoming)
+## 0.15.0 (2026-07-21)
 
-Performance + expansion — lean MCP surface by default, new LangChain adapter, three core stability fixes.
+Performance + expansion — lean MCP surface by default, new LangChain adapter, cross-platform path fix, dependency security hardening, and four core stability fixes.
 
 - **74% fewer tool tokens per turn** (lean profile now default)
 - new `plur-langchain` Python package
-- three core ID-uniqueness and cache-safety fixes
+- Windows path fix for `plur_recall_hybrid`
+- four core ID-uniqueness, cache-safety, and security fixes
 
 ### Changed
 
@@ -18,6 +19,8 @@ Performance + expansion — lean MCP surface by default, new LangChain adapter, 
 
 ### Fixed
 
+- **`plur_recall_hybrid` fails with `ENOENT: mkdir ''` on Windows** (#641, #642): `saveCache` extracted the directory with `cachePath.lastIndexOf('/')`, which returns -1 on Windows backslash paths — `substring(0, -1)` yields `''`, and `mkdirSync('')` throws ENOENT. Replaced with `path.dirname()` (cross-platform) and added a guard against empty dirname. `plur_recall` / `plur_learn` / `plur_doctor` were unaffected; only the hybrid path (`plur_recall_hybrid`) hit `saveCache`. Regression tests added (4 cases, offline mock embedder).
+- **Dependency security overrides** (#632): tightened transitive dependency overrides addressing 30 Dependabot alerts across `openclaw`, `undici`, `linkify-it`, and `js-yaml`.
 - **`generateInjectionId` / `generateEventId` cross-process uniqueness** (#596): IDs are now unique across processes started within the same millisecond. Replaced `Date.now() + 4-char random suffix` with a per-process counter — eliminates the ~0.07% birthday-collision chance per 50-call batch and removes the intermittent `expected 49 to be 50` flake in co-injection tests.
 - **`RemoteStore.load()` — no cache poisoning on mid-pagination error** (#550): a network or server error mid-way through a paginated remote load no longer overwrites the local cache with partial data. The local cache is only updated after a complete, successful load.
 - **PID salt for cross-process ID uniqueness** (#600): ID generation now includes the process ID as a salt, preventing collisions between sibling processes (e.g. parallel nightshift agents) that start in the same millisecond.


### PR DESCRIPTION
## Summary

- Finalizes the `## 0.15.0` section in `CHANGELOG.md` so the manifest gate in `release.sh` passes — every user-facing PR shipped since `v0.14.0` is now declared.
- Promotes the section from `(upcoming)` to a dated release, and adds the Windows ENOENT fix (#641, #642) and the dependency-security overrides (#632).

## What ships in 0.15.0

Performance + expansion:
- Lean MCP tool surface by default — ~74% fewer tool tokens per turn (#625)
- New `plur-langchain` Python package (#529)
- Cross-platform path fix: `plur_recall_hybrid` `ENOENT: mkdir ''` on Windows (#641, #642) — `path.dirname()` replaces the broken `lastIndexOf('/')` approach
- Dependency security hardening — 30 Dependabot alerts across `openclaw` / `undici` / `linkify-it` / `js-yaml` (#632)
- Core ID-uniqueness and cache-safety fixes (#596, #550, #600)

## Next steps (human)

After merging this PR:
```
./scripts/release.sh 0.15.0
```

That handles version bumps (14 places), build, tests, canary publish + smoke, promote to latest, PyPI (hermes), GitHub release, website deploy, and tweet.