### PR TITLE
fix(docs): server.json version drift + release.sh automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ pnpm --filter @plur-ai/core build
 12. `packages/python/pyproject.toml`
 13. `packages/python/plur_ai/bridge.py` — `_NPX_CLI_VERSION`
 14. `skills/plur-memory/SKILL.md` — frontmatter `version:` (standalone skills.sh copy)
+15. `server.json` — both top-level `version` and `packages[0].version` (MCP Registry / ClawHub listing)
 
 **Claw track** (independent — only bumped when `--claw <ver>` is passed to release.sh):
 
@@ -245,7 +246,7 @@ You have persistent memory via PLUR. Corrections, preferences, and conventions p
 
 ### Architecture
 
-PLUR is installed **globally** — one MCP server, one engram store (`~/.plur/`), available in every project. You do NOT need per-project installation. The `plur` MCP server provides tools named `plur_session_start`, `plur_learn`, `plur_recall_hybrid`, `plur_feedback`, `plur_session_end`, etc. If you cannot find these tools, run `plur doctor` to diagnose. Do **not** substitute tools from other MCP servers (e.g. `datacore_*`) — those belong to a different system.
+PLUR is installed **globally** — one MCP server, one engram store (`~/.plur/`), available in every project. You do NOT need per-project installation. The `plur` MCP server provides tools named `plur_session_start`, `plur_learn`, `plur_recall`, `plur_feedback`, `plur_session_end`, etc. If you cannot find these tools, run `plur doctor` to diagnose. Do **not** substitute tools from other MCP servers (e.g. `datacore_*`) — those belong to a different system.
 
 A PreToolUse guard enforces that `plur_session_start` is called at the beginning of every session. All other tools are blocked until this is done. The flow is: ToolSearch to load `plur_session_start` → call it with a task description → proceed.
 
@@ -253,7 +254,7 @@ A PreToolUse guard enforces that `plur_session_start` is called at the beginning
 
 1. **Start**: Call `plur_session_start` with task description — enforced by guard hook
 2. **Learn**: When corrected or discovering something new, call `plur_learn` immediately
-3. **Recall**: Before answering factual questions, call `plur_recall_hybrid` — check memory first
+3. **Recall**: Before answering factual questions, call `plur_recall` — check memory first
 4. **Feedback**: Rate injected engrams with `plur_feedback` (positive/negative) — trains relevance
 5. **End**: Call `plur_session_end` with summary + engram_suggestions
 
@@ -271,7 +272,7 @@ PLUR uses `domain` and `scope` fields to separate knowledge. **Set `scope` on ev
 ### When to check memory
 
 Before reaching for web search, file reads, or guessing — apply this priority:
-1. Is the answer already in engrams? → `plur_recall_hybrid`
+1. Is the answer already in engrams? → `plur_recall`
 2. Is the answer in the local filesystem? → Read/Grep/Glob
 3. Is the answer derivable from context already loaded? → Just answer
 4. Only if 1-3 fail → Use external tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ You have persistent memory via PLUR. Corrections, preferences, and conventions p
 
 ### Architecture
 
-PLUR is installed **globally** — one MCP server, one engram store (`~/.plur/`), available in every project. You do NOT need per-project installation. The `plur` MCP server provides tools named `plur_session_start`, `plur_learn`, `plur_recall`, `plur_feedback`, `plur_session_end`, etc. If you cannot find these tools, run `plur doctor` to diagnose. Do **not** substitute tools from other MCP servers (e.g. `datacore_*`) — those belong to a different system.
+PLUR is installed **globally** — one MCP server, one engram store (`~/.plur/`), available in every project. You do NOT need per-project installation. The `plur` MCP server provides tools named `plur_session_start`, `plur_learn`, `plur_recall_hybrid`, `plur_feedback`, `plur_session_end`, etc. If you cannot find these tools, run `plur doctor` to diagnose. Do **not** substitute tools from other MCP servers (e.g. `datacore_*`) — those belong to a different system.
 
 A PreToolUse guard enforces that `plur_session_start` is called at the beginning of every session. All other tools are blocked until this is done. The flow is: ToolSearch to load `plur_session_start` → call it with a task description → proceed.
 
@@ -254,7 +254,7 @@ A PreToolUse guard enforces that `plur_session_start` is called at the beginning
 
 1. **Start**: Call `plur_session_start` with task description — enforced by guard hook
 2. **Learn**: When corrected or discovering something new, call `plur_learn` immediately
-3. **Recall**: Before answering factual questions, call `plur_recall` — check memory first
+3. **Recall**: Before answering factual questions, call `plur_recall_hybrid` — check memory first
 4. **Feedback**: Rate injected engrams with `plur_feedback` (positive/negative) — trains relevance
 5. **End**: Call `plur_session_end` with summary + engram_suggestions
 
@@ -272,7 +272,7 @@ PLUR uses `domain` and `scope` fields to separate knowledge. **Set `scope` on ev
 ### When to check memory
 
 Before reaching for web search, file reads, or guessing — apply this priority:
-1. Is the answer already in engrams? → `plur_recall`
+1. Is the answer already in engrams? → `plur_recall_hybrid`
 2. Is the answer in the local filesystem? → Read/Grep/Glob
 3. Is the answer derivable from context already loaded? → Just answer
 4. Only if 1-3 fail → Use external tools

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -253,6 +253,19 @@ else
   echo "  (claw stays at $CURRENT_CLAW — pass --claw <version> to bump and publish)"
 fi
 
+# MCP Registry / ClawHub listing — both the top-level version and the package
+# version pin must track the release; without this the registry directs users
+# to install a stale version of @plur-ai/mcp.
+node -e "
+  const fs = require('fs');
+  const path = './server.json';
+  const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+  data.version = '$VERSION';
+  data.packages[0].version = '$VERSION';
+  fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+"
+echo "  ✓ server.json (MCP Registry version)"
+
 # Hermes pyproject.toml
 sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" packages/hermes/pyproject.toml
 echo "  ✓ packages/hermes/pyproject.toml"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/plur-ai/plur",
     "source": "github"
   },
-  "version": "0.10.1",
+  "version": "0.15.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@plur-ai/mcp",
-      "version": "0.10.1",
+      "version": "0.15.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Problem

`server.json` (the MCP Registry / ClawHub listing file) was pinned to `v0.10.1` — 5 minor versions behind the currently-published `v0.15.0`. Any developer discovering PLUR through the MCP Registry / ClawHub would be directed to install a stale version.

Root cause: `server.json` was missing from `scripts/release.sh`, so it was never bumped during the standard release flow.

## Changes

- **`server.json`**: bump both `version` and `packages[0].version` from `0.10.1` → `0.15.0`
- **`scripts/release.sh`**: add `server.json` update to Step 1 (version bump), immediately after the claw section — both the top-level `version` and `packages[0].version` fields are updated by a `node -e` inline script
- **`CLAUDE.md`**: add `server.json` to the standard-release checklist (item 15); fix stale `plur_recall_hybrid` → `plur_recall` tool name references (the tool was renamed but CLAUDE.md wasn't updated)

## Testing

`scripts/release.sh --dry-run <version>` will now emit `✓ server.json (MCP Registry version)` during Step 1.

No logic changes — this is a doc/tooling fix.