### PR TITLE
fix(core): validate type in learn() and learnRouted() — closes #729

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -471,6 +471,8 @@ const TYPE_TO_COGNITIVE: Record<string, string> = {
   architectural: 'evaluate',
 }
 
+const VALID_ENGRAM_TYPES = new Set<string>(['behavioral', 'terminological', 'procedural', 'architectural'])
+
 const INGEST_PATTERNS = [
   { re: /(?:we decided|the decision is|agreed to)\s+(.+?)\.?$/gim, type: 'architectural' as const },
   { re: /(?:always|never|must|should)\s+(.+?)\.?$/gim, type: 'behavioral' as const },
@@ -1833,6 +1835,11 @@ export class Plur {
     if (typeof statement !== 'string' || statement.length === 0) {
       throw new TypeError(`plur.learn: statement must be a non-empty string, got ${typeof statement}`)
     }
+    if (context?.type !== undefined && !VALID_ENGRAM_TYPES.has(context.type)) {
+      throw new TypeError(
+        `plur.learn: invalid type '${context.type}'. Must be one of: behavioral, terminological, procedural, architectural`
+      )
+    }
     if (!this.config.allow_secrets) {
       // Scan statement AND the caller-supplied fields that are exported verbatim /
       // rendered into agent context — `domain`, `tags`, `abstract` (#381, #389).
@@ -2134,6 +2141,11 @@ export class Plur {
    * forget that pretends success and leaves the user with a phantom ID).
    */
   async learnRouted(statement: string, context?: LearnContext): Promise<Engram> {
+    if (context?.type !== undefined && !VALID_ENGRAM_TYPES.has(context.type)) {
+      throw new TypeError(
+        `plur.learnRouted: invalid type '${context.type}'. Must be one of: behavioral, terminological, procedural, architectural`
+      )
+    }
     if (!this.config.allow_secrets) {
       // Scan statement AND the caller-supplied fields that are exported verbatim /
       // rendered into agent context — `domain`, `tags`, `abstract` (#381, #389).

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -345,6 +345,18 @@ describe('Plur', () => {
       expect(engram.temporal).toBeUndefined()
     })
 
+    it('learn rejects an invalid type', async () => {
+      await expect(plur.learn('Something', { type: 'preference' as any })).rejects.toThrow(/invalid type/)
+      await expect(plur.learn('Something', { type: 'unknown' as any })).rejects.toThrow(/invalid type/)
+    })
+
+    it('learn accepts all four valid types', async () => {
+      const types = ['behavioral', 'terminological', 'procedural', 'architectural'] as const
+      for (const t of types) {
+        await expect(plur.learn(`Type test ${t}`, { type: t })).resolves.toBeDefined()
+      }
+    })
+
     it('learn rejects malformed valid_until', async () => {
       await expect(plur.learn('Something', { valid_until: 'end of Q2' })).rejects.toThrow(/valid_until/)
       await expect(plur.learn('Something', { valid_until: '2026-02-30' })).rejects.toThrow(/valid_until/)


### PR DESCRIPTION
## What

`learn()` and `learnRouted()` accepted any string for `context.type` and wrote it verbatim to disk. A caller passing `type: 'preference'` (not a member of the enum) got an engram with an invalid `type` field that fell back through `TYPE_TO_COGNITIVE` and `TYPE_TO_MEMORY_CLASS` by accident of the fallback defaults.

## Fix

- Add `VALID_ENGRAM_TYPES` constant (a `Set<string>`) alongside `TYPE_TO_COGNITIVE`.
- Add a `TypeError` guard in `learn()` and `learnRouted()`, matching the fail-fast style of the secrets and validity-window guards. Both methods validate `type` **before** the secrets scan — cheapest check first, consistent error precedence between the two entry points.
- Two new tests: rejects `'preference'` / `'unknown'`; accepts all four valid types. Both in the async form (`await expect(...).rejects.toThrow` / `.resolves.toBeDefined()`) since `learn()`/`learnRouted()` are now async on `main`.

Rebased onto current `main` (`25b604d`); the branch is the single 24-line commit on top. The earlier `guard-remote-scope` / `guard-fuzz` fixture fixes collapsed to no-ops — `main` already carries them.

## Test

```
pnpm --filter @plur-ai/core test    # 2346 passed | 31 skipped (147/151 files)
pnpm --filter @plur-ai/mcp test     # 300 passed (24 files)
vitest run --project @plur-ai/cli   # 398 passed | 12 skipped (48 files)
pnpm -r build                       # clean
```

## Bench (`pnpm bench:micro`, 100 iterations, main vs branch)

| Operation | main | #733 | Δ mean | Δ % |
|---|---|---|---|---|
| learn | 3.48ms (p95 5.66) | 3.11ms (p95 3.57) | -0.37ms | -10.7% |
| recall_bm25 | 4.88ms (p95 7.95) | 5.02ms (p95 6.96) | +0.14ms | +3.0% |
| recall_hybrid | 111.16ms (p95 24.25) | 26.37ms (p95 34.06) | -84.78ms | -76.3% |
| inject | 0.49ms (p95 0.75) | 0.46ms (p95 0.89) | -0.03ms | -6.3% |
| inject_tokens | 1833 | 1833 | 0 | 0.0% |

The guard is one `Set.has` on the write path; all deltas are noise. `learn` (the only guarded op) is within run-to-run variance. The `recall_hybrid` mean delta is a cold-start artifact — the main run paid the one-time embedder model load in its first iteration (mean 111ms vs p95 24ms on the same run); the branch run had a warm cache. Untouched code path either way.

Closes #729
