### PR TITLE
docs(#671): domain convention — plur.<team>.<area> in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,23 @@ PLUR uses `domain` and `scope` fields to separate knowledge. **Set `scope` on ev
 - Personal preferences / your workflow → leave at the default/local scope.
 - Don't omit `scope` for team-relevant knowledge — it falls back to `global`, which leaks into every project and never reaches the team store. Reserve `global` for genuinely cross-project facts.
 
+### Domain convention
+
+**Always set `domain` on every `plur_learn` call.** An engram without a `domain` cannot auto-route to a team scope — it falls to `global` regardless of its content. Domain is the primary routing signal; omitting it makes the engram effectively invisible to scope routing.
+
+Use dotted namespace `plur.<team>.<area>`:
+
+| Team | Domain prefix | Example |
+|------|--------------|---------|
+| Engineering | `plur.engineering` | `plur.engineering.search`, `plur.engineering.mcp` |
+| Comms / Marketing | `plur.comms` | `plur.comms.positioning`, `plur.comms.release` |
+| Research | `plur.research` | `plur.research.benchmarks`, `plur.research.competitors` |
+| Leadership / Strategy | `plur.leadership` | `plur.leadership.roadmap`, `plur.leadership.hiring` |
+| Company / Org | `plur.company` | `plur.company.legal`, `plur.company.finance` |
+| Personal workflow | (omit or `personal.*`) | — |
+
+The convention is **free-form with documented shape** — a soft convention, not a validated registry. Unknown teams or cross-cutting domains are fine (`plur.infra`, `plur.security`); the table above covers the common cases. A conforming `plur.<team>` domain auto-routes at ≥0.5 confidence after the covers are set (see #668).
+
 ### When to check memory
 
 Before reaching for web search, file reads, or guessing — apply this priority:


### PR DESCRIPTION
## Summary

- Documents the `plur.<team>.<area>` domain convention in CLAUDE.md
- Explains why omitting `domain` makes engrams unroutable (the primary routing signal)
- Provides a team-to-prefix table covering the five common cases
- Keeps the convention free-form (no registry validation) — soft shape, not a hard schema

## Context (#671)

A live audit on 2026-07-23 found 803/2261 engrams (35%) have no `domain`. Because domain-prefix match is the only channel that reliably clears the 0.5 auto-route threshold (covers fix in #668 confirmed this), an engram with no domain is unroutable by construction.

This PR delivers proposal item 2 from #671 (behavioral/agent guidance). The remaining items tracked on that issue:
- **Item 3 (optional code)**: soft warning in `learn()` when `domain` is missing
- **Backfill**: tooling/runbook to retroactively set domains on the existing 803 no-domain engrams

## Test plan

- [ ] CLAUDE.md renders correctly in GitHub
- [ ] Domain convention table is legible and consistent with the covers configured in #668