### PR TITLE
feat(mcp): add side-effect-free ./tools subpath export

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,6 +47,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./tools": {
+      "types": "./dist/tools-export.d.ts",
+      "import": "./dist/tools-export.js"
     }
   }
 }

--- a/packages/mcp/src/tools-export.ts
+++ b/packages/mcp/src/tools-export.ts
@@ -1,0 +1,38 @@
+/**
+ * Side-effect-free subpath export: @plur-ai/mcp/tools
+ *
+ * Importable without starting the MCP server or parsing process.argv.
+ * Use this to access PLUR's tool surface — names, descriptions, input schemas
+ * — from a consumer that re-exposes or validates the definitions without
+ * running the server.
+ */
+export type { ToolAnnotations, ToolDefinition, ToolProfile } from './tools.js'
+export { getToolDefinitions, CURSOR_CORE_TOOL_NAMES, validateToolArgs } from './tools.js'
+
+import type { ToolAnnotations, ToolProfile } from './tools.js'
+import { getToolDefinitions } from './tools.js'
+
+/** Tool definition without the runtime handler — plain data, safe to serialize. */
+export interface ToolSchema {
+  name: string
+  description: string
+  inputSchema: { type: 'object'; [key: string]: unknown }
+  annotations?: ToolAnnotations
+}
+
+/**
+ * Return tool definitions as plain, handler-free schema objects.
+ *
+ * Useful when you need the MCP tool surface — name, description, and input
+ * schema — without the runtime handlers that require a live Plur instance.
+ * A downstream consumer that re-exposes a filtered subset can import this
+ * list and keep its copy in sync without duplicating schemas.
+ */
+export function getToolSchemas(profile?: ToolProfile): ToolSchema[] {
+  return getToolDefinitions(profile).map(({ name, description, inputSchema, annotations }) => ({
+    name,
+    description,
+    inputSchema,
+    ...(annotations !== undefined ? { annotations } : {}),
+  }))
+}

--- a/packages/mcp/test/tools-export.test.ts
+++ b/packages/mcp/test/tools-export.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #714: @plur-ai/mcp/tools subpath export — side-effect-free tool schema access.
+ *
+ * Validates that the ./tools export (src/tools-export.ts) surfaces the tool
+ * definitions as plain, handler-free schema objects without touching
+ * process.argv or starting a server.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  getToolSchemas,
+  getToolDefinitions,
+  CURSOR_CORE_TOOL_NAMES,
+} from '../src/tools-export.js'
+
+describe('@plur-ai/mcp/tools subpath export (#714)', () => {
+  it('getToolSchemas returns objects with no handler field', () => {
+    const schemas = getToolSchemas('full')
+    expect(schemas.length).toBeGreaterThan(0)
+    for (const s of schemas) {
+      expect(s).not.toHaveProperty('handler')
+      expect(typeof s.name).toBe('string')
+      expect(typeof s.description).toBe('string')
+      expect(s.inputSchema.type).toBe('object')
+    }
+  })
+
+  it('getToolSchemas covers the core tool names', () => {
+    const schemas = getToolSchemas()
+    const names = new Set(schemas.map(s => s.name))
+    for (const core of CURSOR_CORE_TOOL_NAMES) {
+      expect(names.has(core)).toBe(true)
+    }
+  })
+
+  it('getToolDefinitions is re-exported (for consumers building MCP servers)', () => {
+    const defs = getToolDefinitions('full')
+    expect(defs.length).toBeGreaterThan(0)
+    expect(typeof defs[0].handler).toBe('function')
+  })
+
+  it('lean and cursor profiles return the same tool count', () => {
+    const lean = getToolSchemas('lean')
+    const cursor = getToolSchemas('cursor')
+    expect(lean.length).toBe(cursor.length)
+    expect(lean.map(s => s.name).sort()).toEqual(cursor.map(s => s.name).sort())
+  })
+
+  it('full profile returns more tools than lean', () => {
+    const full = getToolSchemas('full')
+    const lean = getToolSchemas('lean')
+    expect(full.length).toBeGreaterThan(lean.length)
+  })
+
+  it('CURSOR_CORE_TOOL_NAMES is re-exported', () => {
+    expect(CURSOR_CORE_TOOL_NAMES).toBeInstanceOf(Set)
+    expect(CURSOR_CORE_TOOL_NAMES.has('plur_learn')).toBe(true)
+    expect(CURSOR_CORE_TOOL_NAMES.has('plur_session_start')).toBe(true)
+  })
+})

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/tools-export.ts'],
   format: ['esm'],
   target: 'node22',
   dts: true,


### PR DESCRIPTION
## Summary

Fixes #714.

- Adds `@plur-ai/mcp/tools` subpath export backed by a new `src/tools-export.ts` entry point
- Importing this subpath does **not** parse `process.argv`, touch `process.stdin`, or start the MCP server — it only re-exports the tool surface from `tools.ts`
- `getToolSchemas(profile?)` returns tool definitions as plain, handler-free objects (name, description, inputSchema, annotations) — the "plain data" form the issue asks for
- `getToolDefinitions` and `CURSOR_CORE_TOOL_NAMES` are also re-exported for consumers building MCP servers on top of PLUR
- `tsup.config.ts` gains a second entry so tsup emits `dist/tools-export.{js,d.ts}`
- `package.json` exports map `"./tools"` → `"./dist/tools-export.{js,d.ts}"`

**Usage after this PR:**
```ts
import { getToolSchemas } from '@plur-ai/mcp/tools'

const schemas = getToolSchemas()          // lean/cursor profile (default)
const full = getToolSchemas('full')       // all tools including admin-only ones
```

## Test plan

- [x] `pnpm --filter @plur-ai/mcp build` — both entry points build cleanly, `dist/tools-export.{js,d.ts}` emitted
- [x] New `test/tools-export.test.ts` — 6 tests covering `getToolSchemas`, `getToolDefinitions`, `CURSOR_CORE_TOOL_NAMES` re-export, lean/cursor parity, and full > lean tool count
- [x] `npx vitest run test/tools-export.test.ts` — 6/6 pass
- [x] `npx vitest run test/server.test.ts` — existing server tests unaffected