### PR TITLE
fix(core): recall limit floor leak — slice(0, limit) on all hybrid paths

### DIFF
--- a/packages/core/src/hybrid-search.ts
+++ b/packages/core/src/hybrid-search.ts
@@ -111,8 +111,10 @@ function isAggregationQuery(query: string): boolean {
  * No LLM calls — fully local, ~500ms with cached embeddings.
  *
  * Automatically detects aggregation queries ("how many", "total", etc.)
- * and switches to exhaustive mode — wider retrieval to capture ALL
- * mentions across conversations, not just the top few.
+ * and switches to exhaustive mode — widens the internal candidate pool
+ * (limit floored at 50 for the BM25/embedding legs and the rerank stage)
+ * so relevant mentions are less likely to be crowded out of the ranking.
+ * The returned list is always capped at `limit` (#770).
  */
 export async function hybridSearch(
   engrams: Engram[],

--- a/packages/core/src/hybrid-search.ts
+++ b/packages/core/src/hybrid-search.ts
@@ -186,7 +186,7 @@ export async function hybridSearchWithMeta(
   // recall always returns something.
   const reranked = await applyReranker(ranked.map(s => s.engram), query, rerank)
   return {
-    engrams: reranked.engrams,
+    engrams: reranked.engrams.slice(0, limit),
     mode,
     embedderError,
     topScore,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2594,8 +2594,9 @@ export class Plur {
 
   /** Hybrid search: BM25 + embeddings merged via Reciprocal Rank Fusion. Async, no API calls. Delegates to recallHybridWithMeta so it gets intent/rerank/PGLite routing too. */
   async recallHybrid(query: string, options?: Omit<RecallOptions, 'mode' | 'llm'>): Promise<Engram[]> {
+    const limit = options?.limit ?? 20
     const result = await this.recallHybridWithMeta(query, options)
-    return result.engrams
+    return result.engrams.slice(0, limit)
   }
 
   /**
@@ -2640,6 +2641,16 @@ export class Plur {
     // #776: fold the server leg in (RRF) before reactivation so displaced
     // local rows are not reactivated and server rows rank on merged order.
     result = { ...result, engrams: await this._mergeRemoteRecall(result.engrams, remotePromise, options, limit) }
+    // Belt-and-suspenders: all inner paths apply slice(0, limit) before
+    // returning, but recallHybridWithMeta is called directly by the MCP layer
+    // (#770) and lacks the outer guard that recallHybrid() adds. Note
+    // _mergeRemoteRecall only slices when the remote leg returned rows — on the
+    // common local-only path it returns the local result unsliced. Enforce here
+    // so no over-fetch floor (Math.max(N, 50) for reranker/aggregation paths)
+    // can leak through to callers.
+    if (result.engrams.length > limit) {
+      result = { ...result, engrams: result.engrams.slice(0, limit) }
+    }
     await this._reactivateResults(result.engrams)
     // WS5 demand flywheel: a zero-result or low-top-score recall is a demand
     // signal. Emit an anonymized, content-free miss-signal (query fingerprint +

--- a/packages/core/test/hybrid-search.test.ts
+++ b/packages/core/test/hybrid-search.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '../src/index.js'
-import { setEmbeddingsEnabled } from '../src/embeddings.js'
+import { embedderStatus, setEmbeddingsEnabled } from '../src/embeddings.js'
 
 describe('hybrid search (BM25 + embeddings via RRF)', () => {
   let dir: string
@@ -101,8 +101,11 @@ describe('hybrid search limit — 50-floor regression (#770)', () => {
   // directly (bypassing the outer slice guard in recallHybrid).
   let dir: string
   let plur: Plur
+  let priorEmbeddings: { disabled: boolean; disabledReason: string | null }
 
   beforeAll(async () => {
+    const status = embedderStatus()
+    priorEmbeddings = { disabled: status.disabled, disabledReason: status.disabledReason }
     setEmbeddingsEnabled(false, 'limit regression test — BM25-only for speed')
     dir = mkdtempSync(join(tmpdir(), 'plur-limit-floor-'))
     plur = new Plur({ path: dir })
@@ -121,7 +124,9 @@ describe('hybrid search limit — 50-floor regression (#770)', () => {
   }, 120_000)
 
   afterAll(() => {
-    setEmbeddingsEnabled(true)
+    // Restore whatever state the suite found, not force-enable — another
+    // suite (or the environment) may have disabled embeddings deliberately.
+    setEmbeddingsEnabled(!priorEmbeddings.disabled, priorEmbeddings.disabledReason ?? undefined)
     rmSync(dir, { recursive: true })
   })
 

--- a/packages/core/test/hybrid-search.test.ts
+++ b/packages/core/test/hybrid-search.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest'
 import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '../src/index.js'
+import { setEmbeddingsEnabled } from '../src/embeddings.js'
 
 describe('hybrid search (BM25 + embeddings via RRF)', () => {
   let dir: string
@@ -85,5 +86,62 @@ describe('hybrid search (BM25 + embeddings via RRF)', () => {
     const meta = await empty.recallHybridWithMeta('anything')
     expect(meta.engrams).toHaveLength(0)
     expect(meta.topScore).toBeNull()
+  })
+})
+
+describe('hybrid search limit — 50-floor regression (#770)', () => {
+  // The internal over-fetch floors (Math.max(limit * 3, 50) for the reranker
+  // path, Math.max(limit, 50) for aggregation queries) must not leak through
+  // as the returned count. These tests seed >50 engrams so the floor kicks in,
+  // then verify the caller's limit is the ceiling on what comes back.
+  //
+  // Embeddings are disabled: this is a COUNT correctness test. BM25-only is
+  // fast and exercises the same limit-enforcement code path.
+  // recallHybridWithMeta is called directly because the MCP layer calls it
+  // directly (bypassing the outer slice guard in recallHybrid).
+  let dir: string
+  let plur: Plur
+
+  beforeAll(async () => {
+    setEmbeddingsEnabled(false, 'limit regression test — BM25-only for speed')
+    dir = mkdtempSync(join(tmpdir(), 'plur-limit-floor-'))
+    plur = new Plur({ path: dir })
+    const topics = [
+      'cats', 'dogs', 'fish', 'birds', 'rabbits', 'hamsters', 'turtles', 'snakes',
+      'lions', 'tigers', 'bears', 'wolves', 'foxes', 'deer', 'moose', 'elk',
+      'Python', 'TypeScript', 'Rust', 'Go', 'Java', 'C++', 'Ruby', 'Swift',
+      'React', 'Vue', 'Angular', 'Svelte', 'Next.js', 'Remix', 'Astro', 'Nuxt',
+      'PostgreSQL', 'MySQL', 'SQLite', 'MongoDB', 'Redis', 'Cassandra', 'DynamoDB',
+      'AWS', 'GCP', 'Azure', 'Vercel', 'Netlify', 'Heroku', 'Render', 'Fly.io',
+      'Docker', 'Kubernetes', 'Terraform', 'Ansible', 'GitHub', 'GitLab', 'Bitbucket',
+    ]
+    for (const topic of topics) {
+      await plur.learn(`${topic} is a popular technology used by developers worldwide`, { type: 'terminological' })
+    }
+  }, 120_000)
+
+  afterAll(() => {
+    setEmbeddingsEnabled(true)
+    rmSync(dir, { recursive: true })
+  })
+
+  it('recallHybrid with limit:5 returns ≤5 even with >50 engrams seeded', async () => {
+    const results = await plur.recallHybrid('technology developers', { limit: 5 })
+    expect(results.length).toBeLessThanOrEqual(5)
+  })
+
+  it('recallHybrid aggregation query with limit:5 returns ≤5 — effectiveLimit 50-floor must not leak', async () => {
+    const results = await plur.recallHybrid('all the technologies used by developers', { limit: 5 })
+    expect(results.length).toBeLessThanOrEqual(5)
+  })
+
+  it('recallHybridWithMeta with limit:5 returns ≤5 — MCP tool calls this directly', async () => {
+    const meta = await plur.recallHybridWithMeta('technology developers', { limit: 5 })
+    expect(meta.engrams.length).toBeLessThanOrEqual(5)
+  })
+
+  it('recallHybridWithMeta aggregation query with limit:5 returns ≤5', async () => {
+    const meta = await plur.recallHybridWithMeta('all the technologies used by developers', { limit: 5 })
+    expect(meta.engrams.length).toBeLessThanOrEqual(5)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #770 — `plur_recall` / `plur_recall_hybrid` returning a fixed ~50 results regardless of the requested `limit`.

Three code paths were missing a final `slice(0, limit)` when the internal over-fetch floor (`Math.max(limit * N, 50)`) was active for reranker quality:

1. **`recallHybrid()`** — returned `result.engrams` without slicing (the `recallHybridWithMeta` call it delegates to can return up to the floor count)
2. **`recallHybridWithMeta()`** — lacked an outer guard; the MCP layer calls this directly, bypassing the slice in `recallHybrid()`
3. **`hybridSearchWithMeta()`** — non-PGLite path: after the reranker ran, result was returned without slicing

The PGLite path (`_pgliteHybridRecall`, line 2807) already had the guard. This PR closes the non-PGLite and MCP-facing gaps.

## Changes

- `packages/core/src/index.ts` — `recallHybrid`: add `const limit = options?.limit ?? 20` + `return result.engrams.slice(0, limit)`. `recallHybridWithMeta`: add belt-and-suspenders guard before returning (catches any inner-path that leaks the floor through)
- `packages/core/src/hybrid-search.ts` — `hybridSearchWithMeta`: apply `slice(0, limit)` to `reranked.engrams` before returning
- `packages/core/test/hybrid-search.test.ts` — new `describe('hybrid search limit — 50-floor regression (#770)')` block: seeds 55 engrams, requests limit:5, asserts `≤5` from both `recallHybrid()` and `recallHybridWithMeta()`

## Test results

```
Test Files  1 passed (1)
     Tests  12 passed (12)
  Duration  49.10s
```

All 12 tests pass including the 4 new regression tests. Smoke-tested with a 55-engram store: both call paths return exactly 5 results.

## Post-review update (rebase onto #778 + review fixes)

Rebased onto main after #778 landed. The single conflict hunk in `recallHybridWithMeta` was resolved as the review prescribed: main's `_mergeRemoteRecall` fold is kept, and this PR's belt-and-suspenders guard now sits **after** the fold, as the final boundary before `_reactivateResults`. The guard is still required post-#778: `_mergeRemoteRecall` slices to `limit` only when the remote leg returned rows — on the common local-only path it returns the local result unsliced. `hybrid-search.ts` and the test file merged clean.

Follow-up commits from review:

- `docs(core)`: corrected the `hybridSearch` exhaustive-mode docstring — exhaustive mode widens the internal candidate pool (limit floored at 50); the return value is always capped at the caller's `limit`
- `test(core)`: the limit-floor suite's `afterAll` now restores the prior embeddings state (captured via `embedderStatus()` in `beforeAll`) instead of force-enabling

## Micro-benchmark (main 1ee5dde vs this PR)

`pnpm bench:micro`, 100 iterations, same machine, sequential runs:

| Operation | main | PR | Δ mean | Δ % |
|---|---|---|---|---|
| learn | 5.08ms (p95 9.72) | 5.20ms (p95 7.63) | +0.12ms | +2.4 |
| recall_bm25 | 6.70ms (p95 9.98) | 6.18ms (p95 9.68) | −0.52ms | −7.7 |
| recall_hybrid | 28.23ms (p95 27.03) | 26.30ms (p95 30.92) | −1.93ms | −6.8 |
| inject | 0.60ms (p95 0.91) | 0.67ms (p95 1.15) | +0.06ms | +10.3 |
| inject_tokens | 1833 | 1833 | 0 | 0.0 |

All deltas within run-to-run noise (inject is a sub-millisecond op); no regression. The added work per call is one `slice(0, limit)` on an already-materialized array.

## Post-rebase test results

- `packages/core` default project: 144 files passed (3 unrelated files hit 30s timeouts under full-parallel load — same files pass in isolation on both this branch and main; same class of contention documented in `vitest.config.ts`)
- `core-pglite` serial project (PGLite hybrid recall paths): 15/15 files passed
- `hybrid-search.test.ts`: 12/12 including the 4 regression tests
- `pnpm build`: clean
