### PR TITLE
feat(core): export the engine primitives, and fix a three-way drift in feedback

### DIFF
--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -1,0 +1,104 @@
+/**
+ * What a feedback signal does to an engram.
+ *
+ * This was written out by hand in three places in `Plur.feedback` — once for
+ * the primary store, once for secondary stores, once for packs — and the three
+ * had already drifted: **only the primary copy promoted `commitment`**. The
+ * same engram, given the same positive signal, advanced from `leaning` to
+ * `decided` in your own store and stayed at `leaning` in a team store or an
+ * installed pack. Nothing failed; the engram just quietly meant something
+ * different depending on where it was kept.
+ *
+ * Three copies of a rule is how that happens, so there is now one. It is a pure
+ * mutation over an engram — no I/O, no locking, no history — which is what lets
+ * a server-side deployment reuse it without also inheriting the file-backed
+ * single-user machinery that surrounds it in `Plur`.
+ */
+import type { Engram } from './schemas/engram.js'
+
+export type FeedbackSignal = 'positive' | 'negative' | 'neutral'
+
+/** Strength added on a positive signal. Capped at 1.0. */
+export const POSITIVE_STRENGTH_DELTA = 0.05
+/** Strength removed on a negative signal. Floored at 0.0. */
+export const NEGATIVE_STRENGTH_DELTA = 0.1
+
+/**
+ * Next commitment level after a positive signal.
+ *
+ * Advances one step toward `decided` and never further: reaching `locked`
+ * requires explicit human intent, and no amount of accumulated feedback should
+ * substitute for it.
+ *
+ * `undefined` seeds at `leaning` rather than staying unset. An engram that has
+ * received a positive signal has demonstrably been retrieved and found useful,
+ * which is more than `exploring` claims and exactly what `leaning` means;
+ * leaving it unset would let an older engram accrue unlimited positive signal
+ * while still reading as though nobody had an opinion about it.
+ *
+ * Anything unrecognised is returned untouched. That is load-bearing rather than
+ * defensive: a deployment may extend the enum — `commitment: 'draft'` stages an
+ * engram in a review queue (see the extension note in `schemas/engram.ts`) — and
+ * silently promoting a draft out of review on a thumbs-up would publish
+ * unreviewed content. Unknown means "not mine to advance".
+ */
+export function nextCommitment(current: string | undefined): string | undefined {
+  switch (current) {
+    case undefined:    return 'leaning'
+    case 'exploring':  return 'leaning'
+    case 'leaning':    return 'decided'
+    case 'decided':    return 'decided'
+    case 'locked':     return 'locked'
+    default:           return current
+  }
+}
+
+/**
+ * Apply a feedback signal to an engram, in place.
+ *
+ * Mutates rather than returning a copy because every caller already owns the
+ * engram it loaded and writes the whole collection back; copying would just add
+ * a merge step for each of them to get subtly wrong.
+ *
+ * @param engram  the engram to update
+ * @param signal  the verdict
+ * @param today   date stamp to re-anchor `last_accessed` with, `YYYY-MM-DD`.
+ *                Injectable so tests are not clock-dependent.
+ */
+export function applyFeedbackSignal(
+  engram: Engram,
+  signal: FeedbackSignal,
+  today: string = new Date().toISOString().slice(0, 10),
+): void {
+  if (!engram.feedback_signals) {
+    engram.feedback_signals = { positive: 0, negative: 0, neutral: 0 }
+  }
+  engram.feedback_signals[signal] += 1
+
+  if (signal === 'positive') {
+    engram.activation.retrieval_strength = Math.min(
+      1.0, engram.activation.retrieval_strength + POSITIVE_STRENGTH_DELTA,
+    )
+    const e = engram as Engram & { commitment?: string }
+    const next = nextCommitment(e.commitment)
+    if (next !== undefined) e.commitment = next as typeof e.commitment
+  } else if (signal === 'negative') {
+    engram.activation.retrieval_strength = Math.max(
+      0.0, engram.activation.retrieval_strength - NEGATIVE_STRENGTH_DELTA,
+    )
+  }
+
+  // Re-anchor last_accessed when feedback adjusts stored strength. Read-time
+  // decay (inject.ts decayedStrength) is computed against last_accessed, so
+  // bumping strength without advancing the anchor lets elapsed-time decay
+  // immediately swallow the adjustment — a >4x distortion on stale engrams,
+  // exactly the ones where a fade-vs-keep signal matters most. Mirrors the
+  // strength+anchor pairing in _reactivateResults.
+  //
+  // Neutral is excluded because it changes no strength: there is nothing to
+  // protect from decay, and advancing the anchor would make "no opinion" act
+  // as a liveness ping.
+  if (signal !== 'neutral') {
+    engram.activation.last_accessed = today
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ import { reactivate } from './decay.js'
 import { captureEpisode, queryTimeline } from './episodes.js'
 import { agenticSearch } from './agentic-search.js'
 import { embeddingSearch, embeddingSearchWithScores, type SimilarityResult } from './embeddings.js'
+import { applyFeedbackSignal } from './feedback.js'
 import { hybridSearch, hybridSearchWithMeta, applyReranker, rrfMergeEngrams as pgliteRrfMerge, type HybridSearchResult, type RerankOptions } from './hybrid-search.js'
 import { getReranker, resolveRerankerName, isRerankerOff, rerankerStatus, resetRerankerStatus, _resetRerankerCache, checkRerankerFit, type RerankerAdapter, type RerankerRuntimeStatus, type RerankerName, type FitCheckResult } from './rerankers/index.js'
 import { runRerankerSelfEval, loadRerankerEvalCache, saveRerankerEvalResult, isRerankerEvalStale, logRerankerEvalAdvisory, type RerankerEvalResult } from './reranker-eval.js'
@@ -244,6 +245,22 @@ export {
   type MissSignalOpts,
   type MissSignalPayload,
 } from './telemetry-miss-signal.js'
+
+/**
+ * Engine primitives — the retrieval and mutation rules, without the file-backed
+ * single-user machinery that wraps them in `Plur`.
+ *
+ * Exported so a second deployment can run the SAME ranking and the SAME
+ * feedback arithmetic rather than reimplementing them. A reimplementation does
+ * not announce itself when it drifts: it returns a plausible ordering and a
+ * plausible strength, and the two deployments simply stop agreeing.
+ */
+export { rrfMergeEngrams } from './hybrid-search.js'
+export {
+  applyFeedbackSignal, nextCommitment,
+  POSITIVE_STRENGTH_DELTA, NEGATIVE_STRENGTH_DELTA,
+  type FeedbackSignal,
+} from './feedback.js'
 
 export * from './types.js'
 
@@ -3384,29 +3401,7 @@ export class Plur {
       const engram = engrams.find(e => e.id === id)
       if (!engram) return false
 
-      if (!engram.feedback_signals) {
-        engram.feedback_signals = { positive: 0, negative: 0, neutral: 0 }
-      }
-      engram.feedback_signals[signal] += 1
-
-      if (signal === 'positive') {
-        engram.activation.retrieval_strength = Math.min(1.0, engram.activation.retrieval_strength + 0.05)
-        // Idea 6: Positive feedback promotes commitment level
-        const e = engram as any
-        if (e.commitment === 'exploring') e.commitment = 'leaning'
-        else if (e.commitment === 'leaning') e.commitment = 'decided'
-      } else if (signal === 'negative') {
-        engram.activation.retrieval_strength = Math.max(0.0, engram.activation.retrieval_strength - 0.1)
-      }
-      // Re-anchor last_accessed when feedback adjusts stored strength. Read-time
-      // decay (inject.ts decayedStrength) is computed against last_accessed, so
-      // bumping strength without advancing the anchor lets elapsed-time decay
-      // immediately swallow the adjustment — a >4x distortion on stale engrams,
-      // exactly the ones where a fade-vs-keep signal matters most. Mirrors the
-      // strength+anchor pairing in _reactivateResults.
-      if (signal !== 'neutral') {
-        engram.activation.last_accessed = new Date().toISOString().slice(0, 10)
-      }
+      applyFeedbackSignal(engram, signal)
 
       await this._writeEngrams(this.paths.engrams, engrams)
       await this._syncIndex()
@@ -3442,20 +3437,7 @@ export class Plur {
       const storeEngrams = await this._storeAt(storeInfo.path).load()
       const engram = storeEngrams.find(e => e.id === storeInfo.originalId)
       if (engram) {
-        if (!engram.feedback_signals) {
-          engram.feedback_signals = { positive: 0, negative: 0, neutral: 0 }
-        }
-        engram.feedback_signals[signal] += 1
-        if (signal === 'positive') {
-          engram.activation.retrieval_strength = Math.min(1.0, engram.activation.retrieval_strength + 0.05)
-        } else if (signal === 'negative') {
-          engram.activation.retrieval_strength = Math.max(0.0, engram.activation.retrieval_strength - 0.1)
-        }
-        // Re-anchor last_accessed so read-time decay doesn't swallow the bump
-        // (see the primary-path note above).
-        if (signal !== 'neutral') {
-          engram.activation.last_accessed = new Date().toISOString().slice(0, 10)
-        }
+        applyFeedbackSignal(engram, signal)
         await this._writeEngrams(storeInfo.path, storeEngrams)
         await this._syncIndex()
         this._logInjectionOutcome(id, signal)
@@ -4144,21 +4126,7 @@ export class Plur {
         const engram = engrams.find(e => e.id === id)
         if (!engram) return false
 
-        if (!engram.feedback_signals) {
-          engram.feedback_signals = { positive: 0, negative: 0, neutral: 0 }
-        }
-        engram.feedback_signals[signal] += 1
-
-        if (signal === 'positive') {
-          engram.activation.retrieval_strength = Math.min(1.0, engram.activation.retrieval_strength + 0.05)
-        } else if (signal === 'negative') {
-          engram.activation.retrieval_strength = Math.max(0.0, engram.activation.retrieval_strength - 0.1)
-        }
-        // Re-anchor last_accessed so read-time decay doesn't swallow the bump
-        // (see the primary-path note in feedback()).
-        if (signal !== 'neutral') {
-          engram.activation.last_accessed = new Date().toISOString().slice(0, 10)
-        }
+        applyFeedbackSignal(engram, signal)
 
         await packStore.save(engrams)
         return true

--- a/packages/core/test/feedback.test.ts
+++ b/packages/core/test/feedback.test.ts
@@ -15,7 +15,10 @@ import {
 } from '../src/feedback.js'
 import type { Engram } from '../src/schemas/engram.js'
 
-const mk = (over: Partial<Engram> & { commitment?: string } = {}): Engram & { commitment?: string } => ({
+// `commitment` is widened to `string` on purpose: these tests cover values
+// outside core's enum (a deployment may add `draft`), and `Partial<Engram>`
+// would narrow it straight back to the enum.
+const mk = (over: Omit<Partial<Engram>, 'commitment'> & { commitment?: string } = {}): Engram & { commitment?: string } => ({
   id: 'ENG-2026-0729-001',
   statement: 'a statement',
   type: 'behavioral',

--- a/packages/core/test/feedback.test.ts
+++ b/packages/core/test/feedback.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The feedback mutation, as a unit.
+ *
+ * It existed as three hand-written copies inside `Plur.feedback` — primary
+ * store, secondary stores, packs — and they had drifted: only the primary copy
+ * promoted `commitment`. These tests exist mainly so that cannot happen again,
+ * which is why several of them assert arithmetic that looks too simple to test.
+ * The bug was never that the arithmetic was hard; it was that there were three
+ * of it.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  applyFeedbackSignal, nextCommitment,
+  POSITIVE_STRENGTH_DELTA, NEGATIVE_STRENGTH_DELTA,
+} from '../src/feedback.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+const mk = (over: Partial<Engram> & { commitment?: string } = {}): Engram & { commitment?: string } => ({
+  id: 'ENG-2026-0729-001',
+  statement: 'a statement',
+  type: 'behavioral',
+  scope: 'global',
+  status: 'active',
+  activation: { retrieval_strength: 0.5, storage_strength: 1, frequency: 0, last_accessed: '2026-01-01' },
+  created: '2026-01-01',
+  ...over,
+} as never)
+
+describe('nextCommitment', () => {
+  it('advances one step toward decided', () => {
+    expect(nextCommitment('exploring')).toBe('leaning')
+    expect(nextCommitment('leaning')).toBe('decided')
+  })
+
+  it('stops at decided and never reaches locked', () => {
+    // Locking is a human act. No quantity of positive feedback substitutes.
+    expect(nextCommitment('decided')).toBe('decided')
+    expect(nextCommitment('locked')).toBe('locked')
+  })
+
+  it('seeds an unset commitment at leaning', () => {
+    expect(nextCommitment(undefined)).toBe('leaning')
+  })
+
+  it('leaves an unrecognised commitment alone', () => {
+    // A deployment may extend the enum — `draft` stages an engram in a review
+    // queue. Promoting it here would publish unreviewed content on a thumbs-up.
+    expect(nextCommitment('draft')).toBe('draft')
+    expect(nextCommitment('something-else')).toBe('something-else')
+  })
+})
+
+describe('applyFeedbackSignal', () => {
+  it('counts the signal', () => {
+    const e = mk()
+    applyFeedbackSignal(e, 'positive', '2026-07-29')
+    applyFeedbackSignal(e, 'positive', '2026-07-29')
+    applyFeedbackSignal(e, 'negative', '2026-07-29')
+    applyFeedbackSignal(e, 'neutral', '2026-07-29')
+    expect(e.feedback_signals).toEqual({ positive: 2, negative: 1, neutral: 1 })
+  })
+
+  it('initialises counters when the engram has none', () => {
+    const e = mk()
+    delete (e as { feedback_signals?: unknown }).feedback_signals
+    applyFeedbackSignal(e, 'neutral', '2026-07-29')
+    expect(e.feedback_signals).toEqual({ positive: 0, negative: 0, neutral: 1 })
+  })
+
+  it('moves strength by the documented deltas', () => {
+    const up = mk({ activation: { retrieval_strength: 0.5, storage_strength: 1, frequency: 0, last_accessed: '2026-01-01' } })
+    applyFeedbackSignal(up, 'positive', '2026-07-29')
+    expect(up.activation.retrieval_strength).toBeCloseTo(0.5 + POSITIVE_STRENGTH_DELTA, 10)
+
+    const down = mk({ activation: { retrieval_strength: 0.5, storage_strength: 1, frequency: 0, last_accessed: '2026-01-01' } })
+    applyFeedbackSignal(down, 'negative', '2026-07-29')
+    expect(down.activation.retrieval_strength).toBeCloseTo(0.5 - NEGATIVE_STRENGTH_DELTA, 10)
+  })
+
+  it('clamps to [0, 1]', () => {
+    const hi = mk({ activation: { retrieval_strength: 0.99, storage_strength: 1, frequency: 0, last_accessed: '2026-01-01' } })
+    applyFeedbackSignal(hi, 'positive', '2026-07-29')
+    expect(hi.activation.retrieval_strength).toBe(1)
+
+    const lo = mk({ activation: { retrieval_strength: 0.05, storage_strength: 1, frequency: 0, last_accessed: '2026-01-01' } })
+    applyFeedbackSignal(lo, 'negative', '2026-07-29')
+    expect(lo.activation.retrieval_strength).toBe(0)
+  })
+
+  it('leaves strength untouched on neutral', () => {
+    const e = mk()
+    applyFeedbackSignal(e, 'neutral', '2026-07-29')
+    expect(e.activation.retrieval_strength).toBe(0.5)
+  })
+
+  it('re-anchors last_accessed when it changed strength, and not otherwise', () => {
+    // Read-time decay is measured from last_accessed, so a strength bump that
+    // does not move the anchor is swallowed on the next read. Neutral changes
+    // no strength, so advancing the anchor would make "no opinion" a liveness
+    // ping and keep a dying engram alive.
+    const pos = mk()
+    applyFeedbackSignal(pos, 'positive', '2026-07-29')
+    expect(pos.activation.last_accessed).toBe('2026-07-29')
+
+    const neg = mk()
+    applyFeedbackSignal(neg, 'negative', '2026-07-29')
+    expect(neg.activation.last_accessed).toBe('2026-07-29')
+
+    const neu = mk()
+    applyFeedbackSignal(neu, 'neutral', '2026-07-29')
+    expect(neu.activation.last_accessed).toBe('2026-01-01')
+  })
+
+  it('promotes commitment on positive only', () => {
+    const pos = mk({ commitment: 'exploring' })
+    applyFeedbackSignal(pos, 'positive', '2026-07-29')
+    expect(pos.commitment).toBe('leaning')
+
+    for (const signal of ['negative', 'neutral'] as const) {
+      const e = mk({ commitment: 'exploring' })
+      applyFeedbackSignal(e, signal, '2026-07-29')
+      expect(e.commitment, `${signal} must not promote`).toBe('exploring')
+    }
+  })
+
+  it('does not promote a review-queue draft out of review', () => {
+    const e = mk({ commitment: 'draft' })
+    applyFeedbackSignal(e, 'positive', '2026-07-29')
+    expect(e.commitment, 'a thumbs-up must not publish unreviewed content').toBe('draft')
+    // The rest of the signal still applies — it is staged, not ignored.
+    expect(e.feedback_signals?.positive).toBe(1)
+    expect(e.activation.retrieval_strength).toBeCloseTo(0.55, 10)
+  })
+})


### PR DESCRIPTION
## The bug

`Plur.feedback` had the feedback rule written out three times — primary store, secondary stores, packs — and the three had drifted. **Only the primary copy promoted `commitment`.**

```
$ grep -n "retrieval_strength + 0.05" packages/core/src/index.ts
3393:  ...  ← promotes commitment
3450:  ...  ← does not
4153:  ...  ← does not
```

So the same engram, given the same thumbs-up, advances `leaning → decided` in your own store and stays at `leaning` in a team store or an installed pack. Nothing throws. The engram just quietly means something different depending on where it happens to live.

Three copies of a rule is how that happens, so there is now one: `applyFeedbackSignal`, called from all three sites.

## The commitment ladder, stated once

`nextCommitment` puts the whole ladder in one place, including the cases that were previously implicit:

- **`undefined` seeds at `leaning`.** An engram that has received a positive signal has demonstrably been retrieved and found useful, which is more than `exploring` claims. Leaving it unset let an older engram accumulate unlimited positive signal while still reading as though nobody had an opinion about it. **This is a behaviour change**, and the one intentional one in this PR.
- **`decided` is the ceiling.** Reaching `locked` requires explicit human intent; no quantity of feedback substitutes for it.
- **Anything unrecognised is returned untouched.** Load-bearing rather than defensive: a deployment may extend the enum, and `commitment: 'draft'` stages an engram in a review queue (the extension point is already noted in `schemas/engram.ts`). Silently promoting a draft on a thumbs-up would publish unreviewed content.

## Why these are exported

`rrfMergeEngrams` already existed in `hybrid-search.ts` but was not reachable from the package, so a consumer wanting the same k=60 ranking had to write it again. Same for the feedback arithmetic.

A reimplementation is correct on the day it is written and has no way to announce when it stops being correct. It keeps returning a plausible ordering and a plausible strength; the two implementations simply stop agreeing, and the symptom shows up much later as "the benchmark numbers don't describe this deployment." This repo just found three instances of exactly that internally. There is no reason to let it happen across a package boundary as well.

`applyFeedbackSignal` is a pure mutation — no I/O, no locking, no history — so it is usable without also inheriting the file-backed single-user machinery that surrounds it in `Plur`.

## Testing

- 12 new unit tests in `packages/core/test/feedback.test.ts`, several asserting arithmetic that looks too simple to test. That is deliberate: the bug was never that the arithmetic was hard, it was that there were three of it.
- Full core suite: **153 files, 2325 tests, 0 failures.**

One note on flakiness spotted while verifying, unrelated to this change: `test/secrets.test.ts` → `truncation at the ceiling produces valid UTF-8` timed out at 30 s during one full-suite run and passed in isolation and on a re-run. It is a 1 MiB scan competing with 164 other files for CPU. Worth a longer timeout at some point; not touched here.

## Downstream

This unblocks a second deployment consuming the same primitives instead of maintaining transcriptions of them. Nothing in this PR depends on that.
