### PR TITLE
feat(core): mounted store scopes become read-side visibility grants (#775)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2548,7 +2548,7 @@ export class Plur {
     const fetchLimit = Math.max(intentFetch, rerankFetch)
     let results: Engram[]
     if (this.pgliteAdapter) {
-      results = await this._pgliteSemanticRecall(query, fetchLimit, filtered, options?.scopes)
+      results = await this._pgliteSemanticRecall(query, fetchLimit, filtered, options)
     } else {
       results = await embeddingSearch(filtered, query, fetchLimit, this.paths.root)
     }
@@ -2592,7 +2592,7 @@ export class Plur {
     let result: HybridSearchResult
     if (intent) {
       result = this.pgliteAdapter
-        ? await this._pgliteHybridRecall(query, intentLimit, filtered, undefined, options?.scopes)
+        ? await this._pgliteHybridRecall(query, intentLimit, filtered, undefined, options)
         : await hybridSearchWithMeta(filtered, query, intentLimit, this.paths.root)
       let routed = applyIntentRouting(result.engrams, intent.profile)
       let rerankedCount = result.reranked
@@ -2603,7 +2603,7 @@ export class Plur {
       }
       result = { ...result, engrams: routed.slice(0, limit), reranked: rerankedCount }
     } else if (this.pgliteAdapter) {
-      result = await this._pgliteHybridRecall(query, limit, filtered, rerank, options?.scopes)
+      result = await this._pgliteHybridRecall(query, limit, filtered, rerank, options)
     } else {
       result = await hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
     }
@@ -2752,7 +2752,7 @@ export class Plur {
     limit: number,
     filtered: Engram[],
     rerank?: RerankOptions,
-    scopes?: string[],
+    restrict?: Pick<RecallOptions, 'scope' | 'scopes'>,
   ): Promise<HybridSearchResult> {
     if (!this.pgliteAdapter) {
       return hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
@@ -2780,7 +2780,17 @@ export class Plur {
     // with relevant permitted rows sitting just below the cut. The intersection
     // kept it CORRECT — nothing out of scope was ever returned — but it made it
     // INCOMPLETE, which is the harder failure to notice.
-      const hits = await this.pgliteAdapter.searchVector(queryVec, embLimit, { scopes })
+    //
+    // `scope` + mounted-scope visibilityGrants (#775) go in for the same
+    // reason: `filtered` already honours them, so a k-NN restricted to
+    // `scopes` alone spends `limit` on rows the intersection below is about
+    // to discard — and a granted team engram never surfaces via the vector
+    // leg. Same filter shape searchBM25/loadFiltered get.
+      const hits = await this.pgliteAdapter.searchVector(queryVec, embLimit, {
+        scopes: restrict?.scopes,
+        scope: restrict?.scope,
+        visibilityGrants: this._grantedScopes(),
+      })
       const allowed = new Map<string, Engram>(filtered.map(e => [e.id, e]))
       pgHits = hits.map(h => allowed.get(h.engram.id)).filter((e): e is Engram => !!e)
     } catch (err) {
@@ -2807,7 +2817,12 @@ export class Plur {
    * intersected with the YAML-rooted `filtered` set. Falls back to the JSON
    * cache on cold-start / embedder-unavailable / PGLite error.
    */
-  private async _pgliteSemanticRecall(query: string, limit: number, filtered: Engram[], scopes?: string[]): Promise<Engram[]> {
+  private async _pgliteSemanticRecall(
+    query: string,
+    limit: number,
+    filtered: Engram[],
+    restrict?: Pick<RecallOptions, 'scope' | 'scopes'>,
+  ): Promise<Engram[]> {
     if (!this.pgliteAdapter) return []
     const { embed } = await import('./embeddings.js')
     const queryVec = await embed(query, 'query')
@@ -2825,7 +2840,17 @@ export class Plur {
     // with relevant permitted rows sitting just below the cut. The intersection
     // kept it CORRECT — nothing out of scope was ever returned — but it made it
     // INCOMPLETE, which is the harder failure to notice.
-      const hits = await this.pgliteAdapter.searchVector(queryVec, Math.max(limit * 3, 50), { scopes })
+    //
+    // `scope` + mounted-scope visibilityGrants (#775) go in for the same
+    // reason: `filtered` already honours them, so a k-NN restricted to
+    // `scopes` alone spends `limit` on rows the intersection below is about
+    // to discard — and a granted team engram never surfaces via the vector
+    // leg. Same filter shape searchBM25/loadFiltered get.
+      const hits = await this.pgliteAdapter.searchVector(queryVec, Math.max(limit * 3, 50), {
+        scopes: restrict?.scopes,
+        scope: restrict?.scope,
+        visibilityGrants: this._grantedScopes(),
+      })
       if (hits.length === 0) {
         return embeddingSearch(filtered, query, limit, this.paths.root)
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,7 +52,7 @@ import type { AsyncPrimaryStore } from './store/primary-store.js'
 import { requiresIndexSync, asDerivedIndex } from './storage-adapter.js'
 import type { StorageAdapter } from './storage-adapter.js'
 import { resolveBackendTier, type BackendSelection } from './backend-selection.js'
-import { isSharedScope, isPersonalScope, isScopeWithin, scopeAllowFilter } from './scope-util.js'
+import { isSharedScope, isScopeWithin, scopeAllowFilter, makeVisibilityPredicate } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { Episode } from './schemas/episode.js'
 import type { PackManifest } from './schemas/pack.js'
@@ -107,7 +107,7 @@ export { rankScopes, SCOPE_MATCH_THRESHOLD, WEIGHT_TAG, SUGGEST_DISPLAY_MIN_CONF
 // importing it from here would form index → inject → index. They are imported
 // above for internal use and re-exported here so the public `@plur-ai/core` API
 // (`isSharedScope`, `isPersonalScope`, `SHARED_SCOPE_PREFIXES`) is unchanged.
-export { isSharedScope, isPersonalScope, SHARED_SCOPE_PREFIXES, scopeAllowFilter } from './scope-util.js'
+export { isSharedScope, isPersonalScope, SHARED_SCOPE_PREFIXES, scopeAllowFilter, makeVisibilityPredicate } from './scope-util.js'
 export { detectPlurStorage, type PlurPaths } from './storage.js'
 export { IndexedStorage } from './storage-indexed.js'
 export { PGLiteAdapter, type PGLiteAdapterOptions, type VectorPrecision } from './storage-pglite.js'
@@ -2423,6 +2423,10 @@ export class Plur {
         status: 'active' as const,
         scope: options?.scope,
         scopes: options?.scopes,
+        // Mounted-scope visibility grants (#775) go INTO the pushdown so
+        // `limit` counts granted team rows too. Visibility-only — widens the
+        // `scope` clause, never the `scopes` authorization clause.
+        visibilityGrants: this._grantedScopes(),
         domain: options?.domain,
       }
       // Widen and retry rather than trust a fixed multiplier.
@@ -2954,6 +2958,22 @@ export class Plur {
   }
 
   /**
+   * Mounted-scope visibility grants (#775): the deduplicated scopes of every
+   * `config.yaml` `stores:` entry — path AND url entries alike. Mounting a
+   * store with your own token is the consent act, so its scope passes a
+   * project-scope VISIBILITY filter exactly like the personal family (see
+   * `makeVisibilityPredicate` in scope-util.ts). Always on, no config knob.
+   *
+   * STRICTLY visibility-only: these are threaded into the `scope` visibility
+   * filter (in-memory predicate + `StorageFilter.visibilityGrants` SQL
+   * pushdown) and MUST NEVER be folded into `options.scopes` — that list is
+   * the authorization decision and grants never widen it.
+   */
+  private _grantedScopes(): string[] {
+    return [...new Set((this.config.stores ?? []).map(s => s.scope))]
+  }
+
+  /**
    * Engrams a primary-store pushdown cannot see: secondary (team/project)
    * stores from `config.stores`, and installed packs.
    *
@@ -2978,8 +2998,10 @@ export class Plur {
     }
     if (options?.domain) filtered = filtered.filter(e => e.domain?.startsWith(options.domain!))
     if (options?.scope) {
-      const scope = options.scope
-      filtered = filtered.filter(e => isScopeWithin(e.scope, scope) || isPersonalScope(e.scope))
+      // Visibility filter (#353/#775): scope containment, personal-family
+      // pass-through, and mounted-scope grants — the ONE shared predicate.
+      const visible = makeVisibilityPredicate(options.scope, this._grantedScopes())
+      filtered = filtered.filter(e => visible(e.scope))
     }
     return filtered
   }
@@ -2991,6 +3013,10 @@ export class Plur {
         status: 'active',
         scope: options?.scope,
         scopes: options?.scopes,
+        // Mounted-scope visibility grants (#775) — widen the `scope`
+        // VISIBILITY clause only; a no-op without `scope`, and never touches
+        // the `scopes` authorization pushdown above.
+        visibilityGrants: this._grantedScopes(),
         domain: options?.domain,
       })
     } else {
@@ -3014,18 +3040,18 @@ export class Plur {
         engrams = engrams.filter(e => e.domain?.startsWith(options.domain!))
       }
       if (options?.scope) {
-        const scope = options.scope
-        // Read-side scope filter (#353). Keep the `startsWith` arm so an explicit
-        // personal scope like `user:alice` still catches sub-scopes (e.g.
-        // `user:alice:notes`). `isPersonalScope` passes ALL personal-family
-        // scopes (local, global, user:*, agent:*), not just global — so a
-        // project-scope recall sees personal engrams. D1-ASYMMETRY: an explicit
-        // `global` recall therefore includes all personal-family engrams — wider
-        // than `global` inject, which is targeted to global-only (see inject.ts
-        // INJECT_GLOBAL_IS_TARGETED).
-        engrams = engrams.filter(e =>
-          isScopeWithin(e.scope, scope) || isPersonalScope(e.scope)
-        )
+        // Read-side scope filter (#353/#775) — the ONE shared visibility
+        // predicate. Segment-aware containment keeps the `startsWith` arm so
+        // an explicit personal scope like `user:alice` still catches
+        // sub-scopes (e.g. `user:alice:notes`). `isPersonalScope` passes ALL
+        // personal-family scopes (local, global, user:*, agent:*), not just
+        // global — so a project-scope recall sees personal engrams. Mounted
+        // store scopes (#775) pass the same way. D1-ASYMMETRY: an explicit
+        // `global` recall therefore includes all personal-family engrams —
+        // wider than `global` inject, which is targeted to global-only (see
+        // inject.ts INJECT_GLOBAL_IS_TARGETED).
+        const visible = makeVisibilityPredicate(options.scope, this._grantedScopes())
+        engrams = engrams.filter(e => visible(e.scope))
       }
     }
     // Temporal validity: exclude expired or not-yet-valid engrams.
@@ -3306,6 +3332,11 @@ export class Plur {
       {
         prompt: task,
         scope: options?.scope,
+        // Mounted-scope visibility grants (#775): scopes from config.stores
+        // pass the `scope` VISIBILITY filter inside scoreEngram like the
+        // personal family. Deliberately independent of the `permitted`
+        // authorization filter above — grants never widen `options.scopes`.
+        grantedScopes: this._grantedScopes(),
         maxTokens: budget,
       },
       engrams,

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -5,7 +5,7 @@ import { decayedStrength, decayedCoAccessStrength, daysSince, confidenceDecay } 
 import { classifyPolarity } from './polarity.js'
 import { computeConfidence } from './confidence.js'
 import { freshTailBoost } from './fresh-tail.js'
-import { isPersonalScope, isScopeWithin } from './scope-util.js'
+import { makeVisibilityPredicate } from './scope-util.js'
 
 /**
  * D1-RECALL/INJECT-ASYMMETRY (#353). When an inject is given an EXPLICIT
@@ -27,6 +27,13 @@ export const INJECT_GLOBAL_IS_TARGETED = true
 export interface InjectionContext {
   prompt: string
   scope?: string
+  /**
+   * Mounted-scope visibility grants (#775): scopes from `config.yaml`
+   * `stores:` entries. Engrams in these scopes pass the `scope` visibility
+   * filter like the personal family. Visibility-only — never an
+   * authorization widening; see `makeVisibilityPredicate` in scope-util.ts.
+   */
+  grantedScopes?: readonly string[]
   session_id?: string
   maxTokens?: number      // Default: 8000 (~10% of 80K context)
   minRelevance?: number   // Default: 0.3
@@ -228,6 +235,8 @@ export function scoreEngram(
   packMatchTerms: string[],
   scopeFilter: string | undefined,
   isPack: boolean,
+  // Trailing optional so the post-#759 public signature stays non-breaking.
+  grantedScopes?: readonly string[],
 ): number {
   // Scope filtering: if scope is specified, only include matching engrams
   if (scopeFilter) {
@@ -237,12 +246,16 @@ export function scoreEngram(
       // personal-family pass-through below applies to PROJECT-scope filters
       // only; this branch predates D1 and is intentionally narrower than the
       // project branch (see INJECT_GLOBAL_IS_TARGETED JSDoc + D1-ASYMMETRY tests).
+      // Mounted-scope grants (#775) deliberately do NOT reach this branch:
+      // targeted-global stays global-only, grants or no grants.
       void INJECT_GLOBAL_IS_TARGETED
       if (engram.scope !== 'global') return 0
-    } else if (!isScopeWithin(engram.scope, scopeFilter) && !isPersonalScope(engram.scope)) {
-      // Personal-family scopes (local, global, user:*, agent:*, anything not
-      // isSharedScope) always pass a project-scope filter; only SHARED scopes
-      // that don't match the filter are excluded (#353 read-side fix).
+    } else if (!makeVisibilityPredicate(scopeFilter, grantedScopes)(engram.scope)) {
+      // Visibility filter (#353/#775), ONE predicate for every in-memory call
+      // site: personal-family scopes (local, global, user:*, agent:*, anything
+      // not isSharedScope) always pass a project-scope filter, and so do
+      // scopes granted by mounted `config.yaml` stores. Only SHARED scopes
+      // matching neither the filter nor a grant are excluded.
       return 0
     }
   }
@@ -401,7 +414,7 @@ export function selectAndSpread(
     if (engram.status !== 'active') continue
     if (skipForValidity(engram, today, expiryMode, graceCutoff)) continue
     engramMap.set(engram.id, engram)
-    let raw = scoreEngram(engram, promptLower, promptWords, [], ctx.scope, false)
+    let raw = scoreEngram(engram, promptLower, promptWords, [], ctx.scope, false, ctx.grantedScopes)
     // Embedding boost: semantically similar engrams with zero keyword hits still get scored.
     // Threshold raised from 0.3 -> 0.5 in 0.9.4 — with embeddings now actually running
     // (post-build-config fix), 0.3 was too generous and surfaced spurious matches between
@@ -432,7 +445,7 @@ export function selectAndSpread(
       if (engram.status !== 'active') continue
       if (skipForValidity(engram, today, expiryMode, graceCutoff)) continue
       engramMap.set(engram.id, engram)
-      let raw = scoreEngram(engram, promptLower, promptWords, matchTerms, ctx.scope, true)
+      let raw = scoreEngram(engram, promptLower, promptWords, matchTerms, ctx.scope, true, ctx.grantedScopes)
       const embBoost = embeddingBoosts?.get(engram.id) ?? 0
       if (raw === 0 && embBoost > 0.5) {
         raw = embBoost * 2
@@ -663,12 +676,12 @@ export interface PublicScoredEngram { engram: Engram; score: number }
 export function scoreEngramsPublic(
   engrams: Engram[],
   task: string,
-  options?: { scope?: string },
+  options?: { scope?: string; grantedScopes?: readonly string[] },
 ): PublicScoredEngram[] {
   const promptLower = task.toLowerCase()
   const promptWords = new Set(promptLower.split(/\W+/).filter(w => w.length > 2))
   return engrams.map(e => ({
     engram: e,
-    score: scoreEngram(e, promptLower, promptWords, [], options?.scope, false),
+    score: scoreEngram(e, promptLower, promptWords, [], options?.scope, false, options?.grantedScopes),
   })).sort((a, b) => b.score - a.score)
 }

--- a/packages/core/src/scope-util.ts
+++ b/packages/core/src/scope-util.ts
@@ -74,6 +74,48 @@ export function isScopeWithin(scope: string, queryScope: string): boolean {
 }
 
 /**
+ * Read-side VISIBILITY predicate under a scope filter (#775) — the ONE
+ * in-memory implementation every visibility call site uses (inject scoring,
+ * the YAML arm of `_filterEngrams`, `_engramsOutsidePrimaryStore`). The SQL
+ * arms (storage-indexed / storage-pglite / storage-postgres) inline the
+ * equivalent clause and must stay in lockstep with this.
+ *
+ * An engram passes a `scopeFilter` (e.g. `project:plur/plur-ai/enterprise`
+ * from .plur.yaml) when ANY of:
+ *   1. it falls within the filter itself (segment-aware, #383);
+ *   2. it is personal-family (`local`, `global`, `user:*`, `agent:*`, …) —
+ *      the #353 pass-through;
+ *   3. it falls within a GRANTED scope — a scope explicitly mounted in
+ *      `~/.plur/config.yaml` `stores:` (path AND url entries alike). Mounting
+ *      a store with your own token is the consent act, so its scope passes a
+ *      project-scope visibility filter exactly like the personal family.
+ *      Without this, a project scope filter zeroed every `group:*` engram and
+ *      team engrams from mounted enterprise stores never survived injection
+ *      or recall.
+ *
+ * Grant matching is segment-aware via `isScopeWithin`: a grant for
+ * `group:acme/eng` admits `group:acme/eng` and true descendants
+ * (`group:acme/eng/x`, `group:acme/eng:x`) but NEVER the sibling
+ * string-prefix `group:acme/eng-private` (#383).
+ *
+ * STRICTLY visibility-only. This predicate must NEVER be consulted by (or
+ * folded into) the `scopeAllowFilter` authorization allow-list below —
+ * grants widen what a scope filter shows, never what a principal is
+ * permitted to see. The `INJECT_GLOBAL_IS_TARGETED` branch in inject.ts is
+ * likewise untouched: an explicit `scope: 'global'` inject stays targeted to
+ * `global` only, grants or no grants (D1-ASYMMETRY).
+ */
+export function makeVisibilityPredicate(
+  scopeFilter: string,
+  grants?: readonly string[],
+): (engramScope: string) => boolean {
+  return (engramScope: string) =>
+    isScopeWithin(engramScope, scopeFilter)
+    || isPersonalScope(engramScope)
+    || (grants !== undefined && grants.some(g => isScopeWithin(engramScope, g)))
+}
+
+/**
  * Permitted-scope allow-list predicate — the in-memory twin of the SQL
  * `scope = ANY($n)` pushdown (see `StorageFilter.scopes` in
  * storage-adapter.ts).

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -107,6 +107,26 @@ export interface StorageFilter extends ScopeRestriction {
    * Distinct from `scopes` — see {@link ScopeRestriction}.
    */
   scope?: string
+  /**
+   * Mounted-scope VISIBILITY grants (#775) — scopes explicitly mounted in
+   * `config.yaml` `stores:` (path and url entries alike). Each grant passes
+   * the `scope` visibility filter above exactly like the personal family:
+   * segment-aware containment (`scope = g OR scope LIKE g||':%' OR scope
+   * LIKE g||'/%'`), never a sibling string-prefix (#383).
+   *
+   * NOT AUTHORIZATION — read this twice before touching it. `scopes` (see
+   * {@link ScopeRestriction}) is the authorization allow-list: exact
+   * membership, AND-ed with everything, an empty list means NOTHING.
+   * `visibilityGrants` is the opposite kind of field: it only ever widens
+   * the `scope` VISIBILITY clause, is meaningless without `scope`, and MUST
+   * NEVER be consulted by (or OR-ed into) the `scopes` clause — an engram
+   * outside the `scopes` allow-list stays invisible no matter how many
+   * grants cover it. Confusing the two is a privilege escalation, not a
+   * styling choice.
+   *
+   * Absent and `[]` are equivalent: no extra scopes pass (prior behavior).
+   */
+  visibilityGrants?: readonly string[]
   domain?: string
 }
 

--- a/packages/core/src/storage-indexed.ts
+++ b/packages/core/src/storage-indexed.ts
@@ -4,7 +4,7 @@ import { loadEngrams, storePrefix } from './engrams.js'
 import { isPersonalScope, isScopeWithin } from './scope-util.js'
 import type { Engram } from './schemas/engram.js'
 import type { StoreEntry } from './schemas/config.js'
-import type { StorageFilter } from './storage-adapter.js'
+import { escapeLikePattern, type StorageFilter } from './storage-adapter.js'
 
 const require = createRequire(import.meta.url)
 
@@ -179,11 +179,18 @@ export class IndexedStorage {
       // `scopes` allow-list above is authorization and never widened by grants.
       // SQL twin of makeVisibilityPredicate (scope-util.ts) — keep all four
       // arms (in-memory / sqlite / pglite / postgres) in lockstep.
-      const clauses = ['personal = 1', "scope = ?", "scope LIKE ? || ':%'", "scope LIKE ? || '/%'"]
-      params.push(filter.scope, filter.scope, filter.scope)
+      //
+      // The two LIKE arms of each triple are escaped (escapeLikePattern +
+      // ESCAPE '\'), same as the pglite/postgres copies: a `%`/`_` in a
+      // caller-supplied scope or grant must match literally, not widen the
+      // containment into unrelated namespaces. The equality arm keeps the
+      // raw value. SQLite has NO default LIKE escape character, so the
+      // explicit ESCAPE clause is load-bearing, not style.
+      const clauses = ['personal = 1', "scope = ?", "scope LIKE ? || ':%' ESCAPE '\\'", "scope LIKE ? || '/%' ESCAPE '\\'"]
+      params.push(filter.scope, escapeLikePattern(filter.scope), escapeLikePattern(filter.scope))
       for (const g of filter.visibilityGrants ?? []) {
-        clauses.push("scope = ?", "scope LIKE ? || ':%'", "scope LIKE ? || '/%'")
-        params.push(g, g, g)
+        clauses.push("scope = ?", "scope LIKE ? || ':%' ESCAPE '\\'", "scope LIKE ? || '/%' ESCAPE '\\'")
+        params.push(g, escapeLikePattern(g), escapeLikePattern(g))
       }
       conditions.push(`(${clauses.join(' OR ')})`)
     }

--- a/packages/core/src/storage-indexed.ts
+++ b/packages/core/src/storage-indexed.ts
@@ -169,8 +169,23 @@ export class IndexedStorage {
       // engrams. Segment-aware membership (#383): a descendant matches only on a
       // real delimiter (`:`/`/`), so a sibling string-prefix (project:application
       // under a project:app query) does NOT leak. Mirrors isScopeWithin.
-      conditions.push("(personal = 1 OR scope = ? OR scope LIKE ? || ':%' OR scope LIKE ? || '/%')")
+      //
+      // Mounted-scope visibility grants (#775): each grant contributes the same
+      // segment-aware containment triple as `filter.scope`, so an engram in a
+      // granted scope (or a true descendant of one) passes the visibility
+      // filter like the personal family. The precomputed `personal` column is
+      // untouched — grants vary per query (they come from config.stores), so
+      // they must be OR-clauses, not an indexed flag. VISIBILITY ONLY: the
+      // `scopes` allow-list above is authorization and never widened by grants.
+      // SQL twin of makeVisibilityPredicate (scope-util.ts) — keep all four
+      // arms (in-memory / sqlite / pglite / postgres) in lockstep.
+      const clauses = ['personal = 1', "scope = ?", "scope LIKE ? || ':%'", "scope LIKE ? || '/%'"]
       params.push(filter.scope, filter.scope, filter.scope)
+      for (const g of filter.visibilityGrants ?? []) {
+        clauses.push("scope = ?", "scope LIKE ? || ':%'", "scope LIKE ? || '/%'")
+        params.push(g, g, g)
+      }
+      conditions.push(`(${clauses.join(' OR ')})`)
     }
     if (filter.domain) {
       conditions.push("domain LIKE ? || '%'")

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -586,13 +586,29 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
    * the dilution bug: `LIMIT` would be spent on engrams the caller may not
    * see, so asking for N in-scope results would silently return fewer.
    * Filtering in the query means `limit` counts permitted rows only.
+   *
+   * `opts.scope` + `opts.visibilityGrants` (#775) ride the same filter: the
+   * k-NN WHERE gets the full visibility clause (personal pass-through,
+   * segment-aware containment, escaped grant triples) via buildFilterClause,
+   * exactly like searchBM25/loadFiltered. Without them the vector leg spent
+   * `limit` on rows the visibility filter was about to discard, so a granted
+   * team engram could never surface through vector search.
    */
-  async searchVector(query: Float32Array, limit: number, opts?: ScopeRestriction): Promise<VectorSearchHit[]> {
+  async searchVector(
+    query: Float32Array,
+    limit: number,
+    opts?: ScopeRestriction & Pick<StorageFilter, 'scope' | 'visibilityGrants'>,
+  ): Promise<VectorSearchHit[]> {
     const db = await this.getDb()
     const totalRes = await db.query('SELECT COUNT(*)::int AS c FROM engram_embeddings')
     if (Number(totalRes.rows[0].c) === 0) return []
     // status defaults to 'active' (historical behaviour) but stays overridable.
-    const filter: StorageFilter = { status: 'active', scopes: opts?.scopes }
+    const filter: StorageFilter = {
+      status: 'active',
+      scopes: opts?.scopes,
+      scope: opts?.scope,
+      visibilityGrants: opts?.visibilityGrants,
+    }
     if (this.hasVector) {
       // pgvector path. Cosine distance = 1 - cosine similarity. The query
       // param is cast to the column's ACTUAL type (#223) — pgvector's <=>

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -403,7 +403,7 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
       params.push(filter.scopes)
     }
     if (filter.scope) {
-      // Read-side scope filter, two parts OR'd:
+      // Read-side scope filter, three parts OR'd:
       //  (1) personal-family pass-through — ALL non-shared scopes (local, global,
       //      user:*, agent:*, …), not just 'global'. The old `scope = 'global'`
       //      dropped local/user:/agent: under a project-scope recall (#402, the
@@ -412,14 +412,24 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
       //      kept in sync with SHARED_SCOPE_PREFIXES in scope-util.ts.
       //  (2) segment-aware membership (#383): the requested scope, exactly or a
       //      descendant on a REAL delimiter (`:`/`/`) — never a sibling prefix.
-      conditions.push(
+      //  (3) mounted-scope visibility grants (#775): one segment-aware triple
+      //      per granted scope (config.stores), so team engrams in mounted
+      //      scopes pass a project-scope visibility filter like the personal
+      //      family. VISIBILITY ONLY — the `scopes` authorization clause above
+      //      is never widened by grants. SQL twin of makeVisibilityPredicate
+      //      (scope-util.ts); keep all four arms in lockstep.
+      let clause =
         `((NOT (${col}scope LIKE 'group:%' OR ${col}scope LIKE 'project:%' OR ${col}scope LIKE 'space:%' OR ${col}scope LIKE 'team:%' OR ${col}scope LIKE 'org:%' OR ${col}scope = 'public' OR ${col}scope LIKE 'public:%' OR ${col}scope LIKE 'public/%'))`
-        + ` OR ${col}scope = $${i++} OR ${col}scope LIKE $${i++} || ':%' ESCAPE '\\' OR ${col}scope LIKE $${i++} || '/%' ESCAPE '\\')`,
-      )
+        + ` OR ${col}scope = $${i++} OR ${col}scope LIKE $${i++} || ':%' ESCAPE '\\' OR ${col}scope LIKE $${i++} || '/%' ESCAPE '\\'`
       // Escaped for the same reason as the Postgres copy — these two clauses
       // must stay identical; they have drifted before, and that drift was an
       // authorization bypass.
       params.push(filter.scope, escapeLikePattern(filter.scope), escapeLikePattern(filter.scope))
+      for (const g of filter.visibilityGrants ?? []) {
+        clause += ` OR ${col}scope = $${i++} OR ${col}scope LIKE $${i++} || ':%' ESCAPE '\\' OR ${col}scope LIKE $${i++} || '/%' ESCAPE '\\'`
+        params.push(g, escapeLikePattern(g), escapeLikePattern(g))
+      }
+      conditions.push(clause + ')')
     }
     if (filter.domain) {
       conditions.push(`${col}domain LIKE $${i++} || '%' ESCAPE '\\'`)
@@ -554,10 +564,17 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
    * `opts.scopes` is pushed into the candidate SELECT via loadFiltered, so the
    * BM25 scorer only ever sees permitted engrams — IDF and the top-N cut are
    * both computed over the in-scope corpus, not over the org's.
+   *
+   * The FULL StorageFilter is honoured (#775): this used to forward only
+   * `scopes` and silently drop a caller's `scope` visibility filter (and
+   * `domain`), which the interface doc explicitly calls a silent-wrong-results
+   * bug. The Postgres primary `searchBM25` already spreads the whole filter —
+   * this keeps the two in lockstep, `visibilityGrants` included.
    */
-  async searchBM25(query: string, opts: { limit: number } & ScopeRestriction): Promise<Engram[]> {
-    const candidates = await this.loadFiltered({ status: 'active', scopes: opts.scopes })
-    return searchEngrams(candidates, query, opts.limit)
+  async searchBM25(query: string, opts: { limit: number } & StorageFilter): Promise<Engram[]> {
+    const { limit, ...filter } = opts
+    const candidates = await this.loadFiltered({ ...filter, status: filter.status ?? 'active' })
+    return searchEngrams(candidates, query, limit)
   }
 
   /**

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -1351,15 +1351,24 @@ export function buildFilterClause(filter: StorageFilter): { where: string; param
     params.push(filter.scopes)
   }
   if (filter.scope) {
-    conditions.push(
+    // Mounted-scope visibility grants (#775): one segment-aware containment
+    // triple per granted scope, appended to the visibility OR — identical to
+    // the PGLite copy above and the SQLite/in-memory arms; keep all four in
+    // lockstep. VISIBILITY ONLY: the `scopes` authorization clause is never
+    // widened by grants.
+    let clause =
       `((NOT (scope LIKE 'group:%' OR scope LIKE 'project:%' OR scope LIKE 'space:%' OR scope LIKE 'team:%' OR scope LIKE 'org:%' OR scope = 'public' OR scope LIKE 'public:%' OR scope LIKE 'public/%'))`
-      + ` OR scope = $${i++} OR scope LIKE $${i++} || ':%' ESCAPE '\\' OR scope LIKE $${i++} || '/%' ESCAPE '\\')`,
-    )
-      // The caller's scope is escaped: an unescaped `%` here matches across
-      // unrelated namespaces, defeating the segment-aware containment guard
-      // this clause exists to implement (#383). Verified: `{ scope: '%' }`
-      // returned engrams from two unrelated groups.
+      + ` OR scope = $${i++} OR scope LIKE $${i++} || ':%' ESCAPE '\\' OR scope LIKE $${i++} || '/%' ESCAPE '\\'`
+    // The caller's scope is escaped: an unescaped `%` here matches across
+    // unrelated namespaces, defeating the segment-aware containment guard
+    // this clause exists to implement (#383). Verified: `{ scope: '%' }`
+    // returned engrams from two unrelated groups.
     params.push(filter.scope, escapeLikePattern(filter.scope), escapeLikePattern(filter.scope))
+    for (const g of filter.visibilityGrants ?? []) {
+      clause += ` OR scope = $${i++} OR scope LIKE $${i++} || ':%' ESCAPE '\\' OR scope LIKE $${i++} || '/%' ESCAPE '\\'`
+      params.push(g, escapeLikePattern(g), escapeLikePattern(g))
+    }
+    conditions.push(clause + ')')
   }
   if (filter.domain) {
     conditions.push(`domain LIKE $${i++} || '%' ESCAPE '\\'`)

--- a/packages/core/test/inject-scopes.test.ts
+++ b/packages/core/test/inject-scopes.test.ts
@@ -115,6 +115,96 @@ describe('inject() — permitted-scope allow-list', () => {
 })
 
 /**
+ * Mounted-scope visibility grants (#775) vs the allow-list.
+ *
+ * Mounting a store in `config.yaml` `stores:` grants its scope VISIBILITY
+ * under a project-scope filter — that is the whole feature. What it must NOT
+ * do is widen AUTHORIZATION: `options.scopes` is the fully-resolved
+ * permission decision of a layer above core, and a config file must never
+ * out-vote it. These are the adversarial tests for that boundary.
+ */
+describe('inject() — mounted-scope visibility grants (#775)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-inject-grants-'))
+    const teamPath = join(dir, 'team.yaml')
+    // The mounted team store whose scope becomes the visibility grant.
+    writeFileSync(teamPath, `engrams:
+  - id: ENG-2026-0730-100
+    statement: the team deploys billing via the shared pipeline
+    type: behavioral
+    scope: group:acme/eng
+    status: active
+    version: 2
+    domain: ops.deploy
+    tags: [deploy]
+    activation:
+      retrieval_strength: 0.9
+      storage_strength: 1.0
+      frequency: 0
+      last_accessed: "2026-07-28"
+`)
+    writeFileSync(join(dir, 'config.yaml'), `stores:
+  - path: ${teamPath}
+    scope: group:acme/eng
+`)
+    plur = new Plur({ path: dir })
+    await plur.ready()
+    await plur.learn('alice deploys the billing service with terraform', { scope: 'user:acme:alice' })
+    await plur.learn('deploys are reviewed before release', { scope: 'global' })
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('the mounted scope passes a project-scope VISIBILITY filter', async () => {
+    // Pre-#775 this was zero: a project scope filter scored every `group:*`
+    // engram 0, so team engrams from mounted stores never survived.
+    const res = await plur.inject('how do we deploy billing', { scope: 'project:myapp' })
+    expect(`${res.directives}\n${res.constraints}\n${res.consider}`).toContain('shared pipeline')
+  })
+
+  it('ADVERSARIAL: the grant does NOT widen the options.scopes allow-list', async () => {
+    // The allow-list omits group:acme/eng. However granted for visibility,
+    // the team engram must stay out — authorization always wins.
+    const res = await plur.inject('how do we deploy billing', {
+      scope: 'project:myapp',
+      scopes: ['user:acme:alice', 'global'],
+    })
+    const all = `${res.directives}\n${res.constraints}\n${res.consider}`
+    expect(all, 'a visibility grant leaked past the authorization allow-list').not.toContain('shared pipeline')
+    // …while the permitted scopes still flow: the filter narrowed, it did not break.
+    expect(all).toContain('terraform')
+  })
+
+  it('ADVERSARIAL: an EMPTY allow-list still injects nothing, grants notwithstanding', async () => {
+    const res = await plur.inject('how do we deploy billing', {
+      scope: 'project:myapp',
+      scopes: [],
+    })
+    expect(res.count).toBe(0)
+    expect(res.injected_ids).toEqual([])
+  })
+
+  it('REGRESSION: without a mount the same group scope stays excluded', async () => {
+    // The old behavior is still the right behavior for un-mounted scopes.
+    const dir2 = mkdtempSync(join(tmpdir(), 'plur-inject-nogrant-'))
+    const p2 = new Plur({ path: dir2 })
+    try {
+      await p2.ready()
+      await p2.learn('the team deploys billing via the shared pipeline', { scope: 'group:acme/eng' })
+      const res = await p2.inject('how do we deploy billing', { scope: 'project:myapp' })
+      expect(`${res.directives}\n${res.constraints}\n${res.consider}`).not.toContain('shared pipeline')
+    } finally {
+      rmSync(dir2, { recursive: true, force: true })
+    }
+  })
+})
+
+/**
  * The same allow-list, applied to PACKS.
  *
  * A pack is installed knowledge rather than user data, which makes exempting it

--- a/packages/core/test/pglite-scope-pushdown.test.ts
+++ b/packages/core/test/pglite-scope-pushdown.test.ts
@@ -364,6 +364,134 @@ describe('PGLiteAdapter — mounted-scope visibility grants (#775)', () => {
     expect(ids).not.toContain('ENG-2026-0730-205')
     expect(ids).not.toContain('ENG-2026-0730-206')
   }, PGLITE_TIMEOUT)
+
+  /**
+   * Vector-leg embeddings for the grants corpus: the two rows the caller may
+   * NOT see (sibling + other team) are the NEAREST neighbours, so any
+   * implementation that applies scope/grants AFTER the k-NN query spends
+   * `limit` on them and the granted rows never surface.
+   */
+  async function seedGrantEmbeddings(): Promise<void> {
+    await adapter.upsertEmbedding('ENG-2026-0730-205', vec(1))          // sibling — nearest
+    await adapter.upsertEmbedding('ENG-2026-0730-206', vec(1, 0.001))   // other team — next
+    await adapter.upsertEmbedding('ENG-2026-0730-201', vec(1, 0.5))     // project
+    await adapter.upsertEmbedding('ENG-2026-0730-202', vec(1, 0.6))     // personal
+    await adapter.upsertEmbedding('ENG-2026-0730-203', vec(1, 0.7))     // granted
+    await adapter.upsertEmbedding('ENG-2026-0730-204', vec(1, 0.8))     // true descendant
+  }
+
+  it('searchVector: scope + grants ride the k-NN WHERE — granted rows surface past nearer forbidden ones', async () => {
+    await seedGrantEmbeddings()
+    expect(await adapter.getVectorColumnType()).toBe('vector') // pgvector, not the fallback
+    const hits = await adapter.searchVector(vec(1), 4, {
+      scope: 'project:a',
+      visibilityGrants: ['group:acme/eng'],
+    })
+    const ids = hits.map(h => h.engram.id)
+    // limit=4 with the 2 nearest rows forbidden: a post-filter returns at most
+    // 2 permitted rows; the in-query filter returns all 4.
+    expect(ids).toHaveLength(4)
+    expect(ids).toContain('ENG-2026-0730-201') // the filter scope
+    expect(ids).toContain('ENG-2026-0730-202') // personal pass-through
+    expect(ids).toContain('ENG-2026-0730-203') // granted scope
+    expect(ids).toContain('ENG-2026-0730-204') // true descendant
+  }, PGLITE_TIMEOUT)
+
+  it('searchVector SECURITY: grants never widen the scopes authorization allow-list', async () => {
+    await seedGrantEmbeddings()
+    const hits = await adapter.searchVector(vec(1), 10, {
+      scope: 'project:a',
+      scopes: ['project:a'],
+      visibilityGrants: ['group:acme/eng'],
+    })
+    expect(hits.map(h => h.engram.id)).toEqual(['ENG-2026-0730-201'])
+  }, PGLITE_TIMEOUT)
+
+  it('searchVector SECURITY: a wildcard grant matches literally on the vector leg', async () => {
+    await seedGrantEmbeddings()
+    const hits = await adapter.searchVector(vec(1), 10, {
+      scope: 'project:a',
+      visibilityGrants: ['group:%'],
+    })
+    const ids = hits.map(h => h.engram.id)
+    // `group:%` escaped matches only a literal `group:%` scope — none here.
+    expect(ids.filter(id => ['ENG-2026-0730-203', 'ENG-2026-0730-204', 'ENG-2026-0730-205', 'ENG-2026-0730-206'].includes(id)))
+      .toEqual([])
+    expect(ids).toContain('ENG-2026-0730-201')
+  }, PGLITE_TIMEOUT)
+})
+
+/**
+ * #775 vector-leg WIRING: the Plur recall legs must thread `scope` and the
+ * mounted-store visibilityGrants into `pgliteAdapter.searchVector`, not just
+ * `scopes`. The real-embedder end-to-end version is impractical offline
+ * (embed() returns null and the leg falls back before the adapter is hit), so
+ * embed() is mocked to a fixed vector and the assertion is on the filter the
+ * adapter receives — the SQL semantics of that filter are pinned by the
+ * adapter-level tests above.
+ */
+vi.mock('../src/embeddings.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/embeddings.js')>()
+  return {
+    ...actual,
+    // Non-zero so cosine distance is defined whatever the backend does with it;
+    // the tests only assert on the filter searchVector receives.
+    embed: vi.fn(async () => new Float32Array(384).fill(0.1)),
+  }
+})
+
+describe('Plur recall legs — vector-leg grant threading (#775)', () => {
+  let dir: string
+  const originalBackend = process.env.PLUR_BACKEND
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-775-vecwire-'))
+    process.env.PLUR_BACKEND = 'pglite'
+  })
+
+  afterEach(() => {
+    if (originalBackend === undefined) delete process.env.PLUR_BACKEND
+    else process.env.PLUR_BACKEND = originalBackend
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  async function makePlurWithMountedStore() {
+    const { Plur } = await import('../src/index.js')
+    const teamPath = join(dir, 'team.yaml')
+    writeFileSync(teamPath, yaml.dump({ engrams: [] }, { noRefs: true }))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ path: teamPath, scope: 'group:acme/eng' }],
+    }, { noRefs: true }))
+    const plur = new Plur({ path: dir })
+    await plur.learn('the deployment pipeline uses snake_case naming', { scope: 'global' })
+    await plur.waitForIndex()
+    const adapter = (plur as any).pgliteAdapter
+    expect(adapter, 'PLUR_BACKEND=pglite must construct the PGLite adapter').toBeTruthy()
+    const spy = vi.spyOn(adapter, 'searchVector')
+    return { plur, spy }
+  }
+
+  it('recallHybrid passes scope + visibilityGrants into searchVector', async () => {
+    const { plur, spy } = await makePlurWithMountedStore()
+    await plur.recallHybrid('deployment pipeline', { scope: 'project:a' })
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0][2]).toEqual({
+      scopes: undefined,
+      scope: 'project:a',
+      visibilityGrants: ['group:acme/eng'],
+    })
+  }, PGLITE_TIMEOUT)
+
+  it('recallSemantic passes scope + visibilityGrants into searchVector', async () => {
+    const { plur, spy } = await makePlurWithMountedStore()
+    await plur.recallSemantic('deployment pipeline', { scope: 'project:a', scopes: ['project:a'] })
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0][2]).toEqual({
+      scopes: ['project:a'],
+      scope: 'project:a',
+      visibilityGrants: ['group:acme/eng'],
+    })
+  }, PGLITE_TIMEOUT)
 })
 
 describe('PGLiteAdapter — permitted-scope pushdown on the BYTEA fallback', () => {

--- a/packages/core/test/pglite-scope-pushdown.test.ts
+++ b/packages/core/test/pglite-scope-pushdown.test.ts
@@ -294,6 +294,78 @@ describe('PGLiteAdapter — permitted-scope pushdown', () => {
   })
 })
 
+describe('PGLiteAdapter — mounted-scope visibility grants (#775)', () => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+  let adapter: PGLiteAdapter
+
+  const GRANTS_CORPUS = [
+    mkEngram('ENG-2026-0730-201', 'project deploy row', { scope: 'project:a' }),
+    mkEngram('ENG-2026-0730-202', 'personal deploy row', { scope: 'global' }),
+    mkEngram('ENG-2026-0730-203', 'team deploy row', { scope: 'group:acme/eng' }),
+    mkEngram('ENG-2026-0730-204', 'team sub deploy row', { scope: 'group:acme/eng/sub' }),
+    mkEngram('ENG-2026-0730-205', 'sibling deploy row', { scope: 'group:acme/eng-private' }),
+    mkEngram('ENG-2026-0730-206', 'other team deploy row', { scope: 'group:other/team' }),
+  ]
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-775-pglite-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'store.pglite')
+    seedYaml(yamlPath, GRANTS_CORPUS)
+    adapter = new PGLiteAdapter(yamlPath, dbPath, { vectorDim: DIM })
+    await adapter.reindex()
+  }, PGLITE_TIMEOUT)
+
+  afterEach(async () => {
+    if (adapter) await adapter.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('loadFiltered: a granted scope and its true descendants pass the scope filter', async () => {
+    const ids = (await adapter.loadFiltered({
+      scope: 'project:a',
+      visibilityGrants: ['group:acme/eng'],
+    })).map(e => e.id)
+    expect(ids).toContain('ENG-2026-0730-201') // the filter scope
+    expect(ids).toContain('ENG-2026-0730-202') // personal pass-through
+    expect(ids).toContain('ENG-2026-0730-203') // granted scope
+    expect(ids).toContain('ENG-2026-0730-204') // true descendant
+    expect(ids, 'sibling string-prefix leaked through a grant (#383)').not.toContain('ENG-2026-0730-205')
+    expect(ids, 'an ungranted shared scope leaked').not.toContain('ENG-2026-0730-206')
+  }, PGLITE_TIMEOUT)
+
+  it('grants are inert without a scope filter', async () => {
+    const withGrants = (await adapter.loadFiltered({ visibilityGrants: ['group:acme/eng'] }))
+      .map(e => e.id).sort()
+    const without = (await adapter.loadFiltered({})).map(e => e.id).sort()
+    expect(withGrants).toEqual(without)
+  }, PGLITE_TIMEOUT)
+
+  it('SECURITY: grants never widen the scopes authorization allow-list', async () => {
+    const ids = (await adapter.loadFiltered({
+      scope: 'project:a',
+      scopes: ['project:a'],
+      visibilityGrants: ['group:acme/eng'],
+    })).map(e => e.id)
+    expect(ids).toEqual(['ENG-2026-0730-201'])
+    expect(await adapter.loadFiltered({ scopes: [], visibilityGrants: ['group:acme/eng'] })).toEqual([])
+  }, PGLITE_TIMEOUT)
+
+  it('searchBM25: the granted team row survives a scope-filtered search', async () => {
+    const hits = await adapter.searchBM25('deploy row', {
+      limit: 10,
+      scope: 'project:a',
+      visibilityGrants: ['group:acme/eng'],
+    })
+    const ids = hits.map(e => e.id)
+    expect(ids).toContain('ENG-2026-0730-203')
+    expect(ids).not.toContain('ENG-2026-0730-205')
+    expect(ids).not.toContain('ENG-2026-0730-206')
+  }, PGLITE_TIMEOUT)
+})
+
 describe('PGLiteAdapter — permitted-scope pushdown on the BYTEA fallback', () => {
   let dir: string
   let yamlPath: string

--- a/packages/core/test/postgres-adapter.test.ts
+++ b/packages/core/test/postgres-adapter.test.ts
@@ -458,6 +458,14 @@ describe.skipIf(!DSN)('PGLite and Postgres answer the same filter identically', 
     { domain: 'plur.storage' },
     { domain: 'plur' },
     { scope: 'project:plur', domain: 'plur.storage' },
+    // #775 mounted-scope visibility grants — the two SQL twins must answer
+    // grant-widened visibility identically too.
+    { scope: 'project:plur', visibilityGrants: ['group:plur/eng'] },
+    { scope: 'local', visibilityGrants: ['project:plur'] },
+    // A grant that is a string-prefix sibling of a corpus scope: must NOT
+    // admit project:plurality on either backend (#383).
+    { scope: 'group:plur/eng', visibilityGrants: ['project:plur'] },
+    { scope: 'project:plur', visibilityGrants: ['group:plur/eng'], status: 'active' },
   ]
 
   for (const filter of filters) {

--- a/packages/core/test/postgres-recall-pushdown.test.ts
+++ b/packages/core/test/postgres-recall-pushdown.test.ts
@@ -19,7 +19,7 @@
  * allowed to see.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Plur } from '../src/index.js'
@@ -108,5 +108,71 @@ describe.skipIf(!PG_URL)('Plur.recall() through an injected Postgres adapter (#7
   it('composes scope with the allow-list — both narrow, neither widens', async () => {
     const hits = await plur.recall('deploy', { limit: 10, scope: 'project:alpha', scopes: ['project:beta'] })
     expect(hits, 'AND-ing two disjoint filters returned rows').toEqual([])
+  }, TIMEOUT)
+})
+
+/**
+ * Mounted-scope visibility grants through the Postgres pushdown (#775).
+ *
+ * The grant flows from `config.yaml` `stores:` into `pushdownFilter.
+ * visibilityGrants` and lands in `buildFilterClause` as extra segment-aware
+ * containment triples on the visibility clause. This is the fourth SQL arm's
+ * end-to-end proof — the mounted `group:` engram survives a project-scope
+ * recall on the Postgres tier, and the authorization allow-list is untouched.
+ */
+describe.skipIf(!PG_URL)('mounted-scope visibility grants through the Postgres pushdown (#775)', () => {
+  const GRANT_SCHEMA = 'plur_recall_grants_775'
+  let adapter: PostgresAdapter
+  let plur: Plur
+  let dir: string
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-recall-grants-'))
+    const teamPath = join(dir, 'team.yaml')
+    // The mount IS the grant — the granted engrams themselves live in the
+    // Postgres primary store, so the SQL clause is what admits them.
+    writeFileSync(teamPath, 'engrams: []\n')
+    writeFileSync(join(dir, 'config.yaml'), `stores:\n  - path: ${teamPath}\n    scope: "group:acme/eng"\n`)
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema: GRANT_SCHEMA, vectorIndex: 'exact' })
+    await adapter.save([])
+    plur = new Plur({ path: dir, store: adapter })
+    await plur.ready()
+
+    await plur.learn('deploy the billing service with terraform', { scope: 'project:alpha' })
+    await plur.learn('deploy the billing service via the team pipeline', { scope: 'group:acme/eng' })
+    await plur.learn('deploy the billing service via the sub pipeline', { scope: 'group:acme/eng/sub' })
+    await plur.learn('deploy the billing service via the private pipeline', { scope: 'group:acme/eng-private' })
+    await plur.learn('deploy the billing service via the other pipeline', { scope: 'group:other/team' })
+  }, TIMEOUT)
+
+  afterAll(async () => {
+    await adapter?.dropSchema().catch(() => { /* best effort */ })
+    await adapter?.close().catch(() => { /* best effort */ })
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }, TIMEOUT)
+
+  it('the granted scope and its true descendant survive a project-scope recall', async () => {
+    const stmts = (await plur.recall('deploy billing', { limit: 10, scope: 'project:alpha' }))
+      .map(e => e.statement)
+    expect(stmts).toContain('deploy the billing service with terraform')
+    expect(stmts, 'the mounted group scope was zeroed').toContain('deploy the billing service via the team pipeline')
+    expect(stmts).toContain('deploy the billing service via the sub pipeline')
+  }, TIMEOUT)
+
+  it('the sibling string-prefix and ungranted scopes stay excluded', async () => {
+    const stmts = (await plur.recall('deploy billing', { limit: 10, scope: 'project:alpha' }))
+      .map(e => e.statement)
+    expect(stmts, 'sibling-prefix leak (#383)').not.toContain('deploy the billing service via the private pipeline')
+    expect(stmts, 'ungranted scope leak').not.toContain('deploy the billing service via the other pipeline')
+  }, TIMEOUT)
+
+  it('ADVERSARIAL: the grant does not widen the scopes allow-list', async () => {
+    const hits = await plur.recall('deploy billing', {
+      limit: 10,
+      scope: 'project:alpha',
+      scopes: ['project:alpha'],
+    })
+    expect(hits.map(e => e.statement)).toEqual(['deploy the billing service with terraform'])
+    expect(await plur.recall('deploy billing', { limit: 10, scopes: [] })).toEqual([])
   }, TIMEOUT)
 })

