### PR TITLE
fix(#668): persist scope metadata from /me into local config — activate suggestScope for remote scopes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,23 @@ PLUR uses `domain` and `scope` fields to separate knowledge. **Set `scope` on ev
 - Personal preferences / your workflow → leave at the default/local scope.
 - Don't omit `scope` for team-relevant knowledge — it falls back to `global`, which leaks into every project and never reaches the team store. Reserve `global` for genuinely cross-project facts.
 
+### Domain convention
+
+**Always set `domain` on every `plur_learn` call.** An engram without a `domain` cannot auto-route to a team scope — it falls to `global` regardless of its content. Domain is the primary routing signal; omitting it makes the engram effectively invisible to scope routing.
+
+Use dotted namespace `plur.<team>.<area>`:
+
+| Team | Domain prefix | Example |
+|------|--------------|---------|
+| Engineering | `plur.engineering` | `plur.engineering.search`, `plur.engineering.mcp` |
+| Comms / Marketing | `plur.comms` | `plur.comms.positioning`, `plur.comms.release` |
+| Research | `plur.research` | `plur.research.benchmarks`, `plur.research.competitors` |
+| Leadership / Strategy | `plur.leadership` | `plur.leadership.roadmap`, `plur.leadership.hiring` |
+| Company / Org | `plur.company` | `plur.company.legal`, `plur.company.finance` |
+| Personal workflow | (omit or `personal.*`) | — |
+
+The convention is **free-form with documented shape** — a soft convention, not a validated registry. Unknown teams or cross-cutting domains are fine (`plur.infra`, `plur.security`); the table above covers the common cases. A conforming `plur.<team>` domain auto-routes at ≥0.5 confidence after the covers are set (see #668).
+
 ### When to check memory
 
 Before reaching for web search, file reads, or guessing — apply this priority:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4737,7 +4737,7 @@ Generate an improved version of the procedure that prevents this failure. Return
    */
   async registerDiscoveredScopes(opts?: { url?: string; timeoutMs?: number }): Promise<RegisterDiscoveredResult[]> {
     const discoveries = await this.discoverRemoteScopes(opts)
-    return discoveries.map(d => {
+    const results = discoveries.map(d => {
       if (!d.ok) return { url: d.url, ok: false, added: [], already_registered: [], skipped: [], error: d.error }
       const token = (this.config.stores ?? []).find(s => s.url === d.url)?.token
       const added: string[] = []
@@ -4778,6 +4778,9 @@ Generate an improved version of the procedure that prevents this failure. Return
       }
       return { url: d.url, ok: true, added, already_registered: already, skipped }
     })
+    // Persist covers/description/sensitivity for all registered scopes (#668)
+    this.persistScopeMetadata(discoveries)
+    return results
   }
 
   /**
@@ -4842,6 +4845,8 @@ Generate an improved version of the procedure that prevents this failure. Return
     }
     const token = (this.config.stores ?? []).find(s => s.url === match.url)?.token
     const { status } = this.addStore('', scope, { url: match.url, token })
+    // Persist covers/description/sensitivity so suggestScope activates (#668).
+    this.persistScopeMetadata(discoveries)
     // Registering a scope also clears any prior dismissal of it (#647).
     if ((this.config.dismissed_scopes ?? []).includes(scope)) {
       this.persistDismissedScopes((this.config.dismissed_scopes ?? []).filter(s => s !== scope))
@@ -4888,6 +4893,46 @@ Generate an improved version of the procedure that prevents this failure. Return
     fs.writeFileSync(this.paths.config, yaml.dump(configData, { lineWidth: 120, noRefs: true }))
     this.config = loadConfig(this.paths.config)
     this.configMtimeMs = this.statConfigMtime()
+  }
+
+  /**
+   * Sync server-authoritative scope metadata (covers/description/sensitivity)
+   * from /me discoveries into the matching local config store entries (#668).
+   *
+   * discoverRemoteScopes() fetches scope_metadata from /me but never persisted
+   * covers into local config, so listScopeMetadata() returned empty covers and
+   * suggestScope() was inert for remote scopes. Called after any /me pull
+   * (session_start, registerDiscoveredScopes, registerScope) to close that gap.
+   * Personal-family scopes are skipped — they are never routing targets.
+   * No-op when nothing changed (avoids spurious config writes).
+   */
+  persistScopeMetadata(discoveries: RemoteScopeDiscovery[]): void {
+    const stores = this.config.stores ?? []
+    if (!stores.length) return
+
+    let changed = false
+    const updated = stores.map(entry => {
+      if (!entry.url) return entry                  // local store — no server metadata
+      if (!isSharedScope(entry.scope)) return entry // never write covers to personal scopes
+      const discovery = discoveries.find(d => d.ok && d.url === entry.url)
+      if (!discovery?.metadata.length) return entry
+      const meta = discovery.metadata.find(m => m.scope === entry.scope)
+      if (!meta) return entry
+      // Only write when values differ to avoid spurious config writes
+      const coversMatch = JSON.stringify(meta.covers) === JSON.stringify(entry.covers)
+      const descMatch = meta.description === entry.description
+      const sensMatch = JSON.stringify(meta.sensitivity) === JSON.stringify(entry.sensitivity)
+      if (coversMatch && descMatch && sensMatch) return entry
+      changed = true
+      return {
+        ...entry,
+        ...(meta.covers !== undefined ? { covers: meta.covers } : {}),
+        ...(meta.description !== undefined ? { description: meta.description } : {}),
+        ...(meta.sensitivity !== undefined ? { sensitivity: meta.sensitivity } : {}),
+      }
+    })
+
+    if (changed) this.persistStores(updated)
   }
 
   /** Set a session-level default scope. Used as fallback in learn/learnRouted when no explicit scope is provided. */

--- a/packages/core/test/scope-metadata-sync.test.ts
+++ b/packages/core/test/scope-metadata-sync.test.ts
@@ -1,0 +1,286 @@
+/**
+ * persistScopeMetadata() — closes plur-ai/plur#668.
+ *
+ * discoverRemoteScopes() fetches scope_metadata (covers/description/sensitivity)
+ * from /me but historically never persisted it into local config store entries.
+ * persistScopeMetadata() closes that gap: after any /me pull, each registered
+ * scope's store entry is updated so suggestScope() can actually route.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { StubServer } from './helpers/stub-server.js'
+
+const TOKEN = 'metadata-sync-test-token'
+let server: StubServer
+let baseUrl: string
+
+beforeAll(async () => {
+  server = new StubServer(TOKEN)
+  const info = await server.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => { await server.stop() })
+
+beforeEach(() => {
+  server.reset()
+  server.setMe({
+    username: 'tester',
+    org_id: 'plur',
+    role: 'developer',
+    scopes: [
+      'group:plur/engineering',
+      'group:plur/comms',
+    ],
+    scope_metadata: [
+      {
+        scope: 'group:plur/engineering',
+        description: 'Engineering knowledge',
+        covers: ['plur.engineering', 'ci', 'deploy'],
+      },
+      {
+        scope: 'group:plur/comms',
+        description: 'Comms and marketing',
+        covers: ['plur.comms', 'marketing'],
+      },
+    ],
+  })
+})
+
+function makeDir(stores: unknown[]): { dir: string; plur: Plur } {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-meta-sync-'))
+  writeFileSync(join(dir, 'config.yaml'), yaml.dump({ stores, index: false }, { lineWidth: 120, noRefs: true }))
+  return { dir, plur: new Plur({ path: dir }) }
+}
+
+function readStores(dir: string): unknown[] {
+  const raw = readFileSync(join(dir, 'config.yaml'), 'utf8')
+  return ((yaml.load(raw) as Record<string, unknown>).stores ?? []) as unknown[]
+}
+
+// ---------------------------------------------------------------------------
+// persistScopeMetadata()
+// ---------------------------------------------------------------------------
+
+describe('persistScopeMetadata()', () => {
+  it('persists covers+description into a registered shared scope', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    try {
+      const discoveries = await plur.discoverRemoteScopes()
+      plur.persistScopeMetadata(discoveries)
+
+      const stores = readStores(dir) as Array<Record<string, unknown>>
+      const eng = stores.find(s => s.scope === 'group:plur/engineering')!
+      expect(eng.covers).toEqual(['plur.engineering', 'ci', 'deploy'])
+      expect(eng.description).toBe('Engineering knowledge')
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('persists covers for all registered scopes in one call', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/comms', shared: true, readonly: false },
+    ])
+    try {
+      const discoveries = await plur.discoverRemoteScopes()
+      plur.persistScopeMetadata(discoveries)
+
+      const stores = readStores(dir) as Array<Record<string, unknown>>
+      expect((stores.find(s => s.scope === 'group:plur/engineering') as Record<string, unknown>).covers)
+        .toEqual(['plur.engineering', 'ci', 'deploy'])
+      expect((stores.find(s => s.scope === 'group:plur/comms') as Record<string, unknown>).covers)
+        .toEqual(['plur.comms', 'marketing'])
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('updates covers when the server value changes on re-sync', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    try {
+      const d1 = await plur.discoverRemoteScopes()
+      plur.persistScopeMetadata(d1)
+
+      // Server updates covers for engineering
+      server.setMe({
+        scope_metadata: [{ scope: 'group:plur/engineering', description: 'Eng v2', covers: ['plur.engineering', 'testing'] }],
+      })
+      const d2 = await plur.discoverRemoteScopes()
+      plur.persistScopeMetadata(d2)
+
+      const stores = readStores(dir) as Array<Record<string, unknown>>
+      const eng = stores.find(s => s.scope === 'group:plur/engineering')!
+      expect(eng.covers).toEqual(['plur.engineering', 'testing'])
+      expect(eng.description).toBe('Eng v2')
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('does NOT write covers to personal-family scopes', async () => {
+    // Simulate a discovery where the server metadata includes a personal-family scope.
+    // persistScopeMetadata must skip personal scopes even if there's a store entry for them.
+    const dir2 = mkdtempSync(join(tmpdir(), 'plur-meta-sync-personal-'))
+    writeFileSync(
+      join(dir2, 'config.yaml'),
+      yaml.dump({
+        stores: [
+          // A shared scope registered to the remote
+          { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+        ],
+        index: false,
+      }),
+    )
+    const plur2 = new Plur({ path: dir2 })
+    try {
+      // Server metadata includes a personal-family scope entry — must be ignored
+      const discoveries = [{
+        url: baseUrl, ok: true as const, username: 'u',
+        authorized: ['group:plur/engineering', 'global'],
+        registered: ['group:plur/engineering'],
+        unregistered: [],
+        metadata: [
+          { scope: 'global', description: 'Personal', covers: ['everything'] },
+          { scope: 'group:plur/engineering', description: 'Eng', covers: ['plur.engineering'] },
+        ],
+      }]
+      plur2.persistScopeMetadata(discoveries)
+
+      const stores = readStores(dir2) as Array<Record<string, unknown>>
+      // global is not in stores → no entry to update (personal scopes are never registered)
+      expect(stores.find(s => s.scope === 'global')).toBeUndefined()
+      // The shared scope does get updated
+      expect((stores.find(s => s.scope === 'group:plur/engineering') as Record<string, unknown>).covers)
+        .toEqual(['plur.engineering'])
+    } finally { rmSync(dir2, { recursive: true, force: true }) }
+  })
+
+  it('skips scopes not in the discovery metadata (unregistered)', async () => {
+    // group:plur/comms is registered but NOT in metadata → store entry unchanged
+    server.setMe({
+      scope_metadata: [
+        { scope: 'group:plur/engineering', description: 'Eng', covers: ['plur.engineering'] },
+        // group:plur/comms intentionally absent from metadata
+      ],
+    })
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/comms', shared: true, readonly: false },
+    ])
+    try {
+      const discoveries = await plur.discoverRemoteScopes()
+      plur.persistScopeMetadata(discoveries)
+
+      const stores = readStores(dir) as Array<Record<string, unknown>>
+      const comms = stores.find(s => s.scope === 'group:plur/comms')!
+      expect(comms.covers).toBeUndefined()  // untouched — no metadata for it
+      const eng = stores.find(s => s.scope === 'group:plur/engineering')!
+      expect(eng.covers).toEqual(['plur.engineering'])  // was synced
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('is a no-op when metadata matches existing covers (no spurious write)', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false,
+        description: 'Engineering knowledge', covers: ['plur.engineering', 'ci', 'deploy'] },
+    ])
+    try {
+      const mtimeBefore = (await import('fs')).statSync(join(dir, 'config.yaml')).mtimeMs
+      const discoveries = await plur.discoverRemoteScopes()
+      plur.persistScopeMetadata(discoveries)
+      const mtimeAfter = (await import('fs')).statSync(join(dir, 'config.yaml')).mtimeMs
+      expect(mtimeAfter).toBe(mtimeBefore)  // file not rewritten
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('is a no-op when discovery ok:false', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    try {
+      plur.persistScopeMetadata([
+        { url: baseUrl, ok: false as const, authorized: [], registered: [], unregistered: [], metadata: [], error: 'simulated failure' },
+      ])
+      const stores = readStores(dir) as Array<Record<string, unknown>>
+      expect(stores[0].covers).toBeUndefined()  // not written on failure
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// suggestScope() with synced covers
+// ---------------------------------------------------------------------------
+
+describe('suggestScope() activates after persistScopeMetadata()', () => {
+  it('returns the matching scope for a covers-vocabulary statement', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    try {
+      const discoveries = await plur.discoverRemoteScopes()
+      plur.persistScopeMetadata(discoveries)
+
+      const candidates = plur.suggestScope({ statement: 'deploy pipeline config', domain: 'plur.engineering' })
+      expect(candidates.length).toBeGreaterThan(0)
+      expect(candidates[0].scope).toBe('group:plur/engineering')
+      expect(candidates[0].confidence).toBeGreaterThanOrEqual(0.5)
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('returns [] before covers are synced (inert state)', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    try {
+      // No persistScopeMetadata call — covers never written
+      const candidates = plur.suggestScope({ statement: 'deploy pipeline config', domain: 'plur.engineering' })
+      expect(candidates).toEqual([])
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerDiscoveredScopes() calls persistScopeMetadata internally
+// ---------------------------------------------------------------------------
+
+describe('registerDiscoveredScopes() auto-syncs metadata', () => {
+  it('persists covers for all newly registered scopes', async () => {
+    const { dir, plur } = makeDir([
+      // One pre-registered scope with token
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    try {
+      await plur.registerDiscoveredScopes()
+
+      const stores = readStores(dir) as Array<Record<string, unknown>>
+      // engineering was already registered; comms is newly registered — both get covers
+      const eng = stores.find(s => s.scope === 'group:plur/engineering')!
+      expect(eng.covers).toEqual(['plur.engineering', 'ci', 'deploy'])
+      const comms = stores.find(s => s.scope === 'group:plur/comms')!
+      expect(comms?.covers).toEqual(['plur.comms', 'marketing'])
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerScope() calls persistScopeMetadata internally
+// ---------------------------------------------------------------------------
+
+describe('registerScope() auto-syncs metadata', () => {
+  it('persists covers for the single registered scope', async () => {
+    const { dir, plur } = makeDir([
+      { url: baseUrl, token: TOKEN, scope: 'group:plur/engineering', shared: true, readonly: false },
+    ])
+    try {
+      await plur.registerScope('group:plur/comms')
+
+      const stores = readStores(dir) as Array<Record<string, unknown>>
+      const comms = stores.find(s => s.scope === 'group:plur/comms')!
+      expect(comms.covers).toEqual(['plur.comms', 'marketing'])
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1957,6 +1957,8 @@ function getAllToolDefinitions(): ToolDefinition[] {
           // session_start. Only hints when there's actually something to add.
           try {
             const discoveries = await plur.discoverRemoteScopes({ timeoutMs: 3000 })
+            // Persist covers/description/sensitivity so suggestScope activates (#668).
+            plur.persistScopeMetadata(discoveries)
             // #295: surface auth/reachability failures LOUDLY. discoverRemoteScopes
             // already probed /me per URL — a failure here means team-scoped writes
             // are silently queuing to the outbox. Don't swallow it.


### PR DESCRIPTION
## Problem

`suggestScope()` was silently inert for all remote scopes. The root cause: `discoverRemoteScopes()` fetches `scope_metadata` (including `covers[]`) from `GET /api/v1/me` but never persisted it into the local config store entries that `listScopeMetadata()` reads. So `suggestScope()` always returned `[]` for remote scopes regardless of how well the query matched a scope's declared covers vocabulary.

Closes #668. Unblocks #648 (freshness concern can now arise since the cache is actually populated).

## Fix

**New method**: `persistScopeMetadata(discoveries: RemoteScopeDiscovery[]): void`

After any `/me` pull, iterates the registered store entries and writes `covers[]`, `description`, and `sensitivity` from server metadata into the matching local config entry. Uses the same read-preserve-write pattern as `persistStores()`.

**Three call sites added**:
- `session_start` (tools.ts) — immediately after `discoverRemoteScopes()`, within the existing best-effort try/catch
- `registerDiscoveredScopes()` — after the addStore loop, before returning results
- `registerScope()` — after `addStore()`, before clearing any dismissal

**Safety constraints** (all per #668 spec):
- Personal-family scopes (`global`, `user:*`, `local`, etc.) are skipped — never routing targets
- No-op when metadata already matches existing values — avoids spurious config writes
- No-op when `discovery.ok` is false — never mutates config on network failure
- Unregistered scopes (metadata present, no local store entry) are naturally skipped

## Tests

11 new tests in `packages/core/test/scope-metadata-sync.test.ts`:

| Test | Covers |
|------|--------|
| persists covers+description into registered shared scope | happy path |
| persists covers for all registered scopes in one call | multi-scope |
| updates covers when server value changes on re-sync | freshness (#648 prerequisite) |
| does NOT write covers to personal-family scopes | security guard |
| skips scopes not in discovery metadata | partial metadata |
| is a no-op when metadata matches existing covers | no spurious writes |
| is a no-op when discovery ok:false | failure path |
| suggestScope returns matching scope after sync | end-to-end ranker activation |
| suggestScope returns [] before covers are synced | inert baseline |
| registerDiscoveredScopes() auto-syncs metadata | integration |
| registerScope() auto-syncs metadata | integration |

All 11 pass. Existing 83 scope tests unchanged.

## Testing

```bash
pnpm --filter @plur-ai/core build
npx vitest run test/scope-metadata-sync.test.ts test/scope-routing.test.ts test/scope-discovery.test.ts
```

## Docs to update (follow-up)

Per #668 spec, these are post-merge follow-ups:
- Scope-routing architecture doc: note that `covers[]` originates server-side and must be persisted for `suggestScope` to function
- `plur_suggest_scope` tool description: note it requires locally-synced `covers[]`

🤖 heartbeat — cto