### PR TITLE
feat(core): scopes opt-out — dismissScope / reofferScopes / registerScope (#649)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -274,8 +274,14 @@ export interface RemoteScopeDiscovery {
   authorized: string[]
   /** Scopes already registered in local config for this URL. */
   registered: string[]
-  /** Authorized minus registered — the scopes a user could still add. */
+  /** Authorized minus registered — the scopes a user could still add. Excludes dismissed scopes. */
   unregistered: string[]
+  /**
+   * Authorized scopes the user has dismissed (#647). Excluded from `unregistered`
+   * so they don't surface in the session nudge or CLI list. Present only when
+   * `ok` is true; empty array when nothing is dismissed.
+   */
+  dismissed: string[]
   /**
    * Server-authoritative scope metadata (#345 D2) for the authorized scopes,
    * when the remote serves it via `/api/v1/me` (`scope_metadata`). Each entry
@@ -4569,6 +4575,7 @@ Generate an improved version of the procedure that prevents this failure. Return
   async discoverRemoteScopes(opts?: { url?: string; timeoutMs?: number }): Promise<RemoteScopeDiscovery[]> {
     const timeoutMs = opts?.timeoutMs ?? 5000
     const endpoints = this._distinctRemoteEndpoints().filter(e => !opts?.url || e.url === opts.url)
+    const dismissedSet = new Set(this.config.dismissed_scopes ?? [])
 
     return Promise.all(endpoints.map(async ({ url, token }) => {
       const registered = (this.config.stores ?? []).filter(s => s.url === url).map(s => s.scope)
@@ -4582,6 +4589,7 @@ Generate an improved version of the procedure that prevents this failure. Return
           }),
         ])
         const registeredSet = new Set(registered)
+        const unregisteredAll = me.scopes.filter(s => !registeredSet.has(s))
         return {
           url,
           ok: true,
@@ -4590,7 +4598,9 @@ Generate an improved version of the procedure that prevents this failure. Return
           role: me.role,
           authorized: me.scopes,
           registered,
-          unregistered: me.scopes.filter(s => !registeredSet.has(s)),
+          // Exclude dismissed scopes from the actionable set (#647).
+          unregistered: unregisteredAll.filter(s => !dismissedSet.has(s)),
+          dismissed: unregisteredAll.filter(s => dismissedSet.has(s)),
           // #345 D2: server-authoritative metadata for the authorized scopes,
           // already validated in RemoteStore.me(). Empty for older servers.
           metadata: me.scope_metadata ?? [],
@@ -4598,7 +4608,7 @@ Generate an improved version of the procedure that prevents this failure. Return
       } catch (err) {
         return {
           url, ok: false,
-          authorized: [], registered, unregistered: [], metadata: [],
+          authorized: [], registered, unregistered: [], dismissed: [], metadata: [],
           error: err instanceof Error ? err.message : String(err),
         }
       }
@@ -4718,6 +4728,83 @@ Generate an improved version of the procedure that prevents this failure. Return
       }
       return { url: d.url, ok: true, added, already_registered: already, skipped }
     })
+  }
+
+  /**
+   * Register a single authorized-but-unregistered shared scope (#647).
+   * Factors out the per-scope registration logic from `registerDiscoveredScopes`
+   * so callers can register one scope at a time (e.g. `plur scopes register <scope>`).
+   *
+   * Enforces the same SECURITY guard as `registerDiscoveredScopes`: personal-family
+   * scopes (global/local/user:/agent:) are rejected — only shared-family scopes
+   * (group:/project:/space:/team:/org:/public) are registered this way.
+   *
+   * Returns `'added'` if the store entry was created, `'already_registered'` if
+   * it already existed, or `'skipped'` if the scope was rejected (personal-family)
+   * or could not be registered (conflict with another URL).
+   */
+  registerScope(scope: string, opts?: { url?: string }): 'added' | 'already_registered' | 'skipped' {
+    if (!isSharedScope(scope)) {
+      logger.warning(
+        `[plur] refused to register non-shared scope "${scope}" — ` +
+        `only shared-family scopes (group:/project:/space:/team:/org:/public) can be ` +
+        `registered this way. Use plur stores add for personal-family scopes.`,
+      )
+      return 'skipped'
+    }
+    this.reloadConfigIfChanged()
+    const url = opts?.url ?? (this.config.stores ?? []).find(s => s.url)?.url
+    if (!url) {
+      logger.warning(`[plur] registerScope: no remote URL — configure a remote store first.`)
+      return 'skipped'
+    }
+    const token = (this.config.stores ?? []).find(s => s.url === url)?.token
+    try {
+      const { status } = this.addStore('', scope, { url, token })
+      return status === 'added' ? 'added' : 'already_registered'
+    } catch {
+      return 'skipped'
+    }
+  }
+
+  /**
+   * Dismiss a scope so it stops appearing in discovery and the session nudge (#647).
+   * Persists to `dismissed_scopes` in config.yaml. Call `reofferScopes()` to undo.
+   * No-op if the scope is already dismissed.
+   */
+  dismissScope(scope: string): void {
+    this.reloadConfigIfChanged()
+    const current = this.config.dismissed_scopes ?? []
+    if (current.includes(scope)) return
+    this._persistConfigField('dismissed_scopes', [...current, scope])
+  }
+
+  /**
+   * Clear all dismissed scopes so they re-appear in discovery (#647).
+   * Persists to config.yaml immediately.
+   */
+  reofferScopes(): void {
+    this.reloadConfigIfChanged()
+    this._persistConfigField('dismissed_scopes', [])
+  }
+
+  /**
+   * Persist a single top-level config field to config.yaml, preserving all
+   * other keys, then refresh the in-memory config + mtime.
+   * Same read-preserve-write pattern as `persistStores()`.
+   */
+  private _persistConfigField(key: string, value: unknown): void {
+    let configData: Record<string, unknown> = {}
+    try {
+      const raw = fs.readFileSync(this.paths.config, 'utf8')
+      if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+    }
+    configData[key] = value
+    fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
+    this.config = loadConfig(this.paths.config)
+    this.configMtimeMs = this.statConfigMtime()
   }
 
   /** Set a session-level default scope. Used as fallback in learn/learnRouted when no explicit scope is provided. */

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -244,6 +244,13 @@ export const PlurConfigSchema = z.object({
    * See {@link ScopeRoutingConfigSchema} for per-field semantics.
    */
   scope_routing: ScopeRoutingConfigSchema.default({}),
+  /**
+   * Shared scopes the user has explicitly opted out of being offered (#647).
+   * Scopes in this list are excluded from `discoverRemoteScopes().unregistered`
+   * and from the MCP session-start nudge. Call `reofferScopes()` / `plur scopes
+   * --reoffer` to clear and surface them again.
+   */
+  dismissed_scopes: z.array(z.string()).default([]),
 }).partial()
 
 export type PlurConfig = z.infer<typeof PlurConfigSchema>

--- a/packages/core/test/scope-discovery.test.ts
+++ b/packages/core/test/scope-discovery.test.ts
@@ -306,3 +306,126 @@ describe('Plur.registerDiscoveredScopes()', () => {
     expect(config.stores).toHaveLength(4)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Scopes opt-out — dismissScope / reofferScopes / registerScope (#647, #649)
+// ---------------------------------------------------------------------------
+
+describe('Scopes opt-out (#647/#649)', () => {
+  let dir: string
+
+  const writeConfig = (stores: unknown[], extra: Record<string, unknown> = {}) => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-dismiss-'))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false, ...extra }, { lineWidth: 120, noRefs: true }))
+    return new Plur({ path: dir })
+  }
+
+  afterAll(() => { if (dir) rmSync(dir, { recursive: true, force: true }) })
+
+  beforeEach(() => {
+    server.reset()
+    server.setMe({
+      username: 'crtahlin',
+      org_id: 'plur',
+      role: 'developer',
+      scopes: [
+        'group:plur/plur-ai',
+        'group:plur/plur-ai/engineering',
+        'group:plur/plur-ai/comms',
+        'group:plur/plur-ai/research',
+      ],
+    })
+  })
+
+  it('dismissScope persists to config.yaml and survives reload', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    plur.dismissScope('group:plur/plur-ai/comms')
+
+    const raw = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(raw.dismissed_scopes).toContain('group:plur/plur-ai/comms')
+
+    // Reload from disk — dismissed scope must still be excluded from discovery.
+    const fresh = new Plur({ path: dir })
+    const [d] = await fresh.discoverRemoteScopes()
+    expect(d.dismissed).toContain('group:plur/plur-ai/comms')
+    expect(d.unregistered).not.toContain('group:plur/plur-ai/comms')
+  })
+
+  it('dismissed scope is excluded from discoverRemoteScopes().unregistered', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ], { dismissed_scopes: ['group:plur/plur-ai/comms'] })
+
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.ok).toBe(true)
+    expect(d.unregistered).not.toContain('group:plur/plur-ai/comms')
+    expect(d.dismissed).toContain('group:plur/plur-ai/comms')
+    // Other unregistered scopes still surface.
+    expect(d.unregistered).toContain('group:plur/plur-ai')
+    expect(d.unregistered).toContain('group:plur/plur-ai/research')
+  })
+
+  it('reofferScopes clears dismissals and scope reappears in discovery', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ], { dismissed_scopes: ['group:plur/plur-ai/comms'] })
+
+    plur.reofferScopes()
+
+    const raw = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(raw.dismissed_scopes).toEqual([])
+
+    const [d] = await plur.discoverRemoteScopes()
+    expect(d.unregistered).toContain('group:plur/plur-ai/comms')
+    expect(d.dismissed).toEqual([])
+  })
+
+  it('dismissScope is idempotent — dismissing twice does not duplicate', () => {
+    const plur = writeConfig([])
+    plur.dismissScope('group:plur/plur-ai/comms')
+    plur.dismissScope('group:plur/plur-ai/comms')
+
+    const raw = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(raw.dismissed_scopes.filter((s: string) => s === 'group:plur/plur-ai/comms')).toHaveLength(1)
+  })
+
+  it('registerScope adds exactly one store entry (not all)', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+
+    const result = plur.registerScope('group:plur/plur-ai/comms', { url: baseUrl })
+    expect(result).toBe('added')
+
+    const raw = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    // Only the two stores should exist — the original + the newly-registered one.
+    expect(raw.stores).toHaveLength(2)
+    expect(raw.stores.map((s: any) => s.scope)).toContain('group:plur/plur-ai/comms')
+    expect(raw.stores.map((s: any) => s.scope)).not.toContain('group:plur/plur-ai')
+    expect(raw.stores.map((s: any) => s.scope)).not.toContain('group:plur/plur-ai/research')
+  })
+
+  it('registerScope returns already_registered when scope already exists', () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    const result = plur.registerScope('group:plur/plur-ai/engineering', { url: baseUrl })
+    expect(result).toBe('already_registered')
+  })
+
+  it('personal-family scopes are rejected by registerScope', () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/plur-ai/engineering', shared: true, readonly: false },
+    ])
+    expect(plur.registerScope('global', { url: baseUrl })).toBe('skipped')
+    expect(plur.registerScope('user:crtahlin', { url: baseUrl })).toBe('skipped')
+    expect(plur.registerScope('local', { url: baseUrl })).toBe('skipped')
+
+    // Config must be unchanged — no personal scopes registered.
+    const raw = yaml.load(readFileSync(join(dir, 'config.yaml'), 'utf8')) as any
+    expect(raw.stores).toHaveLength(1)
+    expect(raw.stores[0].scope).toBe('group:plur/plur-ai/engineering')
+  })
+})


