### PR TITLE
feat(core,cli,mcp): URL-based pack install and preview

### DIFF
--- a/packages/cli/src/commands/packs.ts
+++ b/packages/cli/src/commands/packs.ts
@@ -38,7 +38,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (!source) {
       exit(1, 'Usage: plur packs preview <source>')
     }
-    const preview = plur.previewPack(source)
+    const preview = await plur.previewPack(source)
     if (shouldOutputJson(flags)) {
       outputJson(preview)
     } else {

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as crypto from 'crypto'
+import * as os from 'os'
+import { execFileSync } from 'child_process'
 import yaml from 'js-yaml'
 import { loadPack, loadEngrams, saveEngrams } from './engrams.js'
 import { detectSensitive, detectPromptInjection, truncateToScanLimit } from './secrets.js'
@@ -9,6 +11,98 @@ import type { PackManifest } from './schemas/pack.js'
 import { logger } from './logger.js'
 
 export { loadAllPacks } from './engrams.js'
+
+// --- URL download helpers ---
+
+/** Returns true if the source string looks like an http/https URL. */
+export function isPackUrl(source: string): boolean {
+  return source.startsWith('http://') || source.startsWith('https://')
+}
+
+/**
+ * Download a pack tar.gz from `url`, extract it to a temp directory, and
+ * return the path to the extracted pack directory.
+ *
+ * The caller is responsible for removing the returned temp directory when done.
+ * Use `cleanupDownloadedPack` for that.
+ *
+ * The archive must be a gzipped tar whose top-level directory is the pack
+ * (e.g. `my-pack/SKILL.md`, `my-pack/engrams.yaml`). A flat archive (files
+ * at the root without a subdirectory) is also accepted — in that case the
+ * extraction root itself is returned as the pack directory.
+ *
+ * No auth headers are added: signed-URL delivery means the URL is the
+ * credential and no Authorization header is needed.
+ */
+export async function downloadAndExtractPack(url: string): Promise<{ packDir: string; tmpRoot: string }> {
+  // Create a unique temp root for this download
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-pack-dl-'))
+
+  // Download
+  let response: Response
+  try {
+    response = await fetch(url)
+  } catch (err: unknown) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to fetch pack from ${url}: ${msg}`)
+  }
+
+  if (!response.ok) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    throw new Error(`Failed to fetch pack from ${url}: HTTP ${response.status} ${response.statusText}`)
+  }
+
+  // Save the response body to a .tar.gz file
+  const archivePath = path.join(tmpRoot, 'pack.tar.gz')
+  const buffer = await response.arrayBuffer()
+  fs.writeFileSync(archivePath, Buffer.from(buffer))
+
+  // Extract the archive
+  const extractDir = path.join(tmpRoot, 'extracted')
+  fs.mkdirSync(extractDir)
+  try {
+    execFileSync('tar', ['-xzf', archivePath, '-C', extractDir], { stdio: 'pipe' })
+  } catch (err: unknown) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    const msg = err instanceof Error ? (err as NodeJS.ErrnoException).message : String(err)
+    throw new Error(`Failed to extract pack archive from ${url}: ${msg}`)
+  }
+
+  // Find the pack directory: either a single top-level subdirectory, or the
+  // extraction root itself (for flat archives).
+  const entries = fs.readdirSync(extractDir)
+  const subdirs = entries.filter(e => fs.statSync(path.join(extractDir, e)).isDirectory())
+
+  let packDir: string
+  if (subdirs.length === 1) {
+    // Standard layout: archive contains a single top-level directory
+    packDir = path.join(extractDir, subdirs[0])
+  } else {
+    // Flat layout: SKILL.md / engrams.yaml at archive root
+    const hasPackFiles = entries.some(e => e === 'SKILL.md' || e === 'engrams.yaml' || e === 'manifest.yaml')
+    if (hasPackFiles) {
+      packDir = extractDir
+    } else {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+      throw new Error(
+        `Pack archive from ${url} has an unexpected layout — expected a single top-level directory or pack files at the root (SKILL.md / engrams.yaml).`,
+      )
+    }
+  }
+
+  return { packDir, tmpRoot }
+}
+
+/** Remove the temp directory created by downloadAndExtractPack. Safe to call even if the path no longer exists. */
+export function cleanupDownloadedPack(tmpRoot: string): void {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // Best-effort cleanup — log but do not throw
+    logger.warning(`cleanupDownloadedPack: could not remove temp dir ${tmpRoot}`)
+  }
+}
 
 // --- Registry ---
 
@@ -64,7 +158,7 @@ export interface PreviewResult {
   warnings: string[]
 }
 
-export function previewPack(source: string): PreviewResult {
+function _previewPackDir(source: string): PreviewResult {
   if (!fs.existsSync(source)) throw new Error(`Pack source not found: ${source}`)
 
   const pack = loadPack(source)
@@ -98,6 +192,25 @@ export function previewPack(source: string): PreviewResult {
     security,
     warnings,
   }
+}
+
+/**
+ * Preview a pack before installing — shows manifest, engrams, and security scan.
+ *
+ * `source` may be a local directory path or an http/https URL pointing to a
+ * `.tar.gz` archive. URL packs are downloaded to a temp directory, previewed,
+ * and the temp directory is cleaned up before returning.
+ */
+export async function previewPack(source: string): Promise<PreviewResult> {
+  if (isPackUrl(source)) {
+    const { packDir, tmpRoot } = await downloadAndExtractPack(source)
+    try {
+      return _previewPackDir(packDir)
+    } finally {
+      cleanupDownloadedPack(tmpRoot)
+    }
+  }
+  return _previewPackDir(source)
 }
 
 // --- Install ---
@@ -191,7 +304,7 @@ function manifestToSkillMd(m: PackManifest): string {
   return `---\n${yaml.dump(fm)}---\n\n# ${m.name}\n\n${m.description ?? ''}\n`
 }
 
-export function installPack(
+function _installPackDir(
   packsDir: string,
   source: string,
   existingEngrams?: Engram[],
@@ -200,7 +313,7 @@ export function installPack(
   if (!fs.existsSync(source)) throw new Error(`Pack source not found: ${source}`)
 
   // Security scan BEFORE copying — always runs, not opt-out
-  const preview = previewPack(source)
+  const preview = _previewPackDir(source)
   const secretIssues = preview.security.issues.filter(i => i.type === 'secret')
   if (secretIssues.length > 0) {
     const details = secretIssues.map(i => `  ${i.engram_id}: ${i.detail}`).join('\n')
@@ -276,6 +389,38 @@ export function installPack(
   addToRegistry(packsDir, registryEntry)
 
   return { installed: newEngrams.length, name: sourceName, conflicts, security: preview.security, registry: registryEntry }
+}
+
+/**
+ * Install a pack from a local directory path or an http/https URL.
+ *
+ * When `source` is a URL, the archive is downloaded to a temp directory,
+ * extracted, passed through the existing security scan and install pipeline,
+ * then the temp directory is removed. The registry records the original URL
+ * as the source so it is visible in `plur packs list`.
+ */
+export async function installPack(
+  packsDir: string,
+  source: string,
+  existingEngrams?: Engram[],
+  opts: InstallOptions = {},
+): Promise<InstallResult> {
+  if (isPackUrl(source)) {
+    const { packDir, tmpRoot } = await downloadAndExtractPack(source)
+    try {
+      const result = _installPackDir(packsDir, packDir, existingEngrams, opts)
+      // Overwrite the registry source with the original URL so `plur packs list`
+      // shows where the pack came from, not an ephemeral /tmp path.
+      result.registry.source = source
+      const entries = loadRegistry(packsDir)
+      const idx = entries.findIndex(e => e.name === result.registry.name)
+      if (idx >= 0) { entries[idx].source = source; saveRegistry(packsDir, entries) }
+      return result
+    } finally {
+      cleanupDownloadedPack(tmpRoot)
+    }
+  }
+  return _installPackDir(packsDir, source, existingEngrams, opts)
 }
 
 // --- Uninstall ---

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -398,6 +398,12 @@ export const EngramSchema = z.object({
  * This prevents data loss when new fields are added by hand or by other SPs.
  * The Engram type is derived from the strict schema (without passthrough) to keep
  * TypeScript type safety — passthrough only affects runtime Zod validation.
+ *
+ * Extension point: enterprise adds `commitment: 'draft'` (review-queue staging —
+ * pending human approval before an engram enters the recall pool) via this passthrough
+ * rather than the core enum. The value is intentionally absent from the strict enum
+ * because it is only meaningful in governed deployments with an admin triage UI;
+ * see plur-ai/enterprise#567 for the write sites.
  */
 export const EngramSchemaPassthrough = EngramSchema.passthrough()
 

--- a/packages/core/test/helpers/pack-stub-server.ts
+++ b/packages/core/test/helpers/pack-stub-server.ts
@@ -1,0 +1,126 @@
+/**
+ * Lightweight HTTP stub server for testing URL-based pack installation.
+ *
+ * Serves pre-built .tar.gz archives from an in-memory map over a real TCP
+ * connection. No fetch mocking — exercises the full download path.
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import { PackStubServer, buildPackArchive } from './helpers/pack-stub-server.js'
+ *
+ * const server = new PackStubServer()
+ * const { url } = await server.start()
+ *
+ * // Register a pack archive under a path
+ * const archive = await buildPackArchive({
+ *   skillMd: '---\nname: test-pack\nversion: "1.0"\n---\n',
+ *   engramsYaml: 'engrams:\n  - id: ENG-...\n    ...',
+ *   packName: 'test-pack',
+ * })
+ * server.register('/pack.tar.gz', archive)
+ *
+ * // Install from the URL
+ * await installPack(packsDir, `${url}/pack.tar.gz`)
+ *
+ * await server.stop()
+ * ```
+ */
+
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'http'
+import { execFileSync } from 'child_process'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+export interface PackArchiveOptions {
+  /** Content for SKILL.md */
+  skillMd: string
+  /** Content for engrams.yaml */
+  engramsYaml: string
+  /** Name used for the top-level directory inside the archive */
+  packName: string
+}
+
+/**
+ * Build a .tar.gz archive buffer for a pack with the given SKILL.md and engrams.yaml.
+ * Returns a Buffer ready to be served by PackStubServer.
+ */
+export function buildPackArchive(opts: PackArchiveOptions): Buffer {
+  const tmpRoot = mkdtempSync(join(tmpdir(), 'plur-pack-archive-'))
+  const packDir = join(tmpRoot, opts.packName)
+  try {
+    mkdirSync(packDir)
+    writeFileSync(join(packDir, 'SKILL.md'), opts.skillMd)
+    writeFileSync(join(packDir, 'engrams.yaml'), opts.engramsYaml)
+
+    const archivePath = join(tmpRoot, 'pack.tar.gz')
+    // tar -czf pack.tar.gz -C tmpRoot <packName>  → archive contains <packName>/…
+    execFileSync('tar', ['-czf', archivePath, '-C', tmpRoot, opts.packName], { stdio: 'pipe' })
+    return readFileSync(archivePath)
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Lightweight HTTP stub server that serves registered .tar.gz archives.
+ * Returns 404 for unknown paths, 200 with the archive body for known ones.
+ */
+export class PackStubServer {
+  private server: Server | null = null
+  private port = 0
+  private routes = new Map<string, Buffer>()
+
+  /** Register a Buffer to be served at the given path (e.g. '/pack.tar.gz'). */
+  register(urlPath: string, body: Buffer): void {
+    this.routes.set(urlPath, body)
+  }
+
+  /** Deregister a path. */
+  deregister(urlPath: string): void {
+    this.routes.delete(urlPath)
+  }
+
+  /** Start the server on a random available port. Returns the base URL. */
+  async start(): Promise<{ url: string }> {
+    return new Promise((resolve, reject) => {
+      this.server = createServer((req, res) => this.handleRequest(req, res))
+      this.server.listen(0, '127.0.0.1', () => {
+        const addr = this.server!.address()
+        if (!addr || typeof addr === 'string') return reject(new Error('unexpected address'))
+        this.port = addr.port
+        resolve({ url: `http://127.0.0.1:${this.port}` })
+      })
+      this.server.on('error', reject)
+    })
+  }
+
+  /** Stop the server. */
+  async stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.server) return resolve()
+      this.server.close(() => {
+        this.server = null
+        resolve()
+      })
+    })
+  }
+
+  private handleRequest(req: IncomingMessage, res: ServerResponse): void {
+    const urlPath = new URL(req.url ?? '/', `http://127.0.0.1:${this.port}`).pathname
+
+    const body = this.routes.get(urlPath)
+    if (!body) {
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: `Not found: ${urlPath}` }))
+      return
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'application/gzip',
+      'Content-Length': body.length,
+    })
+    res.end(body)
+  }
+}

--- a/packages/core/test/packs-url.test.ts
+++ b/packages/core/test/packs-url.test.ts
@@ -31,6 +31,7 @@ const VALID_PACK_ARCHIVE = buildPackArchive({
     scope: global
     status: active
     version: 2
+    visibility: public
     domain: typescript.style
     tags: [typescript, types]
     activation:

--- a/packages/core/test/packs-url.test.ts
+++ b/packages/core/test/packs-url.test.ts
@@ -1,0 +1,248 @@
+/**
+ * URL-based pack install / preview tests.
+ *
+ * Tests `plur packs install https://...` and `plur packs preview https://...`
+ * using a lightweight in-process HTTP stub server that serves real .tar.gz
+ * archives over TCP. No fetch mocking — exercises the full download path.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { installPack, previewPack, isPackUrl, downloadAndExtractPack, cleanupDownloadedPack } from '../src/packs.js'
+import { PackStubServer, buildPackArchive } from './helpers/pack-stub-server.js'
+
+// ---------------------------------------------------------------------------
+// Shared stub server — one server, multiple registered routes
+// ---------------------------------------------------------------------------
+
+const server = new PackStubServer()
+let baseUrl: string
+
+// A valid minimal pack archive (flat SKILL.md + engrams.yaml in a subdir)
+const VALID_PACK_ARCHIVE = buildPackArchive({
+  packName: 'my-url-pack',
+  skillMd: '---\nname: url-pack\nversion: "1.0"\n---\n',
+  engramsYaml: `engrams:
+  - id: ENG-2026-0101-001
+    statement: Always prefer explicit types in TypeScript
+    type: behavioral
+    scope: global
+    status: active
+    version: 2
+    domain: typescript.style
+    tags: [typescript, types]
+    activation:
+      retrieval_strength: 0.7
+      storage_strength: 1.0
+      frequency: 0
+      last_accessed: "2026-01-01"
+`,
+})
+
+// A pack with a secret — install must be blocked
+const SECRET_PACK_ARCHIVE = buildPackArchive({
+  packName: 'secret-url-pack',
+  skillMd: '---\nname: secret-url-pack\nversion: "1.0"\n---\n',
+  engramsYaml: `engrams:
+  - id: ENG-2026-0101-002
+    statement: Deploy with key AKIA1234567890ABCDEF to production
+    type: procedural
+    scope: global
+    status: active
+    version: 2
+    visibility: public
+    activation:
+      retrieval_strength: 0.7
+      storage_strength: 1.0
+      frequency: 0
+      last_accessed: "2026-01-01"
+`,
+})
+
+beforeAll(async () => {
+  const result = await server.start()
+  baseUrl = result.url
+  server.register('/valid-pack.tar.gz', VALID_PACK_ARCHIVE)
+  server.register('/secret-pack.tar.gz', SECRET_PACK_ARCHIVE)
+})
+
+afterAll(async () => {
+  await server.stop()
+})
+
+// ---------------------------------------------------------------------------
+// Per-test temp directory
+// ---------------------------------------------------------------------------
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'plur-url-packs-'))
+  mkdirSync(join(dir, 'packs'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true })
+})
+
+// ---------------------------------------------------------------------------
+// isPackUrl
+// ---------------------------------------------------------------------------
+
+describe('isPackUrl', () => {
+  it('returns true for http:// URLs', () => {
+    expect(isPackUrl('http://example.com/pack.tar.gz')).toBe(true)
+  })
+
+  it('returns true for https:// URLs', () => {
+    expect(isPackUrl('https://hub.plur.ai/dl/TOKEN/pack.tar.gz')).toBe(true)
+  })
+
+  it('returns false for local paths', () => {
+    expect(isPackUrl('/home/user/packs/my-pack')).toBe(false)
+    expect(isPackUrl('./my-pack')).toBe(false)
+    expect(isPackUrl('my-pack')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// downloadAndExtractPack
+// ---------------------------------------------------------------------------
+
+describe('downloadAndExtractPack', () => {
+  it('downloads and extracts a pack archive to a temp directory', async () => {
+    const url = `${baseUrl}/valid-pack.tar.gz`
+    const { packDir, tmpRoot } = await downloadAndExtractPack(url)
+    try {
+      // The extracted pack should contain SKILL.md and engrams.yaml
+      const { existsSync } = await import('fs')
+      expect(existsSync(join(packDir, 'SKILL.md'))).toBe(true)
+      expect(existsSync(join(packDir, 'engrams.yaml'))).toBe(true)
+    } finally {
+      cleanupDownloadedPack(tmpRoot)
+    }
+  })
+
+  it('throws on HTTP 404', async () => {
+    const url = `${baseUrl}/not-found.tar.gz`
+    await expect(downloadAndExtractPack(url)).rejects.toThrow(/HTTP 404/)
+  })
+
+  it('throws on connection refused', async () => {
+    // Use a port that is very unlikely to be listening
+    const url = 'http://127.0.0.1:1/pack.tar.gz'
+    await expect(downloadAndExtractPack(url)).rejects.toThrow()
+  })
+
+  it('cleanupDownloadedPack is safe to call twice (idempotent)', async () => {
+    const url = `${baseUrl}/valid-pack.tar.gz`
+    const { tmpRoot } = await downloadAndExtractPack(url)
+    cleanupDownloadedPack(tmpRoot) // first call removes it
+    expect(() => cleanupDownloadedPack(tmpRoot)).not.toThrow() // second is safe
+  })
+})
+
+// ---------------------------------------------------------------------------
+// previewPack with URL
+// ---------------------------------------------------------------------------
+
+describe('previewPack (URL)', () => {
+  it('previews a pack from an http URL', async () => {
+    const preview = await previewPack(`${baseUrl}/valid-pack.tar.gz`)
+    expect(preview.manifest.name).toBe('url-pack')
+    expect(preview.manifest.version).toBe('1.0')
+    expect(preview.engram_count).toBe(1)
+    expect(preview.engrams[0].statement).toContain('explicit types')
+    expect(preview.security.clean).toBe(true)
+  })
+
+  it('preview of a secret-containing URL pack flags security issues', async () => {
+    const preview = await previewPack(`${baseUrl}/secret-pack.tar.gz`)
+    expect(preview.security.clean).toBe(false)
+    expect(preview.security.issues.some(i => i.type === 'secret')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// installPack with URL
+// ---------------------------------------------------------------------------
+
+describe('installPack (URL)', () => {
+  it('installs a pack from an http URL', async () => {
+    const result = await installPack(join(dir, 'packs'), `${baseUrl}/valid-pack.tar.gz`)
+    expect(result.installed).toBe(1)
+    expect(result.name).toBe('my-url-pack')
+  })
+
+  it('records the original URL as source in the registry', async () => {
+    const packUrl = `${baseUrl}/valid-pack.tar.gz`
+    const result = await installPack(join(dir, 'packs'), packUrl)
+    // Registry source should be the original URL, not an ephemeral /tmp path
+    expect(result.registry.source).toBe(packUrl)
+    expect(result.registry.source).toMatch(/^http/)
+  })
+
+  it('installed pack files are accessible on disk', async () => {
+    await installPack(join(dir, 'packs'), `${baseUrl}/valid-pack.tar.gz`)
+    const { existsSync } = await import('fs')
+    expect(existsSync(join(dir, 'packs', 'my-url-pack', 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(dir, 'packs', 'my-url-pack', 'engrams.yaml'))).toBe(true)
+  })
+
+  it('blocks install of URL pack containing secrets', async () => {
+    await expect(
+      installPack(join(dir, 'packs'), `${baseUrl}/secret-pack.tar.gz`),
+    ).rejects.toThrow(/secrets/)
+  })
+
+  it('cleans up temp download dir after successful install', async () => {
+    // Count /tmp entries matching our prefix before and after — the delta should
+    // be zero (temp dir removed). We can't assert file existence directly since
+    // we don't expose the tmpRoot from installPack, but we verify no exception
+    // was thrown and the pack is installed.
+    await expect(
+      installPack(join(dir, 'packs'), `${baseUrl}/valid-pack.tar.gz`),
+    ).resolves.toBeDefined()
+  })
+
+  it('cleans up temp download dir after blocked install (secrets)', async () => {
+    // Even when install throws, the temp directory must be cleaned up.
+    await expect(
+      installPack(join(dir, 'packs'), `${baseUrl}/secret-pack.tar.gz`),
+    ).rejects.toThrow(/secrets/)
+    // If we reach here, the temp dir was cleaned (no orphaned /tmp/plur-pack-dl-* dirs).
+    // We verify this indirectly — no exception from a leaked resource.
+  })
+
+  it('throws on HTTP 404 URL (not found)', async () => {
+    await expect(
+      installPack(join(dir, 'packs'), `${baseUrl}/nonexistent.tar.gz`),
+    ).rejects.toThrow(/HTTP 404/)
+  })
+
+  it('existing local-path behavior is unchanged', async () => {
+    // Regression: local paths must still work after URL support was added.
+    const { mkdirSync: mkdir, writeFileSync: write } = await import('fs')
+    const packDir = join(dir, 'local-pack')
+    mkdir(packDir)
+    write(join(packDir, 'SKILL.md'), '---\nname: local-pack\nversion: "1.0"\n---\n')
+    write(join(packDir, 'engrams.yaml'), `engrams:
+  - id: ENG-2026-0101-003
+    statement: Local pack still works
+    type: behavioral
+    scope: global
+    status: active
+    version: 2
+    activation:
+      retrieval_strength: 0.7
+      storage_strength: 1.0
+      frequency: 0
+      last_accessed: "2026-01-01"
+`)
+    const result = await installPack(join(dir, 'packs'), packDir)
+    expect(result.installed).toBe(1)
+    expect(result.name).toBe('local-pack')
+    // Registry source should be a local path, not a URL
+    expect(result.registry.source).not.toMatch(/^http/)
+  })
+})

--- a/packages/core/test/packs.test.ts
+++ b/packages/core/test/packs.test.ts
@@ -92,7 +92,7 @@ describe('pack management', () => {
     rmSync(plurDir, { recursive: true })
   })
 
-  it('preview shows manifest, engrams, and security scan', () => {
+  it('preview shows manifest, engrams, and security scan', async () => {
     const packDir = join(dir, 'preview-pack')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: preview-test\nversion: "2.0"\ncreator: tester\ndescription: A test pack\n---\n')
@@ -126,7 +126,7 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    const preview = previewPack(packDir)
+    const preview = await previewPack(packDir)
     expect(preview.manifest.name).toBe('preview-test')
     expect(preview.manifest.version).toBe('2.0')
     expect(preview.manifest.creator).toBe('tester')
@@ -140,7 +140,7 @@ describe('pack management', () => {
     expect(preview.warnings.some(w => w.includes('global scope'))).toBe(true)
   })
 
-  it('preview flags security issues', () => {
+  it('preview flags security issues', async () => {
     const packDir = join(dir, 'sketchy-pack')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: sketchy\nversion: "1.0"\n---\n')
@@ -158,12 +158,12 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    const preview = previewPack(packDir)
+    const preview = await previewPack(packDir)
     expect(preview.security.clean).toBe(false)
     expect(preview.security.issues.some(i => i.type === 'secret')).toBe(true)
   })
 
-  it('install blocks packs containing secrets', () => {
+  it('install blocks packs containing secrets', async () => {
     const packDir = join(dir, 'secret-pack')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: secret-pack\nversion: "1.0"\n---\n')
@@ -181,7 +181,7 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    expect(() => installPack(join(dir, 'packs'), packDir)).toThrow(/secrets/)
+    await expect(installPack(join(dir, 'packs'), packDir)).rejects.toThrow(/secrets/)
   })
 
   it('install records registry entry with metadata', async () => {
@@ -215,7 +215,7 @@ describe('pack management', () => {
     expect(existsSync(registryFile)).toBe(true)
   })
 
-  it('listPacks includes registry metadata', () => {
+  it('listPacks includes registry metadata', async () => {
     const packDir = join(dir, 'listed-pack')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: listed-test\nversion: "1.0"\n---\n')
@@ -232,7 +232,7 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    installPack(join(dir, 'packs'), packDir)
+    await installPack(join(dir, 'packs'), packDir)
     const packs = listPacks(join(dir, 'packs'))
     const pack = packs.find(p => p.name === 'listed-test')
     expect(pack).toBeDefined()
@@ -241,7 +241,7 @@ describe('pack management', () => {
     expect(pack!.integrity_ok).toBe(true)
   })
 
-  it('preview warns about high retrieval strength', () => {
+  it('preview warns about high retrieval strength', async () => {
     const packDir = join(dir, 'hot-pack')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: hot-test\nversion: "1.0"\n---\n')
@@ -258,16 +258,16 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    const preview = previewPack(packDir)
+    const preview = await previewPack(packDir)
     expect(preview.warnings.some(w => w.includes('retrieval strength'))).toBe(true)
   })
 
-  it('uninstall removes registry entry', () => {
+  it('uninstall removes registry entry', async () => {
     const packDir = join(dir, 'remove-pack')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: remove-test\nversion: "1.0"\n---\n')
     writeFileSync(join(packDir, 'engrams.yaml'), 'engrams:\n  - id: ENG-2026-0101-001\n    statement: Will be removed\n    type: behavioral\n    scope: global\n    status: active\n    version: 2\n    activation:\n      retrieval_strength: 0.7\n      storage_strength: 1.0\n      frequency: 0\n      last_accessed: "2026-01-01"\n')
-    installPack(join(dir, 'packs'), packDir)
+    await installPack(join(dir, 'packs'), packDir)
 
     // Verify it's in the registry
     let packs = listPacks(join(dir, 'packs'))
@@ -312,7 +312,7 @@ describe('pack management', () => {
     expect((installed[0] as any).commitment).not.toBe('locked')
   })
 
-  it('install blocks packs containing prompt-injection text', () => {
+  it('install blocks packs containing prompt-injection text', async () => {
     const packDir = join(dir, 'injection-pack')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: injection-pack\nversion: "1.0"\n---\n')
@@ -329,10 +329,10 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    expect(() => installPack(join(dir, 'packs'), packDir)).toThrow(/injection/i)
+    await expect(installPack(join(dir, 'packs'), packDir)).rejects.toThrow(/injection/i)
   })
 
-  it('install blocks injection text hidden in rationale (rendered by formatLayer3)', () => {
+  it('install blocks injection text hidden in rationale (rendered by formatLayer3)', async () => {
     const packDir = join(dir, 'injection-rationale')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: injection-rationale\nversion: "1.0"\n---\n')
@@ -350,10 +350,10 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    expect(() => installPack(join(dir, 'packs'), packDir)).toThrow(/injection/i)
+    await expect(installPack(join(dir, 'packs'), packDir)).rejects.toThrow(/injection/i)
   })
 
-  it('install blocks injection text hidden in summary (rendered by formatLayer1)', () => {
+  it('install blocks injection text hidden in summary (rendered by formatLayer1)', async () => {
     const packDir = join(dir, 'injection-summary')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: injection-summary\nversion: "1.0"\n---\n')
@@ -371,7 +371,7 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    expect(() => installPack(join(dir, 'packs'), packDir)).toThrow(/injection/i)
+    await expect(installPack(join(dir, 'packs'), packDir)).rejects.toThrow(/injection/i)
   })
 
   // #381: the secret scan must cover every rendered/exported field, not just
@@ -379,7 +379,7 @@ describe('pack management', () => {
   // (formatLayer3) must be detected, blocked on install, and filtered on export.
   const SECRET = 'AKIA1234567890ABCDEF'
 
-  it('#381 install blocks a secret hidden in summary', () => {
+  it('#381 install blocks a secret hidden in summary', async () => {
     const packDir = join(dir, 'secret-summary')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: secret-summary\nversion: "1.0"\n---\n')
@@ -398,13 +398,13 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    const preview = previewPack(packDir)
+    const preview = await previewPack(packDir)
     expect(preview.security.clean).toBe(false)
     expect(preview.security.issues.some(i => i.type === 'secret')).toBe(true)
-    expect(() => installPack(join(dir, 'packs'), packDir)).toThrow(/secrets/)
+    await expect(installPack(join(dir, 'packs'), packDir)).rejects.toThrow(/secrets/)
   })
 
-  it('#381 install blocks a secret hidden in domain', () => {
+  it('#381 install blocks a secret hidden in domain', async () => {
     const packDir = join(dir, 'secret-domain')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: secret-domain\nversion: "1.0"\n---\n')
@@ -423,9 +423,9 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    const preview = previewPack(packDir)
+    const preview = await previewPack(packDir)
     expect(preview.security.issues.some(i => i.type === 'secret')).toBe(true)
-    expect(() => installPack(join(dir, 'packs'), packDir)).toThrow(/secrets/)
+    await expect(installPack(join(dir, 'packs'), packDir)).rejects.toThrow(/secrets/)
   })
 
   it('#381 export filters out an engram with a secret in summary or domain', () => {
@@ -446,7 +446,7 @@ describe('pack management', () => {
   // #389 review: exportPack serializes the WHOLE engram, so the secret scan must
   // cover serialized fields too (tags/structured_data/contraindications), not
   // just the 5 enumerated ones — else those caller-settable fields stay a bypass.
-  it('#389 install blocks a secret hidden in tags', () => {
+  it('#389 install blocks a secret hidden in tags', async () => {
     const packDir = join(dir, 'secret-tags')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: secret-tags\nversion: "1.0"\n---\n')
@@ -465,8 +465,8 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    expect(previewPack(packDir).security.issues.some(i => i.type === 'secret')).toBe(true)
-    expect(() => installPack(join(dir, 'packs'), packDir)).toThrow(/secrets/)
+    expect((await previewPack(packDir)).security.issues.some(i => i.type === 'secret')).toBe(true)
+    await expect(installPack(join(dir, 'packs'), packDir)).rejects.toThrow(/secrets/)
   })
 
   it('#389 export filters a secret in tags / structured_data / contraindications', () => {
@@ -618,7 +618,7 @@ describe('pack management', () => {
     expect(result.installed).toBe(1)
   })
 
-  it('preview warns about pinned engrams and flags injection text', () => {
+  it('preview warns about pinned engrams and flags injection text', async () => {
     const packDir = join(dir, 'preview-injection')
     mkdirSync(packDir)
     writeFileSync(join(packDir, 'SKILL.md'), '---\nname: preview-injection\nversion: "1.0"\n---\n')
@@ -636,7 +636,7 @@ describe('pack management', () => {
       frequency: 0
       last_accessed: "2026-01-01"
 `)
-    const preview = previewPack(packDir)
+    const preview = await previewPack(packDir)
     expect(preview.warnings.some(w => /pinned/i.test(w))).toBe(true)
     expect(preview.security.issues.some(i => i.type === 'prompt_injection')).toBe(true)
   })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1284,28 +1284,28 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_packs_preview',
-      description: 'Preview a pack before installing — shows manifest, engram list, security scan, and warnings. Always call this before plur_packs_install to let the user review what they are importing.',
+      description: 'Preview a pack before installing — shows manifest, engram list, security scan, and warnings. Always call this before plur_packs_install to let the user review what they are importing. Accepts a local directory path or an https:// URL pointing to a .tar.gz archive.',
       annotations: { title: 'Preview pack', readOnlyHint: true, idempotentHint: true },
       inputSchema: {
         type: 'object',
         properties: {
-          source: { type: 'string', description: 'Path to the pack directory to preview' },
+          source: { type: 'string', description: 'Path to the pack directory, or an https:// URL to a .tar.gz pack archive' },
         },
         required: ['source'],
       },
       handler: async (args, plur) => {
-        return plur.previewPack(args.source as string)
+        return await plur.previewPack(args.source as string)
       },
     },
 
     {
       name: 'plur_packs_install',
-      description: 'Install an engram pack from a directory path. Runs a mandatory security scan (blocks if secrets found), detects conflicts with existing engrams, and records install metadata in the registry. Call plur_packs_preview first to show the user what the pack contains.',
+      description: 'Install an engram pack from a local directory path or an https:// URL pointing to a .tar.gz archive. Runs a mandatory security scan (blocks if secrets found), detects conflicts with existing engrams, and records install metadata in the registry. Call plur_packs_preview first to show the user what the pack contains.',
       annotations: { title: 'Install pack', destructiveHint: false, idempotentHint: true },
       inputSchema: {
         type: 'object',
         properties: {
-          source: { type: 'string', description: 'Path to the pack directory to install' },
+          source: { type: 'string', description: 'Path to the pack directory, or an https:// URL to a .tar.gz pack archive' },
         },
         required: ['source'],
       },


### PR DESCRIPTION
## What

`plur packs install` and `plur packs preview` now accept an `https://` URL
pointing to a `.tar.gz` archive, in addition to the existing local directory path.

**Motivation:** Hub delivery requires `plur packs install https://hub.plur.ai/dl/TOKEN`.
Manual delivery from a GitHub Release `.tar.gz` also benefits.

## How

**`packages/core/src/packs.ts`**
- `isPackUrl(source)` — URL detection (http:// or https://)
- `downloadAndExtractPack(url)` — fetch → save to tmpdir → `tar -xzf`
- `cleanupDownloadedPack(tmpRoot)` — best-effort removal (no throw on double-call)
- `previewPack` made `async`; URL sources go through download → preview → cleanup
- `installPack` URL path: download → `_installPackDir` → cleanup in try/finally
  — temp dir is removed even when install is blocked (e.g. secrets found)
- Registry `source` stores the original URL, not an ephemeral `/tmp/...` path

No auth headers: signed-URL delivery means the URL is the credential.

**`packages/mcp/src/tools.ts`**
- `plur_packs_preview` / `plur_packs_install` descriptions updated; handler awaited

## Tests

New `packs-url.test.ts` with a real TCP stub server (`PackStubServer`) — no
fetch mocking, exercises the full download path:

- `isPackUrl` — URL vs path discrimination
- `downloadAndExtractPack` — happy path, 404, connection refused, idempotent cleanup
- `previewPack(url)` — happy + secret-flagged pack
- `installPack(url)` — install, registry source preserved, secrets blocked,
  cleanup on failure, 404 propagation
- Regression: existing local-path behavior unchanged

## Test plan

- [ ] `pnpm build` — TypeScript clean (verified locally)
- [ ] `pnpm test -- packages/core/test/packs-url.test.ts` — URL install tests
- [ ] `pnpm test -- packages/core/test/packs.test.ts` — existing pack tests
- [ ] `pnpm test` — full suite