### PR TITLE
fix(cli): plur doctor probes the configured MCP server, not a synthesised one

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -7,6 +7,8 @@ import { outputText, outputJson, shouldOutputJson } from '../output.js'
 import {
   type ConfigFile,
   buildMcpServerEntry,
+  readPlurMcpEntry,
+  type McpServerEntry,
   cursorProjectMcpConfigPath,
   hasDatacoreMcp,
   hasPlurMcp,
@@ -249,16 +251,50 @@ function inspectConfigs(): ConfigFileReport[] {
  * Times out after 20 seconds — first-run npx fetches the @plur-ai/mcp package
  * (and its native deps), which can take 10-15s. Subsequent runs respond in ~1s.
  */
+/**
+ * The MCP entry doctor should actually launch.
+ *
+ * Prefers whatever a config file declares, in `knownConfigFiles()` order, so
+ * the probe exercises the server the user runs. Falls back to the synthesised
+ * recommendation only when nothing declares one — an install that has not been
+ * wired yet, where "would the recommended entry work" is the useful question.
+ *
+ * This distinction is the whole point of #764. Probing the synthesised entry on
+ * a configured install fails BOTH ways: a working local build reported a 20s
+ * timeout because the cold `npx` fallback takes longer than that, and — worse —
+ * a configured server that crashes on startup reports healthy, because npx
+ * fetched a good copy of a package the user is not running. The crash that
+ * motivated this (a stale dist importing a dependency removed in the SDK v2
+ * migration) is invisible to the old probe by construction.
+ */
+function resolveProbeTarget(): { entry: McpServerEntry; source: string } {
+  for (const cf of knownConfigFiles()) {
+    if (!cf.exists || cf.kind === 'cursor-hooks') continue
+    const declared = readPlurMcpEntry(readConfig(cf.path))
+    if (declared) return { entry: declared, source: cf.label }
+  }
+  return { entry: buildMcpServerEntry(), source: 'recommended default (no config declares a plur server)' }
+}
+
 async function mcpHandshake(
   timeoutMs = 20000,
   envOverride?: Record<string, string>,
-): Promise<{ ok: boolean; serverName?: string; serverVersion?: string; toolCount?: number; error?: string }> {
-  const entry = buildMcpServerEntry()
-  const spawnEnv = envOverride ? { ...process.env, ...envOverride } : undefined
+): Promise<{ ok: boolean; serverName?: string; serverVersion?: string; toolCount?: number; error?: string; probed?: string; command?: string }> {
+  const { entry, source } = resolveProbeTarget()
+  // The entry's own env matters: a config pinning PLUR_TOOL_PROFILE=full gets a
+  // different tool surface, and probing without it would report a count the
+  // user never sees. envOverride still wins — it is how the cursor-profile
+  // probe asks a deliberate what-if.
+  const spawnEnv = (entry.env || envOverride)
+    ? { ...process.env, ...(entry.env ?? {}), ...(envOverride ?? {}) }
+    : undefined
 
   return new Promise((resolve) => {
     let resolved = false
     const finish = (result: { ok: boolean; serverName?: string; serverVersion?: string; toolCount?: number; error?: string }) => {
+      // Always say WHAT was probed — a handshake verdict with no subject is how
+      // a green result on the wrong server gets trusted.
+      result = { ...result, probed: source, command: [entry.command, ...entry.args].join(' ') } as typeof result
       if (resolved) return
       resolved = true
       try { proc.kill() } catch { /* ignore */ }

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -194,6 +194,33 @@ export function hasPlurMcp(config: Record<string, unknown>): boolean {
 }
 
 /**
+ * The `plur` MCP entry a config file actually declares, if any.
+ *
+ * `hasPlurMcp` answers whether one exists; this returns the thing itself, so a
+ * caller can launch what the user launches instead of a reconstruction of it
+ * (#764). `buildMcpServerEntry` synthesises a *recommended* entry — the shim,
+ * else npx — which is right for `plur init` writing a config and wrong for
+ * doctor verifying one: an install that runs the server some other way gets
+ * diagnosed on a path it never uses.
+ *
+ * Returns null when the entry exists but has no `command`, since there is
+ * nothing runnable to probe and guessing would defeat the purpose.
+ */
+export function readPlurMcpEntry(config: Record<string, unknown>): McpServerEntry | null {
+  const servers = (config.mcpServers ?? {}) as Record<string, unknown>
+  const entry = servers.plur as { command?: unknown; args?: unknown; env?: unknown } | undefined
+  if (!entry || typeof entry.command !== 'string' || entry.command.length === 0) return null
+  const args = Array.isArray(entry.args) ? entry.args.filter((a): a is string => typeof a === 'string') : []
+  const env = entry.env && typeof entry.env === 'object'
+    ? Object.fromEntries(
+        Object.entries(entry.env as Record<string, unknown>)
+          .filter(([, v]) => typeof v === 'string') as [string, string][],
+      )
+    : undefined
+  return { command: entry.command, args, ...(env && Object.keys(env).length > 0 ? { env } : {}) }
+}
+
+/**
  * Detect a `datacore` MCP server entry — used by doctor to surface the
  * "plur ≠ datacore" collision warning that has confused users in the wild.
  */

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -176,9 +176,58 @@ describe('plur doctor', () => {
   // a fake MCP shim that starts but never completes the JSON-RPC initialize — the
   // handshake must fail and drive overall to 'fail'. Green today: overall gates on
   // handshake.ok when not skipped (doctor.ts:569-570).
+  it('probes the CONFIGURED server, not the shim it would have recommended (#764)', () => {
+    // Discriminating on purpose. The previous test points the config at the
+    // same shim `buildMcpServerEntry()` prefers, so both the old synthesised
+    // probe and the new config-first one spawn the identical script and no
+    // assertion can tell them apart — it passes either way and guards nothing.
+    //
+    // Here the two disagree: the shim is one script, the config names another.
+    // Only a probe that reads the config launches `configured`.
+    const binDir = join(home, '.plur', 'bin')
+    mkdirSync(binDir, { recursive: true })
+    const shim = join(binDir, 'plur-mcp')
+    writeFileSync(shim, '#!/bin/sh\nsleep 0.5\nexit 0\n', { mode: 0o755 })
+    chmodSync(shim, 0o755)
+
+    const configured = join(home, 'configured-server.sh')
+    writeFileSync(configured, '#!/bin/sh\nsleep 0.5\nexit 0\n', { mode: 0o755 })
+    chmodSync(configured, 0o755)
+
+    writeGlobalSettings({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-inject' }] },
+        ],
+      },
+      mcpServers: { plur: { command: configured, args: [] } },
+    })
+
+    let stdout = ''
+    try {
+      stdout = execSync(`node ${CLI} doctor --json`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+        env: { ...process.env, HOME: home, USERPROFILE: home, PLUR_DISABLE_EMBEDDINGS: '1' },
+        cwd: home,
+      })
+    } catch (err: any) {
+      stdout = err.stdout?.toString() ?? ''
+    }
+    const report = JSON.parse(stdout)
+
+    // The whole point: what got launched.
+    expect(report.handshake.command, 'must launch the configured server').toContain(configured)
+    expect(report.handshake.command, 'must NOT fall back to the recommended shim').not.toContain(shim)
+    expect(report.handshake.probed, 'the report must name the source').toBeTruthy()
+  }, 40000)
+
   it('fails overall when the live handshake is enabled and the server never completes initialize', () => {
-    // buildMcpServerEntry() prefers the local shim at ~/.plur/bin/plur-mcp, so
-    // installing a fake one here makes doctor's handshake spawn OUR script.
+    // doctor probes the entry the CONFIG declares (#764), so pointing
+    // mcpServers.plur at this fake script is what makes the handshake spawn it.
+    // Before #764 the probe was synthesised — it preferred the ~/.plur/bin
+    // shim, then npx — which meant this test passed for the wrong reason: it
+    // was exercising a launch path the config did not name.
     const binDir = join(home, '.plur', 'bin')
     mkdirSync(binDir, { recursive: true })
     const shim = join(binDir, 'plur-mcp')
@@ -194,7 +243,7 @@ describe('plur doctor', () => {
         ],
       },
       mcpServers: {
-        plur: { command: '/bin/sh', args: ['-lc', 'exec npx -y @plur-ai/mcp@latest'] },
+        plur: { command: shim, args: [] },
       },
     })
 
@@ -219,6 +268,11 @@ describe('plur doctor', () => {
     expect(report.handshake.ok).toBe(false)
     expect(report.handshake.error).toBeTruthy()
     expect(report.handshake.error).not.toContain('skipped') // it actually ran
+    // #764: the report must name what it launched, and it must be the
+    // configured command — not a synthesised npx fallback that would have
+    // reported healthy while the configured server was dead.
+    expect(report.handshake.command).toContain(shim)
+    expect(report.handshake.probed).toBeTruthy()
     expect(report.overall).toBe('fail')
     expect(status).toBe(1)
   }, 40000)

--- a/packages/cli/test/mcp-entry-read.test.ts
+++ b/packages/cli/test/mcp-entry-read.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Reading the `plur` MCP entry a config actually declares (#764).
+ *
+ * `buildMcpServerEntry` synthesises the *recommended* entry — the shim, else
+ * npx. That is right for `plur init` writing a config and wrong for `plur
+ * doctor` verifying one: an install that launches the server another way then
+ * gets diagnosed on a path it never uses.
+ *
+ * It fails in both directions, and the second is the dangerous one:
+ *
+ *   - false fail — a working local build reported "timeout after 20000ms",
+ *     because the cold npx fallback measured 25.2s against a 20s budget;
+ *   - false pass — a configured server that crashes on startup reports
+ *     healthy, because npx fetched a good copy of a package the user is not
+ *     running. The crash that motivated this (a stale dist importing a
+ *     dependency removed in the SDK v2 migration) is invisible by construction.
+ */
+import { describe, it, expect } from 'vitest'
+import { readPlurMcpEntry, hasPlurMcp } from '../src/mcp-config.js'
+
+describe('readPlurMcpEntry', () => {
+  it('returns the entry as written, not a reconstruction', () => {
+    // The shape that actually broke: a direct node invocation of a local build,
+    // with an env pin. None of this is recoverable from buildMcpServerEntry().
+    const config = {
+      mcpServers: {
+        plur: {
+          command: 'node',
+          args: ['/Users/x/plur/packages/mcp/dist/index.js'],
+          env: { PLUR_TOOL_PROFILE: 'full' },
+        },
+      },
+    }
+    expect(readPlurMcpEntry(config)).toEqual({
+      command: 'node',
+      args: ['/Users/x/plur/packages/mcp/dist/index.js'],
+      env: { PLUR_TOOL_PROFILE: 'full' },
+    })
+  })
+
+  it('carries env through, because it changes the tool surface', () => {
+    // Probing without the config's env reports a tool count the user never
+    // sees — PLUR_TOOL_PROFILE=full is 40 tools, lean is 12.
+    const withEnv = readPlurMcpEntry({
+      mcpServers: { plur: { command: 'x', env: { PLUR_TOOL_PROFILE: 'full' } } },
+    })
+    expect(withEnv?.env).toEqual({ PLUR_TOOL_PROFILE: 'full' })
+  })
+
+  it('omits env entirely when there is none to carry', () => {
+    const entry = readPlurMcpEntry({ mcpServers: { plur: { command: 'x' } } })
+    expect(entry).toEqual({ command: 'x', args: [] })
+    expect(entry && 'env' in entry).toBe(false)
+  })
+
+  it('defaults args to an empty array rather than undefined', () => {
+    // spawn(cmd, undefined) and spawn(cmd, []) differ; callers should not have
+    // to guard.
+    expect(readPlurMcpEntry({ mcpServers: { plur: { command: 'plur-mcp' } } })?.args).toEqual([])
+  })
+
+  it('returns null when there is nothing runnable to probe', () => {
+    // A malformed entry must not become a fabricated command. Falling back to
+    // the recommended default is honest; inventing one is not.
+    expect(readPlurMcpEntry({})).toBeNull()
+    expect(readPlurMcpEntry({ mcpServers: {} })).toBeNull()
+    expect(readPlurMcpEntry({ mcpServers: { plur: {} } })).toBeNull()
+    expect(readPlurMcpEntry({ mcpServers: { plur: { args: ['x'] } } })).toBeNull()
+    expect(readPlurMcpEntry({ mcpServers: { plur: { command: '' } } })).toBeNull()
+    expect(readPlurMcpEntry({ mcpServers: { plur: { command: 42 } } })).toBeNull()
+  })
+
+  it('drops non-string args and env values instead of passing them to spawn', () => {
+    const entry = readPlurMcpEntry({
+      mcpServers: { plur: { command: 'node', args: ['ok', 7, null], env: { GOOD: 'x', BAD: 3 } } },
+    })
+    expect(entry?.args).toEqual(['ok'])
+    expect(entry?.env).toEqual({ GOOD: 'x' })
+  })
+
+  it('agrees with hasPlurMcp on whether an entry exists', () => {
+    // hasPlurMcp is what doctor already uses to report `hasPlurMcp: true`. If
+    // it says yes and this says null, doctor claims a server is configured and
+    // then probes something else — the exact split this fix removes.
+    const declared = { mcpServers: { plur: { command: 'node', args: ['x'] } } }
+    expect(hasPlurMcp(declared)).toBe(true)
+    expect(readPlurMcpEntry(declared)).not.toBeNull()
+
+    const absent = { mcpServers: { other: { command: 'node' } } }
+    expect(hasPlurMcp(absent)).toBe(false)
+    expect(readPlurMcpEntry(absent)).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #764.

## The bug

doctor's handshake never launched the server the user runs. It rebuilt an entry from scratch:

```
~/.plur/bin/plur-mcp          (if `plur init` made the shim)
  ↓ else
/bin/sh -lc 'exec npx -y @plur-ai/mcp@latest'
```

So any install starting the server another way — a direct `node /path/dist/index.js`, a pinned version, a custom `env` — got diagnosed on a path it never uses.

**False fail.** On a machine whose `.mcp.json` runs a local build, doctor reported `timeout after 20000ms` / `overall: fail` while the configured server handshakes in ~2s with 40 tools. The cold npx fallback measured **25.2s** against a **20s** budget.

**False pass — the one that matters.** A configured server that crashes on startup reports *healthy*, because npx fetched a good copy of a package the user isn't running. That is exactly the break this came from: a stale `dist/` importing a dependency removed in the SDK v2 migration, dying with `ERR_MODULE_NOT_FOUND` before the handshake. doctor could not have seen it.

A diagnostic that can't observe the thing it diagnoses is worse than none, because it gets trusted.

## The fix

doctor reads the `plur` entry from the first config declaring one (in `knownConfigFiles()` order) and launches **that**, carrying the entry's own `env` — a config pinning `PLUR_TOOL_PROFILE=full` yields 40 tools, and probing without it reports a count the user never sees. The synthesised entry stays as the fallback for an unwired install, where *"would the recommended entry work"* is the useful question.

Every result now carries `probed` and `command`. A verdict with no subject is how a green result on the wrong server gets believed.

`readPlurMcpEntry()` returns `null` for a malformed entry rather than inventing a command — falling back to the recommendation is honest, guessing is not.

## Verified end-to-end

Against a **broken** configured server (reproducing the real crash):
```
overall : fail
probed  : Claude Code (.mcp.json)
command : node /tmp/doctor-764/broken-server.js
error   : server exited (code=1) before responding
```

Against the **working** one:
```
probed        : Claude Code (.mcp.json)
ok            : True
serverVersion : 0.16.1
toolCount     : 40      ← proves the config's env was honoured
```

## On the tests — worth reading

The existing handshake test pointed its config at the **same shim** the old code preferred, so both the old and new probe spawned the identical script. It passed either way and guarded nothing. My first attempt at a mutation test confirmed it: reverting the fix changed nothing.

My *second* attempt also passed — because the test spawns the **built** CLI and I had only mutated `src`. Stale build, which is the same trap this PR is about.

With a rebuild and a genuinely discriminating test — shim is one script, config names another — the mutation fails on exactly the assertion that should catch it, and passes when restored.

402 cli tests, `typecheck` + `typecheck:tests` clean.

## Not changed

The 20s timeout. With the configured entry it's ample (~2s); it only bit on the cold-npx fallback, which is now the uncommon path. Raising it would slow the honest failure case for everyone. Happy to revisit if the fallback proves slow in practice.