### PR TITLE
fix(fts): use prefix matching to stop reverse-substring junk from outscoring correct stems (#721)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -62,7 +62,7 @@ export function computeIdf(engrams: Engram[], queryTokens: string[]): Map<string
   for (const qt of queryTokens) {
     let df = 0
     for (const termSet of engramTermSets) {
-      if (termSet.has(qt) || Array.from(termSet).some(t => t.includes(qt) || qt.includes(t))) {
+      if (termSet.has(qt) || Array.from(termSet).some(t => t.includes(qt) || qt.startsWith(t))) {
         df++
       }
     }
@@ -103,7 +103,7 @@ export function ftsScore(engram: Engram, queryTokens: string[], idfWeights?: Map
     // Count term frequency (including substring matches)
     let tf = 0
     for (const t of allTerms) {
-      if (t.includes(qt) || qt.includes(t)) tf++
+      if (t.includes(qt) || qt.startsWith(t)) tf++
     }
     if (tf === 0) continue
 

--- a/packages/core/test/fts.test.ts
+++ b/packages/core/test/fts.test.ts
@@ -125,6 +125,41 @@ describe('BM25 term frequency saturation', () => {
   })
 })
 
+describe('BM25 reverse substring junk (#721)', () => {
+  it('does not match yin to deploying (reverse non-prefix substring)', () => {
+    const junkEngram = makeEngram({ id: 'ENG-2026-0330-001', statement: 'the yin and yang principle' })
+    const deployEngram = makeEngram({ id: 'ENG-2026-0330-002', statement: 'how to deploy services' })
+    const queryTokens = ftsTokenize('deploying')
+    const idf = computeIdf([junkEngram, deployEngram], queryTokens)
+
+    const junkScore = ftsScore(junkEngram, queryTokens, idf)
+    const deployScore = ftsScore(deployEngram, queryTokens, idf)
+
+    expect(junkScore).toBe(0)
+    expect(deployScore).toBeGreaterThan(0)
+  })
+
+  it('does not match res to postgres (reverse non-prefix substring)', () => {
+    const junkEngram = makeEngram({ id: 'ENG-2026-0330-001', statement: 'res configuration system' })
+    const pgEngram = makeEngram({ id: 'ENG-2026-0330-002', statement: 'connect to postgres database' })
+    const queryTokens = ftsTokenize('postgres')
+    const idf = computeIdf([junkEngram, pgEngram], queryTokens)
+
+    const junkScore = ftsScore(junkEngram, queryTokens, idf)
+    const pgScore = ftsScore(pgEngram, queryTokens, idf)
+
+    expect(junkScore).toBe(0)
+    expect(pgScore).toBeGreaterThan(0)
+  })
+
+  it('still matches deploy to deploying (legitimate prefix stem)', () => {
+    const engram = makeEngram({ id: 'ENG-2026-0330-001', statement: 'how to deploy services' })
+    const queryTokens = ftsTokenize('deploying')
+    const idf = computeIdf([engram], queryTokens)
+    expect(ftsScore(engram, queryTokens, idf)).toBeGreaterThan(0)
+  })
+})
+
 describe('BM25 document length normalization', () => {
   it('short doc with rare term beats long doc with same term', () => {
     const engrams = [

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -82,11 +82,16 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
   }
   // mode === 'hybrid' (default)
   const budget = args.budget as { max_tokens?: number; max_results?: number; ttl_seconds?: number } | undefined
-  const effectiveLimit = budget?.max_results ?? (args.limit as number | undefined) ?? 20
+  const cap = budget?.max_results ?? (args.limit as number | undefined) ?? 20
+  // When a max_results budget is set, fetch one extra so we can detect
+  // whether the store had more results than the cap without over-fetching.
+  // Without this, the search layer already caps at `cap` before we can
+  // compare, so `results.length > cap` is always false (#725).
+  const fetchLimit = budget?.max_results != null ? cap + 1 : cap
   const meta = await plur.recallHybridWithMeta(args.query as string, {
     scope: args.scope as string | undefined,
     domain: args.domain as string | undefined,
-    limit: effectiveLimit,
+    limit: fetchLimit,
   })
   // Opt-in, content-free engagement counter (default-off; no query text).
   recordTelemetry('recall')
@@ -95,13 +100,9 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
   // there for ALL consumers (MCP, claw, CLI, direct API), so we do NOT
   // re-emit here and double-count. It is opt-in/default-off and ships only
   // a query fingerprint hash + scope/domain + timestamp, never raw text.
-  const results = meta.engrams
-  let truncated = false
-  let boundedResults = results
-  if (budget?.max_results && results.length > budget.max_results) {
-    boundedResults = results.slice(0, budget.max_results)
-    truncated = true
-  }
+  const truncatedByCount = budget?.max_results != null && meta.engrams.length > cap
+  let truncated = truncatedByCount
+  let boundedResults = truncatedByCount ? meta.engrams.slice(0, cap) : meta.engrams
   if (budget?.max_tokens) {
     let tokenCount = 0
     const withinBudget = []

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -515,6 +515,50 @@ describe('MCP tools', () => {
     expect(squeezed.deprecated).toMatch(/deprecated since 0\.16/)
   })
 
+  // ── #725: truncated flag accuracy when budget.max_results drops results ───
+
+  describe('plur_recall budget.max_results truncation (#725)', () => {
+    beforeEach(async () => {
+      for (let i = 1; i <= 5; i++) {
+        await callTool('plur_learn', { statement: `zephyr convention rule ${i}`, scope: 'global' })
+      }
+    })
+
+    it('sets truncated: true when max_results drops at least one result', async () => {
+      const result = await callTool('plur_recall', {
+        query: 'zephyr convention rule',
+        budget: { max_results: 2 },
+      }) as any
+      expect(result.truncated).toBe(true)
+      expect(result.count).toBe(2)
+      expect(result.results).toHaveLength(2)
+    })
+
+    it('sets truncated: false when all results fit within max_results', async () => {
+      const result = await callTool('plur_recall', {
+        query: 'zephyr convention rule',
+        budget: { max_results: 10 },
+      }) as any
+      expect(result.truncated).toBe(false)
+    })
+
+    it('sets truncated: false when no budget is given', async () => {
+      const result = await callTool('plur_recall', {
+        query: 'zephyr convention rule',
+      }) as any
+      expect(result.truncated).toBe(false)
+    })
+
+    it('plur_recall_hybrid inherits accurate truncated via forwarder', async () => {
+      const result = await callTool('plur_recall_hybrid', {
+        query: 'zephyr convention rule',
+        budget: { max_results: 2 },
+      }) as any
+      expect(result.truncated).toBe(true)
+      expect(result.count).toBe(2)
+    })
+  })
+
   it('plur_inject returns formatted injection', async () => {
     await callTool('plur_learn', { statement: 'Always deploy carefully', scope: 'global' })
     const result = await callTool('plur_inject', { task: 'deploy the application' }) as any


### PR DESCRIPTION
## Summary

- `qt.includes(t)` in `ftsScore` and `computeIdf` was matching any short document token that happened to appear anywhere inside a longer query token — including nonsense cases like `yin` matching `deploying` or `res` matching `postgres`
- Because IDF heavily weights rare tokens, these accidental matches often *outranked* the correct stem (`deploy` scored below `yin` for query `deploying` on a real 3,926-engram store)
- Fix: replace `qt.includes(t)` → `qt.startsWith(t)` — legitimate morphological stems are always prefixes (`deploy`→`deploying`); accidental infix matches never are

## Test plan

- [ ] All three new regression tests in `fts.test.ts` pass — `yin` scores 0 for `deploying`, `res` scores 0 for `postgres`, `deploy` still scores > 0 for `deploying`
- [ ] Existing 10 FTS tests still pass (no ranking regressions in the test suite)
- [ ] Run the plur-bench ablation from plur-ai/plur-bench#49 before merging to verify recall numbers hold

Closes #721