### PR TITLE
docs(release): tighten 0.15.0 CHANGELOG tweet summary — 472→269 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 0.15.0 (2026-07-21)
 
-Performance + expansion — lean MCP surface by default, new LangChain adapter, cross-platform path fix, dependency security hardening, and four core stability fixes.
+Lean default, LangChain, MCP SDK v2.
 
-- **74% fewer tool tokens per turn** (lean profile now default)
-- new `plur-langchain` Python package
-- Windows path fix for `plur_recall_hybrid`
-- four core ID-uniqueness, cache-safety, and security fixes
+- lean default — 74% fewer tokens
+- plur-langchain Python package
+- MCP SDK v2 (split packages)
+- Windows path + ID uniqueness fix
 
 ### Changed
 


### PR DESCRIPTION
## What

The 0.15.0 release tweet was 472 chars — 202 over the 270-char budget. `./scripts/release.sh 0.15.0` would abort at step 3.5 (tweet validation) before any irreversible step, but that means **the release is currently blocked**.

## Fix

Rewrites the `## 0.15.0` summary section (headline + 4 bullets) to produce a 269-char tweet. The detailed prose in `### Changed / Added / Fixed` is untouched — only the short summary block the tweet generator reads changes.

Before: 472 chars
After: 269 chars (✓ fits within 270-char budget — verified with `./scripts/release.sh 0.15.0 --preview-tweet`)

## To release after merge

```bash
cd ~/Data/5-plur/plur
git checkout main && git pull
npm login        # log in as plur9 (browser flow)
./scripts/release.sh 0.15.0
```

🤖 heartbeat — cto 2026-07-22