### PR TITLE
docs(release): add #638 MCP SDK v2 migration to 0.15.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Performance + expansion — lean MCP surface by default, new LangChain adapter, 
 ### Changed
 
 - **Lean tool profile is now the default** (#625): the MCP server exposes 11 tools (down from 40) to every consumer — Claude Code, Cursor, Windsurf, OpenClaw, Hermes, and nightshift agents alike. Per-turn tool-schema overhead drops ~74% (~2K vs ~9K tokens). All 40 tools remain reachable via `plur_admin { action: "<tool>", args: {...} }`. Restore the full surface with `PLUR_TOOL_PROFILE=full`. **Consumers that depend on all 40 tools being available by default must either call via `plur_admin` or set `PLUR_TOOL_PROFILE=full`.**
+- **MCP SDK v2 migration** (#638): `@plur-ai/mcp` now uses the MCP SDK v2 split packages (`@modelcontextprotocol/server`, `@modelcontextprotocol/client`, `@modelcontextprotocol/core` @ 2.0.0-beta.4), replacing the monolithic `@modelcontextprotocol/sdk@^1.12.0`. Prepares for the MCP spec stable release (2026-07-28). The public API of `@plur-ai/mcp` is unchanged; 226 tests pass.
 
 ### Added
 


### PR DESCRIPTION
## What

PR #638 (MCP SDK v1→v2 migration, admin-merged 2026-07-21) landed on main AFTER the 0.15.0 CHANGELOG was cut in #643. It didn't use a `(#638)` PR-number trailer in its squash commit subject, so the manifest gate won't reject it — but the migration is user-visible enough to deserve CHANGELOG coverage.

## Why

The admin-merge commit subject was `compat: MCP SDK v1 → v2 migration (split packages + API update)` with no `(#N)` trailer. That means `release.sh`'s manifest gate **will not block the 0.15.0 release** — but without this entry, users upgrading won't see that `@plur-ai/mcp` now uses the v2 split packages.

## Change

One line added to `## 0.15.0` under `### Changed` — doc-only, no code.

## Merge window

0.15.0 ships tomorrow (deadline 2026-07-22). This PR can be merged before `./scripts/release.sh 0.15.0` runs, or skipped if time is tight (the release won't fail without it).

🤖 heartbeat — cto 2026-07-21