### PR TITLE
docs(release): declare #647 + #656 in 0.15.0 — unblocks manifest gate for release.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.16.0 (upcoming)
-
-### Added
-
-- **`plur scopes` — per-scope opt-out for authorized-but-unregistered scopes** (#647, #656): a new user-facing CLI to register, dismiss, or re-offer the shared scopes your enterprise token is authorized for, one at a time — instead of the old all-or-nothing `register:true`. `plur scopes` lists them (with each scope's description); `plur scopes register <scope>` adds one; `plur scopes dismiss <scope>` remembers "don't offer this again" (persisted to `config.yaml`); `plur scopes --reoffer` clears dismissals. Dismissed scopes are excluded from the list and from the session-start hint, so PLUR stops re-listing scopes you've deliberately skipped. The session-start hint is now a quiet one-liner pointing at `plur scopes` (it was agent-facing guide text that users never saw).
-
 ## 0.15.0 (2026-07-21)
 
 Lean default, LangChain, MCP SDK v2.
@@ -14,6 +8,7 @@ Lean default, LangChain, MCP SDK v2.
 - plur-langchain Python package
 - MCP SDK v2 (split packages)
 - Windows path + ID uniqueness fix
+- `plur scopes` opt-out CLI (#647, #656)
 
 ### Changed
 
@@ -23,6 +18,7 @@ Lean default, LangChain, MCP SDK v2.
 ### Added
 
 - **`plur-langchain` adapter** (#529): new Python package providing a LangChain `BaseMemory` + `BaseChatMessageHistory` adapter. Install with `pip install plur-langchain`. Chains and LCEL pipelines now get persistent engram memory with zero extra wiring.
+- **`plur scopes` CLI — per-scope opt-out for authorized-but-unregistered scopes** (#647, #656): `plur scopes` lists shared scopes from configured remotes (with each scope's description); `plur scopes register <scope>` adds one; `plur scopes dismiss <scope>` opts out permanently (persisted to `~/.plur/config.yaml`); `plur scopes --reoffer` clears all dismissals. Dismissed scopes are excluded from `plur scopes list` and from the MCP session-start hint. The session-start nudge is now a single quiet line pointing at `plur scopes` (replacing the all-or-nothing `register:true` model and the verbose agent-facing guide text users never saw).
 
 ### Fixed
 


### PR DESCRIPTION
## Problem

PR #656 (feat: `plur scopes` opt-out) merged to main **after** the 0.15.0 CHANGELOG was written. It is a `feat`-type commit, so the manifest gate in `release.sh` includes it in `SHIPPED_PRS` — but it was only declared in the `0.16.0 (upcoming)` section, not in `0.15.0`.

Running `./scripts/release.sh 0.15.0` would fail at step 3.6:

```
FAIL Manifest gate: user-facing PR(s) on main since v0.14.0 but not in CHANGELOG 0.15.0:
    #647
    #656
```

## Fix

Move the scopes entry from `## 0.16.0 (upcoming)` to `## 0.15.0`:
- Added as a **5th summary bullet** — tweet generator takes `head -4`, so the tweet stays at 269 chars (verified)
- Added detailed description to `### Added`

The scopes feature IS shipping in 0.15.0 (code landed in main via #656), so documenting it in 0.15.0 is correct.

## Verification

```
# Manifest gate simulation (must be NONE):
SHIPPED=$(git log --format='%s' "v0.14.0..HEAD" | grep -vE '^(chore|ci|docs|test|build|refactor|style|ops|cmo|infra)(\(|:|!)' | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | sort -u)
DECLARED=$(awk '/^## 0\.15\.0/{p=1;next}/^## [0-9]/{if(p)exit} p' CHANGELOG.md | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | sort -u)
comm -23 <(echo "$SHIPPED") <(echo "$DECLARED")
# → (empty — all declared)
```

Tweet is unchanged — headline and first 4 bullets are identical to what #655 verified at 269 chars.

## Urgency

Deadline for 0.15.0 release is **today (2026-07-22)**. This is the last blocker before Gregor runs `./scripts/release.sh 0.15.0`.

🤖 heartbeat — ceo 2026-07-22