### PR TITLE
fix(recall): truncated flag now accurate when budget.max_results drops results (#725)

### DIFF
--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -82,11 +82,16 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
   }
   // mode === 'hybrid' (default)
   const budget = args.budget as { max_tokens?: number; max_results?: number; ttl_seconds?: number } | undefined
-  const effectiveLimit = budget?.max_results ?? (args.limit as number | undefined) ?? 20
+  const cap = budget?.max_results ?? (args.limit as number | undefined) ?? 20
+  // When a max_results budget is set, fetch one extra so we can detect
+  // whether the store had more results than the cap without over-fetching.
+  // Without this, the search layer already caps at `cap` before we can
+  // compare, so `results.length > cap` is always false (#725).
+  const fetchLimit = budget?.max_results != null ? cap + 1 : cap
   const meta = await plur.recallHybridWithMeta(args.query as string, {
     scope: args.scope as string | undefined,
     domain: args.domain as string | undefined,
-    limit: effectiveLimit,
+    limit: fetchLimit,
   })
   // Opt-in, content-free engagement counter (default-off; no query text).
   recordTelemetry('recall')
@@ -95,13 +100,9 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
   // there for ALL consumers (MCP, claw, CLI, direct API), so we do NOT
   // re-emit here and double-count. It is opt-in/default-off and ships only
   // a query fingerprint hash + scope/domain + timestamp, never raw text.
-  const results = meta.engrams
-  let truncated = false
-  let boundedResults = results
-  if (budget?.max_results && results.length > budget.max_results) {
-    boundedResults = results.slice(0, budget.max_results)
-    truncated = true
-  }
+  const truncatedByCount = budget?.max_results != null && meta.engrams.length > cap
+  let truncated = truncatedByCount
+  let boundedResults = truncatedByCount ? meta.engrams.slice(0, cap) : meta.engrams
   if (budget?.max_tokens) {
     let tokenCount = 0
     const withinBudget = []

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -515,6 +515,50 @@ describe('MCP tools', () => {
     expect(squeezed.deprecated).toMatch(/deprecated since 0\.16/)
   })
 
+  // ── #725: truncated flag accuracy when budget.max_results drops results ───
+
+  describe('plur_recall budget.max_results truncation (#725)', () => {
+    beforeEach(async () => {
+      for (let i = 1; i <= 5; i++) {
+        await callTool('plur_learn', { statement: `zephyr convention rule ${i}`, scope: 'global' })
+      }
+    })
+
+    it('sets truncated: true when max_results drops at least one result', async () => {
+      const result = await callTool('plur_recall', {
+        query: 'zephyr convention rule',
+        budget: { max_results: 2 },
+      }) as any
+      expect(result.truncated).toBe(true)
+      expect(result.count).toBe(2)
+      expect(result.results).toHaveLength(2)
+    })
+
+    it('sets truncated: false when all results fit within max_results', async () => {
+      const result = await callTool('plur_recall', {
+        query: 'zephyr convention rule',
+        budget: { max_results: 10 },
+      }) as any
+      expect(result.truncated).toBe(false)
+    })
+
+    it('sets truncated: false when no budget is given', async () => {
+      const result = await callTool('plur_recall', {
+        query: 'zephyr convention rule',
+      }) as any
+      expect(result.truncated).toBe(false)
+    })
+
+    it('plur_recall_hybrid inherits accurate truncated via forwarder', async () => {
+      const result = await callTool('plur_recall_hybrid', {
+        query: 'zephyr convention rule',
+        budget: { max_results: 2 },
+      }) as any
+      expect(result.truncated).toBe(true)
+      expect(result.count).toBe(2)
+    })
+  })
+
   it('plur_inject returns formatted injection', async () => {
     await callTool('plur_learn', { statement: 'Always deploy carefully', scope: 'global' })
     const result = await callTool('plur_inject', { task: 'deploy the application' }) as any


### PR DESCRIPTION
## Summary

Fixes #725. `truncated` was always `false` when `budget.max_results` capped results, because the same value was passed as the search `limit` — so `results.length > max_results` was never true.

**Fix:** request `cap + 1` results from the search layer when `budget.max_results` is set, then compare `results.length > cap`. The extra fetch costs one row and makes truncation detection data-driven rather than inferred.

The fix lives in `recallHandler` (the shared function at the top of `tools.ts`), so both `plur_recall` and `plur_recall_hybrid` (which forwards to it) inherit it automatically. The existing anti-drift test added in #702 holds the forwarder honest.

## Changes

- `packages/mcp/src/tools.ts`: fetch `cap + 1` when `budget.max_results` is set; derive `truncatedByCount` from the actual result count
- `packages/mcp/test/tools.test.ts`: four new tests covering truncated=true (capped), truncated=false (fits), truncated=false (no budget), and alias inheritance

## Acceptance checklist

- [x] `truncated: true` when `budget.max_results` drops at least one result (ordinary query, YAML backend)
- [x] `truncated: false` when results fit within `max_results`
- [x] `truncated: false` when no budget is given (no behavior change)
- [x] `plur_recall_hybrid` alias inherits the fix via forwarder (tested explicitly)
- [x] All 65 existing tests pass