### PR TITLE
feat(core): first-class permitted-scope filter in the storage layer (#710)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,7 +47,7 @@ import { RemoteStore, normalizeEndpointUrl } from './store/remote-store.js'
 import { YamlPrimaryStore } from './store/yaml-primary-store.js'
 import type { PrimaryStore } from './store/primary-store.js'
 import { requiresIndexSync, asDerivedIndex } from './storage-adapter.js'
-import { isSharedScope, isPersonalScope, isScopeWithin } from './scope-util.js'
+import { isSharedScope, isPersonalScope, isScopeWithin, scopeAllowFilter } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { Episode } from './schemas/episode.js'
 import type { PackManifest } from './schemas/pack.js'
@@ -99,11 +99,11 @@ export { rankScopes, SCOPE_MATCH_THRESHOLD, WEIGHT_TAG, SUGGEST_DISPLAY_MIN_CONF
 // importing it from here would form index → inject → index. They are imported
 // above for internal use and re-exported here so the public `@plur-ai/core` API
 // (`isSharedScope`, `isPersonalScope`, `SHARED_SCOPE_PREFIXES`) is unchanged.
-export { isSharedScope, isPersonalScope, SHARED_SCOPE_PREFIXES } from './scope-util.js'
+export { isSharedScope, isPersonalScope, SHARED_SCOPE_PREFIXES, scopeAllowFilter } from './scope-util.js'
 export { detectPlurStorage, type PlurPaths } from './storage.js'
 export { IndexedStorage } from './storage-indexed.js'
 export { PGLiteAdapter, type PGLiteAdapterOptions, type VectorPrecision } from './storage-pglite.js'
-export type { StorageAdapter, StorageFilter, VectorSearchHit, StorageAdapterRole, DerivedIndexAdapter } from './storage-adapter.js'
+export type { ScopeRestriction, StorageAdapter, StorageFilter, VectorSearchHit, StorageAdapterRole, DerivedIndexAdapter } from './storage-adapter.js'
 export { requiresIndexSync, asDerivedIndex } from './storage-adapter.js'
 export { YamlStore, SqliteStore, createStore, migrateStore, type EngramStore, type StorageBackend, type StorageConfig } from './store/index.js'
 export { YamlPrimaryStore, MemoryPrimaryStore, type PrimaryStore, type PrimaryStoreKind } from './store/index.js'
@@ -2359,7 +2359,7 @@ export class Plur {
   }
 
   /** List all active engrams, optionally filtered by scope/domain. No search — returns all matches. */
-  list(options?: { scope?: string; domain?: string; min_strength?: number; include_expired?: boolean }): Engram[] {
+  list(options?: { scope?: string; scopes?: string[]; domain?: string; min_strength?: number; include_expired?: boolean }): Engram[] {
     return this._filterEngrams(options)
   }
 
@@ -2370,6 +2370,7 @@ export class Plur {
       engrams = this.indexedStorage.loadFiltered({
         status: 'active',
         scope: options?.scope,
+        scopes: options?.scopes,
         domain: options?.domain,
       })
     } else {
@@ -2381,6 +2382,14 @@ export class Plur {
       // so the cost is comparable.
       engrams = this._loadAllEngrams()
       engrams = engrams.filter(e => e.status === 'active')
+      if (options?.scopes !== undefined) {
+        // Permitted-scope allow-list (Phase 3). The in-memory twin of the SQL
+        // `scope = ANY($n)` pushdown, so the YAML path can never be the one
+        // read path that silently ignores an authorization filter. EXACT
+        // membership; `[]` matches nothing — see scopeAllowFilter.
+        const allowed = scopeAllowFilter(options.scopes)
+        engrams = engrams.filter(e => allowed(e.scope))
+      }
       if (options?.domain) {
         engrams = engrams.filter(e => e.domain?.startsWith(options.domain!))
       }

--- a/packages/core/src/scope-util.ts
+++ b/packages/core/src/scope-util.ts
@@ -72,3 +72,28 @@ export function isScopeWithin(scope: string, queryScope: string): boolean {
     || scope.startsWith(queryScope + ':')
     || scope.startsWith(queryScope + '/')
 }
+
+/**
+ * Permitted-scope allow-list predicate — the in-memory twin of the SQL
+ * `scope = ANY($n)` pushdown (see `StorageFilter.scopes` in
+ * storage-adapter.ts).
+ *
+ * Returns a predicate so every read path — SQL-backed adapters and the
+ * in-memory YAML path alike — agrees on the same three cases:
+ *   - `undefined` → unrestricted (predicate always true)
+ *   - `[]`        → matches NOTHING (predicate always false). Security-
+ *                   relevant: a principal with no permitted scopes must see
+ *                   nothing. NEVER treat an empty list as "no filter".
+ *   - non-empty   → EXACT membership. No hierarchy expansion, no personal-
+ *                   family pass-through: the list is the fully-resolved
+ *                   authorization decision, so `['project:a']` does NOT admit
+ *                   `project:a:sub`, `global`, or `local`.
+ *
+ * The Set is built once so the per-engram check is O(1) — the caller may be
+ * filtering a whole corpus against a list of tens of scopes.
+ */
+export function scopeAllowFilter(scopes: readonly string[] | undefined): (scope: string) => boolean {
+  if (scopes === undefined) return () => true
+  const allowed = new Set(scopes)
+  return (scope: string) => allowed.has(scope)
+}

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -47,9 +47,52 @@
  */
 import type { Engram } from './schemas/engram.js'
 
+/**
+ * Permitted-scope allow-list — the authorization filter (Phase 3, scope
+ * pushdown).
+ *
+ * This exists so a caller that has ALREADY resolved an identity to a concrete
+ * set of permitted scopes — typically in an identity/permission layer sitting
+ * above core — can push that decision INTO the query, instead of filtering the
+ * result set afterwards.
+ *
+ * Post-filtering an unrestricted nearest-neighbour list is the dilution bug
+ * this type exists to prevent: `LIMIT` counts rows the caller may not be
+ * allowed to see, so with a fixed overfetch factor a caller whose permitted
+ * scopes are a small share of the corpus asks for N results and silently gets
+ * far fewer, while relevant permitted rows sit just below the cut.
+ *
+ * Semantics — all three cases are load-bearing:
+ *   - `undefined` (absent) → NO scope restriction. Identical behaviour to
+ *     before this field existed.
+ *   - `[]` (empty array)   → matches NOTHING. A principal with zero permitted
+ *     scopes must see zero engrams. An empty list is never widened to
+ *     "unrestricted"; that would be a privilege-escalation bug.
+ *   - non-empty            → EXACT set membership (`scope = ANY(list)`).
+ *
+ * Exactness is deliberate. Unlike `StorageFilter.scope` (a *visibility* filter
+ * that is hierarchy-aware and passes personal-family scopes through), `scopes`
+ * is an *authorization* filter: the list is already the complete answer. It
+ * performs NO hierarchy expansion and NO personal-family pass-through, so
+ * `scopes: ['project:a']` admits `project:a` alone — not `project:a:sub`, not
+ * `global`, not `local`. A caller who wants descendants must expand them into
+ * the list itself.
+ *
+ * Composition: `scopes` is AND-ed with every other filter field (`status`,
+ * `scope`, `domain`), so combining them can only ever narrow the result set.
+ */
+export interface ScopeRestriction {
+  /** Permitted-scope allow-list. Absent = unrestricted, `[]` = nothing. */
+  scopes?: string[]
+}
+
 /** Filter shape shared by all adapters. */
-export interface StorageFilter {
+export interface StorageFilter extends ScopeRestriction {
   status?: string
+  /**
+   * Visibility scope (hierarchy-aware, personal-family pass-through).
+   * Distinct from `scopes` — see {@link ScopeRestriction}.
+   */
   scope?: string
   domain?: string
 }
@@ -87,10 +130,23 @@ export interface StorageAdapter {
    * Derived indexes only — absent when `role === 'primary'`.
    */
   reindex?(): Promise<void>
-  /** BM25 keyword search. */
-  searchBM25(query: string, opts: { limit: number }): Promise<Engram[]>
-  /** Vector similarity search (cosine). */
-  searchVector(query: Float32Array, limit: number): Promise<VectorSearchHit[]>
+  /**
+   * BM25 keyword search.
+   *
+   * `opts.scopes` restricts the candidate set BEFORE ranking — see
+   * {@link ScopeRestriction}. An implementation that accepts `scopes` and does
+   * not apply it is a silent-wrong-results bug, not a missing optimization.
+   */
+  searchBM25(query: string, opts: { limit: number } & ScopeRestriction): Promise<Engram[]>
+  /**
+   * Vector similarity search (cosine).
+   *
+   * `opts.scopes` must be applied IN the query (as part of the k-NN
+   * predicate), not to the returned rows — otherwise `limit` is measured
+   * against the org-wide neighbour list and in-scope results are diluted away.
+   * See {@link ScopeRestriction}.
+   */
+  searchVector(query: Float32Array, limit: number, opts?: ScopeRestriction): Promise<VectorSearchHit[]>
   /** Upsert an embedding for a specific engram. */
   upsertEmbedding(engramId: string, vector: Float32Array): Promise<void>
   /** Release resources. */

--- a/packages/core/src/storage-indexed.ts
+++ b/packages/core/src/storage-indexed.ts
@@ -4,6 +4,7 @@ import { loadEngrams, storePrefix } from './engrams.js'
 import { isPersonalScope, isScopeWithin } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { StoreEntry } from './schemas/config.js'
+import type { StorageFilter } from './storage-adapter.js'
 
 const require = createRequire(import.meta.url)
 
@@ -126,7 +127,7 @@ export class IndexedStorage {
   }
 
   /** Load engrams with SQL-level filtering. */
-  loadFiltered(filter: { status?: string; scope?: string; domain?: string }): Engram[] {
+  loadFiltered(filter: StorageFilter): Engram[] {
     if (!existsSync(this.dbPath)) {
       this.reindex()
     }
@@ -137,6 +138,29 @@ export class IndexedStorage {
     if (filter.status) {
       conditions.push('status = ?')
       params.push(filter.status)
+    }
+    if (filter.scopes !== undefined) {
+      // Permitted-scope allow-list pushdown (Phase 3) — the SQLite twin of
+      // storage-pglite's `scope = ANY($n::text[])`. EXACT membership: no
+      // hierarchy expansion and no `personal = 1` pass-through, because the
+      // caller has already resolved identity to a complete permitted set and
+      // widening it here would hand back engrams authorization never granted.
+      //
+      // An EMPTY list must match NOTHING, so it compiles to a literal false
+      // rather than being dropped — `scope IN ()` is not even valid SQLite,
+      // and silently dropping the clause would show a principal with zero
+      // permitted scopes the entire corpus.
+      //
+      // One placeholder per scope. A permitted-scope list is an authorization
+      // decision (tens of entries at most), so SQLite's variable ceiling
+      // (SQLITE_MAX_VARIABLE_NUMBER, 32766 in better-sqlite3) is not in reach;
+      // if it ever were, switch to `IN (SELECT value FROM json_each(?))`.
+      if (filter.scopes.length === 0) {
+        conditions.push('1 = 0')
+      } else {
+        conditions.push(`scope IN (${filter.scopes.map(() => '?').join(', ')})`)
+        params.push(...filter.scopes)
+      }
     }
     if (filter.scope) {
       // Read-side scope filter (#353). `personal = 1` passes ALL personal-family

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -29,7 +29,7 @@ import type { Engram } from './schemas/engram.js'
 import { loadEngrams } from './engrams.js'
 import { searchEngrams } from './fts.js'
 import { logger } from './logger.js'
-import type { DerivedIndexAdapter, StorageFilter, VectorSearchHit } from './storage-adapter.js'
+import type { DerivedIndexAdapter, ScopeRestriction, StorageFilter, VectorSearchHit } from './storage-adapter.js'
 
 /** Vector dimension used by the default BGE-small-en-v1.5 model. */
 const DEFAULT_VECTOR_DIM = 384
@@ -356,14 +356,38 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
     }
   }
 
-  /** Apply a filter to a SELECT query. */
-  private buildFilterClause(filter: StorageFilter): { where: string; params: any[] } {
+  /**
+   * Apply a filter to a SELECT query.
+   *
+   * `opts.alias` qualifies every column (the join in searchVector needs
+   * `e.status`, not a bare `status`); `opts.startIndex` is the first free
+   * placeholder number so the clause can be spliced into a query that already
+   * bound `$1` (the query vector).
+   */
+  private buildFilterClause(
+    filter: StorageFilter,
+    opts?: { alias?: string; startIndex?: number },
+  ): { where: string; params: any[]; nextIndex: number } {
+    const col = opts?.alias ? `${opts.alias}.` : ''
     const conditions: string[] = []
     const params: any[] = []
-    let i = 1
+    let i = opts?.startIndex ?? 1
     if (filter.status) {
-      conditions.push(`status = $${i++}`)
+      conditions.push(`${col}status = $${i++}`)
       params.push(filter.status)
+    }
+    if (filter.scopes !== undefined) {
+      // Permitted-scope allow-list pushdown (Phase 3). EXACT membership — no
+      // hierarchy expansion, no personal-family pass-through: the caller has
+      // already resolved identity to a complete set of permitted scopes, so
+      // widening it here would grant access the authorization layer did not.
+      //
+      // An EMPTY array must match NOTHING: `= ANY(ARRAY[]::text[])` is false
+      // for every row, which is exactly right — a principal with no permitted
+      // scopes sees nothing. This is why the guard is `!== undefined` and not
+      // a truthiness/length test; `[]` is a real filter, not an absent one.
+      conditions.push(`${col}scope = ANY($${i++}::text[])`)
+      params.push(filter.scopes)
     }
     if (filter.scope) {
       // Read-side scope filter, two parts OR'd:
@@ -376,17 +400,17 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
       //  (2) segment-aware membership (#383): the requested scope, exactly or a
       //      descendant on a REAL delimiter (`:`/`/`) — never a sibling prefix.
       conditions.push(
-        `((NOT (scope LIKE 'group:%' OR scope LIKE 'project:%' OR scope LIKE 'space:%' OR scope LIKE 'team:%' OR scope LIKE 'org:%' OR scope = 'public' OR scope LIKE 'public:%' OR scope LIKE 'public/%'))`
-        + ` OR scope = $${i++} OR scope LIKE $${i++} || ':%' OR scope LIKE $${i++} || '/%')`,
+        `((NOT (${col}scope LIKE 'group:%' OR ${col}scope LIKE 'project:%' OR ${col}scope LIKE 'space:%' OR ${col}scope LIKE 'team:%' OR ${col}scope LIKE 'org:%' OR ${col}scope = 'public' OR ${col}scope LIKE 'public:%' OR ${col}scope LIKE 'public/%'))`
+        + ` OR ${col}scope = $${i++} OR ${col}scope LIKE $${i++} || ':%' OR ${col}scope LIKE $${i++} || '/%')`,
       )
       params.push(filter.scope, filter.scope, filter.scope)
     }
     if (filter.domain) {
-      conditions.push(`domain LIKE $${i++} || '%'`)
+      conditions.push(`${col}domain LIKE $${i++} || '%'`)
       params.push(filter.domain)
     }
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
-    return { where, params }
+    return { where, params, nextIndex: i }
   }
 
   /** Parse a `data` row back to an Engram. PGLite returns JSONB as parsed JSON. */
@@ -510,46 +534,64 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
    * yields identical results to load the candidate set into JS and run the
    * existing BM25 scorer. This also keeps fts.ts as the single ranking
    * authority (one tokenizer, one IDF computation).
+   *
+   * `opts.scopes` is pushed into the candidate SELECT via loadFiltered, so the
+   * BM25 scorer only ever sees permitted engrams — IDF and the top-N cut are
+   * both computed over the in-scope corpus, not over the org's.
    */
-  async searchBM25(query: string, opts: { limit: number }): Promise<Engram[]> {
-    const candidates = await this.loadFiltered({ status: 'active' })
+  async searchBM25(query: string, opts: { limit: number } & ScopeRestriction): Promise<Engram[]> {
+    const candidates = await this.loadFiltered({ status: 'active', scopes: opts.scopes })
     return searchEngrams(candidates, query, opts.limit)
   }
 
   /**
    * Vector search. Uses pgvector when available, JS cosine otherwise.
    * Returns scored results so callers can fuse with BM25 via RRF.
+   *
+   * `opts.scopes` is applied INSIDE the k-NN query (Phase 3 scope pushdown),
+   * never to the returned rows. Post-filtering an org-wide neighbour list is
+   * the dilution bug: `LIMIT` would be spent on engrams the caller may not
+   * see, so asking for N in-scope results would silently return fewer.
+   * Filtering in the query means `limit` counts permitted rows only.
    */
-  async searchVector(query: Float32Array, limit: number): Promise<VectorSearchHit[]> {
+  async searchVector(query: Float32Array, limit: number, opts?: ScopeRestriction): Promise<VectorSearchHit[]> {
     const db = await this.getDb()
     const totalRes = await db.query('SELECT COUNT(*)::int AS c FROM engram_embeddings')
     if (Number(totalRes.rows[0].c) === 0) return []
+    // status defaults to 'active' (historical behaviour) but stays overridable.
+    const filter: StorageFilter = { status: 'active', scopes: opts?.scopes }
     if (this.hasVector) {
       // pgvector path. Cosine distance = 1 - cosine similarity. The query
       // param is cast to the column's ACTUAL type (#223) — pgvector's <=>
       // operators are per-type, so a halfvec column needs a halfvec operand.
+      // $1 is the query vector, so the filter's placeholders start at $2 and
+      // LIMIT takes whatever number is free after them.
       const t = this.activeVecType
       const literal = vectorLiteral(query)
+      const { where, params, nextIndex } = this.buildFilterClause(filter, { alias: 'e', startIndex: 2 })
       const res = await db.query(
         `SELECT e.data, 1 - (em.embedding <=> $1::${t}) AS score
          FROM engram_embeddings em
          JOIN engrams e ON e.id = em.engram_id
-         WHERE e.status = 'active'
+         ${where}
          ORDER BY em.embedding <=> $1::${t}
-         LIMIT $2`,
-        [literal, limit],
+         LIMIT $${nextIndex}`,
+        [literal, ...params, limit],
       )
       return res.rows.map((r: any) => ({
         engram: this.parseRow(r),
         score: Number(r.score),
       }))
     }
-    // BYTEA fallback: read all embeddings, compute cosine in JS.
+    // BYTEA fallback: read all embeddings, compute cosine in JS. The scope
+    // filter still runs in SQL — the JS side only does the cosine.
+    const { where, params } = this.buildFilterClause(filter, { alias: 'e' })
     const res = await db.query(
       `SELECT e.data, em.embedding
        FROM engram_embeddings em
        JOIN engrams e ON e.id = em.engram_id
-       WHERE e.status = 'active'`,
+       ${where}`,
+      params,
     )
     const scored: VectorSearchHit[] = res.rows.map((r: any) => {
       const vec = bytesToFloat32(r.embedding)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,6 +115,21 @@ export interface RecallBudget {
 
 export interface RecallOptions {
   scope?: string
+  /**
+   * Permitted-scope allow-list — an AUTHORIZATION filter, distinct from the
+   * `scope` visibility filter above (see `ScopeRestriction` in
+   * storage-adapter.ts for the full contract).
+   *
+   * Absent = unrestricted. `[]` = matches NOTHING (a principal with no
+   * permitted scopes must see nothing — never widened to "no filter").
+   * Non-empty = EXACT membership: no hierarchy expansion, no personal-family
+   * pass-through, because the caller has already resolved identity to a
+   * complete set of permitted scopes.
+   *
+   * Pushed into the query on the indexed paths so `limit` counts permitted
+   * results rather than being spent on rows the caller may not see.
+   */
+  scopes?: string[]
   domain?: string
   limit?: number
   min_strength?: number

--- a/packages/core/test/pglite-scope-pushdown.test.ts
+++ b/packages/core/test/pglite-scope-pushdown.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Scope pushdown — PGLiteAdapter (Phase 3, core half of the enterprise
+ * recall bug).
+ *
+ * The bug this file exists to prevent: a vector search that returns the
+ * ORG-WIDE nearest neighbours and lets the caller filter by scope afterwards.
+ * With a fixed overfetch factor, a caller
+ * whose permitted scopes are a small share of the corpus asks for N results
+ * and silently gets a handful — the relevant in-scope engrams sit just below
+ * the cut and are never seen. Pushing the permitted-scope list INTO the query
+ * makes `limit` count permitted rows, so N asked is N returned.
+ *
+ * Contract under test (see ScopeRestriction in storage-adapter.ts):
+ *   - `scopes` absent      → no scope restriction (byte-identical behaviour)
+ *   - `scopes: []`         → matches NOTHING (security-relevant degenerate
+ *                            case: a principal with no permitted scopes must
+ *                            see zero engrams, never the whole corpus)
+ *   - `scopes: ['a']`      → EXACT membership — no hierarchy expansion, no
+ *                            personal-family pass-through
+ *   - composes (AND) with status / scope / domain
+ *   - applies to loadFiltered, searchBM25 AND searchVector
+ *   - applies on the pgvector path AND the BYTEA/JS-cosine fallback
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function mkEngram(id: string, statement: string, opts: Partial<Engram> = {}): Engram {
+  return {
+    id,
+    statement,
+    type: opts.type ?? 'behavioral',
+    scope: opts.scope ?? 'project:plur',
+    domain: opts.domain ?? 'plur.test',
+    status: opts.status ?? 'active',
+    tags: opts.tags ?? [],
+    activation: {
+      retrieval_strength: 1.0,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-07-26',
+    },
+    feedback_signals: opts.feedback_signals ?? { positive: 0, negative: 0, neutral: 0 },
+  } as Engram
+}
+
+function seedYaml(path: string, engrams: Engram[]): void {
+  writeFileSync(path, yaml.dump({ engrams }), 'utf8')
+}
+
+const DIM = 8
+
+/** Build a DIM-length vector from its leading components. */
+function vec(...head: number[]): Float32Array {
+  const v = new Float32Array(DIM)
+  for (let i = 0; i < head.length && i < DIM; i++) v[i] = head[i]
+  return v
+}
+
+// PGLite WASM startup + schema init; generous because the serial core-pglite
+// project trades wall-clock for correctness.
+const PGLITE_TIMEOUT = 60_000
+
+/**
+ * Dilution fixture: a corpus dominated by engrams the caller may NOT see,
+ * where every out-of-scope engram is a NEARER neighbour than every in-scope
+ * one. Post-filtering `limit * 3` here returns zero in-scope results; a real
+ * pushdown returns exactly `limit`.
+ */
+const OUT_OF_SCOPE = 100
+const IN_SCOPE = 20
+
+async function seedDilutionCorpus(adapter: PGLiteAdapter, yamlPath: string): Promise<void> {
+  const engrams: Engram[] = []
+  for (let i = 0; i < OUT_OF_SCOPE; i++) {
+    engrams.push(mkEngram(`ENG-2026-0726-O${String(i).padStart(3, '0')}`, `other org memory ${i}`, {
+      scope: 'project:other',
+    }))
+  }
+  for (let j = 0; j < IN_SCOPE; j++) {
+    engrams.push(mkEngram(`ENG-2026-0726-M${String(j).padStart(3, '0')}`, `mine org memory ${j}`, {
+      scope: 'project:mine',
+    }))
+  }
+  seedYaml(yamlPath, engrams)
+  await adapter.reindex()
+  // Out-of-scope rows hug the query axis (cosine ~1.0); in-scope rows sit well
+  // off it (cosine ~0.89). Ordering is therefore 100 forbidden rows first.
+  for (let i = 0; i < OUT_OF_SCOPE; i++) {
+    await adapter.upsertEmbedding(`ENG-2026-0726-O${String(i).padStart(3, '0')}`, vec(1, 0.0001 * (i + 1)))
+  }
+  for (let j = 0; j < IN_SCOPE; j++) {
+    await adapter.upsertEmbedding(`ENG-2026-0726-M${String(j).padStart(3, '0')}`, vec(1, 0.5 + 0.001 * j))
+  }
+}
+
+describe('PGLiteAdapter — permitted-scope pushdown', () => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+  let adapter: PGLiteAdapter
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-scope-push-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'store.pglite')
+  })
+
+  afterEach(async () => {
+    if (adapter) await adapter.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  describe('loadFiltered', () => {
+    beforeEach(async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0726-001', 'alpha', { scope: 'project:a' }),
+        mkEngram('ENG-2026-0726-002', 'alpha sub', { scope: 'project:a:sub' }),
+        mkEngram('ENG-2026-0726-003', 'beta', { scope: 'project:b' }),
+        mkEngram('ENG-2026-0726-004', 'personal global', { scope: 'global' }),
+        mkEngram('ENG-2026-0726-005', 'personal local', { scope: 'local' }),
+      ])
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await adapter.reindex()
+    }, PGLITE_TIMEOUT)
+
+    it('REGRESSION GUARD: omitting scopes returns exactly what it returned before', async () => {
+      const all = await adapter.loadFiltered({})
+      expect(all.length).toBe(5)
+      const active = await adapter.loadFiltered({ status: 'active' })
+      expect(active.length).toBe(5)
+      // Explicit `scopes: undefined` must be indistinguishable from absent.
+      const explicitUndefined = await adapter.loadFiltered({ scopes: undefined })
+      expect(explicitUndefined.map(e => e.id).sort()).toEqual(all.map(e => e.id).sort())
+    }, PGLITE_TIMEOUT)
+
+    it('SECURITY: an empty permitted-scope list matches NOTHING', async () => {
+      const none = await adapter.loadFiltered({ scopes: [] })
+      expect(none).toEqual([])
+      // …and stays empty when combined with other filters, rather than the
+      // empty list being quietly dropped.
+      expect(await adapter.loadFiltered({ status: 'active', scopes: [] })).toEqual([])
+      expect(await adapter.loadFiltered({ scope: 'project:a', scopes: [] })).toEqual([])
+    }, PGLITE_TIMEOUT)
+
+    it('restricts to exactly the listed scopes', async () => {
+      const onlyA = await adapter.loadFiltered({ scopes: ['project:a'] })
+      expect(onlyA.map(e => e.id)).toEqual(['ENG-2026-0726-001'])
+      const aAndB = await adapter.loadFiltered({ scopes: ['project:a', 'project:b'] })
+      expect(aAndB.map(e => e.id).sort()).toEqual(['ENG-2026-0726-001', 'ENG-2026-0726-003'])
+    }, PGLITE_TIMEOUT)
+
+    it('does NOT expand the hierarchy and does NOT pass personal scopes through', async () => {
+      // `scopes` is an authorization decision the caller already resolved:
+      // descendants (project:a:sub) and personal-family scopes (global, local)
+      // are NOT implied. This is the opposite of `scope`, deliberately.
+      const onlyA = await adapter.loadFiltered({ scopes: ['project:a'] })
+      const ids = onlyA.map(e => e.id)
+      expect(ids).not.toContain('ENG-2026-0726-002') // project:a:sub
+      expect(ids).not.toContain('ENG-2026-0726-004') // global
+      expect(ids).not.toContain('ENG-2026-0726-005') // local
+      // Contrast: the visibility filter `scope` DOES expand + pass through.
+      const visibility = await adapter.loadFiltered({ scope: 'project:a' })
+      const visIds = visibility.map(e => e.id)
+      expect(visIds).toContain('ENG-2026-0726-002')
+      expect(visIds).toContain('ENG-2026-0726-004')
+    }, PGLITE_TIMEOUT)
+
+    it('composes with status, domain and scope as an AND (intersection)', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0726-010', 'a active plur', { scope: 'project:a', domain: 'plur.search', status: 'active' }),
+        mkEngram('ENG-2026-0726-011', 'a retired plur', { scope: 'project:a', domain: 'plur.search', status: 'retired' }),
+        mkEngram('ENG-2026-0726-012', 'a active other', { scope: 'project:a', domain: 'other.thing', status: 'active' }),
+        mkEngram('ENG-2026-0726-013', 'b active plur', { scope: 'project:b', domain: 'plur.search', status: 'active' }),
+      ])
+      await adapter.reindex()
+      const hits = await adapter.loadFiltered({
+        status: 'active',
+        domain: 'plur',
+        scopes: ['project:a', 'project:b'],
+      })
+      expect(hits.map(e => e.id).sort()).toEqual(['ENG-2026-0726-010', 'ENG-2026-0726-013'])
+      // Intersecting `scope` (visibility) with `scopes` (authorization) can
+      // only narrow: project:b is visible under neither.
+      const both = await adapter.loadFiltered({ scope: 'project:a', scopes: ['project:b'] })
+      expect(both).toEqual([])
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('searchBM25', () => {
+    beforeEach(async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0726-020', 'yaml is the source of truth', { scope: 'project:a' }),
+        mkEngram('ENG-2026-0726-021', 'yaml is the source of truth', { scope: 'project:b' }),
+        mkEngram('ENG-2026-0726-022', 'yaml is the source of truth', { scope: 'global' }),
+      ])
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await adapter.reindex()
+    }, PGLITE_TIMEOUT)
+
+    it('REGRESSION GUARD: omitting scopes searches the whole active corpus', async () => {
+      const hits = await adapter.searchBM25('source of truth', { limit: 10 })
+      expect(hits.map(e => e.id).sort()).toEqual([
+        'ENG-2026-0726-020', 'ENG-2026-0726-021', 'ENG-2026-0726-022',
+      ])
+    }, PGLITE_TIMEOUT)
+
+    it('SECURITY: an empty permitted-scope list returns no hits', async () => {
+      const hits = await adapter.searchBM25('source of truth', { limit: 10, scopes: [] })
+      expect(hits).toEqual([])
+    }, PGLITE_TIMEOUT)
+
+    it('restricts hits to the listed scopes', async () => {
+      const hits = await adapter.searchBM25('source of truth', { limit: 10, scopes: ['project:a'] })
+      expect(hits.map(e => e.id)).toEqual(['ENG-2026-0726-020'])
+    }, PGLITE_TIMEOUT)
+
+    it('DILUTION: limit counts in-scope hits, not org-wide hits', async () => {
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await seedDilutionCorpus(adapter, yamlPath)
+      // Every engram shares the token "memory", so the org-wide candidate set
+      // is 120 and is dominated 5:1 by rows the caller may not see.
+      const hits = await adapter.searchBM25('memory', { limit: 10, scopes: ['project:mine'] })
+      expect(hits.length).toBe(10)
+      expect(hits.every(e => e.scope === 'project:mine')).toBe(true)
+    }, PGLITE_TIMEOUT)
+  })
+
+  describe('searchVector (pgvector path)', () => {
+    it('REGRESSION GUARD: omitting scopes returns the org-wide neighbours, unchanged', async () => {
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await seedDilutionCorpus(adapter, yamlPath)
+      expect(await adapter.getVectorColumnType()).toBe('vector') // pgvector, not the fallback
+      const hits = await adapter.searchVector(vec(1), 10)
+      expect(hits.length).toBe(10)
+      // The nearest 10 are all out-of-scope by construction — this is the
+      // pre-pushdown behaviour, preserved when no allow-list is supplied.
+      expect(hits.every(h => h.engram.scope === 'project:other')).toBe(true)
+    }, PGLITE_TIMEOUT)
+
+    it('SECURITY: an empty permitted-scope list returns no hits', async () => {
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await seedDilutionCorpus(adapter, yamlPath)
+      const hits = await adapter.searchVector(vec(1), 10, { scopes: [] })
+      expect(hits).toEqual([])
+    }, PGLITE_TIMEOUT)
+
+    it('THE BUG: post-filtering a 3x overfetch loses in-scope results the pushdown keeps', async () => {
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await seedDilutionCorpus(adapter, yamlPath)
+      const limit = 10
+
+      // (a) The post-filter approach: fetch limit*3 unrestricted, filter in
+      //     JS afterwards. The caller asked for 10 and gets far fewer.
+      const overfetched = await adapter.searchVector(vec(1), limit * 3)
+      const postFiltered = overfetched.filter(h => h.engram.scope === 'project:mine')
+      expect(postFiltered.length).toBeLessThan(limit)
+
+      // (b) What the pushdown does: filter in the query, so LIMIT counts
+      //     permitted rows. Asked for 10, got 10 — all in scope.
+      const pushed = await adapter.searchVector(vec(1), limit, { scopes: ['project:mine'] })
+      expect(pushed.length).toBe(limit)
+      expect(pushed.every(h => h.engram.scope === 'project:mine')).toBe(true)
+      // Scores stay real cosine similarities, ordered descending.
+      for (let i = 1; i < pushed.length; i++) {
+        expect(pushed[i - 1].score).toBeGreaterThanOrEqual(pushed[i].score)
+      }
+    }, PGLITE_TIMEOUT)
+
+    it('returns every in-scope row when the limit exceeds the permitted corpus', async () => {
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await seedDilutionCorpus(adapter, yamlPath)
+      const hits = await adapter.searchVector(vec(1), 999, { scopes: ['project:mine'] })
+      expect(hits.length).toBe(IN_SCOPE)
+      expect(hits.every(h => h.engram.scope === 'project:mine')).toBe(true)
+    }, PGLITE_TIMEOUT)
+
+    it('still excludes non-active engrams when a permitted-scope list is supplied', async () => {
+      seedYaml(yamlPath, [
+        mkEngram('ENG-2026-0726-030', 'active', { scope: 'project:a', status: 'active' }),
+        mkEngram('ENG-2026-0726-031', 'retired', { scope: 'project:a', status: 'retired' }),
+      ])
+      adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+      await adapter.reindex()
+      await adapter.upsertEmbedding('ENG-2026-0726-030', vec(1))
+      await adapter.upsertEmbedding('ENG-2026-0726-031', vec(1))
+      const hits = await adapter.searchVector(vec(1), 10, { scopes: ['project:a'] })
+      expect(hits.map(h => h.engram.id)).toEqual(['ENG-2026-0726-030'])
+    }, PGLITE_TIMEOUT)
+  })
+})
+
+describe('PGLiteAdapter — permitted-scope pushdown on the BYTEA fallback', () => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-scope-bytea-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'store.pglite')
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@electric-sql/pglite/vector')
+    vi.resetModules()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /**
+   * Load a PGLiteAdapter whose pgvector import yields no `vector` export, so
+   * the adapter takes the BYTEA + JS-cosine fallback. The scope filter must
+   * STILL run in SQL there — a fallback that quietly ignores `scopes` is the
+   * same silent-wrong-results bug wearing a different hat.
+   */
+  async function loadFallbackAdapter(): Promise<typeof PGLiteAdapter> {
+    vi.resetModules()
+    vi.doMock('@electric-sql/pglite/vector', () => ({}))
+    const mod = await import('../src/storage-pglite.js')
+    return mod.PGLiteAdapter
+  }
+
+  it('filters by permitted scopes on the JS-cosine path, including the empty list', async () => {
+    const Adapter = await loadFallbackAdapter()
+    seedYaml(yamlPath, [
+      mkEngram('ENG-2026-0726-040', 'alpha', { scope: 'project:a' }),
+      mkEngram('ENG-2026-0726-041', 'beta', { scope: 'project:b' }),
+      mkEngram('ENG-2026-0726-042', 'gamma', { scope: 'global' }),
+    ])
+    const adapter = new Adapter(yamlPath, dbPath, { vectorDim: DIM })
+    await adapter.reindex()
+    // Self-check: null column type proves we really are on the BYTEA fallback.
+    // Without this the test could silently exercise the pgvector path instead.
+    expect(await adapter.getVectorColumnType()).toBeNull()
+
+    await adapter.upsertEmbedding('ENG-2026-0726-040', vec(1))
+    await adapter.upsertEmbedding('ENG-2026-0726-041', vec(1, 0.01))
+    await adapter.upsertEmbedding('ENG-2026-0726-042', vec(1, 0.02))
+
+    // Unrestricted — regression guard.
+    expect((await adapter.searchVector(vec(1), 10)).length).toBe(3)
+    // Empty allow-list — nothing.
+    expect(await adapter.searchVector(vec(1), 10, { scopes: [] })).toEqual([])
+    // Exact membership.
+    const only = await adapter.searchVector(vec(1), 10, { scopes: ['project:b'] })
+    expect(only.map(h => h.engram.id)).toEqual(['ENG-2026-0726-041'])
+    // BM25 + loadFiltered on the fallback store too.
+    expect(await adapter.loadFiltered({ scopes: [] })).toEqual([])
+    expect((await adapter.searchBM25('alpha', { limit: 10, scopes: ['project:a'] })).map(e => e.id))
+      .toEqual(['ENG-2026-0726-040'])
+
+    await adapter.close()
+  }, PGLITE_TIMEOUT)
+
+  it('DILUTION on the fallback path: limit counts in-scope hits', async () => {
+    const Adapter = await loadFallbackAdapter()
+    const adapter = new Adapter(yamlPath, dbPath, { vectorDim: DIM })
+    await seedDilutionCorpus(adapter as unknown as PGLiteAdapter, yamlPath)
+    expect(await adapter.getVectorColumnType()).toBeNull()
+    const hits = await adapter.searchVector(vec(1), 10, { scopes: ['project:mine'] })
+    expect(hits.length).toBe(10)
+    expect(hits.every(h => h.engram.scope === 'project:mine')).toBe(true)
+    await adapter.close()
+  }, PGLITE_TIMEOUT)
+})

--- a/packages/core/test/scope-pushdown.test.ts
+++ b/packages/core/test/scope-pushdown.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Scope pushdown — the non-PGLite read paths (Phase 3).
+ *
+ * The PGLite adapter is covered in pglite-scope-pushdown.test.ts. This file
+ * covers the other two places a permitted-scope allow-list can be honoured or
+ * silently dropped:
+ *
+ *   1. `scopeAllowFilter` — the shared predicate every in-memory path uses.
+ *   2. `IndexedStorage.loadFiltered` — the legacy better-sqlite3 index; the
+ *      filter must run in SQL (`scope IN (…)`), not after the query.
+ *   3. `Plur.list({ scopes })` — the YAML/in-memory read path, so the default
+ *      no-index configuration is not the one backend that ignores the filter.
+ *
+ * The invariant across all three: absent = unrestricted, `[]` = NOTHING,
+ * non-empty = EXACT membership (no hierarchy expansion, no personal-family
+ * pass-through).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { IndexedStorage } from '../src/storage-indexed.js'
+import { scopeAllowFilter } from '../src/scope-util.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+let hasSqlite = false
+try { require('better-sqlite3'); hasSqlite = true } catch { /* optional dep */ }
+
+function mkEngram(id: string, statement: string, opts: Partial<Engram> = {}): Engram {
+  return {
+    id,
+    statement,
+    type: opts.type ?? 'behavioral',
+    scope: opts.scope ?? 'project:plur',
+    domain: opts.domain ?? 'plur.test',
+    status: opts.status ?? 'active',
+    tags: opts.tags ?? [],
+    activation: {
+      retrieval_strength: 1.0,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-07-26',
+    },
+    feedback_signals: opts.feedback_signals ?? { positive: 0, negative: 0, neutral: 0 },
+  } as Engram
+}
+
+function seedYaml(path: string, engrams: Engram[]): void {
+  writeFileSync(path, yaml.dump({ engrams }), 'utf8')
+}
+
+describe('scopeAllowFilter — the shared allow-list predicate', () => {
+  it('REGRESSION GUARD: undefined means unrestricted', () => {
+    const allow = scopeAllowFilter(undefined)
+    for (const s of ['global', 'local', 'project:a', 'group:x/y', 'user:alice']) {
+      expect(allow(s)).toBe(true)
+    }
+  })
+
+  it('SECURITY: an empty list matches NOTHING — it is never widened to "no filter"', () => {
+    const allow = scopeAllowFilter([])
+    for (const s of ['global', 'local', 'project:a', 'group:x/y', 'user:alice', '']) {
+      expect(allow(s)).toBe(false)
+    }
+  })
+
+  it('matches exactly the listed scopes', () => {
+    const allow = scopeAllowFilter(['project:a', 'group:x/y'])
+    expect(allow('project:a')).toBe(true)
+    expect(allow('group:x/y')).toBe(true)
+    expect(allow('project:b')).toBe(false)
+  })
+
+  it('does NOT expand descendants and does NOT pass personal-family scopes through', () => {
+    const allow = scopeAllowFilter(['project:a'])
+    expect(allow('project:a:sub')).toBe(false)
+    expect(allow('project:a/sub')).toBe(false)
+    expect(allow('project:application')).toBe(false) // sibling string-prefix
+    expect(allow('global')).toBe(false)
+    expect(allow('local')).toBe(false)
+    expect(allow('user:alice')).toBe(false)
+  })
+})
+
+describe.skipIf(!hasSqlite)('IndexedStorage.loadFiltered — permitted-scope pushdown', () => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+  let store: IndexedStorage
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-scope-idx-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'engrams.db')
+  })
+
+  afterEach(() => {
+    if (store) store.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function seedAndOpen(engrams: Engram[]): IndexedStorage {
+    seedYaml(yamlPath, engrams)
+    store = new IndexedStorage(yamlPath, dbPath)
+    store.reindex()
+    return store
+  }
+
+  const BASE = [
+    mkEngram('ENG-2026-0726-001', 'alpha', { scope: 'project:a' }),
+    mkEngram('ENG-2026-0726-002', 'alpha sub', { scope: 'project:a:sub' }),
+    mkEngram('ENG-2026-0726-003', 'beta', { scope: 'project:b' }),
+    mkEngram('ENG-2026-0726-004', 'global', { scope: 'global' }),
+    mkEngram('ENG-2026-0726-005', 'local', { scope: 'local' }),
+  ]
+
+  it('REGRESSION GUARD: omitting scopes returns exactly what it returned before', () => {
+    const s = seedAndOpen(BASE)
+    expect(s.loadFiltered({}).length).toBe(5)
+    expect(s.loadFiltered({ status: 'active' }).length).toBe(5)
+    expect(s.loadFiltered({ scopes: undefined }).map(e => e.id).sort())
+      .toEqual(s.loadFiltered({}).map(e => e.id).sort())
+  })
+
+  it('SECURITY: an empty permitted-scope list matches NOTHING', () => {
+    const s = seedAndOpen(BASE)
+    expect(s.loadFiltered({ scopes: [] })).toEqual([])
+    expect(s.loadFiltered({ status: 'active', scopes: [] })).toEqual([])
+    // Combined with the visibility filter, which on its own returns rows.
+    expect(s.loadFiltered({ scope: 'project:a' }).length).toBeGreaterThan(0)
+    expect(s.loadFiltered({ scope: 'project:a', scopes: [] })).toEqual([])
+  })
+
+  it('restricts to exactly the listed scopes', () => {
+    const s = seedAndOpen(BASE)
+    expect(s.loadFiltered({ scopes: ['project:a'] }).map(e => e.id)).toEqual(['ENG-2026-0726-001'])
+    expect(s.loadFiltered({ scopes: ['project:a', 'project:b'] }).map(e => e.id).sort())
+      .toEqual(['ENG-2026-0726-001', 'ENG-2026-0726-003'])
+  })
+
+  it('does NOT expand the hierarchy and does NOT pass personal scopes through', () => {
+    const s = seedAndOpen(BASE)
+    const ids = s.loadFiltered({ scopes: ['project:a'] }).map(e => e.id)
+    expect(ids).not.toContain('ENG-2026-0726-002') // project:a:sub
+    expect(ids).not.toContain('ENG-2026-0726-004') // global
+    expect(ids).not.toContain('ENG-2026-0726-005') // local
+    // Contrast: `scope` (visibility) DOES expand + pass personal through.
+    const visIds = s.loadFiltered({ scope: 'project:a' }).map(e => e.id)
+    expect(visIds).toContain('ENG-2026-0726-002')
+    expect(visIds).toContain('ENG-2026-0726-004')
+    expect(visIds).toContain('ENG-2026-0726-005')
+  })
+
+  it('composes with status and domain as an AND (intersection)', () => {
+    const s = seedAndOpen([
+      mkEngram('ENG-2026-0726-010', 'x', { scope: 'project:a', domain: 'plur.search', status: 'active' }),
+      mkEngram('ENG-2026-0726-011', 'x', { scope: 'project:a', domain: 'plur.search', status: 'retired' }),
+      mkEngram('ENG-2026-0726-012', 'x', { scope: 'project:a', domain: 'other.thing', status: 'active' }),
+      mkEngram('ENG-2026-0726-013', 'x', { scope: 'project:b', domain: 'plur.search', status: 'active' }),
+    ])
+    expect(s.loadFiltered({ status: 'active', domain: 'plur', scopes: ['project:a', 'project:b'] })
+      .map(e => e.id).sort()).toEqual(['ENG-2026-0726-010', 'ENG-2026-0726-013'])
+    expect(s.loadFiltered({ scope: 'project:a', scopes: ['project:b'] })).toEqual([])
+  })
+
+  it('DILUTION: a corpus dominated by out-of-scope rows still yields every in-scope row', () => {
+    const engrams: Engram[] = []
+    for (let i = 0; i < 100; i++) {
+      engrams.push(mkEngram(`ENG-2026-0726-O${String(i).padStart(3, '0')}`, `other ${i}`, { scope: 'project:other' }))
+    }
+    for (let j = 0; j < 20; j++) {
+      engrams.push(mkEngram(`ENG-2026-0726-M${String(j).padStart(3, '0')}`, `mine ${j}`, { scope: 'project:mine' }))
+    }
+    const s = seedAndOpen(engrams)
+    const mine = s.loadFiltered({ status: 'active', scopes: ['project:mine'] })
+    expect(mine.length).toBe(20)
+    expect(mine.every(e => e.scope === 'project:mine')).toBe(true)
+  })
+})
+
+describe('Plur read paths — permitted-scope pushdown', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-scope-list-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /**
+   * `index: false` exercises the in-memory YAML branch of _filterEngrams;
+   * `index: true` exercises IndexedStorage.loadFiltered. Both must agree.
+   */
+  function makePlur(indexed: boolean): Plur {
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({ index: indexed }, { noRefs: true }))
+    const plur = new Plur({ path: dir })
+    plur.learn('the deployment pipeline uses snake_case for alpha', { scope: 'project:a' })
+    plur.learn('the deployment pipeline uses snake_case for alpha sub', { scope: 'project:a:sub' })
+    plur.learn('the deployment pipeline uses snake_case for beta', { scope: 'project:b' })
+    plur.learn('the deployment pipeline uses snake_case for everyone', { scope: 'global' })
+    plur.learn('the deployment pipeline uses snake_case for me', { scope: 'local' })
+    return plur
+  }
+
+  const modes: Array<[string, boolean]> = hasSqlite
+    ? [['yaml path (index:false)', false], ['indexed path (index:true)', true]]
+    : [['yaml path (index:false)', false]]
+
+  for (const [label, indexed] of modes) {
+    describe(label, () => {
+      it('REGRESSION GUARD: omitting scopes lists the whole active corpus', () => {
+        const plur = makePlur(indexed)
+        expect(plur.list().length).toBe(5)
+        expect(plur.list({ scopes: undefined }).length).toBe(5)
+      })
+
+      it('SECURITY: an empty permitted-scope list lists NOTHING', () => {
+        const plur = makePlur(indexed)
+        expect(plur.list({ scopes: [] })).toEqual([])
+      })
+
+      it('lists exactly the listed scopes — no descendants, no personal pass-through', () => {
+        const plur = makePlur(indexed)
+        const scopes = plur.list({ scopes: ['project:a'] }).map(e => e.scope)
+        expect(scopes).toEqual(['project:a'])
+      })
+
+      it('composes with the visibility scope filter as an intersection', () => {
+        const plur = makePlur(indexed)
+        // `scope: project:a` alone is wide (descendants + personal pass-through)…
+        expect(plur.list({ scope: 'project:a' }).length).toBeGreaterThan(1)
+        // …and intersecting it with an allow-list can only narrow it.
+        expect(plur.list({ scope: 'project:a', scopes: ['project:b'] })).toEqual([])
+        expect(plur.list({ scope: 'project:a', scopes: ['project:a'] }).map(e => e.scope))
+          .toEqual(['project:a'])
+      })
+    })
+  }
+})


### PR DESCRIPTION
Closes #710. Core half of Phase 3 of the [convergence epic](https://github.com/plur-ai/plur/issues/707).

Adds `scopes?: string[]` to `StorageFilter` and threads it through `searchBM25` / `searchVector`, so scope filtering happens **in the query** instead of after it.

## Why

`StorageFilter` had no way to express "restrict to this set of permitted scopes", which leaves any consumer with an authorization model no option but to retrieve broadly and filter afterwards in application code. Post-filtering has two failure modes, both silent:

- **Dilution** — a user whose permitted scopes are a small share of the corpus asks for N and gets a handful, with relevant in-scope engrams sitting just below the cut.
- **Overfetch past the ANN candidate list** — an inflated fetch size interacts badly with an approximate index's search-effort parameter (`ef_search` for HNSW, which pgvector defaults to 40). Once the overfetch exceeds it, recall degrades sharply.

Filtering in the query makes `LIMIT` count *permitted* rows: N asked is N returned.

## Semantics

Documented on the new `ScopeRestriction` interface:

| Value | Meaning |
|---|---|
| absent | no scope restriction — unchanged behaviour |
| `[]` | matches **nothing** |
| non-empty | **exact** set membership |

The empty case is the security-relevant one: a principal with zero permitted scopes must see zero engrams. An empty list is never widened to "unrestricted", which would be privilege escalation.

Exact membership is deliberate, and deliberately unlike the existing `scope` field (a visibility filter, which does expand). By the time a list reaches this layer it is the fully-resolved authorization decision — no hierarchy expansion, no personal-family pass-through. Exact membership is also what a permission model resolving group hierarchies upstream will hand down — the expansion has already happened by then.

`scopes` AND-composes with `status` / `scope` / `domain`, so combining filters can only narrow.

## Applied in every read path

The failure mode to avoid is an adapter that *accepts* an authorization filter and doesn't apply it — worse than not having the feature. So every path that takes a filter got it:

- `PGLiteAdapter.loadFiltered` / `searchBM25` / `searchVector` — SQL `scope = ANY($n::text[])`, on the pgvector path **and** the BYTEA JS-cosine fallback
- `IndexedStorage.loadFiltered` — SQL `scope IN (...)`, with `1 = 0` for the empty list
- `Plur._filterEngrams` YAML branch — via the new shared `scopeAllowFilter` predicate, plus `scopes` on `RecallOptions` and `list()`

## Verification

34 new tests across two files, one set per adapter implementation: regression guard (absent ≡ old behaviour), the empty-list security case, exact membership, AND-composition, and an explicit dilution case.

| Check | Result |
|---|---|
| root `pnpm test` | **2877 passed, 0 failed**, 44 skipped |
| baseline on `main` | 2843 passed — delta is exactly the 34 new tests |
| `core-pglite` project | 56 passed, 1 skipped |

## Related

The corresponding downstream deployment work — supplying the resolved scope list and tuning the index's search-effort parameter — is tracked privately and ships independently. Semantics were kept identical on both sides so the two compose.
