### PR TITLE
fix(release): make MCP Registry publish fire reliably on every release

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -4,9 +4,12 @@ name: Publish to MCP Registry
 # on every GitHub Release. Auth is GitHub OIDC — no secrets, no local install needed.
 # The registry listing propagates to directories that ingest it (PulseMCP, mcp.so, …).
 
+# Triggered explicitly by scripts/release.sh (`gh workflow run` on the release tag)
+# — the single deterministic path. The old `release: published` trigger was removed
+# because that event is suppressed when a release is created by a GITHUB_TOKEN actor
+# (GitHub's recursion guard), which silently skipped the registry publish for v0.14.0.
+# To publish a tag by hand: gh workflow run "Publish to MCP Registry" --ref vX.Y.Z
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -661,6 +661,25 @@ fi
 gh release create "v$VERSION" --title "v$VERSION" --notes "$RELEASE_NOTES" 2>&1 | tail -1
 echo ""
 
+# --- 7b. Publish to the official MCP Registry ---
+# Publishing server.json to registry.modelcontextprotocol.io is what propagates
+# the release to the directories that ingest it (mcp.so, PulseMCP, …); Glama
+# re-scans npm/GitHub on its own. The publish-mcp-registry workflow used to run
+# only on `release: published`, but that event is SUPPRESSED when the release is
+# created by a GITHUB_TOKEN-authenticated actor (GitHub's recursion guard) — which
+# silently skipped the registry publish for v0.14.0. So we dispatch it explicitly
+# on the tag here, which is now the single deterministic trigger (the workflow's
+# release trigger has been removed). Non-fatal: a registry hiccup must never fail
+# an otherwise-good release.
+echo "--- Step 7b: MCP Registry publish ---"
+if gh workflow run "Publish to MCP Registry" --ref "v$VERSION" 2>&1 | tail -1; then
+  echo "  Dispatched registry publish for v$VERSION → registry.modelcontextprotocol.io"
+else
+  echo "  ⚠ Could not dispatch the registry publish. Run it manually:"
+  echo "      gh workflow run \"Publish to MCP Registry\" --ref v$VERSION"
+fi
+echo ""
+
 # --- 8. Website deploy ---
 # Closes engrams ENG-2026-0422-052/053 — plur.ai must be updated as part
 # of every release, not as a follow-up. Looks for the website repo at


### PR DESCRIPTION
## Problem
The `publish-mcp-registry` workflow ran only on `release: published`. That event is **suppressed when a release is created by a GITHUB_TOKEN actor** (GitHub's recursion guard), so the registry publish was silently skipped for **v0.14.0** — the official MCP Registry is stuck at v0.13.0 while npm shipped 0.14. That registry is what mcp.so / PulseMCP ingest.

## Fix
- `scripts/release.sh` **Step 7b**: dispatches the workflow explicitly on the release tag (`gh workflow run … --ref vX.Y.Z`), non-fatal.
- Workflow: **removed the `release: published` trigger** so release.sh is the single deterministic path — no double-runs, no token suppression.

Glama and mcp.so need **nothing** per release — they ingest the registry + rescan npm/GitHub on their own.

## Note for the parallel 0.15 work
Rebase the 0.15 branch onto main to pick this up before releasing. Does not touch `server.json` or the active 0.15 branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)