### PR TITLE
fix(mcp): surface #297 partial array drops and coerce union item schemas

### DIFF
--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -74,7 +74,18 @@ function jsonSchemaPropToZod(prop: any): z.ZodTypeAny {
           return val
         }
       }
-      if (prop.items?.type === 'string') {
+      // The comma-separated fallback must also cover union item schemas that
+      // ACCEPT a bare string, not just `items: {type: 'string'}`. Before this,
+      // `engram_suggestions` — whose items are
+      // `anyOf: [{type:'string'}, {type:'object'}]` (#231) — failed the check
+      // and fell through to `return val`, so the very workaround the #297
+      // error message advertises did not work for it.
+      const items = prop.items as any
+      const itemVariants = (items?.anyOf as any[] | undefined) ?? (items?.oneOf as any[] | undefined)
+      const itemsAcceptString = items?.type === 'string'
+        || (Array.isArray(itemVariants) && itemVariants.some((v: any) => v?.type === 'string'))
+
+      if (itemsAcceptString) {
         return trimmed.length === 0 ? [] : trimmed.split(',').map((s: string) => s.trim()).filter((s: string) => s.length > 0)
       }
       return val
@@ -123,9 +134,31 @@ export function validateToolArgs(
     const details = parsed.error.issues.map(i => `${i.path.join('.') || 'root'}: ${i.message}`).join(', ')
     const hasArrayParam = Object.values((schema.properties ?? {}) as Record<string, any>)
       .some((p: any) => p?.type === 'array')
-    const arrayBugHint = receivedFields.length === 0 && hasArrayParam
-      ? ' Known client-side bug (plur-ai/plur#297): some MCP clients drop the entire arguments payload ' +
-        'when an array-typed parameter is included. Retry passing array parameters as a JSON string ' +
+
+    // #297 has TWO shapes, not one. The original (total drop) loses the whole
+    // arguments object. The partial drop keeps the early scalar fields and
+    // silently discards trailing ones — observed on a large payload where a
+    // ~700-char `summary` plus a 5-element `engram_suggestions` array arrived
+    // as `{summary}` alone. Gating the hint on `receivedFields.length === 0`
+    // meant the partial case — the one that actually looks like a schema bug
+    // to the caller — got a bare "Required" with no workaround. Fire the hint
+    // whenever a *missing* field is itself array-typed.
+    const missingArrayParams = parsed.error.issues
+      .filter((i: any) => i.code === 'invalid_type' && i.received === 'undefined')
+      .map((i: any) => String(i.path[0] ?? ''))
+      .filter((k: string) => (schema.properties as any)?.[k]?.type === 'array')
+
+    const totalDrop = receivedFields.length === 0 && hasArrayParam
+    const partialDrop = missingArrayParams.length > 0
+
+    const arrayBugHint = totalDrop || partialDrop
+      ? ' Known client-side bug (plur-ai/plur#297): some MCP clients drop ' +
+        (partialDrop
+          ? `array-typed parameters from a large arguments payload while keeping the earlier fields ` +
+            `(here: ${missingArrayParams.join(', ')}). This is size-sensitive — the same call often ` +
+            `succeeds with a shorter payload, so shrink the other fields (e.g. a briefer summary) as well. `
+          : 'the entire arguments payload when an array-typed parameter is included. ') +
+        'Retry passing array parameters as a JSON string ' +
         '(e.g. tags: "[\\"a\\",\\"b\\"]") or a comma-separated string (tags: "a, b") — the server coerces ' +
         'both back into arrays.'
       : ''

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -139,6 +139,73 @@ describe('MCP server (wire protocol)', () => {
       expect(parsed.error).toContain('tags')
     })
 
+    // #297 partial drop: the client keeps the early scalar fields and silently
+    // discards a trailing array-typed one. Observed with plur_session_end on a
+    // large payload (long summary + 5-element engram_suggestions) arriving as
+    // {summary} alone. Previously the hint was gated on receivedFields.length
+    // === 0, so this — the shape that most looks like a server schema bug to
+    // the caller — got a bare "Required" and no workaround.
+    it('partial drop of an array param still names the client bug (#297)', async () => {
+      const result = await client.callTool({
+        name: 'plur_session_end',
+        arguments: { summary: 'Trailing array param was dropped by the client' },
+      })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      // The scalar field survived, so this is NOT the empty-payload path.
+      expect(parsed.received_fields).toEqual(['summary'])
+      expect(parsed.error).not.toContain('arguments object was empty')
+      // ...but the caller must still be told what happened and how to retry.
+      expect(parsed.error).toContain('plur-ai/plur#297')
+      expect(parsed.error).toContain('engram_suggestions')
+      expect(parsed.error).toMatch(/JSON string|comma-separated/)
+      // Size is the trigger; say so, or the caller retries an identical payload.
+      expect(parsed.error).toMatch(/size-sensitive|shorter payload/)
+    })
+
+    it('a missing NON-array required field does not mention #297', async () => {
+      // plur_session_end also requires `summary`. Omitting only that is an
+      // ordinary caller error — the array hint would be misleading noise.
+      const result = await client.callTool({
+        name: 'plur_session_end',
+        arguments: { engram_suggestions: ['a real suggestion'] },
+      })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.error).toContain('summary')
+      expect(parsed.error).not.toContain('plur-ai/plur#297')
+    })
+
+    // The workaround the #297 message advertises must actually work for the
+    // parameter it is most often needed on. engram_suggestions has union items
+    // (anyOf: [string, object], #231); the old `items?.type === 'string'` check
+    // was false for it, so comma-separated input fell through uncoerced.
+    it('coerces comma-separated input for union (anyOf) item schemas', async () => {
+      const result = await client.callTool({
+        name: 'plur_session_end',
+        arguments: {
+          summary: 'Union-item coercion',
+          engram_suggestions: 'first learning, second learning',
+        },
+      })
+      expect(result.isError).toBeFalsy()
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.engrams_created).toBe(2)
+    })
+
+    it('coerces a JSON-stringified array for union (anyOf) item schemas', async () => {
+      const result = await client.callTool({
+        name: 'plur_session_end',
+        arguments: {
+          summary: 'Union-item JSON coercion',
+          engram_suggestions: '["json one","json two"]',
+        },
+      })
+      expect(result.isError).toBeFalsy()
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.engrams_created).toBe(2)
+    })
+
     it('empty arguments on a tool with array params names the client bug (#297)', async () => {
       const result = await client.callTool({ name: 'plur_learn', arguments: {} })
       expect(result.isError).toBe(true)


### PR DESCRIPTION
Closes #704. Follow-up to #297, which fixed the total payload drop but not the partial one.

## What

Two defects in `packages/mcp/src/tools.ts` that together made a real client-side truncation bug undiagnosable.

**1. The #297 hint could not fire on a partial drop.**

`validateToolArgs` gated the hint on `receivedFields.length === 0`. But the client also drops parameters *partially* — early scalar fields arrive, trailing ones are silently discarded. A `plur_session_end` call carrying a ~700-char `summary` plus a five-element `engram_suggestions` array arrived as `{summary}` alone.

That shape is the one most likely to be misread as a server schema bug: the caller sees `engram_suggestions: Required` for a field they demonstrably passed, and previously got no hint and no workaround. I retried six times with different array formats before suspecting the client.

The hint now fires whenever a **missing required field is itself array-typed**, names the dropped parameters, and states that the trigger is payload size — so the caller shrinks the other fields instead of retrying an identical call.

**2. The advertised workaround did not work for the parameter that needs it most.**

The comma-separated fallback was gated on `prop.items?.type === 'string'`. `engram_suggestions` has union items (`anyOf: [{type:'string'}, {type:'object'}]`, from #231), so `items.type` is `undefined` and the input fell through uncoerced — meaning the retry shape the error message recommends could not succeed for it. Any item schema that **accepts** a bare string (directly, or as an `anyOf`/`oneOf` variant) now takes the comma-separated path.

## Why it is worth fixing here

Neither change fixes the client — that is upstream. But the failure currently presents as a server-side schema error, which sends the caller down entirely the wrong path. These two changes turn it into a self-correcting one.

## Evidence

Narrowed by varying one thing at a time against the local server:

| Call | Result |
|------|--------|
| `engram_suggestions: ["x"]` | works |
| `["alpha, beta", "gamma"]` | works — commas are not the trigger |
| one 180-char suggestion alone | works — content is not the trigger |
| short `summary` + three long suggestions | works |
| ~700-char `summary` + five long suggestions | **array dropped** |

Full reproduction, including the silent optional-parameter variant (a large `plur_learn` losing its trailing `scope`/`domain`/`type` and misrouting the engram to `global`), is in #704.

## Tests

Four added.

**Two fail without this change** — verified by stashing the source fix and keeping the tests:
- partial drop of an array param still names #297
- comma-separated coercion works for union (`anyOf`) item schemas

**Two are regression guards** that must pass either way:
- a missing **non-array** required field must stay silent about #297 (the hint would be noise)
- the JSON-string path for union items already worked and must keep working

## Verification

- `packages/mcp`: 256 passed, 4 skipped — three consecutive full runs
- `tsc --noEmit` clean

## Pre-existing flake, not introduced here

`test/session.test.ts` → "standalone plur_inject calls accumulate into the session telemetry" was observed failing once, then passing on four subsequent full runs, **with and without** this change. It is flaky independently of this PR: it depends on the module-level `_activeSessionId` / `_sessionTelemetry` globals in `tools.ts`, which are safe only while MCP sessions are sequential within a process. Called out rather than silently re-run; worth its own issue if it recurs.

## Not addressed

The silent optional-parameter drop has no clean server-side detection — an omitted optional field is indistinguishable from a deliberately omitted one. The existing `scope_hint` on `plur_learn` already mitigates the `scope` case, which is how this was noticed. See #704 for discussion.
