### PR TITLE
feat(cli): telemetry opt-in prompt in plur init (H005 gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unified recall surface.
 - **`plur_recall` is now the unified recall tool (#693)**: gains a `mode` parameter — `'hybrid'` (default, BM25 + local embeddings via RRF) or `'keyword'` (BM25-only). Existing callers that pass no `mode` get a quality upgrade without any API change. **Breaking for the lean/cursor profile**: `plur_recall_hybrid` is no longer a top-level lean tool — `plur_recall` takes its slot. Agents configured against the lean profile that call `plur_recall_hybrid` by name will still get results (the tool remains accessible via `plur_admin` dispatch), but should migrate to `plur_recall`.
 - **`plur_recall_hybrid` is a deprecated alias** (#693): it invokes the canonical `plur_recall` handler with `{mode:'hybrid'}` and prepends a one-line `deprecated` notice — a real forwarder, so budget capping, episode expansion, the degraded-embeddings warning and reranker surfacing cannot drift between the two before the alias is removed. Removal target: 0.18. Accessible in both full and lean profiles (via `plur_admin`) to avoid breaking existing CLAUDE.md files and agent templates in the wild.
 
+### Added
+
+- **`plur init` now prompts for anonymous usage statistics opt-in.** On interactive installs a single yes/no prompt asks "Enable anonymous usage statistics? (helps us improve PLUR — no code, no keys) [y/N]" and persists the answer to `~/.plur/telemetry.json`. Non-interactive installs (CI, piped stdin, `--no-prompt`) write `enabled:false` silently — they are never opted in without explicit consent. Already-configured installs skip the prompt entirely, as do installs with an explicit `PLUR_TELEMETRY` env var — env wins at runtime, so no contradictory config file is written. To enable after the fact: `PLUR_TELEMETRY=on` env var or edit `~/.plur/telemetry.json`. See [`docs/telemetry-design.md`](docs/telemetry-design.md) for what is collected (learn/recall counters only — no code, no keys, no content).
+
 ## 0.15.0 (2026-07-21)
 
 Scopes go live + leaner MCP.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'f
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
+import { createInterface } from 'readline'
 import { type GlobalFlags } from '../plur.js'
 import { outputText } from '../output.js'
 import {
@@ -655,12 +656,95 @@ function writeSettings(path: string, settings: Settings): void {
   writeFileSync(path, JSON.stringify(settings, null, 2) + '\n')
 }
 
+// ── Telemetry opt-in prompt ─────────────────────────────────────────────────
+// Asks the user once during `plur init` whether to enable anonymous usage stats.
+// Resolution rules (mirrors telemetry.ts — env var still overrides this):
+//   - Interactive TTY + no existing config → ask the question
+//   - Non-interactive (CI, pipe, --no-prompt) → write enabled:false silently
+//   - Config already present → skip (never nag a returning user)
+
+function telemetryConfigPath(): string {
+  return join(homedir(), '.plur', 'telemetry.json')
+}
+
+function writeTelemetryConfig(enabled: boolean, configPath?: string): void {
+  const target = configPath ?? telemetryConfigPath()
+  mkdirSync(dirname(target), { recursive: true })
+  writeFileSync(target, JSON.stringify({ enabled }, null, 2) + '\n')
+}
+
+/**
+ * Prompt for telemetry opt-in during `plur init`.
+ *
+ * Returns 'opted-in' | 'opted-out' | 'already-configured' | 'non-interactive'.
+ * Exported for testing with injectable config path.
+ */
+export async function promptTelemetryOptIn(opts: {
+  configPath?: string
+  noPrompt?: boolean
+  env?: NodeJS.ProcessEnv
+  input?: NodeJS.ReadableStream & { isTTY?: boolean }
+  output?: NodeJS.WritableStream & { isTTY?: boolean }
+} = {}): Promise<'opted-in' | 'opted-out' | 'already-configured' | 'non-interactive'> {
+  const configPath = opts.configPath ?? telemetryConfigPath()
+  const env = opts.env ?? process.env
+  const input = opts.input ?? process.stdin
+  const output = opts.output ?? process.stdout
+
+  // Skip if config already exists — we only ask once.
+  if (existsSync(configPath)) return 'already-configured'
+
+  // Never write config when the env var is already explicit — env wins at
+  // runtime, so persisting a contradictory file here would both mislead
+  // (`telemetry.json` disagreeing with the active setting) and burn the
+  // one-time prompt, leaving the user never asked once the var is unset.
+  if (env.PLUR_TELEMETRY) return 'already-configured'
+
+  // Non-interactive: CI, piped input, or --no-prompt flag → default off, never prompt.
+  const isInteractive = Boolean(input.isTTY && output.isTTY)
+  if (!isInteractive || opts.noPrompt || env.CI) {
+    writeTelemetryConfig(false, configPath)
+    return 'non-interactive'
+  }
+
+  return new Promise((resolve) => {
+    const rl = createInterface({ input, output })
+    // `rl.close()` fires the 'close' handler synchronously, so both sites race
+    // to settle the same promise. Guard explicitly rather than inferring
+    // settled-ness from the config file existing on disk.
+    let settled = false
+    const settle = (
+      result: 'opted-in' | 'opted-out' | 'non-interactive',
+      enabled: boolean,
+    ) => {
+      if (settled) return
+      settled = true
+      writeTelemetryConfig(enabled, configPath)
+      resolve(result)
+    }
+
+    rl.question(
+      '\nEnable anonymous usage statistics? (helps us improve PLUR — no code, no keys) [y/N] ',
+      (answer) => {
+        const normalized = answer.trim().toLowerCase()
+        const yes = normalized === 'y' || normalized === 'yes'
+        settle(yes ? 'opted-in' : 'opted-out', yes)
+        rl.close()
+      },
+    )
+    // Handle non-TTY / closed stdin gracefully — no answer given, so default off.
+    rl.on('close', () => settle('non-interactive', false))
+  })
+}
+
 function hooksStatusFor(before: string, after: string, hadHooks: boolean): string {
   if (!hadHooks) return 'installed'
   return before === after ? 'already up to date' : 'upgraded'
 }
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  const noPrompt = args.includes('--no-prompt')
+
   // Install local hook shim FIRST — hook commands depend on it (#178)
   const shim = installHookBinary()
   const cmd = shim.shimPath || 'npx @plur-ai/cli' // fallback if shim failed
@@ -816,4 +900,21 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     outputText('')
   }
   outputText('Restart Claude Code to pick up the changes, then run `plur doctor` to verify.')
+
+  // Telemetry opt-in — ask once, never nag. Runs last so it doesn't interrupt the
+  // settings-installation summary above. Non-interactive installs silently write
+  // enabled:false (opt-out), which ensures they are never opted in without consent.
+  const telemetryResult = await promptTelemetryOptIn({ noPrompt })
+  outputText('')
+  if (telemetryResult === 'opted-in') {
+    outputText('Telemetry: enabled (thank you — anonymous counts only, nothing leaves your machine before POST /v1/heartbeat).')
+    outputText('           Disable any time: plur telemetry off  or  set PLUR_TELEMETRY=off')
+  } else if (telemetryResult === 'opted-out') {
+    outputText('Telemetry: disabled. Enable any time: plur telemetry on  or  set PLUR_TELEMETRY=on')
+    outputText('           See docs/telemetry-design.md for what is and is not collected.')
+  } else if (telemetryResult === 'non-interactive') {
+    outputText('Telemetry: disabled (non-interactive install). Enable: set PLUR_TELEMETRY=on')
+    outputText('           See docs/telemetry-design.md for what is collected.')
+  }
+  // 'already-configured' → silent, user already made a choice
 }

--- a/packages/cli/test/init-telemetry.test.ts
+++ b/packages/cli/test/init-telemetry.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for the telemetry opt-in prompt introduced in `plur init`.
+ *
+ * AC coverage:
+ *  (1) Non-interactive mode never writes PLUR_TELEMETRY=true without an explicit flag.
+ *  (2) After `plur init` in non-interactive mode, telemetry-counters.json is NOT created
+ *      (the gate stays off unless explicitly opted in).
+ *  (3) `promptTelemetryOptIn` unit tests: non-interactive → writes enabled:false.
+ *  (4) Already-configured path: existing telemetry.json is never overwritten.
+ *  (5) Interactive answered path: "y" and "n" return the correct status AND
+ *      persist the matching config. Covered by injecting fake TTY streams
+ *      rather than a PTY library — see the `answerPrompt` helper below.
+ *
+ * (5) is a regression guard: `rl.close()` fires its 'close' handler
+ * synchronously, so an implementation that closes before persisting lets the
+ * close handler settle the promise first and report 'non-interactive' for an
+ * answered prompt — telling a user who typed "y" that telemetry is disabled.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+import { PassThrough } from 'stream'
+
+// Unit import — tests the function directly without spawning a child process.
+import { promptTelemetryOptIn } from '../src/commands/init.js'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+// ── Helper: run plur init in non-interactive mode (no TTY) ──────────────────
+
+function runInitNonInteractive(home: string): string {
+  return execSync(
+    `node ${CLI} init --global --no-desktop --no-prompt`,
+    {
+      encoding: 'utf-8',
+      timeout: 15000,
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      cwd: home,
+    },
+  )
+}
+
+describe('plur init — telemetry opt-in prompt', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-telemetry-init-'))
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  // ── AC (3): non-interactive mode never opts in ──────────────────────────
+
+  it('non-interactive install writes enabled:false, never enabled:true', () => {
+    const output = runInitNonInteractive(home)
+    expect(output).toContain('PLUR installed')
+
+    const telemetryPath = join(home, '.plur', 'telemetry.json')
+    expect(existsSync(telemetryPath)).toBe(true)
+
+    const config = JSON.parse(readFileSync(telemetryPath, 'utf-8'))
+    // CRITICAL: non-interactive must never opt in without consent
+    expect(config.enabled).toBe(false)
+  })
+
+  it('non-interactive output reports telemetry as disabled', () => {
+    const output = runInitNonInteractive(home)
+    expect(output).toMatch(/telemetry.*disabled/i)
+  })
+
+  // ── AC (3): after non-interactive init, telemetry counters are not created ─
+
+  it('non-interactive install does not create telemetry-counters.json (gate stays off)', () => {
+    runInitNonInteractive(home)
+    // Counters file should not exist — the gate is off, no events fire
+    const countersPath = join(home, '.plur', 'telemetry-counters.json')
+    expect(existsSync(countersPath)).toBe(false)
+  })
+
+  // ── AC (4): already-configured path ─────────────────────────────────────
+
+  it('does not overwrite an existing telemetry.json', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-unit-'))
+    try {
+      const configPath = join(dir, 'telemetry.json')
+      writeFileSync(configPath, JSON.stringify({ enabled: true }))
+
+      const result = await promptTelemetryOptIn({ configPath, noPrompt: true })
+      expect(result).toBe('already-configured')
+
+      // File must be unchanged
+      const after = JSON.parse(readFileSync(configPath, 'utf-8'))
+      expect(after.enabled).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // ── Unit tests for promptTelemetryOptIn ─────────────────────────────────
+
+  it('promptTelemetryOptIn: noPrompt flag → writes enabled:false, returns non-interactive', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-unit-'))
+    try {
+      mkdirSync(dir, { recursive: true })
+      const configPath = join(dir, 'telemetry.json')
+
+      const result = await promptTelemetryOptIn({ configPath, noPrompt: true })
+      expect(result).toBe('non-interactive')
+
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      expect(config.enabled).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('promptTelemetryOptIn: CI env → writes enabled:false, returns non-interactive', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-unit-'))
+    try {
+      const configPath = join(dir, 'telemetry.json')
+
+      const result = await promptTelemetryOptIn({ configPath, env: { CI: 'true' } })
+      expect(result).toBe('non-interactive')
+
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      expect(config.enabled).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // ── AC (5): interactive answered path ───────────────────────────────────
+
+  /**
+   * Drives the real prompt with fake TTY streams. `PassThrough` with
+   * `isTTY = true` satisfies the interactivity check and gives readline a
+   * stream we can write the answer into — no PTY library needed.
+   */
+  async function answerPrompt(answer: string, configPath: string) {
+    const input = Object.assign(new PassThrough(), { isTTY: true })
+    const output = Object.assign(new PassThrough(), { isTTY: true })
+    output.resume() // drain the prompt text so the stream never stalls
+
+    const pending = promptTelemetryOptIn({ configPath, input, output, env: {} })
+    input.write(answer)
+    const result = await pending
+    return {
+      result,
+      config: JSON.parse(readFileSync(configPath, 'utf-8')),
+    }
+  }
+
+  it('promptTelemetryOptIn: answering "y" returns opted-in and persists enabled:true', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-tty-'))
+    try {
+      const { result, config } = await answerPrompt('y\n', join(dir, 'telemetry.json'))
+      // Regression: a close-before-write implementation returns 'non-interactive'
+      // here, so the user is told telemetry is off while it is actually on.
+      expect(result).toBe('opted-in')
+      expect(config.enabled).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('promptTelemetryOptIn: answering "n" returns opted-out and persists enabled:false', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-tty-'))
+    try {
+      const { result, config } = await answerPrompt('n\n', join(dir, 'telemetry.json'))
+      expect(result).toBe('opted-out')
+      expect(config.enabled).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('promptTelemetryOptIn: answering "yes" is treated as consent', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-tty-'))
+    try {
+      const { result, config } = await answerPrompt('yes\n', join(dir, 'telemetry.json'))
+      expect(result).toBe('opted-in')
+      expect(config.enabled).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('promptTelemetryOptIn: an empty answer defaults to opted-out (the [y/N] default)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-tty-'))
+    try {
+      const { result, config } = await answerPrompt('\n', join(dir, 'telemetry.json'))
+      expect(result).toBe('opted-out')
+      expect(config.enabled).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // ── Explicit PLUR_TELEMETRY env var wins over the prompt ────────────────
+
+  it('promptTelemetryOptIn: explicit PLUR_TELEMETRY skips the prompt and writes nothing', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-unit-'))
+    try {
+      const configPath = join(dir, 'telemetry.json')
+
+      const result = await promptTelemetryOptIn({
+        configPath,
+        env: { PLUR_TELEMETRY: 'on' },
+      })
+      expect(result).toBe('already-configured')
+
+      // No contradictory {enabled:false} file alongside PLUR_TELEMETRY=on
+      expect(existsSync(configPath)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('promptTelemetryOptIn: non-interactive stdin (no TTY) → writes enabled:false', async () => {
+    // process.stdin.isTTY is falsy in test runners — exercises the non-TTY path.
+    const dir = mkdtempSync(join(tmpdir(), 'plur-telem-unit-'))
+    try {
+      const configPath = join(dir, 'telemetry.json')
+
+      // No TTY in vitest → branch evaluates isInteractive=false
+      const result = await promptTelemetryOptIn({ configPath })
+      expect(['non-interactive', 'opted-out']).toContain(result)
+
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      expect(config.enabled).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
Rebased replacement for #700 — same commit, conflict-free against v0.15.0.

## Summary

- `plur init` now includes a single opt-in question at the end of setup: **"Enable anonymous usage statistics? (helps us improve PLUR — no code, no keys) [y/N]"**
- Answers yes/no → persists to `~/.plur/telemetry.json`. Non-interactive installs (CI, piped stdin, `--no-prompt`) silently write `enabled:false` — never opt in without consent.
- Already-configured installs skip the prompt entirely (no nag).
- `PLUR_TELEMETRY` env var still overrides at runtime (existing behavior unchanged).
- CHANGELOG Unreleased section updated.

## Context

H004 E3 closed inconclusive 2026-07-25 (CEO decision): telemetry infrastructure works and ingress is live, but `PLUR_TELEMETRY=on` adoption rate is ~0.09/day — the opt-in is not discoverable in the normal install flow. At 330+ days to ≥30 sample floor, this is a structural bottleneck.

H005 (successor engagement hypothesis) cannot be promoted to active until opt-in discovery improves. This PR directly addresses that gate.

Design follows the precedent set by Next.js, Expo, and other open-source CLIs.

## Replaces

#700 — the original branch accumulated unrelated upstream commits that caused CHANGELOG conflicts after v0.15.0 shipped. This branch is a clean cherry-pick of the single telemetry opt-in commit onto current main.