### PR TITLE
ci: PR issue guard — warn on assignment conflicts, auto-assign if unassigned (closes #593)

### DIFF
--- a/.github/workflows/pr-issue-guard.yml
+++ b/.github/workflows/pr-issue-guard.yml
@@ -1,0 +1,61 @@
+name: PR Issue Guard
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+# Only needs to comment on PRs and assign issues — no code access needed.
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  issue-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+            const prAuthor = context.payload.pull_request.user.login;
+            const { owner, repo } = context.repo;
+
+            // Extract issue numbers from standard closing keywords
+            const re = /(?:closes?|fixes?|resolves?|part\s+of)\s+#(\d+)/gi;
+            const seen = new Set();
+            let m;
+            while ((m = re.exec(body)) !== null) {
+              seen.add(parseInt(m[1], 10));
+            }
+
+            if (seen.size === 0) return;
+
+            for (const issueNumber of seen) {
+              let issue;
+              try {
+                ({ data: issue } = await github.rest.issues.get({ owner, repo, issue_number: issueNumber }));
+              } catch (e) {
+                core.warning(`Could not fetch issue #${issueNumber}: ${e.message}`);
+                continue;
+              }
+
+              const assignees = (issue.assignees || []).map(a => a.login);
+
+              if (assignees.length === 0) {
+                await github.rest.issues.addAssignees({
+                  owner, repo,
+                  issue_number: issueNumber,
+                  assignees: [prAuthor],
+                });
+                core.info(`Auto-assigned #${issueNumber} to @${prAuthor}`);
+              } else if (!assignees.includes(prAuthor)) {
+                const list = assignees.map(a => `@${a}`).join(', ');
+                await github.rest.issues.createComment({
+                  owner, repo,
+                  issue_number: prNumber,
+                  body: `⚠️ This PR addresses #${issueNumber}, which is assigned to ${list} — possible duplicate effort. Confirm coordination before merging.`,
+                });
+                core.warning(`Conflict: #${issueNumber} is assigned to ${list}; PR opened by @${prAuthor}`);
+              }
+            }


### PR DESCRIPTION
## Summary

Clean, single-commit re-cut of the #593 CI guard, split out of #639 (which bundled an unrelated MCP SDK v1→v2-beta migration and a #620 docs change, and was conflicting with main). This branch contains **only** the `pr-issue-guard.yml` workflow — cherry-picked onto current `main`, conflict-free.

The workflow (on `pull_request: [opened, edited, reopened]`):
- Parses `Closes/Fixes/Resolves/Part of #N` from the PR body.
- Unassigned issue → auto-assigns to the PR author.
- Assigned to someone else → posts a warning comment on the PR.
- Comment + assign only, never blocks the merge; deduplicates repeated references; handles missing/private issues gracefully.

Detective control complementing the self-assign step in CONTRIBUTING.md.

## Notes

- Minimal permissions: `issues: write` + `pull-requests: write` (no `contents`). Uses `pull_request` (not `pull_request_target`) and `actions/github-script` — never checks out or runs PR code.
- `pull_request` gives fork PRs a read-only token, so assign/comment would 403 for forks — fine for this private internal repo.
- `part of #N` isn't a GitHub auto-closing keyword but still triggers the conflict-warning (intentional).

Closes #593. Supersedes the CI-guard portion of #639.