### PR TITLE
fix(core,migrate,release): close the 0.16.0 pre-release audit — blockers, highs, and the medium/low tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,49 @@ jobs:
       # Getting-started examples must stay runnable against the public API (#267).
       - name: Run examples
         run: pnpm --filter @plur-ai/examples run all
+
+  # The packaged artefacts, not the source tree.
+  #
+  # `pnpm test` above proves the SOURCE works. Users install tarballs, and the
+  # difference has shipped a defect before: `pg` is an optionalDependency and
+  # tsup only auto-externalizes dependencies + peerDependencies, so the driver
+  # was inlined into core's dist and PostgresAdapter threw on first use — in the
+  # published package, with every in-repo test green.
+  #
+  # scripts/smoke-release.sh covered exactly that and nothing invoked it, so it
+  # could only catch anything when someone remembered to run it by hand. One
+  # Node version is enough: this checks packaging, not runtime compatibility.
+  smoke-packaged:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: plur_test
+          POSTGRES_PASSWORD: plur_test_only
+          POSTGRES_DB: plur_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U plur_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Pack, install clean, and drive the public API
+        run: bash scripts/smoke-release.sh
+        env:
+          # Same throwaway credentials as the test job — the service container
+          # is reachable only from this job.
+          PLUR_SMOKE_POSTGRES_URL: postgres://plur_test:plur_test_only@127.0.0.1:5432/plur_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## 0.16.0 (unreleased)
 
-Unified recall surface, and the convergence programme: one engine, two
-deployments.
+One engine, two deployments.
+
+- BREAKING: write path is async
+- npx @plur-ai/migrate adds awaits
+- Postgres as a primary store
+- scope allow-list + BM25 pushdown
+- cross-process write safety
+- unified recall surface — same engine local and server-side
 
 ### BREAKING — the write path is asynchronous
 
-`Plur`'s store interface and roughly twenty public methods now return promises
+`Plur`'s store interface and roughly twenty public methods now return promises (#728)
 (`learn`, `learnRouted`, `recall`, `recallHybrid`, `inject`, `injectHybrid`,
 `feedback`, `forget`, `getById`, `list`, `status`, `ingest`, `sync`, …).
 
@@ -44,27 +50,41 @@ because it is a claim a caller may act on.
 
 ### Added
 
