### PR TITLE
schema: document enterprise passthrough reliance for extended commitment values

### DIFF
--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -398,6 +398,11 @@ export const EngramSchema = z.object({
  * This prevents data loss when new fields are added by hand or by other SPs.
  * The Engram type is derived from the strict schema (without passthrough) to keep
  * TypeScript type safety — passthrough only affects runtime Zod validation.
+ *
+ * Enterprise deployments also rely on this to pass through extended enum values absent
+ * from the OSS schema (e.g. commitment:'draft' for review-queue staging). Strict
+ * EngramSchema.parse() rejects such values intentionally — use this schema when
+ * parsing enterprise-originated engrams.
  */
 export const EngramSchemaPassthrough = EngramSchema.passthrough()
 


### PR DESCRIPTION
## Summary

- Resolves #718 (Option A — enterprise-only, intentional, won't add to core)
- Adds a 4-line JSDoc note to `EngramSchemaPassthrough` explaining that enterprise deployments rely on `.passthrough()` to pass through extended enum values absent from the OSS schema (e.g. `commitment:'draft'` for review-queue staging)
- No enum change, no behavior change — documentation only

## Decision rationale

`'draft'` is a governance concept meaningful only with an admin triage UI and org-level scope management, which the local OSS store doesn't have. Adding it to the core enum would expose a value that silently never surfaces for non-enterprise users. The `.passthrough()` mechanism already exists as the correct extension point for exactly this pattern.

## Test plan

- [x] Existing schema tests pass (`test/schemas.test.ts` — 12/12)
- [x] No behavior change (comment-only diff)