### PR TITLE
chore(claw): bump ClawHub SKILL.md version 0.10.0 → 0.15.0 (E2 publish unblock)

### DIFF
--- a/packages/claw/clawhub/SKILL.md
+++ b/packages/claw/clawhub/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plur-memory
 description: "Your memory stays on your machine. No cloud, no tracking, no API key. PLUR makes your OpenClaw remember — and shares that memory with every other tool you use."
-version: 0.10.0
+version: 0.15.0
 ---
 
 # PLUR Memory


### PR DESCRIPTION
## Why

ClawHub deduplicates listings on `version`. E0 was published at `0.10.0`. Without this bump, the E2 publish (`npx clawhub publish packages/claw/clawhub --slug plur-memory`) would be rejected with a version conflict.

## What

Single-field bump: `version: 0.10.0` → `version: 0.15.0` in `packages/claw/clawhub/SKILL.md`, aligning the ClawHub listing version with the npm release.

## After merging

Gregor (plur9) runs:
```bash
git checkout main && git pull
npx clawhub login      # browser OAuth — one-time per machine
npx clawhub publish packages/claw/clawhub --slug plur-memory
```

H002 E2 measurement window starts on publish. Deadline: 2026-07-31 (6 days). 14-day window = measurement closes 2026-08-08.

Refs: #516 (P0 ClawHub listing)

🤖 heartbeat — cto 2026-07-25