### PR TITLE
feat(mcp): plur_doctor reports the live tool surface

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { Plur, checkForUpdate } from '@plur-ai/core'
-import { getToolDefinitions, mcpCanary, validateToolArgs, CURSOR_CORE_TOOL_NAMES, type ToolProfile } from './tools.js'
+import { getToolDefinitions, mcpCanary, validateToolArgs, CURSOR_CORE_TOOL_NAMES, type ToolProfile, resolveToolProfile } from './tools.js'
 import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
 
@@ -420,8 +420,10 @@ Please:
 }
 
 export async function runStdio(): Promise<void> {
-  const envProfile = process.env.PLUR_TOOL_PROFILE
-  const profile: ToolProfile = envProfile === 'full' ? 'full' : envProfile === 'cursor' ? 'cursor' : 'lean'
+  // Shared with describeToolSurface (#761) so the surface plur_doctor reports
+  // is resolved from the same rule the server exposes tools with — two copies
+  // of this ternary is how doctor comes to describe a profile nobody is running.
+  const profile: ToolProfile = resolveToolProfile()
   const server = await createServer(undefined, { profile })
   // Opt-in, content-free telemetry: ship any pending daily counter snapshot on
   // process exit (best-effort). Self-gates on telemetry opt-in — an opted-out

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { Plur, checkForUpdate } from '@plur-ai/core'
-import { getToolDefinitions, mcpCanary, validateToolArgs, CURSOR_CORE_TOOL_NAMES, type ToolProfile, resolveToolProfile } from './tools.js'
+import { getToolDefinitions, mcpCanary, validateToolArgs, CURSOR_CORE_TOOL_NAMES, type ToolProfile, resolveToolProfile, setActiveToolProfile } from './tools.js'
 import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
 
@@ -169,7 +169,12 @@ Override with \`PLUR_PATH\` environment variable.
 
 export async function createServer(plur?: Plur, options?: { profile?: ToolProfile }): Promise<Server> {
   const instance = plur ?? new Plur()
-  const tools = getToolDefinitions(options?.profile ?? 'lean')
+  const profile = options?.profile ?? 'lean'
+  // #761: record what we actually exposed, so plur_doctor reports THIS surface
+  // rather than re-deriving one from the environment — which is not the
+  // authority here, since the profile arrives as an option.
+  setActiveToolProfile(profile)
+  const tools = getToolDefinitions(profile)
 
   // Non-blocking version check — fire and forget
   checkForUpdate('@plur-ai/mcp', VERSION, (r) => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -628,6 +628,49 @@ function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
   }
 }
 
+/**
+ * The tool surface as the client actually sees it, for a given profile.
+ *
+ * Exists because a consolidated surface is invisible to a client that only
+ * reads `tools/list` (#761). Under the lean profile most `plur_*` tools are no
+ * longer standalone — they are actions on `plur_admin` — so an agent carrying a
+ * memory of the old names looks one up, misses, and concludes the MCP is down.
+ * It never calls the missing name, so the helpful "call it via plur_admin"
+ * error on that path never fires.
+ *
+ * The observed failure (2026-07-29) is the sharp version of this: `plur_doctor`
+ * reported **green** while the agent switched to an HTTP fallback, because
+ * doctor answers "is the engine healthy" and the actual question was "what is
+ * callable". Health and surface are different questions and only one of them
+ * was answerable in-band.
+ */
+export function resolveToolProfile(env: NodeJS.ProcessEnv = process.env): ToolProfile {
+  const v = env.PLUR_TOOL_PROFILE
+  return v === 'full' ? 'full' : v === 'cursor' ? 'cursor' : 'lean'
+}
+
+export function describeToolSurface(profile: ToolProfile = resolveToolProfile()): {
+  profile: ToolProfile
+  standalone: string[]
+  admin_actions: string[]
+  note: string
+} {
+  const all = getAllToolDefinitions()
+  const exposed = getToolDefinitions(profile)
+  const standalone = exposed.map(t => t.name).sort()
+  const admin_actions = profile === 'full'
+    ? []
+    : all.map(t => t.name).filter(n => !CURSOR_CORE_TOOL_NAMES.has(n)).sort()
+  return {
+    profile,
+    standalone,
+    admin_actions,
+    note: admin_actions.length === 0
+      ? 'All tools are exposed directly under this profile.'
+      : `Only the ${standalone.length} tools in "standalone" are callable by name. Everything in "admin_actions" is reachable as plur_admin { action: "<name>", args: {...} } — same arguments, same validation, same result. A name-lookup miss on one of those means it moved, NOT that the MCP is unavailable. Set PLUR_TOOL_PROFILE=full to expose all tools directly.`,
+  }
+}
+
 export function getToolDefinitions(profile: ToolProfile = 'lean'): ToolDefinition[] {
   const all = getAllToolDefinitions()
   if (profile === 'full') return all
@@ -2013,6 +2056,12 @@ function getAllToolDefinitions(): ToolDefinition[] {
             remediation.push(`Remote ${c.url}: ${c.tokens} distinct tokens are configured across its store entries — consolidate to one token in ~/.plur/config.yaml so recall dials the host once.`)
           }
         } catch { /* best-effort — never let recall status break doctor */ }
+        // #761: report the SURFACE alongside the health. An agent that cannot
+        // find `plur_recall_hybrid` by name needs to learn it moved under
+        // plur_admin — and doctor is the one door that is name-stable across
+        // profiles, so it is where that answer belongs. Without this, doctor
+        // can report green while the caller concludes the MCP is gone.
+        const tool_surface = describeToolSurface(resolveToolProfile())
         return {
           ok: checks.every(c => c.ok),
           checks,
@@ -2021,6 +2070,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
             after_probe: after,
           },
           capabilities: canaryStatuses,
+          tool_surface,
           remediation: remediation.length > 0 ? remediation : ['All checks passed — PLUR is healthy.'],
         }
       },

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -628,6 +628,40 @@ function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
   }
 }
 
+/** Profile from the environment. The default when nobody says otherwise. */
+export function resolveToolProfile(env: NodeJS.ProcessEnv = process.env): ToolProfile {
+  const v = env.PLUR_TOOL_PROFILE
+  return v === 'full' ? 'full' : v === 'cursor' ? 'cursor' : 'lean'
+}
+
+/**
+ * The profile the running server was ACTUALLY built with.
+ *
+ * `createServer` takes an explicit `profile` option, so the environment is not
+ * the authority — `createServer(plur, { profile: 'full' })` with no env var set
+ * exposes 41 tools while `resolveToolProfile()` still says `lean`. Reporting
+ * the env-derived value would make plur_doctor describe a 12-tool surface to a
+ * client looking at 41: confidently wrong, in the one field the client has no
+ * way to check. Left unset it falls back to the environment, which is right for
+ * anything that has not gone through `createServer`.
+ */
+let activeProfile: ToolProfile | null = null
+
+/** Record the profile a server was constructed with. Called by `createServer`. */
+export function setActiveToolProfile(profile: ToolProfile): void {
+  activeProfile = profile
+}
+
+/** Test seam — forget the recorded profile. */
+export function _resetActiveToolProfile(): void {
+  activeProfile = null
+}
+
+/** The profile in force: what the server was built with, else the environment. */
+export function activeToolProfile(): ToolProfile {
+  return activeProfile ?? resolveToolProfile()
+}
+
 /**
  * The tool surface as the client actually sees it, for a given profile.
  *
@@ -638,18 +672,13 @@ function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
  * It never calls the missing name, so the helpful "call it via plur_admin"
  * error on that path never fires.
  *
- * The observed failure (2026-07-29) is the sharp version of this: `plur_doctor`
- * reported **green** while the agent switched to an HTTP fallback, because
- * doctor answers "is the engine healthy" and the actual question was "what is
- * callable". Health and surface are different questions and only one of them
+ * The observed failure (2026-07-29) is the sharp version: `plur_doctor`
+ * reported green while the agent switched to an HTTP fallback, because doctor
+ * answers "is the engine healthy" and the actual question was "what is
+ * callable". Health and surface are different questions, and only one of them
  * was answerable in-band.
  */
-export function resolveToolProfile(env: NodeJS.ProcessEnv = process.env): ToolProfile {
-  const v = env.PLUR_TOOL_PROFILE
-  return v === 'full' ? 'full' : v === 'cursor' ? 'cursor' : 'lean'
-}
-
-export function describeToolSurface(profile: ToolProfile = resolveToolProfile()): {
+export function describeToolSurface(profile: ToolProfile = activeToolProfile()): {
   profile: ToolProfile
   standalone: string[]
   admin_actions: string[]
@@ -2061,7 +2090,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
         // plur_admin — and doctor is the one door that is name-stable across
         // profiles, so it is where that answer belongs. Without this, doctor
         // can report green while the caller concludes the MCP is gone.
-        const tool_surface = describeToolSurface(resolveToolProfile())
+        const tool_surface = describeToolSurface()
         return {
           ok: checks.every(c => c.ok),
           checks,

--- a/packages/mcp/test/tool-surface.test.ts
+++ b/packages/mcp/test/tool-surface.test.ts
@@ -17,11 +17,13 @@
  * report honest — a description that drifts from what is actually exposed is
  * worse than none, because it is the thing an agent would trust.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
   describeToolSurface, resolveToolProfile, getToolDefinitions,
+  activeToolProfile, setActiveToolProfile, _resetActiveToolProfile,
   CURSOR_CORE_TOOL_NAMES,
 } from '../src/tools.js'
+import { createServer } from '../src/server.js'
 
 describe('resolveToolProfile', () => {
   it('defaults to lean, and only the documented values change it', () => {
@@ -32,6 +34,43 @@ describe('resolveToolProfile', () => {
     // exposing 41 tools because someone typoed the value.
     expect(resolveToolProfile({ PLUR_TOOL_PROFILE: 'FULL' } as NodeJS.ProcessEnv)).toBe('lean')
     expect(resolveToolProfile({ PLUR_TOOL_PROFILE: 'nonsense' } as NodeJS.ProcessEnv)).toBe('lean')
+  })
+})
+
+describe('the reported profile is the one actually in force', () => {
+  afterEach(() => _resetActiveToolProfile())
+
+  it('falls back to the environment when no server has been built', () => {
+    _resetActiveToolProfile()
+    expect(activeToolProfile()).toBe(resolveToolProfile())
+  })
+
+  it('follows createServer, not the environment', async () => {
+    // The bug this guards. `createServer` takes the profile as an OPTION, so
+    // the environment is not the authority: building with 'full' while
+    // PLUR_TOOL_PROFILE is unset exposes 41 tools, and an env-derived report
+    // would tell the client it has 12. That is confidently wrong in the one
+    // field the client cannot check for itself.
+    const before = process.env.PLUR_TOOL_PROFILE
+    delete process.env.PLUR_TOOL_PROFILE
+    try {
+      expect(resolveToolProfile()).toBe('lean')          // environment says lean
+      await createServer(undefined, { profile: 'full' }) // server says full
+      expect(activeToolProfile(), 'must follow the server, not the env').toBe('full')
+
+      const surface = describeToolSurface()
+      expect(surface.profile).toBe('full')
+      expect(surface.standalone).toEqual(getToolDefinitions('full').map(t => t.name).sort())
+      expect(surface.admin_actions, 'nothing is hidden under full').toEqual([])
+    } finally {
+      if (before === undefined) delete process.env.PLUR_TOOL_PROFILE
+      else process.env.PLUR_TOOL_PROFILE = before
+    }
+  }, 60_000)
+
+  it('an explicitly passed profile still wins over the recorded one', () => {
+    setActiveToolProfile('full')
+    expect(describeToolSurface('lean').profile).toBe('lean')
   })
 })
 

--- a/packages/mcp/test/tool-surface.test.ts
+++ b/packages/mcp/test/tool-surface.test.ts
@@ -17,7 +17,11 @@
  * report honest — a description that drifts from what is actually exposed is
  * worse than none, because it is the thing an agent would trust.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, settleVersionChecks, clearVersionCache } from '@plur-ai/core'
 import {
   describeToolSurface, resolveToolProfile, getToolDefinitions,
   activeToolProfile, setActiveToolProfile, _resetActiveToolProfile,
@@ -51,11 +55,20 @@ describe('the reported profile is the one actually in force', () => {
     // PLUR_TOOL_PROFILE is unset exposes 41 tools, and an env-derived report
     // would tell the client it has 12. That is confidently wrong in the one
     // field the client cannot check for itself.
+    // Hermetic per the server.test.ts pattern: a temp-dir Plur so the server
+    // never opens the real ~/.plur, and a stubbed fetch so `createServer`'s
+    // fire-and-forget npm version check never leaves the process — drained and
+    // its cache cleared before any assertion runs.
     const before = process.env.PLUR_TOOL_PROFILE
+    const realFetch = globalThis.fetch
+    const dir = mkdtempSync(join(tmpdir(), 'plur-mcp-tool-surface-'))
     delete process.env.PLUR_TOOL_PROFILE
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }) as any
     try {
-      expect(resolveToolProfile()).toBe('lean')          // environment says lean
-      await createServer(undefined, { profile: 'full' }) // server says full
+      expect(resolveToolProfile()).toBe('lean')                       // environment says lean
+      await createServer(new Plur({ path: dir }), { profile: 'full' }) // server says full
+      await settleVersionChecks()
+      clearVersionCache()
       expect(activeToolProfile(), 'must follow the server, not the env').toBe('full')
 
       const surface = describeToolSurface()
@@ -63,6 +76,8 @@ describe('the reported profile is the one actually in force', () => {
       expect(surface.standalone).toEqual(getToolDefinitions('full').map(t => t.name).sort())
       expect(surface.admin_actions, 'nothing is hidden under full').toEqual([])
     } finally {
+      globalThis.fetch = realFetch
+      rmSync(dir, { recursive: true })
       if (before === undefined) delete process.env.PLUR_TOOL_PROFILE
       else process.env.PLUR_TOOL_PROFILE = before
     }

--- a/packages/mcp/test/tool-surface.test.ts
+++ b/packages/mcp/test/tool-surface.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The tool surface has to be answerable in-band (#761).
+ *
+ * Under the lean profile most `plur_*` tools stopped being standalone and
+ * became actions on `plur_admin`. That change is invisible to a client that
+ * only reads `tools/list`: an agent carrying a memory of the old names looks
+ * one up, misses, and concludes the MCP is unavailable. It never *calls* the
+ * missing name, so the server's helpful "call it via plur_admin" error — which
+ * only fires on a call — never reaches it.
+ *
+ * The observed failure is the sharp version: `plur_doctor` reported green while
+ * the caller switched to an HTTP fallback, because doctor answers "is the
+ * engine healthy" and the real question was "what is callable". Those are
+ * different questions, and only one of them had an answer.
+ *
+ * So doctor now reports the surface too, and these tests exist to keep that
+ * report honest — a description that drifts from what is actually exposed is
+ * worse than none, because it is the thing an agent would trust.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  describeToolSurface, resolveToolProfile, getToolDefinitions,
+  CURSOR_CORE_TOOL_NAMES,
+} from '../src/tools.js'
+
+describe('resolveToolProfile', () => {
+  it('defaults to lean, and only the documented values change it', () => {
+    expect(resolveToolProfile({} as NodeJS.ProcessEnv)).toBe('lean')
+    expect(resolveToolProfile({ PLUR_TOOL_PROFILE: 'full' } as NodeJS.ProcessEnv)).toBe('full')
+    expect(resolveToolProfile({ PLUR_TOOL_PROFILE: 'cursor' } as NodeJS.ProcessEnv)).toBe('cursor')
+    // Anything unrecognised must fall back to the safe default rather than
+    // exposing 41 tools because someone typoed the value.
+    expect(resolveToolProfile({ PLUR_TOOL_PROFILE: 'FULL' } as NodeJS.ProcessEnv)).toBe('lean')
+    expect(resolveToolProfile({ PLUR_TOOL_PROFILE: 'nonsense' } as NodeJS.ProcessEnv)).toBe('lean')
+  })
+})
+
+describe('describeToolSurface', () => {
+  it('reports exactly what tools/list exposes — not an approximation', () => {
+    // The load-bearing assertion. If these ever diverge, doctor is telling an
+    // agent it can call something it cannot, which is worse than silence.
+    for (const profile of ['lean', 'cursor', 'full'] as const) {
+      const surface = describeToolSurface(profile)
+      const actual = getToolDefinitions(profile).map(t => t.name).sort()
+      expect(surface.standalone, `standalone drifted from tools/list for "${profile}"`).toEqual(actual)
+    }
+  })
+
+  it('every advertised admin action is really dispatchable', () => {
+    // An action listed here that plur_admin cannot route is a dead end an
+    // agent would follow on our say-so.
+    const surface = describeToolSurface('lean')
+    const everything = new Set(getToolDefinitions('full').map(t => t.name))
+    for (const action of surface.admin_actions) {
+      expect(everything.has(action), `advertised action "${action}" does not exist`).toBe(true)
+      expect(CURSOR_CORE_TOOL_NAMES.has(action), `"${action}" is standalone — it should not be listed as an admin action`).toBe(false)
+    }
+  })
+
+  it('standalone + admin_actions together cover the whole tool set', () => {
+    // No tool may be unreachable: if a name is in neither list, an agent has
+    // no way to discover it at all.
+    const surface = describeToolSurface('lean')
+    const reachable = new Set([...surface.standalone, ...surface.admin_actions])
+    for (const t of getToolDefinitions('full')) {
+      expect(reachable.has(t.name), `"${t.name}" is reachable by neither route`).toBe(true)
+    }
+  })
+
+  it('names the tools that moved, so a lookup miss is self-correcting', () => {
+    const surface = describeToolSurface('lean')
+    // The specific names from the incident report.
+    for (const moved of ['plur_recall_hybrid', 'plur_stores_list', 'plur_suggest_scope']) {
+      expect(surface.admin_actions, `${moved} should be listed as an admin action`).toContain(moved)
+      expect(surface.standalone).not.toContain(moved)
+    }
+    // And the note must say a miss means "moved", not "gone" — that inference
+    // is the entire bug.
+    expect(surface.note).toMatch(/moved, NOT that the MCP is unavailable/)
+    expect(surface.note).toContain('plur_admin')
+  })
+
+  it('says so plainly when nothing is hidden', () => {
+    const full = describeToolSurface('full')
+    expect(full.admin_actions).toEqual([])
+    expect(full.note).toContain('All tools are exposed directly')
+    // plur_admin itself is not needed as a router under full, but the surface
+    // must still be the real list.
+    expect(full.standalone.length).toBeGreaterThan(surfaceCount('lean'))
+  })
+
+  it('keeps the diagnostic door standalone in every profile', () => {
+    // doctor/status are where an agent goes when it thinks the MCP is broken.
+    // If they were ever consolidated, the only in-band way to discover the
+    // surface would itself be undiscoverable.
+    for (const profile of ['lean', 'cursor', 'full'] as const) {
+      const { standalone } = describeToolSurface(profile)
+      expect(standalone, `plur_doctor must stay standalone in "${profile}"`).toContain('plur_doctor')
+      expect(standalone, `plur_status must stay standalone in "${profile}"`).toContain('plur_status')
+    }
+  })
+})
+
+function surfaceCount(profile: 'lean' | 'cursor' | 'full'): number {
+  return describeToolSurface(profile).standalone.length
+}


### PR DESCRIPTION
Addresses #761 — option 2 (self-describing inventory), which composes with option 4 (name-stable diagnostic door).

## Why this one

I checked the five proposed fixes against the code before implementing. Two are already shipped:

- **Option 3 (helpful `plur_admin` errors)** — already there. An unknown action returns `Unknown action "x". Valid actions: ...`, and `plur_admin`'s *description* enumerates every valid action. There's even a deliberate comment explaining why `enum` is omitted from the schema, so an invalid action reaches that handler instead of failing generic validation.
- **Option 5 (migration signal)** — the 0.15.0 CHANGELOG flags it prominently: *"Lean tool profile is now the default (#625, #694) … down from 40 … All 40 tools remain reachable via plur_admin"*, including a bolded note for consumers depending on all 40.

**Option 1 (backward-compat aliases) I'd argue against.** Measured: 41 tool definitions, 12 standalone under lean, **30 under `plur_admin`**. Re-exposing those 30 as aliases puts the surface back at ~41 — which is the ~40-per-workspace cap the consolidation exists to stay under. It trades this bug for the one that caused it.

That leaves option 2 as the real gap, and the incident shows exactly why it matters: **`plur_doctor` was green and the agent still concluded the MCP was down.** Doctor answers *"is the engine healthy"*; the actual question was *"what is callable"*. Its own description even says it does not check the live tool count.

## What changes

`plur_doctor` now returns `tool_surface`:

```json
{
  "profile": "lean",
  "standalone": ["plur_admin", "plur_doctor", "plur_learn", ...],
  "admin_actions": ["plur_recall_hybrid", "plur_stores_list", "plur_suggest_scope", ...],
  "note": "Only the 12 tools in \"standalone\" are callable by name. Everything in \"admin_actions\" is reachable as plur_admin { action: \"<name>\", args: {...} } — same arguments, same validation, same result. A name-lookup miss on one of those means it moved, NOT that the MCP is unavailable. Set PLUR_TOOL_PROFILE=full to expose all tools directly."
}
```

Doctor is the right home: it's where an agent already goes when it thinks the server is broken, and it stays standalone in **every** profile — a surface description that could itself be consolidated would be useless.

`resolveToolProfile()` is now shared with `runStdio` instead of the ternary being written twice. Two copies is how doctor comes to confidently describe a profile nobody is running.

## Tests

The risk with a self-description is that it drifts and becomes a confidently wrong answer — worse than none, because it's the thing an agent would trust. So the tests assert it *can't*:

- `standalone` must equal `getToolDefinitions(profile)` exactly, for all three profiles
- every advertised action must exist **and** not be one of the standalone names
- the two lists together must cover every tool — nothing undiscoverable
- `plur_doctor`/`plur_status` must stay standalone in every profile
- the incident's specific names (`plur_recall_hybrid`, `plur_stores_list`, `plur_suggest_scope`) are asserted present

**Mutation-tested**: claiming an unexposed tool fails 2 tests; weakening the note's "moved, NOT unavailable" wording fails 1.

297 mcp tests, 2325 core tests, `typecheck` + `typecheck:tests` clean.

## Left for triage

Option 5's release-process half — a standing rule that a tool-surface change must be called out in release notes — is a process change rather than code, and #761 suggests splitting it. Happy to file that separately if you want it tracked.