### PR DESCRIPTION
## Summary

Core layer for the scopes opt-out feature (#647). Users can dismiss a shared scope so it stops surfacing in session nudges and `plur scopes list`, and re-offer it when ready.

- `dismissed_scopes: string[]` added to `PlurConfigSchema` (persists to `~/.plur/config.yaml`)
- `discoverRemoteScopes()` — excludes dismissed from `unregistered`; adds `dismissed: string[]` field to `RemoteScopeDiscovery`
- `dismissScope(scope)` — persists scope to `dismissed_scopes`, idempotent
- `reofferScopes()` — clears all dismissed scopes and persists
- `registerScope(scope, {url?})` — registers exactly one scope (factors out per-scope logic from `registerDiscoveredScopes`; same personal-family SECURITY guard)
- `_persistConfigField()` — private helper; same read-preserve-write pattern as `persistStores()`

## Test plan

- [x] dismiss persists and survives reload; dismissed scope excluded from `discoverRemoteScopes().unregistered`
- [x] `registerScope` adds exactly one store entry (not all)
- [x] `reofferScopes` clears dismissals; scope reappears
- [x] personal-family scopes (`global`, `user:*`, `local`) rejected by `registerScope`
- [x] `dismissScope` is idempotent (no duplicate entries on double-dismiss)
- [x] 21/21 scope-discovery tests pass, 226/226 core tests pass, `tsc --noEmit` clean

## Unblocks

- #650 (CLI: `plur scopes list/register/dismiss/--reoffer`)
- #651 (MCP: shrink session nudge + exclude dismissed)

Closes #649.

🤖 heartbeat — cto 2026-07-22