### PR TITLE
fix(core): transmit optional engram fields on remote append

### DIFF
--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -278,11 +278,25 @@ export class RemoteStore implements EngramStore {
    * the server's ID.
    */
   async appendAndGetServerId(engram: Engram): Promise<{ id: string }> {
+    // #768: transmit the full engram, not just the core four — pinned,
+    // rationale, tags, commitment, validity windows and supersedes were
+    // silently dropped, so team-scope pins never round-tripped. Optional
+    // fields are included only when set, so older servers that ignore
+    // unknown keys see no behavioral change.
+    const e = engram as any
     const body = JSON.stringify({
-      statement: (engram as any).statement,
+      statement: e.statement,
       scope:     engram.scope,
-      domain:    (engram as any).domain,
-      type:      (engram as any).type,
+      domain:    e.domain,
+      type:      e.type,
+      ...(Array.isArray(e.tags) && e.tags.length > 0 ? { tags: e.tags } : {}),
+      ...(e.pinned !== undefined            ? { pinned: e.pinned }             : {}),
+      ...(e.rationale != null               ? { rationale: e.rationale }       : {}),
+      ...(e.commitment !== undefined        ? { commitment: e.commitment }     : {}),
+      ...(e.valid_from != null              ? { valid_from: e.valid_from }     : {}),
+      ...(e.valid_until != null             ? { valid_until: e.valid_until }   : {}),
+      ...(Array.isArray(e.supersedes) && e.supersedes.length > 0 ? { supersedes: e.supersedes } : {}),
+      ...(e.locked_reason != null           ? { locked_reason: e.locked_reason } : {}),
     })
     const r = await fetch(`${this.apiBase}/engrams`, {
       method: 'POST',

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -100,7 +100,7 @@ export class RemoteStore implements EngramStore {
    * Authoritative columns (id/scope/status) win over anything in `data`. Returns
    * null (and logs) for malformed rows so callers can drop them. (finding #3)
    */
-  private reshape(raw: { id?: unknown; scope?: unknown; status?: unknown; data?: unknown }): Engram | null {
+  private reshape(raw: { id?: unknown; scope?: unknown; status?: unknown; data?: unknown; created_at?: unknown }): Engram | null {
     const d = raw.data && typeof raw.data === 'object' ? raw.data as Record<string, unknown> : {}
     const candidate = { ...d, id: raw.id, scope: raw.scope, status: raw.status }
     const parsed = RemoteRowSchema.safeParse(candidate)
@@ -114,7 +114,32 @@ export class RemoteStore implements EngramStore {
       logger.warning(`[plur:remote-store] ${this.url} returned a malformed engram (id="${safeId}") — dropped: ${why}`)
       return null
     }
-    return parsed.data as unknown as Engram
+    // #768 round-trip: the server stores the validity window FLAT in row data
+    // (valid_from / valid_until — enterprise#627), while every local consumer
+    // reads the nested `temporal` block (inject's expiry gate, decay). Map
+    // flat → nested on ingest so remote validity windows actually drive local
+    // expiry. Nested values win; only well-typed strings are mapped.
+    const out = parsed.data as Record<string, unknown>
+    const nested = out.temporal && typeof out.temporal === 'object'
+      ? out.temporal as Record<string, unknown>
+      : {}
+    const flatFrom  = typeof out.valid_from  === 'string' ? out.valid_from  : undefined
+    const flatUntil = typeof out.valid_until === 'string' ? out.valid_until : undefined
+    const mapFrom  = flatFrom  !== undefined && typeof nested.valid_from  !== 'string'
+    const mapUntil = flatUntil !== undefined && typeof nested.valid_until !== 'string'
+    if (mapFrom || mapUntil) {
+      out.temporal = {
+        ...nested,
+        // `temporal.learned_at` is required by the schema — prefer what the
+        // row carries, then the row's created_at, then "now" as a last resort.
+        learned_at: typeof nested.learned_at === 'string' ? nested.learned_at
+          : typeof raw.created_at === 'string' ? raw.created_at
+          : new Date().toISOString(),
+        ...(mapFrom  ? { valid_from: flatFrom }   : {}),
+        ...(mapUntil ? { valid_until: flatUntil } : {}),
+      }
+    }
+    return out as unknown as Engram
   }
 
   private headers(extra: Record<string, string> = {}): Record<string, string> {
@@ -258,7 +283,9 @@ export class RemoteStore implements EngramStore {
 
   /**
    * Append a single engram to the remote store. POST /api/v1/engrams
-   * carries statement + scope + domain + type — the server handles
+   * carries the core four (statement + scope + domain + type) plus every
+   * optional field that is set — pinned, rationale, tags, commitment,
+   * validity window, supersedes, locked_reason (#768). The server handles
    * ID assignment, content_hash, status.
    *
    * Returns void to satisfy the EngramStore interface contract. Callers
@@ -284,6 +311,17 @@ export class RemoteStore implements EngramStore {
     // fields are included only when set, so older servers that ignore
     // unknown keys see no behavioral change.
     const e = engram as any
+    // Canonical engrams carry the validity window nested under `temporal`
+    // (temporal.valid_from / temporal.valid_until, #347) and supersession
+    // under `relations.supersedes` (#240) — the wire contract
+    // (POST /api/v1/engrams, enterprise#627) takes them as FLAT top-level
+    // keys, so flatten here. Top-level reads are kept as a fallback for
+    // non-canonical shapes; they are always undefined on production engrams.
+    const valid_from  = e.temporal?.valid_from  ?? e.valid_from
+    const valid_until = e.temporal?.valid_until ?? e.valid_until
+    const supersedes  = Array.isArray(e.relations?.supersedes) && e.relations.supersedes.length > 0
+      ? e.relations.supersedes
+      : e.supersedes
     const body = JSON.stringify({
       statement: e.statement,
       scope:     engram.scope,
@@ -293,9 +331,9 @@ export class RemoteStore implements EngramStore {
       ...(e.pinned !== undefined            ? { pinned: e.pinned }             : {}),
       ...(e.rationale != null               ? { rationale: e.rationale }       : {}),
       ...(e.commitment !== undefined        ? { commitment: e.commitment }     : {}),
-      ...(e.valid_from != null              ? { valid_from: e.valid_from }     : {}),
-      ...(e.valid_until != null             ? { valid_until: e.valid_until }   : {}),
-      ...(Array.isArray(e.supersedes) && e.supersedes.length > 0 ? { supersedes: e.supersedes } : {}),
+      ...(valid_from != null                ? { valid_from }                   : {}),
+      ...(valid_until != null               ? { valid_until }                  : {}),
+      ...(Array.isArray(supersedes) && supersedes.length > 0 ? { supersedes } : {}),
       ...(e.locked_reason != null           ? { locked_reason: e.locked_reason } : {}),
     })
     const r = await fetch(`${this.apiBase}/engrams`, {

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -77,6 +77,10 @@ export class StubServer {
    *  echoes this value as the {engram: ...} body — to simulate a server whose
    *  echoed row fails RemoteRowSchema validation (#327). */
   badPatchEcho: unknown = null
+  /** Raw JSON body of the most recent POST /engrams — lets tests assert what
+   *  the client actually transmits on the wire (#768: optional fields like
+   *  pinned/rationale/tags were silently never sent). */
+  lastAppendBody: Record<string, unknown> | null = null
 
   // --- POST /api/v1/recall (#776 server-authoritative recall envelope) ---
   /** Rows served in the envelope's `results` (top-level engram shape, each
@@ -175,6 +179,7 @@ export class StubServer {
     this.recallEnvelope = {}
     this.recallCalls = 0
     this.lastRecallBody = null
+    this.lastAppendBody = null
   }
 
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
@@ -251,6 +256,7 @@ export class StubServer {
     // POST /api/v1/engrams — create
     if (method === 'POST' && path === '/api/v1/engrams') {
       this.readBody(req, (body) => {
+        this.lastAppendBody = body
         const { statement, scope, domain, type } = body
         const id = `ENG-SRV-${String(++this.idCounter).padStart(3, '0')}`
         const now = new Date().toISOString()

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -68,6 +68,42 @@ describe('RemoteStore against stub server', () => {
     expect((all[0] as any).statement).toBe('hello world')
   })
 
+  it('#768 append transmits optional fields (pinned, rationale, tags, commitment, validity)', async () => {
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
+    await store.append({
+      id: 'tmp',
+      scope: 'group:test',
+      status: 'active',
+      statement: 'a pinned team rule',
+      domain: 'team.policy',
+      type: 'behavioral',
+      pinned: true,
+      rationale: 'why this matters — enters the search corpus',
+      tags: ['policy', 'wire-test'],
+      commitment: 'decided',
+      valid_until: '2026-12-31',
+    } as any)
+
+    const sent = server.lastAppendBody
+    expect(sent).not.toBeNull()
+    expect(sent!.pinned).toBe(true)
+    expect(sent!.rationale).toBe('why this matters — enters the search corpus')
+    expect(sent!.tags).toEqual(['policy', 'wire-test'])
+    expect(sent!.commitment).toBe('decided')
+    expect(sent!.valid_until).toBe('2026-12-31')
+  })
+
+  it('#768 append omits optional fields that are not set (no null/undefined noise)', async () => {
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
+    await store.append({ id: 'tmp', scope: 'group:test', status: 'active', statement: 'bare minimum' } as any)
+
+    const sent = server.lastAppendBody!
+    expect('pinned' in sent).toBe(false)
+    expect('rationale' in sent).toBe(false)
+    expect('tags' in sent).toBe(false)
+    expect('valid_until' in sent).toBe(false)
+  })
+
   it('#404 rejects a malformed server-assigned id on append (does not trust it)', async () => {
     const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
     // A buggy/hostile server returns an id carrying a newline + forged log line.

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -68,8 +68,12 @@ describe('RemoteStore against stub server', () => {
     expect((all[0] as any).statement).toBe('hello world')
   })
 
-  it('#768 append transmits optional fields (pinned, rationale, tags, commitment, validity)', async () => {
+  it('#768 append transmits optional fields from the CANONICAL shape (nested temporal/relations flattened to wire keys)', async () => {
     const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
+    // Canonical engram shape: validity window nested under `temporal` (#347),
+    // supersession under `relations.supersedes` (#240) — this is what learn()
+    // and learnRouted() actually hand to appendAndGetServerId. The wire
+    // contract (enterprise#627) takes these FLAT.
     await store.append({
       id: 'tmp',
       scope: 'group:test',
@@ -81,7 +85,11 @@ describe('RemoteStore against stub server', () => {
       rationale: 'why this matters — enters the search corpus',
       tags: ['policy', 'wire-test'],
       commitment: 'decided',
-      valid_until: '2026-12-31',
+      temporal: { learned_at: '2026-07-01T00:00:00Z', valid_from: '2026-07-01', valid_until: '2026-12-31' },
+      relations: {
+        broader: [], narrower: [], related: [], conflicts: [],
+        supersedes: ['ENG-2026-0101-001'], superseded_by: [],
+      },
     } as any)
 
     const sent = server.lastAppendBody
@@ -90,7 +98,10 @@ describe('RemoteStore against stub server', () => {
     expect(sent!.rationale).toBe('why this matters — enters the search corpus')
     expect(sent!.tags).toEqual(['policy', 'wire-test'])
     expect(sent!.commitment).toBe('decided')
+    // Flat on the wire, read from the nested canonical locations.
+    expect(sent!.valid_from).toBe('2026-07-01')
     expect(sent!.valid_until).toBe('2026-12-31')
+    expect(sent!.supersedes).toEqual(['ENG-2026-0101-001'])
   })
 
   it('#768 append omits optional fields that are not set (no null/undefined noise)', async () => {
@@ -101,7 +112,55 @@ describe('RemoteStore against stub server', () => {
     expect('pinned' in sent).toBe(false)
     expect('rationale' in sent).toBe(false)
     expect('tags' in sent).toBe(false)
+    expect('valid_from' in sent).toBe(false)
     expect('valid_until' in sent).toBe(false)
+    expect('supersedes' in sent).toBe(false)
+  })
+
+  it('#768 load maps flat server-row validity (valid_from/valid_until) into nested temporal', async () => {
+    // enterprise#627 stores the validity window FLAT in row data; the local
+    // expiry gate reads `temporal.valid_until`. Without the reshape mapping a
+    // remote engram's validity window never drives local expiry.
+    server.seedEngram({
+      id: 'ENG-SRV-EXP-001',
+      scope: 'group:test',
+      status: 'active',
+      data: {
+        statement: 'expires at year end',
+        type: 'behavioral',
+        valid_from: '2026-07-01',
+        valid_until: '2026-12-31',
+      },
+    })
+
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
+    const all = await store.load()
+    expect(all.length).toBe(1)
+    const t = (all[0] as any).temporal
+    expect(t).toBeTruthy()
+    expect(t.valid_from).toBe('2026-07-01')
+    expect(t.valid_until).toBe('2026-12-31')
+    expect(typeof t.learned_at).toBe('string')
+  })
+
+  it('#768 load keeps an existing nested temporal intact (nested wins over flat)', async () => {
+    server.seedEngram({
+      id: 'ENG-SRV-EXP-002',
+      scope: 'group:test',
+      status: 'active',
+      data: {
+        statement: 'nested temporal already present',
+        temporal: { learned_at: '2026-06-01T00:00:00Z', valid_until: '2026-09-30' },
+        valid_until: '2026-12-31',
+      },
+    })
+
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
+    const all = await store.load()
+    expect(all.length).toBe(1)
+    const t = (all[0] as any).temporal
+    expect(t.valid_until).toBe('2026-09-30')
+    expect(t.learned_at).toBe('2026-06-01T00:00:00Z')
   })
 
   it('#404 rejects a malformed server-assigned id on append (does not trust it)', async () => {
@@ -399,6 +458,42 @@ describe('Plur integration with stub server', () => {
       const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams?: any[] } | null
       return (local?.engrams ?? []).find((e: any) => e.statement === 'integration test engram')
     }, { timeout: 10_000, interval: 25 }).toBeUndefined()
+  })
+
+  it('#768 learn with valid_until + supersedes transmits them flat on the wire (real routed path)', async () => {
+    // Drives the REAL production write path — learn() with a routing-matched
+    // scope builds the canonical engram shape (validity nested under
+    // `temporal`, supersession under `relations.supersedes`) and pushes it
+    // through appendAndGetServerId. The wire body must carry the fields FLAT
+    // (enterprise#627 contract); reading them at the engram top level would
+    // silently drop them (the original #768 review finding).
+    const plur = new Plur({ path: primaryDir })
+    await plur.learn('team rule with expiry — wire shape test', {
+      scope: 'group:test',
+      type: 'behavioral',
+      pinned: true,
+      rationale: 'routed-path wire assertion',
+      tags: ['wire'],
+      commitment: 'decided',
+      valid_from: '2026-07-01',
+      valid_until: '2026-12-31',
+      supersedes: ['ENG-2026-0101-001'],
+    })
+
+    // The remote append is fire-and-forget from learn()'s perspective — poll.
+    await expect.poll(() => server.lastAppendBody, { timeout: 10_000, interval: 25 }).not.toBeNull()
+    const sent = server.lastAppendBody!
+    expect(sent.statement).toBe('team rule with expiry — wire shape test')
+    expect(sent.pinned).toBe(true)
+    expect(sent.rationale).toBe('routed-path wire assertion')
+    expect(sent.tags).toEqual(['wire'])
+    expect(sent.commitment).toBe('decided')
+    expect(sent.valid_from).toBe('2026-07-01')
+    expect(sent.valid_until).toBe('2026-12-31')
+    expect(sent.supersedes).toEqual(['ENG-2026-0101-001'])
+    // The canonical nested containers must NOT leak onto the wire.
+    expect('temporal' in sent).toBe(false)
+    expect('relations' in sent).toBe(false)
   })
 
   it('learn with unmatched scope writes locally', async () => {


### PR DESCRIPTION
Closes #768 (client half).

## Problem

`RemoteStore.appendAndGetServerId` serialized only `{statement, scope, domain, type}`. Everything else — `pinned`, `rationale`, `tags`, `commitment`, `valid_from`/`valid_until`, `supersedes`, `locked_reason` — was silently dropped on every remote write. Team-scope policy engrams written as pins were therefore never pinned for any subscriber, and rationale never reached the shared search corpus.

## Fix

Include optional fields in the POST body only when they are set. Bare engrams produce the same minimal body as before, so servers that ignore unknown keys see no behavioral change.

## Tests

- `#768 append transmits optional fields` — asserts the wire body carries pinned/rationale/tags/commitment/valid_until (via new `StubServer.lastAppendBody` capture)
- `#768 append omits optional fields that are not set` — guards against null/undefined noise in minimal appends
- Full core suite: 2327 passed, 0 failed

## Server half

Verified against a live deployment: `POST /api/v1/engrams` currently discards these fields even when transmitted (while `PATCH` accepts `pinned`). The server-side create path needs to accept the same optional set — tracked in #768 comments for the enterprise repo. This PR makes the client correct regardless; the round-trip completes once the server half lands.