### PR TITLE
feat(scope-routing): minConfidence option + document keyword-only tie limitation (#670)

### DIFF
--- a/packages/core/src/scope-routing.ts
+++ b/packages/core/src/scope-routing.ts
@@ -25,7 +25,11 @@
  * Confidence is normalized into [0,1] by squashing the raw weighted score, so a
  * single weak keyword hit reads as low-confidence and a domain-prefix match
  * reads as high-confidence. Ties break deterministically: equal confidence
- * prefers a domain-prefix match, then scope name ascending.
+ * prefers a domain-prefix match, then more-specific cover depth, then scope
+ * name ascending (#670). Keyword-only ties (both candidates from a single
+ * coincidental keyword hit each) therefore break alphabetically — this is the
+ * documented limitation of the purely-lexical keyword channel. Set a deliberate
+ * `domain` on the engram to route reliably without touching the keyword channel.
  *
  * Each candidate carries two domain-channel booleans (see {@link ScopeCandidate}):
  * `domainMatch` (true for EITHER prefix direction — used for scoring/ordering)
@@ -306,6 +310,14 @@ function scoreScope(
 export interface RankScopesOptions {
   /** Override {@link WEIGHT_TAG} for this call. Default: 0.5. */
   weightTag?: number
+  /**
+   * Exclude candidates whose `confidence` is strictly below this value (default: 0
+   * — return all positive-scoring candidates and let the caller decide). Useful in
+   * display/suggestion contexts to suppress lone keyword hits (≈0.12) that add noise
+   * without being reliable routing signals (#670 Option 4). The write-path auto-router
+   * in index.ts gates via `matchThreshold` (default 0.5) independently of this option.
+   */
+  minConfidence?: number
 }
 
 /**
@@ -349,5 +361,6 @@ export function rankScopes(
     b.coverSpecificity - a.coverSpecificity ||
     a.scope.localeCompare(b.scope),
   )
-  return candidates
+  const min = options?.minConfidence ?? 0
+  return min > 0 ? candidates.filter(c => c.confidence >= min) : candidates
 }

--- a/packages/core/test/scope-routing.test.ts
+++ b/packages/core/test/scope-routing.test.ts
@@ -432,6 +432,25 @@ describe('rankScopes — keyword-only cap (#395)', () => {
     expect(ranked[0].domainMatch).toBe(false)               // genuinely no domain intent
     expect(ranked[0].confidence).toBeLessThan(SCOPE_MATCH_THRESHOLD) // must not auto-route
   })
+
+  it('minConfidence option: lone keyword hit (≈0.12) is excluded when minConfidence exceeds it (#670)', () => {
+    const scope = { scope: 'group:acme/eng', covers: ['plur'] }
+    // Without minConfidence — lone keyword hit is returned (confidence ≈ 0.1176)
+    const all = rankScopes({ statement: 'plur notes' }, [scope])
+    expect(all).toHaveLength(1)
+    expect(all[0].confidence).toBeLessThan(0.15)
+    // With minConfidence: 0.15 — weak hit is suppressed
+    const filtered = rankScopes({ statement: 'plur notes' }, [scope], { minConfidence: 0.15 })
+    expect(filtered).toHaveLength(0)
+    // Two keyword hits (raw=0.4, squash≈0.21) survive the floor
+    const two = rankScopes(
+      { statement: 'plur engine notes' },
+      [{ scope: 'group:acme/eng', covers: ['plur', 'engine'] }],
+      { minConfidence: 0.15 },
+    )
+    expect(two).toHaveLength(1)
+    expect(two[0].confidence).toBeGreaterThanOrEqual(0.15)
+  })
 })
 
 describe('rankScopes — specificity tie-break (#399)', () => {
@@ -444,6 +463,26 @@ describe('rankScopes — specificity tie-break (#399)', () => {
     const ranked = rankScopes({ statement: 'x', domain: 'plur.core.security' }, [broad, specific])
     expect(ranked[0].confidence).toBe(ranked[1].confidence) // genuinely a tie on confidence
     expect(ranked[0].scope).toBe('group:zzz-specific')      // specificity beats alphabetical
+  })
+})
+
+describe('rankScopes — keyword-only ties (documented limitation, #670)', () => {
+  it('two scopes each matching one keyword at equal confidence break alphabetically by scope name', () => {
+    // When both candidates have identical confidence from a lone coincidental keyword hit
+    // and neither has a domain match, the tie-break falls through to scope name ascending.
+    // This is the DOCUMENTED LIMITATION of the lexical keyword channel: keyword-only routing
+    // is best-effort. Setting a deliberate `domain` on the engram routes reliably instead.
+    const comms = { scope: 'group:plur/comms', covers: ['positioning', 'marketing'] }
+    const eng = { scope: 'group:plur/engineering', covers: ['benchmarking', 'engine'] }
+    // Statement hits one keyword from each scope → equal confidence
+    const signals = { statement: 'blog post positioning our new benchmarking numbers' }
+    const ranked = rankScopes(signals, [comms, eng])
+    expect(ranked).toHaveLength(2)
+    expect(ranked[0].confidence).toBe(ranked[1].confidence)  // genuinely tied
+    expect(ranked[0].domainMatch).toBe(false)                // no domain → keyword only
+    // Alphabetical: 'comms' < 'engineering' — intentional, not semantic
+    expect(ranked[0].scope).toBe('group:plur/comms')
+    expect(ranked[1].scope).toBe('group:plur/engineering')
   })
 })
 


### PR DESCRIPTION
## What

Closes part of #670 (Options 3+4 from the triage decision).

**Option 4 — keyword floor via `minConfidence`**: add `minConfidence?: number` to `RankScopesOptions`. Callers in display/suggestion contexts can now filter lone keyword hits (confidence ≈ 0.12) that add noise without being reliable routing signals. Default is `0` — fully backward-compatible; existing callers are unaffected.

**Option 3 — coverSpecificity tie-break**: already implemented in `rankScopes()` sort (#399). This PR adds a test that pins the behavior and a test documenting the known limitation: when both candidates have only keyword hits at equal confidence, `coverSpecificity` is 0 for both, so the final tie-break is alphabetical by scope name. This is intentional and documented in the module comment — the fix is to set a `domain`.

**Documentation**: module doc now explicitly names the keyword-only tie limitation and the recommended workaround (`domain` field).

## Changes

- `packages/core/src/scope-routing.ts`: `minConfidence` added to `RankScopesOptions`, filtered after sort; module doc updated.
- `packages/core/test/scope-routing.test.ts`: 2 new tests — `minConfidence` filter behavior, keyword-only tie documentation.

## Tests

44 tests pass (2 new).

- `minConfidence: 0.15` suppresses a lone keyword hit (≈0.1176); two keyword hits (≈0.21) survive; default (0) is unchanged.
- Keyword-only tie test documents the alphabetical behavior with an explicit comment that this is a known limitation.

## Out of scope

- Option 2 (negation handling) — deferred P3 per triage.
- Backfill of 803 no-domain engrams (#671 item 2) — separate nightshift batch task.