### PR TITLE
fix(core,mcp): filesystem store materializes on registration; outbox skips retired engrams (#766)

### DIFF
--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -27,7 +27,11 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const engram = await plur.getById(target)
     if (!engram) exit(1, `Engram not found: ${target}`)
     if (engram.status === 'retired') exit(1, `Already retired: ${target}`)
-    await plur.forget(target, reason)
+    // force (#766): `plur forget` is an explicit user-facing forget — same
+    // surface as MCP plur_forget. Without force, a multiply-learned engram
+    // (reference_count > 1) only decrements and stays active, and a later
+    // learn() at a different scope re-matches it and inherits the old scope.
+    await plur.forget(target, reason, { force: true })
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: target, statement: engram.statement } })
     } else {
@@ -49,7 +53,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
   if (matches.length === 1) {
-    await plur.forget(matches[0].id, reason)
+    // force (#766): explicit user-facing forget — full retirement, not a
+    // ref-count decrement (see the direct-ID branch above).
+    await plur.forget(matches[0].id, reason, { force: true })
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: matches[0].id, statement: matches[0].statement } })
     } else {

--- a/packages/cli/test/forget.test.ts
+++ b/packages/cli/test/forget.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
@@ -45,6 +45,25 @@ describe('plur forget', () => {
     const output = JSON.parse(run('forget "unique penguin"'))
     expect(output.success).toBe(true)
     expect(output.retired.statement).toContain('penguin')
+  })
+
+  it('fully retires a multiply-learned engram — CLI is an explicit user-facing forget (#766 force semantics)', async () => {
+    // Learn the same statement twice: hash-dedup returns the existing engram
+    // with reference_count incremented — the #766 resurrection precondition.
+    const id = await learn('convention learned twice for dedup')
+    const id2 = await learn('convention learned twice for dedup')
+    expect(id2).toBe(id)
+
+    const output = JSON.parse(run(`forget ${id}`))
+    expect(output.success).toBe(true)
+
+    // Without { force: true } a reference_count > 1 engram only DECREMENTS and
+    // stays active — a later learn() at a different scope re-matches it and
+    // inherits the old scope. The CLI must fully retire, same as MCP plur_forget.
+    const raw = readFileSync(join(dir, 'engrams.yaml'), 'utf-8')
+    expect(raw).toMatch(/status: "?retired"?/)
+    // And a second forget refuses — the engram is genuinely retired.
+    expect(() => run(`forget ${id}`)).toThrow()
   })
 
   it('exits 1 with no argument', () => {

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -95,6 +95,13 @@ export function saveEngrams(filePath: string, engrams: Engram[]): void {
   atomicWrite(filePath, content)
 }
 
+/** Initialize an empty filesystem store file (creates parent dirs via atomicWrite).
+ * Use this from index.ts instead of calling saveEngrams directly — keeps
+ * the source-of-truth abstraction intact (#766). */
+export function initFilesystemStore(filePath: string): void {
+  saveEngrams(filePath, [])
+}
+
 export interface LoadedPack {
   manifest: PackManifest
   engrams: Engram[]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4659,10 +4659,15 @@ export class Plur {
     return getSyncStatus(this.paths.root)
   }
 
-  /** Count engrams pending remote sync (outbox entries). */
+  /** Count engrams pending remote sync (outbox entries). Must mirror
+   *  flushOutbox()'s filter exactly: a retired engram still carrying `_outbox`
+   *  (direct YAML edit, older client) is skipped by the flush forever, so
+   *  counting it would report a permanent phantom "pending" (#766). */
   async outboxCount(): Promise<number> {
     const engrams = await this._loadCached(this.paths.engrams)
-    return engrams.filter(e => (e as any).structured_data?._outbox).length
+    return engrams.filter(e =>
+      (e as any).structured_data?._outbox && e.status !== 'retired'
+    ).length
   }
 
   /**
@@ -5749,6 +5754,13 @@ Generate an improved version of the procedure that prevents this failure. Return
         logger.info(`[plur:addStore] rotated token for ${options.url} (scope "${sameEntry.scope}")`)
         return { status: 'token_rotated', scope: sameEntry.scope }
       }
+      // #766 heal: a local store registered BEFORE the materialization fix can
+      // sit in exactly the broken state this fix closes — config entry exists,
+      // file absent — and re-running stores_add with the same path is the
+      // natural post-upgrade repair. Run the same init block on the idempotent
+      // re-add so it actually heals (and the MCP "Store initialized" note is
+      // truthful on this path too). Idempotent and cheap when the file exists.
+      if (!isRemote) this._materializeLocalStore(storePath)
       return { status: 'already_registered', scope: sameEntry.scope }
     }
 
@@ -5783,24 +5795,40 @@ Generate an improved version of the procedure that prevents this failure. Return
           readonly: options?.readonly ?? false,
         }
     // Filesystem stores: initialize the file now so the path materializes
-    // immediately. atomicWrite (inside initFilesystemStore) creates parent dirs.
-    // Fail loudly if the path is unwritable — better than silently landing
-    // writes in the primary store when the file never exists (#766).
-    if (!isRemote && !fs.existsSync(storePath)) {
-      try {
-        initFilesystemStore(storePath)
-      } catch (err) {
-        throw new Error(
-          `addStore: cannot initialize store at "${storePath}": ${(err as Error).message}`,
-        )
-      }
-    }
+    // immediately. Fail loudly if the path is unwritable — better than
+    // silently landing writes in the primary store when the file never
+    // exists (#766).
+    if (!isRemote) this._materializeLocalStore(storePath)
 
     const stores = scopeConflict
       ? [...(config.stores ?? []).filter(s => s.scope !== scope), newEntry]
       : [...(config.stores ?? []), newEntry]
     this.persistStores(stores)
     return { status: scopeConflict ? 'overwritten' : 'added', scope }
+  }
+
+  /**
+   * Materialize a filesystem store file if absent — the existsSync→write
+   * sequence runs under the store's own `<path>.lock` file so it cannot race
+   * a concurrent writer or a second registration and clobber their content
+   * (store-write convention; see `_withStoreLock`). `addStore` is sync and
+   * reachable from the constructor via `autoDiscoverStores`, so this takes
+   * the SAME lock file via the sync `withLock` rather than the async
+   * `_withStoreLock`. Parent dirs are created up front — the lock file lives
+   * next to the store file (this used to be atomicWrite's job).
+   */
+  private _materializeLocalStore(storePath: string): void {
+    try {
+      const dir = dirname(storePath)
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+      withLock(storePath, () => {
+        if (!fs.existsSync(storePath)) initFilesystemStore(storePath)
+      })
+    } catch (err) {
+      throw new Error(
+        `addStore: cannot initialize store at "${storePath}": ${(err as Error).message}`,
+      )
+    }
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ import { detectPlurStorage, type PlurPaths } from './storage.js'
 import { IndexedStorage } from './storage-indexed.js'
 import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
-import { generateEngramId, loadAllPacks, storePrefix, saveEngrams } from './engrams.js'
+import { generateEngramId, loadAllPacks, storePrefix, initFilesystemStore } from './engrams.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats } from './fts.js'
 import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer } from './inject.js'
@@ -5783,12 +5783,12 @@ Generate an improved version of the procedure that prevents this failure. Return
           readonly: options?.readonly ?? false,
         }
     // Filesystem stores: initialize the file now so the path materializes
-    // immediately. atomicWrite (used inside saveEngrams) creates parent dirs.
+    // immediately. atomicWrite (inside initFilesystemStore) creates parent dirs.
     // Fail loudly if the path is unwritable — better than silently landing
     // writes in the primary store when the file never exists (#766).
     if (!isRemote && !fs.existsSync(storePath)) {
       try {
-        saveEngrams(storePath, [])
+        initFilesystemStore(storePath)
       } catch (err) {
         throw new Error(
           `addStore: cannot initialize store at "${storePath}": ${(err as Error).message}`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ import { detectPlurStorage, type PlurPaths } from './storage.js'
 import { IndexedStorage } from './storage-indexed.js'
 import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
-import { generateEngramId, loadAllPacks, storePrefix } from './engrams.js'
+import { generateEngramId, loadAllPacks, storePrefix, saveEngrams } from './engrams.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats } from './fts.js'
 import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer } from './inject.js'
@@ -4152,13 +4152,21 @@ export class Plur {
     return all.filter(e => (e as any).pinned === true && e.status === 'active')
   }
 
-  /** Set engram status to 'retired'. Supports primary and store engrams. */
-  async forget(id: string, reason?: string): Promise<void> {
+  /** Set engram status to 'retired'. Supports primary and store engrams.
+   *
+   * options.force=true bypasses reference_count and retires immediately,
+   * regardless of how many sources reference the engram (#766). Use for
+   * explicit user-facing forget (MCP plur_forget), where one call = full
+   * retirement. The default decrement-until-zero behavior is for internal
+   * dedup tracking (two agents learned the same fact; one forgets — the
+   * other's reference should remain). */
+  async forget(id: string, reason?: string, options?: { force?: boolean }): Promise<void> {
     // Check primary first.
     // Reference-counted retirement (#107): decrement reference_count; only
     // physically retire when it reaches 0. forget() called N times on an
     // engram with reference_count=N retires it; called fewer times, the
     // engram stays active with a lower count.
+    // options.force=true overrides this: retires immediately (#766).
     const foundInPrimary = await this._withStoreLock(this.paths.engrams, async () => {
       const engrams = await this._primaryStore.load()
       const engram = engrams.find(e => e.id === id)
@@ -4172,13 +4180,21 @@ export class Plur {
       // don't get prematurely retired.
       const currentCount = (engram as any).reference_count
         ?? Math.max(1, ((engram as any).sources?.length ?? 1))
-      const newCount = Math.max(0, currentCount - 1)
+      const newCount = options?.force ? 0 : Math.max(0, currentCount - 1)
       ;(engram as any).reference_count = newCount
 
       if (newCount === 0) {
         engram.status = 'retired'
         if (reason && !engram.rationale) {
           engram.rationale = `Retired: ${reason}`
+        }
+        // Cancel any pending outbox push — a retired engram must not be
+        // resurrected on the remote by a queued flush (#766). Strip _outbox
+        // now so flushOutbox() never attempts to push this engram.
+        if ((engram as any).structured_data?._outbox) {
+          const sd = { ...((engram as any).structured_data as Record<string, unknown>) }
+          delete sd._outbox
+          ;(engram as any).structured_data = Object.keys(sd).length > 0 ? sd : undefined
         }
       }
 
@@ -4231,7 +4247,7 @@ export class Plur {
         // Same legacy-engram migration as primary path (audit iter-2, Data).
         const currentCount = (engram as any).reference_count
           ?? Math.max(1, ((engram as any).sources?.length ?? 1))
-        const newCount = Math.max(0, currentCount - 1)
+        const newCount = options?.force ? 0 : Math.max(0, currentCount - 1)
         ;(engram as any).reference_count = newCount
 
         if (newCount === 0) {
@@ -4659,7 +4675,13 @@ export class Plur {
    */
   async flushOutbox(): Promise<{ flushed: number; failed: number; expired_warnings: string[] }> {
     const engrams = await this._primaryStore.load()
-    const pending = engrams.filter(e => (e as any).structured_data?._outbox)
+    // #766: skip retired engrams — a retired engram must not be pushed to the
+    // remote and resurrected. The cancel-outbox path in forget() strips _outbox
+    // on retirement; this guard is belt-and-suspenders for any path that retires
+    // without explicitly cancelling (e.g. direct YAML edits, older client versions).
+    const pending = engrams.filter(e =>
+      (e as any).structured_data?._outbox && e.status !== 'retired'
+    )
     if (pending.length === 0) return { flushed: 0, failed: 0, expired_warnings: [] }
 
     let flushed = 0
@@ -5760,6 +5782,20 @@ Generate an improved version of the procedure that prevents this failure. Return
           shared:   options?.shared   ?? false,
           readonly: options?.readonly ?? false,
         }
+    // Filesystem stores: initialize the file now so the path materializes
+    // immediately. atomicWrite (used inside saveEngrams) creates parent dirs.
+    // Fail loudly if the path is unwritable — better than silently landing
+    // writes in the primary store when the file never exists (#766).
+    if (!isRemote && !fs.existsSync(storePath)) {
+      try {
+        saveEngrams(storePath, [])
+      } catch (err) {
+        throw new Error(
+          `addStore: cannot initialize store at "${storePath}": ${(err as Error).message}`,
+        )
+      }
+    }
+
     const stores = scopeConflict
       ? [...(config.stores ?? []).filter(s => s.scope !== scope), newEntry]
       : [...(config.stores ?? []), newEntry]

--- a/packages/core/test/cross-scope-recurrence.test.ts
+++ b/packages/core/test/cross-scope-recurrence.test.ts
@@ -260,6 +260,34 @@ describe('cross-scope recurrence (#176)', () => {
       expect(fresh.recurrence_count).toBe(0)
     })
 
+    it('force forget (#766): cross-scope recurrence bumps reference_count to 2; force=true retires in one call', async () => {
+      // Learn at global — simulates a prior session's engram
+      const eng = await plur.learn('comms rule', { scope: 'global' })
+      expect((eng as any).reference_count).toBe(1)
+
+      // Cross-scope relearn → reference_count=2, same engram returned
+      const relearned = await plur.learn('comms rule', { scope: 'group:team/comms' })
+      expect(relearned.id).toBe(eng.id)  // cross-scope recurrence matched, same ID
+      expect((relearned as any).reference_count).toBe(2)
+
+      // Without force: one forget only decrements → still active
+      await plur.forget(eng.id)
+      const afterDecrement = await plur.getById(eng.id)
+      expect(afterDecrement?.status).toBe('active')
+      expect((afterDecrement as any).reference_count).toBe(1)
+
+      // With force: one call retires completely (#766 fix)
+      await plur.forget(eng.id, undefined, { force: true })
+      const afterForce = await plur.getById(eng.id)
+      expect(afterForce?.status).toBe('retired')
+
+      // Re-learn at a different scope creates fresh engram — resurrection is prevented
+      const fresh = await plur.learn('comms rule', { scope: 'group:team/infra' })
+      expect(fresh.id).not.toBe(eng.id)
+      expect(fresh.scope).toBe('group:team/infra')
+      expect((fresh as any).recurrence_count).toBe(0)
+    })
+
     it('normalization-equivalent statements (punct/case) match across scopes', async () => {
       await plur.learn('Always Use Semicolons!', { scope: 'project:a' })
       const second = await plur.learn('always use   semicolons', { scope: 'project:b' })

--- a/packages/core/test/multi-store.test.ts
+++ b/packages/core/test/multi-store.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
 import { Plur } from '../src/index.js'
-import { storePrefix } from '../src/engrams.js'
+import { storePrefix, loadEngrams } from '../src/engrams.js'
 
 /** Minimal valid engram for store YAML files */
 function makeEngram(overrides: Record<string, unknown> = {}) {
@@ -292,6 +292,19 @@ describe('Multi-store', () => {
     expect(storePrefix('ab')).toBe('ABA')
     // Edge: single char scope
     expect(storePrefix('x')).toBe('XXX')
+  })
+
+  it('addStore creates the filesystem file when path does not exist (#766)', async () => {
+    // Do NOT pre-create the file — addStore should initialize it
+    const newStorePath = join(storeDir, 'subdir', 'new-store.yaml')
+    const plur = createPlur()
+    const result = plur.addStore(newStorePath, 'group:new-scope', { shared: true })
+    expect(result.status).toBe('added')
+    // File must exist now (addStore initializes it)
+    expect(existsSync(newStorePath)).toBe(true)
+    // And it loads as empty
+    const content = loadEngrams(newStorePath)
+    expect(content).toEqual([])
   })
 
   it('cache invalidates after feedback, next recall reflects change', async () => {

--- a/packages/core/test/multi-store.test.ts
+++ b/packages/core/test/multi-store.test.ts
@@ -307,6 +307,38 @@ describe('Multi-store', () => {
     expect(content).toEqual([])
   })
 
+  it('addStore heals a pre-fix registration: already_registered re-add materializes the missing file (#766)', async () => {
+    // A store registered BEFORE the materialization fix is in exactly the
+    // broken state: config entry exists, file absent. Re-running stores_add
+    // with the same path (the natural post-upgrade repair) must run the init
+    // block on the sameEntry path too — not return early with the file still
+    // missing.
+    const brokenPath = join(storeDir, 'pre-fix-store.yaml')
+    writeConfig([{ path: brokenPath, scope: 'group:pre-fix', shared: true }])
+    expect(existsSync(brokenPath)).toBe(false)
+
+    const plur = createPlur()
+    const result = plur.addStore(brokenPath, 'group:pre-fix', { shared: true })
+    expect(result.status).toBe('already_registered')
+    expect(result.scope).toBe('group:pre-fix')
+    // The heal: the file now exists and loads as empty
+    expect(existsSync(brokenPath)).toBe(true)
+    expect(loadEngrams(brokenPath)).toEqual([])
+  })
+
+  it('addStore already_registered re-add does NOT clobber an existing file (#766 heal is init-if-absent only)', async () => {
+    writeStoreEngrams([makeEngram({ statement: 'Pre-existing store content survives re-add' })])
+    writeConfig([{ path: storePath, scope: 'datafund' }])
+
+    const plur = createPlur()
+    const result = plur.addStore(storePath, 'datafund')
+    expect(result.status).toBe('already_registered')
+    // Content untouched
+    const content = loadEngrams(storePath)
+    expect(content).toHaveLength(1)
+    expect((content[0] as any).statement).toBe('Pre-existing store content survives re-add')
+  })
+
   it('cache invalidates after feedback, next recall reflects change', async () => {
     writeStoreEngrams([makeEngram({
       statement: 'Cache test engram with low strength',

--- a/packages/core/test/outbox.test.ts
+++ b/packages/core/test/outbox.test.ts
@@ -488,4 +488,34 @@ describe('outbox pattern (issue #26)', () => {
     )
     expect(postCalls.length).toBe(0)
   })
+
+  it('outboxCount() excludes retired engrams still carrying _outbox — no permanent phantom pending (#766)', async () => {
+    // A retired engram with a stale _outbox marker (direct YAML edit, older
+    // client — retirement without the cancel path) is skipped by flushOutbox
+    // forever. outboxCount must mirror the flush filter, or the count reports
+    // "pending" entries no flush will ever clear.
+    mockRemoteFailure('connection refused')
+    writeStoresConfig(primaryDir, storeConfig())
+    const plur = new Plur({ path: primaryDir })
+
+    await plur.learnRouted('phantom pending one', { scope: REMOTE_SCOPE, type: 'behavioral' })
+    await plur.learnRouted('phantom pending two', { scope: REMOTE_SCOPE, type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 50))
+
+    const engramsPath = join(primaryDir, 'engrams.yaml')
+    const queued = await readLocalEngrams(primaryDir)
+    expect(queued.filter((e: any) => e.structured_data?._outbox)).toHaveLength(2)
+
+    // Retire one WITHOUT the cancel path: flip status in the YAML directly,
+    // leaving the stale _outbox marker in place.
+    const doc = yaml.load(readFileSync(engramsPath, 'utf-8')) as { engrams: any[] }
+    const victim = doc.engrams.find((e: any) => e.statement === 'phantom pending one')
+    victim.status = 'retired'
+    writeFileSync(engramsPath, yaml.dump(doc, { lineWidth: 120, noRefs: true }))
+
+    // Fresh instance (no stale cache): only the active engram counts — the
+    // retired one is invisible to flush and must be invisible to the count.
+    const plur2 = new Plur({ path: primaryDir })
+    expect(await plur2.outboxCount()).toBe(1)
+  })
 })

--- a/packages/core/test/outbox.test.ts
+++ b/packages/core/test/outbox.test.ts
@@ -409,4 +409,83 @@ describe('outbox pattern (issue #26)', () => {
     expect(result.failed).toBe(1)
     expect(result.expired_warnings.some(w => w.includes('no matching remote store'))).toBe(true)
   })
+
+  it('flushOutbox() skips retired engrams — no remote push, no resurrection (#766)', async () => {
+    // 1. Create an engram in the outbox (remote push fails)
+    mockRemoteFailure('connection refused')
+    writeStoresConfig(primaryDir, storeConfig())
+    const plur = new Plur({ path: primaryDir })
+
+    await plur.learnRouted('pinned team rule', {
+      scope: REMOTE_SCOPE,
+      type: 'behavioral',
+    })
+    await new Promise(r => setTimeout(r, 50))
+
+    const localBefore = await readLocalEngrams(primaryDir)
+    const queued = localBefore.find((e: any) => e.statement === 'pinned team rule')
+    expect(queued).toBeDefined()
+    expect(queued.structured_data._outbox).toBeDefined()
+
+    // 2. Retire the engram locally — simulates user calling plur_forget before flush
+    await plur.forget(queued.id, undefined, { force: true })
+
+    const localAfterForget = await readLocalEngrams(primaryDir)
+    const retired = localAfterForget.find((e: any) => e.id === queued.id)
+    expect(retired?.status).toBe('retired')
+    // _outbox metadata is stripped on retirement (#766 cancel-outbox)
+    expect(retired?.structured_data?._outbox).toBeUndefined()
+
+    // 3. flushOutbox must NOT push the retired engram
+    fetchMock.mockClear()
+    mockRemoteSuccess()
+    const result = await plur.flushOutbox()
+
+    expect(result.flushed).toBe(0)
+    expect(result.failed).toBe(0)
+    // fetch was NOT called with POST (no push attempt)
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, init]: [string, RequestInit]) => (init?.method ?? 'GET') === 'POST'
+    )
+    expect(postCalls.length).toBe(0)
+  })
+
+  it('flushOutbox() skips retired engrams even when _outbox is present (YAML edited without cancel, #766)', async () => {
+    // Simulate a retired engram that still has _outbox (e.g. older client, direct YAML edit)
+    const engramsPath = join(primaryDir, 'engrams.yaml')
+    writeFileSync(
+      engramsPath,
+      yaml.dump({
+        engrams: [{
+          id: 'ENG-LEGACY-RETIRED',
+          statement: 'legacy stale outbox engram',
+          scope: REMOTE_SCOPE,
+          status: 'retired',
+          structured_data: {
+            _outbox: {
+              target_url: REMOTE_URL,
+              target_scope: REMOTE_SCOPE,
+              queued_at: new Date().toISOString(),
+              last_attempt: new Date().toISOString(),
+              attempt_count: 0,
+              last_error: '',
+            },
+          },
+        }],
+      }, { lineWidth: 120, noRefs: true })
+    )
+    writeStoresConfig(primaryDir, storeConfig())
+    const plur = new Plur({ path: primaryDir })
+
+    fetchMock.mockClear()
+    mockRemoteSuccess()
+    const result = await plur.flushOutbox()
+
+    expect(result.flushed).toBe(0)
+    expect(result.failed).toBe(0)
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, init]: [string, RequestInit]) => (init?.method ?? 'GET') === 'POST'
+    )
+    expect(postCalls.length).toBe(0)
+  })
 })

--- a/packages/core/test/outbox.test.ts
+++ b/packages/core/test/outbox.test.ts
@@ -444,8 +444,8 @@ describe('outbox pattern (issue #26)', () => {
     expect(result.flushed).toBe(0)
     expect(result.failed).toBe(0)
     // fetch was NOT called with POST (no push attempt)
-    const postCalls = fetchMock.mock.calls.filter(
-      ([, init]: [string, RequestInit]) => (init?.method ?? 'GET') === 'POST'
+    const postCalls = (fetchMock.mock.calls as [string, RequestInit][]).filter(
+      ([, init]) => (init?.method ?? 'GET') === 'POST'
     )
     expect(postCalls.length).toBe(0)
   })
@@ -483,8 +483,8 @@ describe('outbox pattern (issue #26)', () => {
 
     expect(result.flushed).toBe(0)
     expect(result.failed).toBe(0)
-    const postCalls = fetchMock.mock.calls.filter(
-      ([, init]: [string, RequestInit]) => (init?.method ?? 'GET') === 'POST'
+    const postCalls = (fetchMock.mock.calls as [string, RequestInit][]).filter(
+      ([, init]) => (init?.method ?? 'GET') === 'POST'
     )
     expect(postCalls.length).toBe(0)
   })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1187,13 +1187,16 @@ function getAllToolDefinitions(): ToolDefinition[] {
           const engram = await plur.getById(args.id as string)
           if (engram) {
             if (engram.status === 'retired') return { success: false, error: `Already retired: ${args.id}` }
-            await plur.forget(args.id as string)
+            // force:true — explicit user forget always fully retires, ignoring
+            // reference_count. The ref-count decrement path is for internal
+            // multi-agent dedup; one plur_forget call = full retirement (#766).
+            await plur.forget(args.id as string, undefined, { force: true })
             return { success: true, retired: { id: engram.id, statement: engram.statement } }
           }
           // Not in local store — fall through to plur.forget() which routes to
           // remote stores (with prefix stripping per #86 / PR #186). Throws
           // "Engram not found" if it's nowhere.
-          await plur.forget(args.id as string)
+          await plur.forget(args.id as string, undefined, { force: true })
           return { success: true, retired: { id: args.id as string } }
         }
         if (args.search) {
@@ -1202,7 +1205,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           const matches = await plur.recall(args.search as string, { limit: 100, remote: false })
           if (matches.length === 0) return { success: false, error: `No active engrams matching "${args.search}"` }
           if (matches.length === 1) {
-            await plur.forget(matches[0].id)
+            await plur.forget(matches[0].id, undefined, { force: true })
             return { success: true, retired: { id: matches[0].id, statement: matches[0].statement } }
           }
           return {
@@ -2505,6 +2508,14 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
             note: `This path is already registered under scope "${result.scope}". A local store is keyed by its path, so the requested scope "${requestedScope}" was NOT added. Use a separate store file for a different scope, or remove the existing entry first.`,
           } : {}),
           kind: url ? 'remote' : 'filesystem',
+          // Filesystem stores are read sources — plur_learn writes to the
+          // primary engrams.yaml and carries the scope label there (#766).
+          // Pre-populate the file via plur_packs_export or direct YAML edit
+          // to inject team engrams; plur_learn with this scope will land them
+          // in your primary store tagged with the scope.
+          ...(path && !scopeDropped && !url ? {
+            note: `Store initialized at ${path}. plur_learn calls with scope "${result.scope}" are tagged with that scope but stored in your primary engrams.yaml. To share engrams across machines via this file, populate it via plur_packs_export or direct YAML and commit it to your repo.`,
+          } : {}),
         }
       },
     },


### PR DESCRIPTION
## Summary

Fixes two interacting data-integrity bugs in v0.16.x (reported in #766):

- **Filesystem store never created on `plur_stores_add`** — `addStore()` registered the scope/path mapping but never touched the filesystem, so the registered file did not exist until something explicitly wrote it (e.g. a pack export), and reads against the store silently saw nothing. Write routing is unaffected by design: `learnRouted()` routes only to *remote* stores, so `plur_learn` persists to the primary `engrams.yaml` carrying the scope label — filesystem stores are read sources. The fix materializes the file at registration (and on an idempotent re-add of the same path, which heals registrations broken by the pre-fix behavior), failing loudly when the path is unwritable. The existsSync→init sequence runs under the store's own lock file so it cannot race a concurrent writer.

- **Retired engram resurrected via outbox flush** — `flushOutbox()` pushed all pending engrams regardless of status, reactivating retired engrams on the remote side. Additionally, user-facing forget surfaces used the ref-count decrement path (intended for multi-agent dedup) rather than immediate retirement, leaving the engram active with a reduced count — so a subsequent `learn()` of the same statement matched the still-active engram and inherited its old scope, ignoring the caller's explicit scope. Both the MCP `plur_forget` and the CLI `plur forget` now pass `force: true`. `outboxCount()` mirrors the flush filter so a retired engram with a stale `_outbox` marker is not reported as permanently "pending".

## Changes

| File | What changed |
|------|-------------|
| `packages/core/src/index.ts` | `addStore()` materializes the store file at registration via `initFilesystemStore` — including on the `already_registered` re-add path (heals pre-fix registrations) — under the store's lock file; `forget()` gains `options.force`; `forget()` strips `_outbox` on retirement; `flushOutbox()` skips retired engrams; `outboxCount()` mirrors the flush filter |
| `packages/core/src/engrams.ts` | `initFilesystemStore()` extracted so `index.ts` never calls `saveEngrams` directly (source-of-truth guard) |
| `packages/mcp/src/tools.ts` | `plur_forget` passes `force: true` to `forget()` |
| `packages/cli/src/commands/forget.ts` | CLI `plur forget` passes `force: true` too — same explicit-user-intent surface as MCP |
| `packages/core/test/outbox.test.ts` | flush skips retired; belt-and-suspenders guard for direct YAML edit; `outboxCount` excludes retired-with-`_outbox` |
| `packages/core/test/cross-scope-recurrence.test.ts` | `force=true` retires immediately; re-learn creates fresh engram in requested scope |
| `packages/core/test/multi-store.test.ts` | `addStore` initialization; heal-on-re-add materializes a missing file; re-add never clobbers an existing file |
| `packages/cli/test/forget.test.ts` | CLI forget fully retires a multiply-learned engram |

## Test plan

- [x] `pnpm vitest run` on the touched core/cli test files — all pass
- [x] `pnpm -r build` — clean
- [ ] Reproduce: `plur_stores_add` a filesystem path → verify file appears immediately; re-add a pre-fix broken registration → file materializes
- [ ] Reproduce: `plur_forget` then `plur_learn` same statement at different scope → verify new engram created in new scope, not resurrected at global

Sprint: 2026-W29-sprint4, item: #766