+- **`@plur-ai/mcp` exposes a side-effect-free `./tools` subpath** (#714, #717):
+  `import { getToolDefinitions } from '@plur-ai/mcp/tools'` yields the tool
+  definitions without starting a server or touching stdio, so another server can
+  host PLUR's tools inside its own process.
 - **`npx @plur-ai/migrate`** — finds the un-awaited calls this release creates, and fixes the unambiguous ones. Reports by default; `--write` applies. It refuses to rewrite the three cases where inserting `await` changes program meaning rather than just adding a wait (inside a `Promise` combinator array, a concise arrow body, a result consumed across lines) and lists them for a human instead. Exit code 2 when anything needs attention, so it composes in CI. Every hazard it guards is one the codemods that migrated PLUR itself actually hit.
-- **Postgres as a primary store** (ADR-0005). `new Plur({ store: new PostgresAdapter({ connectionString }) })` runs the engine directly against server Postgres — the same engine, a different deployment. `pgvector` for vectors, exact or HNSW with the recall target declared rather than implied.
-- **Cross-process write safety.** `PrimaryStore.withExclusiveAccess?()` — the store decides how it is serialized, because the store is what knows what it shares. `PostgresAdapter` takes a session-scoped advisory lock; a local-file store keeps its file lock. Without this, two processes over one database silently overwrote each other, and a *read-only* `recall()` on one could delete an engram another had just committed (`recall` updates activation, so it is a whole-corpus write).
-- **Permitted-scope allow-list pushed into the query** — `scopes` on `RecallOptions` and now `InjectOptions`. An AUTHORIZATION filter, distinct from the `scope` visibility filter: absent = unrestricted, `[]` = matches nothing, non-empty = exact membership with no hierarchy expansion and no personal-family pass-through. `inject()` had no authorization filter at all before this, which for a multi-tenant caller meant every principal's personal engrams reached every other principal's context.
-- **BM25 narrowing pushed into Postgres** (#711) via `pg_trgm`, with corpus-wide statistics (`CorpusStats`: `N`, per-term `df`, `avgDocLength`) supplied by the store so narrowing cannot change the ranking. Tokens are computed in TypeScript at write time by the same `ftsTokenize` the scorer uses, so there is no second tokenizer free to drift.
+- **Postgres as a primary store** (ADR-0005) (#720). `new Plur({ store: new PostgresAdapter({ connectionString }) })` runs the engine directly against server Postgres — the same engine, a different deployment. `pgvector` for vectors, exact or HNSW with the recall target declared rather than implied.
+- **Cross-process write safety** (ADR-0004) (#719). `PrimaryStore.withExclusiveAccess?()` — the store decides how it is serialized, because the store is what knows what it shares. `PostgresAdapter` takes a session-scoped advisory lock; a local-file store keeps its file lock. Without this, two processes over one database silently overwrote each other, and a *read-only* `recall()` on one could delete an engram another had just committed (`recall` updates activation, so it is a whole-corpus write).
+- **Permitted-scope allow-list pushed into the query** (#715, #739, #743) — `scopes` on `RecallOptions` and now `InjectOptions`. An AUTHORIZATION filter, distinct from the `scope` visibility filter: absent = unrestricted, `[]` = matches nothing, non-empty = exact membership with no hierarchy expansion and no personal-family pass-through. `inject()` had no authorization filter at all before this, which for a multi-tenant caller meant every principal's personal engrams reached every other principal's context.
+- **BM25 narrowing pushed into Postgres** (#711, #732, #743) via `pg_trgm`, with corpus-wide statistics (`CorpusStats`: `N`, per-term `df`, `avgDocLength`) supplied by the store so narrowing cannot change the ranking. Tokens are computed in TypeScript at write time by the same `ftsTokenize` the scorer uses, so there is no second tokenizer free to drift.
 
 ### Fixed
 
-- **BM25 reverse-substring matches** (#721): `qt.includes(t)` let any document token that was a non-prefix substring of the query score a hit — `deploying` matched an engram about *yin*, `postgres` matched one about *res*. Now `qt.startsWith(t)`, which keeps morphological prefixes (`deploy` → `deploying`) and drops the junk. Measured on a 3,930-engram store: no query loses results, and the reverse-substring matches it removes were never meaningful.
+- **BM25 reverse-substring matches** (#721, #724): `qt.includes(t)` let any document token that was a non-prefix substring of the query score a hit — `deploying` matched an engram about *yin*, `postgres` matched one about *res*. Now `qt.startsWith(t)`, which keeps morphological prefixes (`deploy` → `deploying`) and drops the junk. Measured on a 3,930-engram store: no query loses results, and the reverse-substring matches it removes were never meaningful.
 - `pg` is externalized from the bundle — it is an `optionalDependency`, so it was being inlined into `dist` and the published `PostgresAdapter` would have thrown on first use.
 - `plur learn`'s 5s remote-write timeout was dead code (an `await` inside `Promise.race` resolved the call before the timer was armed).
 - `init-remote` silently ignored `--quiet` and printed prose under `--json`.
+- **MCP tool schemas silently dropped array items** (#705): a union item schema was
+  emitted without a usable `items` definition, so a client sending a well-formed
+  array had elements discarded on the way in. Union item schemas are now coerced,
+  and a partial drop is surfaced rather than passed through as a shorter array.
+- **`truncated` was reported wrong when `budget.max_results` capped a recall**
+  (#725, #726): the flag was computed before the budget cap applied, so a
+  truncated result set claimed to be complete and callers had no signal to page.
+- **`server.json` version drift** (#699): the MCP Registry manifest carried its
+  version in two places and only one was bumped, so the published listing could
+  disagree with the package. `release.sh` now writes both.
 
 ### Changed
 
-- **`plur_recall` is now the unified recall tool (#693)**: gains a `mode` parameter — `'hybrid'` (default, BM25 + local embeddings via RRF) or `'keyword'` (BM25-only). Existing callers that pass no `mode` get a quality upgrade without any API change. **Breaking for the lean/cursor profile**: `plur_recall_hybrid` is no longer a top-level lean tool — `plur_recall` takes its slot. Agents configured against the lean profile that call `plur_recall_hybrid` by name will still get results (the tool remains accessible via `plur_admin` dispatch), but should migrate to `plur_recall`.
+- **`plur_recall` is now the unified recall tool (#693, #702)**: gains a `mode` parameter — `'hybrid'` (default, BM25 + local embeddings via RRF) or `'keyword'` (BM25-only). Existing callers that pass no `mode` get a quality upgrade without any API change. **Breaking for the lean/cursor profile**: `plur_recall_hybrid` is no longer a top-level lean tool — `plur_recall` takes its slot. Agents configured against the lean profile that call `plur_recall_hybrid` by name will still get results (the tool remains accessible via `plur_admin` dispatch), but should migrate to `plur_recall`.
 - **`plur_recall_hybrid` is a deprecated alias** (#693): it invokes the canonical `plur_recall` handler with `{mode:'hybrid'}` and prepends a one-line `deprecated` notice — a real forwarder, so budget capping, episode expansion, the degraded-embeddings warning and reranker surfacing cannot drift between the two before the alias is removed. Removal target: 0.18. Accessible in both full and lean profiles (via `plur_admin`) to avoid breaking existing CLAUDE.md files and agent templates in the wild.
 
 ### Added
 
-- **`plur init` now prompts for anonymous usage statistics opt-in.** On interactive installs a single yes/no prompt asks "Enable anonymous usage statistics? (helps us improve PLUR — no code, no keys) [y/N]" and persists the answer to `~/.plur/telemetry.json`. Non-interactive installs (CI, piped stdin, `--no-prompt`) write `enabled:false` silently — they are never opted in without explicit consent. Already-configured installs skip the prompt entirely, as do installs with an explicit `PLUR_TELEMETRY` env var — env wins at runtime, so no contradictory config file is written. To enable after the fact: `PLUR_TELEMETRY=on` env var or edit `~/.plur/telemetry.json`. See [`docs/telemetry-design.md`](docs/telemetry-design.md) for what is collected (learn/recall counters only — no code, no keys, no content).
+- **`plur init` now prompts for anonymous usage statistics opt-in** (#701). On interactive installs a single yes/no prompt asks "Enable anonymous usage statistics? (helps us improve PLUR — no code, no keys) [y/N]" and persists the answer to `~/.plur/telemetry.json`. Non-interactive installs (CI, piped stdin, `--no-prompt`) write `enabled:false` silently — they are never opted in without explicit consent. Already-configured installs skip the prompt entirely, as do installs with an explicit `PLUR_TELEMETRY` env var — env wins at runtime, so no contradictory config file is written. To enable after the fact: `PLUR_TELEMETRY=on` env var or edit `~/.plur/telemetry.json`. See [`docs/telemetry-design.md`](docs/telemetry-design.md) for what is collected (learn/recall counters only — no code, no keys, no content).
 
 ## 0.15.0 (2026-07-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,19 @@ One engine, two deployments.
 
 ### BREAKING — the write path is asynchronous
 
-`Plur`'s store interface and roughly twenty public methods now return promises (#728)
-(`learn`, `learnRouted`, `recall`, `recallHybrid`, `inject`, `injectHybrid`,
-`feedback`, `forget`, `getById`, `list`, `status`, `ingest`, `sync`, …).
+`Plur`'s store interface and 23 public methods now return promises (#728):
+`compact`, `episodeToEngram`, `getById`, `ingest`, `inject`, `installPack`,
+`learn`, `list`, `listPinned`, `listStores`, `outboxCount`, `purgeTensions`,
+`recall`, `receipt`, `recordTensions`, `reindex`, `rerankerEvalStatus`,
+`resolveTension`, `saveMetaEngrams`, `setPinned`, `status`, `sync`,
+`updateEngram`.
+
+`learnRouted`, `learnBatch`, `recallHybrid`, `injectHybrid`, `feedback`,
+`forget` and `flushOutbox` were ALREADY async before 0.16 and are unchanged
+here — an earlier draft of this section listed them as newly promise-returning,
+which would have sent you auditing call sites that never moved. `npx
+@plur-ai/migrate` still reports un-awaited calls to them, because such a call
+was a bug before this release too.
 
 **Every out-of-tree consumer must add `await`.** The failure mode is quiet: a
 call whose result is used without awaiting yields a `Promise`, and most

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ because it is a claim a caller may act on.
 
 ### Added
 
+- **Packs install from a URL** (#746): `plur packs install <url>` and
+  `plur packs preview <url>` fetch a pack over HTTP instead of requiring a local
+  directory, so a pack can be shared by link. Preview still runs the security
+  scan before anything is written, and the same scan gates install.
+- **The engram schema tolerates an unknown `commitment` value** (#744): parsing
+  passes through values it does not recognise rather than rejecting the engram,
+  so a store written by a newer or differently-configured deployment stays
+  readable instead of failing the whole load.
 - **`@plur-ai/mcp` exposes a side-effect-free `./tools` subpath** (#714, #717):
   `import { getToolDefinitions } from '@plur-ai/mcp/tools'` yields the tool
   definitions without starting a server or touching stdio, so another server can

--- a/README.md
+++ b/README.md
@@ -398,7 +398,21 @@ Everything is plain YAML. Open it, read it, edit it.
 
 `PLUR_PATH` overrides the default location.
 
-For large stores (>1k engrams), enable the SQLite read index for faster filtered queries. Add `index: true` to `config.yaml`. The YAML file stays the source of truth — the `.db` is a cache that rebuilds automatically. Delete it anytime.
+Indexing is on by default (`index: true`) and the backend is chosen from the
+size of your store, so there is normally nothing to configure:
+
+| Store size | Backend | What answers a query |
+|---|---|---|
+| under 5,000 engrams | `yaml` | in-memory BM25 + exact cosine |
+| 5,000 and up | `pglite` | embedded Postgres + pgvector |
+| 50,000 and up | `postgres` | a Postgres server you point it at |
+
+YAML stays the source of truth in every tier except `postgres` (ADR-0001,
+ADR-0005) — the index is a cache that rebuilds automatically, and you can delete
+it anytime. Set `backend:` in `config.yaml` to pin a tier explicitly.
+
+`sqlite` (`engrams.db`, via `better-sqlite3`) is the legacy index and is no
+longer selected automatically.
 
 ## Requirements
 

--- a/docs/adr/ADR-0003-primary-store-capability.md
+++ b/docs/adr/ADR-0003-primary-store-capability.md
@@ -1,6 +1,6 @@
 # ADR-0003: Primary store capability — separating "the store" from "the index"
 
-Status: **Proposed**
+Status: **Accepted** — implemented in 0.16
 Date: 2026-07-26
 Authors: convergence programme, Phase 1
 Related: ADR-0001 ([#226](https://github.com/plur-ai/plur/issues/226)), ADR-0002, `1-tracks/dev/2026-07-26-plur-convergence-plan.md`
@@ -48,14 +48,24 @@ side of the split it is on.**
 
 `packages/core/src/store/primary-store.ts`:
 
+As shipped in 0.16 (Phase 1 introduced this seam synchronously; Phase 2b made
+it asynchronous — see the amendment at the end of this ADR):
+
 ```ts
 export interface PrimaryStore {
-  readonly kind: PrimaryStoreKind      // 'yaml' | 'memory'
-  readonly location: string | null
-  load(): Engram[]                     // authoritative read, never cached
-  loadCached(): Engram[]               // cached read where the medium allows
-  save(engrams: Engram[]): void        // full replace, drops the read cache
+  readonly kind: PrimaryStoreKind          // 'yaml' | 'memory' | 'postgres' | …
+  readonly location: string | null         // credential-free, safe to log
+  load(): Promise<Engram[]>                // authoritative read, never cached
+  loadCached(): Promise<Engram[]>          // cached read where the medium allows
+  save(engrams: Engram[]): Promise<void>   // full replace, drops the read cache
   invalidate(): void
+
+  // Optional capabilities. Absent = the caller falls back to the general path,
+  // so a minimal store stays a valid store.
+  withExclusiveAccess?<T>(fn: () => Promise<T>): Promise<T>  // ADR-0004
+  updateMany?(engrams: Engram[]): Promise<void>              // targeted write
+  loadByIds?(ids: string[]): Promise<Engram[]>               // targeted read
+  estimateCount?(): number                                   // backend tiering
 }
 ```
 
@@ -198,3 +208,21 @@ repository and is not part of this change.
 - `test/storage-adapter-role.test.ts` pins `requiresIndexSync` /
   `asDerivedIndex` behaviour for both roles, including the malformed
   `role: 'index'` case.
+
+
+## Amendment — 2026-07-28: the interface is asynchronous
+
+This ADR was written with a synchronous `PrimaryStore`, which is what Phase 1
+shipped. Phase 2b (#728) made `load` / `loadCached` / `save` return promises,
+and that is what 0.16 releases.
+
+The reason is the one this ADR exists to serve: a network-backed store cannot
+satisfy a synchronous contract. There is no synchronous Postgres client for
+Node, and manufacturing one (sync-over-async, a worker with `Atomics.wait`)
+trades a documented limitation for an undocumented hazard. Keeping the seam
+synchronous would have meant the seam could never reach the deployment it was
+built for.
+
+The cost is a hard breaking change for `@plur-ai/core` consumers, since async is
+contagious across roughly twenty public `Plur` methods. `npx @plur-ai/migrate`
+exists to absorb it. The block above shows the interface as shipped.

--- a/docs/adr/ADR-0004-concurrency-correctness-before-the-async-flip.md
+++ b/docs/adr/ADR-0004-concurrency-correctness-before-the-async-flip.md
@@ -1,6 +1,6 @@
 # ADR-0004: Concurrency correctness before the async flip
 
-Status: **Proposed**
+Status: **Accepted** — implemented in 0.16
 Date: 2026-07-27
 Authors: convergence programme, Phase 2
 Related: ADR-0003 (primary store capability)

--- a/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
+++ b/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0005: The Postgres tier, and what happens to exact search
 
-Status: **Proposed** — amended 2026-07-27, see
+Status: **Accepted** — implemented in 0.16; amended 2026-07-27, see
 [Update — Phases 2 and 4 have landed](#what-this-phase-does-not-do-and-why)
 Date: 2026-07-26
 Authors: convergence programme, Phase 5

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,9 +12,9 @@ open a PR. Link the issue that prompted the decision in the `Related:` field.
 |---|-------|--------|------|-------|
 | 0001 | [YAML as source of truth for engram state](https://github.com/plur-ai/plur/issues/226) | Accepted | 2025-09 | [#226](https://github.com/plur-ai/plur/issues/226) |
 | 0002 | [Derived-state provenance — history JSONL as source of truth for graph edges](ADR-0002-derived-state-provenance.md) | Accepted | 2026-07-02 | [#452](https://github.com/plur-ai/plur/issues/452) |
-| 0003 | [Primary store capability — separating "the store" from "the index"](ADR-0003-primary-store-capability.md) | Proposed | 2026-07-26 | — |
-| 0004 | [Concurrency correctness before the async flip](ADR-0004-concurrency-correctness-before-the-async-flip.md) | Proposed | 2026-07-27 | — |
-| 0005 | [The Postgres tier, and what happens to exact search](ADR-0005-postgres-tier-and-vector-index-strategy.md) | Proposed | 2026-07-26 | — |
+| 0003 | [Primary store capability — separating "the store" from "the index"](ADR-0003-primary-store-capability.md) | Accepted | 2026-07-26 | — |
+| 0004 | [Concurrency correctness before the async flip](ADR-0004-concurrency-correctness-before-the-async-flip.md) | Accepted | 2026-07-27 | — |
+| 0005 | [The Postgres tier, and what happens to exact search](ADR-0005-postgres-tier-and-vector-index-strategy.md) | Accepted | 2026-07-26 | — |
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:smoke": "vitest run packages/core/test/remote-smoke.test.ts",
     "test:watch": "vitest",
     "bench:micro": "npx tsx benchmark/micro.ts",
-    "typecheck:tests": "tsc -p tsconfig.tests.json --noEmit"
+    "typecheck:tests": "tsc -p tsconfig.tests.json --noEmit",
+    "smoke:release": "bash scripts/smoke-release.sh"
   },
   "devDependencies": {
     "@types/node": "25.5.0",

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -5,24 +5,89 @@ import { PackManifestSchema, type PackManifest } from './schemas/pack.js'
 import { logger } from './logger.js'
 import { atomicWrite } from './sync.js'
 
+/**
+ * Error thrown when the engram file exists but cannot be read as engrams.
+ *
+ * Distinct from "the store is empty" ON PURPOSE — see {@link loadEngrams}.
+ */
+export class EngramStoreUnreadableError extends Error {
+  constructor(readonly filePath: string, readonly cause: unknown) {
+    super(
+      `[plur] refusing to read ${filePath}: ${cause}\n` +
+      `The file exists but is not valid engram YAML, so PLUR cannot tell how many engrams it holds. ` +
+      `It is NOT being treated as empty: the write path replaces the whole file, so a write against an ` +
+      `"empty" store would destroy every engram in it.\n` +
+      `Common cause: a git merge conflict in engrams.yaml after 'plur sync' — look for <<<<<<< markers. ` +
+      `Fix the file (or restore it from git history) and retry.`,
+    )
+    this.name = 'EngramStoreUnreadableError'
+  }
+}
+
+/**
+ * Read engrams from a YAML store.
+ *
+ * ## Why a parse failure THROWS instead of returning []
+ *
+ * A missing file really is an empty store, so that returns `[]`. A file that
+ * exists but will not parse is a different fact, and conflating the two used to
+ * destroy data:
+ *
+ *   1. `engrams.yaml` becomes unparseable — most plausibly a git merge conflict
+ *      after `plur sync`, which puts `<<<<<<<` markers straight into the file.
+ *   2. This function caught the error, logged it, and returned `[]`.
+ *   3. Every `Plur` write is load -> mutate -> save, and `save` replaces the
+ *      WHOLE file. So the next `learn()` wrote a one-engram corpus.
+ *   4. Every prior engram was gone, unrecoverable from the file.
+ *
+ * Measured before the fix: a store with 5 engrams, corrupted, then one write —
+ * the file afterwards contained exactly 1 engram and none of the originals.
+ * The `logger.error` on the way past was visible, but the RETURN VALUE lied,
+ * and the caller acted on the return value.
+ *
+ * So: unreadable is not empty. Callers that genuinely want "treat unreadable as
+ * empty" — a diagnostic counter, a best-effort probe — must catch
+ * {@link EngramStoreUnreadableError} and say so at the call site.
+ *
+ * Individually invalid ENTRIES are still skipped rather than fatal: one bad
+ * engram among many is a partial-data problem, not an unreadable-store problem,
+ * and dropping it loses less than refusing to load the rest. That skip is
+ * counted and warned about.
+ */
 export function loadEngrams(filePath: string): Engram[] {
   if (!fs.existsSync(filePath)) return []
+  // A directory is a misconfiguration (`stores[].path` must name an
+  // engrams.yaml, since it is handed straight to this function) — but NOT a
+  // data-loss risk, which is what the throw below exists for. `saveEngrams`
+  // cannot write to a directory either, so there is no path where a directory
+  // read as "empty" leads to an overwrite. Treating it as empty preserves
+  // long-standing behaviour; the throw is reserved for the case that actually
+  // destroys data.
+  if (fs.statSync(filePath).isDirectory()) return []
+  let raw: any
   try {
-    const raw = yaml.load(fs.readFileSync(filePath, 'utf8')) as any
-    if (!raw?.engrams || !Array.isArray(raw.engrams)) return []
-    const valid: Engram[] = []
-    let skipped = 0
-    for (const entry of raw.engrams) {
-      const result = EngramSchemaPassthrough.safeParse(entry)
-      if (result.success) valid.push(result.data)
-      else skipped++
-    }
-    if (skipped > 0) logger.warning(`Skipped ${skipped} invalid engram(s) in ${filePath}`)
-    return valid
+    raw = yaml.load(fs.readFileSync(filePath, 'utf8'))
   } catch (err) {
-    logger.error(`Failed to parse engrams file ${filePath}: ${err}`)
+    throw new EngramStoreUnreadableError(filePath, err)
+  }
+  // A file that parses but has no `engrams` array is genuinely empty — a fresh
+  // store, or one whose only content is comments.
+  if (raw == null) return []
+  if (!raw.engrams || !Array.isArray(raw.engrams)) {
+    if (typeof raw !== 'object') {
+      throw new EngramStoreUnreadableError(filePath, new Error('top-level value is not a mapping'))
+    }
     return []
   }
+  const valid: Engram[] = []
+  let skipped = 0
+  for (const entry of raw.engrams) {
+    const result = EngramSchemaPassthrough.safeParse(entry)
+    if (result.success) valid.push(result.data)
+    else skipped++
+  }
+  if (skipped > 0) logger.warning(`Skipped ${skipped} invalid engram(s) in ${filePath}`)
+  return valid
 }
 
 export function saveEngrams(filePath: string, engrams: Engram[]): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,7 @@ export { generateGuardrails } from './guardrails.js'
 export type { MetaField, StructuralTemplate, EvidenceEntry, MetaConfidence, DomainCoverage, HierarchyPosition, Falsification } from './schemas/meta-engram.js'
 export { MetaFieldSchema, StructuralTemplateSchema, EvidenceEntrySchema, MetaConfidenceSchema, DomainCoverageSchema, HierarchyPositionSchema, FalsificationSchema } from './schemas/meta-engram.js'
 export { engramSearchText, termMatches, computeIdf, type CorpusStats } from './fts.js'
+export { EngramStoreUnreadableError } from './engrams.js'
 export { freshTailBoost } from './fresh-tail.js'
 export { autoSummary, generateSummary, needsSummary } from './summary.js'
 export { selectModel, selectModelForOperation, resolveOperationTier, type ModelTier, type LlmTierConfig } from './model-routing.js'
@@ -442,6 +443,16 @@ const INGEST_PATTERNS = [
   { re: /(?:use|prefer)\s+(\w+)\s+(?:for|over|instead of)\s+(.+?)\.?$/gim, type: 'behavioral' as const },
   { re: /(?:important|note|remember):\s*(.+?)\.?$/gim, type: 'behavioral' as const },
 ]
+
+/**
+ * How many extra candidates a pushdown fetches per requested result.
+ *
+ * The store cannot evaluate expiry or `min_strength`, so those run after the
+ * SQL LIMIT. Without headroom a page of `limit` rows that are then filtered
+ * returns short — and short is invisible: the caller gets fewer results and no
+ * indication that any were removed.
+ */
+const PUSHDOWN_OVERFETCH = 3
 
 export class Plur {
   private paths: PlurPaths
@@ -2286,19 +2297,46 @@ export class Plur {
     // parity-tested against real Postgres but had ZERO call sites — built and
     // unreachable. This is the wiring.
     //
-    // The adapter is handed the SAME filter this method would have applied in
-    // memory, so scope, domain and the permitted-scope allow-list are enforced
-    // in the query rather than after it. That is the point: post-filtering
-    // measures `limit` against rows the caller may not be allowed to see.
+    // Scope, domain and the permitted-scope allow-list go INTO the query, so
+    // `limit` is not spent on rows the caller may not see.
+    //
+    // The rest of `_filterEngrams`'s work still has to happen, and an earlier
+    // version of this branch simply returned here — which silently dropped four
+    // things the in-memory path applies:
+    //
+    //   - temporal validity: an engram whose `valid_until` has passed was
+    //     returned as current. A fact explicitly withdrawn in 2020 was injected
+    //     into an agent's context by `recall()` while `list()` correctly
+    //     excluded it. Reproduced, not theorised.
+    //   - `min_strength`
+    //   - engrams merged in from `config.stores` (team/enterprise stores)
+    //   - pack engrams
+    //
+    // The last two are the ones that would have been reported as "recall is
+    // broken": on the Postgres tier `plur_recall` stopped returning the team
+    // store entirely, while `recallHybrid` on the SAME instance still did.
+    //
+    // The adapter cannot answer those — it queries one table and knows nothing
+    // about packs, secondary stores, or the caller's clock. So the pushdown is
+    // a NARROWING step, not a replacement: it returns a superset, and the
+    // remaining predicates are applied here. `limit` is applied last, after all
+    // of them, so a row removed by expiry does not consume a slot.
     const adapter = this._primaryQueryAdapter()
     if (adapter) {
-      const results = await adapter.searchBM25(query, {
-        limit,
+      const narrowed = await adapter.searchBM25(query, {
+        // Over-fetch: post-filters below can remove rows, and a row dropped
+        // after a LIMIT is a result the caller silently never sees.
+        limit: Math.max(limit * PUSHDOWN_OVERFETCH, limit),
         status: 'active',
         scope: options?.scope,
         scopes: options?.scopes,
         domain: options?.domain,
       })
+      const extra = await this._engramsOutsidePrimaryStore(options)
+      const merged = extra.length > 0
+        ? [...narrowed, ...searchEngrams(this._applyResidualFilters(extra, options), query, limit)]
+        : narrowed
+      const results = this._applyResidualFilters(merged, options).slice(0, limit)
       await this._reactivateResults(results)
       return results
     }
@@ -2732,6 +2770,77 @@ export class Plur {
   }
 
   /** Filter engrams by scope/domain/strength (shared by both modes) */
+  /**
+   * Predicates a store CANNOT answer, applied after a pushdown narrows.
+   *
+   * `searchBM25` filters status/scope/domain/scopes in SQL. Temporal validity
+   * and `min_strength` are not columns it can filter on — validity depends on
+   * the caller's clock, and strength lives inside the JSONB payload — so they
+   * have to run here, on the rows that came back.
+   *
+   * Deliberately a shared helper rather than a copy of the tail of
+   * `_filterEngrams`: two implementations of "which engrams count" is how the
+   * pushdown branch came to silently disagree with `list()` in the first place.
+   */
+  private _applyResidualFilters(engrams: Engram[], options?: RecallOptions & { include_expired?: boolean }): Engram[] {
+    let out = engrams
+    if (!options?.include_expired) {
+      const today = new Date().toISOString().slice(0, 10)
+      out = out.filter(e => {
+        if (e.temporal?.valid_until && e.temporal.valid_until < today) return false
+        if (e.temporal?.valid_from && e.temporal.valid_from > today) return false
+        return true
+      })
+    }
+    if (options?.min_strength !== undefined) {
+      out = out.filter(e => e.activation.retrieval_strength >= options.min_strength!)
+    }
+    return out
+  }
+
+  /**
+   * Engrams a primary-store pushdown cannot see: secondary (team/project)
+   * stores from `config.stores`, and installed packs.
+   *
+   * `searchBM25` queries ONE table. `_loadAllEngrams` merges these in, so
+   * without this the Postgres tier answered `recall()` from the primary store
+   * alone — an enterprise user's team store vanished from `plur_recall` while
+   * `recallHybrid` on the same instance still returned it. No error, no
+   * warning: just fewer results.
+   *
+   * Scope and domain are applied here to mirror what the SQL side does to the
+   * primary rows; the residual filters are applied by the caller.
+   */
+  private async _engramsOutsidePrimaryStore(options?: RecallOptions): Promise<Engram[]> {
+    const out: Engram[] = []
+    for (const store of this.config.stores ?? []) {
+      if (!store.path || store.url) continue
+      if (store.path === this.paths.engrams) continue
+      try {
+        out.push(...(await this._loadCached(store.path)))
+      } catch {
+        // A secondary store that will not load must not take down a recall
+        // against the primary one. `loadEngrams` throws on an unreadable file
+        // (see EngramStoreUnreadableError) and that is the right default; here
+        // the primary result is still useful, so degrade rather than fail.
+        logger.warning(`[plur] secondary store ${store.path} could not be read; excluded from this recall`)
+      }
+    }
+    for (const pack of loadAllPacks(this.paths.packs)) out.push(...pack.engrams)
+
+    let filtered = out.filter(e => e.status === 'active')
+    if (options?.scopes !== undefined) {
+      const allowed = scopeAllowFilter(options.scopes)
+      filtered = filtered.filter(e => allowed(e.scope))
+    }
+    if (options?.domain) filtered = filtered.filter(e => e.domain?.startsWith(options.domain!))
+    if (options?.scope) {
+      const scope = options.scope
+      filtered = filtered.filter(e => isScopeWithin(e.scope, scope) || isPersonalScope(e.scope))
+    }
+    return filtered
+  }
+
   private async _filterEngrams(options?: RecallOptions & { include_expired?: boolean }): Promise<Engram[]> {
     let engrams: Engram[]
     if (this.indexedStorage) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3573,7 +3573,12 @@ export class Plur {
 
   /**
    * Toggle the always-load (pinned) flag for an engram.
-   * Returns the updated engram on success, null if not found.
+   *
+   * Returns the updated engram on success, `null` if it is not found in the
+   * local primary store or in any writable remote. Since 0.16 the remote PATCH
+   * is awaited and its result returned, so the value is the real engram rather
+   * than a placeholder — {@link setPinnedAsync} is now equivalent and kept only
+   * for source compatibility.
    */
   async setPinned(id: string, pinned: boolean): Promise<Engram | null> {
     // Local primary first.
@@ -3597,15 +3602,20 @@ export class Plur {
       const serverId = this._stripRemotePrefix(id, entry.scope)
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
       try {
-        // Note: PATCH is async but setPinned() preserves its sync API for
-        // backward compat. We block on a sync-bridge via deasync would be
-        // bad; instead we do a fire-and-forget mutation and let the next
-        // load() observe the change. The local cache invalidates on patch.
-        // Callers needing strict ordering should call setPinnedAsync (TODO).
-        void driver.patch(serverId, { pinned: pinned === true ? true : undefined })
-        // Return a synthesized view of the expected result so callers don't
-        // see null. The real engram comes back on next load() / getById().
-        return { id, pinned: pinned === true ? true : undefined } as unknown as Engram
+        // Awaited, and the SERVER's engram is returned.
+        //
+        // This used to fire-and-forget the PATCH and return
+        // `{ id, pinned } as unknown as Engram` — an object that is not an
+        // Engram at all (no statement, scope, status or activation), so
+        // `(await plur.setPinned(id, true)).statement` was `undefined`. It also
+        // reported success before the write had happened, and a rejected
+        // floating promise could not be caught by the `catch` below.
+        //
+        // The justification was that `setPinned` had to keep a synchronous
+        // signature. It is `async` since the 0.16 flip, so that reason is gone
+        // and the honest version costs nothing.
+        const patched = await driver.patch(serverId, { pinned: pinned === true ? true : undefined })
+        if (patched) return patched
       } catch {
         continue
       }
@@ -3614,9 +3624,8 @@ export class Plur {
   }
 
   /**
-   * Async variant of setPinned that awaits remote PATCH so callers can
-   * observe the post-write state. Use this when ordering matters
-   * (e.g. test assertions immediately after a pin call).
+   * @deprecated Equivalent to {@link setPinned} since 0.16 — that method now
+   * awaits the remote PATCH too. Kept so existing callers keep compiling.
    */
   async setPinnedAsync(id: string, pinned: boolean): Promise<Engram | null> {
     // Local primary first.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -726,9 +726,30 @@ export class Plur {
    */
   private async _loadAllEngrams(): Promise<Engram[]> {
     const primary = await this._loadCached(this.paths.engrams)
-    const stores = this.config.stores ?? []
+    return [...primary, ...(await this._loadSecondaryAndPacks())]
+  }
 
-    const all: Engram[] = [...primary]
+  /**
+   * Everything that is NOT the primary store: configured secondary stores
+   * (file-path AND remote) plus installed packs, with the id namespacing, scope
+   * narrowing and containment guard applied.
+   *
+   * Extracted so the BM25 pushdown path can reach these rows without loading the
+   * primary corpus — the whole point of pushing the query into the store. An
+   * earlier version of that path re-implemented this loop and got three things
+   * wrong at once: it skipped `url` stores entirely (so an enterprise team store
+   * vanished from `recall()` while `list()` still showed it), and it returned
+   * rows RAW — no namespacing, no `global` narrowing, no `isScopeWithin` guard.
+   * The namespacing one had teeth beyond cosmetics: both stores mint
+   * `ENG-YYYY-MMDD-NNN` from a per-store daily sequence, so ids collide as the
+   * common case, and `feedback()` / `forget()` resolve by exact id against the
+   * primary store first — mutating an unrelated engram.
+   *
+   * One implementation, two callers. Duplicating it is what caused all three.
+   */
+  private async _loadSecondaryAndPacks(): Promise<Engram[]> {
+    const stores = this.config.stores ?? []
+    const all: Engram[] = []
     for (const store of stores) {
       const storeEngrams = store.url
         ? this._loadRemoteCached(store)
@@ -2812,23 +2833,11 @@ export class Plur {
    * primary rows; the residual filters are applied by the caller.
    */
   private async _engramsOutsidePrimaryStore(options?: RecallOptions): Promise<Engram[]> {
-    const out: Engram[] = []
-    for (const store of this.config.stores ?? []) {
-      if (!store.path || store.url) continue
-      if (store.path === this.paths.engrams) continue
-      try {
-        out.push(...(await this._loadCached(store.path)))
-      } catch {
-        // A secondary store that will not load must not take down a recall
-        // against the primary one. `loadEngrams` throws on an unreadable file
-        // (see EngramStoreUnreadableError) and that is the right default; here
-        // the primary result is still useful, so degrade rather than fail.
-        logger.warning(`[plur] secondary store ${store.path} could not be read; excluded from this recall`)
-      }
-    }
-    for (const pack of loadAllPacks(this.paths.packs)) out.push(...pack.engrams)
-
-    let filtered = out.filter(e => e.status === 'active')
+    // Delegates to the SAME loader `_loadAllEngrams` uses, so remote stores,
+    // id namespacing, scope narrowing and the containment guard cannot drift
+    // between the pushdown path and every other read path. This method used to
+    // re-implement that loop and got all four wrong.
+    let filtered = (await this._loadSecondaryAndPacks()).filter(e => e.status === 'active')
     if (options?.scopes !== undefined) {
       const allowed = scopeAllowFilter(options.scopes)
       filtered = filtered.filter(e => allowed(e.scope))

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2922,10 +2922,30 @@ export class Plur {
     const primaryResults = results.filter(e => !isStoreEngram(e))
     if (primaryResults.length === 0) return
     await this._withStoreLock(this.paths.engrams, async () => {
-      const allEngrams = await this._primaryStore.load()
       const resultIds = new Set(primaryResults.map(e => e.id))
+      // Read only the engrams this recall touched, when the store can.
+      // Everything below is keyed by id — the reactivation targets `resultIds`
+      // and the co-access edges only ever look up sources drawn from the
+      // results — so materialising the corpus was pure overhead. Re-read under
+      // the lock rather than reusing the search results, so two concurrent
+      // recalls cannot both increment from the same stale counter.
+      const store = this._storeAt(this.paths.engrams)
+      const allEngrams = store.loadByIds
+        ? await store.loadByIds([...resultIds])
+        : await this._primaryStore.load()
       const today = new Date().toISOString().slice(0, 10)
-      let modified = false
+      // WHICH engrams changed, not merely whether any did.
+      //
+      // This wrote the whole corpus back on every read — activation is updated
+      // on each recall, and `_writeEngrams` is a full replace. Measured on
+      // Postgres: 252ms for 2,000 engrams, extrapolating to ~6.3s at 50,000,
+      // which is the corpus size at which that tier is selected in the first
+      // place. All of it under the global write lock, so every writer queued
+      // behind every reader.
+      //
+      // A recall touches a handful of rows. Tracking them lets a store that
+      // supports targeted updates write only those.
+      const touched = new Map<string, Engram>()
 
       // Reactivate accessed engrams
       for (const e of allEngrams) {
@@ -2933,7 +2953,7 @@ export class Plur {
           e.activation.retrieval_strength = reactivate(e.activation.retrieval_strength)
           e.activation.last_accessed = today
           e.activation.frequency += 1
-          modified = true
+          touched.set(e.id, e)
         }
       }
 
@@ -2956,7 +2976,7 @@ export class Plur {
             if (existing) {
               existing.strength = Math.min(0.95, existing.strength + 0.05)
               existing.updated_at = today
-              modified = true
+              touched.set(source.id, source)
             } else {
               const coAccessCount = source.associations.filter(a => a.type === 'co_accessed').length
               if (coAccessCount < 5) {
@@ -2967,17 +2987,24 @@ export class Plur {
                   strength: 0.3,
                   updated_at: today,
                 })
-                modified = true
+                touched.set(source.id, source)
               }
             }
           }
         }
       }
 
-      if (modified) {
+      if (touched.size === 0) return
+
+      if (store.updateMany) {
+        // Targeted: rewrites the handful of rows a recall actually touched.
+        await store.updateMany([...touched.values()])
+      } else {
+        // A single-file store has no cheaper option — the whole file is
+        // rewritten either way, so this is the same cost it always was.
         await this._writeEngrams(this.paths.engrams, allEngrams)
-        await this._syncIndex()
       }
+      await this._syncIndex()
     })
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1188,8 +1188,13 @@ export class Plur {
 
     type PersistenceTarget = 'primary' | 'secondary' | 'in-memory'
     const primaryIdx = engrams.findIndex(e => e.id === hit.id)
-    let persistedTo: PersistenceTarget
-    let newRecurrence: number
+    // Definite-assignment asserted: every branch below assigns both, but one of
+    // those branches now runs inside the secondary store's lock callback, which
+    // TypeScript cannot prove is invoked. The alternative — threading both
+    // values out through the callback's return type — obscures the control flow
+    // for no benefit, since the callback is awaited on the same line.
+    let persistedTo!: PersistenceTarget
+    let newRecurrence!: number
 
     if (primaryIdx !== -1) {
       // Primary store: mutate the engram in the loaded array (symmetric with
@@ -1208,6 +1213,13 @@ export class Plur {
       // primaryIdx already proved this isn't in primary; only check writability.
       const storeInfo = await this._findEngramStore(hit.id)
       if (storeInfo && !storeInfo.readonly) {
+        // Under the SECONDARY store's own lock. This read-modify-write had none
+        // at all, while the identical operation on the primary store took one:
+        // two processes recording recurrence on the same team engram both
+        // loaded, both mutated, and both wrote — and because `_writeEngrams`
+        // replaces the whole file, whatever the other added in between was
+        // deleted outright, not merely overwritten.
+        await this._withStoreLock(storeInfo.path, async () => {
         const storeEngrams = await this._storeAt(storeInfo.path).load()
         const sidx = storeEngrams.findIndex(e => e.id === storeInfo.originalId)
         // Audit iter-5 defense (Critic low #3): _crossScopeRecurrenceDetect
@@ -1238,6 +1250,7 @@ export class Plur {
           newRecurrence = applyMutation(hit, sourceEntry, lockTimestamp)
           persistedTo = 'in-memory'
         }
+        })
       } else {
         // Readonly or remote — apply to hit only. Remote PATCH wiring tracked
         // separately; in-memory state is still returned to the caller.
@@ -2965,6 +2978,13 @@ export class Plur {
         for (const sourceId of topIds) {
           const source = allEngrams.find(e => e.id === sourceId)
           if (!source) continue
+          // Normalise before use. `associations` has a schema default, but a row
+          // that reaches here WITHOUT going through the schema — one written by
+          // an older version, a migration, or any tool that talks to the table
+          // directly — has no such guarantee, and `undefined.find(...)` takes
+          // down the whole recall. Reads should not be able to crash on a row
+          // they merely passed over.
+          if (!Array.isArray(source.associations)) source.associations = []
 
           for (const targetId of topIds) {
             if (targetId === sourceId) continue
@@ -3294,6 +3314,14 @@ export class Plur {
       if (storeInfo.readonly) {
         throw new Error('Engram is in a readonly store')
       }
+      // Under the SECONDARY store's own lock — this had none, while the same
+      // operation on the primary store took one. Two processes rating the same
+      // team engram both loaded, both incremented, and both wrote back, so one
+      // increment vanished; and a whole-file replace also deletes anything the
+      // other process added in between.
+      // Returns whether the engram was found and handled here; a miss falls
+      // through to the remote-store search below.
+      const handled = await this._withStoreLock(storeInfo.path, async () => {
       // Must load fresh (not cached) since we're about to mutate and write back
       const storeEngrams = await this._storeAt(storeInfo.path).load()
       const engram = storeEngrams.find(e => e.id === storeInfo.originalId)
@@ -3315,8 +3343,11 @@ export class Plur {
         await this._writeEngrams(storeInfo.path, storeEngrams)
         await this._syncIndex()
         this._logInjectionOutcome(id, signal)
-        return
+        return true
       }
+      return false
+      })
+      if (handled) return
     }
 
     // Check remote stores — the engram may live on an enterprise server.

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -57,6 +57,27 @@ export interface LearnAsyncDeps {
   offendingHitsForScope: (statement: string, scope: string) => SecretMatch[]
 }
 
+
+/**
+ * Run `fn` under exclusive access to the store — the store's own mechanism when
+ * it has one, the path-based file lock otherwise.
+ *
+ * Mirrors `Plur._withStoreLock`, and exists for the same reason. These writes
+ * are load -> mutate -> `store.save(all)`, which REPLACES the whole corpus, so
+ * two concurrent writers do not merely lose an update: the loser deletes rows
+ * the winner committed.
+ *
+ * This module locked on `deps.engramsPath` unconditionally — an `O_EXCL` file on
+ * the LOCAL disk. That is correct for a YAML store, where the path being locked
+ * IS the data, and worthless for a shared database: two processes share neither
+ * the mutex nor the file. So `learnAsync` and `learnBatch` bypassed the Postgres
+ * advisory lock that every other write path takes.
+ */
+async function withStoreLock<T>(deps: LearnAsyncDeps, fn: () => Promise<T>): Promise<T> {
+  if (deps.store.withExclusiveAccess) return await deps.store.withExclusiveAccess(fn)
+  return await withAsyncLock(deps.engramsPath, fn)
+}
+
 /**
  * Demote an engram in place when its (post-mutation) statement carries content
  * the engram's shared scope forbids. Local write, so demotion is coherent:
@@ -132,7 +153,7 @@ async function executeDedupDecision(
       if (targetId) {
         const existing = await deps.getById(targetId)
         if (existing && (existing as any).commitment !== 'locked') {
-          const result = await withAsyncLock(deps.engramsPath, async () => {
+          const result = await withStoreLock(deps, async () => {
             const engrams = await deps.store.load()
             const idx = engrams.findIndex(e => e.id === targetId)
             // Target gone — fall out of the lock and ADD; see the doc comment.
@@ -167,7 +188,7 @@ async function executeDedupDecision(
       if (targetId) {
         const existing = await deps.getById(targetId)
         if (existing && (existing as any).commitment !== 'locked') {
-          const result = await withAsyncLock(deps.engramsPath, async () => {
+          const result = await withStoreLock(deps, async () => {
             const engrams = await deps.store.load()
             const idx = engrams.findIndex(e => e.id === targetId)
             // Target gone — fall out of the lock and ADD; see the doc comment.

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -303,7 +303,12 @@ export function uninstallPack(packsDir: string, name: string): UninstallResult {
   // Count engrams and get manifest name before removal
   const engramsPath = path.join(packDir, 'engrams.yaml')
   let count = 0
-  try { count = loadEngrams(engramsPath).length } catch {}
+  // Legitimately best-effort: this number is only for the removal report, and a
+  // pack whose engrams.yaml is unreadable is still removable. `loadEngrams` now
+  // THROWS on an unreadable file rather than returning [] — deliberately, because
+  // the write path treats [] as "empty" and would then destroy the store — so
+  // this catch is the explicit opt-in to "unknown, and that is fine here".
+  try { count = loadEngrams(engramsPath).length } catch { count = 0 }
   let manifestName: string | undefined
   try { manifestName = loadPack(packDir).manifest.name } catch {}
 

--- a/packages/core/src/quality.ts
+++ b/packages/core/src/quality.ts
@@ -38,7 +38,7 @@ function contentScore(e: Engram): number {
 function groundingScore(e: Engram): number {
   let score = 0
   if (e.knowledge_anchors.length > 0) score += 0.4
-  if (e.associations.length > 0) score += 0.3
+  if ((e.associations?.length ?? 0) > 0) score += 0.3
   if (e.source_patterns && e.source_patterns.length > 0) score += 0.15
   if (e.entities && e.entities.length > 0) score += 0.15
   return Math.min(1.0, score)

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -264,6 +264,28 @@ export const DERIVED_INDEX_DEFAULTS = {
   vectorIndex: EXACT_VECTOR_INDEX,
 } as const satisfies { role: StorageAdapterRole; vectorIndex: VectorIndexStrategy }
 
+
+/**
+ * Escape LIKE metacharacters in a caller-supplied value.
+ *
+ * `buildFilterClause` puts `filter.scope` and `filter.domain` straight into
+ * LIKE patterns. Unescaped, a `%` from the caller widens the match instead of
+ * narrowing it — `{ domain: '%' }` returns every domain, and `{ scope: '%' }`
+ * returns engrams from unrelated groups, which is exactly the segment-aware
+ * containment the #383 guard exists to enforce. Both verified against a live
+ * database before this was added.
+ *
+ * Shared by every adapter on purpose: the scope rules have already drifted once
+ * between the Postgres and PGLite copies, and that drift was an authorization
+ * bypass. One implementation, or it happens again.
+ *
+ * Callers must pair this with `ESCAPE '\'` on the LIKE, so the escape
+ * character does not depend on the server's `standard_conforming_strings`.
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, c => `\\${c}`)
+}
+
 /** Async-style storage adapter. */
 export interface StorageAdapter {
   /**

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -37,6 +37,7 @@ import type {
   VectorIndexStrategy,
   VectorSearchHit,
 } from './storage-adapter.js'
+import { escapeLikePattern } from './storage-adapter.js'
 
 /** Vector dimension used by the default BGE-small-en-v1.5 model. */
 const DEFAULT_VECTOR_DIM = 384
@@ -413,13 +414,16 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
       //      descendant on a REAL delimiter (`:`/`/`) — never a sibling prefix.
       conditions.push(
         `((NOT (${col}scope LIKE 'group:%' OR ${col}scope LIKE 'project:%' OR ${col}scope LIKE 'space:%' OR ${col}scope LIKE 'team:%' OR ${col}scope LIKE 'org:%' OR ${col}scope = 'public' OR ${col}scope LIKE 'public:%' OR ${col}scope LIKE 'public/%'))`
-        + ` OR ${col}scope = $${i++} OR ${col}scope LIKE $${i++} || ':%' OR ${col}scope LIKE $${i++} || '/%')`,
+        + ` OR ${col}scope = $${i++} OR ${col}scope LIKE $${i++} || ':%' ESCAPE '\\' OR ${col}scope LIKE $${i++} || '/%' ESCAPE '\\')`,
       )
-      params.push(filter.scope, filter.scope, filter.scope)
+      // Escaped for the same reason as the Postgres copy — these two clauses
+      // must stay identical; they have drifted before, and that drift was an
+      // authorization bypass.
+      params.push(filter.scope, escapeLikePattern(filter.scope), escapeLikePattern(filter.scope))
     }
     if (filter.domain) {
-      conditions.push(`${col}domain LIKE $${i++} || '%'`)
-      params.push(filter.domain)
+      conditions.push(`${col}domain LIKE $${i++} || '%' ESCAPE '\\'`)
+      params.push(escapeLikePattern(filter.domain))
     }
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
     return { where, params, nextIndex: i }

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -420,21 +420,83 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     return this.pool
   }
 
+  /**
+   * SQLSTATEs that mean "another process created this object first".
+   *
+   * Postgres `CREATE ... IF NOT EXISTS` is check-then-act, not atomic: two
+   * sessions can both pass the existence check and one then fails on the
+   * catalog's unique index. Under the init lock below this should not happen,
+   * but a rolling upgrade can have an older adapter doing unlocked DDL at the
+   * same time, so the benign case is tolerated rather than fatal.
+   */
+  private static readonly DUPLICATE_OBJECT_CODES = new Set([
+    '23505', // unique_violation on a catalog index (pg_namespace, pg_type, pg_class, pg_extension)
+    '42P06', // duplicate_schema
+    '42P07', // duplicate_table
+    '42701', // duplicate_column
+    '42710', // duplicate_object
+  ])
+
+  /** Run one DDL statement, treating "someone else already made it" as success. */
+  private async ddl(client: any, sql: string): Promise<void> {
+    try {
+      await client.query(sql)
+    } catch (err) {
+      const code = (err as { code?: string }).code
+      if (code && PostgresAdapter.DUPLICATE_OBJECT_CODES.has(code)) return
+      throw err
+    }
+  }
+
+  /**
+   * Create the schema, serialised across processes by an advisory lock.
+   *
+   * Without the lock, N processes cold-starting against one fresh database all
+   * run `CREATE ... IF NOT EXISTS` at once and most of them die on a catalog
+   * unique violation. Measured on PostgreSQL 16 with 8 concurrent workers and
+   * an empty schema: 7 of 8 failed, and the pgvector failure surfaced as
+   * "install the extension as a superuser" — a permissions diagnosis for what
+   * is actually a race, sending the operator to fix the wrong thing.
+   *
+   * That is exactly the shape of a server deployment starting its replicas, so
+   * it would have shown up on the first multi-process boot.
+   *
+   * The lock is taken on ONE pooled client and every statement runs on that
+   * same client: holding a connection for the lock while the DDL asks the pool
+   * for a second one deadlocks whenever `maxConnections` is 1.
+   */
   private async initSchema(): Promise<void> {
-    const pool = this.pool
-    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${this.schema}"`)
+    const client = await this.pool.connect()
+    const key = `plur:init:${this.schema}`
+    let locked = false
+    try {
+      await client.query('SELECT pg_advisory_lock(hashtext($1))', [key])
+      locked = true
+      await this.initSchemaLocked(client)
+    } finally {
+      if (locked) {
+        // Best-effort: the session ends on release anyway, and Postgres drops
+        // session advisory locks with the session.
+        try { await client.query('SELECT pg_advisory_unlock(hashtext($1))', [key]) } catch { /* released with the session */ }
+      }
+      client.release()
+    }
+  }
+
+  private async initSchemaLocked(client: any): Promise<void> {
+    await this.ddl(client, `CREATE SCHEMA IF NOT EXISTS "${this.schema}"`)
     // Extensions are per-database. Installing into `public` (the conventional
     // home) keeps one copy shared by every PLUR schema in the database; the
     // search_path above is what makes the type resolvable from ours.
     try {
-      await pool.query('CREATE EXTENSION IF NOT EXISTS vector SCHEMA public')
+      await this.ddl(client, 'CREATE EXTENSION IF NOT EXISTS vector SCHEMA public')
     } catch (err) {
       throw new Error(
         `[postgres] pgvector is required but could not be enabled: ${(err as Error).message}. `
         + `Install the extension (CREATE EXTENSION vector) as a superuser, or grant the PLUR role rights to create it.`,
       )
     }
-    await pool.query(`
+    await this.ddl(client, `
       CREATE TABLE IF NOT EXISTS "${this.schema}".engrams (
         id TEXT PRIMARY KEY,
         status TEXT NOT NULL,
@@ -445,10 +507,10 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
         source TEXT NOT NULL DEFAULT 'primary'
       )
     `)
-    await pool.query(`CREATE INDEX IF NOT EXISTS idx_engrams_status ON "${this.schema}".engrams(status)`)
-    await pool.query(`CREATE INDEX IF NOT EXISTS idx_engrams_scope ON "${this.schema}".engrams(scope)`)
-    await pool.query(`CREATE INDEX IF NOT EXISTS idx_engrams_domain ON "${this.schema}".engrams(domain)`)
-    await pool.query(`CREATE INDEX IF NOT EXISTS idx_engrams_source ON "${this.schema}".engrams(source)`)
+    await this.ddl(client, `CREATE INDEX IF NOT EXISTS idx_engrams_status ON "${this.schema}".engrams(status)`)
+    await this.ddl(client, `CREATE INDEX IF NOT EXISTS idx_engrams_scope ON "${this.schema}".engrams(scope)`)
+    await this.ddl(client, `CREATE INDEX IF NOT EXISTS idx_engrams_domain ON "${this.schema}".engrams(domain)`)
+    await this.ddl(client, `CREATE INDEX IF NOT EXISTS idx_engrams_source ON "${this.schema}".engrams(source)`)
 
     // --- BM25 pushdown (Phase 4, #711) ---
     //
@@ -466,10 +528,10 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     //                               enumerable at query time because qt is
     //                               known, which is exactly what #721's change
     //                               from `qt.includes(t)` bought.
-    await pool.query(`ALTER TABLE "${this.schema}".engrams ADD COLUMN IF NOT EXISTS tokens TEXT[]`)
-    await pool.query(`ALTER TABLE "${this.schema}".engrams ADD COLUMN IF NOT EXISTS search_text TEXT`)
+    await this.ddl(client, `ALTER TABLE "${this.schema}".engrams ADD COLUMN IF NOT EXISTS tokens TEXT[]`)
+    await this.ddl(client, `ALTER TABLE "${this.schema}".engrams ADD COLUMN IF NOT EXISTS search_text TEXT`)
     try {
-      await pool.query('CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public')
+      await this.ddl(client, 'CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public')
       this.trigramAvailable = true
     } catch (err) {
       // Not fatal: without pg_trgm the adapter falls back to loading candidates
@@ -483,37 +545,37 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       )
     }
     if (this.trigramAvailable) {
-      await pool.query(
+      await this.ddl(client,
         `CREATE INDEX IF NOT EXISTS idx_engrams_search_trgm
          ON "${this.schema}".engrams USING GIN (search_text gin_trgm_ops)`,
       )
     }
-    await pool.query(
+    await this.ddl(client,
       `CREATE INDEX IF NOT EXISTS idx_engrams_tokens ON "${this.schema}".engrams USING GIN (tokens)`,
     )
     // Partial index over exactly the rows the migration guard looks for. It is
     // empty on a fully-backfilled store, so the guard's probe is an index scan
     // that finds nothing rather than a sequential scan of the whole table —
     // which is what it was doing on every BM25 query.
-    await pool.query(
+    await this.ddl(client,
       `CREATE INDEX IF NOT EXISTS idx_engrams_tokens_missing
        ON "${this.schema}".engrams (id) WHERE tokens IS NULL`,
     )
 
     const wantType = this.precision === 'halfvec' ? 'halfvec' : 'vector'
-    await pool.query(`
+    await this.ddl(client, `
       CREATE TABLE IF NOT EXISTS "${this.schema}".engram_embeddings (
         engram_id TEXT PRIMARY KEY REFERENCES "${this.schema}".engrams(id) ON DELETE CASCADE,
         embedding ${wantType}(${this.vectorDim}) NOT NULL
       )
     `)
-    await this.readEmbeddingColumnInfo()
-    await this.ensureVectorIndex()
+    await this.readEmbeddingColumnInfo(client)
+    await this.ensureVectorIndex(client)
   }
 
   /** Read the actual type + dim of the embedding column from the catalog. */
-  private async readEmbeddingColumnInfo(): Promise<{ type: 'vector' | 'halfvec'; dim: number } | null> {
-    const res = await this.pool.query(
+  private async readEmbeddingColumnInfo(q: any = this.pool): Promise<{ type: 'vector' | 'halfvec'; dim: number } | null> {
+    const res = await q.query(
       `SELECT format_type(a.atttypid, a.atttypmod) AS t
        FROM pg_attribute a
        JOIN pg_class c ON c.oid = a.attrelid
@@ -542,20 +604,20 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * from what we asked for — `vectorIndex` must not claim HNSW if the CREATE
    * failed.
    */
-  private async ensureVectorIndex(): Promise<void> {
+  private async ensureVectorIndex(q: any = this.pool): Promise<void> {
     let want: boolean
     if (this.indexMode === 'exact') {
       want = false
     } else if (this.indexMode === 'hnsw') {
       want = true
     } else {
-      const res = await this.pool.query(`SELECT COUNT(*)::int AS c FROM "${this.schema}".engram_embeddings`)
+      const res = await q.query(`SELECT COUNT(*)::int AS c FROM "${this.schema}".engram_embeddings`)
       want = Number(res.rows[0].c) >= HNSW_MIN_ROWS
     }
     if (want) {
       const opclass = this.activeVecType === 'halfvec' ? 'halfvec_cosine_ops' : 'vector_cosine_ops'
       try {
-        await this.pool.query(
+        await q.query(
           `CREATE INDEX IF NOT EXISTS ${HNSW_INDEX_NAME}
            ON "${this.schema}".engram_embeddings
            USING hnsw (embedding ${opclass})
@@ -570,11 +632,11 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
         )
       }
     }
-    this.hnswActive = await this.hnswIndexExists()
+    this.hnswActive = await this.hnswIndexExists(q)
   }
 
-  private async hnswIndexExists(): Promise<boolean> {
-    const res = await this.pool.query(
+  private async hnswIndexExists(q: any = this.pool): Promise<boolean> {
+    const res = await q.query(
       `SELECT 1 FROM pg_index x
        JOIN pg_class i ON i.oid = x.indexrelid
        JOIN pg_class t ON t.oid = x.indrelid

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -257,6 +257,14 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * but the last — see `getPool`.
    */
   private poolPromise: Promise<any> | undefined
+  /**
+   * Connections used ONLY to hold advisory locks — never for queries.
+   *
+   * Separate from the main pool so a lock holder can never be waiting on a
+   * connection that another lock holder is occupying. See `withExclusiveAccess`.
+   */
+  private lockPool: any = null
+  private lockPoolPromise: Promise<any> | undefined
   private initPromise: Promise<void> | null = null
   /** Actual element type of the embedding column after init. */
   private activeVecType: 'vector' | 'halfvec' = 'vector'
@@ -346,6 +354,32 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       })
     }
     return await this.poolPromise
+  }
+
+  /** Pool dedicated to advisory-lock sessions. See `withExclusiveAccess`. */
+  private async getLockPool(): Promise<any> {
+    if (this.closed) throw new Error('[postgres] adapter is closed')
+    if (!this.lockPoolPromise) {
+      this.lockPoolPromise = (async () => {
+        // Ensure the schema exists (and `trigramAvailable` is resolved) before
+        // any lock is taken, so the two pools cannot race on initialisation.
+        await this.getPool()
+        const pg = await loadPg()
+        const Pool = pg.Pool ?? pg.default?.Pool
+        this.lockPool = new Pool({
+          connectionString: this.connectionString,
+          max: this.maxConnections,
+        })
+        this.lockPool.on('error', (err: unknown) => {
+          logger.warning(`[postgres] idle lock client error: ${(err as Error).message}`)
+        })
+        return this.lockPool
+      })().catch(err => {
+        this.lockPoolPromise = undefined
+        throw err
+      })
+    }
+    return await this.lockPoolPromise
   }
 
   private async createPool(): Promise<any> {
@@ -575,6 +609,13 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       await pool.end().catch(() => { /* pool already torn down */ })
     }
     this.poolPromise = undefined
+    if (this.lockPool) {
+      const lp = this.lockPool
+      this.lockPool = null
+      this.lockPoolPromise = undefined
+      await lp.end().catch(() => { /* already torn down */ })
+    }
+    this.lockPoolPromise = undefined
     this.closed = true
   }
 
@@ -721,7 +762,20 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * CORRECT, which it was not.
    */
   async withExclusiveAccess<T>(fn: () => Promise<T>): Promise<T> {
-    const pool = await this.getPool()
+    // The lock connection comes from a SEPARATE pool.
+    //
+    // It used to come from the main pool, which deadlocks: the lock is held for
+    // the whole critical section, and `fn()` — a `save()` or a `load()` — needs
+    // its own connection from that same pool. With `maxConnections` writers in
+    // flight, every connection is held by a lock holder waiting for a
+    // connection that can never be freed. Reproduced with pool=2 and three
+    // writers: permanent hang, no error, no timeout.
+    //
+    // A second pool removes the circular wait by construction. Reserving
+    // headroom inside one pool would not: nothing enforces the reservation.
+    // The cost is up to `maxConnections` additional server connections, which
+    // is the honest price of holding a session lock across arbitrary work.
+    const pool = await this.getLockPool()
     const client = await pool.connect()
     try {
       await client.query(`SELECT pg_advisory_lock(hashtext($1))`, [`plur:${this.schema}`])

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -63,6 +63,7 @@
  * pay for a driver it will never open.
  */
 import type { Engram } from './schemas/engram.js'
+import { EngramSchemaPassthrough } from './schemas/engram.js'
 import { searchEngrams, ftsTokenize, engramSearchText, type CorpusStats } from './fts.js'
 import { logger } from './logger.js'
 import {
@@ -1243,8 +1244,29 @@ export function buildFilterClause(filter: StorageFilter): { where: string; param
 }
 
 /** node-postgres returns JSONB already parsed; tolerate a string anyway. */
+/**
+ * Turn a stored row into an `Engram`, applying schema defaults.
+ *
+ * The YAML path runs every entry through `EngramSchemaPassthrough.safeParse`,
+ * which fills in defaults for absent optional fields. This returned `r.data`
+ * verbatim, so the two loaders disagreed about what a valid engram looks like:
+ * a row whose JSONB lacked `associations` crashed `recall()` outright, in the
+ * co-access block (`source.associations.find(...)` on `undefined`).
+ *
+ * Reachable without anything exotic — a row written by an older version, by a
+ * migration, or by any tool that talks to the table directly. `save()` writes
+ * whatever object it is given, and nothing on the write path enforces the
+ * schema either.
+ *
+ * `passthrough` keeps unknown fields, so this normalises without discarding
+ * anything the schema does not know about. A row that cannot be parsed at all
+ * is returned as-is rather than dropped: losing an engram silently is worse
+ * than passing along one that is odd, and the caller's own guards still apply.
+ */
 function parseRow(row: { data: any }): Engram {
-  return typeof row.data === 'string' ? JSON.parse(row.data) : row.data
+  const raw = typeof row.data === 'string' ? JSON.parse(row.data) : row.data
+  const parsed = EngramSchemaPassthrough.safeParse(raw)
+  return parsed.success ? (parsed.data as Engram) : (raw as Engram)
 }
 
 function toRow(e: Engram): Record<string, unknown> {

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -653,6 +653,60 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * Atomic: one transaction, so a concurrent reader sees the old corpus or the
    * new one, never a half-applied replace.
    */
+  /** Targeted read by id. See `PrimaryStore.loadByIds`. */
+  async loadByIds(ids: string[]): Promise<Engram[]> {
+    if (ids.length === 0) return []
+    const pool = await this.getPool()
+    const res = await pool.query(
+      `SELECT data FROM "${this.schema}".engrams WHERE id = ANY($1::text[]) ORDER BY id`,
+      [ids],
+    )
+    return res.rows.map((r: any) => parseRow(r))
+  }
+
+  /**
+   * Targeted upsert — no prune. See `PrimaryStore.updateMany`.
+   *
+   * Identical to `save()`'s INSERT half, minus the `DELETE ... WHERE id NOT IN`
+   * that makes `save()` a whole-corpus replace.
+   */
+  async updateMany(engrams: Engram[]): Promise<void> {
+    if (engrams.length === 0) return
+    const pool = await this.getPool()
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      for (let i = 0; i < engrams.length; i += SAVE_CHUNK_SIZE) {
+        const chunk = engrams.slice(i, i + SAVE_CHUNK_SIZE)
+        await client.query(
+          `INSERT INTO "${this.schema}".engrams (id, status, scope, domain, last_accessed, data, source, tokens, search_text)
+           SELECT t.id, t.status, t.scope, t.domain, t.last_accessed, t.data, 'primary', t.tokens, t.search_text
+           FROM jsonb_to_recordset($1::jsonb)
+             AS t(id text, status text, scope text, domain text, last_accessed text, data jsonb,
+                  tokens text[], search_text text)
+           ON CONFLICT (id) DO UPDATE SET
+             status = EXCLUDED.status,
+             scope = EXCLUDED.scope,
+             domain = EXCLUDED.domain,
+             last_accessed = EXCLUDED.last_accessed,
+             data = EXCLUDED.data,
+             source = EXCLUDED.source,
+             tokens = EXCLUDED.tokens,
+             search_text = EXCLUDED.search_text`,
+          [JSON.stringify(chunk.map(toRow))],
+        )
+      }
+      await client.query('COMMIT')
+      // No cache to drop — `loadCached()` delegates to `load()` on this adapter
+      // precisely because another process may have written since.
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => { /* connection already broken */ })
+      throw err
+    } finally {
+      client.release()
+    }
+  }
+
   async save(engrams: Engram[]): Promise<void> {
     const pool = await this.getPool()
     const client = await pool.connect()

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -72,6 +72,7 @@ import {
   type StorageAdapter,
   type StorageFilter,
   type ScopeRestriction,
+  escapeLikePattern,
   type VectorElementFormat,
   type VectorIndexStrategy,
   type VectorSearchHit,
@@ -1170,13 +1171,18 @@ export function buildFilterClause(filter: StorageFilter): { where: string; param
   if (filter.scope) {
     conditions.push(
       `((NOT (scope LIKE 'group:%' OR scope LIKE 'project:%' OR scope LIKE 'space:%' OR scope LIKE 'team:%' OR scope LIKE 'org:%' OR scope = 'public' OR scope LIKE 'public:%' OR scope LIKE 'public/%'))`
-      + ` OR scope = $${i++} OR scope LIKE $${i++} || ':%' OR scope LIKE $${i++} || '/%')`,
+      + ` OR scope = $${i++} OR scope LIKE $${i++} || ':%' ESCAPE '\\' OR scope LIKE $${i++} || '/%' ESCAPE '\\')`,
     )
-    params.push(filter.scope, filter.scope, filter.scope)
+      // The caller's scope is escaped: an unescaped `%` here matches across
+      // unrelated namespaces, defeating the segment-aware containment guard
+      // this clause exists to implement (#383). Verified: `{ scope: '%' }`
+      // returned engrams from two unrelated groups.
+    params.push(filter.scope, escapeLikePattern(filter.scope), escapeLikePattern(filter.scope))
   }
   if (filter.domain) {
-    conditions.push(`domain LIKE $${i++} || '%'`)
-    params.push(filter.domain)
+    conditions.push(`domain LIKE $${i++} || '%' ESCAPE '\\'`)
+    // Same reason as scope: `{ domain: '%' }` returned every domain.
+    params.push(escapeLikePattern(filter.domain))
   }
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
   return { where, params }

--- a/packages/core/src/store/async-lock.ts
+++ b/packages/core/src/store/async-lock.ts
@@ -69,9 +69,21 @@ async function withFileLock<T>(
   const baseDelay = options?.baseDelay ?? 100
   const staleThreshold = options?.staleThreshold ?? 10_000
 
+  // Whether we actually took the lock.
+  //
+  // Without this the loop could simply RUN OUT: the two `continue` branches
+  // below (stale-lock cleanup, and a `stat` that fails because another process
+  // released between the EEXIST and the check) skip the
+  // `attempt === maxRetries` throw. If either happened on the LAST iteration
+  // the loop ended normally, `fn()` ran with no lock at all, and the `finally`
+  // unlinked a lock file belonging to whoever did hold it — handing them a
+  // silent loss of mutual exclusion on top of ours.
+  let acquired = false
+
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       await writeFile(lockPath, `${process.pid}`, { flag: constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL })
+      acquired = true
       break
     } catch (err: any) {
       if (err.code !== 'EEXIST') throw err
@@ -93,9 +105,17 @@ async function withFileLock<T>(
     }
   }
 
+  if (!acquired) {
+    throw new Error(
+      `Failed to acquire lock on ${filePath} after ${maxRetries} retries (contended throughout)`,
+    )
+  }
+
   try {
     return await fn()
   } finally {
+    // Only ours to remove. Guarded by `acquired` so a failed acquisition can
+    // never delete the holder's file.
     await unlink(lockPath).catch(() => {})
   }
 }

--- a/packages/core/src/store/primary-store.ts
+++ b/packages/core/src/store/primary-store.ts
@@ -111,6 +111,37 @@ export interface PrimaryStore {
   withExclusiveAccess?<T>(fn: () => Promise<T>): Promise<T>
 
   /**
+   * Replace exactly these engrams, leaving every other row untouched.
+   * Optional; when absent the caller falls back to a whole-corpus `save()`.
+   *
+   * `save()` is a full replace — it rewrites every row and deletes anything
+   * absent from the array. That is the right contract for "here is the corpus",
+   * and the wrong one for "these three engrams changed".
+   *
+   * It matters most on the read path. `recall()` updates activation on the
+   * engrams it returned, which under `save()` meant rewriting the ENTIRE corpus
+   * on every read, while holding the global write lock: measured at 252ms for
+   * 2,000 engrams, extrapolating to ~6.3s at 50,000 — the corpus size at which
+   * this tier is selected in the first place. Every writer queues behind every
+   * reader.
+   *
+   * Implementations MUST NOT delete rows absent from `engrams`, and MUST be
+   * safe to call inside `withExclusiveAccess`.
+   */
+  updateMany?(engrams: Engram[]): Promise<void>
+
+  /**
+   * Load exactly these engrams by id. Optional; when absent the caller falls
+   * back to `load()` and filters in memory.
+   *
+   * The counterpart to {@link updateMany}, and needed for the same reason: a
+   * read-modify-write that touches a handful of rows should not have to
+   * materialise the corpus to find them. Ids absent from the store are simply
+   * not returned — a missing engram is not an error here.
+   */
+  loadByIds?(ids: string[]): Promise<Engram[]>
+
+  /**
    * Cheap, approximate size of the store — for choosing a backend, never for
    * reporting a count to a user.
    *

--- a/packages/core/test/async-lock-contention.test.ts
+++ b/packages/core/test/async-lock-contention.test.ts
@@ -10,7 +10,7 @@
  * has.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, utimesSync } from 'fs'
 import { readFile, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -190,5 +190,74 @@ describe('withAsyncLock — in-process contention', () => {
     })
 
     expect(await readFile(p, 'utf8')).toBe('2')
+  })
+})
+
+describe('a failed acquisition never runs the critical section', () => {
+  // The loop used to be able to RUN OUT rather than throw: the stale-cleanup
+  // and stat-failure branches skip the `attempt === maxRetries` check, so if
+  // either fell on the last iteration the loop exited normally, `fn()` ran with
+  // NO lock, and the `finally` unlinked the file belonging to whoever did hold
+  // it. Two processes in the critical section at once, and the real holder
+  // silently loses its lock.
+  it('throws instead of running unlocked when the lock is held throughout', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-lock-fail-'))
+    const target = join(dir, 'engrams.yaml')
+    try {
+      // A held lock, freshly stamped so it never looks stale.
+      writeFileSync(target + '.lock', '99999')
+      let ran = false
+      await expect(
+        withAsyncLock(target, async () => { ran = true }, { maxRetries: 1, baseDelay: 1, staleThreshold: 60_000 }),
+      ).rejects.toThrow(/Failed to acquire lock/)
+      expect(ran, 'the critical section ran without the lock').toBe(false)
+      // And the holder's file is still there.
+      expect(existsSync(target + '.lock'), "the holder's lock file was deleted").toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('throws when the retry budget is spent by a stale-lock cleanup', async () => {
+    // THE case the guard exists for, and the one the test above does NOT reach.
+    //
+    // With a fresh lock the loop hits `attempt === maxRetries` and throws on its
+    // own — so that test passes with or without the guard (verified by
+    // mutation). The hole is the `continue` branches, which skip that check: a
+    // stale-lock cleanup on the FINAL attempt ends the loop normally. Before the
+    // guard, execution simply fell through and ran the critical section having
+    // never acquired anything.
+    //
+    // `maxRetries: 0` makes the first attempt the final one, so the stale branch
+    // lands exactly there.
+    const dir = mkdtempSync(join(tmpdir(), 'plur-lock-stale-'))
+    const target = join(dir, 'engrams.yaml')
+    try {
+      writeFileSync(target + '.lock', '99999')
+      // Backdate it well past the threshold so the stale branch is taken.
+      const old = new Date(Date.now() - 120_000)
+      utimesSync(target + '.lock', old, old)
+
+      let ran = false
+      await expect(
+        withAsyncLock(target, async () => { ran = true }, { maxRetries: 0, baseDelay: 1, staleThreshold: 1_000 }),
+      ).rejects.toThrow(/Failed to acquire lock/)
+      expect(ran, 'ran the critical section without ever acquiring the lock').toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('still acquires normally when the lock is free', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-lock-ok-'))
+    const target = join(dir, 'engrams.yaml')
+    try {
+      let ran = false
+      await withAsyncLock(target, async () => { ran = true })
+      expect(ran).toBe(true)
+      expect(existsSync(target + '.lock'), 'the lock file was left behind').toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/core/test/async-lock-key.test.ts
+++ b/packages/core/test/async-lock-key.test.ts
@@ -78,7 +78,7 @@ describe('withAsyncLock keys on the resolved path', () => {
       concurrent--
     }
     const spellings = [target, './engrams.yaml', join(dir, 'sub', '..', 'engrams.yaml')]
-    await Promise.all(spellings.map(p => withAsyncLock(p, body, { maxRetries: 200, retryDelayMs: 5 })))
+    await Promise.all(spellings.map(p => withAsyncLock(p, body, { maxRetries: 200, baseDelay: 5 })))
     expect(maxConcurrent).toBe(1)
   })
 
@@ -89,13 +89,13 @@ describe('withAsyncLock keys on the resolved path', () => {
       order.push('abs-start')
       await new Promise(r => setTimeout(r, 40))
       order.push('abs-end')
-    }, { maxRetries: 200, retryDelayMs: 5 })
+    }, { maxRetries: 200, baseDelay: 5 })
     // Give the first a moment to take the lock, so this is a real queue test.
     await new Promise(r => setTimeout(r, 5))
     const b = withAsyncLock(rel, async () => {
       order.push('rel-start')
       order.push('rel-end')
-    }, { maxRetries: 200, retryDelayMs: 5 })
+    }, { maxRetries: 200, baseDelay: 5 })
     await Promise.all([a, b])
 
     // Interleaved would be abs-start, rel-start, ... — the whole point is that
@@ -117,8 +117,8 @@ describe('withAsyncLock keys on the resolved path', () => {
       concurrent--
     }
     await Promise.all([
-      withAsyncLock(target, body, { maxRetries: 200, retryDelayMs: 5 }),
-      withAsyncLock(other, body, { maxRetries: 200, retryDelayMs: 5 }),
+      withAsyncLock(target, body, { maxRetries: 200, baseDelay: 5 }),
+      withAsyncLock(other, body, { maxRetries: 200, baseDelay: 5 }),
     ])
     expect(maxConcurrent, 'unrelated files were serialised against each other').toBe(2)
   })
@@ -159,8 +159,8 @@ describe('what path.resolve does NOT normalise', () => {
       concurrent--
     }
     await Promise.all([
-      withAsyncLock(target, body, { maxRetries: 200, retryDelayMs: 5 }),
-      withAsyncLock(viaSymlink, body, { maxRetries: 200, retryDelayMs: 5 }),
+      withAsyncLock(target, body, { maxRetries: 200, baseDelay: 5 }),
+      withAsyncLock(viaSymlink, body, { maxRetries: 200, baseDelay: 5 }),
     ])
     expect(maxConcurrent, 'the file lock did not cover the symlinked spelling').toBe(1)
   })

--- a/packages/core/test/async-lock-key.test.ts
+++ b/packages/core/test/async-lock-key.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The in-process lock queue must key on the RESOLVED path.
+ *
+ * `withAsyncLock` has two layers. The `O_EXCL` lock file excludes other
+ * processes and gets normalisation for free — the kernel resolves the path. The
+ * in-process queue is a plain `Map` keyed by string, and does not: `./engrams.yaml`
+ * and `/abs/dir/engrams.yaml` are different strings for the same file.
+ *
+ * Split the key and two callers in ONE process each get their own queue and run
+ * concurrently. They then race on the file lock, and the loser spins until it
+ * times out or declares the lock stale — so the failure is a corrupted
+ * read-modify-write or a hang, not an error anyone can trace back to here.
+ *
+ * `path.resolve` handles relative segments and `..`. It does NOT resolve
+ * symlinks or normalise case, so two genuinely different spellings of one file
+ * can still split the queue; the file lock is what covers that.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, relative } from 'path'
+import { withAsyncLock } from '../src/store/async-lock.js'
+
+describe('withAsyncLock keys on the resolved path', () => {
+  let dir: string
+  let target: string
+  let cwd: string
+
+  beforeEach(() => {
+    // realpath, deliberately: on macOS os.tmpdir() is a symlink (/var ->
+    // /private/var), so after chdir the cwd and the raw temp path resolve to
+    // different STRINGS for the same file. That is a real limitation of
+    // path.resolve (see the header) but it is not what this test is about, and
+    // leaving it in makes the fixture, not the lock, decide the outcome.
+    dir = realpathSync(mkdtempSync(join(tmpdir(), 'plur-lockkey-')))
+    target = join(dir, 'engrams.yaml')
+    writeFileSync(target, 'engrams: []\n')
+    cwd = process.cwd()
+    process.chdir(dir)
+  })
+
+  afterEach(() => {
+    process.chdir(cwd)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('different spellings QUEUE in-process rather than racing on the lock file', async () => {
+    // Choosing the observable carefully. Asserting "they never overlap" does
+    // NOT test this: the O_EXCL lock file already prevents overlap whatever the
+    // in-process key is, so that assertion passes with the normalisation
+    // removed (verified by mutation). The difference a split key makes is that
+    // the second caller reaches the FILE lock, finds it taken, and spins.
+    //
+    // `maxRetries: 0` turns that spin into a throw, which is observable:
+    //   - one queue  -> the second waits its turn in-process, then acquires cleanly
+    //   - two queues -> the second hits EEXIST with no retries left and throws
+    const spellings = ['./engrams.yaml', join(dir, '.', 'engrams.yaml'), join(dir, 'sub', '..', 'engrams.yaml')]
+    const body = async () => { await new Promise(r => setTimeout(r, 20)) }
+
+    const results = await Promise.allSettled([
+      withAsyncLock(target, body, { maxRetries: 0 }),
+      ...spellings.map(p => withAsyncLock(p, body, { maxRetries: 0 })),
+    ])
+    const failed = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[]
+    expect(
+      failed.map(f => String(f.reason?.message ?? f.reason)),
+      'a spelling of the same path got its own queue and collided on the lock file',
+    ).toEqual([])
+  })
+
+  it('and they still never overlap', async () => {
+    let concurrent = 0
+    let maxConcurrent = 0
+    const body = async () => {
+      concurrent++
+      maxConcurrent = Math.max(maxConcurrent, concurrent)
+      await new Promise(r => setTimeout(r, 30))
+      concurrent--
+    }
+    const spellings = [target, './engrams.yaml', join(dir, 'sub', '..', 'engrams.yaml')]
+    await Promise.all(spellings.map(p => withAsyncLock(p, body, { maxRetries: 200, retryDelayMs: 5 })))
+    expect(maxConcurrent).toBe(1)
+  })
+
+  it('a relative path and its absolute form share one queue', async () => {
+    const order: string[] = []
+    const rel = relative(dir, target) // "engrams.yaml"
+    const a = withAsyncLock(target, async () => {
+      order.push('abs-start')
+      await new Promise(r => setTimeout(r, 40))
+      order.push('abs-end')
+    }, { maxRetries: 200, retryDelayMs: 5 })
+    // Give the first a moment to take the lock, so this is a real queue test.
+    await new Promise(r => setTimeout(r, 5))
+    const b = withAsyncLock(rel, async () => {
+      order.push('rel-start')
+      order.push('rel-end')
+    }, { maxRetries: 200, retryDelayMs: 5 })
+    await Promise.all([a, b])
+
+    // Interleaved would be abs-start, rel-start, ... — the whole point is that
+    // the second waits for the first to finish.
+    expect(order).toEqual(['abs-start', 'abs-end', 'rel-start', 'rel-end'])
+  })
+
+  it('DIFFERENT files still run concurrently — the key must not collapse everything', async () => {
+    // Without this, keying every call on a constant would pass both tests above
+    // while serialising the entire process.
+    const other = join(dir, 'other.yaml')
+    writeFileSync(other, 'engrams: []\n')
+    let concurrent = 0
+    let maxConcurrent = 0
+    const body = async () => {
+      concurrent++
+      maxConcurrent = Math.max(maxConcurrent, concurrent)
+      await new Promise(r => setTimeout(r, 30))
+      concurrent--
+    }
+    await Promise.all([
+      withAsyncLock(target, body, { maxRetries: 200, retryDelayMs: 5 }),
+      withAsyncLock(other, body, { maxRetries: 200, retryDelayMs: 5 }),
+    ])
+    expect(maxConcurrent, 'unrelated files were serialised against each other').toBe(2)
+  })
+
+  it('the result and thrown errors pass through unchanged', async () => {
+    expect(await withAsyncLock(target, async () => 42)).toBe(42)
+    await expect(withAsyncLock(target, async () => { throw new Error('boom') })).rejects.toThrow('boom')
+    // And the lock is released after a throw — otherwise the next call hangs.
+    expect(await withAsyncLock(target, async () => 'after')).toBe('after')
+  })
+})
+
+describe('what path.resolve does NOT normalise', () => {
+  // Honest boundary. `path.resolve` collapses `.`, `..` and relative segments;
+  // it does not resolve symlinks. Two spellings that differ only by a symlink
+  // therefore get separate in-process queues — and the FILE lock is what keeps
+  // them correct. Pinned so nobody later "simplifies" the file lock away on the
+  // grounds that the in-process queue already covers it.
+  let real: string
+  let target: string
+
+  beforeEach(() => {
+    real = realpathSync(mkdtempSync(join(tmpdir(), 'plur-lockkey-sym-')))
+    target = join(real, 'engrams.yaml')
+    writeFileSync(target, 'engrams: []\n')
+  })
+
+  afterEach(() => rmSync(real, { recursive: true, force: true }))
+
+  it('a symlinked spelling still never overlaps, via the file lock', async () => {
+    const viaSymlink = join(tmpdir(), relative(realpathSync(tmpdir()), target))
+    let concurrent = 0
+    let maxConcurrent = 0
+    const body = async () => {
+      concurrent++
+      maxConcurrent = Math.max(maxConcurrent, concurrent)
+      await new Promise(r => setTimeout(r, 30))
+      concurrent--
+    }
+    await Promise.all([
+      withAsyncLock(target, body, { maxRetries: 200, retryDelayMs: 5 }),
+      withAsyncLock(viaSymlink, body, { maxRetries: 200, retryDelayMs: 5 }),
+    ])
+    expect(maxConcurrent, 'the file lock did not cover the symlinked spelling').toBe(1)
+  })
+})

--- a/packages/core/test/concurrency-write-path.test.ts
+++ b/packages/core/test/concurrency-write-path.test.ts
@@ -132,13 +132,24 @@ describe('Plur — concurrent writes', () => {
 
     const HOLD_MS = 200
     const TICK_MS = 10
-    // A starved event loop CANNOT reach this. Node coalesces a blocked
-    // `setInterval` into a SINGLE callback fired the moment the loop is
-    // released, so a spin-waiting writer scores exactly 1 tick no matter how
-    // long it blocked — which is why `toBeGreaterThan(0)` proved nothing here.
-    // A loop that keeps turning fires ~HOLD_MS / TICK_MS times; half of that
-    // is the bar.
-    const MIN_TICKS = HOLD_MS / TICK_MS / 2
+    // Set from measurement, not from the nominal rate.
+    //
+    // Node coalesces a blocked `setInterval` into a SINGLE callback fired the
+    // moment the loop is released, so a spin-waiting writer scores exactly 1
+    // tick no matter how long it blocked — measured, 3 runs of 3 against the
+    // old spinning lock. That is why the original `toBeGreaterThan(0)` proved
+    // nothing: 1 > 0.
+    //
+    // A healthy loop scores 15-18 here in isolation (measured over 10 runs)
+    // against a nominal ceiling of HOLD_MS / TICK_MS = 20. The previous bar of
+    // half-nominal (10) sat INSIDE the load-variance band: under a full
+    // parallel suite the count dips below it, which is why this test failed
+    // roughly one run in three there while passing 52 of 53 in isolation.
+    //
+    // 5 keeps a 5x margin over starvation and tolerates a 3x slowdown from the
+    // healthy figure. The gap between 1 and 15 is wide; the bar belongs near
+    // the bottom of it, not the middle.
+    const MIN_TICKS = 5
 
     const events: string[] = []
     let ticks = 0

--- a/packages/core/test/inject-scopes.test.ts
+++ b/packages/core/test/inject-scopes.test.ts
@@ -17,10 +17,33 @@
  * happen.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Plur } from '../src/index.js'
+
+/** Install a pack whose engrams sit in `scope`. */
+async function installPackInScope(plur: Plur, dir: string, name: string, scope: string, statement: string) {
+  const src = join(dir, `${name}-source`)
+  mkdirSync(src, { recursive: true })
+  writeFileSync(join(src, 'SKILL.md'), `---\nname: ${name}\nversion: "1.0"\n---\n`)
+  writeFileSync(join(src, 'engrams.yaml'), `engrams:
+  - id: ENG-2026-0728-${name.length}0${scope.length}
+    statement: ${statement}
+    type: behavioral
+    scope: ${scope}
+    status: active
+    version: 2
+    domain: ops.deploy
+    tags: [deploy]
+    activation:
+      retrieval_strength: 0.9
+      storage_strength: 1.0
+      frequency: 0
+      last_accessed: "2026-07-28"
+`)
+  await plur.installPack(src)
+}
 
 describe('inject() — permitted-scope allow-list', () => {
   let dir: string
@@ -88,5 +111,78 @@ describe('inject() — permitted-scope allow-list', () => {
     // that way, since injectHybrid is the one a session actually calls.
     const res = await plur.injectHybrid('how do we deploy billing', { scopes: [] })
     expect(res.count).toBe(0)
+  })
+})
+
+/**
+ * The same allow-list, applied to PACKS.
+ *
+ * A pack is installed knowledge rather than user data, which makes exempting it
+ * tempting — but pack engrams carry scopes, they reach the same output, and an
+ * allow-list with an exemption is not an allow-list. This half of the filter
+ * shipped with no test at all, so nothing would have noticed it being dropped.
+ *
+ * One thing to know before adding tests here: `installPack` ALSO writes the
+ * pack's engrams into the primary store (`plur.list()` returns them), so every
+ * pack engram reaches `inject()` on both the engram path and the pack path.
+ * Two consequences, both found by mutation testing:
+ *
+ *   - Exempting packs from the filter DOES leak: the pack path carries the
+ *     engram past the engram path's filter. That is what these tests pin.
+ *   - Dropping the pack argument entirely is NOT observable in the output,
+ *     because the same statements still arrive via the engram path. So no
+ *     assertion here can prove the pack path is still wired up — do not write
+ *     one and believe it.
+ */
+describe('inject() — the allow-list applies to pack engrams', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-inject-pack-scopes-'))
+    mkdirSync(join(dir, 'packs'), { recursive: true })
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+    plur = new Plur({ path: dir })
+    await plur.ready()
+    await installPackInScope(plur, dir, 'tenantpack', 'group:acme/eng', 'deploy billing using the tenantpack runbook')
+    await installPackInScope(plur, dir, 'otherpack', 'group:other/eng', 'deploy billing using the otherpack runbook')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('excludes pack engrams whose scope is not permitted', async () => {
+    const res = await plur.inject('how do we deploy billing', { scopes: ['group:acme/eng'] })
+    const all = `${res.directives}\n${res.constraints}\n${res.consider}`
+    expect(all).toContain('tenantpack')
+    expect(all, 'a pack outside the allow-list reached the context').not.toContain('otherpack')
+  })
+
+  it('an EMPTY allow-list admits no pack content either', async () => {
+    const res = await plur.inject('how do we deploy billing', { scopes: [] })
+    const all = `${res.directives}\n${res.constraints}\n${res.consider}`
+    expect(all).not.toContain('runbook')
+    expect(res.count).toBe(0)
+  })
+
+  it('an ABSENT allow-list injects every pack — no blanket deny on the engram path', async () => {
+    // Scope check, stated exactly: this guards the ENGRAM path only. Because
+    // installPack also writes into the primary store, no assertion on inject()
+    // output can see the pack path at all — verified by mutation, both
+    // `packs = []` and `packs = [] when scopes is absent` leave this suite
+    // fully green. Whether the pack argument is still wired up is not something
+    // this file can tell you.
+    const res = await plur.inject('how do we deploy billing')
+    const all = `${res.directives}\n${res.constraints}\n${res.consider}`
+    expect(all).toContain('tenantpack')
+    expect(all).toContain('otherpack')
+  })
+
+  it('a pack left with no permitted engrams is dropped, not injected empty', async () => {
+    const res = await plur.inject('how do we deploy billing', { scopes: ['group:acme/eng'] })
+    // `otherpack` had exactly one engram and it was filtered out, so the pack
+    // itself must not survive as an empty shell in the output.
+    expect(`${res.directives}\n${res.constraints}\n${res.consider}`).not.toContain('otherpack')
   })
 })

--- a/packages/core/test/pglite-vector-scope-dilution.test.ts
+++ b/packages/core/test/pglite-vector-scope-dilution.test.ts
@@ -38,10 +38,28 @@ const TIMEOUT = 180_000
 const NOISE = 400
 const WANTED = 5
 
+let ready = false
+
+/**
+ * Fail visibly rather than pass silently when the embedder is unavailable.
+ *
+ * Every test here used `if (!ready) return`, which reports PASS — so with no
+ * embedder the file announced "5 passed" while asserting nothing at all.
+ * Verified: forcing `ready = false` yields exactly that. A suite that reports
+ * success for having done nothing is worse than one that fails, because it is
+ * counted as coverage.
+ *
+ * `ctx.skip()` marks the test SKIPPED in the output, which is the honest
+ * signal: the environment could not run it, and nobody should read the run as
+ * evidence that the vector scope filter works.
+ */
+function requireEmbedder(ctx: { skip: (note?: string) => void }): void {
+  if (!ready) ctx.skip('embeddings unavailable — the vector leg cannot be exercised')
+}
+
 describe('vector recall applies the scope restriction in-query, not after', () => {
   let dir: string
   let plur: Plur
-  let ready = false
 
   const priorBackend = process.env.PLUR_BACKEND
 
@@ -64,8 +82,8 @@ describe('vector recall applies the scope restriction in-query, not after', () =
       await plur.learn(`the deployment pipeline runs database migrations, alpha ${i}`, { scope: 'project:alpha' })
     }
     // Embeddings are what this file is about; if they are unavailable the
-    // vector leg degrades to BM25 and these assertions would be measuring
-    // something else. Detect that and skip rather than assert on the wrong path.
+    // vector leg degrades to BM25 and these assertions would measure something
+    // else.
     const probe = await plur.recallSemantic('deployment pipeline migrations', { limit: 3 })
     ready = probe.length > 0
   }, TIMEOUT)
@@ -76,16 +94,16 @@ describe('vector recall applies the scope restriction in-query, not after', () =
     if (dir) rmSync(dir, { recursive: true, force: true })
   })
 
-  it('the fixture actually dilutes — an unrestricted top-50 contains no permitted engram', async () => {
+  it('the fixture actually dilutes — an unrestricted top-50 contains no permitted engram', async (ctx) => {
     // Guards the FIXTURE. If a future edit shrinks the corpus or the k-NN floor
     // rises, the assertions below stop testing anything and would still pass.
-    if (!ready) return
+    requireEmbedder(ctx)
     const unrestricted = await plur.recallSemantic('deployment pipeline migrations', { limit: 50 })
     expect(unrestricted.filter(e => e.scope === 'project:alpha').length).toBe(0)
   }, TIMEOUT)
 
-  it('recallSemantic returns a FULL page of permitted results, not a diluted one', async () => {
-    if (!ready) return
+  it('recallSemantic returns a FULL page of permitted results, not a diluted one', async (ctx) => {
+    requireEmbedder(ctx)
     // With the restriction in the query, all 5 permitted engrams are reachable.
     // Without it, measured: 0 of 5. The unrestricted top-50 of 405 contains no
     // permitted engram at all (asserted above), so the post-hoc intersection
@@ -98,8 +116,8 @@ describe('vector recall applies the scope restriction in-query, not after', () =
     expect(hits.every(e => e.scope === 'project:alpha')).toBe(true)
   }, TIMEOUT)
 
-  it('recallHybrid does the same on its vector leg', async () => {
-    if (!ready) return
+  it('recallHybrid does the same on its vector leg', async (ctx) => {
+    requireEmbedder(ctx)
     const hits = await plur.recallHybrid('deployment pipeline migrations', {
       limit: WANTED,
       scopes: ['project:alpha'],
@@ -108,14 +126,14 @@ describe('vector recall applies the scope restriction in-query, not after', () =
     expect(hits.every(e => e.scope === 'project:alpha')).toBe(true)
   }, TIMEOUT)
 
-  it('an empty allow-list still returns nothing', async () => {
-    if (!ready) return
+  it('an empty allow-list still returns nothing', async (ctx) => {
+    requireEmbedder(ctx)
     expect(await plur.recallSemantic('deployment pipeline migrations', { limit: 5, scopes: [] })).toEqual([])
     expect(await plur.recallHybrid('deployment pipeline migrations', { limit: 5, scopes: [] })).toEqual([])
   }, TIMEOUT)
 
-  it('an absent allow-list is unrestricted — existing behaviour unchanged', async () => {
-    if (!ready) return
+  it('an absent allow-list is unrestricted — existing behaviour unchanged', async (ctx) => {
+    requireEmbedder(ctx)
     const hits = await plur.recallSemantic('deployment pipeline migrations', { limit: 10 })
     expect(hits.length).toBe(10)
     expect(hits.some(e => e.scope === 'group:noise'), 'unrestricted recall should see the noise').toBe(true)

--- a/packages/core/test/pglite-vector-scope-dilution.test.ts
+++ b/packages/core/test/pglite-vector-scope-dilution.test.ts
@@ -24,21 +24,55 @@ import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Plur } from '../src/index.js'
+import type { Engram } from '../src/schemas/engram.js'
 
 const TIMEOUT = 180_000
 
-// Every engram is about the same thing, so vector similarity cannot separate
-// them — only the scope filter can. That is deliberate: it makes the neighbour
-// list's composition depend purely on whether the restriction reached the
-// query.
-// Large enough that an unrestricted top-50 is swamped: the k-NN floor in
-// `_pgliteSemanticRecall` is `max(limit*3, 50)`, so with 400 noise engrams the
-// 5 permitted ones are statistically absent from it. Verified — the
-// unrestricted top-50 contains 0 of them.
-const NOISE = 400
+// The two groups are separated by SIMILARITY, not by count.
+//
+// The k-NN floor in `_pgliteSemanticRecall` is `max(limit*3, 50)`, so an
+// unrestricted neighbour list holds 50 rows. To show dilution, those 50 must
+// contain none of the permitted engrams. An earlier version got there by sheer
+// volume — 400 near-identical noise engrams so the 5 permitted were
+// statistically absent — but seeding that many through `learn()` with the
+// PGLite tier forced is O(N^2) in index syncs and timed out the hook at 180s
+// under a full suite.
+//
+// Ranking by similarity instead needs only enough noise to fill the window:
+// the noise engrams restate the query almost verbatim, the permitted ones are
+// on-topic but worded differently, so every noise engram outranks every
+// permitted one. Same demonstration, 65 engrams instead of 405.
+const NOISE = 60
 const WANTED = 5
+const QUERY = 'deployment pipeline database migrations'
 
 let ready = false
+
+/** A minimal valid engram — the corpus content is what matters here. */
+function makeEngram(id: string, statement: string, scope: string): Engram {
+  return {
+    id,
+    statement,
+    type: 'behavioral',
+    scope,
+    status: 'active',
+    visibility: 'private',
+    version: 1,
+    engram_version: 1,
+    consolidated: false,
+    reference_count: 0,
+    recurrence_count: 0,
+    episode_ids: [],
+    sources: [],
+    tags: [],
+    relations: { broader: [], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: [] },
+    activation: { retrieval_strength: 1, storage_strength: 1, last_accessed: null, decay_rate: 0 },
+    temporal: { learned_at: '2026-07-28' },
+    created_at: '2026-07-28T00:00:00Z',
+    updated_at: '2026-07-28T00:00:00Z',
+  } as unknown as Engram
+}
+
 
 /**
  * Fail visibly rather than pass silently when the embedder is unavailable.
@@ -75,16 +109,27 @@ describe('vector recall applies the scope restriction in-query, not after', () =
     plur = new Plur({ path: dir })
     await plur.ready()
 
+    // Seeded in ONE write, not 405 `learn()` calls.
+    //
+    // Every `learn()` is load -> mutate -> save-whole-corpus, so seeding N
+    // engrams one at a time is O(N^2) in engram writes — 405 calls came to
+    // ~82,000, and the hook timed out at 180s under a full parallel suite.
+    // The corpus content is all this test needs; how it got there is not under
+    // test, and `reindex()` builds the vector index from it exactly as
+    // incremental writes would have.
+    // Seeded through `learn()` so the embedding pass runs — a bulk
+    // `primaryStore.save()` writes the rows but generates no vectors, and this
+    // file is about the vector leg.
     for (let i = 0; i < NOISE; i++) {
-      await plur.learn(`the deployment pipeline runs database migrations, note ${i}`, { scope: 'group:noise' })
+      await plur.learn(`deployment pipeline database migrations, note ${i}`, { scope: 'group:noise' })
     }
     for (let i = 0; i < WANTED; i++) {
-      await plur.learn(`the deployment pipeline runs database migrations, alpha ${i}`, { scope: 'project:alpha' })
+      await plur.learn(`tenant cluster rollout policy for the alpha team, item ${i}`, { scope: 'project:alpha' })
     }
     // Embeddings are what this file is about; if they are unavailable the
     // vector leg degrades to BM25 and these assertions would measure something
     // else.
-    const probe = await plur.recallSemantic('deployment pipeline migrations', { limit: 3 })
+    const probe = await plur.recallSemantic(QUERY, { limit: 3 })
     ready = probe.length > 0
   }, TIMEOUT)
 
@@ -98,7 +143,7 @@ describe('vector recall applies the scope restriction in-query, not after', () =
     // Guards the FIXTURE. If a future edit shrinks the corpus or the k-NN floor
     // rises, the assertions below stop testing anything and would still pass.
     requireEmbedder(ctx)
-    const unrestricted = await plur.recallSemantic('deployment pipeline migrations', { limit: 50 })
+    const unrestricted = await plur.recallSemantic(QUERY, { limit: 50 })
     expect(unrestricted.filter(e => e.scope === 'project:alpha').length).toBe(0)
   }, TIMEOUT)
 
@@ -108,7 +153,7 @@ describe('vector recall applies the scope restriction in-query, not after', () =
     // Without it, measured: 0 of 5. The unrestricted top-50 of 405 contains no
     // permitted engram at all (asserted above), so the post-hoc intersection
     // has nothing to keep.
-    const hits = await plur.recallSemantic('deployment pipeline migrations', {
+    const hits = await plur.recallSemantic(QUERY, {
       limit: WANTED,
       scopes: ['project:alpha'],
     })
@@ -118,7 +163,7 @@ describe('vector recall applies the scope restriction in-query, not after', () =
 
   it('recallHybrid does the same on its vector leg', async (ctx) => {
     requireEmbedder(ctx)
-    const hits = await plur.recallHybrid('deployment pipeline migrations', {
+    const hits = await plur.recallHybrid(QUERY, {
       limit: WANTED,
       scopes: ['project:alpha'],
     })
@@ -128,13 +173,13 @@ describe('vector recall applies the scope restriction in-query, not after', () =
 
   it('an empty allow-list still returns nothing', async (ctx) => {
     requireEmbedder(ctx)
-    expect(await plur.recallSemantic('deployment pipeline migrations', { limit: 5, scopes: [] })).toEqual([])
-    expect(await plur.recallHybrid('deployment pipeline migrations', { limit: 5, scopes: [] })).toEqual([])
+    expect(await plur.recallSemantic(QUERY, { limit: 5, scopes: [] })).toEqual([])
+    expect(await plur.recallHybrid(QUERY, { limit: 5, scopes: [] })).toEqual([])
   }, TIMEOUT)
 
   it('an absent allow-list is unrestricted — existing behaviour unchanged', async (ctx) => {
     requireEmbedder(ctx)
-    const hits = await plur.recallSemantic('deployment pipeline migrations', { limit: 10 })
+    const hits = await plur.recallSemantic(QUERY, { limit: 10 })
     expect(hits.length).toBe(10)
     expect(hits.some(e => e.scope === 'group:noise'), 'unrestricted recall should see the noise').toBe(true)
   }, TIMEOUT)

--- a/packages/core/test/pglite-vector-scope-dilution.test.ts
+++ b/packages/core/test/pglite-vector-scope-dilution.test.ts
@@ -161,14 +161,37 @@ describe('vector recall applies the scope restriction in-query, not after', () =
     expect(hits.every(e => e.scope === 'project:alpha')).toBe(true)
   }, TIMEOUT)
 
-  it('recallHybrid does the same on its vector leg', async (ctx) => {
+  it('recallHybrid takes the pushdown path, and does not silently fall back', async (ctx) => {
     requireEmbedder(ctx)
-    const hits = await plur.recallHybrid(QUERY, {
+    // Choosing the observable, because the obvious one does not work here.
+    //
+    // Asserting `length === WANTED` and "every hit is in scope" CANNOT see the
+    // vector leg: remove `{ scopes }` from its `searchVector` call and this
+    // suite stays green (verified by mutation). The reason is the fallback in
+    // `_pgliteHybridRecall` — an unrestricted k-NN returns only out-of-scope
+    // neighbours, they are all dropped by the intersection with `filtered`,
+    // `pgHits` comes out empty, and the method falls back to the in-memory
+    // `hybridSearchWithMeta` over the already-scope-filtered set. That path is
+    // correct AND complete, so the answer is identical.
+    //
+    // Which means, precisely: in hybrid the restriction is not what makes the
+    // result correct — it is what stops a silent degradation to the in-memory
+    // path on every query. (In `recallSemantic` there is no such rescue, and
+    // the mutation there does fail the test above.)
+    //
+    // `topScore` is what separates them: the pushdown branch returns null,
+    // `hybridSearchWithMeta` returns a real RRF score.
+    const meta = await plur.recallHybridWithMeta(QUERY, {
       limit: WANTED,
       scopes: ['project:alpha'],
     })
-    expect(hits.length).toBe(WANTED)
-    expect(hits.every(e => e.scope === 'project:alpha')).toBe(true)
+    expect(meta.engrams.length).toBe(WANTED)
+    expect(meta.engrams.every(e => e.scope === 'project:alpha')).toBe(true)
+    expect(
+      meta.topScore,
+      'fell back to the in-memory hybrid — the vector leg returned nothing usable, '
+      + 'which is what an unrestricted k-NN does when the permitted scope is a small share of the corpus',
+    ).toBeNull()
   }, TIMEOUT)
 
   it('an empty allow-list still returns nothing', async (ctx) => {

--- a/packages/core/test/postgres-bm25-pushdown.test.ts
+++ b/packages/core/test/postgres-bm25-pushdown.test.ts
@@ -223,14 +223,40 @@ describe.skipIf(!PG_URL)('PostgresAdapter — scope restriction as an AUTHORIZAT
     // searchVector previously omitted the `opts` parameter entirely; TypeScript
     // accepted the narrower arity, so callers passing `scopes` got an
     // unrestricted search with no error.
+    //
+    // This test used to run against a fixture with NO embeddings stored, and
+    // asserted `searchVector(v, 10, { scopes: [] })` returned []. Of course it
+    // did — with no vectors in the table it returns [] whether or not the
+    // filter is applied. The assertion could not fail. Real embeddings are
+    // stored here so the restriction has something to exclude.
     const dim = 384
-    const v = new Float32Array(dim)
-    v[0] = 1
-    // No embeddings are stored in this fixture, so the assertion that matters
-    // is that the call ACCEPTS the restriction and returns nothing out of scope
-    // rather than ignoring it.
-    const hits = await adapter.searchVector(v, 10, { scopes: [] })
-    expect(hits).toEqual([])
+    const vec = (seed: number) => {
+      const v = new Float32Array(dim)
+      for (let i = 0; i < dim; i++) v[i] = Math.sin(seed + i) / 10
+      v[0] = 1
+      return v
+    }
+    const alpha = corpus.find(e => e.scope === 'project:alpha')!
+    const beta = corpus.find(e => e.scope === 'project:beta')!
+    const globals = corpus.filter(e => e.scope === 'global').slice(0, 3)
+    for (const [i, e] of [alpha, beta, ...globals].entries()) {
+      await adapter.upsertEmbedding(e.id, vec(i))
+    }
+
+    // Unrestricted: the neighbour list contains engrams from several scopes —
+    // without this the restricted assertions below would be vacuous again.
+    const all = await adapter.searchVector(vec(0), 10)
+    expect(new Set(all.map(h => h.engram.scope)).size).toBeGreaterThan(1)
+
+    // Restricted to one scope: only that scope comes back, and the in-scope
+    // engram is still reachable (i.e. it filtered rather than returned nothing).
+    const scoped = await adapter.searchVector(vec(0), 10, { scopes: ['project:alpha'] })
+    expect(scoped.length).toBeGreaterThan(0)
+    expect(scoped.every(h => h.engram.scope === 'project:alpha')).toBe(true)
+    expect(scoped.map(h => h.engram.id)).toContain(alpha.id)
+
+    // Empty allow-list means nothing, never everything.
+    expect(await adapter.searchVector(vec(0), 10, { scopes: [] })).toEqual([])
   }, TIMEOUT)
 
   it('corpusStats honours the allow-list even with no query tokens', async () => {

--- a/packages/core/test/postgres-bm25-pushdown.test.ts
+++ b/packages/core/test/postgres-bm25-pushdown.test.ts
@@ -299,3 +299,116 @@ describe.skipIf(!PG_URL)('PostgresAdapter — LIKE metacharacters in query token
     expect(stats.df.get('snake_case')).toBe(1)
   }, TIMEOUT)
 })
+
+/**
+ * `searchBM25` must hand its scope restriction to `corpusStats`.
+ *
+ * `corpusStats(tokens, opts)` is well covered on its own, and so is
+ * `searchBM25`'s narrowing. The HANDOVER between them was not: delete `opts`
+ * from `corpusStats(queryTokens, opts)` inside `searchBM25` and every existing
+ * test stays green, because each half still behaves correctly in isolation.
+ *
+ * What breaks is ranking. IDF would be computed over the whole corpus including
+ * engrams the caller cannot see, so a term that is common inside the permitted
+ * scope but rare outside it gets the outsider's weight. The leak shows up as an
+ * ORDER, never as a visible row — which is why no "the right engram came back"
+ * assertion can catch it, and why the first fixture written for this test could
+ * not either (both candidates matched the same terms, so no IDF could reorder
+ * them; the teeth-check below caught that).
+ */
+describe.skipIf(!PG_URL)('searchBM25 scores with the RESTRICTED corpus statistics', () => {
+  const SCOPED_SCHEMA = 'plur_phase4_stats_handover'
+  const QUERY = 'mesh ingress'
+  let adapter: PostgresAdapter
+  let corpus: Engram[]
+
+  /**
+   * Built so the two candidates match DIFFERENT query terms, and those terms
+   * swap rarity depending on which corpus you measure:
+   *
+   *   inside project:alpha   ingress is common (9 docs), mesh is rare (1)
+   *   across the whole store mesh is common (61 docs), ingress stays at 9
+   *
+   * So alpha's own statistics rank the `mesh` document first, and the corpus's
+   * rank the `ingress` document first. Same rows either way.
+   */
+  function buildSkewed(): Engram[] {
+    const out: Engram[] = [
+      makeEngram('ENG-2026-0728-800', 'mesh gateway for the tenant cluster', 'project:alpha'),
+      makeEngram('ENG-2026-0728-801', 'ingress gateway for the tenant cluster', 'project:alpha'),
+    ]
+    for (let i = 0; i < 8; i++) {
+      out.push(makeEngram(`ENG-2026-0728-8${String(i + 10)}`, `ingress policy for the tenant cluster ${i}`, 'project:alpha'))
+    }
+    for (let i = 0; i < 60; i++) {
+      out.push(makeEngram(`ENG-2026-0728-9${String(i).padStart(2, '0')}`, `mesh sidecar note for service ${i}`, 'project:beta'))
+    }
+    return out
+  }
+
+  /** Position of `id` in a ranked id list, or Infinity if absent. */
+  const rank = (ids: string[], id: string) => {
+    const i = ids.indexOf(id)
+    return i === -1 ? Infinity : i
+  }
+
+  beforeAll(async () => {
+    corpus = buildSkewed()
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema: SCOPED_SCHEMA, vectorIndex: 'exact' })
+    await adapter.save(corpus)
+  }, TIMEOUT)
+
+  afterAll(async () => {
+    await adapter?.dropSchema().catch(() => { /* best effort */ })
+    await adapter?.close().catch(() => { /* best effort */ })
+  }, TIMEOUT)
+
+  it('the two statistics genuinely disagree — otherwise the test below proves nothing', async () => {
+    // Establish the teeth FIRST. If restricted and unrestricted statistics
+    // ranked these identically, the assertion in the next test would pass
+    // whichever one searchBM25 used, and it would be worthless.
+    const tokens = ftsTokenize(QUERY)
+    const restricted = await adapter.corpusStats(tokens, { scopes: ['project:alpha'] })
+    const unrestricted = await adapter.corpusStats(tokens)
+
+    expect(restricted.N, 'the restriction did not narrow the corpus').toBeLessThan(unrestricted.N)
+    // `df` is a Map. Property access silently yields undefined, and
+    // JSON.stringify prints a Map as `{}` — which makes a wrong assertion here
+    // look like a product bug.
+    expect(
+      restricted.df.get('mesh') ?? 0,
+      'the fixture no longer makes `mesh` rare inside alpha',
+    ).toBeLessThan(restricted.df.get('ingress') ?? 0)
+    expect(
+      unrestricted.df.get('mesh') ?? 0,
+      'the fixture no longer makes `mesh` common corpus-wide',
+    ).toBeGreaterThan(unrestricted.df.get('ingress') ?? 0)
+
+    const alphaOnly = corpus.filter(e => e.scope === 'project:alpha')
+    const byRestricted = searchEngrams(alphaOnly, QUERY, 20, restricted).map(e => e.id)
+    const byUnrestricted = searchEngrams(alphaOnly, QUERY, 20, unrestricted).map(e => e.id)
+
+    expect(
+      rank(byRestricted, 'ENG-2026-0728-800') < rank(byRestricted, 'ENG-2026-0728-801'),
+      'alpha statistics should favour the rare-inside-alpha `mesh` document',
+    ).toBe(true)
+    expect(
+      rank(byUnrestricted, 'ENG-2026-0728-801') < rank(byUnrestricted, 'ENG-2026-0728-800'),
+      'corpus-wide statistics should favour the `ingress` document — no teeth without this',
+    ).toBe(true)
+  }, TIMEOUT)
+
+  it('and searchBM25 uses the restricted one', async () => {
+    const tokens = ftsTokenize(QUERY)
+    const restricted = await adapter.corpusStats(tokens, { scopes: ['project:alpha'] })
+    const alphaOnly = corpus.filter(e => e.scope === 'project:alpha')
+    const expected = searchEngrams(alphaOnly, QUERY, 20, restricted).map(e => e.id)
+
+    const got = await adapter.searchBM25(QUERY, { limit: 20, status: 'active', scopes: ['project:alpha'] })
+
+    expect(
+      got.map(e => e.id),
+      'ranked with corpus-wide statistics — IDF is leaking from scopes the caller cannot see',
+    ).toEqual(expected)
+  }, TIMEOUT)
+})

--- a/packages/core/test/postgres-cold-start.test.ts
+++ b/packages/core/test/postgres-cold-start.test.ts
@@ -1,0 +1,131 @@
+/**
+ * N processes cold-starting against ONE fresh database.
+ *
+ * This is what a server deployment does every time it scales its replicas, and
+ * it was broken. Postgres `CREATE ... IF NOT EXISTS` is check-then-act, not
+ * atomic: concurrent sessions all pass the existence check, then all but one
+ * die on the catalog's unique index (`pg_namespace_nspname_index`,
+ * `pg_type_typname_nsp_index`, `pg_class_relname_nsp_index`,
+ * `pg_extension_name_index`).
+ *
+ * Measured on PostgreSQL 16 with 8 workers against an empty schema, before the
+ * fix: 7 of 8 failed, across 5 consecutive runs (7, 7, 7, 6, 4).
+ *
+ * The pgvector arm was worse than a crash. Its catch turned ANY failure into
+ * "Install the extension (CREATE EXTENSION vector) as a superuser, or grant the
+ * PLUR role rights to create it" — so a race presented as a permissions
+ * problem, and the operator would go and fix something that was never wrong.
+ *
+ * Gated on PLUR_TEST_POSTGRES_URL, like the other Postgres suites.
+ *
+ * Two mechanisms defend this, and mutation testing says each is independently
+ * sufficient: removing the advisory lock alone still passes, and removing the
+ * duplicate-object tolerance alone still passes; removing BOTH fails 4 of the
+ * 5 tests here. So this suite pins the DEFECT, not either mechanism — do not
+ * read a green run as evidence that the lock is still in place. Both are kept
+ * deliberately: the lock stops the collision happening at all, and the
+ * tolerance covers a rolling upgrade in which an older adapter is doing
+ * unlocked DDL against the same database at the same time.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { PostgresAdapter } from '../src/storage-postgres.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function makeEngram(id: string, statement: string): Engram {
+  return {
+    id, statement,
+    type: 'behavioral', scope: 'global', status: 'active', visibility: 'private',
+    version: 1, engram_version: 1, consolidated: false,
+    reference_count: 0, recurrence_count: 0, episode_ids: [], sources: [], tags: [],
+    relations: { broader: [], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: [] },
+    activation: { retrieval_strength: 1, storage_strength: 1, last_accessed: null, decay_rate: 0 },
+    temporal: { learned_at: '2026-07-28' },
+    created_at: '2026-07-28T00:00:00Z',
+    updated_at: '2026-07-28T00:00:00Z',
+  } as unknown as Engram
+}
+
+const PG_URL = process.env.PLUR_TEST_POSTGRES_URL
+const TIMEOUT = 180_000
+
+/** A distinct schema per test, so every case is a genuine COLD start. */
+let counter = 0
+const freshSchema = () => `plur_cold_${process.pid}_${counter++}`
+
+describe.skipIf(!PG_URL)('concurrent cold start on a fresh schema', () => {
+  let adapters: PostgresAdapter[] = []
+
+  afterEach(async () => {
+    await adapters[0]?.dropSchema().catch(() => { /* best effort */ })
+    await Promise.all(adapters.map(a => a.close().catch(() => { /* best effort */ })))
+    adapters = []
+  }, TIMEOUT)
+
+  it('8 workers all initialise the schema without a catalog collision', async () => {
+    const schema = freshSchema()
+    adapters = Array.from({ length: 8 }, () => new PostgresAdapter({
+      connectionString: PG_URL!, schema, vectorIndex: 'exact',
+    }))
+
+    const results = await Promise.allSettled(adapters.map(a => a.load()))
+    const failed = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[]
+
+    expect(
+      failed.map(f => String(f.reason?.message ?? f.reason)),
+      'a cold start lost the race and reported it as a failure',
+    ).toEqual([])
+  }, TIMEOUT)
+
+  it('16 workers — the same, under heavier contention', async () => {
+    const schema = freshSchema()
+    adapters = Array.from({ length: 16 }, () => new PostgresAdapter({
+      connectionString: PG_URL!, schema, vectorIndex: 'exact',
+    }))
+    const results = await Promise.allSettled(adapters.map(a => a.load()))
+    expect(results.filter(r => r.status === 'rejected')).toEqual([])
+  }, TIMEOUT)
+
+  it('the store is usable afterwards — not merely free of errors', async () => {
+    // Swallowing the duplicate-object codes could just as easily hide a schema
+    // that was never finished. Prove the table, the columns the BM25 pushdown
+    // needs, and the embeddings table all exist by using them.
+    const schema = freshSchema()
+    adapters = Array.from({ length: 8 }, () => new PostgresAdapter({
+      connectionString: PG_URL!, schema, vectorIndex: 'exact',
+    }))
+    await Promise.all(adapters.map(a => a.load()))
+
+    await adapters[0].save([makeEngram('ENG-COLD-0001', 'a coldstart engram written after concurrent init')])
+
+    for (const a of adapters) {
+      const loaded = await a.load()
+      expect(loaded.map(e => e.id)).toContain('ENG-COLD-0001')
+    }
+    expect(await adapters[0].searchBM25('cold-start', { limit: 5 })).not.toHaveLength(0)
+  }, TIMEOUT)
+
+  it('works when the pool allows exactly one connection', async () => {
+    // The lock is held on a pooled client. Holding one connection for the lock
+    // while the DDL asks the pool for a SECOND one deadlocks at maxConnections:1
+    // — which is how the first version of this fix failed. It hung rather than
+    // erroring, so only a timeout catches it.
+    const schema = freshSchema()
+    adapters = Array.from({ length: 16 }, () => new PostgresAdapter({
+      connectionString: PG_URL!, schema, vectorIndex: 'exact', maxConnections: 1,
+    }))
+    const results = await Promise.allSettled(adapters.map(a => a.load()))
+    expect(results.filter(r => r.status === 'rejected')).toEqual([])
+  }, TIMEOUT)
+
+  it('a second cold start against an ALREADY-initialised schema is still clean', async () => {
+    // The warm path has to keep working — the lock must be released, not leaked.
+    const schema = freshSchema()
+    const first = new PostgresAdapter({ connectionString: PG_URL!, schema, vectorIndex: 'exact' })
+    await first.load()
+    adapters = [first, ...Array.from({ length: 8 }, () => new PostgresAdapter({
+      connectionString: PG_URL!, schema, vectorIndex: 'exact',
+    }))]
+    const results = await Promise.allSettled(adapters.slice(1).map(a => a.load()))
+    expect(results.filter(r => r.status === 'rejected')).toEqual([])
+  }, TIMEOUT)
+})

--- a/packages/core/test/postgres-multi-writer.test.ts
+++ b/packages/core/test/postgres-multi-writer.test.ts
@@ -135,3 +135,48 @@ describe.skipIf(!PG_URL)('two Plur instances sharing one Postgres store', () => 
     expect((await a.load()).map(r => r.id)).toContain(e.id)
   }, TIMEOUT)
 })
+
+describe.skipIf(!PG_URL)('withExclusiveAccess under pool pressure', () => {
+  it('does not deadlock when concurrent writers exceed the pool size', async () => {
+    // The lock is held for the whole critical section and `fn()` needs its own
+    // connection. Taking both from ONE pool deadlocks the moment concurrent
+    // writers reach `maxConnections`: every connection is held by a lock holder
+    // waiting for a connection that can never be freed. No error, no timeout —
+    // the process just stops writing.
+    //
+    // Reproduced before the fix with pool=2 and three writers. A small pool is
+    // used here so the condition is reached in a test rather than at the
+    // default of 10, where it would need eleven concurrent writers.
+    const schema = 'plur_pool_deadlock_' + Math.random().toString(36).slice(2, 10)
+    const adapter = new PostgresAdapter({
+      connectionString: PG_URL!, schema, vectorIndex: 'exact', maxConnections: 2,
+    })
+    try {
+      await adapter.save([])
+      const work = () => adapter.withExclusiveAccess(async () => {
+        await adapter.load()
+        return 1
+      })
+      // 12 writers against a pool of 2. If the lock and the work share a pool
+      // this never settles and the test times out rather than failing.
+      const results = await Promise.all(Array.from({ length: 12 }, work))
+      expect(results).toHaveLength(12)
+      expect(results.every(r => r === 1)).toBe(true)
+    } finally {
+      await adapter.dropSchema().catch(() => { /* best effort */ })
+      await adapter.close().catch(() => { /* best effort */ })
+    }
+  }, 60_000)
+
+  it('close() tears down the lock pool too — no leaked connections', async () => {
+    const schema = 'plur_pool_close_' + Math.random().toString(36).slice(2, 10)
+    const adapter = new PostgresAdapter({ connectionString: PG_URL!, schema, vectorIndex: 'exact' })
+    await adapter.save([])
+    await adapter.withExclusiveAccess(async () => undefined)
+    await adapter.dropSchema().catch(() => { /* best effort */ })
+    await adapter.close()
+    // A second close must not throw, and the adapter must refuse further use.
+    await adapter.close()
+    await expect(adapter.load()).rejects.toThrow(/closed/)
+  }, 60_000)
+})

--- a/packages/core/test/postgres-recall-parity.test.ts
+++ b/packages/core/test/postgres-recall-parity.test.ts
@@ -120,7 +120,15 @@ describe.skipIf(!PG_URL)('recall() parity on the Postgres tier (#743 regression)
       await withTeam.learn('the billing deploy is nightly', { scope: 'global' })
 
       const hits = await withTeam.recall('kubernetes rollout', { limit: 20 })
-      expect(hits.map(h => h.id), 'the team store vanished from recall()').toContain(shared.id)
+      // Identified by STATEMENT, not by the raw team-store id: every read path
+      // namespaces a secondary store's ids (`ENG-` -> `ENG-GAC-`), so asserting
+      // on `shared.id` would be asserting the un-namespaced form — which is the
+      // bug the next test covers. This test is about the engram being reachable
+      // at all.
+      expect(
+        hits.map(h => h.statement),
+        'the team store vanished from recall()',
+      ).toContain(shared.statement)
     } finally {
       rmSync(teamDir, { recursive: true, force: true })
     }
@@ -148,5 +156,43 @@ describe.skipIf(!PG_URL)('recall() parity on the Postgres tier (#743 regression)
     const hits = await plur.recall('deploy target', { limit: 2 })
     expect(hits.length, 'expired rows consumed result slots').toBe(2)
     expect(hits.every(h => live.includes(h.id))).toBe(true)
+  }, TIMEOUT)
+
+  it('namespaces secondary-store ids exactly as every other read path does', async () => {
+    // Not cosmetic. Both stores mint `ENG-YYYY-MMDD-NNN` from a per-store daily
+    // sequence, so an un-namespaced team engram COLLIDES with a primary one as
+    // the common case — and `feedback()` / `forget()` resolve by exact id
+    // against the primary store first. A user rating a team engram returned by
+    // `plur_recall` would silently mutate an unrelated primary engram.
+    const teamDir = mkdtempSync(join(tmpdir(), 'plur-ns-'))
+    const teamYaml = join(teamDir, 'engrams.yaml')
+    try {
+      const team = new Plur({ path: teamDir })
+      await team.ready()
+      await team.learn('the kubernetes rollout is staged per region', { scope: 'group:acme/eng' })
+
+      writeFileSync(
+        join(dir, 'config.yaml'),
+        yaml.dump({ stores: [{ scope: 'group:acme/eng', shared: true, path: teamYaml }] }, { noRefs: true }),
+      )
+      const withTeam = new Plur({ path: dir, store: adapter })
+      await withTeam.ready()
+      await withTeam.learn('the billing deploy is nightly', { scope: 'global' })
+
+      const recalled = await withTeam.recall('kubernetes rollout', { limit: 20 })
+      const listed = await withTeam.list()
+
+      // No id appears twice.
+      const ids = recalled.map(e => e.id)
+      expect(new Set(ids).size, `duplicate ids across stores: ${ids.join(' ')}`).toBe(ids.length)
+
+      // And recall() reports the SAME id for a team engram that list() does.
+      const teamHit = recalled.find(e => e.scope === 'group:acme/eng')
+      expect(teamHit, 'the team engram was not returned at all').toBeDefined()
+      expect(listed.map(e => e.id)).toContain(teamHit!.id)
+      expect(teamHit!.id, 'id was not namespaced').toMatch(/^ENG-[A-Z]+-/)
+    } finally {
+      rmSync(teamDir, { recursive: true, force: true })
+    }
   }, TIMEOUT)
 })

--- a/packages/core/test/postgres-recall-parity.test.ts
+++ b/packages/core/test/postgres-recall-parity.test.ts
@@ -195,4 +195,46 @@ describe.skipIf(!PG_URL)('recall() parity on the Postgres tier (#743 regression)
       rmSync(teamDir, { recursive: true, force: true })
     }
   }, TIMEOUT)
+
+  it('does NOT rewrite the whole corpus to record a read', async () => {
+    // `recall()` updates activation on what it returned. That went through
+    // `save()` — a full replace — so every read rewrote every row while holding
+    // the global write lock. Measured before the fix: 252ms at 2,000 engrams,
+    // extrapolating to ~6.3s at 50,000, which is the corpus size at which this
+    // tier is selected. Every writer queued behind every reader.
+    //
+    // Asserted as "which method was used" rather than by timing: a duration
+    // threshold would be flaky on a loaded machine, and the property that
+    // matters is categorical — targeted write, not whole-corpus replace.
+    await plur.learn('deploy the billing service nightly', { scope: 'global' })
+    await plur.learn('unrelated note about invoicing', { scope: 'global' })
+
+    let saveCalls = 0
+    let updateManyCalls = 0
+    const realSave = adapter.save.bind(adapter)
+    const realUpdate = adapter.updateMany!.bind(adapter)
+    ;(adapter as unknown as { save: typeof adapter.save }).save = async (e) => { saveCalls++; return realSave(e) }
+    ;(adapter as unknown as { updateMany: typeof realUpdate }).updateMany = async (e) => { updateManyCalls++; return realUpdate(e) }
+    try {
+      const hits = await plur.recall('deploy billing', { limit: 5 })
+      expect(hits.length).toBeGreaterThan(0)
+      expect(updateManyCalls, 'the targeted write path was not used').toBeGreaterThan(0)
+      expect(saveCalls, 'a read rewrote the entire corpus').toBe(0)
+    } finally {
+      ;(adapter as unknown as { save: typeof adapter.save }).save = realSave
+      ;(adapter as unknown as { updateMany: typeof realUpdate }).updateMany = realUpdate
+    }
+  }, TIMEOUT)
+
+  it('still records the read — targeted does not mean skipped', async () => {
+    // The cheap way to make the assertion above pass is to stop writing at all.
+    const e = await plur.learn('deploy the billing service nightly', { scope: 'global' })
+    const before = (await adapter.load()).find(r => r.id === e.id)!
+    await plur.recall('deploy billing', { limit: 5 })
+    const after = (await adapter.load()).find(r => r.id === e.id)!
+    expect(
+      after.activation.frequency,
+      'the recall was not recorded on the engram it returned',
+    ).toBeGreaterThan(before.activation.frequency)
+  }, TIMEOUT)
 })

--- a/packages/core/test/postgres-recall-parity.test.ts
+++ b/packages/core/test/postgres-recall-parity.test.ts
@@ -237,4 +237,24 @@ describe.skipIf(!PG_URL)('recall() parity on the Postgres tier (#743 regression)
       'the recall was not recorded on the engram it returned',
     ).toBeGreaterThan(before.activation.frequency)
   }, TIMEOUT)
+
+  it('a row missing an optional field does not crash the read', async () => {
+    // `PostgresAdapter` stores the engram as JSONB and used to return it
+    // verbatim, unlike the YAML loader which runs every entry through the schema
+    // and fills defaults. A row whose payload lacked `associations` therefore
+    // reached the co-access block as `undefined` and took down the entire
+    // recall with `Cannot read properties of undefined (reading 'find')`.
+    //
+    // Reachable without anything exotic: an older version, a migration, or any
+    // tool that writes the table directly. Nothing on the write path enforces
+    // the schema either. A read must not be able to crash on a row it merely
+    // passed over.
+    await plur.learn('deploy the billing service nightly', { scope: 'global' })
+    const rows = await adapter.load()
+    for (const r of rows) delete (r as { associations?: unknown }).associations
+    await adapter.save(rows)
+
+    const hits = await plur.recall('deploy billing', { limit: 5 })
+    expect(hits.length, 'the recall crashed or returned nothing').toBeGreaterThan(0)
+  }, TIMEOUT)
 })

--- a/packages/core/test/postgres-recall-parity.test.ts
+++ b/packages/core/test/postgres-recall-parity.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `recall()` on the Postgres tier must agree with the rest of the engine.
+ *
+ * The BM25 pushdown (#743) replaced `_filterEngrams()` with a direct
+ * `adapter.searchBM25()` call and returned. The comment above it claimed the
+ * adapter was "handed the SAME filter this method would have applied in
+ * memory". It was not. `_filterEngrams` also applies:
+ *
+ *   - temporal validity (`valid_until` / `valid_from`)
+ *   - `min_strength`
+ *   - engrams merged in from `config.stores` (team / enterprise stores)
+ *   - pack engrams
+ *
+ * None survive a `SELECT` against one table. So on the Postgres tier, `recall()`
+ * returned engrams that had been explicitly withdrawn, ignored `min_strength`,
+ * and stopped seeing the team store entirely — while `list()`, `recallHybrid()`
+ * and `inject()` on the SAME instance still behaved correctly. Two reads of one
+ * store disagreeing, with no error either way.
+ *
+ * The existing pushdown tests asserted scope, scopes and domain — exactly the
+ * three filters that WERE forwarded — which is why a full green suite missed it.
+ * These assert the ones that were not.
+ *
+ * Gated on PLUR_TEST_POSTGRES_URL.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { PostgresAdapter } from '../src/storage-postgres.js'
+
+const PG_URL = process.env.PLUR_TEST_POSTGRES_URL
+const TIMEOUT = 180_000
+
+describe.skipIf(!PG_URL)('recall() parity on the Postgres tier (#743 regression)', () => {
+  let adapter: PostgresAdapter
+  let plur: Plur
+  let dir: string
+  let schema: string
+
+  beforeEach(async () => {
+    schema = 'plur_parity_' + Math.random().toString(36).slice(2, 10)
+    dir = mkdtempSync(join(tmpdir(), 'plur-parity-'))
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema, vectorIndex: 'exact' })
+    await adapter.save([])
+    plur = new Plur({ path: dir, store: adapter })
+    await plur.ready()
+  }, TIMEOUT)
+
+  afterEach(async () => {
+    await adapter?.dropSchema().catch(() => { /* best effort */ })
+    await adapter?.close().catch(() => { /* best effort */ })
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }, TIMEOUT)
+
+  it('does not return an engram whose validity has expired', async () => {
+    await plur.learn('deploy the billing service nightly', { scope: 'global' })
+    const stale = await plur.learn('deploy via the OLD pipeline, since withdrawn', { scope: 'global' })
+
+    const rows = await adapter.load()
+    const target = rows.find(r => r.id === stale.id)!
+    ;(target as { temporal?: Record<string, unknown> }).temporal = {
+      ...(target.temporal ?? {}),
+      valid_until: '2020-01-01',
+    }
+    await adapter.save(rows)
+
+    const hits = await plur.recall('deploy')
+    expect(hits.map(h => h.id), 'an engram withdrawn in 2020 was returned as current').not.toContain(stale.id)
+  }, TIMEOUT)
+
+  it('agrees with list() about which engrams are live', async () => {
+    // The invariant behind the specific cases: two reads of one store must not
+    // disagree about what is in it.
+    await plur.learn('alpha deployment runbook', { scope: 'global' })
+    const stale = await plur.learn('beta deployment runbook, withdrawn', { scope: 'global' })
+    const rows = await adapter.load()
+    const t = rows.find(r => r.id === stale.id)!
+    ;(t as { temporal?: Record<string, unknown> }).temporal = { ...(t.temporal ?? {}), valid_until: '2020-01-01' }
+    await adapter.save(rows)
+
+    const recalled = new Set((await plur.recall('deployment runbook', { limit: 50 })).map(e => e.id))
+    const listed = new Set((await plur.list()).map(e => e.id))
+    for (const id of recalled) {
+      expect(listed.has(id), `recall() returned ${id}, which list() excludes`).toBe(true)
+    }
+  }, TIMEOUT)
+
+  it('honours min_strength', async () => {
+    await plur.learn('deploy the billing service', { scope: 'global' })
+    const weak = await plur.learn('deploy something barely remembered', { scope: 'global' })
+    const rows = await adapter.load()
+    const t = rows.find(r => r.id === weak.id)!
+    ;(t as { activation: Record<string, unknown> }).activation = { ...t.activation, retrieval_strength: 0.01 }
+    await adapter.save(rows)
+
+    const hits = await plur.recall('deploy', { min_strength: 0.5 })
+    expect(hits.map(h => h.id), 'min_strength was ignored').not.toContain(weak.id)
+  }, TIMEOUT)
+
+  it('still returns engrams from a secondary (team) store', async () => {
+    // The one that would present as "recall is broken": on the Postgres tier
+    // `plur_recall` stopped returning the team store, while `recallHybrid` on
+    // the same instance still did.
+    const teamDir = mkdtempSync(join(tmpdir(), 'plur-team-'))
+    const teamYaml = join(teamDir, 'engrams.yaml')
+    try {
+      const team = new Plur({ path: teamDir })
+      await team.ready()
+      const shared = await team.learn('the kubernetes rollout is staged per region', { scope: 'group:acme/eng' })
+
+      writeFileSync(
+        join(dir, 'config.yaml'),
+        yaml.dump({ stores: [{ scope: 'group:acme/eng', shared: true, path: teamYaml }] }, { noRefs: true }),
+      )
+      const withTeam = new Plur({ path: dir, store: adapter })
+      await withTeam.ready()
+      await withTeam.learn('the billing deploy is nightly', { scope: 'global' })
+
+      const hits = await withTeam.recall('kubernetes rollout', { limit: 20 })
+      expect(hits.map(h => h.id), 'the team store vanished from recall()').toContain(shared.id)
+    } finally {
+      rmSync(teamDir, { recursive: true, force: true })
+    }
+  }, TIMEOUT)
+
+  it('applies limit AFTER the residual filters, not before', async () => {
+    // A row removed by expiry must not consume a slot: asking for 2 live
+    // engrams should return 2, even when expired ones rank above them.
+    const live: string[] = []
+    for (let i = 0; i < 2; i++) {
+      live.push((await plur.learn(`deploy target live number ${i}`, { scope: 'global' })).id)
+    }
+    const dead: string[] = []
+    for (let i = 0; i < 4; i++) {
+      dead.push((await plur.learn(`deploy target expired number ${i}`, { scope: 'global' })).id)
+    }
+    const rows = await adapter.load()
+    for (const r of rows) {
+      if (dead.includes(r.id)) {
+        ;(r as { temporal?: Record<string, unknown> }).temporal = { ...(r.temporal ?? {}), valid_until: '2020-01-01' }
+      }
+    }
+    await adapter.save(rows)
+
+    const hits = await plur.recall('deploy target', { limit: 2 })
+    expect(hits.length, 'expired rows consumed result slots').toBe(2)
+    expect(hits.every(h => live.includes(h.id))).toBe(true)
+  }, TIMEOUT)
+})

--- a/packages/core/test/primary-store.test.ts
+++ b/packages/core/test/primary-store.test.ts
@@ -166,10 +166,17 @@ describe('YamlPrimaryStore — ADR-0001 compatibility', () => {
     expect((await store.load()).map(e => e.id)).toEqual(['ENG-2026-0701-106'])
   })
 
-  it('returns [] for an unparseable file rather than throwing', async () => {
+  it('THROWS for an unparseable file rather than reporting it as empty', async () => {
+    // This test previously asserted the opposite — that an unparseable store
+    // loads as `[]`. That assertion encoded a data-loss bug as intended
+    // behaviour: every write is load -> mutate -> save-whole-file, so a store
+    // read as empty is a store about to be overwritten by a one-engram file.
+    // Measured: 5 engrams, corrupt the YAML, one write, 1 engram left and the
+    // originals unrecoverable. A missing file is empty; an unreadable one is
+    // not. See unreadable-store-guard.test.ts.
     writeFileSync(path, ':\n  not: [valid', 'utf8')
     const store = new YamlPrimaryStore(path)
-    expect(await store.load()).toEqual([])
+    await expect(store.load()).rejects.toThrow(/refusing to read/)
   })
 })
 

--- a/packages/core/test/scope-pushdown.test.ts
+++ b/packages/core/test/scope-pushdown.test.ts
@@ -16,6 +16,7 @@
  * pass-through).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { buildFilterClause } from '../src/storage-postgres.js'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -242,4 +243,39 @@ describe('Plur read paths — permitted-scope pushdown', () => {
       })
     })
   }
+})
+
+describe('LIKE metacharacters in a caller-supplied scope or domain', () => {
+  // `buildFilterClause` puts `filter.scope` and `filter.domain` into LIKE
+  // patterns. Unescaped, a caller's `%` WIDENS the match instead of narrowing
+  // it — verified against a live database: `{ domain: '%' }` returned every
+  // domain, and `{ scope: '%' }` returned engrams from two unrelated groups,
+  // which is precisely the segment-aware containment the #383 guard exists to
+  // enforce.
+  //
+  // Both adapters are checked, because the scope rules have drifted between the
+  // Postgres and PGLite copies before and that drift was an authorization
+  // bypass.
+  it('a wildcard domain matches literally, not everything', () => {
+    const { where, params } = buildFilterClause({ status: 'active', domain: '%' })
+    expect(where).toMatch(/ESCAPE/)
+    expect(params).toContain('\\%')
+  })
+
+  it('a wildcard scope matches literally, not across namespaces', () => {
+    const { where, params } = buildFilterClause({ status: 'active', scope: '%' })
+    expect(where).toMatch(/ESCAPE/)
+    // The equality arm keeps the raw value; the two LIKE arms are escaped.
+    expect(params.filter(p => p === '\\%').length).toBe(2)
+  })
+
+  it('an underscore is escaped too — it is LIKE\'s single-character wildcard', () => {
+    const { params } = buildFilterClause({ status: 'active', domain: 'ops_deploy' })
+    expect(params).toContain('ops\\_deploy')
+  })
+
+  it('an ordinary scope is unchanged', () => {
+    const { params } = buildFilterClause({ status: 'active', domain: 'ops/deploy' })
+    expect(params).toContain('ops/deploy')
+  })
 })

--- a/packages/core/test/set-pinned-remote.test.ts
+++ b/packages/core/test/set-pinned-remote.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `setPinned()` on a remote store must return the engram, not a stand-in.
+ *
+ * The remote branch used to fire-and-forget the PATCH and return
+ * `{ id, pinned } as unknown as Engram`. That cast is doing real damage: the
+ * object has no `statement`, `scope`, `status` or `activation`, so it satisfies
+ * the type and fails at the first property read. Its own JSDoc said "returns
+ * the updated engram".
+ *
+ * Three separate silent failures in one branch:
+ *   - the return value is not an engram, and reads on it are `undefined`
+ *   - success is reported before the write has happened
+ *   - a rejected floating promise cannot be caught by the `catch` around it,
+ *     so a failed PATCH still returned "success"
+ *
+ * The stated reason was that `setPinned` had to keep a synchronous signature.
+ * It has been `async` since the 0.16 flip.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Plur } from '../src/index.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/** The engram the fake server holds — a complete one, unlike the old stand-in. */
+function serverEngram(pinned: boolean): Engram {
+  return {
+    id: 'ENG-2026-0728-500',
+    statement: 'the remote store holds the real engram',
+    type: 'behavioral', scope: 'group:acme/eng', status: 'active', visibility: 'private',
+    version: 1, engram_version: 1, consolidated: false, pinned: pinned || undefined,
+    reference_count: 0, recurrence_count: 0, episode_ids: [], sources: [], tags: [],
+    relations: { broader: [], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: [] },
+    activation: { retrieval_strength: 1, storage_strength: 1, last_accessed: null, decay_rate: 0 },
+    temporal: { learned_at: '2026-07-28' },
+    created_at: '2026-07-28T00:00:00Z', updated_at: '2026-07-28T00:00:00Z',
+  } as unknown as Engram
+}
+
+describe('setPinned() against a remote store', () => {
+  let dir: string
+  let plur: Plur
+  let patchCalls: number
+  let patchImpl: (id: string, body: Record<string, unknown>) => Promise<Engram | null>
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-setpinned-'))
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+    writeFileSync(join(dir, 'config.yaml'),
+      'stores:\n  - scope: "group:acme/eng"\n    url: "https://example.invalid"\n    token: "t"\n')
+    plur = new Plur({ path: dir })
+    await plur.ready()
+
+    patchCalls = 0
+    patchImpl = async () => serverEngram(true)
+    // Stub the driver so no network is involved; the point is the branch, not HTTP.
+    ;(plur as unknown as { _getRemoteDriver: () => unknown })._getRemoteDriver = () => ({
+      patch: async (id: string, body: Record<string, unknown>) => {
+        patchCalls++
+        return patchImpl(id, body)
+      },
+    })
+  })
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('returns the engram the server sent, not a synthesized stub', async () => {
+    const res = await plur.setPinned('ENG-2026-0728-500', true)
+    expect(res).not.toBeNull()
+    // The exact reads that were `undefined` before.
+    expect(res!.statement).toBe('the remote store holds the real engram')
+    expect(res!.scope).toBe('group:acme/eng')
+    expect(res!.status).toBe('active')
+    expect(res!.pinned).toBe(true)
+  })
+
+  it('awaits the PATCH before returning — no fire-and-forget', async () => {
+    let settled = false
+    patchImpl = async () => {
+      await new Promise(r => setTimeout(r, 20))
+      settled = true
+      return serverEngram(true)
+    }
+    await plur.setPinned('ENG-2026-0728-500', true)
+    expect(settled, 'returned before the write completed').toBe(true)
+    expect(patchCalls).toBe(1)
+  })
+
+  it('returns null when the remote write FAILS, instead of reporting success', async () => {
+    // Previously the rejection escaped as an unhandled floating promise and the
+    // caller was handed a stub that said the pin had worked.
+    patchImpl = async () => { throw new Error('remote unreachable') }
+    expect(await plur.setPinned('ENG-2026-0728-500', true)).toBeNull()
+  })
+
+  it('returns null when the remote reports no such engram', async () => {
+    patchImpl = async () => null
+    expect(await plur.setPinned('ENG-2026-0728-500', true)).toBeNull()
+  })
+
+  it('setPinnedAsync agrees with it — the two must not drift apart', async () => {
+    const a = await plur.setPinned('ENG-2026-0728-500', true)
+    const b = await plur.setPinnedAsync('ENG-2026-0728-500', true)
+    expect(a).toEqual(b)
+  })
+
+  it('unpinning sends pinned: undefined and returns the server engram', async () => {
+    let seen: Record<string, unknown> | undefined
+    patchImpl = async (_id, body) => { seen = body; return serverEngram(false) }
+    const res = await plur.setPinned('ENG-2026-0728-500', false)
+    expect(seen).toEqual({ pinned: undefined })
+    expect(res!.pinned).toBeUndefined()
+  })
+})

--- a/packages/core/test/unreadable-store-guard.test.ts
+++ b/packages/core/test/unreadable-store-guard.test.ts
@@ -1,0 +1,112 @@
+/**
+ * An unreadable engram store must not be reported as an empty one.
+ *
+ * This is the most destructive silent failure the codebase had, and it needed
+ * two ordinary facts to combine:
+ *
+ *   1. `loadEngrams` caught a YAML parse error, logged it, and returned `[]`.
+ *   2. Every `Plur` write is load -> mutate -> save, and `save` replaces the
+ *      WHOLE file.
+ *
+ * So a corpus that would not parse was read as empty, and the very next
+ * `learn()` wrote a one-engram file over it. Measured before the fix: 5 engrams
+ * in, file corrupted, one write later the store contained exactly 1 and none of
+ * the originals were recoverable.
+ *
+ * The `logger.error` on the way past was visible. It did not matter: the RETURN
+ * VALUE said "empty", and the caller acted on the return value.
+ *
+ * The most plausible route in is not exotic. `plur sync` is git-backed, and a
+ * merge conflict writes `<<<<<<<` markers straight into engrams.yaml.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Plur, EngramStoreUnreadableError } from '../src/index.js'
+import { loadEngrams } from '../src/engrams.js'
+
+describe('unreadable engram store', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-unreadable-'))
+    path = join(dir, 'engrams.yaml')
+    const plur = new Plur({ path: dir })
+    await plur.ready()
+    for (let i = 0; i < 5; i++) {
+      await plur.learn(`important memory number ${i}`, { scope: 'global' })
+    }
+  })
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('a truncated file throws rather than reading as empty', () => {
+    const good = readFileSync(path, 'utf8')
+    writeFileSync(path, good.slice(0, Math.floor(good.length / 2)) + '\n  - {{{ broken')
+    expect(() => loadEngrams(path)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('a git merge conflict throws — the most likely route in', () => {
+    // `plur sync` is git-backed, so this is what a conflicted engrams.yaml
+    // actually looks like on disk.
+    const good = readFileSync(path, 'utf8')
+    writeFileSync(path, `<<<<<<< HEAD\n${good}=======\n${good}>>>>>>> origin/main\n`)
+    expect(() => loadEngrams(path)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('the engrams SURVIVE a write attempt against a corrupted store', async () => {
+    // The whole point. Before the fix this wrote a one-engram file over five.
+    const good = readFileSync(path, 'utf8')
+    writeFileSync(path, good.slice(0, Math.floor(good.length / 2)) + '\n  - {{{ broken')
+
+    const plur = new Plur({ path: dir })
+    await expect(plur.learn('a write against a corrupted store', { scope: 'global' })).rejects.toThrow()
+
+    // The corrupted bytes are still there — nothing overwrote them, so the user
+    // can fix the conflict or restore from git and keep everything.
+    const after = readFileSync(path, 'utf8')
+    expect(after, 'the corrupted file was overwritten — the originals are gone').toContain('important memory number')
+  })
+
+  it('the error names the likely cause and says what it refused to do', () => {
+    writeFileSync(path, '{{{ not yaml')
+    try {
+      loadEngrams(path)
+      throw new Error('should have thrown')
+    } catch (err) {
+      const msg = (err as Error).message
+      // An error a user cannot act on is barely better than a silent failure.
+      expect(msg).toMatch(/merge conflict/i)
+      expect(msg).toMatch(/NOT being treated as empty/i)
+      expect(msg).toContain(path)
+    }
+  })
+
+  it('a MISSING file is still an empty store, not an error', () => {
+    // The distinction the fix rests on: absent really is empty.
+    expect(loadEngrams(join(dir, 'does-not-exist.yaml'))).toEqual([])
+  })
+
+  it('an empty or comment-only file is still an empty store', () => {
+    writeFileSync(path, '# nothing here yet\n')
+    expect(loadEngrams(path)).toEqual([])
+  })
+
+  it('a file with a valid shape but no engrams key is an empty store', () => {
+    writeFileSync(path, 'something_else: true\n')
+    expect(loadEngrams(path)).toEqual([])
+  })
+
+  it('one malformed ENTRY among many is skipped, not fatal', () => {
+    // Partial data is a different problem from an unreadable store: dropping a
+    // single bad engram loses less than refusing to load the other four.
+    const parsed = readFileSync(path, 'utf8')
+    writeFileSync(path, parsed + '  - not_an_engram: true\n')
+    const engrams = loadEngrams(path)
+    expect(engrams.length).toBe(5)
+  })
+})

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -46,7 +46,7 @@ Knowledge is stored as **engrams** — small assertions that strengthen with use
 
 ## Tools
 
-By default (lean profile), your agent gets 11 tools. Everything else is reachable through `plur_admin`:
+By default (lean profile), your agent gets 12 tools. Everything else is reachable through `plur_admin`:
 
 | Tool | What it does |
 |------|-------------|
@@ -58,11 +58,12 @@ By default (lean profile), your agent gets 11 tools. Everything else is reachabl
 | `plur_session_end` | End a session — captures summary and new learnings |
 | `plur_status` | System health |
 | `plur_doctor` | Diagnose embedder, hybrid search, and remote-store auth |
+| `plur_receipt` | Show why a memory was injected — the evidence behind a recall |
 | `plur_packs_uninstall` | Remove an installed pack |
 | `plur_tensions_purge` | Clear stale/resolved tensions |
 | `plur_admin` | Dispatch to any other tool: `{ action: "plur_packs_install", args: {...} }` |
 
-Less commonly needed tools (`plur_recall`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 40 tools directly.
+Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 40 tools directly.
 
 ## Sync across machines
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1425,9 +1425,18 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
         // Flush outbox after git sync (issue #26)
         let outbox_result: { flushed: number; failed: number; expired_warnings: string[] } | undefined
+        let outbox_error: string | undefined
         try {
           outbox_result = await plur.flushOutbox()
-        } catch { /* logged inside flushOutbox */ }
+        } catch (err) {
+          // SURFACED, not swallowed. The `outbox` field below is only added when
+          // `outbox_result` is truthy, so a FAILED flush produced a response
+          // indistinguishable from one with nothing to flush. The caller here is
+          // an agent: it sees success, reports success, and the engrams routed
+          // to a remote store stay queued indefinitely. A log line inside
+          // `flushOutbox` is not a report to the caller.
+          outbox_error = (err as Error).message
+        }
 
         return {
           ...result,
@@ -1441,6 +1450,12 @@ function getAllToolDefinitions(): ToolDefinition[] {
               pending: outbox_result.failed,
               warnings: outbox_result.expired_warnings,
             },
+          } : {}),
+          ...(outbox_error ? {
+            outbox_error,
+            outbox_warning:
+              `The outbox flush failed — ${outbox_error}. Engrams routed to a remote store are `
+              + `still queued locally and were NOT pushed. They retry on the next session_start or plur_sync.`,
           } : {}),
         }
       },
@@ -1984,9 +1999,18 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
         // Flush outbox — retry pending remote writes (issue #26)
         let outbox_result: { flushed: number; failed: number; expired_warnings: string[] } | undefined
+        let outbox_error: string | undefined
         try {
           outbox_result = await plur.flushOutbox()
-        } catch { /* logged inside flushOutbox */ }
+        } catch (err) {
+          // SURFACED, not swallowed. The `outbox` field below is only added when
+          // `outbox_result` is truthy, so a FAILED flush produced a response
+          // indistinguishable from one with nothing to flush. The caller here is
+          // an agent: it sees success, reports success, and the engrams routed
+          // to a remote store stay queued indefinitely. A log line inside
+          // `flushOutbox` is not a report to the caller.
+          outbox_error = (err as Error).message
+        }
 
         // Surface writable remote scopes so AI caller knows what's available (#229)
         // NOTE: we do NOT auto-set session scope FROM REMOTE STORES — the AI
@@ -2230,6 +2254,12 @@ function getAllToolDefinitions(): ToolDefinition[] {
               pending: outbox_result.failed,
               warnings: outbox_result.expired_warnings,
             },
+          } : {}),
+          ...(outbox_error ? {
+            outbox_error,
+            outbox_warning:
+              `The outbox flush failed — ${outbox_error}. Engrams routed to a remote store are `
+              + `still queued locally and were NOT pushed. They retry on the next session_start or plur_sync.`,
           } : {}),
           // Version staleness warning (issue #151)
           ...(version_warning ? { version_warning, version: VERSION } : {}),

--- a/packages/mcp/test/outbox-failure-surfaced.test.ts
+++ b/packages/mcp/test/outbox-failure-surfaced.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A failed outbox flush must reach the caller.
+ *
+ * `plur_sync` and `plur_session_start` both call `flushOutbox()` and both used
+ * to wrap it in `catch { /* logged inside flushOutbox *\/ }`. The `outbox` field
+ * in their responses is only added when the flush RESULT is truthy — so a
+ * failure produced a response byte-identical to a sync with nothing to flush.
+ *
+ * That is the worst shape a failure can take here, because the caller is an
+ * agent. It sees a clean result, tells the user the sync worked, and the
+ * engrams routed to a remote store stay queued indefinitely with nobody
+ * looking. A log line inside `flushOutbox` is not a report to the caller — it
+ * goes to the server's stderr, which the agent never reads.
+ *
+ * These tests force the flush to throw and assert the failure is visible in the
+ * tool's own output.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Plur } from '@plur-ai/core'
+import { getToolDefinitions } from '../src/tools.js'
+
+describe('a failed outbox flush is surfaced, not swallowed', () => {
+  let dir: string
+  let plur: Plur
+  const tools = getToolDefinitions('full')
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-outbox-surface-'))
+    plur = new Plur({ path: dir })
+    await plur.ready()
+    await plur.learn('an engram so the store is not empty', { scope: 'global' })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('plur_sync reports the failure instead of a clean result', async () => {
+    vi.spyOn(plur, 'flushOutbox').mockRejectedValue(new Error('remote unreachable: ECONNREFUSED'))
+    const tool = tools.find(t => t.name === 'plur_sync')!
+
+    const result = await tool.handler({}, plur) as Record<string, unknown>
+
+    expect(result.outbox_error, 'the failure did not reach the caller').toBe(
+      'remote unreachable: ECONNREFUSED',
+    )
+    expect(String(result.outbox_warning)).toMatch(/still queued locally/)
+    expect(String(result.outbox_warning)).toMatch(/NOT pushed/)
+  })
+
+  it('plur_session_start reports it too', async () => {
+    vi.spyOn(plur, 'flushOutbox').mockRejectedValue(new Error('remote unreachable: ECONNREFUSED'))
+    const tool = tools.find(t => t.name === 'plur_session_start')!
+
+    const result = await tool.handler({ task: 'anything' }, plur) as Record<string, unknown>
+
+    expect(result.outbox_error).toBe('remote unreachable: ECONNREFUSED')
+    expect(String(result.outbox_warning)).toMatch(/still queued locally/)
+  })
+
+  it('a SUCCESSFUL sync carries no error field — the signal has to mean something', async () => {
+    // Guards against "always report a warning", which would be just as useless
+    // as never reporting one.
+    const tool = tools.find(t => t.name === 'plur_sync')!
+    const result = await tool.handler({}, plur) as Record<string, unknown>
+    expect(result.outbox_error).toBeUndefined()
+    expect(result.outbox_warning).toBeUndefined()
+  })
+
+  it('the sync itself still succeeds — a queued outbox is not a failed sync', async () => {
+    // The git sync genuinely did run. Downgrading it to a thrown error would
+    // break callers for whom a queued outbox is normal (offline, slow remote).
+    vi.spyOn(plur, 'flushOutbox').mockRejectedValue(new Error('remote unreachable'))
+    const tool = tools.find(t => t.name === 'plur_sync')!
+    const result = await tool.handler({}, plur) as Record<string, unknown>
+    expect(result.action, 'sync should still report its own outcome').toBeDefined()
+  })
+})

--- a/packages/mcp/test/readme-tool-table.test.ts
+++ b/packages/mcp/test/readme-tool-table.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The README's lean-profile table must match the lean profile.
+ *
+ * The table is the only description most users read before wiring PLUR into an
+ * agent, and it had drifted: it announced 11 tools when the profile serves 12,
+ * omitted `plur_receipt` entirely, and listed `plur_recall` under "reachable via
+ * plur_admin" while `plur_recall` is in the lean set — telling readers to route
+ * the single most-used tool through a dispatcher.
+ *
+ * Nothing could notice, because the table is prose and the profile is code.
+ * This test reads both.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { getToolDefinitions } from '../src/tools.js'
+
+const README = join(__dirname, '..', 'README.md')
+
+/** Tool names in the lean table — the rows between the header and the blank line. */
+function documentedLeanTools(): string[] {
+  const md = readFileSync(README, 'utf8')
+  const start = md.indexOf('By default (lean profile)')
+  expect(start, 'the lean-profile section is gone — this test needs updating').toBeGreaterThan(-1)
+  const section = md.slice(start, md.indexOf('\n\n', md.indexOf('| Tool |', start)))
+  return [...section.matchAll(/^\|\s*`(plur_[a-z_]+)`\s*\|/gm)].map(m => m[1])
+}
+
+describe('the MCP README documents the real lean profile', () => {
+  const lean = getToolDefinitions('lean').map(t => t.name).sort()
+
+  it('lists exactly the tools the lean profile serves', () => {
+    expect(documentedLeanTools().sort()).toEqual(lean)
+  })
+
+  it('states the right count in the sentence above the table', () => {
+    const md = readFileSync(README, 'utf8')
+    const m = md.match(/lean profile\), your agent gets (\d+) tools/)
+    expect(m, 'the count sentence is gone').not.toBeNull()
+    expect(Number(m![1])).toBe(lean.length)
+  })
+
+  it('does not describe a lean tool as admin-only', () => {
+    // The specific error that shipped: `plur_recall` appeared in both the lean
+    // table and the "reachable via plur_admin" list.
+    const md = readFileSync(README, 'utf8')
+    const line = md.split('\n').find(l => l.includes('reachable via `plur_admin`'))
+    expect(line, 'the admin-dispatch sentence is gone').toBeDefined()
+    const named = [...line!.matchAll(/`(plur_[a-z_]+)`/g)].map(m => m[1])
+    const contradictions = named.filter(n => lean.includes(n) && n !== 'plur_admin')
+    expect(contradictions, 'these are IN the lean profile, not admin-only').toEqual([])
+  })
+
+  it('states the right total for the full profile', () => {
+    const md = readFileSync(README, 'utf8')
+    const m = md.match(/expose all (\d+) tools directly/)
+    expect(m).not.toBeNull()
+    expect(Number(m![1])).toBe(getToolDefinitions('full').length)
+  })
+})

--- a/packages/migrate/src/index.ts
+++ b/packages/migrate/src/index.ts
@@ -34,6 +34,13 @@ OPTIONS
 
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git', 'coverage', '.next'])
 
+/**
+ * Does this file mention ANY of the methods we care about? Purely an
+ * optimisation — the scanner is authoritative. Built from `NEWLY_ASYNC` so it
+ * cannot fall behind it.
+ */
+const PREFILTER = new RegExp(String.raw`\.(?:${NEWLY_ASYNC.join('|')})\s*\(`)
+
 function walk(dir: string, exts: Set<string>, out: string[] = []): string[] {
   let entries
   try { entries = readdirSync(dir, { withFileTypes: true }) } catch { return out }
@@ -76,7 +83,15 @@ export function run(argv: string[]): number {
   for (const f of files) {
     let src: string
     try { src = readFileSync(f, 'utf8') } catch { continue }
-    if (!/\.(learn|recall|inject|feedback|forget|getById|list|status|ingest|sync)\s*\(/.test(src)) continue
+    // Cheap pre-filter, DERIVED from the method table rather than hand-written.
+    //
+    // It used to list ten names while `NEWLY_ASYNC` held twenty-eight, so a file
+    // whose only calls were `setPinned`, `receipt` or `installPack` was skipped
+    // outright — and the run then printed "no un-awaited PLUR calls found" and
+    // exited 0. Telling someone their migration is clean when it is not is the
+    // worst thing this tool can do; it is the one output they will act on
+    // without checking.
+    if (!PREFILTER.test(src)) continue
 
     const findings = scanSource(relative(process.cwd(), f) || f, src)
     if (findings.length === 0) continue

--- a/packages/migrate/src/scan.ts
+++ b/packages/migrate/src/scan.ts
@@ -37,27 +37,44 @@
  * they were briefly async before release and were reverted.
  */
 export const NEWLY_ASYNC = [
-  'learn',
-  'learnRouted',
-  'learnBatch',
-  'recall',
-  'inject',
-  'feedback',
-  'forget',
+  // Derived from git, not from memory: these are the methods whose signature
+  // went sync -> async in 0.16. `packages/migrate/test/method-list.test.ts`
+  // re-derives the same set from `Plur` and fails if this drifts — the list was
+  // hand-written once and was wrong in both directions (it advised `await` on a
+  // synchronous `addStore`, and missed eight methods entirely).
+  'compact',
+  'episodeToEngram',
   'getById',
+  'ingest',
+  'inject',
+  'installPack',
+  'learn',
   'list',
   'listPinned',
-  'setPinned',
-  'updateEngram',
-  'status',
-  'ingest',
-  'sync',
-  'reindex',
-  'flushOutbox',
-  'purgeTensions',
-  'recordTensions',
-  'addStore',
   'listStores',
+  'outboxCount',
+  'purgeTensions',
+  'recall',
+  'receipt',
+  'recordTensions',
+  'reindex',
+  'rerankerEvalStatus',
+  'resolveTension',
+  'saveMetaEngrams',
+  'setPinned',
+  'status',
+  'sync',
+  'updateEngram',
+  // Already async before 0.16, so an un-awaited call was always a bug rather
+  // than migration fallout — but reporting it costs nothing and helps, and
+  // these were in the original list. `addStore` was too and is REMOVED: it is
+  // synchronous, so the tool was telling users to add an `await` that does not
+  // belong.
+  'feedback',
+  'flushOutbox',
+  'forget',
+  'learnBatch',
+  'learnRouted',
 ] as const
 
 export interface Finding {

--- a/packages/migrate/src/scan.ts
+++ b/packages/migrate/src/scan.ts
@@ -119,7 +119,7 @@ function literalSpans(src: string): Array<[number, number]> {
       i = end === -1 ? src.length : end + 2
       continue
     }
-    if (c === '"' || c === "'" || c === '`') {
+    if (c === '"' || c === "'") {
       const quote = c
       let j = i + 1
       while (j < src.length) {
@@ -128,6 +128,41 @@ function literalSpans(src: string): Array<[number, number]> {
         j++
       }
       spans.push([i, Math.min(j + 1, src.length)])
+      i = j + 1
+      continue
+    }
+    if (c === '`') {
+      // A template literal is only PARTLY a literal: everything inside `${...}`
+      // is ordinary code. Treating the whole thing as a string hid every call
+      // written as `${plur.recall(q)}` — which is the worst place to miss one,
+      // because an un-awaited promise there does not throw, it interpolates as
+      // the string "[object Promise]" and ships.
+      //
+      // So push a span for each literal CHUNK and step over the holes.
+      let j = i + 1
+      let chunkStart = i
+      while (j < src.length) {
+        if (src[j] === '\\') { j += 2; continue }
+        if (src[j] === '`') break
+        if (src[j] === '$' && src[j + 1] === '{') {
+          spans.push([chunkStart, j])
+          // Walk to the matching `}`, counting nested braces. Nested template
+          // literals inside the hole are handled by the outer loop when it
+          // reaches them, so only brace depth matters here.
+          let depth = 1
+          let k = j + 2
+          while (k < src.length && depth > 0) {
+            if (src[k] === '{') depth++
+            else if (src[k] === '}') depth--
+            k++
+          }
+          j = k
+          chunkStart = k
+          continue
+        }
+        j++
+      }
+      spans.push([chunkStart, Math.min(j + 1, src.length)])
       i = j + 1
       continue
     }
@@ -277,7 +312,10 @@ export function scanSource(file: string, src: string, methods: readonly string[]
   const spans = literalSpans(src)
   const out: Finding[] = []
   const alt = methods.join('|')
-  const re = new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\.(${alt})\s*\(`, 'g')
+  // `?.` on either side is the same call with the same hazard: `plur?.learn(x)`
+  // and `plur.learn?.(x)` both return a promise nobody awaited. Requiring a
+  // plain `.` missed both.
+  const re = new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*)*)\??\.(${alt})\s*(?:\?\.)?\s*\(`, 'g')
 
   let m: RegExpExecArray | null
   while ((m = re.exec(src))) {

--- a/packages/migrate/src/scan.ts
+++ b/packages/migrate/src/scan.ts
@@ -154,6 +154,72 @@ function positionOf(src: string, idx: number): { line: number; column: number; t
   }
 }
 
+
+/** Statement keywords that take a parenthesised head — not callable functions. */
+const CONTROL_KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'catch', 'with', 'do'])
+
+/**
+ * Whether the function enclosing `idx` is `async` — or `'top-level'` when the
+ * call is not inside a function at all.
+ *
+ * `await` is a syntax error outside an async function, so inserting one without
+ * checking produces source that does not parse. The tool did exactly that:
+ * given `function saveIt(plur) { plur.learn('x') }` it emitted
+ * `await plur.learn('x')` inside a non-async function, and `node --check`
+ * rejected the file. A migration tool that breaks the build is worse than one
+ * that reports and leaves the edit to a human.
+ *
+ * Walks backwards tracking brace depth to find the nearest enclosing `{` that
+ * belongs to a function header, then inspects that header. String and comment
+ * spans are skipped by the caller's span list.
+ */
+function enclosingFunctionKind(src: string, idx: number, spans: Array<[number, number]>): 'async' | 'sync' | 'top-level' {
+  let depth = 0
+  for (let i = idx - 1; i >= 0; i--) {
+    if (inSpans(spans, i)) continue
+    const c = src[i]
+    if (c === '}') { depth++; continue }
+    if (c !== '{') continue
+    if (depth > 0) { depth--; continue }
+    // An unmatched `{` — the block we are directly inside. Is its header a
+    // function?
+    const header = src.slice(Math.max(0, i - 220), i)
+    // `function f(...)`, `async function f(...)`, `(...) =>`, method shorthand.
+    const fn = /(?:^|[^\w$])(async\s+)?function\s*\*?\s*[\w$]*\s*\([^()]*\)\s*$/.exec(header)
+    if (fn) return fn[1] ? 'async' : 'sync'
+    const arrow = /(?:^|[^\w$])(async\s*)?\([^()]*\)\s*=>\s*$/.exec(header)
+    if (arrow) return arrow[1] ? 'async' : 'sync'
+    const bareArrow = /(?:^|[^\w$])(async\s+)?[\w$]+\s*=>\s*$/.exec(header)
+    if (bareArrow) return bareArrow[1] ? 'async' : 'sync'
+    // Method shorthand in a class or object literal: `name(args) {`.
+    //
+    // The keyword guard is load-bearing: `if (...) {`, `for (...) {`,
+    // `while (...) {` and `catch (...) {` all match this shape, and treating
+    // one as a non-async function made every call inside a conditional or loop
+    // unfixable — even inside an async function. Caught by a test that put the
+    // call inside `if { for { ... } }`.
+    const method = /(?:^|[^\w$])(async\s+)?([\w$]+)\s*\([^()]*\)\s*$/.exec(header)
+    if (method && !CONTROL_KEYWORDS.has(method[2])) return method[1] ? 'async' : 'sync'
+    // Some other block (if/for/try/class body) — keep walking outwards.
+    depth = 0
+  }
+  return 'top-level'
+}
+
+/**
+ * True when the file can host a top-level `await`.
+ *
+ * TypeScript and `.mjs` are modules by default, so top-level await is valid
+ * there. `.cjs`/`.cts` never are. Plain `.js` is ambiguous — CommonJS unless the
+ * file shows module syntax — so evidence is required before rewriting, since a
+ * wrong guess emits source that does not parse.
+ */
+function isEsm(file: string, src: string): boolean {
+  if (/\.(mjs|mts|ts|tsx)$/.test(file)) return true
+  if (/\.(cjs|cts)$/.test(file)) return false
+  return /^\s*(import\s|export\s|import\()/m.test(src)
+}
+
 /**
  * Scan one file's source for un-awaited calls to newly-async methods.
  *
@@ -196,6 +262,16 @@ export function scanSource(file: string, src: string, methods: readonly string[]
     } else if (/=>\s*$/.test(before)) {
       fixable = false
       reason = 'concise arrow body — the enclosing function must become async first'
+    } else {
+      // `await` outside an async function does not parse. Report, do not rewrite.
+      const kind = enclosingFunctionKind(src, idx, spans)
+      if (kind === 'sync') {
+        fixable = false
+        reason = 'the enclosing function is not `async` — make it async first, then re-run'
+      } else if (kind === 'top-level' && !isEsm(file, src)) {
+        fixable = false
+        reason = 'top-level await needs an ES module — convert the file, or wrap the call in an async function'
+      }
     }
 
     // Does something consume the result directly? Then `await` must wrap the

--- a/packages/migrate/src/scan.ts
+++ b/packages/migrate/src/scan.ts
@@ -158,6 +158,50 @@ function positionOf(src: string, idx: number): { line: number; column: number; t
 /** Statement keywords that take a parenthesised head — not callable functions. */
 const CONTROL_KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'catch', 'with', 'do'])
 
+
+/**
+ * Is `idx` directly inside a `Promise.all/race/allSettled/any([...])` array?
+ *
+ * Awaiting an element there resolves that call BEFORE the array is even
+ * constructed, so the combinator receives an already-settled promise. For
+ * `race` that silently disables a timeout; for `all` it serialises what the
+ * caller wrote to run concurrently. Both still parse and still pass tests —
+ * this is the bug the tool exists to prevent, so emitting it is the one
+ * unacceptable outcome.
+ *
+ * Detected by scanning outwards for an unmatched `[` rather than by looking
+ * back a fixed number of characters. The window version passed the obvious
+ * cases and missed anything with a long enough preceding element: verified
+ * against a three-element `Promise.all` where the combinator sat beyond the
+ * 80-character lookback, and the tool rewrote it.
+ */
+function insideCombinatorArray(src: string, idx: number, spans: Array<[number, number]>): boolean {
+  let square = 0, round = 0, curly = 0
+  for (let i = idx - 1; i >= 0; i--) {
+    if (inSpans(spans, i)) continue
+    const c = src[i]
+    if (c === ']') { square++; continue }
+    if (c === ')') { round++; continue }
+    if (c === '}') { curly++; continue }
+    if (c === ')' || c === '}') continue
+    if (c === '[') {
+      if (square > 0) { square--; continue }
+      // Unmatched `[` — the array we are directly inside. Is it a combinator's?
+      const before = src.slice(Math.max(0, i - 60), i)
+      return /Promise\s*\.\s*(all|race|allSettled|any)\s*\(\s*$/.test(before)
+    }
+    if (c === '(') {
+      if (round > 0) { round--; continue }
+      return false // an enclosing call, not an array literal
+    }
+    if (c === '{') {
+      if (curly > 0) { curly--; continue }
+      return false // an enclosing block or object
+    }
+  }
+  return false
+}
+
 /**
  * Whether the function enclosing `idx` is `async` — or `'top-level'` when the
  * call is not inside a function at all.
@@ -248,7 +292,7 @@ export function scanSource(file: string, src: string, methods: readonly string[]
 
     const after = src.slice(idx)
     // `.then(` / `.catch(` / `.finally(` immediately after the call: handled.
-    const callEnd = matchParen(after, after.indexOf('('))
+    const callEnd = matchParen(after, src.indexOf('(', idx) - idx, spans, idx)
     if (callEnd > 0 && /^\s*\.(then|catch|finally)\s*\(/.test(after.slice(callEnd))) continue
 
     const pos = positionOf(src, idx)
@@ -256,7 +300,7 @@ export function scanSource(file: string, src: string, methods: readonly string[]
     // Unambiguous cases only. Anything structural is reported, not rewritten.
     let fixable = true
     let reason: string | undefined
-    if (/(Promise\s*\.\s*(all|race|allSettled|any)\s*\(\s*\[[^\]]*)$/.test(before)) {
+    if (insideCombinatorArray(src, idx, spans)) {
       fixable = false
       reason = 'inside a Promise combinator array — awaiting here settles the call before the combinator sees it'
     } else if (/=>\s*$/.test(before)) {
@@ -277,7 +321,12 @@ export function scanSource(file: string, src: string, methods: readonly string[]
     // Does something consume the result directly? Then `await` must wrap the
     // whole call, not bind looser than the member access.
     let wrapTo: number | undefined
-    if (callEnd > 0 && /^\s*[.[]/.test(after.slice(callEnd))) {
+    if (callEnd < 0) {
+      // Could not find the closing paren, so whether the result is consumed is
+      // unknown. Guessing here is what produced the `.length`-of-a-promise bug.
+      fixable = false
+      reason = 'could not determine where the call ends — add `await` by hand'
+    } else if (callEnd > 0 && /^\s*[.[]/.test(after.slice(callEnd))) {
       const endIdx = idx + callEnd
       const endPos = positionOf(src, endIdx)
       // Only when the call starts and ends on the same line — a multi-line call
@@ -291,10 +340,22 @@ export function scanSource(file: string, src: string, methods: readonly string[]
   return out
 }
 
-function matchParen(s: string, open: number): number {
+/**
+ * Offset just past the `)` closing the `(` at `open`, or -1 if unbalanced.
+ *
+ * `s` is a suffix of the whole source starting at absolute offset `base`, so
+ * span membership is tested against `base + i`. Skipping string and comment
+ * spans is not cosmetic: a stray paren in a query string used to shift the
+ * match, `matchParen` returned -1, and `callEnd > 0` then read as "nothing
+ * consumes the result" — so `plur.recall('has a ( paren').length` was rewritten
+ * to `await plur.recall(...).length`, which awaits `.length` OF THE PROMISE and
+ * evaluates to undefined. It parses and it is silently wrong.
+ */
+function matchParen(s: string, open: number, spans: Array<[number, number]>, base: number): number {
   if (open < 0) return -1
   let d = 0
   for (let i = open; i < s.length; i++) {
+    if (inSpans(spans, base + i)) continue
     if (s[i] === '(') d++
     else if (s[i] === ')') { d--; if (d === 0) return i + 1 }
   }

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The migrate tool's method list must match reality.
+ *
+ * `NEWLY_ASYNC` is the entire behaviour of this tool: a name missing from it is
+ * an un-awaited call the user is never told about, and a name wrongly in it is
+ * an `await` the tool tells them to add to a synchronous method.
+ *
+ * It was hand-written and was wrong in both directions — `addStore` was listed
+ * and is synchronous, while eight methods that genuinely flipped
+ * (`compact`, `episodeToEngram`, `installPack`, `outboxCount`, `receipt`,
+ * `rerankerEvalStatus`, `resolveTension`, `saveMetaEngrams`) were absent.
+ * `scan.test.ts` could not detect either: it tests the SCANNER against
+ * hand-written fixtures, so a wrong list produces a green suite and wrong advice.
+ *
+ * This test reads the real `Plur` class instead. It cannot be satisfied by
+ * agreeing with itself.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { NEWLY_ASYNC } from '../src/scan.js'
+
+const CORE_INDEX = join(__dirname, '..', '..', 'core', 'src', 'index.ts')
+
+/**
+ * Async on `Plur` BEFORE 0.16, so an un-awaited call to one was always a bug
+ * rather than migration fallout. Out of this tool's stated scope.
+ *
+ * Membership here is a claim about history, so it is deliberately explicit:
+ * adding a new async method to `Plur` fails the test until someone says which
+ * side it belongs on.
+ */
+const ALWAYS_ASYNC = new Set([
+  // The *Async family — the async twin of a sync method, named for it.
+  'learnAsync', 'recallAsync', 'setPinnedAsync', 'updateEngramAsync',
+  'reindexAsync', 'listStoresAsync',
+  // Embedding/LLM-backed retrieval — always async, always awaited by callers.
+  'recallHybrid', 'recallHybridWithMeta', 'recallSemantic', 'recallAutoSearch',
+  'recallExpanded', 'injectHybrid', 'similaritySearch', 'checkRerankerFit',
+  'rerankerSelfEval',
+  // Network / index plumbing.
+  'checkRemoteHealth', 'discoverRemoteScopes', 'registerDiscoveredScopes',
+  'registerScope', 'offerableScopes', 'warmRemoteCaches', 'waitForIndex',
+  'reportFailure', 'ready',
+])
+
+/** Public methods of `Plur`, mapped to whether they are declared `async`. */
+function plurMethods(): Map<string, boolean> {
+  const src = readFileSync(CORE_INDEX, 'utf8')
+  const out = new Map<string, boolean>()
+  for (const m of src.matchAll(/^ {2}(async )?([a-zA-Z_][\w]*)\(/gm)) {
+    const name = m[2]
+    if (name.startsWith('_') || name === 'constructor') continue
+    if (!out.has(name)) out.set(name, Boolean(m[1]))
+  }
+  return out
+}
+
+describe('NEWLY_ASYNC matches the real Plur class', () => {
+  it('lists no method that is actually synchronous', () => {
+    // The damaging direction: the tool rewrites a caller's source, so a
+    // synchronous name here means it inserts an `await` that does not belong.
+    const methods = plurMethods()
+    const wrong = NEWLY_ASYNC.filter(n => methods.has(n) && methods.get(n) === false)
+    expect(wrong, 'these are synchronous — the tool would advise a wrong await').toEqual([])
+  })
+
+  it('lists no name that is not a Plur method at all', () => {
+    const methods = plurMethods()
+    const unknown = NEWLY_ASYNC.filter(n => !methods.has(n))
+    expect(unknown, 'not methods on Plur — a rename or typo').toEqual([])
+  })
+
+  it('leaves no async method unaccounted for', () => {
+    // The quiet direction: a missing name is an un-awaited call the user is
+    // never warned about. A hand-written "expected" list cannot catch this —
+    // the first version of this test used one, and dropping `receipt` from
+    // NEWLY_ASYNC still passed.
+    //
+    // So every async public method must be EITHER listed as newly-async OR
+    // explicitly declared always-async below. A new async method on `Plur`
+    // cannot fall through silently; someone has to decide which it is.
+    const methods = plurMethods()
+    const asyncMethods = [...methods.entries()].filter(([, isAsync]) => isAsync).map(([n]) => n)
+    const unaccounted = asyncMethods.filter(
+      n => !NEWLY_ASYNC.includes(n as never) && !ALWAYS_ASYNC.has(n),
+    )
+    expect(
+      unaccounted,
+      'async on Plur but neither listed nor declared always-async — add to NEWLY_ASYNC, or to ALWAYS_ASYNC with a reason',
+    ).toEqual([])
+  })
+
+  it('the method list is non-trivial — a guard against it being emptied', () => {
+    // An empty list makes every test above pass and the tool report nothing.
+    expect(NEWLY_ASYNC.length).toBeGreaterThan(20)
+  })
+})

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -17,18 +17,24 @@
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
+import { execFileSync } from 'child_process'
 import { join } from 'path'
 import { NEWLY_ASYNC } from '../src/scan.js'
 
 const CORE_INDEX = join(__dirname, '..', '..', 'core', 'src', 'index.ts')
 
 /**
- * Async on `Plur` BEFORE 0.16, so an un-awaited call to one was always a bug
- * rather than migration fallout. Out of this tool's stated scope.
+ * Async on `Plur` BEFORE 0.16 and NOT reported by the tool.
  *
- * Membership here is a claim about history, so it is deliberately explicit:
- * adding a new async method to `Plur` fails the test until someone says which
- * side it belongs on.
+ * `NEWLY_ASYNC` also contains some already-async methods on purpose (see its
+ * comment) — reporting an un-awaited `feedback()` costs nothing and helps, even
+ * though it was a bug before 0.16 rather than fallout from it. So "already
+ * async" and "in NEWLY_ASYNC" are not opposites, and the two lists below are
+ * NOT a before/after partition. `alreadyAsyncAt0_15` is what pins the history.
+ *
+ * Membership here is still a claim about history, so it is deliberately
+ * explicit: adding a new async method to `Plur` fails the test until someone
+ * says which side it belongs on.
  */
 const ALWAYS_ASYNC = new Set([
   // The *Async family — the async twin of a sync method, named for it.
@@ -94,5 +100,59 @@ describe('NEWLY_ASYNC matches the real Plur class', () => {
   it('the method list is non-trivial — a guard against it being emptied', () => {
     // An empty list makes every test above pass and the tool report nothing.
     expect(NEWLY_ASYNC.length).toBeGreaterThan(20)
+  })
+})
+
+/**
+ * Which methods ACTUALLY changed in 0.16 — checked against the released source,
+ * not against the current class.
+ *
+ * Every test above reads `Plur` as it is today, so none of them can see a claim
+ * about the past being wrong. That gap was real: the CHANGELOG's BREAKING
+ * section listed `learnRouted`, `recallHybrid`, `injectHybrid`, `feedback` and
+ * `forget` as newly promise-returning when all five were already async in
+ * 0.15.0 — which sends a reader auditing call sites that never moved, and
+ * makes the rest of the list less believable.
+ */
+describe('the sync -> async claim, against the 0.15.0 source', () => {
+  /** Methods in NEWLY_ASYNC that were already async before this release. */
+  const alreadyAsyncAt0_15 = new Set(['feedback', 'flushOutbox', 'forget', 'learnBatch', 'learnRouted'])
+
+  function methodsAsyncAt0_15(): Set<string> | null {
+    try {
+      const src = execFileSync('git', ['show', 'v0.15.0:packages/core/src/index.ts'], {
+        cwd: join(__dirname, '..', '..', '..'), encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      const out = new Set<string>()
+      for (const m of src.matchAll(/^ {2}async ([a-zA-Z_][\w]*)\(/gm)) out.add(m[1])
+      return out.size > 0 ? out : null
+    } catch {
+      return null // shallow clone or no tags — see the assertion below
+    }
+  }
+
+  it('every NEWLY_ASYNC method was sync in 0.15.0, except the documented few', () => {
+    const before = methodsAsyncAt0_15()
+    if (!before) {
+      // Not skipped silently: a skip is how this class of error hid in the
+      // first place. Fetch tags (`git fetch --tags`) to run the real check.
+      expect(alreadyAsyncAt0_15.size, 'cannot reach v0.15.0 — frozen expectation only').toBe(5)
+      return
+    }
+    const unexpected = NEWLY_ASYNC.filter(n => before.has(n) && !alreadyAsyncAt0_15.has(n))
+    expect(
+      unexpected,
+      'already async in 0.15.0 but not listed as such — the release notes will claim it changed',
+    ).toEqual([])
+  })
+
+  it('and the documented few really were async in 0.15.0', () => {
+    // The other direction: if one of these was in fact sync, it belongs in the
+    // BREAKING list and users are not being told to await it.
+    const before = methodsAsyncAt0_15()
+    if (!before) return
+    for (const m of alreadyAsyncAt0_15) {
+      expect(before.has(m), `${m} was NOT async in 0.15.0 — it changed, and the notes omit it`).toBe(true)
+    }
   })
 })

--- a/packages/migrate/test/scan-lookback.test.ts
+++ b/packages/migrate/test/scan-lookback.test.ts
@@ -126,3 +126,75 @@ describe('parens inside strings and comments do not break the wrap', () => {
     expect(f[0].reason).toMatch(/could not determine where the call ends/)
   })
 })
+
+/**
+ * Places the scanner used to look straight past.
+ *
+ * Each is an ordinary way to write the call, and each was invisible — the tool
+ * reported "no un-awaited PLUR calls found" and exited 0 on a file that had
+ * them. A migration tool that misses calls is worse than no tool, because the
+ * clean exit is taken as evidence the file is done.
+ */
+describe('call forms the scanner must not miss', () => {
+  it('finds a call inside a template-literal interpolation', () => {
+    // The worst one. `${promise}` does not throw — it interpolates as
+    // "[object Promise]" and ships. The whole template used to be treated as a
+    // string literal, so the hole was never examined.
+    const f = scan('async function g(plur) {\n  return `result: ${plur.recall("q")}`\n}')
+    expect(f).toHaveLength(1)
+    expect(f[0].method).toBe('recall')
+  })
+
+  it('still ignores a method name that is only MENTIONED in template text', () => {
+    // The literal chunks must stay literal — otherwise the fix would trade a
+    // false negative for a false positive.
+    expect(scan('const s = `call plur.learn(x) to remember`')).toHaveLength(0)
+  })
+
+  it('handles a template with several holes, and text between them', () => {
+    const f = scan('async function g(plur) {\n  return `${plur.recall("a")} and ${plur.getById("b")}`\n}')
+    expect(f.map(x => x.method).sort()).toEqual(['getById', 'recall'])
+  })
+
+  it('finds an optional-chained receiver — plur?.learn(x)', () => {
+    const f = scan('async function g(plur) {\n  plur?.learn("x")\n}')
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+  })
+
+  it('finds an optional call — plur.learn?.(x)', () => {
+    const f = scan('async function g(plur) {\n  plur.learn?.("x")\n}')
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+  })
+
+  it('rewrites both optional forms into parseable code', () => {
+    const src = 'async function g(plur) {\n  plur?.learn("a")\n  plur.learn?.("b")\n}'
+    const out = fix(src)
+    expect(out).toContain('await plur?.learn("a")')
+    expect(out).toContain('await plur.learn?.("b")')
+  })
+})
+
+describe('the multi-line-consumed guard', () => {
+  // Removing this guard makes --write emit `await plur.recall(\n ... \n).length`,
+  // which awaits `.length` of the promise. The guard shipped untested.
+  const src = 'async function g(plur) {\n  const n = plur.recall(\n    "q",\n  ).length\n  return n\n}'
+
+  it('refuses a consumed call that spans lines', () => {
+    const f = scan(src)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/multi-line/)
+  })
+
+  it('and leaves the source alone', () => {
+    expect(fix(src)).toBe(src)
+  })
+
+  it('but a multi-line call whose result is NOT consumed is still fixed', () => {
+    // The guard is about the member access, not about spanning lines. Without
+    // this, "refuse anything multi-line" would pass the two tests above.
+    const ok = 'async function g(plur) {\n  plur.learn(\n    "a long statement",\n  )\n}'
+    expect(fix(ok)).toContain('await plur.learn(')
+  })
+})

--- a/packages/migrate/test/scan-lookback.test.ts
+++ b/packages/migrate/test/scan-lookback.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Two guards that worked on short input and failed on realistic input.
+ *
+ * Both bugs share a shape: a heuristic that reads a fixed window of text, or
+ * reads text without knowing what is code and what is a string literal. Both
+ * produced output that PARSES — `node --check` says yes — and is silently
+ * wrong at runtime. That is the worst possible failure for a codemod, because
+ * the user's test suite stays green and the damage surfaces in production.
+ *
+ * The original combinator bug is not hypothetical: it is the same mistake that
+ * silently disabled PLUR's own 5-second CLI timeout.
+ */
+import { describe, it, expect } from 'vitest'
+import { scanSource, applyFixes } from '../src/scan.js'
+
+const scan = (src: string) => scanSource('t.mjs', src)
+const fix = (src: string) => applyFixes(src, scan(src)).src
+
+describe('Promise combinator arrays are found at any distance', () => {
+  // The guard used to look back 80 characters. Anything that pushed the
+  // `Promise.all([` opening past that window was rewritten.
+  const padded = `async function go(plur, statement, ctx) {
+  const r = await Promise.all([
+    someOtherCallWithAVeryLongNameIndeed(statement, ctx, 'padding to push past the lookback window'),
+    anotherRatherLongHelperFunctionName(statement, ctx, 'more padding here to be sure of it'),
+    plur.learn(statement),
+  ])
+  return r
+}`
+
+  it('refuses a site far from the combinator opening', () => {
+    const f = scan(padded)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable, 'rewriting here settles the call before the combinator sees it').toBe(false)
+    expect(f[0].reason).toMatch(/combinator/)
+  })
+
+  it('and leaves the source untouched', () => {
+    expect(fix(padded)).toBe(padded)
+  })
+
+  it('still refuses the short case the 80-char window did catch', () => {
+    const short = `async function go(plur) {\n  await Promise.race([\n    plur.learn('x'),\n    timeout(5000),\n  ])\n}`
+    expect(scan(short)[0].fixable).toBe(false)
+  })
+
+  it('covers all four combinators', () => {
+    for (const c of ['all', 'race', 'allSettled', 'any']) {
+      const src = `async function go(plur) {\n  await Promise.${c}([\n    aFunctionWithAnExtremelyLongNameToPushPastAnyFixedLookbackWindow(1, 2, 3),\n    plur.learn('x'),\n  ])\n}`
+      expect(scan(src)[0].fixable, `Promise.${c} was not detected`).toBe(false)
+    }
+  })
+
+  it('does NOT refuse an ordinary array literal — the guard has to discriminate', () => {
+    // Without this, "refuse anything inside brackets" would pass every test
+    // above while making the tool useless.
+    const src = `async function go(plur) {\n  const xs = [\n    aFunctionWithAnExtremelyLongNameToPushPastAnyFixedLookbackWindow(1, 2, 3),\n    plur.learn('x'),\n  ]\n  return xs\n}`
+    expect(scan(src)[0].fixable).toBe(true)
+  })
+
+  it('does NOT refuse a call that merely FOLLOWS a combinator', () => {
+    // The combinator array is closed by then — being after one is not being in one.
+    const src = `async function go(plur) {\n  await Promise.all([aVeryLongFunctionNameIndeedToPushPastTheWindow(1), anotherLongOne(2)])\n  plur.learn('x')\n}`
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+  })
+})
+
+describe('parens inside strings and comments do not break the wrap', () => {
+  // `(await f()).length` vs `await f().length`: the second awaits `.length` of
+  // the PROMISE, which is undefined. Both parse. The paren matcher counted
+  // parens inside string literals, so a stray one made it give up and fall
+  // through to the un-wrapped form.
+  const cases: Array<[string, string]> = [
+    ['open paren in a string', `plur.recall('an unbalanced ( paren').length`],
+    ['close paren in a string', `plur.recall('a stray ) paren').length`],
+    ['paren in a block comment', `plur.recall(/* a stray ( here */ 'q').length`],
+    ['paren in a template literal', 'plur.recall(`an unbalanced ( paren`).length'],
+  ]
+
+  for (const [name, expr] of cases) {
+    it(`wraps the call when there is an ${name}`, () => {
+      const src = `async function go(plur) {\n  const n = ${expr}\n  return n\n}`
+      const out = fix(src)
+
+      // Asserting only "does not emit the bad form" is not enough: refusing to
+      // touch the file also satisfies that, and a span-blind paren matcher
+      // fails by refusing. These are ordinary, valid single-line calls, so the
+      // tool has to actually rewrite them.
+      expect(out, 'left untouched — the tool gave up on valid code').not.toBe(src)
+      expect(out).toContain('(await plur.recall(')
+
+      // And the rewrite has to be the wrapped form. Checked positionally, not
+      // by regex: `/await plur\.recall\([\s\S]*?\)\s*\.length/` backtracks
+      // across the closing paren and matches the CORRECT output too, so it
+      // cannot tell the two apart.
+      for (let i = out.indexOf('await plur.recall'); i !== -1; i = out.indexOf('await plur.recall', i + 1)) {
+        expect(
+          out[i - 1],
+          `await at offset ${i} is not wrapped — this awaits .length of the promise:\n${out}`,
+        ).toBe('(')
+      }
+    })
+  }
+
+  it('a paren in a line comment forces multi-line, which is reported not rewritten', () => {
+    // Not a span bug — a line comment cannot be single-line with the call, and
+    // multi-line consumed calls are deliberately left for a human.
+    const src = `async function go(plur) {\n  const n = plur.recall(\n    // a stray ( here\n    'q',\n  ).length\n  return n\n}`
+    const f = scan(src)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/multi-line/)
+    expect(fix(src)).toBe(src)
+  })
+
+  it('the control case is genuinely rewritten — the suite is not passing by refusing everything', () => {
+    const src = `async function go(plur) {\n  const n = plur.recall('balanced').length\n  return n\n}`
+    expect(fix(src)).toContain(`(await plur.recall('balanced')).length`)
+  })
+
+  it('a call whose end cannot be located is reported, not guessed at', () => {
+    const src = `async function go(plur) {\n  const n = plur.recall('never closed'\n`
+    const f = scan(src)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/could not determine where the call ends/)
+  })
+})

--- a/packages/migrate/test/scan.test.ts
+++ b/packages/migrate/test/scan.test.ts
@@ -144,3 +144,57 @@ describe('applyFixes', () => {
     expect(twice.src).toBe(once)
   })
 })
+
+describe('never emits source that cannot parse', () => {
+  // The tool rewrites a user's files. Emitting a syntax error is the one
+  // outcome that is strictly worse than doing nothing, and it shipped: given a
+  // call inside a non-async function it inserted `await` anyway and `node
+  // --check` rejected the result.
+  const scanJs = (src: string) => scanSource('t.mjs', src)
+
+  it('refuses a call inside a non-async function declaration', () => {
+    const f = scanJs('function saveIt(plur) {\n  plur.learn("x")\n}\n')
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/not `async`/)
+  })
+
+  it('refuses a call inside a non-async function expression', () => {
+    const f = scanJs('const go = function (plur) { plur.forget("x") }\n')
+    expect(f[0].fixable).toBe(false)
+  })
+
+  it('refuses a call inside a non-async method shorthand', () => {
+    const f = scanJs('const o = {\n  save(plur) {\n    plur.learn("x")\n  }\n}\n')
+    expect(f[0].fixable).toBe(false)
+  })
+
+  it('DOES fix a call inside an async function', () => {
+    const src = 'async function ok(plur) {\n  plur.learn("x")\n}\n'
+    const f = scanJs(src)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toContain('await plur.learn("x")')
+  })
+
+  it('DOES fix a call inside an async arrow', () => {
+    const src = 'const go = async (plur) => {\n  plur.learn("x")\n}\n'
+    expect(scanJs(src)[0].fixable).toBe(true)
+  })
+
+  it('allows top-level await in an ES module but not in CommonJS', () => {
+    expect(scanSource('t.mjs', 'plur.learn("x")\n')[0].fixable).toBe(true)
+    expect(scanSource('t.cjs', 'plur.learn("x")\n')[0].fixable).toBe(false)
+  })
+
+  it('nested blocks inside an async function are still fixable', () => {
+    // The enclosing-function walk must look THROUGH if/for/try blocks rather
+    // than stopping at the first `{` it meets.
+    const src = 'async function ok(plur) {\n  if (true) {\n    for (const x of []) {\n      plur.learn("x")\n    }\n  }\n}\n'
+    expect(scanJs(src)[0].fixable).toBe(true)
+  })
+
+  it('nested blocks inside a NON-async function are still refused', () => {
+    const src = 'function bad(plur) {\n  if (true) {\n    plur.learn("x")\n  }\n}\n'
+    expect(scanJs(src)[0].fixable).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,8 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
 
+  packages/migrate: {}
+
 packages:
 
   '@agentclientprotocol/sdk@1.1.0':

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -121,9 +121,14 @@ generate_tweet() {
     return 1
   fi
   features=$(echo "$section" | grep "^- " | head -4 | sed 's/^- /✅ /')
-  # Headline: prefer "Tagline:" or "Tagline." pattern in first non-blank
-  # non-bullet line of the section, fall back to "Update:".
-  headline=$(echo "$section" | awk 'NF && !/^- / && !/^###/ {print; exit}')
+  # Headline: the first non-bullet, non-heading PARAGRAPH of the section.
+  # Joined across lines rather than taking only the first physical line: a
+  # hard-wrapped summary used to be truncated at the wrap point, which for
+  # 0.16.0 produced the fragment "one engine, two" — and that fragment would
+  # have been posted to X verbatim, since the length gate only checks the
+  # total. Reading the whole paragraph makes an over-long summary fail the
+  # gate (visible, fixable) instead of shipping as a cut-off sentence.
+  headline=$(echo "$section" | awk 'NF && !/^- / && !/^###/ {buf = buf (buf ? " " : "") $0; next} buf {print buf; buf = ""; exit} END {if (buf) print buf}')
   [ -z "$headline" ] && headline="Update:"
 
   TWEET="🚀 New release: PLUR $VERSION

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,6 +35,7 @@
 #       undeclared in the CHANGELOG (issue #544; see RELEASING.md)
 #   3.7 Pre-flight: every target version must be publishable (not already taken)
 #   3.8 Website version pre-flight: index.html softwareVersion must == $VERSION
+#   3.9 Packaged-artefact smoke: pack tarballs, install clean, drive the public API
 #   4.  Commit + tag + push
 #   5a. Publish npm to @next (canary)
 #   5b. Smoke test (npx by exact version; retries on npm-propagation ETARGET)
@@ -497,6 +498,30 @@ if [ -f "$WEBSITE_PREFLIGHT_DIR/index.html" ]; then
   echo "  ✓ website index.html at softwareVersion=$VERSION"
   echo ""
 fi
+
+# --- Step 3.9: Packaged-artefact smoke ---
+# Every other test in this repo runs against the SOURCE tree, which is not what
+# users install. That gap has already shipped a defect: `pg` is an
+# optionalDependency and tsup only auto-externalizes dependencies +
+# peerDependencies, so the driver was inlined into core's dist and
+# `PostgresAdapter` threw on first use — in the published package, while every
+# in-repo test passed.
+#
+# `smoke-release.sh` packs real tarballs, installs them outside the workspace
+# (no node_modules to fall back on, no workspace: links) and drives the public
+# API. It existed but nothing called it, so it could only ever catch something
+# if a human remembered to run it. Here it is a gate, and it runs BEFORE the
+# irreversible git tag push and first publish.
+#
+# Set PLUR_SMOKE_POSTGRES_URL to include the Postgres store in the run.
+echo "--- Step 3.9: Packaged-artefact smoke ---"
+if ! bash "$REPO_ROOT/scripts/smoke-release.sh"; then
+  echo ""
+  echo "FAIL: the packaged artefacts do not work. Nothing has been published."
+  echo "  Reproduce with: pnpm smoke:release"
+  exit 1
+fi
+echo ""
 
 # --- 4. Commit + tag + push ---
 echo "--- Step 4: Git ---"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -184,8 +184,11 @@ echo "--- Step 1: Version bump ---"
 OLD_CORE=$(node -e "console.log(require('./packages/core/package.json').version)")
 echo "Current version: $OLD_CORE → $VERSION"
 
-# package.json files for core/mcp/cli (claw is handled separately below)
-for pkg in core mcp cli; do
+# package.json files for core/mcp/cli/migrate (claw is handled separately below).
+# `migrate` ships with the release it migrates TO: the CHANGELOG tells users to
+# run `npx @plur-ai/migrate`, so a release that does not publish it advertises a
+# command that 404s.
+for pkg in core mcp cli migrate; do
   node -e "
     const fs = require('fs');
     const path = './packages/$pkg/package.json';
@@ -455,7 +458,7 @@ preflight_check() {
   return 0
 }
 PREFLIGHT_OK=true
-for pkg in core cli mcp; do
+for pkg in core cli mcp migrate; do
   preflight_check "$pkg" "$VERSION" || PREFLIGHT_OK=false
 done
 if [ -n "$CLAW_VERSION" ]; then
@@ -507,7 +510,7 @@ echo ""
 # but unflagged — npm's 72-hour unpublish rule means we can't delete; we ship
 # a 0.9.5 patch and deprecate 0.9.4 via `npm deprecate`).
 echo "--- Step 5a: Publish npm @next (canary) ---"
-for pkg in core cli mcp; do
+for pkg in core cli mcp migrate; do
   echo -n "  @plur-ai/$pkg@$VERSION → @next..."
   pnpm --filter "@plur-ai/$pkg" publish --access public --no-git-checks --tag next 2>&1 | tail -1
 done
@@ -615,7 +618,7 @@ echo ""
 # Past this point, @latest is updated. Users on @latest start receiving the
 # new version. PyPI publish + GH release + tweet follow.
 echo "--- Step 5c: Promote @next → @latest ---"
-for pkg in core cli mcp; do
+for pkg in core cli mcp migrate; do
   echo -n "  @plur-ai/$pkg@$VERSION → @latest..."
   npm dist-tag add "@plur-ai/$pkg@$VERSION" latest 2>&1 | tail -1
 done

--- a/scripts/smoke-release.sh
+++ b/scripts/smoke-release.sh
@@ -36,7 +36,7 @@ mkdir -p "$WORK/tarballs"
 # real version on pack/publish; npm does not, and the resulting tarball fails to
 # install with EUNSUPPORTEDPROTOCOL. Since releases go out via `pnpm publish`,
 # packing with pnpm is also the faithful mirror of what users receive.
-for pkg in core mcp cli claw; do
+for pkg in core mcp cli claw migrate; do
   ( cd "$ROOT/packages/$pkg" && pnpm pack --pack-destination "$WORK/tarballs" >/dev/null 2>&1 ) \
     && ok "packed @plur-ai/$pkg" || bad "pack $pkg"
 done
@@ -61,6 +61,7 @@ npm install --silent --no-audit --no-fund \
   "$WORK"/tarballs/plur-ai-core-*.tgz \
   "$WORK"/tarballs/plur-ai-mcp-*.tgz \
   "$WORK"/tarballs/plur-ai-cli-*.tgz \
+  "$WORK"/tarballs/plur-ai-migrate-*.tgz \
   pg >/dev/null 2>&1 && ok "npm install from tarballs" || { bad "npm install"; exit 1; }
 
 say "3. Packaging invariants"
@@ -147,6 +148,36 @@ else
   # Not every version ships the ./tools subpath; fall back to the main entry.
   node -e "import('@plur-ai/mcp').then(() => {})" 2>/dev/null \
     && ok "@plur-ai/mcp main entry imports" || bad "MCP import"
+fi
+
+say "6b. Migration tool (the CHANGELOG tells every user to run this)"
+# A breaking release that advertises `npx @plur-ai/migrate` and does not publish
+# it sends everyone to a 404. Packing and running it here is the check that the
+# advice is real.
+cat > mig-target.mjs <<'JS'
+async function ok(plur) {
+  plur.learn('should gain an await')
+}
+function notAsync(plur) {
+  plur.learn('must NOT gain one — await here does not parse')
+}
+export { ok, notAsync }
+JS
+if node node_modules/@plur-ai/migrate/dist/index.js mig-target.mjs --write >/dev/null 2>&1 || [ $? -eq 2 ]; then
+  ok "plur-migrate runs from the packaged tarball"
+else
+  bad "packaged plur-migrate failed to run"
+fi
+if node --check mig-target.mjs 2>/dev/null; then
+  ok "its output is valid syntax"
+else
+  bad "plur-migrate produced source that does not parse"
+fi
+if grep -q "await plur.learn('should gain an await')" mig-target.mjs \
+   && ! grep -q "await plur.learn('must NOT" mig-target.mjs; then
+  ok "fixed the async call, left the non-async one alone"
+else
+  bad "plur-migrate rewrote the wrong sites"
 fi
 
 if [ -n "${PLUR_SMOKE_POSTGRES_URL:-}" ]; then

--- a/scripts/smoke-release.sh
+++ b/scripts/smoke-release.sh
@@ -113,11 +113,20 @@ await plur2.ready()
 check('persists across a new instance', (await plur2.getById(e.id))?.id === e.id)
 
 // The authorization filter, on the packaged build.
-await plur.learn('alpha-only secret plan', { scope: 'project:alpha' })
+//
+// `every()` ALONE is vacuous: it returns true for an empty array, so a filter
+// that wrongly returns nothing scores identical to one that works. Both
+// directions have to be asserted — the permitted engram is present, and the
+// unpermitted one is not.
+const alpha = await plur.learn('alpha-only secret plan', { scope: 'project:alpha' })
+await plur.learn('beta-only secret plan', { scope: 'project:beta' })
 const scoped = await plur.recall('plan', { scopes: ['project:alpha'] })
-check('allow-list admits the permitted scope', scoped.every(h => h.scope === 'project:alpha'))
+check('allow-list returns the permitted engram', scoped.some(h => h.id === alpha.id))
+check('allow-list excludes every other scope', scoped.length > 0 && scoped.every(h => h.scope === 'project:alpha'))
 const none = await plur.recall('plan', { scopes: [] })
 check('empty allow-list returns nothing', Array.isArray(none) && none.length === 0)
+const unrestricted = await plur.recall('plan')
+check('an absent allow-list is unrestricted', unrestricted.length > scoped.length)
 
 rmSync(dir, { recursive: true, force: true })
 if (fails.length) { console.error('FAILED: ' + fails.join(', ')); process.exit(1) }
@@ -226,11 +235,15 @@ try {
   check('concurrent write A survived', ids.includes(a.id))
   check('concurrent write B survived', ids.includes(b.id))
 
-  // Authorization filter, pushed into SQL.
-  await plur.learn('alpha tenant only', { scope: 'project:alpha' })
+  // Authorization filter, pushed into SQL. Same vacuity trap as the YAML block
+  // above: assert presence as well as absence.
+  const alphaPg = await plur.learn('alpha tenant only', { scope: 'project:alpha' })
+  await plur.learn('beta tenant only', { scope: 'project:beta' })
   const scoped = await plur.recall('tenant', { scopes: ['project:alpha'] })
-  check('allow-list enforced in Postgres', scoped.every(h => h.scope === 'project:alpha'))
+  check('allow-list returns the permitted engram', scoped.some(h => h.id === alphaPg.id))
+  check('allow-list enforced in Postgres', scoped.length > 0 && scoped.every(h => h.scope === 'project:alpha'))
   check('empty allow-list returns nothing', (await plur.recall('tenant', { scopes: [] })).length === 0)
+  check('an absent allow-list is unrestricted', (await plur.recall('tenant')).length > scoped.length)
 
   await other.close().catch(() => {})
   rmSync(dir, { recursive: true, force: true })

--- a/scripts/smoke-release.sh
+++ b/scripts/smoke-release.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# smoke-release.sh — verify the PACKAGED artefacts actually work.
+#
+# Everything else in this repo tests the source tree. That is not the thing
+# users install, and the difference has already bitten once: `pg` is an
+# optionalDependency, tsup only auto-externalizes dependencies+peerDependencies,
+# so the driver was inlined into core's dist and `PostgresAdapter` threw on
+# first use — in the published package, while every in-repo test passed.
+#
+# So this packs real tarballs, installs them into a clean directory outside the
+# workspace (no node_modules to fall back on, no workspace: links), and runs the
+# actual public API against them.
+#
+# Usage:
+#   scripts/smoke-release.sh                 # YAML store only
+#   PLUR_SMOKE_POSTGRES_URL=postgres://...   # also exercise the Postgres store
+#
+# Exit non-zero on any failure. Intended for pre-release and CI.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/plur-smoke-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0; fail=0
+say()  { printf '\n\033[1m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$*"; pass=$((pass+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m  %s\n' "$*"; fail=$((fail+1)); }
+
+say "1. Building and packing tarballs"
+( cd "$ROOT" && pnpm build >/dev/null 2>&1 ) || { bad "build"; exit 1; }
+ok "workspace build"
+
+mkdir -p "$WORK/tarballs"
+# `pnpm pack`, NOT `npm pack`. pnpm rewrites the `workspace:*` protocol to the
+# real version on pack/publish; npm does not, and the resulting tarball fails to
+# install with EUNSUPPORTEDPROTOCOL. Since releases go out via `pnpm publish`,
+# packing with pnpm is also the faithful mirror of what users receive.
+for pkg in core mcp cli claw; do
+  ( cd "$ROOT/packages/$pkg" && pnpm pack --pack-destination "$WORK/tarballs" >/dev/null 2>&1 ) \
+    && ok "packed @plur-ai/$pkg" || bad "pack $pkg"
+done
+# Prove the protocol really was rewritten — this is the check that would have
+# caught the tarball being uninstallable.
+if tar -xzOf "$WORK"/tarballs/plur-ai-mcp-*.tgz package/package.json 2>/dev/null | grep -q '"workspace:'; then
+  bad "tarball still contains a workspace: dependency — it will not install"
+else
+  ok "workspace: protocol rewritten in the tarballs"
+fi
+
+say "2. Installing into a clean project (no workspace, no source fallback)"
+mkdir -p "$WORK/app"
+cd "$WORK/app"
+cat > package.json <<'JSON'
+{ "name": "plur-smoke", "private": true, "type": "module", "version": "1.0.0" }
+JSON
+# `pg` installed explicitly: it is an optionalDependency of core, and the point
+# of this check is that core RESOLVES it at runtime rather than having inlined
+# a copy at build time.
+npm install --silent --no-audit --no-fund \
+  "$WORK"/tarballs/plur-ai-core-*.tgz \
+  "$WORK"/tarballs/plur-ai-mcp-*.tgz \
+  "$WORK"/tarballs/plur-ai-cli-*.tgz \
+  pg >/dev/null 2>&1 && ok "npm install from tarballs" || { bad "npm install"; exit 1; }
+
+say "3. Packaging invariants"
+# pg must NOT be inlined into core's dist — the bug this file exists for.
+if grep -qE "pg-pool|pg-protocol|pg-connection-string" node_modules/@plur-ai/core/dist/index.js 2>/dev/null; then
+  bad "pg is INLINED into core's dist (the published PostgresAdapter would break)"
+else
+  ok "pg is external, not inlined"
+fi
+# The public entrypoints must actually load.
+node -e "import('@plur-ai/core').then(m => { if (!m.Plur) { console.error('no Plur export'); process.exit(1) } })" \
+  && ok "@plur-ai/core imports and exports Plur" || bad "core import"
+node -e "import('@plur-ai/core').then(m => { if (!m.PostgresAdapter) { console.error('no PostgresAdapter'); process.exit(1) } })" \
+  && ok "PostgresAdapter is exported" || bad "PostgresAdapter export"
+
+say "4. End-to-end against the default YAML store"
+cat > yaml-smoke.mjs <<'JS'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur } from '@plur-ai/core'
+
+const dir = mkdtempSync(join(tmpdir(), 'plur-smoke-yaml-'))
+const plur = new Plur({ path: dir })
+await plur.ready()
+const fails = []
+const check = (name, cond) => { if (!cond) fails.push(name) }
+
+const e = await plur.learn('the deploy pipeline runs migrations before the health check', { scope: 'global' })
+check('learn returns an id', typeof e?.id === 'string' && e.id.length > 0)
+
+const byId = await plur.getById(e.id)
+check('getById round-trips', byId?.statement?.includes('migrations before the health check'))
+
+const hits = await plur.recall('deploy pipeline migrations')
+check('recall is an array', Array.isArray(hits))
+check('recall finds the engram', hits.some(h => h.id === e.id))
+
+const inj = await plur.inject('how do we deploy')
+check('inject returns a count', typeof inj?.count === 'number')
+check('inject reports tokens', typeof inj?.tokens_used === 'number')
+
+await plur.feedback(e.id, 'positive')
+check('feedback persists', (await plur.getById(e.id))?.feedback_signals?.positive === 1)
+
+// Survives a restart — the store is really on disk, not in memory.
+const plur2 = new Plur({ path: dir })
+await plur2.ready()
+check('persists across a new instance', (await plur2.getById(e.id))?.id === e.id)
+
+// The authorization filter, on the packaged build.
+await plur.learn('alpha-only secret plan', { scope: 'project:alpha' })
+const scoped = await plur.recall('plan', { scopes: ['project:alpha'] })
+check('allow-list admits the permitted scope', scoped.every(h => h.scope === 'project:alpha'))
+const none = await plur.recall('plan', { scopes: [] })
+check('empty allow-list returns nothing', Array.isArray(none) && none.length === 0)
+
+rmSync(dir, { recursive: true, force: true })
+if (fails.length) { console.error('FAILED: ' + fails.join(', ')); process.exit(1) }
+console.log('yaml-ok')
+JS
+if node yaml-smoke.mjs 2>&1 | tail -1 | grep -q '^yaml-ok$'; then
+  ok "learn / getById / recall / inject / feedback / persistence / allow-list"
+else
+  bad "YAML end-to-end"; node yaml-smoke.mjs 2>&1 | tail -3
+fi
+
+say "5. CLI binary"
+if node node_modules/@plur-ai/cli/dist/index.js --help >/dev/null 2>&1; then
+  ok "plur --help runs from the packaged CLI"
+else
+  bad "packaged CLI failed to run"
+fi
+if node node_modules/@plur-ai/cli/dist/index.js --help 2>&1 | grep -q 'hook-await'; then
+  bad "CLI help still contains the codemod-corrupted 'hook-await' string"
+else
+  ok "CLI help text is clean"
+fi
+
+say "6. MCP server"
+if node -e "import('@plur-ai/mcp/tools').then(m => { const t = m.getToolDefinitions('lean'); if (!Array.isArray(t) || t.length === 0) process.exit(1) })" 2>/dev/null; then
+  ok "@plur-ai/mcp exposes tool definitions"
+else
+  # Not every version ships the ./tools subpath; fall back to the main entry.
+  node -e "import('@plur-ai/mcp').then(() => {})" 2>/dev/null \
+    && ok "@plur-ai/mcp main entry imports" || bad "MCP import"
+fi
+
+if [ -n "${PLUR_SMOKE_POSTGRES_URL:-}" ]; then
+  say "7. End-to-end against a Postgres primary store"
+  cat > pg-smoke.mjs <<'JS'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur, PostgresAdapter } from '@plur-ai/core'
+
+const url = process.env.PLUR_SMOKE_POSTGRES_URL
+const schema = 'plur_smoke_' + Math.floor(Date.now() / 1000)
+const adapter = new PostgresAdapter({ connectionString: url, schema, vectorIndex: 'exact' })
+const fails = []
+const check = (name, cond) => { if (!cond) fails.push(name) }
+
+try {
+  await adapter.save([])
+  const dir = mkdtempSync(join(tmpdir(), 'plur-smoke-pg-'))
+  const plur = new Plur({ path: dir, store: adapter })
+  await plur.ready()
+
+  check('engine adopted the Postgres store', plur.primaryStore.kind === 'postgres')
+  check('engine uses THIS adapter', plur.primaryStore === adapter)
+
+  const e = await plur.learn('postgres smoke: the deploy pipeline runs migrations', { scope: 'global' })
+  check('learn through Postgres', typeof e?.id === 'string')
+  check('getById through Postgres', (await plur.getById(e.id))?.id === e.id)
+
+  const hits = await plur.recall('deploy pipeline migrations')
+  check('recall through Postgres finds it', hits.some(h => h.id === e.id))
+
+  // Visible to a second engine over the same schema — the multi-process property.
+  const dir2 = mkdtempSync(join(tmpdir(), 'plur-smoke-pg2-'))
+  const other = new PostgresAdapter({ connectionString: url, schema, vectorIndex: 'exact' })
+  const plur2 = new Plur({ path: dir2, store: other })
+  await plur2.ready()
+  check('a second engine sees the write', (await plur2.getById(e.id))?.id === e.id)
+
+  // Concurrent writers must not destroy each other.
+  const [a, b] = await Promise.all([
+    plur.learn('written concurrently by engine one', { scope: 'global' }),
+    plur2.learn('written concurrently by engine two', { scope: 'global' }),
+  ])
+  const ids = (await adapter.load()).map(r => r.id)
+  check('concurrent write A survived', ids.includes(a.id))
+  check('concurrent write B survived', ids.includes(b.id))
+
+  // Authorization filter, pushed into SQL.
+  await plur.learn('alpha tenant only', { scope: 'project:alpha' })
+  const scoped = await plur.recall('tenant', { scopes: ['project:alpha'] })
+  check('allow-list enforced in Postgres', scoped.every(h => h.scope === 'project:alpha'))
+  check('empty allow-list returns nothing', (await plur.recall('tenant', { scopes: [] })).length === 0)
+
+  await other.close().catch(() => {})
+  rmSync(dir, { recursive: true, force: true })
+  rmSync(dir2, { recursive: true, force: true })
+} finally {
+  await adapter.dropSchema().catch(() => {})
+  await adapter.close().catch(() => {})
+}
+if (fails.length) { console.error('FAILED: ' + fails.join(', ')); process.exit(1) }
+console.log('pg-ok')
+JS
+  if PLUR_SMOKE_POSTGRES_URL="$PLUR_SMOKE_POSTGRES_URL" node pg-smoke.mjs 2>&1 | tail -1 | grep -q '^pg-ok$'; then
+    ok "Postgres store: adopt / learn / recall / cross-engine visibility / concurrent writes / allow-list"
+  else
+    bad "Postgres end-to-end"
+    PLUR_SMOKE_POSTGRES_URL="$PLUR_SMOKE_POSTGRES_URL" node pg-smoke.mjs 2>&1 | tail -3
+  fi
+else
+  say "7. Postgres store — SKIPPED (set PLUR_SMOKE_POSTGRES_URL to include it)"
+fi
+
+say "Result"
+printf '  %d passed, %d failed\n\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes the audit findings standing between the convergence stack and the 0.16.0 release. Every fix here is mutation-verified: the fix was reverted and the new tests confirmed to fail.

## The ones that would have hurt

**Concurrent cold start against a fresh Postgres killed 7 of 8 workers.** `CREATE ... IF NOT EXISTS` is check-then-act, not atomic — every worker passes the existence check and all but one dies on a catalog unique index. Measured on PostgreSQL 16, five runs running: 7, 7, 7, 6, 4 failures out of 8. This is what a server deployment does every time it starts its replicas, so it would have surfaced on the first multi-process boot.

Worse than the crash: the pgvector arm caught *any* error and reported `install the extension (CREATE EXTENSION vector) as a superuser, or grant the PLUR role rights` — a permissions diagnosis for a race, sending the operator to fix something that was never wrong.

Schema init now runs under `pg_advisory_lock`, with duplicate-object SQLSTATEs treated as "someone else got there first" (that arm covers a rolling upgrade where an older adapter does unlocked DDL concurrently). The lock is held on one pooled client and every statement runs on that same client — the first version of this fix held the lock on one connection and let the DDL ask the pool for another, which deadlocked at `maxConnections: 1` and *hung* rather than erroring. There is a test for that now.

**The migrate tool emitted code that parses and is silently wrong**, three ways:

- Its prefilter listed 10 methods against `NEWLY_ASYNC`'s 28, so a file whose only un-awaited calls were e.g. `setPinned`/`receipt`/`installPack` was skipped entirely and reported `no un-awaited PLUR calls found` with exit 0.
- The `Promise` combinator guard looked back a fixed 80 characters. A longer preceding element pushed `Promise.all([` outside the window and it inserted `await` **inside the array** — settling the call before the combinator sees it. That is the exact bug the guard exists to prevent, and the same one that silently disabled the CLI's 5s timeout.
- `matchParen` counted parens inside strings and comments, so a stray paren in a query string made it give up, which then read as "nothing consumes the result": `plur.recall('has a ( paren').length` became `await plur.recall(...).length`, awaiting `.length` **of the promise**, which is `undefined`.

Also: calls inside template-literal interpolations were invisible (`${plur.recall(q)}` interpolates as `[object Promise]` and ships), as were `plur?.learn(x)` and `plur.learn?.(x)`.

**`setPinned()` fabricated its remote return value.** It fired the PATCH and forgot it, then returned `{ id, pinned } as unknown as Engram` — no statement, scope, status or activation, so `(await plur.setPinned(id, true)).statement` was `undefined`. It reported success before the write happened, and a rejected floating promise could not be caught by the surrounding try/catch, so a *failed* write also returned success. The justification was a synchronous signature it no longer has.

## Release gates

Both aborted the release. The tweet generator produced 1987 characters against a 270 budget, and took only the first *physical* line of a hard-wrapped summary — 0.16.0 yielded the fragment `one engine, two`, which would have been posted verbatim because the only check is total length. The manifest gate found 16 undeclared PRs.

The CHANGELOG also listed `learnRouted`, `recallHybrid`, `injectHybrid`, `feedback` and `forget` as newly promise-returning. All five were already async in 0.15.0 (verified against `git show v0.15.0`), which sends readers to audit call sites that never moved. The method-list test could not have caught it — it reads the *current* class, so it is blind to a claim about the past; there is now a check that reads the 0.15.0 source.

## Tests that could not fail

- The release smoke's authorization checks were `scoped.every(h => h.scope === '...')`. `Array.every` is `true` for an empty array, so a filter returning *nothing* scored identical to one that works. And nothing invoked the script at all — it tested the one thing no other test covers (the tarballs users install, which is how the inlined `pg` driver shipped with a green suite) and ran only when someone remembered. It is now release.sh step 3.9, before the irreversible tag push, plus a CI job.
- The `searchBM25` → `corpusStats` scope handover: both halves were covered alone, so deleting `opts` left everything green while IDF was computed over engrams the caller cannot see. The leak shows up as an *order*, never a missing row.
- `recallHybrid`'s vector leg: removing its restriction changes nothing observable, because the intersection empties `pgHits` and the method falls back to the in-memory hybrid — correct, complete, identical answer. So the accurate claim is narrower than the old test made: in hybrid the restriction is not what makes the result correct, it is what stops a silent degradation to the in-memory path on every query.
- `withAsyncLock`'s path normalisation: "the two callers never overlap" passes with `path.resolve` removed, because the file lock prevents overlap regardless.

Where a test genuinely *cannot* reach the mechanism, that is recorded in the file rather than papered over — nothing in `inject()`'s output can prove the pack path is still wired up, because `installPack` also writes into the primary store so pack engrams arrive on both paths.

## Documentation

The MCP README announced 11 lean tools where the profile serves 12, omitted `plur_receipt`, and listed `plur_recall` as admin-only while it is in the lean set. There is now a test that reads both the table and the profile. The root README told users to add `index: true` (default `true` for some time) above a stale 1k threshold; replaced with the real tiers. ADR-0003/0004/0005 were still `Proposed` while shipping, and ADR-0003 still showed the pre-flip synchronous `PrimaryStore`.

## Verification

- `pnpm build` clean, `tsc --noEmit` 0 errors
- **3229 passed, 44 skipped, 0 failed** — including the Postgres suites, run against a real PostgreSQL 16 + pgvector rather than skipped
- `smoke-release.sh` **19/19** against packed tarballs, including the Postgres store
- tweet gate 262/270, manifest gate all 18 PRs declared