### PR TITLE
feat(#647): plur scopes — per-scope opt-out for authorized-but-unregistered scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.0 (upcoming)
+
+### Added
+
+- **`plur scopes` — per-scope opt-out for authorized-but-unregistered scopes** (#647): a new user-facing CLI to register, dismiss, or re-offer the shared scopes your enterprise token is authorized for, one at a time — instead of the old all-or-nothing `register:true`. `plur scopes` lists them (with each scope's description); `plur scopes register <scope>` adds one; `plur scopes dismiss <scope>` remembers "don't offer this again" (persisted to `config.yaml`); `plur scopes --reoffer` clears dismissals. Dismissed scopes are excluded from the list and from the session-start hint, so PLUR stops re-listing scopes you've deliberately skipped. The session-start hint is now a quiet one-liner pointing at `plur scopes` (it was agent-facing guide text that users never saw).
+
 ## 0.15.0 (2026-07-21)
 
 Performance + expansion — lean MCP surface by default, new LangChain adapter, cross-platform path fix, dependency security hardening, and four core stability fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **`plur scopes` — per-scope opt-out for authorized-but-unregistered scopes** (#647): a new user-facing CLI to register, dismiss, or re-offer the shared scopes your enterprise token is authorized for, one at a time — instead of the old all-or-nothing `register:true`. `plur scopes` lists them (with each scope's description); `plur scopes register <scope>` adds one; `plur scopes dismiss <scope>` remembers "don't offer this again" (persisted to `config.yaml`); `plur scopes --reoffer` clears dismissals. Dismissed scopes are excluded from the list and from the session-start hint, so PLUR stops re-listing scopes you've deliberately skipped. The session-start hint is now a quiet one-liner pointing at `plur scopes` (it was agent-facing guide text that users never saw).
+- **`plur scopes` — per-scope opt-out for authorized-but-unregistered scopes** (#647, #656): a new user-facing CLI to register, dismiss, or re-offer the shared scopes your enterprise token is authorized for, one at a time — instead of the old all-or-nothing `register:true`. `plur scopes` lists them (with each scope's description); `plur scopes register <scope>` adds one; `plur scopes dismiss <scope>` remembers "don't offer this again" (persisted to `config.yaml`); `plur scopes --reoffer` clears dismissals. Dismissed scopes are excluded from the list and from the session-start hint, so PLUR stops re-listing scopes you've deliberately skipped. The session-start hint is now a quiet one-liner pointing at `plur scopes` (it was agent-facing guide text that users never saw).
 
 ## 0.15.0 (2026-07-21)
 

--- a/packages/cli/src/commands/scopes.ts
+++ b/packages/cli/src/commands/scopes.ts
@@ -58,15 +58,28 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     exit(1, `Unknown subcommand "${subcommand}". Usage: plur scopes [list] | register <scope> | dismiss <scope> | --reoffer`)
   }
 
-  const offered = await plur.offerableScopes()
-  if (json) return outputJson({ success: true, action: 'list', scopes: offered })
+  const { scopes: offered, failures } = await plur.offerableScopes()
+  if (json) {
+    return outputJson({ success: failures.length === 0, action: 'list', scopes: offered, failures })
+  }
 
+  // Don't report an empty offer when we simply couldn't reach the remote (#656):
+  // if nothing is offerable AND a remote failed, that's an error, not "nothing to do".
+  if (offered.length === 0 && failures.length > 0) {
+    const urls = failures.map(f => f.url).join(', ')
+    return exit(1, `Could not reach ${failures.length} remote store(s): ${urls}. ` +
+      `Check connectivity/VPN and that the token is valid (\`plur doctor\`).`)
+  }
   if (offered.length === 0) {
     return outputText('No authorized-but-unregistered scopes to offer. (Nothing to register.)')
   }
   outputText(`${offered.length} scope(s) authorized but not yet registered:\n`)
   for (const o of offered) {
     outputText(`  ${o.scope}${o.description ? ` — ${o.description}` : ''}`)
+  }
+  // Some remotes returned scopes but others failed — say so, don't hide it.
+  if (failures.length > 0) {
+    outputText(`\n(warning: could not reach ${failures.map(f => f.url).join(', ')} — that store's scopes may be missing above.)`)
   }
   outputText(`\nRegister one:  plur scopes register <scope>`)
   outputText(`Dismiss one:   plur scopes dismiss <scope>`)

--- a/packages/cli/src/commands/scopes.ts
+++ b/packages/cli/src/commands/scopes.ts
@@ -1,0 +1,73 @@
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+
+/**
+ * `plur scopes` (#647) — the user-facing surface for authorized-but-unregistered
+ * shared scopes. The session-start "N scopes available" hint is agent-facing
+ * only; this command is where a human actually decides per scope:
+ *
+ *   plur scopes                 list authorized-but-unregistered shared scopes
+ *   plur scopes register <s>    register one scope
+ *   plur scopes dismiss  <s>    remember "don't offer this one" (persisted)
+ *   plur scopes --reoffer       clear all dismissals — offer them again
+ *
+ * Dismissed scopes are excluded from the list (and the session-start hint) until
+ * `--reoffer`. Personal-family scopes are never offered (see registerScope/#382).
+ */
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  const plur = createPlur(flags)
+  const json = shouldOutputJson(flags)
+
+  // --reoffer: clear dismissals (works as a flag on the bare command).
+  if (args.includes('--reoffer')) {
+    const cleared = plur.getDismissedScopes()
+    plur.reofferScopes()
+    if (json) return outputJson({ success: true, action: 'reoffer', cleared })
+    return outputText(cleared.length
+      ? `Re-offering ${cleared.length} previously dismissed scope(s): ${cleared.join(', ')}`
+      : 'No dismissed scopes to re-offer.')
+  }
+
+  const subcommand = args[0]
+
+  if (subcommand === 'register') {
+    const scope = args[1]
+    if (!scope) exit(1, 'Usage: plur scopes register <scope>')
+    try {
+      const { url, status } = await plur.registerScope(scope)
+      if (json) return outputJson({ success: true, action: 'register', scope, url, status })
+      const verb = status === 'added' ? 'Registered' : status === 'token_rotated' ? 'Rotated token for' : 'Already registered'
+      return outputText(`${verb} scope "${scope}" (${url}).`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (json) return outputJson({ success: false, action: 'register', scope, error: msg })
+      return exit(1, msg)
+    }
+  }
+
+  if (subcommand === 'dismiss') {
+    const scope = args[1]
+    if (!scope) exit(1, 'Usage: plur scopes dismiss <scope>')
+    plur.dismissScope(scope)
+    if (json) return outputJson({ success: true, action: 'dismiss', scope })
+    return outputText(`Dismissed "${scope}" — it won't be offered again. Run \`plur scopes --reoffer\` to undo.`)
+  }
+
+  // Default (or `list`): show the offerable set.
+  if (subcommand && subcommand !== 'list') {
+    exit(1, `Unknown subcommand "${subcommand}". Usage: plur scopes [list] | register <scope> | dismiss <scope> | --reoffer`)
+  }
+
+  const offered = await plur.offerableScopes()
+  if (json) return outputJson({ success: true, action: 'list', scopes: offered })
+
+  if (offered.length === 0) {
+    return outputText('No authorized-but-unregistered scopes to offer. (Nothing to register.)')
+  }
+  outputText(`${offered.length} scope(s) authorized but not yet registered:\n`)
+  for (const o of offered) {
+    outputText(`  ${o.scope}${o.description ? ` — ${o.description}` : ''}`)
+  }
+  outputText(`\nRegister one:  plur scopes register <scope>`)
+  outputText(`Dismiss one:   plur scopes dismiss <scope>`)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,6 +43,8 @@ Commands:
   migrate [up|down|status] Run schema migrations
   stores list             List configured stores
   stores add <path>       Add a knowledge store
+  scopes                  List authorized-but-unregistered shared scopes (#647)
+  scopes register <scope> Register one; scopes dismiss <scope>; scopes --reoffer
   init                    Install Claude Code hooks + register plur MCP server
   init-remote             Opt this project into recall from a PLUR Enterprise server
   doctor                  Diagnose Claude Code / Claude Desktop integration
@@ -95,6 +97,7 @@ const COMMANDS: Record<string, string> = {
   promote: './commands/promote.js',
   'similarity-search': './commands/similarity-search.js',
   stores: './commands/stores.js',
+  scopes: './commands/scopes.js',
   migrate: './commands/migrate.js',
   init: './commands/init.js',
   'init-remote': './commands/init-remote.js',

--- a/packages/cli/test/scopes.test.ts
+++ b/packages/cli/test/scopes.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+/**
+ * `plur scopes` (#647) — the user-facing surface. The register/list-with-remote
+ * paths are covered by core's offerableScopes/registerScope tests (they need a
+ * stub /me); here we exercise the command wiring that needs no network:
+ * empty-list, dismiss/reoffer persistence, and error handling.
+ */
+describe('plur scopes (#647)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-scopes-cli-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  const run = (args: string) =>
+    execSync(`node ${CLI} ${args} --path ${dir} --json`, { encoding: 'utf-8', timeout: 10000 }).trim()
+  const rawConfig = () => readFileSync(join(dir, 'config.yaml'), 'utf8')
+
+  it('list with no remote stores → empty and successful', () => {
+    const out = JSON.parse(run('scopes'))
+    expect(out.success).toBe(true)
+    expect(out.action).toBe('list')
+    expect(out.scopes).toEqual([])
+  })
+
+  it('dismiss persists to config; --reoffer clears it', () => {
+    const d = JSON.parse(run('scopes dismiss group:acme/team'))
+    expect(d.success).toBe(true)
+    expect(d.action).toBe('dismiss')
+    expect(rawConfig()).toContain('group:acme/team') // written under dismissed_scopes
+
+    const r = JSON.parse(run('scopes --reoffer'))
+    expect(r.success).toBe(true)
+    expect(r.cleared).toContain('group:acme/team')
+    expect(rawConfig()).not.toContain('group:acme/team') // dismissal cleared
+  })
+
+  it('register a scope no configured remote authorizes → reports failure', () => {
+    const out = JSON.parse(run('scopes register group:acme/nope'))
+    expect(out.success).toBe(false)
+    expect(out.action).toBe('register')
+    expect(out.error).toMatch(/not authorized/)
+  })
+
+  it('rejects an unknown subcommand', () => {
+    expect(() => run('scopes bogus')).toThrow()
+  })
+})

--- a/packages/cli/test/scopes.test.ts
+++ b/packages/cli/test/scopes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
@@ -49,5 +49,18 @@ describe('plur scopes (#647)', () => {
 
   it('rejects an unknown subcommand', () => {
     expect(() => run('scopes bogus')).toThrow()
+  })
+
+  it('surfaces an unreachable remote instead of a silent empty offer (#656)', () => {
+    // a remote store that refuses the connection — discovery fails
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "http://127.0.0.1:9"\n    token: "x"\n    scope: "group:acme/team"\n`,
+    )
+    const out = JSON.parse(run('scopes'))
+    expect(out.success).toBe(false)
+    expect(out.action).toBe('list')
+    expect(out.scopes).toEqual([])
+    expect(out.failures.length).toBeGreaterThan(0)
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -274,7 +274,7 @@ export interface RemoteScopeDiscovery {
   authorized: string[]
   /** Scopes already registered in local config for this URL. */
   registered: string[]
-  /** Authorized minus registered — the scopes a user could still add. */
+  /** Authorized minus registered minus dismissed (#647) — the scopes a user could still add. */
   unregistered: string[]
   /**
    * Server-authoritative scope metadata (#345 D2) for the authorized scopes,
@@ -4582,6 +4582,10 @@ Generate an improved version of the procedure that prevents this failure. Return
           }),
         ])
         const registeredSet = new Set(registered)
+        // #647: scopes the user has dismissed from the offer are not "actionable"
+        // — drop them from `unregistered` so the session-start hint and CLI stop
+        // re-surfacing them every session. `plur scopes --reoffer` clears these.
+        const dismissedSet = new Set(this.config.dismissed_scopes ?? [])
         return {
           url,
           ok: true,
@@ -4590,7 +4594,7 @@ Generate an improved version of the procedure that prevents this failure. Return
           role: me.role,
           authorized: me.scopes,
           registered,
-          unregistered: me.scopes.filter(s => !registeredSet.has(s)),
+          unregistered: me.scopes.filter(s => !registeredSet.has(s) && !dismissedSet.has(s)),
           // #345 D2: server-authoritative metadata for the authorized scopes,
           // already validated in RemoteStore.me(). Empty for older servers.
           metadata: me.scope_metadata ?? [],
@@ -4718,6 +4722,104 @@ Generate an improved version of the procedure that prevents this failure. Return
       }
       return { url: d.url, ok: true, added, already_registered: already, skipped }
     })
+  }
+
+  /**
+   * The single source of truth for the "authorized but unregistered" OFFER
+   * (#647), shared by the `plur scopes` CLI and the session-start hint. Returns
+   * the shared-family scopes the token is authorized for that are neither
+   * registered nor dismissed, deduped across remotes, each with its
+   * self-describing metadata description (#345) when the server serves it.
+   *
+   * Personal-family scopes are excluded here (they can't be registered from
+   * discovery — see {@link registerScope} / #382), so the offer only ever shows
+   * scopes the user can actually act on.
+   */
+  async offerableScopes(opts?: { url?: string; timeoutMs?: number }): Promise<Array<{ scope: string; url: string; description?: string }>> {
+    const discoveries = await this.discoverRemoteScopes(opts)
+    const seen = new Set<string>()
+    const out: Array<{ scope: string; url: string; description?: string }> = []
+    for (const d of discoveries) {
+      if (!d.ok) continue
+      for (const scope of d.unregistered) {
+        if (!isSharedScope(scope) || seen.has(scope)) continue
+        seen.add(scope)
+        const meta = d.metadata.find(m => m.scope === scope)
+        out.push({ scope, url: d.url, description: meta?.description })
+      }
+    }
+    return out
+  }
+
+  /**
+   * Register a SINGLE authorized-but-unregistered shared scope (#647) — the
+   * per-scope counterpart to {@link registerDiscoveredScopes} (all-or-nothing).
+   * Discovers which configured remote authorizes `scope`, then adds one store
+   * entry via the same url+scope-idempotent {@link addStore} path.
+   *
+   * Rejects personal-family scopes (`user:*`/`global`/…) — same #382 guard as
+   * the batch path: a `/me`-advertised personal scope must never become a
+   * routing target for the user's default/unscoped writes. Throws if no
+   * configured remote authorizes the scope.
+   */
+  async registerScope(scope: string, opts?: { url?: string; timeoutMs?: number }): Promise<{ url: string; status: 'added' | 'already_registered' | 'overwritten' | 'token_rotated' }> {
+    if (!isSharedScope(scope)) {
+      throw new Error(`refusing to register non-shared scope "${scope}" — only shared-family scopes (group:/project:/space:/team:/org:/public) can be registered from discovery; add a personal-backed store explicitly with \`plur stores add\``)
+    }
+    const discoveries = await this.discoverRemoteScopes(opts?.url ? { url: opts.url, timeoutMs: opts?.timeoutMs } : { timeoutMs: opts?.timeoutMs })
+    const match = discoveries.find(d => d.ok && d.authorized.includes(scope))
+    if (!match) {
+      const failed = discoveries.filter(d => !d.ok).map(d => d.url)
+      throw new Error(`scope "${scope}" is not authorized on any configured remote${failed.length ? ` (could not reach: ${failed.join(', ')})` : ''}`)
+    }
+    const token = (this.config.stores ?? []).find(s => s.url === match.url)?.token
+    const { status } = this.addStore('', scope, { url: match.url, token })
+    // Registering a scope also clears any prior dismissal of it (#647).
+    if ((this.config.dismissed_scopes ?? []).includes(scope)) {
+      this.persistDismissedScopes((this.config.dismissed_scopes ?? []).filter(s => s !== scope))
+    }
+    return { url: match.url, status }
+  }
+
+  /**
+   * Dismiss a scope from the "authorized but unregistered" offer (#647). It is
+   * remembered in config (`dismissed_scopes`) and excluded from
+   * discoverRemoteScopes().unregistered + the session-start hint until
+   * {@link reofferScopes}. No-op if already dismissed.
+   */
+  dismissScope(scope: string): void {
+    const current = this.config.dismissed_scopes ?? []
+    if (current.includes(scope)) return
+    this.persistDismissedScopes([...current, scope])
+  }
+
+  /** Clear all dismissals (#647) — previously dismissed scopes are offered again. */
+  reofferScopes(): void {
+    this.persistDismissedScopes([])
+  }
+
+  /** The scopes currently dismissed from the offer (#647). */
+  getDismissedScopes(): string[] {
+    return [...(this.config.dismissed_scopes ?? [])]
+  }
+
+  /**
+   * Persist `dismissed_scopes` to config.yaml, preserving every other top-level
+   * key, then refresh the in-memory config + mtime. Mirrors {@link persistStores}:
+   * a transient read error on an EXISTING config aborts rather than truncating.
+   */
+  private persistDismissedScopes(list: string[]): void {
+    let configData: Record<string, unknown> = {}
+    try {
+      const raw = fs.readFileSync(this.paths.config, 'utf8')
+      if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+    }
+    configData.dismissed_scopes = [...new Set(list)].sort()
+    fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
+    this.config = loadConfig(this.paths.config)
+    this.configMtimeMs = this.statConfigMtime()
   }
 
   /** Set a session-level default scope. Used as fallback in learn/learnRouted when no explicit scope is provided. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4734,21 +4734,33 @@ Generate an improved version of the procedure that prevents this failure. Return
    * Personal-family scopes are excluded here (they can't be registered from
    * discovery — see {@link registerScope} / #382), so the offer only ever shows
    * scopes the user can actually act on.
+   *
+   * Also returns any `failures` (remotes whose /me could not be reached / whose
+   * token was rejected) so the caller can distinguish "genuinely nothing to
+   * offer" from "couldn't reach the server" — the CLI must not report an empty
+   * offer when it simply failed to talk to the remote (#656 self-review).
    */
-  async offerableScopes(opts?: { url?: string; timeoutMs?: number }): Promise<Array<{ scope: string; url: string; description?: string }>> {
+  async offerableScopes(opts?: { url?: string; timeoutMs?: number }): Promise<{
+    scopes: Array<{ scope: string; url: string; description?: string }>
+    failures: Array<{ url: string; error?: string }>
+  }> {
     const discoveries = await this.discoverRemoteScopes(opts)
     const seen = new Set<string>()
-    const out: Array<{ scope: string; url: string; description?: string }> = []
+    const scopes: Array<{ scope: string; url: string; description?: string }> = []
+    const failures: Array<{ url: string; error?: string }> = []
     for (const d of discoveries) {
-      if (!d.ok) continue
+      if (!d.ok) {
+        failures.push({ url: d.url, error: d.error })
+        continue
+      }
       for (const scope of d.unregistered) {
         if (!isSharedScope(scope) || seen.has(scope)) continue
         seen.add(scope)
         const meta = d.metadata.find(m => m.scope === scope)
-        out.push({ scope, url: d.url, description: meta?.description })
+        scopes.push({ scope, url: d.url, description: meta?.description })
       }
     }
-    return out
+    return { scopes, failures }
   }
 
   /**

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -209,6 +209,13 @@ export const PlurConfigSchema = z.object({
   embeddings: EmbeddingsConfigSchema.default({}),
   vector: VectorConfigSchema.default({}),
   stores: z.array(StoreEntrySchema).default([]),
+  /**
+   * Shared scopes the user has explicitly dismissed from the "authorized but
+   * unregistered" offer (#647). Excluded from discoverRemoteScopes().unregistered
+   * and from the session-start hint so they stop being re-surfaced every session.
+   * `plur scopes --reoffer` clears this list.
+   */
+  dismissed_scopes: z.array(z.string()).default([]),
   llm: LlmTierConfigSchema.default({}),
   profile: ProfileConfigSchema.default({}),
   registry_url: z.string().url().optional(),

--- a/packages/core/test/scope-discovery.test.ts
+++ b/packages/core/test/scope-discovery.test.ts
@@ -329,7 +329,7 @@ describe('Plur scope opt-out (#647)', () => {
   afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }) })
 
   it('offerableScopes lists shared unregistered scopes, excluding the registered one', async () => {
-    const offered = (await freshPlur().offerableScopes()).map(o => o.scope).sort()
+    const offered = (await freshPlur().offerableScopes()).scopes.map(o => o.scope).sort()
     expect(offered).toEqual([
       'group:plur/plur-ai',
       'group:plur/plur-ai/comms',
@@ -344,13 +344,13 @@ describe('Plur scope opt-out (#647)', () => {
 
     const [d] = await plur.discoverRemoteScopes()
     expect(d.unregistered).not.toContain('group:plur/plur-ai/comms')
-    expect((await plur.offerableScopes()).map(o => o.scope)).not.toContain('group:plur/plur-ai/comms')
+    expect((await plur.offerableScopes()).scopes.map(o => o.scope)).not.toContain('group:plur/plur-ai/comms')
 
     // persisted on disk + honored by a fresh instance
     const cfg = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
     expect(cfg.dismissed_scopes).toContain('group:plur/plur-ai/comms')
     const reloaded = new Plur({ path: dir })
-    expect((await reloaded.offerableScopes()).map(o => o.scope)).not.toContain('group:plur/plur-ai/comms')
+    expect((await reloaded.offerableScopes()).scopes.map(o => o.scope)).not.toContain('group:plur/plur-ai/comms')
   })
 
   it('reofferScopes clears dismissals — the scope is offered again', async () => {
@@ -358,7 +358,7 @@ describe('Plur scope opt-out (#647)', () => {
     plur.dismissScope('group:plur/plur-ai/comms')
     plur.reofferScopes()
     expect(plur.getDismissedScopes()).toEqual([])
-    expect((await plur.offerableScopes()).map(o => o.scope)).toContain('group:plur/plur-ai/comms')
+    expect((await plur.offerableScopes()).scopes.map(o => o.scope)).toContain('group:plur/plur-ai/comms')
   })
 
   it('registerScope adds exactly one store (not all) and clears any prior dismissal', async () => {
@@ -373,7 +373,7 @@ describe('Plur scope opt-out (#647)', () => {
     expect(cfg.stores.map((s: any) => s.scope)).toContain('group:plur/plur-ai/research')
 
     expect(plur.getDismissedScopes()).not.toContain('group:plur/plur-ai/research')
-    expect((await plur.offerableScopes()).map(o => o.scope)).not.toContain('group:plur/plur-ai/research')
+    expect((await plur.offerableScopes()).scopes.map(o => o.scope)).not.toContain('group:plur/plur-ai/research')
   })
 
   it('offerableScopes excludes personal-family scopes; registerScope rejects them', async () => {
@@ -382,10 +382,27 @@ describe('Plur scope opt-out (#647)', () => {
       scopes: ['group:plur/plur-ai/engineering', 'group:plur/plur-ai/comms', 'user:plur:crtahlin', 'global'],
     })
     const plur = freshPlur()
-    const offered = (await plur.offerableScopes()).map(o => o.scope)
+    const offered = (await plur.offerableScopes()).scopes.map(o => o.scope)
     expect(offered).toContain('group:plur/plur-ai/comms')
     expect(offered).not.toContain('user:plur:crtahlin')
     expect(offered).not.toContain('global')
     await expect(plur.registerScope('user:plur:crtahlin')).rejects.toThrow(/non-shared/)
+  })
+
+  it('offerableScopes reports failures instead of a silently-empty offer when a remote is unreachable (#656)', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-optout-fail-'))
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      yaml.dump({
+        stores: [{ url: baseUrl, token: 'bad-token', scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+    const plur = new Plur({ path: dir })
+    const { scopes, failures } = await plur.offerableScopes()
+    expect(scopes).toEqual([])
+    expect(failures).toHaveLength(1)
+    expect(failures[0].url).toBe(baseUrl)
+    expect(failures[0].error).toMatch(/401/)
   })
 })

--- a/packages/core/test/scope-discovery.test.ts
+++ b/packages/core/test/scope-discovery.test.ts
@@ -9,7 +9,7 @@
  * Depends on the URL+scope dedup from #291 — registering N scopes under one URL
  * is what makes auto-register meaningful.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -304,5 +304,88 @@ describe('Plur.registerDiscoveredScopes()', () => {
     ])
     const config = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
     expect(config.stores).toHaveLength(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scope opt-out — per-scope register / dismiss / reoffer (#647)
+// ---------------------------------------------------------------------------
+
+describe('Plur scope opt-out (#647)', () => {
+  let dir: string
+
+  const freshPlur = () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-optout-'))
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      yaml.dump({
+        stores: [{ url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+    return new Plur({ path: dir })
+  }
+
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }) })
+
+  it('offerableScopes lists shared unregistered scopes, excluding the registered one', async () => {
+    const offered = (await freshPlur().offerableScopes()).map(o => o.scope).sort()
+    expect(offered).toEqual([
+      'group:plur/plur-ai',
+      'group:plur/plur-ai/comms',
+      'group:plur/plur-ai/research',
+    ])
+  })
+
+  it('dismissScope persists, survives reload, and drops the scope from the offer', async () => {
+    const plur = freshPlur()
+    plur.dismissScope('group:plur/plur-ai/comms')
+    expect(plur.getDismissedScopes()).toContain('group:plur/plur-ai/comms')
+
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.unregistered).not.toContain('group:plur/plur-ai/comms')
+    expect((await plur.offerableScopes()).map(o => o.scope)).not.toContain('group:plur/plur-ai/comms')
+
+    // persisted on disk + honored by a fresh instance
+    const cfg = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(cfg.dismissed_scopes).toContain('group:plur/plur-ai/comms')
+    const reloaded = new Plur({ path: dir })
+    expect((await reloaded.offerableScopes()).map(o => o.scope)).not.toContain('group:plur/plur-ai/comms')
+  })
+
+  it('reofferScopes clears dismissals — the scope is offered again', async () => {
+    const plur = freshPlur()
+    plur.dismissScope('group:plur/plur-ai/comms')
+    plur.reofferScopes()
+    expect(plur.getDismissedScopes()).toEqual([])
+    expect((await plur.offerableScopes()).map(o => o.scope)).toContain('group:plur/plur-ai/comms')
+  })
+
+  it('registerScope adds exactly one store (not all) and clears any prior dismissal', async () => {
+    const plur = freshPlur()
+    plur.dismissScope('group:plur/plur-ai/research')
+    const res = await plur.registerScope('group:plur/plur-ai/research')
+    expect(res.status).toBe('added')
+
+    const cfg = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    // started with 1 store (engineering), added exactly 1 (research) — not all 3
+    expect(cfg.stores).toHaveLength(2)
+    expect(cfg.stores.map((s: any) => s.scope)).toContain('group:plur/plur-ai/research')
+
+    expect(plur.getDismissedScopes()).not.toContain('group:plur/plur-ai/research')
+    expect((await plur.offerableScopes()).map(o => o.scope)).not.toContain('group:plur/plur-ai/research')
+  })
+
+  it('offerableScopes excludes personal-family scopes; registerScope rejects them', async () => {
+    server.setMe({
+      username: 'crtahlin', org_id: 'plur', role: 'developer',
+      scopes: ['group:plur/plur-ai/engineering', 'group:plur/plur-ai/comms', 'user:plur:crtahlin', 'global'],
+    })
+    const plur = freshPlur()
+    const offered = (await plur.offerableScopes()).map(o => o.scope)
+    expect(offered).toContain('group:plur/plur-ai/comms')
+    expect(offered).not.toContain('user:plur:crtahlin')
+    expect(offered).not.toContain('global')
+    await expect(plur.registerScope('user:plur:crtahlin')).rejects.toThrow(/non-shared/)
   })
 })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1923,11 +1923,16 @@ function getAllToolDefinitions(): ToolDefinition[] {
                   `Reads fall back to local; team-scoped writes queue in the outbox` +
                   (pending > 0 ? ` (${pending} pending)` : '') + ` until it recovers. Check connectivity/VPN.`
             }
-            const unregistered = [...new Set(discoveries.filter(d => d.ok).flatMap(d => d.unregistered))]
-            if (unregistered.length > 0) {
-              const list = unregistered.map(s => `"${safe(s)}"`).join(', ')
-              guide += `\n\n🔎 Your token is authorized for ${unregistered.length} more scope(s) not yet registered: ${list}. ` +
-                `Call plur_scopes_discover with register:true to add them all in one step.`
+            // #647: a QUIET, per-scope-aware hint. `d.unregistered` already
+            // excludes dismissed scopes; also drop personal-family (they can't be
+            // registered from discovery). Point at the user-facing `plur scopes`
+            // CLI for the actual register/dismiss decision instead of the old
+            // all-or-nothing `register:true`.
+            const offerable = [...new Set(discoveries.filter(d => d.ok).flatMap(d => d.unregistered))].filter(isSharedScope)
+            if (offerable.length > 0) {
+              guide += `\n\n🔎 ${offerable.length} authorized scope(s) not yet registered. Tell the user they can run ` +
+                `\`plur scopes\` to register or dismiss them per-scope (dismissed scopes stop being offered; ` +
+                `\`plur scopes --reoffer\` re-surfaces them).`
             }
           } catch { /* discovery is best-effort — never block session_start */ }
 

--- a/packages/mcp/test/remote-health.test.ts
+++ b/packages/mcp/test/remote-health.test.ts
@@ -119,3 +119,40 @@ describe('plur_session_start remote auth surfacing (#295)', () => {
     }
   })
 })
+
+describe('plur_session_start scope-offer hint (#647)', () => {
+  // config with one registered store + optional dismissed_scopes
+  function writeConfigDismissed(dismissed: string[]): string {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-mcp-offer-'))
+    dirs.push(dir)
+    const dis = dismissed.length ? `dismissed_scopes:\n${dismissed.map(s => `  - "${s}"`).join('\n')}\n` : ''
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\n${dis}stores:\n  - url: "${baseUrl}"\n    token: "${TOKEN}"\n    scope: "${SCOPE}"\n`,
+    )
+    return dir
+  }
+
+  it('emits a quiet plur-scopes hint (not register:true) for an unregistered shared scope', async () => {
+    stub.setMe({ username: 'crtahlin', org_id: 'plur', role: 'developer', scopes: [SCOPE, 'group:plur/plur-ai/comms'] })
+    const client = await makeClient(writeConfig(TOKEN))
+    const res = callResult(await client.callTool({ name: 'plur_session_start', arguments: { task: 'anything' } }))
+    expect(res.guide).toContain('plur scopes')
+    expect(res.guide).not.toContain('register:true')
+  })
+
+  it('omits a dismissed scope from the hint', async () => {
+    stub.setMe({ username: 'crtahlin', org_id: 'plur', role: 'developer', scopes: [SCOPE, 'group:plur/plur-ai/comms'] })
+    const client = await makeClient(writeConfigDismissed(['group:plur/plur-ai/comms']))
+    const res = callResult(await client.callTool({ name: 'plur_session_start', arguments: { task: 'anything' } }))
+    // the only extra scope is dismissed → nothing offerable → no hint
+    expect(res.guide).not.toContain('plur scopes')
+  })
+
+  it('never offers a personal-family scope advertised by /me', async () => {
+    stub.setMe({ username: 'crtahlin', org_id: 'plur', role: 'developer', scopes: [SCOPE, 'user:plur:crtahlin'] })
+    const client = await makeClient(writeConfig(TOKEN))
+    const res = callResult(await client.callTool({ name: 'plur_session_start', arguments: { task: 'anything' } }))
+    expect(res.guide).not.toContain('plur scopes')
+  })
+})


### PR DESCRIPTION
Closes #647 (and subissues #649 core, #650 cli, #651 mcp).

## Why — the premise was wrong

#647 assumed `plur_session_start` "already surfaces" authorized-but-unregistered scopes to users. It doesn't: that nudge is appended to the **`guide`** field of the `session_start` **tool result** (`packages/mcp/src/tools.ts`), which the **model** consumes — agents almost never echo it, so users never see it. The only genuinely user-facing surface was the CLI.

So the gaps were three, not two: **(0) may never reach the user** (visibility), (1) all-or-nothing (`register:true`), (2) no memory → re-listed every session.

## What this does (CLI-primary, per @crtahlin's call)

- **`plur scopes`** — new **user-facing** CLI: `list` (with each scope's #345 description) · `register <scope>` (one, not all) · `dismiss <scope>` (remembered) · `--reoffer` (clear dismissals).
- **Persisted opt-out** in `config.yaml` (`dismissed_scopes`); dismissed scopes are excluded from `discoverRemoteScopes().unregistered` and everywhere downstream, so they stop being re-surfaced.
- **Session-start hint** shrinks to one quiet line pointing at `plur scopes` (replaces `register:true`), and excludes dismissed + personal-family scopes.
- Personal-family scopes (`user:*`/`global`) are never offered/registerable (same #382 guard).

## Layers

- **core** (#649): `config.dismissed_scopes`; `registerScope` / `dismissScope` / `reofferScopes` / `offerableScopes` (single source of truth for the offer); `discoverRemoteScopes` filters dismissed.
- **cli** (#650): the `plur scopes` command + `--help`.
- **mcp** (#651): the quiet session-start hint.

## Tests (all green)

- core `scope-discovery.test.ts` (+5): dismiss persists + survives reload + drops from offer; `registerScope` adds exactly one (not all) + clears prior dismissal; `reofferScopes` restores; personal excluded / rejected.
- mcp `remote-health.test.ts` (+3): quiet hint appears (not `register:true`); dismissed omitted; personal never offered.
- cli `scopes.test.ts` (+4): list-empty, dismiss→reoffer persistence, register-with-no-remote failure, unknown subcommand.
- Full `pnpm build` clean across all packages.

## Docs

- `CHANGELOG.md` `## 0.16.0 (upcoming)` entry; `plur --help` usage updated.