### PR TITLE
fix(core): BM25 reverse-substring junk matches — qt.includes(t) → qt.startsWith(t) (#721)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -62,7 +62,7 @@ export function computeIdf(engrams: Engram[], queryTokens: string[]): Map<string
   for (const qt of queryTokens) {
     let df = 0
     for (const termSet of engramTermSets) {
-      if (termSet.has(qt) || Array.from(termSet).some(t => t.includes(qt) || qt.includes(t))) {
+      if (termSet.has(qt) || Array.from(termSet).some(t => t.includes(qt) || qt.startsWith(t))) {
         df++
       }
     }
@@ -103,7 +103,7 @@ export function ftsScore(engram: Engram, queryTokens: string[], idfWeights?: Map
     // Count term frequency (including substring matches)
     let tf = 0
     for (const t of allTerms) {
-      if (t.includes(qt) || qt.includes(t)) tf++
+      if (t.includes(qt) || qt.startsWith(t)) tf++
     }
     if (tf === 0) continue
 

--- a/packages/core/src/intent/rewrite.ts
+++ b/packages/core/src/intent/rewrite.ts
@@ -11,7 +11,7 @@
  * embedding/cross-encoder models are trained on questions; BM25 is not.
  *
  * Why scaffolding hurts BM25 here: `ftsScore` uses substring matching
- * (`t.includes(qt) || qt.includes(t)`), so interrogative tokens are not
+ * (`t.includes(qt) || qt.startsWith(t)`), so interrogative tokens are not
  * inert — "what" matches "whatsapp", "how" matches "showed" — and every
  * scaffold token that substring-matches anything consumes IDF budget and
  * pulls in distractors.

--- a/packages/core/test/fts.test.ts
+++ b/packages/core/test/fts.test.ts
@@ -125,6 +125,38 @@ describe('BM25 term frequency saturation', () => {
   })
 })
 
+describe('BM25 reverse substring junk matching (#721)', () => {
+  // qt.includes(t) allowed any document token that is a non-prefix substring of
+  // the query to score a TF hit. e.g. "deploying".includes("yin") = true, so
+  // an engram about "yin yang" matched the query "deploying" and could outscore
+  // the correct "deploy" stem (which had higher df → lower IDF).
+  // Fix: require qt.startsWith(t) so only true morphological prefixes match.
+
+  it('"yin" is a non-prefix substring of "deploying" and must not produce a result', () => {
+    // With the bug: 'deploying'.includes('yin') = true → tf=1 → engram surfaces
+    // With the fix: 'deploying'.startsWith('yin') = false → tf=0 → no result
+    const yin = makeEngram({ id: 'ENG-2026-0330-010', statement: 'yin yang balance practice' })
+    const results = searchEngrams([yin], 'deploying')
+    expect(results).toHaveLength(0)
+  })
+
+  it('"res" is a non-prefix substring of "postgres" and must not produce a result', () => {
+    // "postgres"[5:8] = "res" — 'postgres'.includes('res') = true (non-prefix)
+    // "res" must be a standalone token: use "res judicata" so it survives ftsTokenize
+    const res = makeEngram({ id: 'ENG-2026-0330-012', statement: 'res judicata legal doctrine principle' })
+    const results = searchEngrams([res], 'postgres')
+    expect(results).toHaveLength(0)
+  })
+
+  it('morphological prefix "deploy" still matches query "deploying"', () => {
+    // "deploy" is a true prefix of "deploying" → must survive the fix
+    const deploy = makeEngram({ id: 'ENG-2026-0330-014', statement: 'deploy application server production' })
+    const results = searchEngrams([deploy], 'deploying')
+    expect(results).toHaveLength(1)
+    expect(results[0].id).toBe('ENG-2026-0330-014')
+  })
+})
+
 describe('BM25 document length normalization', () => {
   it('short doc with rare term beats long doc with same term', () => {
     const engrams = [


### PR DESCRIPTION
## Problem

`ftsScore` and `computeIdf` both used `qt.includes(t)` as the reverse-containment clause — matching any document token that is a substring of the query token. This inverts IDF-based ranking for multi-syllable queries:

| query | matched token | IDF | verdict |
|---|---|---|---|
| `deploying` | `yin` | 6.89 | junk — scored **highest** |
| `deploying` | `deploy` | 3.55 | correct stem — scored **lowest** |

Rare accidental tokens (`yin`, `res`, `pos`) were up to 1.94× heavier than the intended stem.

## Fix

Replace `qt.includes(t)` with `qt.startsWith(t)` in both sites. A document token scores a TF hit only when it is a **prefix** of the query term — which is the morphological case (`deploy` → `deploying`), not an arbitrary infix coincidence.

The `t.includes(qt)` direction (document token *contains* query token — e.g. `deployer` matching `deploy`) is unchanged and correct.

## Tests

Three regression tests added to `fts.test.ts`:

- `yin` does not match query `deploying` (non-prefix junk)
- `res` does not match query `postgres` (non-prefix junk)
- `deploy` still matches query `deploying` (legitimate morphological prefix)

All 13 FTS tests pass.

## Related

Closes #721
See also #711 (Phase 4 BM25 pushdown, which will need to express the same semantics)