### PR TITLE
test(core): fix flaky MERGE demotion test in pr5-hardening (#680)

### DIFF
--- a/packages/core/test/pr5-hardening.test.ts
+++ b/packages/core/test/pr5-hardening.test.ts
@@ -76,7 +76,10 @@ describe('MED-20 + LOW-9 — learnAsync UPDATE/MERGE demotion (real guard, share
     const seed = plur.learn('the staging cluster is documented in the handbook', { scope: SHARED_SCOPE, type: 'procedural' }) as Engram
 
     const llm = dedupLlm('MERGE', seed.id)
-    const result = await plur.learnAsync(`reachable at ${PUBLIC_IP}:8877`, { llm })
+    // "staging" is shared with the seed so BM25 finds the candidate even when
+    // embeddings are unavailable under full-suite load (prevents a flake where
+    // zero-overlap candidates caused an ADD instead of MERGE — see #680).
+    const result = await plur.learnAsync(`staging cluster reachable at ${PUBLIC_IP}:8877`, { llm })
 
     expect(result.decision).toBe('MERGE')
     const e = result.engram as Engram & { visibility?: string; structured_data?: { _demoted?: { from: string; to: string; patterns: string } } }


### PR DESCRIPTION
## Root cause

The MERGE test in `pr5-hardening.test.ts` had **zero BM25 token overlap** between the seed statement and the merge statement:

- Seed: `'the staging cluster is documented in the handbook'` → tokens: `staging, cluster, documented, handbook`
- Merge: `'reachable at 139.59.155.82:8877'` → tokens: `reachable, 139, 155, 8877`

`learnAsync` candidate retrieval runs BM25 + embeddings. With no term overlap, BM25 returns empty. Under full-suite load (embedding model warming up concurrently across test files / forked processes), embeddings can also return empty on cold start. This collapses `learnAsync` to the ADD early-return path — `result.decision === 'ADD'` instead of `'MERGE'` — failing the test.

The UPDATE and BOUNDARY tests were fine — both share `deploy` with their respective statements.

## Fix

Changed the merge statement to include `staging cluster` so BM25 always finds the seed, independent of embedding availability:

```diff
-const result = await plur.learnAsync(`reachable at ${PUBLIC_IP}:8877`, { llm })
+const result = await plur.learnAsync(`staging cluster reachable at ${PUBLIC_IP}:8877`, { llm })
```

The test intent is unchanged: a MERGE that adds a public IP to a shared-scope engram must demote it to local/private.

## Verification

- 12/12 pass in isolation (unchanged)
- The statement change adds 2 overlapping BM25 tokens (`staging`, `cluster`), making candidate retrieval deterministic regardless of embedding state

Closes #680