### PR TITLE
fix(#625): lean-audit — actionable hidden-tool errors + enforced destructive-dispatch block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Scopes go live + leaner MCP.
 
 ### Changed
 
-- **Lean tool profile is now the default** (#625): the MCP server exposes 11 tools (down from 40) to every consumer — Claude Code, Cursor, Windsurf, OpenClaw, Hermes, and nightshift agents alike. Per-turn tool-schema overhead drops ~74% (~2K vs ~9K tokens). All 40 tools remain reachable via `plur_admin { action: "<tool>", args: {...} }`. Restore the full surface with `PLUR_TOOL_PROFILE=full`. **Consumers that depend on all 40 tools being available by default must either call via `plur_admin` or set `PLUR_TOOL_PROFILE=full`.**
+- **Lean tool profile is now the default** (#625): the MCP server exposes 12 tools — 11 core + the `plur_admin` dispatch (down from 40) to every consumer — Claude Code, Cursor, Windsurf, OpenClaw, Hermes, and nightshift agents alike. Per-turn tool-schema overhead drops ~74% (~2K vs ~9K tokens). All 40 tools remain reachable via `plur_admin { action: "<tool>", args: {...} }`. Restore the full surface with `PLUR_TOOL_PROFILE=full`. **Consumers that depend on all 40 tools being available by default must either call via `plur_admin` or set `PLUR_TOOL_PROFILE=full`.**
 - **MCP SDK v2 migration** (#638): `@plur-ai/mcp` now uses the MCP SDK v2 split packages (`@modelcontextprotocol/server`, `@modelcontextprotocol/client`, `@modelcontextprotocol/core` @ 2.0.0-beta.4), replacing the monolithic `@modelcontextprotocol/sdk@^1.12.0`. Prepares for the MCP spec stable release (2026-07-28). The public API of `@plur-ai/mcp` is unchanged; 226 tests pass.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Scopes go live + leaner MCP.
 
 ### Changed
 
-- **Lean tool profile is now the default** (#625): the MCP server exposes 12 tools — 11 core + the `plur_admin` dispatch (down from 40) to every consumer — Claude Code, Cursor, Windsurf, OpenClaw, Hermes, and nightshift agents alike. Per-turn tool-schema overhead drops ~74% (~2K vs ~9K tokens). All 40 tools remain reachable via `plur_admin { action: "<tool>", args: {...} }`. Restore the full surface with `PLUR_TOOL_PROFILE=full`. **Consumers that depend on all 40 tools being available by default must either call via `plur_admin` or set `PLUR_TOOL_PROFILE=full`.**
+- **Lean tool profile is now the default** (#625, #694): the MCP server exposes 12 tools — 11 core + the `plur_admin` dispatch (down from 40) to every consumer — Claude Code, Cursor, Windsurf, OpenClaw, Hermes, and nightshift agents alike. Per-turn tool-schema overhead drops ~74% (~2K vs ~9K tokens). All 40 tools remain reachable via `plur_admin { action: "<tool>", args: {...} }`. Restore the full surface with `PLUR_TOOL_PROFILE=full`. **Consumers that depend on all 40 tools being available by default must either call via `plur_admin` or set `PLUR_TOOL_PROFILE=full`.**
 - **MCP SDK v2 migration** (#638): `@plur-ai/mcp` now uses the MCP SDK v2 split packages (`@modelcontextprotocol/server`, `@modelcontextprotocol/client`, `@modelcontextprotocol/core` @ 2.0.0-beta.4), replacing the monolithic `@modelcontextprotocol/sdk@^1.12.0`. Prepares for the MCP spec stable release (2026-07-28). The public API of `@plur-ai/mcp` is unchanged; 226 tests pass.
 
 ### Added

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -47,6 +47,8 @@ export const INSTRUCTIONS = `PLUR is your persistent memory. Corrections, prefer
 
 PLUR is a GLOBAL tool — one MCP server, one engram store (~/.plur/), available in every project. Multi-project scoping uses domain/scope fields on engrams, not separate installations.
 
+TOOL PROFILE: by default only the core session tools are exposed directly (lean profile). Every other plur_* operation is reachable via plur_admin: { action: "<tool name>", args: {...} } — same arguments and validation as a direct call. PLUR_TOOL_PROFILE=full exposes everything directly.
+
 SESSION LIFECYCLE:
 - With hooks installed (plur init): engrams are injected automatically on first message. You do NOT need to call plur_session_start — it happens via hooks. Just call plur_session_end before the conversation ends.
 - Without hooks: call plur_session_start at the start, plur_session_end at the end.
@@ -202,6 +204,22 @@ export async function createServer(plur?: Plur, options?: { profile?: ToolProfil
   server.setRequestHandler('tools/call', async (request) => {
     const tool = tools.find(t => t.name === request.params.name)
     if (!tool) {
+      // #625 audit: under a gated profile, a REAL tool that is merely hidden
+      // must return an ACTIONABLE error, not a dead-end "Unknown tool" —
+      // agents carrying pre-lean instructions (docs, engrams, templates) call
+      // hidden tools by their old names and need a machine-readable recovery
+      // path in the error itself, at the moment recovery matters.
+      const hidden = getToolDefinitions('full').find(t => t.name === request.params.name)
+      if (hidden) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({
+            error: `Tool "${request.params.name}" exists but is not directly callable under the current tool profile.`,
+            success: false,
+            hint: `Call it via plur_admin: { action: "${request.params.name}", args: { ... } } — same arguments, same validation, same result. To expose all tools directly, set PLUR_TOOL_PROFILE=full.`,
+          }) }],
+          isError: true,
+        }
+      }
       return {
         content: [{ type: 'text', text: JSON.stringify({ error: `Unknown tool: ${request.params.name}`, success: false }) }],
         isError: true,
@@ -292,7 +310,9 @@ export async function createServer(plur?: Plur, options?: { profile?: ToolProfil
           `${[...CURSOR_CORE_TOOL_NAMES].join(', ')} are top-level tools here. ` +
           'Everything else in this guide is reachable through **plur_admin**: call it with ' +
           '`{ action: "<tool name above>", args: {...} }`. ' +
-          'Set `PLUR_TOOL_PROFILE=full` to expose all 40 tools directly.'
+          // Count computed, not hardcoded (#625 audit) — a literal "40" goes
+          // silently stale the moment a tool is added or removed.
+          `Set \`PLUR_TOOL_PROFILE=full\` to expose all ${getToolDefinitions('full').length} tools directly.`
         : ''
       return {
         contents: [{

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -279,14 +279,18 @@ export type ToolProfile = 'full' | 'lean' | 'cursor'
 // surface alone would consume ~97.5% of that budget.
 //
 // Destructive tools are kept OUT of plur_admin's dispatch specifically
-// (audit fix — evaluator review, 2026-07-08): a client that gates
+// (audit fix — evaluator review, 2026-07-08; ENFORCED in the handler since
+// the 2026-07-24 lean audit — previously they were only omitted from the
+// advertised list while byName still dispatched them): a client that gates
 // confirmation prompts or audit trails off MCP tool annotations — the whole
 // point of the annotations field — can no longer tell "delete a pack and
 // all its engrams" apart from "check status" once both are wrapped behind
 // the same generic dispatch tool, whose own single static annotation
 // (`{ title: 'Admin dispatch', readOnlyHint: false }`) can't carry a
-// per-action risk signal. Two more core tools (11 total) is still far under
-// the ~40-tool cap, so there's no budget reason to wrap them either.
+// per-action risk signal. The handler refuses any target with
+// `destructiveHint: true` and points at the direct tool. Two more core
+// tools (11 total) is still far under the ~40-tool cap, so there's no
+// budget reason to wrap them either.
 // Exported (audit fix — evaluator review, iteration 2, 2026-07-09) so
 // server.ts's plur://guide resource can build its cursor-profile redirect
 // note FROM this set instead of hardcoding a second, independent copy of
@@ -340,6 +344,22 @@ function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
       if (!target) {
         return { error: `Unknown action "${action}". Valid actions: ${adminActions.join(', ')}`, success: false, _isError: true }
       }
+      // #625 audit: ENFORCE the annotation-visibility guarantee the module
+      // comment documents. Destructive tools must never execute through this
+      // generic dispatch — plur_admin's single static annotation carries no
+      // per-action risk signal, so a client gating confirmation prompts on
+      // `destructiveHint` would silently lose that gate for a wrapped call.
+      // Every destructive tool is in CURSOR_CORE_TOOL_NAMES (directly
+      // callable in every profile, with its real annotations), so refusing
+      // dispatch loses nothing. Keyed off destructiveHint, not a name list,
+      // so future destructive tools are protected automatically.
+      if (target.annotations?.destructiveHint === true) {
+        return {
+          error: `"${action}" is a destructive operation and cannot be dispatched via plur_admin — call the ${action} tool directly (it is exposed in every profile) so your client sees its destructiveHint annotation.`,
+          success: false,
+          _isError: true,
+        }
+      }
       const innerArgs = (args.args as Record<string, unknown>) ?? {}
       const validated = validateToolArgs(target, innerArgs)
       if (!validated.ok) {
@@ -370,7 +390,7 @@ function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
 export function getToolDefinitions(profile: ToolProfile = 'lean'): ToolDefinition[] {
   const all = getAllToolDefinitions()
   if (profile === 'full') return all
-  // 'lean' and 'cursor' are identical: 10 core tools + plur_admin dispatch
+  // 'lean' and 'cursor' are identical: 11 core tools + plur_admin dispatch (12 exposed)
   const core = all.filter(t => CURSOR_CORE_TOOL_NAMES.has(t.name))
   return [...core, buildAdminDispatchTool(all)]
 }

--- a/packages/mcp/test/tool-profile.test.ts
+++ b/packages/mcp/test/tool-profile.test.ts
@@ -158,5 +158,91 @@ describe('tool profiles', () => {
         expect(text).toContain(name)
       }
     })
+
+    // --- #625 lean audit (2026-07-24) ---
+
+    it('direct call of a REAL-but-hidden tool returns an actionable plur_admin hint, not a dead end', async () => {
+      const result = await client.callTool({ name: 'plur_sync', arguments: {} })
+      expect(result.isError).toBe(true)
+      const data = JSON.parse((result.content as any)[0].text)
+      expect(data.success).toBe(false)
+      expect(data.error).toContain('plur_sync')
+      expect(data.hint).toContain('plur_admin')
+      expect(data.hint).toContain('PLUR_TOOL_PROFILE=full')
+    })
+
+    it('a genuinely unknown tool still gets the bare Unknown-tool error (no false hint)', async () => {
+      const result = await client.callTool({ name: 'plur_totally_fake', arguments: {} })
+      expect(result.isError).toBe(true)
+      const data = JSON.parse((result.content as any)[0].text)
+      expect(data.error).toContain('Unknown tool')
+      expect(data.hint).toBeUndefined()
+    })
+
+    it('plur_admin REFUSES to dispatch destructive tools — the annotation-visibility guarantee is enforced', async () => {
+      for (const action of ['plur_forget', 'plur_packs_uninstall', 'plur_tensions_purge']) {
+        const result = await client.callTool({
+          name: 'plur_admin',
+          arguments: { action, args: {} },
+        })
+        expect(result.isError).toBe(true)
+        const data = JSON.parse((result.content as any)[0].text)
+        expect(data.success).toBe(false)
+        expect(data.error).toContain('destructive')
+        expect(data.error).toContain(action)
+      }
+    })
+
+    it('destructive tools still work as DIRECT calls (the sanctioned path)', async () => {
+      const result = await client.callTool({ name: 'plur_tensions_purge', arguments: {} })
+      expect(result.isError).toBeFalsy()
+    })
+
+    it('plur_admin cannot dispatch itself (recursion blocked)', async () => {
+      const result = await client.callTool({
+        name: 'plur_admin',
+        arguments: { action: 'plur_admin', args: { action: 'plur_status' } },
+      })
+      const data = JSON.parse((result.content as any)[0].text)
+      expect(data.success).toBe(false)
+      expect(data.error).toContain('Unknown action')
+    })
+
+    it('prototype-key action names are rejected as unknown actions', async () => {
+      for (const action of ['__proto__', 'constructor', '']) {
+        const result = await client.callTool({
+          name: 'plur_admin',
+          arguments: { action, args: {} },
+        })
+        const data = JSON.parse((result.content as any)[0].text)
+        expect(data.success).toBe(false)
+        expect(data.error).toContain('Unknown action')
+      }
+    })
+
+    it('every advertised admin action dispatches — none is orphaned by a filter regression', { timeout: 120_000 }, async () => {
+      // The advertised set = full minus core. Each must reach its handler:
+      // any response is acceptable EXCEPT the "Unknown action" dead end
+      // (validation errors and handler errors prove reachability).
+      const full = getToolDefinitions('full').map((t) => t.name)
+      const { tools } = await client.listTools()
+      const core = new Set(tools.map((t) => t.name))
+      const advertised = full.filter((n) => !core.has(n))
+      expect(advertised.length).toBeGreaterThanOrEqual(28)
+      for (const action of advertised) {
+        const result = await client.callTool({
+          name: 'plur_admin',
+          arguments: { action, args: {} },
+        })
+        const text = (result.content as any)[0].text as string
+        expect(text, `action ${action} hit the Unknown-action dead end`).not.toContain('Unknown action')
+      }
+    })
+
+    it('the guide tool count is computed from the full profile, never a stale literal', async () => {
+      const { contents } = await client.readResource({ uri: 'plur://guide' })
+      const text = (contents as any)[0].text as string
+      expect(text).toContain(`all ${getToolDefinitions('full').length} tools`)
+    })
   })
 })


### PR DESCRIPTION
## What

Pre-release adversarial audit of the lean default (shipping in 0.15.0) — full dispatch/validation/recursion/SDK-v2 sweep came back clean, with two gaps now fixed:

| Severity | Finding | Fix |
|---|---|---|
| gating | Direct call of a hidden tool → bare `Unknown tool` dead end (silent agent breakage) | Error now distinguishes real-but-hidden from unknown and carries the `plur_admin {action, args}` recovery hint + `PLUR_TOOL_PROFILE=full` pointer |
| security-property | `plur_admin` **claimed** destructive tools were excluded from dispatch but only hid them from the advertised list — all three executed through it, bypassing `destructiveHint`-keyed confirmation gates | Handler refuses any `destructiveHint: true` target (annotation-keyed, future-proof) and points at the direct tool, which every profile exposes with real annotations |
| doc | Count drift: comment said 10 core, CHANGELOG said 11, reality is 11 core + dispatch = 12; guide hardcoded "40" | Corrected; guide count computed from `getToolDefinitions('full').length` |
| doc | Server INSTRUCTIONS never mentioned the profile (only the guide resource did) | One TOOL PROFILE paragraph added |

## Audit results that needed no fix

Dispatch completeness (all 40 reachable), validation parity via the shared `validateToolArgs`, recursion + prototype-pollution blocked (Map lookup), no handler branches on call-path, inner args never logged, SDK v2 static-list model correct (no `listChanged` needed).

## Tests

8 new in `tool-profile.test.ts`: hidden-tool hint, bare-unknown negative, destructive refusal ×3 + direct-path sanity, `plur_admin`→`plur_admin` recursion, `__proto__`/`constructor`/empty action names, **29-action reachability sweep** (no orphaned action can regress silently), computed guide count. 107 pass across the mcp suites.

Part of the 0.15.0 release gate for #625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjCUCfkFkGEArJQQgmQfuY