### PR TITLE
harden: 0.16.0 pre-release audit — close every gap the evaluator pass found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,16 @@ jobs:
             echo "::error::spec/*.json is out of sync with the Zod schemas. Run 'pnpm --filter @plur-ai/core gen:schemas' and commit."
             exit 1
           }
+      # Four suites (pr1-indexed-migration, read-side-scope-visibility,
+      # scope-pushdown, storage-indexed) gate themselves on
+      # `require('better-sqlite3')` inside try/catch and SKIP silently when the
+      # optionalDependency failed to build. Nothing asserted CI was actually in
+      # the ran-them state — a runner image change that breaks the native build
+      # would quietly shrink coverage with every job still green. Fail here
+      # instead, before the test step, with an unambiguous message.
+      - name: Assert better-sqlite3 built — the gated suites must run, not skip
+        run: node -e "require('better-sqlite3'); console.log('better-sqlite3 present — the sqlite-gated suites will run')"
+        working-directory: packages/core
       - run: pnpm test
         env:
           # Throwaway credentials for the ephemeral service container above —
@@ -137,11 +147,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Tags, so packages/migrate/test/method-list.test.ts can read the
-          # 0.15.0 source and actually verify its sync -> async claim. Without
-          # them that test takes a no-assertion early return and passes
-          # vacuously — which is how a wrong claim about the past reached the
-          # CHANGELOG in the first place.
+          # Full history so this job builds the same artefacts a release build
+          # would see (release.sh runs from a full clone with tags). The
+          # method-list.test.ts justification the `test` job carries does NOT
+          # apply here — this job never runs vitest; the comment used to be a
+          # copy-paste of that one, claiming a reason that was not this job's.
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,22 @@ because it is a claim a caller may act on.
   tool's combinator/paren/template/optional-chaining scanning, `setPinned`'s
   fabricated remote return, the release smoke's authorization checks and its CI
   wiring, plus lean-tool/storage/ADR documentation drift.
+- **A `recall()` could delete the corpus on a partially-targeted store** (#749).
+  `loadByIds` and `updateMany` are independently optional on `PrimaryStore`;
+  with the targeted read present and the targeted write absent, reactivation's
+  whole-file fallback replaced the corpus with the current result page —
+  measured: 12 engrams in, `recall(limit 3)`, 3 left. Both paths are now gated
+  behind one capability check (the pair, or neither), and `updateEngram`'s
+  remote-store error path no longer takes down the MCP server. The same PR made
+  `pnpm smoke:release` a real gate: packed tarballs installed outside the
+  workspace, driven through the public API, Postgres included.
+- **`recall()` returned the wrong rows on a pushdown store** (#750). Two bugs:
+  secondary-store and pack engrams were appended AFTER primary results, so a
+  team engram that was the single best match never appeared once the primary
+  store had `limit` hits — they are now ranked together; and the fixed 3x
+  over-fetch starved recall when residual filters (expiry, `min_strength`)
+  rejected more than two thirds of a page — the fetch now widens and re-queries,
+  bounded at three rounds (recoverable rejection ceiling 26/27 ≈ 96.3%).
 ### Fixed
 
 - **BM25 reverse-substring matches** (#721, #724): `qt.includes(t)` let any document token that was a non-prefix substring of the query score a hit — `deploying` matched an engram about *yin*, `postgres` matched one about *res*. Now `qt.startsWith(t)`, which keeps morphological prefixes (`deploy` → `deploying`) and drops the junk. Measured on a 3,930-engram store: no query loses results, and the reverse-substring matches it removes were never meaningful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,10 @@ because it is a claim a caller may act on.
   text; recall's multi-store union is now scored with exact union corpus
   statistics instead of primary-only ones (a term absent from the primary
   corpus priced as maximally rare and buried the best match); vacuous fallback
-  paths in the migrate method-list guard now hard-fail in CI; the
+  paths in the migrate method-list guard now hard-fail in CI; `Plur`'s
+  constructor warns when a supplied store implements exactly one of
+  `loadByIds`/`updateMany` (safe via the call-site fallback, but almost
+  certainly an implementation mistake); the
   `PostgresAdapter.close()` construction-race leak is actually documented
   (#751); release.sh gained a working-tree preflight and canary-publish
   recovery guidance; README states the Postgres-tier embeddings caveat.
@@ -117,9 +120,7 @@ because it is a claim a caller may act on.
   whole-file fallback replaced the corpus with the current result page —
   measured: 12 engrams in, `recall(limit 3)`, 3 left. Both paths are now gated
   behind one capability check (the pair, or neither), and `updateEngram`'s
-  remote-store error path no longer takes down the MCP server. The same PR made
-  `pnpm smoke:release` a real gate: packed tarballs installed outside the
-  workspace, driven through the public API, Postgres included.
+  remote-store error path no longer takes down the MCP server.
 - **`recall()` returned the wrong rows on a pushdown store** (#750). Two bugs:
   secondary-store and pack engrams were appended AFTER primary results, so a
   team engram that was the single best match never appeared once the primary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,17 @@ because it is a claim a caller may act on.
   tool's combinator/paren/template/optional-chaining scanning, `setPinned`'s
   fabricated remote return, the release smoke's authorization checks and its CI
   wiring, plus lean-tool/storage/ADR documentation drift.
+- **Independent pre-release audit fixes** (#752, #755): the migrate tool's ASI
+  hazard (a line-leading `(await ...)` after an unterminated statement parses
+  as a call on the previous expression — it now refuses), bracket-indexed
+  receivers it silently missed, and a combinator false positive from comment
+  text; recall's multi-store union is now scored with exact union corpus
+  statistics instead of primary-only ones (a term absent from the primary
+  corpus priced as maximally rare and buried the best match); vacuous fallback
+  paths in the migrate method-list guard now hard-fail in CI; the
+  `PostgresAdapter.close()` construction-race leak is actually documented
+  (#751); release.sh gained a working-tree preflight and canary-publish
+  recovery guidance; README states the Postgres-tier embeddings caveat.
 - **A `recall()` could delete the corpus on a partially-targeted store** (#749).
   `loadByIds` and `updateMany` are independently optional on `PrimaryStore`;
   with the targeted read present and the targeted write absent, reactivation's

--- a/README.md
+++ b/README.md
@@ -407,11 +407,19 @@ size of your store, so there is normally nothing to configure:
 |---|---|---|
 | under 5,000 engrams | `yaml` | in-memory BM25 + exact cosine |
 | 5,000 and up | `pglite` | embedded Postgres + pgvector |
-| 50,000 and up | `postgres` | a Postgres server you point it at |
+| 50,000 and up | `postgres` | a Postgres server you point it at — BM25 in SQL; semantic recall scores in memory (see below) |
 
 YAML stays the source of truth in every tier except `postgres` (ADR-0001,
 ADR-0005) — the index is a cache that rebuilds automatically, and you can delete
 it anytime. Set `backend:` in `config.yaml` to pin a tier explicitly.
+
+One caveat on the `postgres` tier, stated here because it is this table's
+headline row: **core does not write embeddings to a Postgres primary store**
+(ADR-0005 amendment). Keyword/BM25 recall runs in SQL, but `engram_embeddings`
+stays empty unless your deployment populates it, so semantic and hybrid recall
+fall back to loading engrams and scoring in memory — correct results, at the
+O(N) cost this tier otherwise avoids. The adapter says so once at schema init;
+`vectorIndex: 'exact'` acknowledges and silences it.
 
 `sqlite` (`engrams.db`, via `better-sqlite3`) is the legacy index and is no
 longer selected automatically.

--- a/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
+++ b/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0005: The Postgres tier, and what happens to exact search
 
-Status: **Accepted** — implemented in 0.16; amended 2026-07-27, see
+Status: **Accepted** — implemented in 0.16; amended 2026-07-28, see
 [Update — Phases 2 and 4 have landed](#what-this-phase-does-not-do-and-why)
 Date: 2026-07-26
 Authors: convergence programme, Phase 5

--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -151,6 +151,59 @@ export function computeIdf(
   return idf
 }
 
+/**
+ * Extend store-supplied corpus statistics with documents that live OUTSIDE
+ * that store, so a union of primary + outsider engrams is scored against the
+ * union's true statistics instead of the primary corpus's.
+ *
+ * Why this exists: scoring outsiders (secondary-store and pack engrams) with
+ * primary-only stats leaves any query term that is ABSENT from the primary
+ * corpus at `df = 0`, so `computeIdf` prices it as maximally rare —
+ * `log(N/1)`, unbounded in primary-corpus size and completely decoupled from
+ * the term's real prevalence among the outsiders. Measured before this
+ * function existed: a query mixing one primary-corpus term with one term
+ * common across a 196-engram secondary store ranked the single strongest
+ * primary match at position 197, below every weak outsider row. Team-specific
+ * jargon is exactly the vocabulary that is common in a team store and absent
+ * from a personal one, so the failure mode sat on the normal multi-store path,
+ * not an edge case.
+ *
+ * The outsiders are already fully materialised in memory by the time the
+ * union is ranked (that is how they got into the candidate list), so exact
+ * union figures cost one tokenisation pass — there is nothing to approximate.
+ * `df` counts under {@link termMatches}, the same rule `computeIdf`'s local
+ * path applies; see the CorpusStats.df doc for why drifting from that rule is
+ * worse than supplying no stats at all.
+ */
+export function extendCorpusStats(
+  stats: CorpusStats,
+  queryTokens: string[],
+  outsiders: Engram[],
+): CorpusStats {
+  if (outsiders.length === 0) return stats
+  const termSets: Array<Set<string>> = []
+  let totalLen = 0
+  for (const e of outsiders) {
+    const terms = ftsTokenize(engramSearchText(e))
+    totalLen += terms.length
+    termSets.push(new Set(terms))
+  }
+  const df = new Map(stats.df)
+  for (const qt of queryTokens) {
+    let added = 0
+    for (const set of termSets) {
+      if (set.has(qt) || Array.from(set).some(t => termMatches(t, qt))) added++
+    }
+    if (added > 0) df.set(qt, (df.get(qt) ?? 0) + added)
+  }
+  const N = stats.N + outsiders.length
+  return {
+    N,
+    df,
+    avgDocLength: N > 0 ? (stats.avgDocLength * stats.N + totalLen) / N : 0,
+  }
+}
+
 const BM25_K1 = 1.2
 const BM25_B = 0.75
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
 import { generateEngramId, loadAllPacks, storePrefix } from './engrams.js'
 import { logger } from './logger.js'
-import { searchEngrams, ftsTokenize } from './fts.js'
+import { searchEngrams, ftsTokenize, extendCorpusStats } from './fts.js'
 import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer } from './inject.js'
 import { reactivate } from './decay.js'
 import { captureEpisode, queryTimeline } from './episodes.js'
@@ -456,10 +456,23 @@ const PUSHDOWN_OVERFETCH = 3
 /**
  * How many times `recall`'s pushdown may widen its fetch before giving up.
  *
- * 3 rounds at 3x is 27x the requested limit — enough for a corpus where the
- * residual filters (expiry, min_strength) reject the overwhelming majority of
- * matches, without letting a pathological filter turn one recall into an
- * unbounded scan.
+ * 3 rounds at 3x is 27x the requested limit. Derived, not picked: the
+ * recoverable rejection ceiling is `1 - OVERFETCH^(-MAX_ROUNDS)` = 1 - 3⁻³ =
+ * 26/27 ≈ 96.3%. Residual filters (expiry, min_strength) may reject up to
+ * that fraction of every page and a full `limit` still comes back; past it
+ * the shortfall is bounded and deterministic — recall returns what the last
+ * 27x page yielded rather than escalating into an unbounded scan.
+ *
+ * Cost note, measured against the one shipping `role: 'primary'` adapter:
+ * `PostgresAdapter.searchBM25` deliberately computes the FULL candidate set
+ * regardless of the fetch limit (its trigram prefilter cannot rank, so SQL
+ * LIMIT before scoring would drop true positives). For that adapter a widening
+ * round therefore re-runs an identical query to take a longer slice of an
+ * answer it already computed — a 2–3x amplification exactly in the
+ * high-rejection case, correctness-preserving but wasteful. The loop cannot
+ * see this: `narrowed.length == fetch` is indistinguishable from "more rows
+ * exist". An adapter-side exhaustion signal (return fewer than `fetch` when
+ * the candidate set is complete) is the fix, tracked in #753.
  */
 const PUSHDOWN_MAX_ROUNDS = 3
 
@@ -568,6 +581,29 @@ export class Plur {
   constructor(options?: { path?: string; store?: AsyncPrimaryStore; autoDiscover?: boolean; cwd?: string }) {
     this.paths = detectPlurStorage(options?.path)
     this._primaryStore = options?.store ?? new YamlPrimaryStore(this.paths.engrams)
+    // `loadByIds` and `updateMany` are a capability PAIR: recall's targeted
+    // reactivation uses them together or not at all (`canTarget` in
+    // `_reactivateResults` — implementing only one silently falls back to the
+    // whole-corpus load/replace path). Historically, one-without-the-other was
+    // a data-loss hazard (#749: targeted read + whole-file write replaced a
+    // 12-engram corpus with the 3 recalled rows). The call-site guard makes the
+    // split SAFE now, but it is still almost certainly an implementation
+    // mistake — so say so at attachment time, where the implementor is looking,
+    // instead of leaving it to a JSDoc they may never read. A warning rather
+    // than a throw: a split store works correctly today, and construction is
+    // not the place to turn a performance mistake into an outage.
+    if (options?.store) {
+      const s = options.store as Partial<AsyncPrimaryStore>
+      const hasLoadByIds = typeof s.loadByIds === 'function'
+      const hasUpdateMany = typeof s.updateMany === 'function'
+      if (hasLoadByIds !== hasUpdateMany) {
+        logger.warning(
+          `[plur] the supplied primary store implements ${hasLoadByIds ? 'loadByIds' : 'updateMany'} but not `
+          + `${hasLoadByIds ? 'updateMany' : 'loadByIds'} — they are used as a pair, so recall falls back to `
+          + `whole-corpus reactivation. Implement both to enable targeted reads/writes.`,
+        )
+      }
+    }
     this.config = loadConfig(this.paths.config)
     this._autoDiscover = Plur.resolveAutoDiscover(options?.autoDiscover)
     // Auto-discover project stores from CWD (skips temp dirs for test safety).
@@ -2407,12 +2443,24 @@ export class Plur {
         // all. The bug is invisible from the primary store's side: results come
         // back, they are just the wrong ones.
         //
-        // Scored with the primary corpus's statistics so the ranking matches
-        // what the same query returns without a pushdown. The outsiders are not
-        // part of that corpus, so their IDF is an approximation — but one
-        // consistent ranking beats two ranked lists concatenated by origin.
-        const stats = adapter.corpusStats
-          ? await adapter.corpusStats(ftsTokenize(query), pushdownFilter)
+        // Scored with the UNION's statistics: the store supplies corpus-wide
+        // figures for the primary side, and `extendCorpusStats` folds the
+        // outsiders in exactly — they are already materialised in memory, so
+        // their `df`/length contributions cost one tokenisation pass.
+        //
+        // The first version of this ranking scored the union with primary-only
+        // stats and called the outsiders' IDF "an approximation". It was not a
+        // bounded one: a query term absent from the primary corpus priced at
+        // log(N/1) — maximally rare regardless of how common it is in the
+        // store it actually lives in — and team-store jargon is by nature
+        // common there and absent here. Measured: the single best primary
+        // match for a mixed query ranked 197th behind 196 weak outsider rows.
+        const queryTokens = ftsTokenize(query)
+        const primaryStats = adapter.corpusStats
+          ? await adapter.corpusStats(queryTokens, pushdownFilter)
+          : undefined
+        const stats = primaryStats
+          ? extendCorpusStats(primaryStats, queryTokens, extra)
           : undefined
         results = searchEngrams([...surviving, ...extra], query, limit, stats)
       } else {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2431,7 +2431,8 @@ export class Plur {
         fetch *= PUSHDOWN_OVERFETCH
       }
 
-      const extra = this._applyResidualFilters(await this._engramsOutsidePrimaryStore(options), options)
+      const outsiders = await this._engramsOutsidePrimaryStore(options)
+      const extra = this._applyResidualFilters(outsiders, options)
       let results: Engram[]
       if (extra.length > 0) {
         // Rank the union TOGETHER, rather than appending the outsiders.
@@ -2455,12 +2456,20 @@ export class Plur {
         // store it actually lives in — and team-store jargon is by nature
         // common there and absent here. Measured: the single best primary
         // match for a mixed query ranked 197th behind 196 weak outsider rows.
+        // The fold takes the PRE-residual outsiders, deliberately asymmetric
+        // with the `extra` that gets ranked: the primary side's `corpusStats`
+        // counts every active row — SQL cannot evaluate expiry or
+        // min_strength — so folding only residual-surviving outsiders would
+        // describe a hybrid corpus (full primary + filtered outsiders) and
+        // under-weight outsider vocabulary whenever outsiders are expired or
+        // weak. Both sides now contribute the same population: post-scope,
+        // pre-residual (#752, iteration 2).
         const queryTokens = ftsTokenize(query)
         const primaryStats = adapter.corpusStats
           ? await adapter.corpusStats(queryTokens, pushdownFilter)
           : undefined
         const stats = primaryStats
-          ? extendCorpusStats(primaryStats, queryTokens, extra)
+          ? extendCorpusStats(primaryStats, queryTokens, outsiders)
           : undefined
         results = searchEngrams([...surviving, ...extra], query, limit, stats)
       } else {

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -698,6 +698,25 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     return this.vectorIndex
   }
 
+  /**
+   * Tear down both pools and refuse further use.
+   *
+   * KNOWN LIMITATION (#751): `close()` racing construction leaks the pool.
+   * `const p = a.load(); await a.close(); await p` — `close()` runs while
+   * `getPool()` is still mid-flight, sees `this.pool === null`, and tears down
+   * nothing; the pool finishes constructing afterwards and its connection
+   * stays open, invisible to this method. Verified against a live server: the
+   * orphaned backend sits idle until node-postgres's own idle-timeout reclaims
+   * it — the process exits cleanly, nothing hangs, but the connection outlives
+   * `close()` by seconds. Subsequent calls on the adapter DO fail correctly
+   * (`[postgres] adapter is closed`).
+   *
+   * Deliberately not fixed in 0.16.0: two attempts turned the leaked
+   * connection into a hung process, which is strictly worse. The working fix
+   * needs a checkout-tracking set plus a refusal inside `acquire()` once
+   * closed — see #751. Until then: await construction (any first operation)
+   * before calling `close()`.
+   */
   async close(): Promise<void> {
     if (this.pool) {
       const pool = this.pool

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -711,11 +711,13 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * `close()` by seconds. Subsequent calls on the adapter DO fail correctly
    * (`[postgres] adapter is closed`).
    *
-   * Deliberately not fixed in 0.16.0: two attempts turned the leaked
-   * connection into a hung process, which is strictly worse. The working fix
-   * needs a checkout-tracking set plus a refusal inside `acquire()` once
-   * closed — see #751. Until then: await construction (any first operation)
-   * before calling `close()`.
+   * Deliberately not fixed in 0.16.0: earlier attempts (three failed variants
+   * are recorded on the #751 fix branch — two drain-based, one
+   * destroy-tracked-clients) turned the leaked connection into a hung
+   * process, which is strictly worse. The working fix needs a
+   * checkout-tracking set plus a refusal inside `acquire()` once closed —
+   * see #751. Until then: await construction (any first operation) before
+   * calling `close()`.
    */
   async close(): Promise<void> {
     if (this.pool) {

--- a/packages/core/test/corpus-stats.test.ts
+++ b/packages/core/test/corpus-stats.test.ts
@@ -14,7 +14,7 @@
  * the failure, so that the fix has something to be a fix OF.
  */
 import { describe, it, expect } from 'vitest'
-import { computeIdf, ftsTokenize, ftsScore, searchEngrams, termMatches, engramSearchText, type CorpusStats } from '../src/fts.js'
+import { computeIdf, ftsTokenize, ftsScore, searchEngrams, termMatches, engramSearchText, extendCorpusStats, type CorpusStats } from '../src/fts.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 function makeEngram(id: string, statement: string): Engram {
@@ -296,5 +296,83 @@ describe('CorpusStats — length normalisation (#711)', () => {
     // deriving avgdl from the candidates reverses them.
     const naive = searchEngrams(candidates, QUERY, 10).map(e => e.id)
     expect(naive).not.toEqual(viaPushdown)
+  })
+})
+
+describe('extendCorpusStats — the union is scored with union statistics (#752)', () => {
+  // The multi-store shape from the audit's end-to-end demonstration, scaled
+  // verbatim: `widget` is common in the primary corpus (100 of 200 docs, one
+  // of them matching it 5x), `zephyr` never appears there but is common in
+  // the secondary store (195 of 196 docs). Primary-only stats price `zephyr`
+  // at df=0 → log(N/1) — maximally rare, unbounded in primary-corpus size —
+  // so every weak outsider row outranked the strongest on-topic primary
+  // match, which landed at rank 197.
+  function buildUnion() {
+    const primary: Engram[] = []
+    primary.push(makeEngram('ENG-2026-0728-500', 'widget widget widget widget widget'))
+    for (let i = 0; i < 99; i++) {
+      primary.push(makeEngram(`ENG-2026-0728-5${String(i + 1).padStart(2, '0')}`, `widget filler note ${i}`))
+    }
+    for (let i = 0; i < 100; i++) {
+      primary.push(makeEngram(`ENG-2026-0728-6${String(i).padStart(2, '0')}`, `plain filler note ${i}`))
+    }
+    const outsiders: Engram[] = []
+    for (let i = 0; i < 195; i++) {
+      outsiders.push(makeEngram(`ENG-2026-0728-7${String(i).padStart(2, '0')}`, `zephyr team note ${i}`))
+    }
+    outsiders.push(makeEngram('ENG-2026-0728-799', 'unrelated outsider entry'))
+    return { primary, outsiders }
+  }
+
+  const QUERY = 'widget zephyr'
+
+  it('folds outsider documents into N, df, and avgdl exactly', () => {
+    const { primary, outsiders } = buildUnion()
+    const tokens = ftsTokenize(QUERY)
+    const base = statsFrom(primary, tokens)
+    const union = extendCorpusStats(base, tokens, outsiders)
+
+    expect(union.N).toBe(base.N + outsiders.length)
+    // `zephyr` was invisible to the primary corpus; the union sees all 195.
+    expect(base.df.get('zephyr')).toBe(0)
+    expect(union.df.get('zephyr')).toBe(195)
+    // `widget` gains nothing — no outsider mentions it.
+    expect(union.df.get('widget')).toBe(base.df.get('widget'))
+    // avgdl is the length-weighted mean, not a copy of either side's.
+    const outsiderTotal = outsiders.reduce((s, e) => s + ftsTokenize(engramSearchText(e)).length, 0)
+    const want = (base.avgDocLength * base.N + outsiderTotal) / union.N
+    expect(union.avgDocLength).toBeCloseTo(want, 10)
+    // And the input object is not mutated.
+    expect(base.df.get('zephyr')).toBe(0)
+  })
+
+  it('returns the same stats object untouched when there are no outsiders', () => {
+    const { primary } = buildUnion()
+    const tokens = ftsTokenize(QUERY)
+    const base = statsFrom(primary, tokens)
+    expect(extendCorpusStats(base, tokens, [])).toBe(base)
+  })
+
+  it('a term absent from the primary corpus no longer buries the strongest primary match', () => {
+    const { primary, outsiders } = buildUnion()
+    const tokens = ftsTokenize(QUERY)
+    const base = statsFrom(primary, tokens)
+
+    // The candidate set recall() would rank: the strong match, a page of weak
+    // primary hits, and every outsider.
+    const strong = primary[0]
+    const candidates = [strong, ...primary.slice(1, 6), ...outsiders]
+
+    // With primary-only stats the inversion is real, not hypothetical — this
+    // is the failure the fix is a fix OF, pinned so it cannot quietly return.
+    const buried = searchEngrams(candidates, QUERY, 5, base)
+    expect(
+      buried.map(e => e.id),
+      'under primary-only stats the weak zephyr rows must outrank the strong match — if this fails, the fixture no longer reproduces the bug and proves nothing',
+    ).not.toContain(strong.id)
+
+    // With union stats the strong match is first.
+    const ranked = searchEngrams(candidates, QUERY, 5, extendCorpusStats(base, tokens, outsiders))
+    expect(ranked[0]?.id).toBe(strong.id)
   })
 })

--- a/packages/core/test/postgres-adapter.test.ts
+++ b/packages/core/test/postgres-adapter.test.ts
@@ -19,7 +19,7 @@
  * Everything runs inside a per-run schema which is dropped in teardown, so this
  * can share a database with anything else without colliding.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -27,6 +27,7 @@ import yaml from 'js-yaml'
 import { PostgresAdapter, HNSW_RECALL_TARGET } from '../src/storage-postgres.js'
 import { PGLiteAdapter } from '../src/storage-pglite.js'
 import { requiresIndexSync, asDerivedIndex, efSearchFor, PGVECTOR_DEFAULT_EF_SEARCH } from '../src/storage-adapter.js'
+import { logger } from '../src/logger.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 const DSN = process.env.PLUR_TEST_POSTGRES_URL
@@ -109,10 +110,18 @@ describe.skipIf(!DSN)('PostgresAdapter (requires PLUR_TEST_POSTGRES_URL)', () =>
     it('identifies itself as a postgres-kind primary store with a credential-free location', () => {
       expect(adapter.kind).toBe('postgres')
       // `location` is what ends up in logs and status output, so the password
-      // from the DSN must not survive into it.
-      const password = new URL(DSN!).password
-      if (password) expect(adapter.location).not.toContain(password)
-      expect(adapter.location).toContain(new URL(DSN!).hostname)
+      // from the DSN must not survive into it. Checked in its credential
+      // position (`:pw@`), not as a bare substring: a password that happens
+      // to be a substring of the database or host name — `plur` inside
+      // `plurtest`, found by the 0.16.0 audit run — false-positived the bare
+      // check against a correctly masked URL, and a guard that cries wolf on
+      // legitimate setups is a guard people learn to ignore.
+      const url = new URL(DSN!)
+      if (url.password) {
+        expect(adapter.location).not.toContain(`:${url.password}@`)
+        expect(adapter.location, 'the credential slot must be masked, not merely dropped').toContain(':***@')
+      }
+      expect(adapter.location).toContain(url.hostname)
     })
   })
 
@@ -458,4 +467,41 @@ describe.skipIf(!DSN)('PGLite and Postgres answer the same filter identically', 
       expect(a).toEqual(b)
     }, TIMEOUT)
   }
+})
+
+describe.skipIf(!DSN)('the embeddings-gap warning at schema init (#752)', () => {
+  // The 0.16.0 release ships the Postgres tier WITHOUT core writing
+  // embeddings (ADR-0005 amendment): `engram_embeddings` stays empty and
+  // semantic recall silently falls back to in-memory scoring. The stated
+  // mitigation is a one-shot warning at schema init. That warning had zero
+  // test coverage — a refactor deleting it would strip the only runtime
+  // disclosure of the gap and nothing in CI would notice.
+  it('fires once for a non-exact vectorIndex, and not at all for exact', async () => {
+    const spy = vi.spyOn(logger, 'warning').mockImplementation(() => {})
+    const gapCalls = () => spy.mock.calls.filter(c => String(c[0]).includes('does not write embeddings'))
+    const auto = new PostgresAdapter({
+      connectionString: DSN!, schema: `${SCHEMA}_egap_a`, vectorDim: VECTOR_DIM,
+    })
+    const exact = new PostgresAdapter({
+      connectionString: DSN!, schema: `${SCHEMA}_egap_e`, vectorDim: VECTOR_DIM, vectorIndex: 'exact',
+    })
+    try {
+      await auto.save([])           // first schema init — warns
+      expect(gapCalls()).toHaveLength(1)
+      expect(String(gapCalls()[0][0])).toContain("vectorIndex:'exact' to silence")
+      await auto.load()             // second operation — no repeat
+      await auto.refreshVectorIndex()
+      expect(gapCalls()).toHaveLength(1)
+
+      await exact.save([])          // documented escape hatch — silent
+      await exact.load()
+      expect(gapCalls()).toHaveLength(1)
+    } finally {
+      await auto.dropSchema().catch(() => {})
+      await exact.dropSchema().catch(() => {})
+      await auto.close().catch(() => {})
+      await exact.close().catch(() => {})
+      spy.mockRestore()
+    }
+  }, TIMEOUT)
 })

--- a/packages/core/test/postgres-recall-quality.test.ts
+++ b/packages/core/test/postgres-recall-quality.test.ts
@@ -81,6 +81,57 @@ describe.skipIf(!PG_URL)('recall() quality on a pushdown store', () => {
       hits.map(e => e.statement),
       'the best match lives in a secondary store and was appended after the primary page',
     ).toContain('kubernetes ingress autoscaling policy for the tenant cluster')
+    // Inclusion alone has no teeth: a mutation that includes outsiders but
+    // ranks them at a fixed low slot still lands them somewhere in the top 5
+    // of this fixture. The secondary engram matches every query term while
+    // each primary row matches one — it must be FIRST, not merely present
+    // (#752, audit finding on this very test).
+    expect(
+      hits[0]?.statement,
+      'ranked together means ranked correctly — the all-terms match must win, not just appear',
+    ).toBe('kubernetes ingress autoscaling policy for the tenant cluster')
+  }, TIMEOUT)
+
+  it('a term common in a secondary store does not bury the best primary match', async () => {
+    // The IDF direction of the union bug (#752). Outsiders used to be scored
+    // with primary-only corpus statistics, so a query term ABSENT from the
+    // primary corpus priced at df=0 → log(N/1): maximally rare, however
+    // common it is in the store it lives in. Team jargon is exactly that
+    // shape — common in the team store, absent from the personal one — and it
+    // made every weak jargon row outrank a strong on-topic primary match
+    // (measured: rank 197 of 297). Union statistics restore the order.
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema: freshSchema(), vectorIndex: 'exact' })
+    const primary: Engram[] = [
+      makeEngram('ENG-2026-0728-400', 'widget widget widget widget widget'),
+    ]
+    for (let i = 0; i < 19; i++) {
+      primary.push(makeEngram(`ENG-2026-0728-4${String(i + 10)}`, `widget filler note ${i}`))
+    }
+    for (let i = 0; i < 20; i++) {
+      primary.push(makeEngram(`ENG-2026-0728-4${String(i + 40)}`, `plain filler note ${i}`))
+    }
+    await adapter.save(primary)
+
+    const storePath = join(storeDir, 'team.yaml')
+    writeFileSync(storePath, yaml.dump({
+      engrams: Array.from({ length: 19 }, (_, i) => ({
+        ...makeEngram(`ENG-2026-0728-8${String(i).padStart(2, '0')}`, `zephyr team note ${i}`),
+        activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 0, last_accessed: '2026-07-28' },
+        feedback_signals: { positive: 0, negative: 0, neutral: 0 }, associations: [], derivation_count: 1,
+      })),
+    }))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ path: storePath, scope: 'datafund', readonly: false }], index: false,
+    }))
+
+    const plur = new Plur({ path: dir, store: adapter })
+    await plur.ready()
+
+    const hits = await plur.recall('widget zephyr', { limit: 5 })
+    expect(
+      hits[0]?.statement,
+      'the 5x on-topic primary match lost to a row whose only merit is a term the primary corpus has never seen',
+    ).toBe('widget widget widget widget widget')
   }, TIMEOUT)
 
   it('returns a full page even when residual filters reject most of the corpus', async () => {

--- a/packages/core/test/postgres-recall-quality.test.ts
+++ b/packages/core/test/postgres-recall-quality.test.ts
@@ -134,6 +134,58 @@ describe.skipIf(!PG_URL)('recall() quality on a pushdown store', () => {
     ).toBe('widget widget widget widget widget')
   }, TIMEOUT)
 
+  it('expired outsiders still count in the union statistics — and are still never returned', async () => {
+    // The fold population is PRE-residual on purpose (#752 iteration 2): the
+    // primary side's corpusStats counts every active row because SQL cannot
+    // evaluate expiry or min_strength, so folding only residual SURVIVORS
+    // would re-create a miniature of the original inversion whenever a
+    // store's rows mass-expire — df collapses to the survivor count and the
+    // term re-inflates toward maximally-rare. Measured on this fixture:
+    // df(zephyr) 19 vs 1, idf 0.70 vs 4.61, and under the survivor-only fold
+    // the weak current outsider outranks the strong primary match.
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema: freshSchema(), vectorIndex: 'exact' })
+    const primary: Engram[] = [
+      makeEngram('ENG-2026-0728-400', 'widget widget widget widget widget'),
+    ]
+    for (let i = 0; i < 19; i++) {
+      primary.push(makeEngram(`ENG-2026-0728-4${String(i + 10)}`, `widget filler note ${i}`))
+    }
+    for (let i = 0; i < 20; i++) {
+      primary.push(makeEngram(`ENG-2026-0728-4${String(i + 40)}`, `plain filler note ${i}`))
+    }
+    await adapter.save(primary)
+
+    // 18 expired zephyr rows + 1 current weak one. Expiry is a residual
+    // filter: the store hands all 19 back; core must fold all 19 into df yet
+    // return none of the expired ones.
+    const storePath = join(storeDir, 'team.yaml')
+    writeFileSync(storePath, yaml.dump({
+      engrams: Array.from({ length: 19 }, (_, i) => ({
+        ...makeEngram(`ENG-2026-0728-8${String(i).padStart(2, '0')}`, `zephyr team note ${i}`, i < 18
+          ? { temporal: { learned_at: '2026-01-01', valid_until: '2026-01-02' } }
+          : {}),
+        activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 0, last_accessed: '2026-07-28' },
+        feedback_signals: { positive: 0, negative: 0, neutral: 0 }, associations: [], derivation_count: 1,
+      })),
+    }))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ path: storePath, scope: 'datafund', readonly: false }], index: false,
+    }))
+
+    const plur = new Plur({ path: dir, store: adapter })
+    await plur.ready()
+
+    const hits = await plur.recall('widget zephyr', { limit: 5 })
+    expect(
+      hits[0]?.statement,
+      'a survivor-only fold re-inflates zephyr to maximally-rare and the weak outsider wins again',
+    ).toBe('widget widget widget widget widget')
+    expect(
+      hits.filter(e => e.temporal?.valid_until === '2026-01-02'),
+      'expired engrams may shape the statistics but must never be returned',
+    ).toEqual([])
+  }, TIMEOUT)
+
   it('returns a full page even when residual filters reject most of the corpus', async () => {
     // The starvation bug. A FIXED 3x over-fetch is only enough while expiry /
     // min_strength remove less than two thirds of the narrowed page.

--- a/packages/core/test/reactivate-partial-store.test.ts
+++ b/packages/core/test/reactivate-partial-store.test.ts
@@ -18,12 +18,13 @@
  * destroys data. No in-tree store does this (Postgres has both, YAML has
  * neither), so nothing would have caught it until someone wrote a store.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Plur } from '../src/index.js'
 import { YamlPrimaryStore } from '../src/store/yaml-primary-store.js'
+import { logger } from '../src/logger.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 /**
@@ -98,5 +99,38 @@ describe('a store with loadByIds but no updateMany', () => {
 
     const freqAfter = (await plur.getById(e.id))!.activation.frequency
     expect(freqAfter, 'recall no longer reactivates').toBeGreaterThan(freqBefore)
+  })
+})
+
+describe('the capability pair is called out at attachment (#752)', () => {
+  // The call-site guard makes a split store SAFE; the constructor makes it
+  // VISIBLE. A store implementing exactly one of loadByIds/updateMany is
+  // almost certainly an implementation mistake — the pair is used together or
+  // not at all — and the implementor should hear that where they are looking,
+  // not in a JSDoc they may never read.
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-pairwarn-')) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('warns once when exactly one of loadByIds/updateMany is supplied', () => {
+    const spy = vi.spyOn(logger, 'warning').mockImplementation(() => {})
+    try {
+      void new Plur({ path: dir, store: new HalfTargetedStore(join(dir, 'engrams.yaml')) })
+      const pairWarnings = spy.mock.calls.filter(c => String(c[0]).includes('loadByIds'))
+      expect(pairWarnings).toHaveLength(1)
+      expect(String(pairWarnings[0][0])).toContain('updateMany')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('stays silent for a store implementing neither — YAML-shaped stores are the norm', () => {
+    const spy = vi.spyOn(logger, 'warning').mockImplementation(() => {})
+    try {
+      void new Plur({ path: dir, store: new YamlPrimaryStore(join(dir, 'engrams.yaml')) })
+      expect(spy.mock.calls.filter(c => String(c[0]).includes('loadByIds'))).toHaveLength(0)
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/packages/migrate/src/scan.ts
+++ b/packages/migrate/src/scan.ts
@@ -179,13 +179,33 @@ function inSpans(spans: Array<[number, number]>, idx: number): boolean {
 /**
  * Characters after which a line-starting `(` cannot splice onto the previous
  * statement: statement terminators (`;`), openers (`{ ( [`), separators
- * (`, :`), and binary/prefix operator tails (`= > & | + - * / % < ! ~ ^ ?`
+ * (`, :`), and binary/prefix operator tails (`= > & | + - * % < ~ ^ ?`
  * — `>` also covers `=>`). Everything else — `)`, `]`, `}`, quotes,
  * identifier characters — can legally absorb a following `(` as a call or
  * index, which is the ASI splice. See the guard in `scanSource`.
+ *
+ * Two characters that LOOK like dangling operators are deliberately absent,
+ * because both far more often END a complete expression (iteration 2 of the
+ * #752 audit reproduced runtime splices for each):
+ *
+ *   - `/` — the tail of a regex literal. `literalSpans` does not lex regexes,
+ *     so `const re = /foo/` reaches this check as a bare `/`, and a regex
+ *     followed by `(` is a CallExpression — no ASI. A genuine dangling
+ *     division at end of line effectively does not occur.
+ *   - `!` — TypeScript's non-null assertion (`map.get(k)!`), a standard
+ *     end-of-line idiom in exactly the no-semicolon TS codebases this tool
+ *     targets; `expr!(args)` is a call. A dangling prefix-`!` at end of line
+ *     effectively does not occur.
+ *
+ * Known caveat, documented rather than removed: `>` stays because dangling
+ * comparisons (`count >` at end of line) are real and the wrap there is both
+ * safe and wanted — but a TS 4.7+ instantiation expression tail
+ * (`const g = f<string>` at end of line) also ends in `>` and DOES splice,
+ * silently. That shape is rare enough that refusing every dangling comparison
+ * to block it would cost more than it saves.
  */
 const ASI_SAFE_BEFORE_PAREN = new Set([
-  ';', '{', ',', '(', '[', ':', '=', '>', '&', '|', '+', '-', '*', '/', '%', '<', '!', '~', '^', '?',
+  ';', '{', ',', '(', '[', ':', '=', '>', '&', '|', '+', '-', '*', '%', '<', '~', '^', '?',
 ])
 
 /** The span containing `idx`, or null. */
@@ -358,13 +378,15 @@ function isEsm(file: string, src: string): boolean {
  * receiver it saw so the reader can dismiss it instantly.
  *
  * Receiver chains may include single-level bracket indexes — `stores[0]`,
- * `byName['team']`, `pool[i + 1]` — because arrays/maps of stores are ordinary
- * shapes for this API and a receiver the regex cannot see is a call the user
- * is never told about (the 0.16.0 audit found `arr[0].learn(x)` scanned
- * clean, #752). A NESTED index (`m[a[0]].learn(x)`) still does not match:
- * `[^\]]` cannot span the inner `]`, and every partial interpretation fails
- * to reach the method dot, so the site is missed — not misreported, and
- * never rewritten at the wrong offset.
+ * `byName['team']`, `pool[i + 1]`, `arr?.[0]` — because arrays/maps of stores
+ * are ordinary shapes for this API and a receiver the regex cannot see is a
+ * call the user is never told about (the 0.16.0 audit found `arr[0].learn(x)`
+ * scanned clean, #752; its second pass found `arr?.[0].learn(x)` still did).
+ * Two index shapes remain documented misses: a NESTED index
+ * (`m[a[0]].learn(x)`) and an index whose string key contains `]`
+ * (`m["a]b"].learn(x)`) — `[^\]]` cannot span the inner `]`, and every
+ * partial interpretation fails to reach the method dot, so both are missed —
+ * not misreported, and never rewritten at the wrong offset.
  */
 export function scanSource(file: string, src: string, methods: readonly string[] = NEWLY_ASYNC): Finding[] {
   const spans = literalSpans(src)
@@ -373,7 +395,7 @@ export function scanSource(file: string, src: string, methods: readonly string[]
   // `?.` on either side is the same call with the same hazard: `plur?.learn(x)`
   // and `plur.learn?.(x)` both return a promise nobody awaited. Requiring a
   // plain `.` missed both.
-  const re = new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*|\[[^\]\n]*\])*)\??\.(${alt})\s*(?:\?\.)?\s*\(`, 'g')
+  const re = new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*|(?:\?\.)?\[[^\]\n]*\])*)\??\.(${alt})\s*(?:\?\.)?\s*\(`, 'g')
 
   let m: RegExpExecArray | null
   while ((m = re.exec(src))) {

--- a/packages/migrate/src/scan.ts
+++ b/packages/migrate/src/scan.ts
@@ -176,6 +176,44 @@ function inSpans(spans: Array<[number, number]>, idx: number): boolean {
   return false
 }
 
+/**
+ * Characters after which a line-starting `(` cannot splice onto the previous
+ * statement: statement terminators (`;`), openers (`{ ( [`), separators
+ * (`, :`), and binary/prefix operator tails (`= > & | + - * / % < ! ~ ^ ?`
+ * — `>` also covers `=>`). Everything else — `)`, `]`, `}`, quotes,
+ * identifier characters — can legally absorb a following `(` as a call or
+ * index, which is the ASI splice. See the guard in `scanSource`.
+ */
+const ASI_SAFE_BEFORE_PAREN = new Set([
+  ';', '{', ',', '(', '[', ':', '=', '>', '&', '|', '+', '-', '*', '/', '%', '<', '!', '~', '^', '?',
+])
+
+/** The span containing `idx`, or null. */
+function spanAt(spans: Array<[number, number]>, idx: number): [number, number] | null {
+  for (const s of spans) if (idx >= s[0] && idx < s[1]) return s
+  return null
+}
+
+/**
+ * The last significant character at or before `from`: whitespace is skipped,
+ * COMMENT spans are skipped whole, and a string/template literal is
+ * significant — its closing quote/backtick is returned, because a string can
+ * absorb a following `(` as a call (`'s'(...)` / tagged template), so for the
+ * ASI guard it must count as hazardous, not vanish like a comment.
+ */
+function lastSignificantChar(src: string, from: number, spans: Array<[number, number]>): string | null {
+  for (let j = from; j >= 0; j--) {
+    const span = spanAt(spans, j)
+    if (span) {
+      if (src[span[0]] === '/') { j = span[0]; continue } // comment — skip whole
+      return src[j] // inside a string/template literal
+    }
+    if (/\s/.test(src[j])) continue
+    return src[j]
+  }
+  return null
+}
+
 /** Index of the line containing `idx`, and the column within it. */
 function positionOf(src: string, idx: number): { line: number; column: number; text: string } {
   const before = src.slice(0, idx)
@@ -222,7 +260,18 @@ function insideCombinatorArray(src: string, idx: number, spans: Array<[number, n
     if (c === '[') {
       if (square > 0) { square--; continue }
       // Unmatched `[` — the array we are directly inside. Is it a combinator's?
-      const before = src.slice(Math.max(0, i - 60), i)
+      //
+      // The lookback is built from SIGNIFICANT characters only — comment and
+      // string spans are skipped, exactly as the bracket walk above skips
+      // them. A raw `src.slice` here matched the literal text `Promise.all(`
+      // inside an adjacent COMMENT (`process(\n  // Promise.all(\n  [...]`)
+      // and refused two perfectly ordinary calls; the false positive fails
+      // safe but sends a human to investigate nothing.
+      let before = ''
+      for (let j = i - 1; j >= 0 && before.length < 60; j--) {
+        if (inSpans(spans, j)) continue
+        before = src[j] + before
+      }
       return /Promise\s*\.\s*(all|race|allSettled|any)\s*\(\s*$/.test(before)
     }
     if (c === '(') {
@@ -307,6 +356,15 @@ function isEsm(file: string, src: string): boolean {
  * `db.list()` too. That is the correct trade for a text tool: a false positive
  * costs a glance, a false negative ships a silent bug. The report says which
  * receiver it saw so the reader can dismiss it instantly.
+ *
+ * Receiver chains may include single-level bracket indexes — `stores[0]`,
+ * `byName['team']`, `pool[i + 1]` — because arrays/maps of stores are ordinary
+ * shapes for this API and a receiver the regex cannot see is a call the user
+ * is never told about (the 0.16.0 audit found `arr[0].learn(x)` scanned
+ * clean, #752). A NESTED index (`m[a[0]].learn(x)`) still does not match:
+ * `[^\]]` cannot span the inner `]`, and every partial interpretation fails
+ * to reach the method dot, so the site is missed — not misreported, and
+ * never rewritten at the wrong offset.
  */
 export function scanSource(file: string, src: string, methods: readonly string[] = NEWLY_ASYNC): Finding[] {
   const spans = literalSpans(src)
@@ -315,7 +373,7 @@ export function scanSource(file: string, src: string, methods: readonly string[]
   // `?.` on either side is the same call with the same hazard: `plur?.learn(x)`
   // and `plur.learn?.(x)` both return a promise nobody awaited. Requiring a
   // plain `.` missed both.
-  const re = new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*)*)\??\.(${alt})\s*(?:\?\.)?\s*\(`, 'g')
+  const re = new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*|\[[^\]\n]*\])*)\??\.(${alt})\s*(?:\?\.)?\s*\(`, 'g')
 
   let m: RegExpExecArray | null
   while ((m = re.exec(src))) {
@@ -330,7 +388,15 @@ export function scanSource(file: string, src: string, methods: readonly string[]
 
     const after = src.slice(idx)
     // `.then(` / `.catch(` / `.finally(` immediately after the call: handled.
-    const callEnd = matchParen(after, src.indexOf('(', idx) - idx, spans, idx)
+    //
+    // The call's `(` is the LAST character of the regex match — taken from the
+    // match, not from `indexOf('(', idx)`, which finds the first paren after
+    // the receiver's start and therefore lands INSIDE a computed index like
+    // `arr[fn(1)].learn(x)`. Balancing from there ends the "call" mid-index,
+    // the `.length`-consumption check reads the wrong position, and the
+    // rewrite silently awaits the wrong expression — the failure class this
+    // tool exists to prevent.
+    const callEnd = matchParen(after, m[0].length - 1, spans, idx)
     if (callEnd > 0 && /^\s*\.(then|catch|finally)\s*\(/.test(after.slice(callEnd))) continue
 
     const pos = positionOf(src, idx)
@@ -371,6 +437,42 @@ export function scanSource(file: string, src: string, methods: readonly string[]
       // is reported for a human rather than rewritten blind.
       if (endPos.line === pos.line) wrapTo = endPos.column
       else { fixable = false; reason = 'result is consumed by a multi-line call — needs `(await ...)` by hand' }
+    }
+
+    // ASI hazard — the third failure class in the header comment, and the one
+    // that shipped without its guard until the 0.16.0 pre-release audit
+    // reproduced it (#752). A `wrapTo` rewrite starts the line with `(`. If
+    // the PREVIOUS statement never terminated, that `(` splices both lines
+    // into one expression:
+    //
+    //     const x = someFunc()          const x = someFunc()
+    //     plur.list().length      ->    (await plur.list()).length
+    //
+    // parses as `someFunc()(await plur.list()).length` — the previous line's
+    // result is CALLED, at runtime, with the awaited value as its argument.
+    // Only the paren-wrap form is exposed: a plain inserted `await` cannot
+    // continue the previous expression (`f() await` is invalid, so ASI still
+    // splits the lines exactly as it did before the rewrite).
+    //
+    // Applies only when the call starts its line; mid-line insertions sit
+    // inside an expression whose parsing is already fixed. The previous
+    // significant character decides: an operator, opener, `;`, `,` or `:`
+    // means the `(` either starts a fresh statement or continues an
+    // expression that was ALREADY continuing — while `)`, `]`, `}`, a quote,
+    // or an identifier tail can all legally absorb a following `(` as a call.
+    // `}` is refused even though it is usually a block end, because it is
+    // also how a function EXPRESSION ends, and `let f = function () {}`
+    // followed by `(await ...)` is the splice again. Refusal costs a glance;
+    // the splice costs a runtime failure in rewritten user source.
+    if (fixable && wrapTo !== undefined) {
+      const lineStart = idx - (pos.column - 1)
+      if (/^\s*$/.test(src.slice(lineStart, idx))) {
+        const prev = lastSignificantChar(src, lineStart - 1, spans)
+        if (prev !== null && !ASI_SAFE_BEFORE_PAREN.has(prev)) {
+          fixable = false
+          reason = 'previous line has no terminator — a leading `(await ...)` splices onto it (ASI); end it with `;` or add `(await ...)` by hand'
+        }
+      }
     }
 
     out.push({ file, line: pos.line, column: pos.column, method: m[2], text: pos.text, fixable, reason, wrapTo })

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -131,14 +131,32 @@ describe('the sync -> async claim, against the 0.15.0 source', () => {
     }
   }
 
-  it('every NEWLY_ASYNC method was sync in 0.15.0, except the documented few', () => {
-    const before = methodsAsyncAt0_15()
-    if (!before) {
-      // Not skipped silently: a skip is how this class of error hid in the
-      // first place. Fetch tags (`git fetch --tags`) to run the real check.
-      expect(alreadyAsyncAt0_15.size, 'cannot reach v0.15.0 — frozen expectation only').toBe(5)
-      return
+  /**
+   * When v0.15.0 is unreachable, these tests must not PASS — that is the
+   * vacuous-early-return class this file already fell to twice. The first
+   * version took a bare `return` (no assertion, reported green in every
+   * shallow clone); the second "fix" asserted the size of a hardcoded Set
+   * literal defined nine lines above — a tautology that can never fail, found
+   * by the 0.16.0 pre-release audit (#752). So:
+   *
+   *   - In CI, unreachable history is a hard FAILURE: both workflow checkouts
+   *     use `fetch-depth: 0` precisely so this check can run, and a regression
+   *     that drops it must break the build, not quietly disable the guard.
+   *   - Locally (a `--depth 1` clone, no tags), the tests SKIP — visible in
+   *     the report as not-run, unlike a pass. `git fetch --tags` runs them.
+   */
+  const requireHistory = (before: Set<string> | null, ctx: { skip: () => void }): before is Set<string> => {
+    if (before) return true
+    if (process.env.CI) {
+      expect.fail('v0.15.0 unreachable in CI — the checkout must fetch tags (fetch-depth: 0); this guard cannot run without them')
     }
+    ctx.skip()
+    return false
+  }
+
+  it('every NEWLY_ASYNC method was sync in 0.15.0, except the documented few', ctx => {
+    const before = methodsAsyncAt0_15()
+    if (!requireHistory(before, ctx)) return
     const unexpected = NEWLY_ASYNC.filter(n => before.has(n) && !alreadyAsyncAt0_15.has(n))
     expect(
       unexpected,
@@ -146,11 +164,11 @@ describe('the sync -> async claim, against the 0.15.0 source', () => {
     ).toEqual([])
   })
 
-  it('and the documented few really were async in 0.15.0', () => {
+  it('and the documented few really were async in 0.15.0', ctx => {
     // The other direction: if one of these was in fact sync, it belongs in the
     // BREAKING list and users are not being told to await it.
     const before = methodsAsyncAt0_15()
-    if (!before) return
+    if (!requireHistory(before, ctx)) return
     for (const m of alreadyAsyncAt0_15) {
       expect(before.has(m), `${m} was NOT async in 0.15.0 — it changed, and the notes omit it`).toBe(true)
     }

--- a/packages/migrate/test/scan-asi.test.ts
+++ b/packages/migrate/test/scan-asi.test.ts
@@ -102,4 +102,40 @@ describe('ASI splice — a leading `(await ...)` after an unterminated line', ()
     expect(f[0].fixable).toBe(true)
     expect(applyFixes(src, f).src).toBe('const ok = flag &&\n(await plur.list()).length\n')
   })
+
+  it('a dangling comparison `>` tail keeps the wrap — the documented trade', () => {
+    // `>` stays in the safe set for real dangling comparisons, at the
+    // documented cost of the rare TS instantiation-expression tail
+    // (`const g = f<string>`), which would splice. See ASI_SAFE_BEFORE_PAREN.
+    const src = 'const more = count >\nplur.list().length\n'
+    const f = scan(src)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('const more = count >\n(await plur.list()).length\n')
+  })
+
+  it('refuses after a regex-literal tail — `/` ends an expression, not a division (#752 iteration 2)', () => {
+    // literalSpans does not lex regex literals, so `const re = /foo/` reaches
+    // the guard as a bare `/`. A regex followed by `(` is a CALL — no ASI —
+    // and the first version of this guard listed `/` as a safe operator tail,
+    // emitting `const re = /foo/\n(await plur.list()).length`, which invokes
+    // the regex at runtime. A genuine dangling division at end of line
+    // effectively does not occur, so refusal here is free.
+    const src = 'const re = /foo/\nplur.list().length\n'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/ASI/)
+    expect(applyFixes(src, f).src).toBe(src)
+  })
+
+  it('refuses after a TS non-null assertion tail — `expr!(...)` is a call (#752 iteration 2)', () => {
+    // `map.get(k)!` at end of line is a standard idiom in the no-semicolon
+    // TypeScript codebases this tool targets, and `!` far more often ends a
+    // complete expression there than dangles as a prefix operator.
+    const src = 'const s = map.get(k)!\nplur.list().length\n'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+    expect(applyFixes(src, f).src).toBe(src)
+  })
 })

--- a/packages/migrate/test/scan-asi.test.ts
+++ b/packages/migrate/test/scan-asi.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The third hazard class from scan.ts's header — ASI splices — pinned.
+ *
+ * The header named it from day one: "a line beginning `(await ...)` after a
+ * line with no semicolon parses as a call on the previous expression." The
+ * guard for it did not exist until the 0.16.0 pre-release audit (#752)
+ * reproduced the splice: the tool rewrote
+ *
+ *     const x = someFunc()              const x = someFunc()
+ *     plur.list().length          to    (await plur.list()).length
+ *
+ * which executes as `someFunc()(await plur.list()).length` — the previous
+ * line's result is CALLED. Valid syntax, green suite, broken at runtime, in
+ * user source. Every case here is asserted through `applyFixes` where a
+ * rewrite is expected, because the finding list is not the product — the
+ * emitted source is.
+ */
+import { describe, it, expect } from 'vitest'
+import { scanSource, applyFixes } from '../src/scan.js'
+
+const scan = (src: string) => scanSource('t.ts', src)
+
+describe('ASI splice — a leading `(await ...)` after an unterminated line', () => {
+  it('refuses the audit repro: paren-wrap after a call with no semicolon', () => {
+    const src = 'const x = someFunc()\nplur.list().length\n'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/ASI/)
+    // The refusal must reach the output: nothing may be rewritten.
+    expect(applyFixes(src, f).src).toBe(src)
+  })
+
+  it('refuses after a line ending in an identifier, `]`, or a string', () => {
+    for (const prev of ['let a = b', 'const a = arr[0]', "const s = 'text'", 'const t = `tpl`']) {
+      const f = scan(`${prev}\nplur.list().length\n`)
+      expect(f, prev).toHaveLength(1)
+      expect(f[0].fixable, `after \`${prev}\` the wrap must be refused`).toBe(false)
+    }
+  })
+
+  it('refuses after `}` — a function expression end is indistinguishable from a block end', () => {
+    // `let f = function () {}` + `(await ...)` calls f. A block-closing `}`
+    // would be safe, but the scanner cannot tell them apart from one
+    // character, and refusal costs a glance while the splice costs a runtime
+    // failure.
+    const f = scan('let f = function () {}\nplur.list().length\n')
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+  })
+
+  it('rewrites when the previous line is terminated', () => {
+    const cases: Array<[string, string]> = [
+      ['someFunc();\nplur.list().length\n', 'someFunc();\n(await plur.list()).length\n'],
+      ['async function f() {\nplur.list().length\n}', 'async function f() {\n(await plur.list()).length\n}'],
+    ]
+    for (const [src, want] of cases) {
+      const f = scan(src)
+      expect(f).toHaveLength(1)
+      expect(f[0].fixable, src).toBe(true)
+      expect(applyFixes(src, f).src).toBe(want)
+    }
+  })
+
+  it('rewrites at the start of the file — there is no previous line to splice onto', () => {
+    const src = 'plur.list().length\n'
+    const f = scan(src)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('(await plur.list()).length\n')
+  })
+
+  it('a comment between the lines is not a terminator — the code before it decides', () => {
+    // Comment spans are skipped whole: after `;` + comment the wrap is safe,
+    // after an unterminated call + comment it is still the splice.
+    const safe = 'someFunc();\n// note\nplur.list().length\n'
+    expect(scan(safe)[0].fixable).toBe(true)
+    const splice = 'const x = someFunc()\n// note\nplur.list().length\n'
+    expect(scan(splice)[0].fixable).toBe(false)
+  })
+
+  it('mid-line paren-wraps are untouched — parsing there is already fixed', () => {
+    const src = 'const x = someFunc()\nconst n = plur.list().length\n'
+    const f = scan(src)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('const x = someFunc()\nconst n = (await plur.list()).length\n')
+  })
+
+  it('plain `await` insertion is immune — `f() await` cannot continue an expression', () => {
+    // Before the rewrite ASI splits `someFunc()` / `plur.learn(x)`; after it,
+    // `someFunc() await` is invalid so ASI splits identically. Same statement
+    // boundaries, awaited call — exactly the intended change.
+    const src = 'const x = someFunc()\nplur.learn("x")\n'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('const x = someFunc()\nawait plur.learn("x")\n')
+  })
+
+  it('an operator tail keeps the wrap — the expression was already continuing', () => {
+    const src = 'const ok = flag &&\nplur.list().length\n'
+    const f = scan(src)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('const ok = flag &&\n(await plur.list()).length\n')
+  })
+})

--- a/packages/migrate/test/scan-lookback.test.ts
+++ b/packages/migrate/test/scan-lookback.test.ts
@@ -198,3 +198,44 @@ describe('the multi-line-consumed guard', () => {
     expect(fix(ok)).toContain('await plur.learn(')
   })
 })
+
+describe('the combinator lookback reads code, not comments or strings', () => {
+  // The lookback slice used to be raw text. A COMMENT whose literal content
+  // was `Promise.all(` sitting immediately before an unrelated array made two
+  // perfectly ordinary calls "manual" — a fail-safe false positive, but exit
+  // code 2 in CI sends a human to investigate nothing. Found by the 0.16.0
+  // audit (#752).
+  it('a comment mentioning Promise.all( does not poison the array after it', () => {
+    const src = `async function go(plur) {
+  process(
+    // Promise.all(
+    [plur.learn('a'), plur.learn('b')],
+    'other',
+  )
+}`
+    const f = scan(src)
+    expect(f).toHaveLength(2)
+    expect(f.every(x => x.fixable)).toBe(true)
+  })
+
+  it('a string argument mentioning Promise.all( does not either', () => {
+    const src = `async function go(plur, f) {
+  f("Promise.all(", [plur.learn('a')])
+}`
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+  })
+
+  it('a REAL combinator is still refused when a comment sits between it and the array', () => {
+    const src = `async function go(plur) {
+  await Promise.all( // settle both
+    [plur.learn('a'), plur.learn('b')],
+  )
+}`
+    const f = scan(src)
+    expect(f).toHaveLength(2)
+    expect(f.every(x => x.fixable === false)).toBe(true)
+    expect(f[0].reason).toMatch(/combinator/)
+  })
+})

--- a/packages/migrate/test/scan.test.ts
+++ b/packages/migrate/test/scan.test.ts
@@ -28,6 +28,50 @@ describe('scanSource — what it finds', () => {
     expect(scan('this.memory.plur.feedback(id, "positive")')).toHaveLength(1)
   })
 
+  it('finds calls on bracket-indexed receivers — arrays and maps of stores are ordinary shapes', () => {
+    // These scanned CLEAN before the 0.16.0 audit (#752): the receiver
+    // pattern only knew dot-chains, and a clean exit is read as "this file is
+    // done" — the silent-omission failure the tool's own header warns about.
+    for (const src of [
+      'async function go(arr) { arr[0].learn("x") }',
+      'async function go(byName) { byName[\'team\'].recall(q) }',
+      'async function go(pool, i) { pool[i + 1].learn("x") }',
+      'async function go(app) { app.stores[0].plur.learn("x") }',
+    ]) {
+      const f = scan(src)
+      expect(f, src).toHaveLength(1)
+      expect(f[0].fixable, src).toBe(true)
+    }
+  })
+
+  it('wraps a bracket-indexed receiver correctly when the result is consumed', () => {
+    const src = 'async function go(byName) { const n = byName["team"].recall(q).length }'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(applyFixes(src, f).src).toBe(
+      'async function go(byName) { const n = (await byName["team"].recall(q)).length }',
+    )
+  })
+
+  it('a computed-call index does not derail the wrap — the call paren comes from the match, not indexOf', () => {
+    // `indexOf('(', idx)` lands on `fn(`'s paren, ends the "call" mid-index,
+    // and the rewrite awaits the wrong expression. The paren must be the
+    // match's own last character.
+    const src = 'async function go(arr) { const n = arr[fn(1)].recall(q).length }'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(applyFixes(src, f).src).toBe(
+      'async function go(arr) { const n = (await arr[fn(1)].recall(q)).length }',
+    )
+  })
+
+  it('a NESTED bracket index is missed, never misreported at an inner offset', () => {
+    // `[^\]]` cannot span the inner `]`; every partial interpretation fails to
+    // reach the method dot. A miss is the documented trade — what must never
+    // happen is a finding anchored inside the index (`m[await a[0]].learn`).
+    expect(scan('async function go(m, a) { m[a[0]].learn("x") }')).toEqual([])
+  })
+
   it('reports each occurrence separately', () => {
     expect(scan('plur.learn("a")\nplur.forget("b")\n')).toHaveLength(2)
   })

--- a/packages/migrate/test/scan.test.ts
+++ b/packages/migrate/test/scan.test.ts
@@ -72,6 +72,23 @@ describe('scanSource — what it finds', () => {
     expect(scan('async function go(m, a) { m[a[0]].learn("x") }')).toEqual([])
   })
 
+  it('finds optional-chain bracket receivers — ?.[ is ordinary modern TS (#752 iteration 2)', () => {
+    // `arr?.[0].learn(x)` scanned clean after the first bracket-receiver fix:
+    // the index alternative had no `?.` prefix, while `arr[0]?.learn(x)`
+    // (optional on the METHOD dot) was already found. Both sides now match.
+    const src = 'async function go(arr) { arr?.[0].learn("x") }'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('async function go(arr) { await arr?.[0].learn("x") }')
+  })
+
+  it('an index key containing `]` is missed, never misreported', () => {
+    // Same character-class boundary as the nested case, same invariant: a
+    // clean miss, no finding anchored inside the string key.
+    expect(scan('async function go(m) { m["a]b"].learn("x") }')).toEqual([])
+  })
+
   it('reports each occurrence separately', () => {
     expect(scan('plur.learn("a")\nplur.forget("b")\n')).toHaveLength(2)
   })

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -184,6 +184,40 @@ echo "=== PLUR Release $VERSION ==="
 echo "Dry run: $DRY_RUN"
 echo ""
 
+# --- Step 0: Working-tree preflight ---
+# Step 4 runs `git add -A` and commits WHATEVER is in the tree, then pushes to
+# main. Before this gate existed, any stray file present at release time — a
+# scratch script, an unrelated in-progress edit, another session's work — was
+# silently folded into "chore: release vX.Y.Z" and published to the world.
+# The 0.16.0 pre-release audit (#752) flagged it: every other irreversible
+# step in this script has a gate in front of it; the commit had none.
+# Skipped for --dry-run, which never commits and is legitimately run on a
+# feature branch while iterating.
+if [ "$DRY_RUN" = false ]; then
+  echo "--- Step 0: Working-tree preflight ---"
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$BRANCH" != "main" ]; then
+    echo "✗ Releases ship from main; this is '$BRANCH'."
+    exit 1
+  fi
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "✗ Working tree is not clean. Step 4 commits with 'git add -A', so anything"
+    echo "  listed below would be silently folded into the release commit:"
+    git status --short
+    echo "  Commit, stash, or remove it first."
+    exit 1
+  fi
+  git fetch origin main --quiet
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+    echo "✗ Local main is not origin/main ($(git rev-parse --short HEAD) vs $(git rev-parse --short origin/main))."
+    echo "  Pull or push first — releasing from a diverged main either loses the"
+    echo "  divergence or fails at the push AFTER npm has already published."
+    exit 1
+  fi
+  echo "  ✓ on main, clean tree, in sync with origin/main"
+  echo ""
+fi
+
 # --- 1. Version bump (11 locations) ---
 echo "--- Step 1: Version bump ---"
 
@@ -551,7 +585,24 @@ echo ""
 echo "--- Step 5a: Publish npm @next (canary) ---"
 for pkg in core cli mcp migrate; do
   echo -n "  @plur-ai/$pkg@$VERSION → @next..."
-  pnpm --filter "@plur-ai/$pkg" publish --access public --no-git-checks --tag next 2>&1 | tail -1
+  if ! pnpm --filter "@plur-ai/$pkg" publish --access public --no-git-checks --tag next 2>&1 | tail -1; then
+    # Every other failure branch in this script prints its recovery steps;
+    # this one aborted bare (set -euo pipefail) and left you to reconstruct
+    # which of the four packages made it out. Blast radius is small — @latest
+    # only moves in Step 5c — but a partial @next needs finishing BY HAND: a
+    # full re-run fails Step 3.7 for every package already published.
+    echo ""
+    echo "FAIL: @plur-ai/$pkg@$VERSION did not reach @next."
+    echo "  Published so far this run: the packages BEFORE '$pkg' in (core cli mcp migrate)."
+    echo "  @latest has not moved; users are unaffected. To recover:"
+    echo "    1. Fix the cause, then for '$pkg' and each remaining package:"
+    echo "       pnpm --filter @plur-ai/<pkg> publish --access public --no-git-checks --tag next"
+    echo "    2. Verify: npm view @plur-ai/<pkg>@$VERSION dist-tags"
+    echo "    3. Continue manually from Step 5b (smoke from @next, then promote via"
+    echo "       npm dist-tag add @plur-ai/<pkg>@$VERSION latest), or roll back with"
+    echo "       npm dist-tag rm @plur-ai/<pkg> next"
+    exit 1
+  fi
 done
 if [ -n "$CLAW_VERSION" ]; then
   echo -n "  @plur-ai/claw@$CLAW_VERSION → @next..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -207,7 +207,11 @@ if [ "$DRY_RUN" = false ]; then
     echo "  Commit, stash, or remove it first."
     exit 1
   fi
-  git fetch origin main --quiet
+  if ! git fetch origin main --quiet; then
+    echo "✗ Step 0: could not fetch origin/main — offline, or the remote is unreachable."
+    echo "  The sync check needs a fresh origin/main; restore connectivity and re-run."
+    exit 1
+  fi
   if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
     echo "✗ Local main is not origin/main ($(git rev-parse --short HEAD) vs $(git rev-parse --short origin/main))."
     echo "  Pull or push first — releasing from a diverged main either loses the"
@@ -568,6 +572,13 @@ echo ""
 
 # --- 4. Commit + tag + push ---
 echo "--- Step 4: Git ---"
+# The tree was verified clean at Step 0, but build + tests + smoke ran for
+# minutes since. `git add -A` cannot distinguish this script's own version
+# bumps from a file the toolchain dropped mid-run, so print exactly what is
+# being swept into the release commit — visible in the release log rather
+# than silently folded in.
+echo "Committing the following changes:"
+git status --short
 git add -A
 git commit -m "chore: release v$VERSION"
 git tag "v$VERSION"


### PR DESCRIPTION
Closes the fix-side of #752. Four independent evaluator passes (devil's-advocate, algorithms, execution-against-real-Postgres, release-readiness) attacked `main` at `d03cf6b`; this branch fixes everything they found. Full findings and verdicts are being posted to #752.

## Blockers fixed
- **migrate emitted a semantics-changing rewrite** — the ASI hazard its own header names had no guard: a line-leading `(await ...)` after an unterminated statement parses as a call on the previous expression. Reproduced at runtime before fixing. Guarded + pinned in `scan-asi.test.ts`.
- **Manifest gate would have aborted the release** — #749 and #750 were shipped but undeclared in the CHANGELOG. Declared (and this PR's own entry added).

## Majors fixed
- **Union-ranking IDF was unbounded-wrong for primary-absent terms** (`log(N/1)` regardless of outsider prevalence; measured burying the best match at rank 197). `extendCorpusStats()` computes exact union statistics from the already-materialised outsiders. Pinned at the fts level and end-to-end against real Postgres.
- **migrate silently missed bracket-indexed receivers** (`arr[0].learn(x)`); the call paren now comes from the regex match rather than `indexOf` (which would land inside computed indexes and mis-wrap).
- **migrate falsely refused calls when a nearby comment/string contained `Promise.all(`** — combinator lookback now reads significant characters only.
- **`method-list.test.ts` had a second vacuous early-return and a tautological frozen expectation** — unreachable history now hard-fails in CI, visibly skips locally.
- **The #750 regression test asserted inclusion, not rank** — now asserts the all-terms match is first.
- **`PostgresAdapter.close()`'s construction-race leak was claimed "documented in JSDoc"; no such JSDoc existed** — written, with verified behavior (leaks, does not hang) and #751 linked.
- **README's postgres-tier row omitted the ADR-0005 amendment caveat** (no embeddings written; semantic recall falls back to O(N) in-memory) — stated under the table.
- **release.sh** gains a Step 0 preflight (main / clean tree / synced with origin) in front of its `git add -A`, and the canary loop prints recovery steps on a partial @next.

## Medium/minor
- Embedding-gap warning now has coverage (fires once; `exact` silences).
- Constructor warns on a store implementing exactly one of `loadByIds`/`updateMany`.
- `PUSHDOWN_MAX_ROUNDS` comment carries the derived 26/27 ≈ 96.3% recoverable-rejection ceiling and the measured PostgresAdapter re-query amplification (adapter-side fix tracked in #753).
- CI asserts better-sqlite3 built (the four gated suites must run, not skip); smoke job's checkout comment states its real reason; ADR-0005 amendment date consistent; location-masking test checks the credential position instead of a bare substring.

## Verification
- 7/7 mutation probes: every new or strengthened guard FAILS when its guarded code is broken (canTarget pair, max-rounds, union wiring, the original #750 bug shape, ASI guard, gap warning, store-lock passthrough).
- Full suite green locally against PostgreSQL 16 + pgvector; `pnpm typecheck:tests` clean.
- Deferred with tracking, deliberately not rushed into this release: #753, #754, #751.