--- a/packages/core/test/read-side-scope-visibility.test.ts
+++ b/packages/core/test/read-side-scope-visibility.test.ts
@@ -188,6 +188,114 @@ describe('#383 isScopeWithin predicate', () => {
   })
 })
 
+// --- #775: mounted-scope visibility grants ---
+//
+// A project scope filter (e.g. `project:plur/plur-ai/enterprise` from
+// .plur.yaml) used to zero every `group:*` engram — team engrams from mounted
+// enterprise stores never survived injection or recall. Scopes explicitly
+// mounted in `config.yaml` `stores:` are VISIBILITY GRANTS: engrams in those
+// scopes (segment-aware) pass a project-scope visibility filter exactly like
+// the personal family. Strictly visibility-only — the `options.scopes`
+// authorization allow-list and the INJECT_GLOBAL_IS_TARGETED branch are
+// untouched (both pinned below and in inject-scopes.test.ts).
+//
+// Both read paths: indexed (SQLite `visibilityGrants` pushdown) and
+// non-indexed (makeVisibilityPredicate in the YAML arm of _filterEngrams).
+for (const indexed of [true, false]) {
+  const label = indexed ? 'indexed' : 'non-indexed'
+  const block = indexed ? describe.skipIf(!hasSqlite) : describe
+  block(`#775 mounted-scope visibility grants (${label} path)`, () => {
+    let dir: string
+    let plur: Plur
+
+    const storeEngram = (id: string, statement: string, scope: string) => ({
+      id,
+      statement,
+      type: 'behavioral',
+      scope,
+      status: 'active',
+      version: 2,
+      domain: 'ops.deploy',
+      tags: ['deploy'],
+      activation: {
+        retrieval_strength: 0.9,
+        storage_strength: 1.0,
+        frequency: 0,
+        last_accessed: '2026-07-28',
+      },
+    })
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'plur-775-'))
+      const teamPath = join(dir, 'team.yaml')
+      // The mounted team store — mounting it IS the visibility grant.
+      writeFileSync(teamPath, yaml.dump({
+        engrams: [
+          storeEngram('ENG-2026-0730-001', STMT('teamstore'), 'group:acme/eng'),
+          storeEngram('ENG-2026-0730-002', STMT('teamsub'), 'group:acme/eng/sub'),
+        ],
+      }, { noRefs: true }))
+      writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+        index: indexed,
+        stores: [{ path: teamPath, scope: 'group:acme/eng' }],
+      }, { noRefs: true }))
+      plur = new Plur({ path: dir })
+    })
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+    // Store engrams get namespaced ids on load, so match by statement.
+    async function recallSeesStmt(scope: string, marker: string): Promise<boolean> {
+      return (await plur.recall(QUERY, { scope })).some(e => e.statement.includes(marker))
+    }
+    async function injectSeesStmt(scope: string, marker: string): Promise<boolean> {
+      const res = await plur.inject(QUERY, { scope })
+      return `${res.directives}\n${res.constraints}\n${res.consider}`.includes(marker)
+    }
+
+    it('a mounted group: scope IS visible under project-scope recall AND inject', async () => {
+      expect(await recallSeesStmt(PROJECT, 'teamstore')).toBe(true)
+      expect(await injectSeesStmt(PROJECT, 'teamstore')).toBe(true)
+    })
+
+    it('a true descendant of the granted scope passes too (group:acme/eng/sub)', async () => {
+      expect(await recallSeesStmt(PROJECT, 'teamsub')).toBe(true)
+      expect(await injectSeesStmt(PROJECT, 'teamsub')).toBe(true)
+    })
+
+    it('sibling-prefix: the grant does NOT admit group:acme/eng-private (#383)', async () => {
+      // The sibling lives in the PRIMARY store — the grant is a scope-level
+      // decision, and a scope that merely shares a string prefix with the
+      // granted one must stay invisible.
+      await plur.learn(STMT('grpprivate'), { scope: 'group:acme/eng-private' })
+      expect(await recallSeesStmt(PROJECT, 'grpprivate')).toBe(false)
+      expect(await injectSeesStmt(PROJECT, 'grpprivate')).toBe(false)
+    })
+
+    it('an UNgranted shared scope is still excluded under a project-scope filter', async () => {
+      await plur.learn(STMT('grpother'), { scope: 'group:other/team' })
+      expect(await recallSeesStmt(PROJECT, 'grpother')).toBe(false)
+      expect(await injectSeesStmt(PROJECT, 'grpother')).toBe(false)
+    })
+
+    it('a granted-scope engram in the PRIMARY store passes too — the grant is per scope, not per source', async () => {
+      await plur.learn(STMT('primgrp'), { scope: 'group:acme/eng' })
+      expect(await recallSeesStmt(PROJECT, 'primgrp')).toBe(true)
+      expect(await injectSeesStmt(PROJECT, 'primgrp')).toBe(true)
+    })
+
+    it('D1 guard: explicit scope=global INJECT stays targeted — grants do NOT leak into it', async () => {
+      // INJECT_GLOBAL_IS_TARGETED is untouched by #775: a targeted global
+      // inject returns ONLY global-scoped engrams, mounted stores or not.
+      expect(await injectSeesStmt('global', 'teamstore')).toBe(false)
+    })
+
+    it('list({ scope }) sees the mounted scope as well (the _filterEngrams path)', async () => {
+      const stmts = (await plur.list({ scope: PROJECT })).map(e => e.statement)
+      expect(stmts.some(s => s.includes('teamstore'))).toBe(true)
+    })
+  })
+}
+
 // End-to-end isolation across BOTH read paths (indexed SQL + non-indexed filter)
 // and BOTH directions, asserting true descendants stay visible. (#383)
 for (const indexed of [true, false]) {

--- a/packages/core/test/scope-pushdown.test.ts
+++ b/packages/core/test/scope-pushdown.test.ts
@@ -181,6 +181,49 @@ describe.skipIf(!hasSqlite)('IndexedStorage.loadFiltered — permitted-scope pus
     expect(mine.length).toBe(20)
     expect(mine.every(e => e.scope === 'project:mine')).toBe(true)
   })
