### PR TITLE
fix(core): close() no longer leaks a pool or hangs on a held client

### DIFF
--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -253,6 +253,20 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
   private trigramAvailable: boolean | undefined
   /** One-shot latch for the embedding-gap warning — see ensureVectorIndex. */
   private embeddingGapWarned = false
+  /**
+   * Every client currently checked out of either pool.
+   *
+   * `close()` needs this because `pool.end()` DRAINS: it waits for checked-out
+   * clients to come back. Two sites hold one for a long time — `initSchema`
+   * for its DDL sequence, and `withExclusiveAccess` across arbitrary caller
+   * work — so a `close()` racing either of them waited forever. Measured: both
+   * a drain-based teardown and one that awaited `initPromise` hung the process
+   * rather than closing it.
+   *
+   * With the set, `close()` destroys outstanding clients instead of waiting for
+   * them, and `end()` then resolves immediately.
+   */
+  private readonly liveClients = new Set<any>()
   private readonly vectorDim: number
   private readonly precision: VectorElementFormat | undefined
   private readonly indexMode: PostgresVectorIndexMode
@@ -475,7 +489,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * for a second one deadlocks whenever `maxConnections` is 1.
    */
   private async initSchema(): Promise<void> {
-    const client = await this.pool.connect()
+    const client = await this.acquire(this.pool)
     const key = `plur:init:${this.schema}`
     let locked = false
     try {
@@ -699,44 +713,91 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
   }
 
   /**
-   * Tear down both pools and refuse further use.
+   * Check out a client and remember it until it is released.
    *
-   * KNOWN LIMITATION (#751): `close()` racing construction leaks the pool.
-   * `const p = a.load(); await a.close(); await p` — `close()` runs while
-   * `getPool()` is still mid-flight, sees `this.pool === null`, and tears down
-   * nothing; the pool finishes constructing afterwards and its connection
-   * stays open, invisible to this method. Verified against a live server: the
-   * orphaned backend sits idle until node-postgres's own idle-timeout reclaims
-   * it — the process exits cleanly, nothing hangs, but the connection outlives
-   * `close()` by seconds. Subsequent calls on the adapter DO fail correctly
-   * (`[postgres] adapter is closed`).
+   * Every `connect()` in this class goes through here, so `close()` can always
+   * account for what is outstanding. A site that calls `pool.connect()`
+   * directly is invisible to teardown and reintroduces the hang.
+   */
+  private async acquire(pool: any): Promise<any> {
+    const client = await pool.connect()
+    // A checkout that resolves AFTER close() began must not be handed out: it
+    // would not be in `liveClients` when close() drained the set, and
+    // `pool.end()` would then wait for a client nobody knows about. This is the
+    // same late-arrival race as the pool assignment itself, one level down —
+    // and it is why destroying tracked clients alone still hung.
+    if (this.closed) {
+      try { client.release(new Error('[postgres] adapter closed')) } catch { /* already gone */ }
+      throw new Error('[postgres] adapter is closed')
+    }
+    this.liveClients.add(client)
+    const release = client.release.bind(client)
+    let released = false
+    client.release = (err?: unknown) => {
+      if (released) return
+      released = true
+      this.liveClients.delete(client)
+      return release(err)
+    }
+    return client
+  }
+
+  /**
+   * Tear down both pools. After this resolves, no connection remains open.
    *
-   * Deliberately not fixed in 0.16.0: earlier attempts (three failed variants
-   * are recorded on the #751 fix branch — two drain-based, one
-   * destroy-tracked-clients) turned the leaked connection into a hung
-   * process, which is strictly worse. The working fix needs a
-   * checkout-tracking set plus a refusal inside `acquire()` once closed —
-   * see #751. Until then: await construction (any first operation) before
-   * calling `close()`.
+   * Two things make that harder than `pool.end()`.
+   *
+   * First, `createPool` assigns `this.pool` only AFTER awaiting the driver
+   * import, so a `close()` landing in that window used to see `null`, skip the
+   * teardown, and leave the pool that arrived a moment later with nothing
+   * holding a reference to end it. Reproduced: `const p = a.load(); await
+   * a.close(); await p` left a live connection. So construction in flight is
+   * adopted, not ignored.
+   *
+   * Second, `pool.end()` DRAINS — it waits for checked-out clients. `initSchema`
+   * holds one for its DDL, and `withExclusiveAccess` holds one across arbitrary
+   * caller work, so draining could wait forever. Two earlier attempts (awaiting
+   * `initPromise`, and awaiting only `poolPromise`) both hung the process
+   * instead of closing it. Outstanding clients are therefore DESTROYED:
+   * `release(err)` with a truthy argument makes pg-pool `_remove` the
+   * connection rather than return it to idle, so `end()` has nothing to wait
+   * for.
+   *
+   * A caller mid-`withExclusiveAccess` sees its connection die. That is the
+   * consequence of closing during exclusive work — a caller error either way —
+   * and it is strictly better than hanging.
    */
   async close(): Promise<void> {
+    // Refuse new work first, so nothing starts building behind the teardown.
+    this.closed = true
+
+    // Adopt construction already in flight. Only the POOL promises: awaiting
+    // `initPromise` is one of the two deadlocks described above.
+    for (const pending of [this.poolPromise, this.lockPoolPromise]) {
+      if (pending) await Promise.resolve(pending).catch(() => { /* nothing to tear down */ })
+    }
+
+    // Destroy what is checked out, so the drains below resolve.
+    const closeErr = new Error('[postgres] adapter closed')
+    for (const client of [...this.liveClients]) {
+      try { client.release(closeErr) } catch { /* already gone */ }
+    }
+    this.liveClients.clear()
+
     if (this.pool) {
       const pool = this.pool
       this.pool = null
-      this.poolPromise = undefined
-      this.initPromise = null
-      this.closed = true
-      await pool.end().catch(() => { /* pool already torn down */ })
+      await pool.end().catch(() => { /* already torn down */ })
     }
     this.poolPromise = undefined
+    this.initPromise = null
+
     if (this.lockPool) {
       const lp = this.lockPool
       this.lockPool = null
-      this.lockPoolPromise = undefined
       await lp.end().catch(() => { /* already torn down */ })
     }
     this.lockPoolPromise = undefined
-    this.closed = true
   }
 
   // ------------------------------------------------------- AsyncPrimaryStore
@@ -792,7 +853,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
   async updateMany(engrams: Engram[]): Promise<void> {
     if (engrams.length === 0) return
     const pool = await this.getPool()
-    const client = await pool.connect()
+    const client = await this.acquire(pool)
     try {
       await client.query('BEGIN')
       for (let i = 0; i < engrams.length; i += SAVE_CHUNK_SIZE) {
@@ -828,7 +889,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
 
   async save(engrams: Engram[]): Promise<void> {
     const pool = await this.getPool()
-    const client = await pool.connect()
+    const client = await this.acquire(pool)
     try {
       await client.query('BEGIN')
       for (let i = 0; i < engrams.length; i += SAVE_CHUNK_SIZE) {
@@ -950,7 +1011,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     // The cost is up to `maxConnections` additional server connections, which
     // is the honest price of holding a session lock across arbitrary work.
     const pool = await this.getLockPool()
-    const client = await pool.connect()
+    const client = await this.acquire(pool)
     try {
       await client.query(`SELECT pg_advisory_lock(hashtext($1))`, [`plur:${this.schema}`])
       try {
@@ -1188,7 +1249,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     const pool = await this.getPool()
     const t = this.activeVecType
     const literal = vectorLiteral(query)
-    const client = await pool.connect()
+    const client = await this.acquire(pool)
     try {
       await client.query('BEGIN')
       if (this.hnswActive) {

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -259,9 +259,9 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * `close()` needs this because `pool.end()` DRAINS: it waits for checked-out
    * clients to come back. Two sites hold one for a long time — `initSchema`
    * for its DDL sequence, and `withExclusiveAccess` across arbitrary caller
-   * work — so a `close()` racing either of them waited forever. Measured: both
-   * a drain-based teardown and one that awaited `initPromise` hung the process
-   * rather than closing it.
+   * work — so a `close()` racing either of them waited forever. Measured:
+   * drain-based teardowns (including one that first awaited `initPromise`)
+   * hung the process rather than closing it.
    *
    * With the set, `close()` destroys outstanding clients instead of waiting for
    * them, and `end()` then resolves immediately.
@@ -756,12 +756,18 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    *
    * Second, `pool.end()` DRAINS — it waits for checked-out clients. `initSchema`
    * holds one for its DDL, and `withExclusiveAccess` holds one across arbitrary
-   * caller work, so draining could wait forever. Two earlier attempts (awaiting
-   * `initPromise`, and awaiting only `poolPromise`) both hung the process
-   * instead of closing it. Outstanding clients are therefore DESTROYED:
-   * `release(err)` with a truthy argument makes pg-pool `_remove` the
-   * connection rather than return it to idle, so `end()` has nothing to wait
-   * for.
+   * caller work, so draining could wait forever. Earlier drain-based teardown
+   * attempts (with and without first awaiting the init/pool promises) hung the
+   * process instead of closing it. Outstanding clients are therefore
+   * DESTROYED: `release(err)` with a truthy argument makes the pg driver's
+   * pool internals `_remove` the connection rather than return it to idle, so
+   * `end()` has nothing to wait for.
+   *
+   * One wait IS accepted: adopting in-flight construction transitively awaits
+   * schema init — `createPool` resolves only after `initSchema` settles — so a
+   * `close()` that lands during a cold start blocks until the adapter's own
+   * DDL completes or rejects. That is bounded, adapter-owned work, unlike a
+   * caller-held client.
    *
    * A caller mid-`withExclusiveAccess` sees its connection die. That is the
    * consequence of closing during exclusive work — a caller error either way —
@@ -771,8 +777,11 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     // Refuse new work first, so nothing starts building behind the teardown.
     this.closed = true
 
-    // Adopt construction already in flight. Only the POOL promises: awaiting
-    // `initPromise` is one of the two deadlocks described above.
+    // Adopt construction already in flight so a pool assigned after this line
+    // cannot outlive the teardown. On a cold start this transitively awaits
+    // `initSchema` (`createPool` resolves only once init settles), so close()
+    // waits for the adapter's own DDL to finish — bounded work, unlike the
+    // caller-held clients that made drain-based teardowns hang.
     for (const pending of [this.poolPromise, this.lockPoolPromise]) {
       if (pending) await Promise.resolve(pending).catch(() => { /* nothing to tear down */ })
     }

--- a/packages/core/test/postgres-close.test.ts
+++ b/packages/core/test/postgres-close.test.ts
@@ -12,11 +12,12 @@
  *    one for its DDL and `withExclusiveAccess` holds one across arbitrary
  *    caller work, so draining could wait forever.
  *
- * Three attempts are recorded in `close()`'s JSDoc because each failed in a way
- * worth remembering: awaiting `initPromise` deadlocked, awaiting only
- * `poolPromise` deadlocked, and destroying tracked clients STILL hung — because
- * a checkout that resolves after close() began was never in the tracking set.
- * That last one is why `acquire()` refuses once closed.
+ * The failed attempts are recorded in `close()`'s JSDoc because each failed in
+ * a way worth remembering: drain-based teardowns deadlocked on held clients
+ * (whichever promise they awaited first — an in-flight `createPool` transitively
+ * awaits `initSchema` anyway), and destroying tracked clients STILL hung —
+ * because a checkout that resolves after close() began was never in the
+ * tracking set. That last one is why `acquire()` refuses once closed.
  *
  * These tests fail by TIMING OUT rather than asserting, which is the honest
  * shape: the bug is a hang.

--- a/packages/core/test/postgres-close.test.ts
+++ b/packages/core/test/postgres-close.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `close()` must always terminate, and must leave nothing open.
+ *
+ * Two independent races, both of which hung or leaked before:
+ *
+ * 1. `createPool` assigns `this.pool` only AFTER awaiting the driver import, so
+ *    a `close()` in that window saw `null`, skipped teardown, and the pool that
+ *    arrived a moment later was never ended — a live connection with nothing
+ *    holding a reference to it.
+ *
+ * 2. `pool.end()` DRAINS: it waits for checked-out clients. `initSchema` holds
+ *    one for its DDL and `withExclusiveAccess` holds one across arbitrary
+ *    caller work, so draining could wait forever.
+ *
+ * Three attempts are recorded in `close()`'s JSDoc because each failed in a way
+ * worth remembering: awaiting `initPromise` deadlocked, awaiting only
+ * `poolPromise` deadlocked, and destroying tracked clients STILL hung — because
+ * a checkout that resolves after close() began was never in the tracking set.
+ * That last one is why `acquire()` refuses once closed.
+ *
+ * These tests fail by TIMING OUT rather than asserting, which is the honest
+ * shape: the bug is a hang.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { PostgresAdapter } from '../src/storage-postgres.js'
+
+const PG_URL = process.env.PLUR_TEST_POSTGRES_URL
+const TIMEOUT = 30_000
+let counter = 0
+const freshSchema = () => `plur_close_${process.pid}_${counter++}`
+
+/** The tracking set is private; reading it is the point of these assertions. */
+const liveCount = (a: PostgresAdapter) =>
+  ((a as unknown as { liveClients: Set<unknown> }).liveClients ?? new Set()).size
+const poolOf = (a: PostgresAdapter) => (a as unknown as { pool: unknown }).pool
+
+describe.skipIf(!PG_URL)('PostgresAdapter.close()', () => {
+  let adapters: PostgresAdapter[] = []
+  const track = (a: PostgresAdapter) => { adapters.push(a); return a }
+
+  afterEach(async () => {
+    await Promise.all(adapters.map(a => a.close().catch(() => { /* already closed */ })))
+    adapters = []
+  }, TIMEOUT)
+
+  it('tears down a pool whose construction was still in flight', async () => {
+    // The original leak: close() lands before `this.pool` is assigned.
+    const a = track(new PostgresAdapter({ connectionString: PG_URL!, schema: freshSchema(), vectorIndex: 'exact' }))
+    const inFlight = a.load().catch(() => { /* expected: closed underneath */ })
+    await a.close()
+    await inFlight
+
+    expect(poolOf(a), 'a pool built after close() was left open').toBeNull()
+    expect(liveCount(a), 'clients were still checked out after close()').toBe(0)
+  }, TIMEOUT)
+
+  it('returns instead of hanging when a client is held across caller work', async () => {
+    // `withExclusiveAccess` holds a lockPool client for as long as `fn` runs.
+    // A drain-based teardown waits for it; this must not.
+    const a = track(new PostgresAdapter({ connectionString: PG_URL!, schema: freshSchema(), vectorIndex: 'exact' }))
+    await a.load()
+
+    let releaseHold: () => void = () => {}
+    const held = new Promise<void>(r => { releaseHold = r })
+    const exclusive = a.withExclusiveAccess!(async () => { await held })
+      .catch(() => { /* the connection dies under it — expected */ })
+
+    // Give the lock a moment to actually be taken.
+    await new Promise(r => setTimeout(r, 250))
+    await a.close()          // must resolve, not hang
+
+    releaseHold()
+    await exclusive
+    expect(liveCount(a)).toBe(0)
+  }, TIMEOUT)
+
+  it('is idempotent', async () => {
+    const a = track(new PostgresAdapter({ connectionString: PG_URL!, schema: freshSchema(), vectorIndex: 'exact' }))
+    await a.load()
+    await a.close()
+    await a.close()
+    expect(poolOf(a)).toBeNull()
+  }, TIMEOUT)
+
+  it('an ordinary open/close cycle still works — teardown must not be vacuous', async () => {
+    // Guards against "close() does nothing" satisfying everything above: the
+    // adapter has to be usable first.
+    const schema = freshSchema()
+    const a = track(new PostgresAdapter({ connectionString: PG_URL!, schema, vectorIndex: 'exact' }))
+    await a.save([])
+    const rows = await a.load()
+    expect(Array.isArray(rows)).toBe(true)
+    await a.close()
+    expect(poolOf(a)).toBeNull()
+
+    // And it really is closed: further use is refused rather than silently
+    // reconnecting.
+    await expect(a.load()).rejects.toThrow(/closed/i)
+  }, TIMEOUT)
+})


### PR DESCRIPTION
**Not for 0.16.** This is teardown on the flagship tier and deserves its own review rather than riding along with the release-hardening work. The gap is currently documented in `close()`'s JSDoc on main, so 0.16 ships it as a known, visible limitation.

## The two races

**A pool built after `close()` was orphaned.** `createPool` assigns `this.pool` only *after* awaiting the driver import, so a `close()` landing in that window saw `null`, skipped teardown, and the pool that arrived a moment later had nothing holding a reference to end it.

```
const p = a.load(); await a.close(); await p   // -> a.pool non-null, connection open
```

**`pool.end()` drains.** It waits for checked-out clients to come back. `initSchema` holds one for its DDL sequence, and `withExclusiveAccess` holds one across arbitrary caller work — so draining could wait forever.

## Three attempts that failed

Recorded in the JSDoc, because each is a trap worth remembering:

| Attempt | Result |
|---|---|
| `await initPromise`, then drain | deadlock — init holds a client while a caller inside `getPool()` awaits the same promise |
| `await poolPromise` only, then drain | deadlock — `end()` waits for that same checked-out client |
| destroy tracked clients, then `end()` | **still hung** — a checkout that resolves *after* `close()` began was never in the tracking set |

That third one is the subtle one, and it is the same late-arrival race as the pool assignment itself, one level down.

## What works

Both halves together:

- every `connect()` goes through `acquire()`, which registers the client **and refuses once `closed` is set**, so nothing is handed out behind the teardown
- `close()` destroys whatever is outstanding rather than waiting for it — `release(err)` with a truthy argument makes pg-pool `_remove` the connection instead of returning it to idle (verified in `pg-pool@3.14.0`, `_release` → `_remove` when `err` is truthy), so `end()` has nothing left to wait for

A caller mid-`withExclusiveAccess` sees its connection die. That is the consequence of closing during exclusive work — a caller error either way — and strictly better than hanging.

## Verification

Mutation-verified, and the two halves are **independently necessary**:

- remove `acquire()`'s closed-guard → the in-flight-construction test hangs
- remove the destroy loop → the held-client test hangs

Both fail by **timing out** rather than asserting, which is the honest shape: the bug is a hang, so the test has to be able to hang.

- 4/4 new tests pass; 44/44 across the other Postgres suites unaffected
- `tsc -p packages/core` and `pnpm typecheck:tests` clean

## Post-review update (rebase + smoke-packaged fix)

Rebased onto main (#778). Both conflicts resolved as the review prescribed: `liveClients` now sits alongside main's `embeddingGapWarned` latch (#750) at the declaration site, and this PR's `close()` JSDoc replaces main's "KNOWN LIMITATION (#751)" note (#755). The `acquire()` invariant survives the rebase — main has the same five `pool.connect()` sites this PR converts, and no new ones.

**smoke-packaged root cause fixed:** the review's [90] finding was correct — the failure was this PR's own `close()` JSDoc naming the pg driver's pool package literally. tsup preserves comments in the non-minified dist bundle, so the literal landed in `dist/index.js` and false-positived `scripts/smoke-release.sh`'s inlining grep. The comment now says "the pg driver's pool internals" instead; the smoke grep is untouched. Verified locally: `dist/index.js` has zero matches for the banned literals after build.

Also corrected the [50]-class overstatement in the teardown comments: an in-flight `createPool` transitively awaits `initSchema`, so `close()` during cold construction waits for init to settle (bounded, adapter-owned DDL) — the earlier drain-based attempts hung on caller-held clients, not because of which promise they awaited first. The "attempts that failed" table above should be read with that correction.

Post-rebase verification: `packages/core` default project 147 files passed; `core-pglite` serial project incl. `postgres-close.test.ts` against a live pgvector/pg16 all pass; `pnpm build` clean.
