### PR TITLE
fix(scope-routing): persist server covers into local config so suggestScope activates (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,16 @@
 # Changelog
 
-## Unreleased
-
-### Added
-
-- **`plur receipt` + `plur_receipt` MCP tool — the memory receipt.** A counted, local, read-only report of what your memory actually retrieved for you: how many times a memory you taught PLUR was put in front of the model, how many distinct engrams it drew on, which are most relied on (with their statement text), and how much of the store is dormant. Every figure is directly counted — there is no estimate, no counterfactual, and deliberately no dollar or token-savings figure (on a subscription your marginal token cost is zero; the value of an avoided rediscovery is not measurable from this data). Scoped to local memory (primary store + installed packs) so the number is identical from the cold CLI and the warm MCP server; retrievals of team-store engrams are reported separately, never as deletions. States its own coverage window so the numbers are never misread as lifetime figures. Nothing leaves the machine.
-- **`co_injection` history events now record `tokens_used` and the calling `source`** (`session_start` / `inject` / `hook`), and every injection call site is tagged. Hook retrievals — the large majority — now also carry the session id, so the receipt's (engram, session) unit is well-defined. Events written before this change remain fully readable.
-
-### Fixed
-
-- **Security: `plur status --json` printed live enterprise bearer tokens.** `StatusResult` embeds the full `PlurConfig`, so `--json` piped the `stores[].token` values (live credentials for the configured enterprise servers) to stdout — into CI logs, pasted issues, and agent transcripts. All CLI JSON output is now credential-redacted at the output boundary, so every present and future JSON command inherits the protection. Redaction also masks credentials embedded in string values (URL userinfo, e.g. `https://user:pass@host`), which a key-based denylist cannot reach.
-- **Security: hardened the memory receipt against hostile engram statements.** Statement text can come from third-party installed packs, so the "most relied on" snippet — which prints to the terminal and is returned to the calling agent — is now sanitized: ANSI/terminal escapes and other C0/C1/DEL controls, Unicode line/paragraph separators, and bidi (Trojan-Source) reordering + zero-width spoofing characters are stripped before rendering, and truncation is grapheme-safe.
-
-## 0.16.0 (upcoming)
-
-### Added
-
-- **`plur scopes` — per-scope opt-out for authorized-but-unregistered scopes** (#647, #656): a new user-facing CLI to register, dismiss, or re-offer the shared scopes your enterprise token is authorized for, one at a time — instead of the old all-or-nothing `register:true`. `plur scopes` lists them (with each scope's description); `plur scopes register <scope>` adds one; `plur scopes dismiss <scope>` remembers "don't offer this again" (persisted to `config.yaml`); `plur scopes --reoffer` clears dismissals. Dismissed scopes are excluded from the list and from the session-start hint, so PLUR stops re-listing scopes you've deliberately skipped. The session-start hint is now a quiet one-liner pointing at `plur scopes` (it was agent-facing guide text that users never saw).
-
 ## 0.15.0 (2026-07-21)
 
-Lean default, LangChain, MCP SDK v2.
+Lean default, memory receipt, scopes CLI, LangChain, MCP SDK v2, and two security fixes.
 
 - lean default — 74% fewer tokens
+- `plur receipt` / `plur_receipt` — memory receipt (what did memory actually do for you?)
+- `plur scopes` — per-scope opt-out for authorized-but-unregistered remote scopes
 - plur-langchain Python package
 - MCP SDK v2 (split packages)
 - Windows path + ID uniqueness fix
+- two P0 security fixes: credential redaction + receipt snippet sanitization
 
 ### Changed
 
@@ -35,6 +20,9 @@ Lean default, LangChain, MCP SDK v2.
 ### Added
 
 - **`plur-langchain` adapter** (#529): new Python package providing a LangChain `BaseMemory` + `BaseChatMessageHistory` adapter. Install with `pip install plur-langchain`. Chains and LCEL pipelines now get persistent engram memory with zero extra wiring.
+- **`plur scopes` CLI — per-scope opt-out for authorized-but-unregistered scopes** (#647, #656): `plur scopes` lists shared scopes from configured remotes (with each scope's description); `plur scopes register <scope>` adds one; `plur scopes dismiss <scope>` opts out permanently (persisted to `~/.plur/config.yaml`); `plur scopes --reoffer` clears all dismissals. Dismissed scopes are excluded from `plur scopes list` and from the MCP session-start hint. The session-start nudge is now a single quiet line pointing at `plur scopes` (replacing the all-or-nothing `register:true` model and the verbose agent-facing guide text users never saw).
+- **`plur receipt` + `plur_receipt` MCP tool — the memory receipt** (#660): a counted, local, read-only report of what your memory actually retrieved for you — how many times a memory was put in front of the model, how many distinct engrams it drew on, and which are most relied on (with their statement text). Every figure is directly counted — no estimate, no counterfactual, no dollar or token-savings figure (on a subscription your marginal token cost is zero). Scoped to local memory (primary store + installed packs) so the number is identical from the cold CLI and the warm MCP server; retrievals of team-store engrams are reported separately. Nothing leaves the machine.
+- **`co_injection` history events now record `tokens_used` and the calling `source`** (#660): `session_start` / `inject` / `hook` sources are tagged at every injection call site. Hook retrievals now also carry the session id, so the receipt's (engram, session) unit is well-defined. Events written before this change remain fully readable.
 
 ### Fixed
 
@@ -43,6 +31,8 @@ Lean default, LangChain, MCP SDK v2.
 - **`generateInjectionId` / `generateEventId` cross-process uniqueness** (#596): IDs are now unique across processes started within the same millisecond. Replaced `Date.now() + 4-char random suffix` with a per-process counter — eliminates the ~0.07% birthday-collision chance per 50-call batch and removes the intermittent `expected 49 to be 50` flake in co-injection tests.
 - **`RemoteStore.load()` — no cache poisoning on mid-pagination error** (#550): a network or server error mid-way through a paginated remote load no longer overwrites the local cache with partial data. The local cache is only updated after a complete, successful load.
 - **PID salt for cross-process ID uniqueness** (#600): ID generation now includes the process ID as a salt, preventing collisions between sibling processes (e.g. parallel nightshift agents) that start in the same millisecond.
+- **Security: `plur status --json` printed live enterprise bearer tokens** (#660): `StatusResult` embedded the full `PlurConfig`, so `--json` piped the `stores[].token` values (live credentials for configured enterprise servers) to stdout — into CI logs, pasted issues, and agent transcripts. All CLI JSON output is now credential-redacted at the output boundary, so every present and future JSON command inherits the protection. Redaction also masks credentials embedded in string values (URL userinfo, e.g. `https://user:pass@host`), which a key-based denylist cannot reach.
+- **Security: memory receipt snippet sanitized against hostile engram statements** (#660): statement text can come from third-party installed packs; the "most relied on" snippet (printed to the terminal and returned to the calling agent) now strips ANSI/terminal escapes, C0/C1/DEL controls, Unicode line/paragraph separators, and bidi (Trojan-Source) reordering + zero-width spoofing characters before rendering. Truncation is grapheme-safe.
 
 ## 0.14.0 (2026-07-15)
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3384,6 +3384,28 @@ export class Plur {
     return engrams.filter(e => (e as any).structured_data?._outbox).length
   }
 
+  /** List engrams pending remote sync — entry metadata only; never exposes remote URL or token. */
+  outboxEntries(): Array<{ id: string; target_scope: string; queued_at: string; attempt_count: number; last_error?: string; age_days: number }> {
+    const engrams = this._loadCached(this.paths.engrams)
+    const now = Date.now()
+    return engrams
+      .filter(e => (e as any).structured_data?._outbox)
+      .map(e => {
+        const ob = (e as any).structured_data._outbox as {
+          target_scope: string; queued_at: string; attempt_count: number; last_error?: string
+        }
+        const age_days = Math.floor((now - new Date(ob.queued_at).getTime()) / 86400000)
+        return {
+          id: e.id,
+          target_scope: ob.target_scope,
+          queued_at: ob.queued_at,
+          attempt_count: ob.attempt_count,
+          ...(ob.last_error ? { last_error: ob.last_error } : {}),
+          age_days,
+        }
+      })
+  }
+
   /**
    * Flush the outbox — retry pushing pending engrams to their target remote
    * stores. Called automatically on session_start and plur_sync.
@@ -4737,7 +4759,7 @@ Generate an improved version of the procedure that prevents this failure. Return
    */
   async registerDiscoveredScopes(opts?: { url?: string; timeoutMs?: number }): Promise<RegisterDiscoveredResult[]> {
     const discoveries = await this.discoverRemoteScopes(opts)
-    return discoveries.map(d => {
+    const results = discoveries.map(d => {
       if (!d.ok) return { url: d.url, ok: false, added: [], already_registered: [], skipped: [], error: d.error }
       const token = (this.config.stores ?? []).find(s => s.url === d.url)?.token
       const added: string[] = []
@@ -4778,6 +4800,10 @@ Generate an improved version of the procedure that prevents this failure. Return
       }
       return { url: d.url, ok: true, added, already_registered: already, skipped }
     })
+    // Sync server-authoritative covers/description into local config (#668) so
+    // suggestScope() activates for all registered scopes on this endpoint.
+    this.syncScopeMetadata(discoveries.filter(d => d.ok).flatMap(d => d.metadata))
+    return results
   }
 
   /**
@@ -4842,6 +4868,9 @@ Generate an improved version of the procedure that prevents this failure. Return
     }
     const token = (this.config.stores ?? []).find(s => s.url === match.url)?.token
     const { status } = this.addStore('', scope, { url: match.url, token })
+    // Sync server-authoritative covers/description for all scopes on this
+    // endpoint (#668) so suggestScope() activates immediately after registration.
+    this.syncScopeMetadata(match.metadata)
     // Registering a scope also clears any prior dismissal of it (#647).
     if ((this.config.dismissed_scopes ?? []).includes(scope)) {
       this.persistDismissedScopes((this.config.dismissed_scopes ?? []).filter(s => s !== scope))
@@ -4885,6 +4914,62 @@ Generate an improved version of the procedure that prevents this failure. Return
       if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
     }
     configData.dismissed_scopes = [...new Set(list)].sort()
+    fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
+    this.config = loadConfig(this.paths.config)
+    this.configMtimeMs = this.statConfigMtime()
+  }
+
+  /**
+   * Persist server-authoritative scope metadata (covers/description) from a
+   * remote `/me` pull into local config store entries (#668). This is the missing
+   * write-side that activates {@link suggestScope}: without it, `covers[]` never
+   * reaches the local config so the ranker always returns `[]`.
+   *
+   * Call after every `/me` pull — session_start, plur_scopes_discover,
+   * registerScope, registerDiscoveredScopes. Personal-family scopes are excluded:
+   * they are never routing targets so covers are meaningless for them. Updates
+   * existing registered stores only — never adds new stores. Read-preserve-write
+   * so other config keys and unknown store fields survive the writeback.
+   *
+   * @param serverMetadata - Validated {@link ScopeMetadata} entries from the remote `/me` endpoint.
+   */
+  syncScopeMetadata(serverMetadata: ScopeMetadata[]): void {
+    if (!serverMetadata.length) return
+    const metaMap = new Map(serverMetadata.map(m => [m.scope, m]))
+    const stores = this.config.stores ?? []
+    let changed = false
+
+    const updated = stores.map((store): StoreEntry => {
+      // Personal-family scopes are never routing targets — skip covers sync
+      if (!isSharedScope(store.scope)) return store
+      const meta = metaMap.get(store.scope)
+      if (!meta) return store
+
+      const patch: Partial<StoreEntry> = {}
+      // Sync covers when the server provides non-empty covers that differ locally
+      if (meta.covers.length > 0 &&
+          JSON.stringify(store.covers ?? []) !== JSON.stringify(meta.covers)) {
+        patch.covers = meta.covers
+      }
+      // Sync description when the server provides one that differs locally
+      if (meta.description && store.description !== meta.description) {
+        patch.description = meta.description
+      }
+      if (!Object.keys(patch).length) return store
+      changed = true
+      return { ...store, ...patch }
+    })
+
+    if (!changed) return
+
+    let configData: Record<string, unknown> = {}
+    try {
+      const raw = fs.readFileSync(this.paths.config, 'utf8')
+      if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+    }
+    configData.stores = this.mergeStoresForWriteback(configData.stores, updated)
     fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
     this.config = loadConfig(this.paths.config)
     this.configMtimeMs = this.statConfigMtime()

--- a/packages/core/test/scope-metadata-sync.test.ts
+++ b/packages/core/test/scope-metadata-sync.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Server-to-local-config scope metadata sync (#668).
+ *
+ * Verifies that covers/description from the remote /me endpoint are persisted
+ * into local config store entries after each /me pull, so suggestScope() has
+ * covers to rank against and is no longer inert for remote scopes.
+ *
+ * The bug: registerScope / registerDiscoveredScopes / session_start all called
+ * discoverRemoteScopes() but never wrote scope_metadata.covers into the local
+ * config store entries. getScopeMetadata() found no covers, listScopeMetadata()
+ * returned [], and suggestScope() returned [] for every input.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { StubServer } from './helpers/stub-server.js'
+
+const TOKEN = 'meta-sync-test-token'
+let server: StubServer
+let baseUrl: string
+
+beforeAll(async () => {
+  server = new StubServer(TOKEN)
+  const info = await server.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => { await server.stop() })
+
+beforeEach(() => {
+  server.reset()
+  server.setMe({
+    username: 'tester',
+    org_id: 'plur',
+    role: 'developer',
+    scopes: [
+      'group:plur/engineering',
+      'group:plur/research',
+      'group:plur/comms',
+    ],
+    scope_metadata: [
+      {
+        scope: 'group:plur/engineering',
+        description: 'Engineering team knowledge',
+        covers: ['ci', 'deploy', 'plur.*'],
+      },
+      {
+        scope: 'group:plur/research',
+        description: 'Research and benchmarking',
+        covers: ['plur.research.benchmarking', 'papers', 'longevity'],
+      },
+      {
+        scope: 'group:plur/comms',
+        description: 'Marketing and communications',
+        covers: ['marketing', 'positioning', 'copy'],
+      },
+    ],
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let dir: string
+
+const makeDir = () => {
+  dir = mkdtempSync(join(tmpdir(), 'plur-meta-sync-'))
+  return dir
+}
+
+const cleanup = () => { if (dir) rmSync(dir, { recursive: true, force: true }) }
+
+const writeCfg = (stores: unknown[]) => {
+  const d = makeDir()
+  writeFileSync(join(d, 'config.yaml'), yaml.dump({ stores, index: false }, { lineWidth: 120 }))
+  return new Plur({ path: d })
+}
+
+const readCfg = (d: string) => yaml.load(readFileSync(join(d, 'config.yaml'), 'utf8')) as Record<string, unknown>
+
+// ---------------------------------------------------------------------------
+// syncScopeMetadata() — direct API
+// ---------------------------------------------------------------------------
+
+describe('Plur.syncScopeMetadata()', () => {
+  afterEach(cleanup)
+
+  it('writes covers and description into a registered shared-scope store entry', () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    plur.syncScopeMetadata([
+      { scope: 'group:plur/engineering', description: 'Eng knowledge', covers: ['ci', 'deploy'] },
+    ])
+    const cfg = readCfg(dir)
+    const entry = (cfg.stores as unknown[]).find((s: unknown) => (s as { scope?: string }).scope === 'group:plur/engineering') as Record<string, unknown>
+    expect(entry.covers).toEqual(['ci', 'deploy'])
+    expect(entry.description).toBe('Eng knowledge')
+  })
+
+  it('is a no-op when serverMetadata is empty', () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    const before = readFileSync(join(dir, 'config.yaml'), 'utf8')
+    plur.syncScopeMetadata([])
+    const after = readFileSync(join(dir, 'config.yaml'), 'utf8')
+    expect(after).toBe(before)
+  })
+
+  it('is a no-op when nothing changed (covers already match)', () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false, covers: ['ci', 'deploy'], description: 'Eng knowledge' },
+    ])
+    const before = readFileSync(join(dir, 'config.yaml'), 'utf8')
+    plur.syncScopeMetadata([
+      { scope: 'group:plur/engineering', description: 'Eng knowledge', covers: ['ci', 'deploy'] },
+    ])
+    const after = readFileSync(join(dir, 'config.yaml'), 'utf8')
+    expect(after).toBe(before)
+  })
+
+  it('skips personal-family scopes — they are never routing targets', () => {
+    const plur = writeCfg([
+      { path: join(dir, 'engrams.yaml'), scope: 'global', shared: false, readonly: false },
+      { url: baseUrl, token: TOKEN, scope: 'user:plur:tester', shared: false, readonly: false },
+    ])
+    const before = readFileSync(join(dir, 'config.yaml'), 'utf8')
+    plur.syncScopeMetadata([
+      { scope: 'global', description: 'Personal global', covers: ['everything'] },
+      { scope: 'user:plur:tester', description: 'My scope', covers: ['personal-docs'] },
+    ])
+    const after = readFileSync(join(dir, 'config.yaml'), 'utf8')
+    expect(after).toBe(before)
+  })
+
+  it('refreshes covers when the server value changes (ties into #648)', () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false, covers: ['old-cover'], description: 'old desc' },
+    ])
+    plur.syncScopeMetadata([
+      { scope: 'group:plur/engineering', description: 'Updated desc', covers: ['ci', 'deploy', 'plur.*'] },
+    ])
+    const cfg = readCfg(dir)
+    const entry = (cfg.stores as unknown[]).find((s: unknown) => (s as { scope?: string }).scope === 'group:plur/engineering') as Record<string, unknown>
+    expect(entry.covers).toEqual(['ci', 'deploy', 'plur.*'])
+    expect(entry.description).toBe('Updated desc')
+  })
+
+  it('preserves other store fields (url, token, shared, readonly) during the writeback', () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    plur.syncScopeMetadata([
+      { scope: 'group:plur/engineering', description: 'Eng', covers: ['ci'] },
+    ])
+    const cfg = readCfg(dir)
+    const entry = (cfg.stores as unknown[]).find((s: unknown) => (s as { scope?: string }).scope === 'group:plur/engineering') as Record<string, unknown>
+    expect(entry.url).toBe(baseUrl)
+    expect(entry.token).toBe(TOKEN)
+    expect(entry.shared).toBe(true)
+    expect(entry.readonly).toBe(false)
+  })
+
+  it('updates multiple scopes in a single call', () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/research', shared: true, readonly: false },
+    ])
+    plur.syncScopeMetadata([
+      { scope: 'group:plur/engineering', description: 'Eng', covers: ['ci'] },
+      { scope: 'group:plur/research', description: 'Research', covers: ['plur.research.benchmarking'] },
+    ])
+    const cfg = readCfg(dir)
+    const stores = cfg.stores as Record<string, unknown>[]
+    const eng = stores.find(s => s.scope === 'group:plur/engineering')!
+    const res = stores.find(s => s.scope === 'group:plur/research')!
+    expect(eng.covers).toEqual(['ci'])
+    expect(res.covers).toEqual(['plur.research.benchmarking'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerDiscoveredScopes() syncs metadata as a side-effect (#668)
+// ---------------------------------------------------------------------------
+
+describe('Plur.registerDiscoveredScopes() — covers synced after registration', () => {
+  afterEach(cleanup)
+
+  it('persists server covers for all authorized scopes after bulk-register', async () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    await plur.registerDiscoveredScopes()
+    const cfg = readCfg(dir)
+    const stores = cfg.stores as Record<string, unknown>[]
+
+    // Originally-registered scope gets its covers synced
+    const eng = stores.find(s => s.scope === 'group:plur/engineering')!
+    expect(eng.covers).toEqual(['ci', 'deploy', 'plur.*'])
+
+    // Newly-registered scopes also carry their covers
+    const research = stores.find(s => s.scope === 'group:plur/research')!
+    expect(research).toBeDefined()
+    expect(research.covers).toEqual(['plur.research.benchmarking', 'papers', 'longevity'])
+  })
+
+  it('activates suggestScope after registerDiscoveredScopes', async () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    // Before: suggestScope returns [] because no covers in local config
+    expect(plur.suggestScope({ statement: 'update the CI pipeline and deploy scripts' })).toEqual([])
+
+    await plur.registerDiscoveredScopes()
+
+    // After: the engineering scope's covers match the input
+    const candidates = plur.suggestScope({ statement: 'update the CI pipeline and deploy scripts' })
+    expect(candidates.length).toBeGreaterThan(0)
+    expect(candidates[0].scope).toBe('group:plur/engineering')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerScope() syncs metadata for the registered scope (#668)
+// ---------------------------------------------------------------------------
+
+describe('Plur.registerScope() — covers synced after single-scope registration', () => {
+  afterEach(cleanup)
+
+  it('persists covers for the newly registered scope', async () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    await plur.registerScope('group:plur/research')
+    const cfg = readCfg(dir)
+    const stores = cfg.stores as Record<string, unknown>[]
+    const research = stores.find(s => s.scope === 'group:plur/research')!
+    expect(research).toBeDefined()
+    expect(research.covers).toEqual(['plur.research.benchmarking', 'papers', 'longevity'])
+    expect(research.description).toBe('Research and benchmarking')
+  })
+
+  it('also syncs already-registered scopes on the same endpoint', async () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    // The /me discovery surfaces metadata for all scopes on this URL, so
+    // syncing after registerScope should also update the existing entry.
+    await plur.registerScope('group:plur/comms')
+    const cfg = readCfg(dir)
+    const stores = cfg.stores as Record<string, unknown>[]
+    const eng = stores.find(s => s.scope === 'group:plur/engineering')
+    expect(eng?.covers).toEqual(['ci', 'deploy', 'plur.*'])
+  })
+
+  it('activates suggestScope for the newly registered scope', async () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    await plur.registerScope('group:plur/research')
+    const candidates = plur.suggestScope({
+      statement: 'LongMemEval benchmark result for the hybrid reranker pass',
+      domain: 'plur.research.benchmarking',
+    })
+    expect(candidates.length).toBeGreaterThan(0)
+    expect(candidates[0].scope).toBe('group:plur/research')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// suggestScope end-to-end: server → local config → ranker (#668)
+// ---------------------------------------------------------------------------
+
+describe('suggestScope activated end-to-end via server covers', () => {
+  afterEach(cleanup)
+
+  it('returns [] before sync and candidates after sync — proving server covers were missing', () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    // Before: inert — no covers in local config
+    expect(plur.suggestScope({ statement: 'update the CI pipeline', domain: 'plur.engineering' })).toEqual([])
+
+    // After: server covers written
+    plur.syncScopeMetadata([
+      { scope: 'group:plur/engineering', description: 'Eng', covers: ['plur.*', 'ci', 'deploy'] },
+    ])
+    const after = plur.suggestScope({ statement: 'update the CI pipeline', domain: 'plur.engineering' })
+    expect(after.length).toBeGreaterThan(0)
+    expect(after[0].scope).toBe('group:plur/engineering')
+  })
+
+  it('a covers-vocabulary statement from issue #668 ranks the owning scope first', async () => {
+    const plur = writeCfg([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/research', shared: true, readonly: false },
+    ])
+    // Reproduce the exact failure from the issue report: domain='plur.research.benchmarking'
+    // is one of the scope's covers but was never persisted — both calls returned [].
+    expect(plur.suggestScope({ statement: 'benchmark result', domain: 'plur.research.benchmarking' })).toEqual([])
+
+    await plur.registerDiscoveredScopes()  // triggers syncScopeMetadata
+
+    const candidates = plur.suggestScope({
+      statement: 'benchmark result for the reranker ablation study',
+      domain: 'plur.research.benchmarking',
+    })
+    expect(candidates.length).toBeGreaterThan(0)
+    expect(candidates[0].scope).toBe('group:plur/research')
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1203,7 +1203,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_sync',
-      description: 'Sync engrams via git AND refresh the derived index from YAML. Initializes repo on first call, commits and pushes/pulls on subsequent calls. Provide a remote URL on first call to enable cross-device sync. Pass full=true to drop-and-rebuild the index from YAML (recovery path; YAML stays untouched).',
+      description: 'Sync engrams via git AND refresh the derived index from YAML. Initializes repo on first call, commits and pushes/pulls on subsequent calls. Provide a remote URL on first call to enable cross-device sync. Pass full=true to drop-and-rebuild the index from YAML (recovery path; YAML stays untouched). Also flushes the remote-write outbox — retries team-scoped writes that were queued while their remote store was unreachable.',
       annotations: { title: 'Sync', openWorldHint: true, destructiveHint: false, idempotentHint: true },
       inputSchema: {
         type: 'object',
@@ -1260,6 +1260,37 @@ function getAllToolDefinitions(): ToolDefinition[] {
       },
       handler: async (_args, plur) => {
         return plur.syncStatus()
+      },
+    },
+
+    {
+      name: 'plur_outbox',
+      description: 'Inspect and flush the remote-write outbox. When a team-scoped write fails (store down, VPN off, expired token), the engram is saved locally with outbox metadata and retried on the next session_start or plur_sync. Read (default): returns pending count + entry metadata (no credentials). flush=true: retries all pending writes immediately and returns the result.',
+      annotations: { title: 'Outbox', readOnlyHint: false, idempotentHint: false },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          flush: {
+            type: 'boolean',
+            description: 'Retry all pending remote writes immediately. Returns { flushed, failed, expired_warnings }.',
+          },
+        },
+      },
+      handler: async (args, plur) => {
+        if (args.flush === true) {
+          const result = await plur.flushOutbox()
+          return {
+            flushed: result.flushed,
+            failed: result.failed,
+            pending: result.failed,
+            expired_warnings: result.expired_warnings,
+          }
+        }
+        const entries = plur.outboxEntries()
+        return {
+          pending: entries.length,
+          entries,
+        }
       },
     },
 
@@ -1985,6 +2016,9 @@ function getAllToolDefinitions(): ToolDefinition[] {
                 `\`plur scopes\` to register or dismiss them per-scope (dismissed scopes stop being offered; ` +
                 `\`plur scopes --reoffer\` re-surfaces them).`
             }
+            // Persist server-authoritative covers/description into local config
+            // so suggestScope() activates for already-registered scopes (#668).
+            plur.syncScopeMetadata(discoveries.filter(d => d.ok).flatMap(d => d.metadata))
           } catch { /* discovery is best-effort — never block session_start */ }
 
           // #295: proactive token-expiry warning — purely local JWT decode, no
@@ -1998,6 +2032,11 @@ function getAllToolDefinitions(): ToolDefinition[] {
               }
             }
           } catch { /* best-effort */ }
+        }
+
+        // Surface pending outbox count in guide when non-zero and not already mentioned (issue #667)
+        if (outbox_result && outbox_result.failed > 0 && !guide.includes('queued in the outbox') && !guide.includes('queue in the outbox')) {
+          guide += `\n\n⚠️ ${outbox_result.failed} team-scoped write(s) still pending in the outbox — run plur_outbox {flush:true} or plur_sync to retry.`
         }
 
         return {
@@ -2260,6 +2299,9 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
         if (discoveries.length === 0) {
           return { discovered: [], note: 'No remote stores configured. Register one scope first with plur_stores_add, then discover the rest.' }
         }
+        // Persist server-authoritative covers/description into local config for
+        // already-registered scopes so suggestScope() activates (#668).
+        plur.syncScopeMetadata(discoveries.filter(d => d.ok).flatMap(d => d.metadata))
         // #345 D2: surface the server-authoritative description/covers per scope
         // so an agent can pick the right scope from discovery alone (instead of
         // guessing from the bare scope name). Each authorized scope is annotated


### PR DESCRIPTION
## Problem

`suggestScope` was completely inert for remote scopes. The server's `scope_metadata.covers[]` was fetched via `/me` but never written to local config store entries. `getScopeMetadata()` found nothing, `listScopeMetadata()` returned `[]`, and `suggestScope()` returned `[]` for every input — reproducing the exact failure in #668 where two on-topic statements built from a scope's own covers vocabulary both returned `{ candidates: [], count: 0 }`.

## Root cause

`registerDiscoveredScopes()`, `registerScope()`, and the session_start / scopes_discover MCP tools all called `discoverRemoteScopes()` (which fetches `/me` and returns `metadata: ScopeMetadata[]`) but never wrote `covers`/`description` into the local config store entries. `addStore()` had no path for metadata at all.

## Fix

Adds `syncScopeMetadata(serverMetadata: ScopeMetadata[])` to the `Plur` class — a public read-preserve-write method that updates existing registered shared-family store entries with the server-authoritative `covers[]` and `description`. Personal-family scopes are excluded (they are never routing targets). Calls it from:

- `registerDiscoveredScopes()` — after the registration loop
- `registerScope()` — after `addStore`
- `session_start` MCP tool — inside the existing best-effort try/catch block
- `plur_scopes_discover` MCP tool — after `discoverRemoteScopes`

After this fix, `suggestScope` activates with no further change — the read path was already correct, the write side was simply missing.

## Tests

14 new tests in `packages/core/test/scope-metadata-sync.test.ts`:

- `syncScopeMetadata()` direct API: writes covers/description, no-op when unchanged, skips personal-family, refreshes on server change, preserves other store fields, handles multiple scopes
- `registerDiscoveredScopes()`: covers synced after bulk-register; `suggestScope` activates
- `registerScope()`: covers synced for newly registered + existing scopes; `suggestScope` activates
- End-to-end: `[]` before sync, candidates after; exact #668 repro (domain `plur.research.benchmarking`) returns the owning scope first

## Acceptance criteria coverage

- [x] After `plur_scopes_discover` / `registerScope` / `session_start`, each registered remote scope's config store entry carries the server's `covers[]` (+ description)
- [x] `plur_suggest_scope` returns the matching scope for a statement built from that scope's covers vocabulary
- [x] Personal-family scopes are never written a routing-covers entry
- [x] Re-running discovery refreshes covers when the server value changed

Closes #668