### PR TITLE
schema: document enterprise 'draft' commitment extension via passthrough

### DIFF
--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -398,6 +398,12 @@ export const EngramSchema = z.object({
  * This prevents data loss when new fields are added by hand or by other SPs.
  * The Engram type is derived from the strict schema (without passthrough) to keep
  * TypeScript type safety — passthrough only affects runtime Zod validation.
+ *
+ * Extension point: enterprise adds `commitment: 'draft'` (review-queue staging —
+ * pending human approval before an engram enters the recall pool) via this passthrough
+ * rather than the core enum. The value is intentionally absent from the strict enum
+ * because it is only meaningful in governed deployments with an admin triage UI;
+ * see plur-ai/enterprise#567 for the write sites.
  */
 export const EngramSchemaPassthrough = EngramSchema.passthrough()
 


### PR DESCRIPTION
## Summary

- Closes #718 with Option A: enterprise-only, intentional, won't add to core
- Adds a 5-line JSDoc note to `EngramSchemaPassthrough` documenting that enterprise uses `.passthrough()` to introduce `commitment: 'draft'` (review-queue staging)
- No enum change, no functional change — documentation only

## Decision record

`'draft'` is intentionally absent from the strict `commitment` enum because it is only meaningful in governed deployments with an admin triage UI, approval workflow, and org-level scope governance. The local open-source store has none of these; adding the value would expose a lifecycle state that silently never surfaces engrams for non-enterprise users.

`.passthrough()` is the correct extension mechanism for exactly this pattern. The write sites in enterprise are documented at plur-ai/enterprise#567.

## Why this matters

Without documentation, a reader seeing `EngramSchemaPassthrough` has no signal that external code relies on `passthrough()` to extend the enum. A future "tighten to strict parse" refactor would be a silent authorization bypass for governed deployments.