+
+  // --- #775: mounted-scope visibility grants ---
+
+  const GRANTS_CORPUS = [
+    mkEngram('ENG-2026-0730-101', 'project row', { scope: 'project:a' }),
+    mkEngram('ENG-2026-0730-102', 'personal row', { scope: 'global' }),
+    mkEngram('ENG-2026-0730-103', 'team row', { scope: 'group:acme/eng' }),
+    mkEngram('ENG-2026-0730-104', 'team sub row', { scope: 'group:acme/eng/sub' }),
+    mkEngram('ENG-2026-0730-105', 'team sibling row', { scope: 'group:acme/eng-private' }),
+    mkEngram('ENG-2026-0730-106', 'other team row', { scope: 'group:other/team' }),
+  ]
+
+  it('#775: visibilityGrants admit the granted scope AND its true descendants under a scope filter', async () => {
+    const s = await seedAndOpen(GRANTS_CORPUS)
+    const ids = (await s.loadFiltered({ scope: 'project:a', visibilityGrants: ['group:acme/eng'] }))
+      .map(e => e.id)
+    expect(ids).toContain('ENG-2026-0730-101') // the filter scope itself
+    expect(ids).toContain('ENG-2026-0730-102') // personal pass-through, unchanged
+    expect(ids).toContain('ENG-2026-0730-103') // the granted scope
+    expect(ids).toContain('ENG-2026-0730-104') // its true descendant
+    expect(ids, 'sibling string-prefix leaked through a grant (#383)').not.toContain('ENG-2026-0730-105')
+    expect(ids, 'an ungranted shared scope leaked').not.toContain('ENG-2026-0730-106')
+  })
+
+  it('#775: grants are inert without a scope filter — visibility only widens visibility', async () => {
+    const s = await seedAndOpen(GRANTS_CORPUS)
+    const withGrants = (await s.loadFiltered({ visibilityGrants: ['group:acme/eng'] })).map(e => e.id).sort()
+    const without = (await s.loadFiltered({})).map(e => e.id).sort()
+    expect(withGrants).toEqual(without)
+  })
+
+  it('#775 SECURITY: grants never widen the scopes authorization allow-list', async () => {
+    const s = await seedAndOpen(GRANTS_CORPUS)
+    // The allow-list omits the granted scope: the team row must stay out.
+    const ids = (await s.loadFiltered({
+      scope: 'project:a',
+      scopes: ['project:a'],
+      visibilityGrants: ['group:acme/eng'],
+    })).map(e => e.id)
+    expect(ids).toEqual(['ENG-2026-0730-101'])
+    // And the empty allow-list still matches NOTHING, grants or no grants.
+    expect(await s.loadFiltered({ scopes: [], visibilityGrants: ['group:acme/eng'] })).toEqual([])
+  })
 })
 
 describe('Plur read paths — permitted-scope pushdown', () => {
@@ -277,5 +320,44 @@ describe('LIKE metacharacters in a caller-supplied scope or domain', () => {
   it('an ordinary scope is unchanged', () => {
     const { params } = buildFilterClause({ status: 'active', domain: 'ops/deploy' })
     expect(params).toContain('ops/deploy')
+  })
+})
+
+describe('buildFilterClause — mounted-scope visibility grants (#775)', () => {
+  it('each grant appends one segment-aware containment triple to the visibility clause', () => {
+    const { where, params } = buildFilterClause({
+      scope: 'project:a',
+      visibilityGrants: ['group:acme/eng'],
+    })
+    // 3 params for the filter scope + 3 per grant, in order.
+    expect(params).toEqual([
+      'project:a', 'project:a', 'project:a',
+      'group:acme/eng', 'group:acme/eng', 'group:acme/eng',
+    ])
+    // Two LIKE arms per triple, all escaped.
+    expect((where.match(/LIKE \$\d+ \|\| ':%' ESCAPE/g) ?? []).length).toBe(2)
+    expect((where.match(/LIKE \$\d+ \|\| '\/%' ESCAPE/g) ?? []).length).toBe(2)
+  })
+
+  it('a wildcard grant matches literally, not across namespaces', () => {
+    const { params } = buildFilterClause({ scope: 'project:a', visibilityGrants: ['group:%'] })
+    // The equality arm keeps the raw grant; both LIKE arms are escaped.
+    expect(params.filter(p => p === 'group:%').length).toBe(1)
+    expect(params.filter(p => p === 'group:\\%').length).toBe(2)
+  })
+
+  it('grants without a scope filter contribute nothing', () => {
+    const bare = buildFilterClause({ status: 'active' })
+    const granted = buildFilterClause({ status: 'active', visibilityGrants: ['group:acme/eng'] })
+    expect(granted.where).toBe(bare.where)
+    expect(granted.params).toEqual(bare.params)
+  })
+
+  it('grants never touch the scopes authorization clause', () => {
+    const { where, params } = buildFilterClause({ scopes: [], visibilityGrants: ['group:acme/eng'] })
+    // The empty allow-list still compiles to `= ANY` over the empty array —
+    // matching nothing — and no grant parameter appears anywhere.
+    expect(where).toContain('= ANY')
+    expect(params).toEqual([[]])
   })
 })

--- a/packages/core/test/scope-pushdown.test.ts
+++ b/packages/core/test/scope-pushdown.test.ts
@@ -224,6 +224,46 @@ describe.skipIf(!hasSqlite)('IndexedStorage.loadFiltered — permitted-scope pus
     // And the empty allow-list still matches NOTHING, grants or no grants.
     expect(await s.loadFiltered({ scopes: [], visibilityGrants: ['group:acme/eng'] })).toEqual([])
   })
+
+  it('#775 SECURITY: LIKE metacharacters in a grant match literally on the SQLite arm', async () => {
+    // Same treatment as the pglite/postgres arms (escapeLikePattern +
+    // ESCAPE '\'): SQLite's LIKE has NO default escape character, so without
+    // the explicit clause a `_` in a grant is a single-character wildcard and
+    // a `%` matches across namespaces — a grant of `group:acme/e_g` would
+    // admit `group:acme/eXg:*`, and `group:%` would admit every group.
+    const s = await seedAndOpen([
+      mkEngram('ENG-2026-0731-301', 'exact underscore', { scope: 'group:acme/e_g' }),
+      mkEngram('ENG-2026-0731-302', 'true descendant', { scope: 'group:acme/e_g:sub' }),
+      mkEngram('ENG-2026-0731-303', 'wildcard victim', { scope: 'group:acme/eXg:sub' }),
+      mkEngram('ENG-2026-0731-304', 'percent victim', { scope: 'group:evil/team:sub' }),
+    ])
+    const underscore = (await s.loadFiltered({
+      scope: 'project:a',
+      visibilityGrants: ['group:acme/e_g'],
+    })).map(e => e.id)
+    expect(underscore).toContain('ENG-2026-0731-301') // equality arm keeps the raw value
+    expect(underscore).toContain('ENG-2026-0731-302') // escaped containment still matches literally
+    expect(underscore, 'unescaped `_` widened a grant into a sibling namespace')
+      .not.toContain('ENG-2026-0731-303')
+    const percent = (await s.loadFiltered({
+      scope: 'project:a',
+      visibilityGrants: ['group:%'],
+    })).map(e => e.id)
+    expect(percent, 'unescaped `%` in a grant matched across namespaces')
+      .not.toContain('ENG-2026-0731-304')
+    expect(percent).not.toContain('ENG-2026-0731-303')
+  })
+
+  it('#775 SECURITY: LIKE metacharacters in the filter scope match literally too', async () => {
+    const s = await seedAndOpen([
+      mkEngram('ENG-2026-0731-310', 'literal target', { scope: 'project:a_b:sub' }),
+      mkEngram('ENG-2026-0731-311', 'wildcard victim', { scope: 'project:aXb:sub' }),
+    ])
+    const ids = (await s.loadFiltered({ scope: 'project:a_b' })).map(e => e.id)
+    expect(ids).toContain('ENG-2026-0731-310')
+    expect(ids, 'unescaped `_` in the filter scope crossed namespaces')
+      .not.toContain('ENG-2026-0731-311')
+  })
 })
 
 describe('Plur read paths — permitted-scope pushdown', () => {


### PR DESCRIPTION
Closes #775. Part of the recall program (audit 2026-07-31): a project scope filter zeroed every `group:*` engram, so team engrams from mounted enterprise stores never survived hook injection or scoped recall.

## Semantics
Scopes explicitly mounted in `config.yaml` `stores:` (path AND url entries) are **visibility grants** — engrams in those scopes pass a project-scope visibility filter exactly like the personal family. Strictly visibility-only: the `options.scopes` authorization allow-list is untouched (adversarially tested), `INJECT_GLOBAL_IS_TARGETED` untouched. Default ON — mounting a store with your own token is the consent act; relevance scoring still gates injection.

## Changes
- `scope-util.ts`: `makeVisibilityPredicate(scopeFilter, grants?)` — the ONE in-memory predicate, exported.
- `inject.ts`: `InjectionContext.grantedScopes`; `scoreEngram` trailing optional param (non-breaking post-#759).
- `index.ts`: `_grantedScopes()` wired into `_formatInjection`, both `_filterEngrams` arms, `_engramsOutsidePrimaryStore`, recall pushdown.
- `StorageFilter.visibilityGrants` + all four SQL arms in lockstep (indexed / pglite / postgres; sqlite `personal` column untouched — grants are per-query).
- **Lockstep bug fix**: `PGLiteAdapter.searchBM25` was silently dropping the `scope` visibility filter (forwarded only `scopes`) — now honours the full `StorageFilter`.

## Tests (36 new)
Grants pass a project filter on yaml + indexed arms; sibling-prefix (`group:acme/eng` ≠ `group:acme/eng-private`, #383 fixtures); D1-global guard; adversarial never-widen-`options.scopes`; un-mounted regression pin; PGLite loadFiltered/searchBM25; Postgres parity + end-to-end recall pushdown (run against a live pgvector container).

Results: core 146 files / 2283 tests passed, core-pglite 15 files / 166 passed, 0 failures; build clean.

Benchmarks (bench:micro): vs main — learn 3.08→3.31ms (+0.24ms), recall BM25 4.03→3.97ms (−0.06ms), recallHybrid 17.57→16.69ms (−0.88ms), inject 0.42→0.41ms (−0.01ms); all within run-to-run noise.
