### PR TITLE
feat(core): server-authoritative remote recall with per-host degradation surfacing (#776)

### DIFF
--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -36,8 +36,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
 
-  // Search mode
-  const matches = await plur.recall(target, { limit: 100 })
+  // Search mode. remote:false (#776) — forget-by-search resolves LOCAL
+  // retirement targets; dialing every remote host with the search phrase
+  // would leak it and could surface un-forgettable remote rows as matches.
+  const matches = await plur.recall(target, { limit: 100, remote: false })
   if (matches.length === 0) {
     if (shouldOutputJson(flags)) {
       outputJson({ success: false, error: `No active engrams matching "${target}"` })

--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -271,7 +271,10 @@ function processDeferredWrapups(): string | null {
 
 // Self-watchdog ceiling for hook-inject. Hooks are fail-open — a silent
 // exit after the ceiling is always better than an immortal orphan process
-// when a background RemoteStore.load() hangs on a degraded network (#504).
+// (#504). The ceiling bounds OVERALL hook runtime: the floating background
+// RemoteStore.load() that originally motivated it is gone (#776 — the remote
+// leg is a budgeted, awaited call inside injectHybrid), but embedder loads,
+// filesystem stalls, or any future stray async work still need a hard stop.
 // Defaults to 55 s (within the 90 s harness timeout); override via env.
 // The timer is unref()ed so a normal clean exit isn't delayed.
 const HOOK_CEILING_MS = parseInt(process.env.PLUR_HOOK_CEILING_MS ?? '', 10) || 55_000
@@ -289,8 +292,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // Lets hooks be installed globally without affecting non-plur projects.
   if (!isPlurConfigured()) return
 
-  // Watchdog: guarantee this process exits even if a background network call
-  // hangs (#504). Installed after isPlurConfigured() so it only fires for
+  // Watchdog: guarantee this process exits even if something in the hook run
+  // hangs (#504) — remote calls are individually budgeted since #776, so this
+  // is the ceiling on the WHOLE run (embedder load, fs stalls, stray async).
+  // Installed after isPlurConfigured() so it only fires for
   // sessions that actually do work. unref() prevents it from delaying clean exit.
   const watchdog = setTimeout(() => process.exit(0), HOOK_CEILING_MS)
   watchdog.unref()
@@ -407,7 +412,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // is the org context for dialing). Personal/non-project sessions without a
   // project scope or remote_project dial nothing — the strict
   // scope-relevance rule keeps prompts from a CWD without an implicated
-  // remote store off the network entirely.
+  // remote store off the network entirely, with ONE exception: a store the
+  // user marked `dial: always` in config.yaml is dialed from any CWD. That
+  // is an explicit per-store opt-in to send (truncated) prompt text to that
+  // host, not something a project can turn on.
   const injectOpts = {
     source: 'hook' as const,
     remote_timeout_ms: REMOTE_TIMEOUT_MS,

--- a/packages/cli/src/commands/hook-inject.ts
+++ b/packages/cli/src/commands/hook-inject.ts
@@ -5,27 +5,20 @@ import { randomUUID } from 'crypto'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { isPlurConfigured } from '../lib/plur-configured.js'
 
-// Hard cap on the prompt text sent to Enterprise. Engram retrieval only
-// needs enough signal to rank candidates; the rest is privacy bleed
-// (Taleb #5, critic #4). 1KB is generous for relevance and trivial for
-// the network.
-const MAX_REMOTE_TASK_CHARS = 1000
-
-// Hard cap on remote response body. Prevents OOM/stall from a misconfigured
-// or adversarial server returning multi-megabyte JSON (critic #9).
-const MAX_REMOTE_RESPONSE_BYTES = 128 * 1024  // 128 KB
-
-// AbortController timeout — keep low. The hook is on the hot path of
-// every prompt; slow networks make this a perceptible latency tax
-// (Taleb #4). 1500ms is the trade-off: long enough for healthy remote
-// round trips, short enough to be invisible when the network is fine.
+// Remote budget for the recall leg inside injectHybrid (#776). The hook is
+// on the hot path of every prompt; slow networks make this a perceptible
+// latency tax (Taleb #4). 1500ms is the trade-off: long enough for healthy
+// remote round trips, short enough to be invisible when the network is fine.
+// The leg runs in PARALLEL with the local pipeline, so effective added
+// latency is max(0, remote − local). PLUR_REMOTE_RECALL_TIMEOUT_MS overrides.
 const REMOTE_TIMEOUT_MS = 1500
 
-// Failure-log dir. tryRemoteInject is fail-open by design (it MUST
+// Failure-log dir. The remote recall leg is fail-open by design (it MUST
 // never block the user's prompt) — but silent fail-open is unfalsifiable
 // (Taleb #2): you cannot distinguish "Enterprise is working but had no
 // engrams for this query" from "Enterprise is unreachable and we
-// silently degraded to local." Each remote attempt writes ONE JSON LINE.
+// silently degraded to local." Each per-host recall outcome writes ONE
+// JSON LINE.
 //
 // File-per-day rotation avoids the truncation race the earlier size-
 // based scheme had (dijkstra DEF-1): two concurrent hooks could both
@@ -42,7 +35,10 @@ function remoteInjectLogPath(): string {
 function logRemoteAttempt(entry: {
   ts:        string
   url:       string
+  // #776: the recall leg's per-host states join the legacy outcome values so
+  // old log tooling keeps parsing the same field.
   outcome:   'ok' | 'http_error' | 'timeout' | 'network_error' | 'bad_response' | 'oversize'
+           | 'unreachable' | 'auth_expired' | 'forbidden' | 'rate_limited' | 'unsupported' | 'skipped_cooldown'
   ms:        number
   http?:     number
   engrams?:  number
@@ -88,112 +84,36 @@ const REMINDER_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
 // so both this hook AND the MCP server's session_start handler can use it
 // (the original duplication was the root cause of #177 — session_start
 // ignored .plur.yaml because the reader lived in this CLI-only file).
-import { findProjectConfigPath, readProjectConfig, type ProjectConfig } from '@plur-ai/core'
+import { readProjectConfig, claimHookDegradationLines, type Plur } from '@plur-ai/core'
 
 /**
- * POST to ${remote_url}/api/v1/inject — fire a fast HTTP injection.
- *
- * Returns the formatted context text on success, or null on any failure.
- * NEVER throws: hooks must degrade open or they break the user's prompt.
- *
- * Privacy:
- *   - Only the first MAX_REMOTE_TASK_CHARS of the task are sent (truncated
- *     locally before transmission). Engram ranking doesn't need the full
- *     prompt; truncation reduces inadvertent exfiltration of pasted
- *     secrets, credentials, or proprietary content (critic #4, taleb #5).
- *   - URL is normalized via the URL constructor — strips path/query/
- *     fragment cleanly so /api/v1/inject doesn't double up if the user
- *     wrote `remote_url: https://x.com/api` (data #EC07).
- *
- * Robustness:
- *   - AbortController stays live through the full request lifecycle
- *     (headers + body). Cleared in finally so the timer doesn't fire
- *     against a settled request (critic #1, cto #4, data #EC01, dijkstra #7).
- *   - Response body is capped at MAX_REMOTE_RESPONSE_BYTES via
- *     content-length check; oversize responses → null (critic #9).
- *   - data.text trimmed before truthy check; whitespace-only payloads
- *     are treated as empty (data #EC08).
+ * #776: the former `tryRemoteInject` remote-first POST /api/v1/inject path
+ * is REPLACED by the recall leg inside `injectHybrid` — the core dials each
+ * relevant host once (POST /api/v1/recall) in parallel with local search and
+ * merges the rows, so a prompt costs AT MOST ONE remote call per host (a
+ * degraded host must not cost two sequential remote budgets per prompt).
+ * The `.plur.yaml` `remote_url`/`remote_token` is passed through as
+ * `remote_project`: project config wins for the hook path — its presence IS
+ * the org context for dialing. Per-host outcomes land in the JSONL log below
+ * and, on state change, as ONE degradation header line via
+ * `claimHookDegradationLines` (suppression persisted in remote-health.json).
  */
-async function tryRemoteInject(
-  config: ProjectConfig,
-  task:   string,
-): Promise<{ text: string; count: number; injectedIds: string[] } | null> {
-  if (!config.remote_url || !config.remote_token) return null
-  const startTs = Date.now()
-
-  // Normalize the URL to the origin so /api/v1/inject can't double up
-  // on a misconfigured remote_url with a path component.
-  let base: string
+function surfaceRemoteOutcomes(plur: Plur): string[] {
   try {
-    base = new URL(config.remote_url).origin
+    const outcomes = plur.remoteStoreStatus()
+    if (outcomes.length === 0) return []
+    for (const o of outcomes) {
+      logRemoteAttempt({
+        ts: new Date().toISOString(),
+        url: o.host,
+        outcome: o.status,
+        ms: o.ms ?? 0,
+        engrams: o.count ?? 0,
+      })
+    }
+    return claimHookDegradationLines(outcomes, { statePath: plur.remoteHealthStatePath() })
   } catch {
-    logRemoteAttempt({ ts: new Date().toISOString(), url: config.remote_url ?? '?', outcome: 'bad_response', ms: 0, detail: 'invalid URL' })
-    return null  // bogus URL → silent local fallback
-  }
-  const url  = `${base}/api/v1/inject`
-
-  // Truncate task before it leaves the machine.
-  const truncatedTask = task.length > MAX_REMOTE_TASK_CHARS
-    ? task.slice(0, MAX_REMOTE_TASK_CHARS)
-    : task
-
-  const body: Record<string, unknown> = { task: truncatedTask }
-  if (config.remote_scopes && config.remote_scopes.length > 0) {
-    body.scopes = config.remote_scopes
-  }
-
-  const ctrl = new AbortController()
-  const t = setTimeout(() => ctrl.abort(), REMOTE_TIMEOUT_MS)
-  try {
-    const r = await fetch(url, {
-      method: 'POST',
-      signal: ctrl.signal,
-      headers: {
-        'authorization': `Bearer ${config.remote_token}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    })
-    if (!r.ok) {
-      logRemoteAttempt({ ts: new Date().toISOString(), url, outcome: 'http_error', ms: Date.now() - startTs, http: r.status })
-      return null
-    }
-
-    // Guard against oversized response. content-length is advisory but
-    // most servers set it correctly; for missing/chunked responses the
-    // AbortController still terminates the body read at timeout.
-    const contentLength = r.headers.get('content-length')
-    if (contentLength && parseInt(contentLength, 10) > MAX_REMOTE_RESPONSE_BYTES) {
-      logRemoteAttempt({ ts: new Date().toISOString(), url, outcome: 'oversize', ms: Date.now() - startTs, http: r.status, detail: `content-length=${contentLength}` })
-      return null
-    }
-
-    // r.json() reads the body — AbortController still live so a slow
-    // body trickle gets cut off at REMOTE_TIMEOUT_MS overall budget.
-    const data = await r.json() as { text?: string; count?: number; injected_ids?: string[] }
-    if (typeof data.text !== 'string' || !data.text.trim()) {
-      logRemoteAttempt({ ts: new Date().toISOString(), url, outcome: 'bad_response', ms: Date.now() - startTs, http: r.status, detail: 'empty or non-string text field' })
-      return null
-    }
-    const count = typeof data.count === 'number' ? data.count : 0
-    logRemoteAttempt({ ts: new Date().toISOString(), url, outcome: 'ok', ms: Date.now() - startTs, http: r.status, engrams: count })
-    return {
-      text:        data.text,
-      count,
-      injectedIds: Array.isArray(data.injected_ids) ? data.injected_ids : [],
-    }
-  } catch (err: unknown) {
-    const isAbort = err instanceof Error && err.name === 'AbortError'
-    logRemoteAttempt({
-      ts: new Date().toISOString(),
-      url,
-      outcome: isAbort ? 'timeout' : 'network_error',
-      ms: Date.now() - startTs,
-      detail: err instanceof Error ? err.message.slice(0, 120) : undefined,
-    })
-    return null
-  } finally {
-    clearTimeout(t)
+    return [] // surfacing must never break the prompt
   }
 }
 
@@ -481,55 +401,60 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
   let injectSessionId: string | undefined
   try { injectSessionId = JSON.parse(readFileSync(marker, 'utf8')).sessionId } catch { /* fail-open */ }
+  // #776: the remote leg rides INSIDE injectHybrid — at most one remote call
+  // per host per prompt. `.plur.yaml`'s remote_url/remote_token pass through
+  // as remote_project (project config wins for the hook path; its presence
+  // is the org context for dialing). Personal/non-project sessions without a
+  // project scope or remote_project dial nothing — the strict
+  // scope-relevance rule keeps prompts from a CWD without an implicated
+  // remote store off the network entirely.
   const injectOpts = {
     source: 'hook' as const,
+    remote_timeout_ms: REMOTE_TIMEOUT_MS,
     ...(projectConfig.scope ? { scope: projectConfig.scope } : {}),
     ...(injectSessionId ? { session_id: injectSessionId } : {}),
+    ...(projectConfig.remote_url && projectConfig.remote_token
+      ? {
+          remote_project: {
+            url: projectConfig.remote_url,
+            token: projectConfig.remote_token,
+            ...(projectConfig.remote_scopes && projectConfig.remote_scopes.length > 0
+              ? { scopes: projectConfig.remote_scopes }
+              : {}),
+          },
+        }
+      : {}),
   }
   let context: string | null = null
   let count = 0
-  let remoteUsed = false
 
-  // Remote-first when the project has opted in (.plur.yaml has remote_url +
-  // remote_token). Personal/non-project sessions skip this entirely —
-  // findProjectConfigPath returns null and the config is empty, so the
-  // network call is never made. Privacy guarantee: prompts from a CWD
-  // without a .plur.yaml never reach Enterprise.
-  if (projectConfig.remote_url && projectConfig.remote_token) {
-    const remote = await tryRemoteInject(projectConfig, task)
-    if (remote && remote.count > 0) {
-      context = remote.text
-      count = remote.count
-      remoteUsed = true
+  try {
+    const result = await plur.injectHybrid(task, injectOpts)
+    if (result.count > 0) {
+      const parts: string[] = []
+      if (result.directives) parts.push(result.directives)
+      if (result.constraints) parts.push(result.constraints)
+      if (result.consider) parts.push(result.consider)
+      context = parts.join('\n')
+      count = result.count
     }
-    // If remote returned null or zero engrams, fall through to local so
-    // the user still gets personal-store context.
-  }
-
-  if (!remoteUsed) {
-    try {
-      const result = await plur.injectHybrid(task, injectOpts)
-      if (result.count > 0) {
-        const parts: string[] = []
-        if (result.directives) parts.push(result.directives)
-        if (result.constraints) parts.push(result.constraints)
-        if (result.consider) parts.push(result.consider)
-        context = parts.join('\n')
-        count = result.count
-      }
-    } catch {
-      // Fall back to BM25
-      const result = await plur.inject(task, injectOpts)
-      if (result.count > 0) {
-        const parts: string[] = []
-        if (result.directives) parts.push(result.directives)
-        if (result.constraints) parts.push(result.constraints)
-        if (result.consider) parts.push(result.consider)
-        context = parts.join('\n')
-        count = result.count
-      }
+  } catch {
+    // Fall back to BM25 (local-only by design — inject() never dials).
+    const result = await plur.inject(task, injectOpts)
+    if (result.count > 0) {
+      const parts: string[] = []
+      if (result.directives) parts.push(result.directives)
+      if (result.constraints) parts.push(result.constraints)
+      if (result.consider) parts.push(result.consider)
+      context = parts.join('\n')
+      count = result.count
     }
   }
+
+  // A4′ (#776): per-host recall outcomes → JSONL log + rate-limited
+  // degradation header lines (printed on state change, then ≤ once per 4h
+  // per (host, state); skipped_cooldown/unsupported never print).
+  const degradationLines = surfaceRemoteOutcomes(plur)
 
   // Build session header
   const parts: string[] = []
@@ -537,11 +462,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // Session id for the label — already read above for injection attribution.
   const sessionId = injectSessionId
 
-  const sourceLabel = remoteUsed ? ' (Enterprise)' : ''
   if (isRehydrate) {
-    parts.push(`[PLUR Memory${sourceLabel} — rehydrated after compaction, ${count} engrams]`)
+    parts.push(`[PLUR Memory — rehydrated after compaction, ${count} engrams]`)
   } else {
-    parts.push(`[PLUR Memory${sourceLabel} — session started, ${count} engrams injected]`)
+    parts.push(`[PLUR Memory — session started, ${count} engrams injected]`)
     if (sessionId) parts.push(`Session ID: ${sessionId}`)
     if (projectConfig.domain) parts.push(`Project domain: ${projectConfig.domain}`)
     if (projectConfig.scope) parts.push(`Project scope: ${projectConfig.scope} — use this scope for plur_learn calls`)
@@ -550,6 +474,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const deferredNotice = processDeferredWrapups()
     if (deferredNotice) parts.push('', deferredNotice)
   }
+
+  // A4′ (#776): degradation header — one line per (host, state) change.
+  for (const line of degradationLines) parts.push(line)
 
   if (context) {
     parts.push('')

--- a/packages/cli/test/hook-remote-recall.test.ts
+++ b/packages/cli/test/hook-remote-recall.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Hook path × server-authoritative recall (#776, plan A2′/A4′).
+ *
+ * The former remote-first `tryRemoteInject` POST /api/v1/inject path is
+ * REPLACED by the recall leg inside `injectHybrid`. Pinned here, against a
+ * real-HTTP stub server from a real spawned hook process:
+ *
+ *   - the hook makes AT MOST ONE remote call per host per prompt (a degraded
+ *     host must not cost two sequential remote budgets)
+ *   - it dials POST /api/v1/recall (not /inject) with the 1500ms hook budget
+ *     threaded through as `timeout_ms`
+ *   - `.plur.yaml` remote_url/remote_token is the org context for dialing
+ *   - PLUR_REMOTE_RECALL=off → zero remote calls from the hook
+ *   - a degraded host prints ONE [PLUR] header line on state change, and the
+ *     suppression state persists ACROSS hook processes (second spawned run
+ *     stays silent)
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { spawn } from 'child_process'
+import { StubServer } from '../../core/test/helpers/stub-server.js'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+const TOKEN = 'hook-recall-token'
+const SCOPE = 'group:test'
+
+let server: StubServer
+let baseUrl: string
+
+describe('hook-inject × remote recall (#776)', () => {
+  let dir: string
+  let runIdx = 0
+
+  beforeAll(async () => {
+    server = new StubServer(TOKEN)
+    const info = await server.start()
+    baseUrl = info.url
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-hook-rr-'))
+    server.reset()
+    mkdirSync(join(dir, '.plur'), { recursive: true })
+    writeFileSync(
+      join(dir, '.plur', 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "${baseUrl}"\n    token: "${TOKEN}"\n    scope: "${SCOPE}"\n`,
+    )
+    // .plur.yaml: project scope (org 'test' → implicates the store above) AND
+    // the remote_url/remote_token project opt-in. Its presence also satisfies
+    // isPlurConfigured for the spawned hook.
+    writeFileSync(
+      join(dir, '.plur.yaml'),
+      `scope: project:test/app\nremote_url: ${baseUrl}\nremote_token: ${TOKEN}\n`,
+    )
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // ASYNC spawn, deliberately: the StubServer lives in THIS process, and a
+  // spawnSync would block the event loop for the child's whole lifetime — the
+  // stub could never accept the child's connection and every hook dial would
+  // read as a timeout (the deadlock is the harness's, not the hook's).
+  function runHook(extraEnv: Record<string, string> = {}): Promise<{ stdout: string; status: number }> {
+    // Fresh TMPDIR per invocation: the session marker is keyed on ppid, and a
+    // reused marker turns the second run into a reminder no-op.
+    const tmp = join(dir, `tmp-${runIdx++}`)
+    mkdirSync(tmp, { recursive: true })
+    return new Promise((resolve, reject) => {
+      const child = spawn('node', [CLI, 'hook-inject'], {
+        env: {
+          ...process.env,
+          HOME: dir,
+          USERPROFILE: dir,
+          TMPDIR: tmp,
+          PLUR_PATH: join(dir, '.plur'),
+          ...extraEnv,
+        },
+        cwd: dir,
+      })
+      let stdout = ''
+      let settled = false
+      const timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        child.kill('SIGKILL')
+        reject(new Error(`hook-inject timed out; partial stdout: ${stdout.slice(0, 400)}`))
+      }, 20000)
+      child.stdout.on('data', (d) => { stdout += String(d) })
+      child.on('error', (err) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        reject(err)
+      })
+      child.on('close', (code) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve({ stdout, status: code ?? 1 })
+      })
+      child.stdin.write(JSON.stringify({ prompt: 'what are the deployment conventions' }))
+      child.stdin.end()
+    })
+  }
+
+  it('makes exactly ONE remote call per host per prompt, to /recall, with the 1500ms budget', async () => {
+    server.recallRows = [{
+      id: 'ENG-2026-0731-070', scope: SCOPE, status: 'active',
+      statement: 'deployment conventions require canary verification', score: 1,
+    }]
+    const { stdout, status } = await runHook()
+    expect(status).toBe(0)
+    // ≤1 remote call per host per prompt — the replaced tryRemoteInject path
+    // must NOT fire a second budget.
+    expect(server.recallCalls).toBe(1)
+    // Opts threading: hook budget 1500ms reaches the wire as timeout_ms.
+    expect(server.lastRecallBody?.timeout_ms).toBe(1500)
+    // The server row made it into the injected context.
+    expect(stdout).toContain('PLUR Memory')
+    expect(stdout).toContain('canary verification')
+  })
+
+  it('PLUR_REMOTE_RECALL=off → zero remote calls from the hook', async () => {
+    server.recallRows = [{
+      id: 'ENG-2026-0731-071', scope: SCOPE, status: 'active',
+      statement: 'should never be fetched', score: 1,
+    }]
+    const { status } = await runHook({ PLUR_REMOTE_RECALL: 'off' })
+    expect(status).toBe(0)
+    expect(server.recallCalls).toBe(0)
+  })
+
+  it('degraded host prints ONE [PLUR] header line, suppressed across hook processes', async () => {
+    server.recallStatus = 500
+    const first = await runHook()
+    expect(first.status).toBe(0)
+    expect(first.stdout).toMatch(/\[PLUR\] .*unreachable — team memory skipped/)
+
+    // Second one-shot process, same state: the suppression marker persisted
+    // in remote-health.json keeps the header out of the next prompt.
+    const second = await runHook()
+    expect(second.status).toBe(0)
+    expect(second.stdout).not.toMatch(/unreachable — team memory skipped/)
+  })
+
+  it('a healthy host prints no degradation header', async () => {
+    server.recallRows = []
+    const { stdout, status } = await runHook()
+    expect(status).toBe(0)
+    expect(stdout).not.toContain('[PLUR] ')
+  })
+})

--- a/packages/cli/test/hook-remote-recall.test.ts
+++ b/packages/cli/test/hook-remote-recall.test.ts
@@ -30,7 +30,9 @@ let server: StubServer
 let baseUrl: string
 
 describe('hook-inject × remote recall (#776)', () => {
+  let root: string
   let dir: string
+  let home: string
   let runIdx = 0
 
   beforeAll(async () => {
@@ -44,7 +46,18 @@ describe('hook-inject × remote recall (#776)', () => {
   })
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'plur-hook-rr-'))
+    // The spawned hook's HOME must NOT be the project cwd (#778):
+    // findProjectConfigPath deliberately refuses a `.plur.yaml` that sits
+    // directly in HOME (privacy guard), so a HOME==cwd harness reads an
+    // EMPTY project config — no scope, no remote_project, zero dialing.
+    // That shape only ever passed on macOS, where the /var→/private/var
+    // tmpdir symlink made the (pre-canonicalization) home comparison miss.
+    // Model the real deployment: project dir and home are separate.
+    root = mkdtempSync(join(tmpdir(), 'plur-hook-rr-'))
+    dir = join(root, 'project')
+    home = join(root, 'home')
+    mkdirSync(dir, { recursive: true })
+    mkdirSync(home, { recursive: true })
     server.reset()
     mkdirSync(join(dir, '.plur'), { recursive: true })
     writeFileSync(
@@ -61,7 +74,7 @@ describe('hook-inject × remote recall (#776)', () => {
   })
 
   afterEach(() => {
-    rmSync(dir, { recursive: true, force: true })
+    rmSync(root, { recursive: true, force: true })
   })
 
   // ASYNC spawn, deliberately: the StubServer lives in THIS process, and a
@@ -71,14 +84,14 @@ describe('hook-inject × remote recall (#776)', () => {
   function runHook(extraEnv: Record<string, string> = {}): Promise<{ stdout: string; status: number }> {
     // Fresh TMPDIR per invocation: the session marker is keyed on ppid, and a
     // reused marker turns the second run into a reminder no-op.
-    const tmp = join(dir, `tmp-${runIdx++}`)
+    const tmp = join(root, `tmp-${runIdx++}`)
     mkdirSync(tmp, { recursive: true })
     return new Promise((resolve, reject) => {
       const child = spawn('node', [CLI, 'hook-inject'], {
         env: {
           ...process.env,
-          HOME: dir,
-          USERPROFILE: dir,
+          HOME: home,
+          USERPROFILE: home,
           TMPDIR: tmp,
           PLUR_PATH: join(dir, '.plur'),
           ...extraEnv,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,10 @@ import { engramDate } from './tensions.js'
 import { resolveValidity, buildTemporal } from './expiry.js'
 import { decodeJwtExpiry } from './jwt.js'
 import { RemoteStore, normalizeEndpointUrl } from './store/remote-store.js'
+import {
+  remoteRecall, isRemoteRecallDisabled, resolveRemoteRecallTimeoutMs, scopeOrg,
+  type RemoteRecallHost, type RemoteRecallResult, type HostRecallOutcome, type RemoteStoreStatusEntry,
+} from './remote-recall.js'
 import { YamlPrimaryStore } from './store/yaml-primary-store.js'
 import { withAsyncLock } from './store/async-lock.js'
 import { SessionScopeRegistry } from './session-scopes.js'
@@ -70,6 +74,7 @@ import type {
   CaptureContext,
   TimelineQuery,
   LlmFunction,
+  RemoteProjectConfig,
 } from './types.js'
 
 export * from './meta/index.js'
@@ -256,6 +261,19 @@ export {
  * plausible strength, and the two deployments simply stop agreeing.
  */
 export { rrfMergeEngrams } from './hybrid-search.js'
+// Server-authoritative remote recall (#776) — client, health persistence,
+// degradation string table (A4′), and env knobs. The MCP server and CLI hook
+// consume these so all three surfaces share ONE state vocabulary + strings.
+export {
+  remoteRecall, isRemoteRecallDisabled, resolveRemoteRecallTimeoutMs,
+  remoteHealthPath, readRemoteHealth, scopeOrg,
+  mcpRemoteWarningLine, hookRemoteHeaderLine, doctorRemoteRemediation,
+  claimHookDegradationLines,
+  MAX_REMOTE_QUERY_CHARS, MAX_REMOTE_RESPONSE_BYTES, DEFAULT_REMOTE_RECALL_TIMEOUT_MS,
+  BREAKER_FAILURE_THRESHOLD, BREAKER_COOLDOWN_MS, UNSUPPORTED_TTL_MS, HOOK_HEADER_REPEAT_MS,
+  type RemoteRecallHost, type RemoteRecallResult, type HostRecallOutcome,
+  type RemoteHostState, type RemoteStoreStatusEntry, type RemoteRecallOptions,
+} from './remote-recall.js'
 export {
   applyFeedbackSignal, nextCommitment,
   POSITIVE_STRENGTH_DELTA, NEGATIVE_STRENGTH_DELTA,
@@ -877,27 +895,22 @@ export class Plur {
    * first call after process start returns [] for that store, and only the
    * call after the first refresh completes sees the data.
    *
-   * The reason that USED to justify it no longer holds. It was written when
-   * `_loadAllEngrams` was synchronous and physically could not await a
-   * network load; convergence Phase 2 made `_loadAllEngrams` async, and its
-   * sibling branch already does `await this._loadCached(...)`. So this is now
-   * a workaround for a constraint that was removed — awaiting `driver.load()`
-   * here would be legal and would delete the cold-start hole outright.
-   *
-   * Left as-is deliberately: making it await changes when remote engrams
-   * appear and puts a network round-trip on the first recall of every
-   * session, which is a behavioural change that wants its own change and its
-   * own tests rather than a drive-by inside a docs fix. Follow-up: await the
-   * load and drop the private-cache peek (the `as unknown as { cache }` cast
-   * below is reaching past `RemoteStore`'s encapsulation to sustain it).
+   * #776 (server-authoritative recall): this peek is DEMOTED. Live recall now
+   * reaches remote engrams through `remoteRecall` (`POST /api/v1/recall` per
+   * host, merged at the call sites), so the peek serves only the non-recall
+   * duties that still route through `_loadSecondaryAndPacks` (stores_list
+   * counts, feedback/getById resolution) plus warm-site loads. The floating
+   * `void driver.load()` background refresh that used to fire here on EVERY
+   * read is gone with it — the refresh existed to make the NEXT recall less
+   * cold, and recall no longer feeds from this cache. Warm sites
+   * (`warmRemoteCaches`) still populate it explicitly.
    */
   private _remoteStores = new Map<string, RemoteStore>()
   private _loadRemoteCached(store: StoreEntry): Engram[] {
     const driver = this._getRemoteDriver({ url: store.url!, token: store.token, scope: store.scope })
-    // Synchronously read whatever the driver currently has cached.
-    // Trigger a refresh in the background; the next call sees fresh data.
+    // Synchronously read whatever the driver currently has cached — no
+    // background refresh (#776, see JSDoc above).
     const cached = (driver as unknown as { cache: { engrams: Engram[] } | null }).cache
-    void driver.load().catch(() => { /* errors logged inside RemoteStore */ })
     return cached?.engrams ?? []
   }
 
@@ -2343,8 +2356,12 @@ export class Plur {
   private async _learnAsyncDeps() {
     return {
       hashDedup: async (statement: string, scope?: string) => this._hashDedup(statement, await this._loadAllEngrams(), scope),
-      recallHybrid: (query: string, options?: { limit?: number }) => this.recallHybrid(query, options),
-      recall: (query: string, options?: { limit?: number }) => this.recall(query, options),
+      // remote:false (#776) — dedup queries are DERIVED FROM STATEMENTS. With
+      // the remote leg on, every plur_learn would fire statement-derived POSTs
+      // to all hosts, and a namespaced remote row could silently suppress a
+      // local write as a "dedup match". Dedup is a local decision.
+      recallHybrid: (query: string, options?: { limit?: number }) => this.recallHybrid(query, { ...options, remote: false }),
+      recall: (query: string, options?: { limit?: number }) => this.recall(query, { ...options, remote: false }),
       learn: (statement: string, context?: LearnContext) => this.learn(statement, context),
       getById: (id: string) => this.getById(id),
       store: this._primaryStore,
@@ -2381,9 +2398,17 @@ export class Plur {
    *   - 'fast' (default): BM25 keyword search, instant, no API calls
    *   - 'agentic': LLM-assisted semantic search, higher accuracy, requires llm function
    */
-  /** Search engrams using fast BM25 keyword matching. Sync, no API calls. */
+  /** Search engrams using fast BM25 keyword matching over the local corpus,
+   *  merged with the live server-authoritative remote leg (#776) when a
+   *  configured remote host is implicated by the current project/work.
+   *  `remote: false` (internal callers) or PLUR_REMOTE_RECALL=off keeps it
+   *  fully local. */
   async recall(query: string, options?: Omit<RecallOptions, 'mode' | 'llm'>): Promise<Engram[]> {
     const limit = options?.limit ?? 20
+
+    // #776: start the remote leg BEFORE the local pipeline so the effective
+    // added latency is max(0, remote − local), not remote + local.
+    const remotePromise = this._startRemoteRecall(query, options)
 
     // Push the search into the store when the store can answer it.
     //
@@ -2496,14 +2521,16 @@ export class Plur {
       } else {
         results = surviving.slice(0, limit)
       }
-      await this._reactivateResults(results)
-      return results
+      const merged = await this._mergeRemoteRecall(results, remotePromise, options, limit)
+      await this._reactivateResults(merged)
+      return merged
     }
 
     const filtered = await this._filterEngrams(options)
     const results = searchEngrams(filtered, query, limit)
-    await this._reactivateResults(results)
-    return results
+    const merged = await this._mergeRemoteRecall(results, remotePromise, options, limit)
+    await this._reactivateResults(merged)
+    return merged
   }
 
   /**
@@ -2580,6 +2607,9 @@ export class Plur {
     query: string,
     options?: Omit<RecallOptions, 'mode' | 'llm'>,
   ): Promise<HybridSearchResult> {
+    // #776: remote leg starts BEFORE the local pipeline (added latency =
+    // max(0, remote − local)); merged below via RRF.
+    const remotePromise = this._startRemoteRecall(query, options)
     const filtered = await this._filterEngrams(options)
     const limit = options?.limit ?? 20
     const rerank = await this._resolveRerankOptions(options?.rerank)
@@ -2607,6 +2637,9 @@ export class Plur {
     } else {
       result = await hybridSearchWithMeta(filtered, query, limit, this.paths.root, rerank)
     }
+    // #776: fold the server leg in (RRF) before reactivation so displaced
+    // local rows are not reactivated and server rows rank on merged order.
+    result = { ...result, engrams: await this._mergeRemoteRecall(result.engrams, remotePromise, options, limit) }
     await this._reactivateResults(result.engrams)
     // WS5 demand flywheel: a zero-result or low-top-score recall is a demand
     // signal. Emit an anonymized, content-free miss-signal (query fingerprint +
@@ -2998,6 +3031,243 @@ export class Plur {
     return [...new Set((this.config.stores ?? []).map(s => s.scope))]
   }
 
+  // -------------------------------------------------------------------------
+  // Server-authoritative remote recall (#776, plan A2′)
+  // -------------------------------------------------------------------------
+
+  /** Last per-host recall outcomes (in-process), keyed by normalized URL —
+   *  feeds `remoteStoreStatus()` (plan A4′). */
+  private _lastRemoteOutcomes = new Map<string, HostRecallOutcome>()
+
+  /** Where breaker/cooldown/unsupported state persists across processes.
+   *  Inside the store root so tests and PLUR_PATH overrides isolate it. */
+  remoteHealthStatePath(): string {
+    return join(this.paths.root, 'cache', 'remote-health.json')
+  }
+
+  /**
+   * Strict scope-relevance dialing (#776, user decision — plan rows 39/44).
+   *
+   * For each configured (url, token) endpoint group, the dialed scope set is
+   * the subset of its granted scopes relevant to the current project/work:
+   *   (a) shared (group:/project:/…) scopes sharing the ORG segment with the
+   *       session's project scope — org of `project:plur/plur-ai/enterprise`
+   *       is `plur`, so every `group:plur/…` + `project:plur/…` scope on that
+   *       host is relevant;
+   *   (b) the host's personal-family (`user:*`, …) scopes ONLY when an org
+   *       context exists implicating that host.
+   * No project/work context implicating a remote store → ZERO remote calls.
+   * A host whose relevant subset is empty is NOT dialed — a datafund-org host
+   * is never dialed from plur-org work (cross-org exfiltration solved by
+   * construction).
+   *
+   * Overrides: per-store `dial: never` removes the entry from dialing;
+   * `dial: always` forces its host to be dialed with that entry's scope,
+   * context or not. A `.plur.yaml` `remote_url`/`remote_token`
+   * (`options.remote_project`, hook path) IS the org context for its host —
+   * project config wins: a matching mounted group dials with the project's
+   * token when one is supplied, and an unmounted project endpoint dials
+   * standalone with the project's `remote_scopes`.
+   *
+   * Grouping is by (url, token), not url alone — `_distinctRemoteEndpoints`'s
+   * "tokens should be identical" assumption is unchecked, and differing
+   * tokens per host mean one POST per token. `remoteEndpointTokenConflicts`
+   * feeds the doctor warning for that misconfiguration.
+   */
+  private _remoteRecallHosts(options?: { scope?: string; remote_project?: RemoteProjectConfig }): RemoteRecallHost[] {
+    const stores = (this.config.stores ?? []).filter(s => s.url)
+    const rp = options?.remote_project
+    const rpKey = rp ? normalizeEndpointUrl(rp.url) : null
+    const sessionOrg = scopeOrg(options?.scope)
+
+    const groups = new Map<string, { url: string; token?: string; entries: StoreEntry[] }>()
+    for (const s of stores) {
+      const key = `${normalizeEndpointUrl(s.url!)} ${s.token ?? ''}`
+      let g = groups.get(key)
+      if (!g) { g = { url: s.url!, token: s.token, entries: [] }; groups.set(key, g) }
+      g.entries.push(s)
+    }
+
+    const hosts: RemoteRecallHost[] = []
+    for (const g of groups.values()) {
+      const dialable = g.entries.filter(e => e.dial !== 'never')
+      if (dialable.length === 0) continue
+      const always = dialable.filter(e => e.dial === 'always')
+      const shared = dialable.filter(e => isSharedScope(e.scope))
+      const personal = dialable.filter(e => !isSharedScope(e.scope))
+      const orgAffine = sessionOrg ? shared.filter(e => scopeOrg(e.scope) === sessionOrg) : []
+      const projectImplicated = rpKey !== null && rpKey === normalizeEndpointUrl(g.url)
+      const orgContext = orgAffine.length > 0 || projectImplicated
+      if (!orgContext && always.length === 0) continue
+      const selected = new Set<StoreEntry>(orgAffine)
+      if (projectImplicated) for (const e of shared) selected.add(e)
+      for (const e of always) selected.add(e)
+      if (orgContext) for (const e of personal) selected.add(e)
+      // Config order preserved — row→entry mapping must be deterministic.
+      const dialEntries = dialable.filter(e => selected.has(e))
+      if (dialEntries.length === 0) continue
+      hosts.push({
+        url: g.url,
+        token: (projectImplicated && rp?.token) ? rp.token : (g.token ?? ''),
+        scopes: [...new Set(dialEntries.map(e => e.scope))],
+        entries: dialEntries.map(e => ({ scope: e.scope })),
+      })
+    }
+
+    // Standalone `.plur.yaml` endpoint not mounted in config.stores: dial it
+    // with the project's own remote_scopes (the scope guard needs a scope set
+    // to admit rows against; without one there is nothing safe to accept).
+    if (rp?.token && rpKey && !stores.some(s => normalizeEndpointUrl(s.url!) === rpKey)) {
+      const scopes = [...new Set(rp.scopes ?? [])]
+      if (scopes.length > 0) {
+        hosts.push({ url: rp.url, token: rp.token, scopes, entries: scopes.map(scope => ({ scope })) })
+      }
+    }
+    return hosts
+  }
+
+  /**
+   * Start the remote recall leg — called BEFORE the local pipeline so the
+   * effective added latency is max(0, remote − local). Returns null (zero
+   * fetches, zero new latency) when: the caller opted out (`remote: false` —
+   * learn-dedup, forget-by-search, self-eval), the `PLUR_REMOTE_RECALL`
+   * kill-switch is set, the query is empty, or no host is implicated by the
+   * current project/work. The returned promise NEVER rejects.
+   */
+  private _startRemoteRecall(
+    query: string,
+    options?: { scope?: string; remote?: boolean; remote_timeout_ms?: number; remote_project?: RemoteProjectConfig; limit?: number },
+  ): Promise<RemoteRecallResult> | null {
+    if (options?.remote === false) return null
+    if (isRemoteRecallDisabled()) return null
+    if (!query || !query.trim()) return null
+    const hosts = this._remoteRecallHosts(options)
+    if (hosts.length === 0) return null
+    return remoteRecall(hosts, query, {
+      timeoutMs: resolveRemoteRecallTimeoutMs(options?.remote_timeout_ms),
+      limit: options?.limit,
+      statePath: this.remoteHealthStatePath(),
+    }).then(result => {
+      for (const o of result.outcomes) this._lastRemoteOutcomes.set(normalizeEndpointUrl(o.url), o)
+      return result
+    }).catch((): RemoteRecallResult => ({ engrams: [], scores: new Map(), outcomes: [] }))
+  }
+
+  /**
+   * Apply the SAME read-side filters to server rows that every local read
+   * path applies: `options.scopes` authorization (exact membership),
+   * `options.scope` visibility (with grants — server rows sit in granted
+   * scopes by construction after the scope guard's global admission +
+   * narrowing), domain, and the residual temporal/strength filters.
+   */
+  private _filterRemoteRows(rows: Engram[], options?: RecallOptions & { include_expired?: boolean }): Engram[] {
+    let filtered = rows.filter(e => e.status === 'active')
+    if (options?.scopes !== undefined) {
+      const allowed = scopeAllowFilter(options.scopes)
+      filtered = filtered.filter(e => allowed(e.scope))
+    }
+    if (options?.domain) filtered = filtered.filter(e => e.domain?.startsWith(options.domain!))
+    if (options?.scope) {
+      const visible = makeVisibilityPredicate(options.scope, this._grantedScopes())
+      filtered = filtered.filter(e => visible(e.scope))
+    }
+    return this._applyResidualFilters(filtered, options)
+  }
+
+  /**
+   * Merge the remote leg into a local result set via RRF. Server rows go
+   * FIRST so the server copy wins object identity for ids present in both
+   * sets (the local set can hold a stale peek-cache copy of the same remote
+   * row); RRF scoring itself is order-independent, so this affects identity
+   * only, not ranking.
+   */
+  private async _mergeRemoteRecall(
+    local: Engram[],
+    remotePromise: Promise<RemoteRecallResult> | null,
+    options: (RecallOptions & { include_expired?: boolean }) | undefined,
+    limit: number,
+  ): Promise<Engram[]> {
+    if (!remotePromise) return local
+    const remote = await remotePromise
+    const rows = this._filterRemoteRows(remote.engrams, options)
+    if (rows.length === 0) return local
+    return pgliteRrfMerge([rows, local]).slice(0, limit)
+  }
+
+  /**
+   * Server rows for the injection path (#776): filtered for authorization +
+   * visibility BEFORE boosts are assigned — the boost channel resurrects
+   * scope-zeroed rows otherwise (`scoreEngram` returns 0 for both
+   * no-keyword-hits and scope-excluded, and `raw = embBoost*2` revives
+   * anything > 0.5). Boost = 0.55 + 0.45·score, so every server-ranked row
+   * clears the 0.5 semantic threshold and the server's top row maps to 1.0.
+   */
+  private async _remoteInjectCandidates(
+    remotePromise: Promise<RemoteRecallResult> | null,
+    options?: InjectOptions,
+  ): Promise<{ engrams: Engram[]; boosts: Map<string, number> } | undefined> {
+    if (!remotePromise) return undefined
+    const remote = await remotePromise
+    if (remote.engrams.length === 0) return undefined
+    const permitted = options?.scopes
+    let rows = remote.engrams.filter(e => e.status === 'active')
+    if (permitted !== undefined) rows = rows.filter(e => permitted.includes(e.scope))
+    if (options?.scope) {
+      if (options.scope === 'global') {
+        // INJECT_GLOBAL_IS_TARGETED (D1-ASYMMETRY): explicit global inject is
+        // targeted to the global namespace only. Server rows are namespaced —
+        // global rows were narrowed to their store scope — so none pass here,
+        // by design; grants do not reach the targeted-global branch.
+        rows = rows.filter(e => e.scope === 'global')
+      } else {
+        const visible = makeVisibilityPredicate(options.scope, this._grantedScopes())
+        rows = rows.filter(e => visible(e.scope))
+      }
+    }
+    if (rows.length === 0) return undefined
+    const boosts = new Map<string, number>()
+    for (const e of rows) {
+      const s = remote.scores.get(e.id) ?? 0
+      boosts.set(e.id, 0.55 + 0.45 * Math.max(0, Math.min(1, s)))
+    }
+    return { engrams: rows, boosts }
+  }
+
+  /**
+   * Per-host remote recall degradation status (plan A4′), fed by the last
+   * outcomes this process observed — NOT by driver caches or fresh probes.
+   * MCP surfaces attach a `remote_stores` block from this when any host is
+   * non-ok (or silently scope-narrowed); plur_doctor renders remediation.
+   */
+  remoteStoreStatus(): RemoteStoreStatusEntry[] {
+    return [...this._lastRemoteOutcomes.values()].map(o => ({
+      host: normalizeEndpointUrl(o.url),
+      status: o.state,
+      ...(o.dropped_scopes && o.dropped_scopes.length > 0 ? { dropped_scopes: o.dropped_scopes } : {}),
+      ms: o.ms,
+      count: o.count,
+    }))
+  }
+
+  /**
+   * Endpoints configured with more than one distinct token (#776). The
+   * (url, token) fan-out dials once per token, so this is a misconfiguration
+   * worth a doctor warning — same user, same instance should mean one token.
+   */
+  remoteEndpointTokenConflicts(): Array<{ url: string; tokens: number }> {
+    const byUrl = new Map<string, { url: string; tokens: Set<string> }>()
+    for (const s of this.config.stores ?? []) {
+      if (!s.url) continue
+      const key = normalizeEndpointUrl(s.url)
+      let rec = byUrl.get(key)
+      if (!rec) { rec = { url: s.url, tokens: new Set() }; byUrl.set(key, rec) }
+      rec.tokens.add(s.token ?? '')
+    }
+    return [...byUrl.values()]
+      .filter(r => r.tokens.size > 1)
+      .map(r => ({ url: r.url, tokens: r.tokens.size }))
+  }
+
   /**
    * Engrams a primary-store pushdown cannot see: secondary (team/project)
    * stores from `config.stores`, and installed packs.
@@ -3219,6 +3489,16 @@ export class Plur {
 
   /** Scored injection with embedding boost when available. Falls back to BM25 if embeddings not installed. */
   async injectHybrid(task: string, options?: InjectOptions): Promise<InjectionResult> {
+    // #776: the remote leg starts FIRST — it runs in parallel with the local
+    // embedding work below and REPLACES the old hook `tryRemoteInject`
+    // remote-first POST /inject path, so a prompt costs at most ONE remote
+    // call per host.
+    const remotePromise = this._startRemoteRecall(task, {
+      scope: options?.scope,
+      remote: options?.remote,
+      remote_timeout_ms: options?.remote_timeout_ms,
+      remote_project: options?.remote_project,
+    })
     // Use actual cosine similarity scores as boosts so the 0.5 threshold in
     // selectAndSpread is meaningful. (Pre-0.9.4 used rank-based 1/(1+i*0.1)
     // which gave the top result boost=1.0 even when its cosine was 0.4 —
@@ -3318,12 +3598,43 @@ export class Plur {
     } catch {
       // Embeddings unavailable — continue without boosts
     }
-    return await this._formatInjection(task, options, embeddingBoosts)
+    // #776: server rows join the candidate pool + boost channel. Visibility/
+    // authorization run over them INSIDE _remoteInjectCandidates, before any
+    // boost exists to resurrect a scope-excluded row.
+    const remote = await this._remoteInjectCandidates(remotePromise, options)
+    return await this._formatInjection(task, options, embeddingBoosts, remote)
   }
 
-  private async _formatInjection(task: string, options?: InjectOptions, embeddingBoosts?: Map<string, number>): Promise<InjectionResult> {
-    const allEngrams = await this._loadAllEngrams()
+  private async _formatInjection(
+    task: string,
+    options?: InjectOptions,
+    embeddingBoosts?: Map<string, number>,
+    // #776: pre-filtered server rows + their score-derived boosts. Only
+    // injectHybrid supplies this — the BM25-only inject() path NEVER makes a
+    // remote call.
+    remote?: { engrams: Engram[]; boosts: Map<string, number> },
+  ): Promise<InjectionResult> {
+    let allEngrams = await this._loadAllEngrams()
     const allPacks = loadAllPacks(this.paths.packs)
+
+    if (remote && remote.engrams.length > 0) {
+      // Candidate-pool dedup by namespaced id — the SERVER copy wins (fresher
+      // than any peek-cache copy of the same remote row that
+      // _loadSecondaryAndPacks may have merged in).
+      const serverIds = new Set(remote.engrams.map(e => e.id))
+      allEngrams = [...allEngrams.filter(e => !serverIds.has(e.id)), ...remote.engrams]
+      // Boost-channel entry. The map is SHARED with the local cosine/reranker
+      // writes — collision rule is max-merge, so neither channel can lower
+      // the other's signal.
+      if (embeddingBoosts) {
+        for (const [id, boost] of remote.boosts) {
+          const cur = embeddingBoosts.get(id)
+          embeddingBoosts.set(id, cur === undefined ? boost : Math.max(cur, boost))
+        }
+      } else {
+        embeddingBoosts = remote.boosts
+      }
+    }
 
     // Permitted-scope allow-list — AUTHORIZATION, applied before selection.
     //
@@ -5675,8 +5986,14 @@ Generate an improved version of the procedure that prevents this failure. Return
    * per spelling and split its registered-scope view across the copies. The
    * FIRST configured spelling is what gets reported/queried; stored values are
    * never rewritten.
+   *
+   * Public since #776 (was private) so the remote-recall leg's callers and
+   * tests can enumerate endpoint identity — but note recall dialing groups by
+   * (url, token) via `_remoteRecallHosts`, NOT by url alone: this method's
+   * first-token-wins collapse is only safe for probes (`/me`, health) where
+   * any of the tokens answers the identity question.
    */
-  private _distinctRemoteEndpoints(): Array<{ url: string; token?: string }> {
+  _distinctRemoteEndpoints(): Array<{ url: string; token?: string }> {
     const byUrl = new Map<string, { url: string; token?: string }>()
     for (const s of this.config.stores ?? []) {
       if (!s.url) continue
@@ -5688,8 +6005,9 @@ Generate an improved version of the procedure that prevents this failure. Return
 
   /** All store entries registered against `url` under ANY spelling of that
    *  endpoint (scope-audit 2026-07-24) — the identity-normalized counterpart of
-   *  `stores.filter(s => s.url === url)`. */
-  private _storesForEndpoint(url: string): StoreEntry[] {
+   *  `stores.filter(s => s.url === url)`. Public since #776 (was private) for
+   *  the remote-recall leg's callers and tests. */
+  _storesForEndpoint(url: string): StoreEntry[] {
     const key = normalizeEndpointUrl(url)
     return (this.config.stores ?? []).filter(s => s.url !== undefined && normalizeEndpointUrl(s.url) === key)
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -889,11 +889,11 @@ export class Plur {
    * RemoteStore holds its own internal TTL cache so repeated load()
    * within ttlMs returns the same array without a network call.
    *
-   * This method is synchronous, so it does not await `RemoteStore.load()`:
-   * it returns whatever is in the driver's cache and fires the real load
-   * into the background. The consequence is unchanged and still real — the
-   * first call after process start returns [] for that store, and only the
-   * call after the first refresh completes sees the data.
+   * `_loadRemoteCached` is a synchronous PEEK: it returns whatever the
+   * driver's in-memory cache currently holds and NEVER fires a load —
+   * background or otherwise. Until something explicitly warms the driver
+   * (`warmRemoteCaches()`, e.g. via session_start), it returns [] for that
+   * store every time, not just on the first call.
    *
    * #776 (server-authoritative recall): this peek is DEMOTED. Live recall now
    * reaches remote engrams through `remoteRecall` (`POST /api/v1/recall` per
@@ -3082,7 +3082,12 @@ export class Plur {
 
     const groups = new Map<string, { url: string; token?: string; entries: StoreEntry[] }>()
     for (const s of stores) {
-      const key = `${normalizeEndpointUrl(s.url!)} ${s.token ?? ''}`
+      // Same `::` composite-key convention as _getRemoteDriver (#394) — a
+      // printable separator (an earlier draft used a raw \x00, which made
+      // tooling treat this whole source file as binary). Normalized URLs and
+      // tokens don't contain `::` in practice, and a contrived collision only
+      // merges two entries into one endpoint group — same POST, same token.
+      const key = `${normalizeEndpointUrl(s.url!)}::${s.token ?? ''}`
       let g = groups.get(key)
       if (!g) { g = { url: s.url!, token: s.token, entries: [] }; groups.set(key, g) }
       g.entries.push(s)
@@ -5856,9 +5861,12 @@ Generate an improved version of the procedure that prevents this failure. Return
 
   /**
    * @deprecated Use {@link listStoresAsync} for accurate remote engram counts.
-   * The sync variant returns engram_count: 0 for remote stores on the first
-   * call after server start because the remote cache hasn't populated yet
-   * (issue #184). Retained for callers that cannot await.
+   * The sync variant reads only the remote drivers' in-memory peek cache,
+   * which no longer self-populates (#776 removed the background refresh): a
+   * remote store's engram_count stays 0 on EVERY call — not just the first
+   * (issue #184) — until something explicitly warms the cache
+   * (`warmRemoteCaches()`, e.g. via session_start). Retained for callers
+   * that cannot await.
    */
   async listStores(): Promise<Array<StoreSummary>> {
     this.reloadConfigIfChanged()  // pick up out-of-process config edits (#307)

--- a/packages/core/src/project-config.ts
+++ b/packages/core/src/project-config.ts
@@ -1,6 +1,22 @@
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, realpathSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
+
+/**
+ * Same #521 canonicalization as the CLI's `isPlurConfigured` guard:
+ * `process.cwd()` is kernel-canonical (getcwd resolves symlinks) while
+ * `homedir()` returns `$HOME` verbatim, so the same directory can spell two
+ * ways when a path component is a symlink (macOS `/var` → `/private/var`).
+ * The home-refusal below is a PRIVACY guard — a string-equality check that
+ * misses on spelling silently fails OPEN, and a stray `~/.plur.yaml` then
+ * intercepts every project (with `remote_url` set, that routes prompt text
+ * off-box). Canonicalize before comparing; returned paths keep the caller's
+ * spelling. (#778 — this mismatch also let the hook test's HOME==cwd setup
+ * pass on macOS while failing on Linux CI, where /tmp has no symlink.)
+ */
+function canonicalize(p: string): string {
+  try { return realpathSync(p) } catch { return resolve(p) }
+}
 
 /**
  * Project-level PLUR config (`.plur.yaml`) — read by both `hook-inject`
@@ -47,21 +63,23 @@ export interface ProjectConfig {
  * symlink components, and `..` segments.
  */
 export function findProjectConfigPath(startDir: string = process.cwd()): string | null {
-  const home = resolve(homedir())
+  const home = canonicalize(homedir())
   let dir = resolve(startDir)
   const MAX_DEPTH = 12  // hard ceiling — beyond ~12 dirs deep, give up
   for (let depth = 0; depth < MAX_DEPTH; depth++) {
     // Refuse to accept a .plur.yaml that lives directly in HOME.
     // That's the failure mode where a stray home-level config silently
-    // intercepts every project the user opens.
-    if (dir !== home) {
+    // intercepts every project the user opens. Canonical comparison so a
+    // symlinked spelling of HOME cannot bypass the guard (see canonicalize).
+    const atHome = canonicalize(dir) === home
+    if (!atHome) {
       const candidate = join(dir, '.plur.yaml')
       if (existsSync(candidate)) return candidate
     }
     // Stop at .git boundary — never escape the current project.
     if (existsSync(join(dir, '.git'))) return null
     // Hard ceilings: home, root, current-dir sentinel.
-    if (dir === home || dir === '/' || dir === '.') return null
+    if (atHome || dir === '/' || dir === '.') return null
     const parent = dirname(dir)
     if (parent === dir) return null
     dir = parent

--- a/packages/core/src/remote-recall.ts
+++ b/packages/core/src/remote-recall.ts
@@ -25,10 +25,11 @@
  * | breaker open         | `skipped_cooldown` | 3 straight failures → 5 min cooldown        |
  *
  * Breaker / cooldown / unsupported state is PERSISTED across processes in
- * `<plur root>/cache/remote-health.json` (atomic unique-tmp write): hooks are
- * one-shot processes at ~86% of recall volume, so in-memory state would reset
- * every prompt and an off-LAN host would burn the connect budget on every
- * prompt indefinitely.
+ * `<plur root>/cache/remote-health.json` (atomic unique-tmp write; mutations
+ * are read-merge-write under the shared file lock so concurrent processes
+ * don't lose each other's updates): hooks are one-shot processes at ~86% of
+ * recall volume, so in-memory state would reset every prompt and an off-LAN
+ * host would burn the connect budget on every prompt indefinitely.
  *
  * ## Dialing rule (strict scope relevance — user decision, plan rows 39/44)
  *
@@ -56,6 +57,7 @@ import { RemoteRowSchema, normalizeEndpointUrl } from './store/remote-store.js'
 import { isScopeWithin, isSharedScope } from './scope-util.js'
 import { storePrefix } from './engrams.js'
 import { logger } from './logger.js'
+import { withLock } from './sync.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -233,8 +235,10 @@ export function readRemoteHealth(path: string): RemoteHealthFile {
 
 /**
  * Atomic unique-tmp write: two concurrent one-shot hook processes must never
- * interleave partial writes. Unique tmp name (pid + random) then rename —
- * last writer wins wholesale, which is acceptable for advisory health state.
+ * interleave partial writes. Unique tmp name (pid + random) then rename.
+ * Atomicity alone is not enough against LOST UPDATES — callers that mutate
+ * state they read earlier must go through {@link mergeWriteRemoteHealth} or
+ * {@link withRemoteHealthLock}, which re-read under the file lock.
  */
 function writeRemoteHealth(path: string, file: RemoteHealthFile): void {
   try {
@@ -243,6 +247,59 @@ function writeRemoteHealth(path: string, file: RemoteHealthFile): void {
     fs.writeFileSync(tmp, JSON.stringify(file))
     fs.renameSync(tmp, path)
   } catch { /* health persistence is best-effort — never break recall */ }
+}
+
+/** Lock options for remote-health.json — the critical section is a
+ *  read+merge+rename of a small JSON file (milliseconds), and withLock's
+ *  retry delay is a synchronous busy-wait, so keep the worst-case wait small
+ *  (25+50+100 = 175 ms) rather than the 3.1 s engrams.yaml default. */
+const HEALTH_LOCK_OPTS = { maxRetries: 3, baseDelay: 25 }
+
+/**
+ * Run `fn` holding the remote-health.json file lock (the same #685 F7
+ * `withLock` used for engrams.yaml/config.yaml persistence). Health state is
+ * ADVISORY — if the lock cannot be acquired, `fallback` runs unlocked rather
+ * than failing recall or dropping a degradation header.
+ */
+function withRemoteHealthLock<T>(statePath: string, fn: () => T, fallback: () => T): T {
+  try {
+    fs.mkdirSync(dirname(statePath), { recursive: true })
+    return withLock(statePath, fn, HEALTH_LOCK_OPTS)
+  } catch {
+    return fallback()
+  }
+}
+
+/**
+ * Merge-persist the host entries this process touched (lost-update fix).
+ *
+ * The naive end-of-call `writeRemoteHealth(path, healthReadAtEntry)` loses
+ * concurrent updates: two processes read the same base, each writes its
+ * whole in-memory copy, and the second write erases the first's breaker /
+ * cooldown / suppression progress. Instead: re-read the CURRENT file inside
+ * the lock and overlay only the entries in `touched`, so writers touching
+ * different hosts both survive. Same-host collisions resolve last-writer-wins
+ * at host granularity — acceptable for advisory state.
+ *
+ * The overlay deliberately KEEPS the current file's `printed_state` /
+ * `printed_at`: remoteRecall never modifies those fields, and clobbering
+ * them with the entry-time snapshot would undo a concurrent
+ * {@link claimHookDegradationLines} claim and double-print headers.
+ */
+function mergeWriteRemoteHealth(statePath: string, touched: Record<string, HostHealth>): void {
+  const readMergeWrite = (): void => {
+    const current = readRemoteHealth(statePath)
+    for (const [key, h] of Object.entries(touched)) {
+      const cur = current.hosts[key]
+      current.hosts[key] = cur
+        ? { ...h, printed_state: cur.printed_state, printed_at: cur.printed_at }
+        : h
+    }
+    writeRemoteHealth(statePath, current)
+  }
+  // Unlocked fallback is the same read-merge-write — still narrower than the
+  // old whole-file overwrite even when the lock is unavailable.
+  withRemoteHealthLock(statePath, readMergeWrite, readMergeWrite)
 }
 
 // ---------------------------------------------------------------------------
@@ -431,8 +488,10 @@ function parseRetryAfterMs(header: string | null, now: number): number | null {
  * Dial every host in parallel (`Promise.allSettled`), each within its own
  * AbortController budget (connect-phase budget shorter than total), and
  * return validated/namespaced rows + per-host outcomes. Never throws; never
- * blocks past the budget. Health state is read once at entry and written
- * once at exit (atomic).
+ * blocks past the budget. Health state is read once at entry; at exit only
+ * the touched host entries are persisted, read-merge-write under the file
+ * lock (see {@link mergeWriteRemoteHealth}) so concurrent processes don't
+ * lose each other's updates.
  */
 export async function remoteRecall(
   hosts: RemoteRecallHost[],
@@ -474,6 +533,9 @@ export async function remoteRecall(
     }
     const networkFailure = (state: 'timeout' | 'unreachable', detail?: string) => {
       h.failures = (h.failures ?? 0) + 1
+      // Any observed non-403 response/failure breaks a 403 streak — the
+      // forbidden threshold means 2 CONSECUTIVE 403s, not 2 total.
+      h.forbidden_count = 0
       if (h.failures >= BREAKER_FAILURE_THRESHOLD) {
         h.cooldown_until = now() + BREAKER_COOLDOWN_MS
         h.failures = 0
@@ -531,11 +593,13 @@ export async function remoteRecall(
       }
       if (res.status === 404) {
         h.failures = 0
+        h.forbidden_count = 0 // a non-403 breaks the consecutive-403 streak
         h.unsupported_until = now() + UNSUPPORTED_TTL_MS
         return finish('unsupported', { detail: 'http_404' })
       }
       if (res.status === 429) {
         h.failures = 0
+        h.forbidden_count = 0 // a non-403 breaks the consecutive-403 streak
         const retryMs = parseRetryAfterMs(res.headers.get('retry-after'), now())
         h.cooldown_until = now() + Math.min(retryMs ?? RATE_LIMIT_DEFAULT_COOLDOWN_MS, RATE_LIMIT_MAX_COOLDOWN_MS)
         return finish('rate_limited')
@@ -602,7 +666,15 @@ export async function remoteRecall(
       scores.set(e.id, sc)
     }
   }
-  writeRemoteHealth(statePath, health)
+  // Persist only the host entries this call touched, read-merge-write under
+  // the file lock — a concurrent process's updates to other hosts (or to the
+  // print-suppression fields) survive. See mergeWriteRemoteHealth.
+  const touched: Record<string, HostHealth> = {}
+  for (const host of hosts) {
+    const key = normalizeEndpointUrl(host.url)
+    if (health.hosts[key]) touched[key] = health.hosts[key]
+  }
+  mergeWriteRemoteHealth(statePath, touched)
   return { engrams, scores, outcomes }
 }
 
@@ -714,7 +786,10 @@ export function doctorRemoteRemediation(o: RemoteStoreStatusEntry): string | nul
  * `ok` resets the printed state (silently) so a recurrence prints again.
  *
  * "Claim" semantics: calling this consumes the print budget for the lines it
- * returns — callers must actually print them.
+ * returns — callers must actually print them. The read→claim→write runs
+ * under the remote-health file lock (read-merge-write), so two concurrent
+ * hook processes cannot both read the pre-claim state and double-print, and
+ * a claim cannot be erased by a concurrent whole-file persist.
  */
 export function claimHookDegradationLines(
   outcomes: RemoteStoreStatusEntry[],
@@ -722,36 +797,43 @@ export function claimHookDegradationLines(
 ): string[] {
   const statePath = opts.statePath ?? remoteHealthPath(opts.env ?? process.env)
   const now = (opts.now ?? Date.now)()
-  const health = readRemoteHealth(statePath)
-  const lines: string[] = []
-  let dirty = false
-  for (const o of outcomes) {
-    const key = normalizeEndpointUrl(o.host)
-    const h: HostHealth = health.hosts[key] ?? {}
-    health.hosts[key] = h
-    const line = hookRemoteHeaderLine(o)
-    // The suppression key distinguishes plain-ok (never prints) from
-    // ok-with-dropped-scopes (prints like a state).
-    const printKey = o.status === 'ok' && o.dropped_scopes?.length ? 'dropped_scopes' : o.status
-    if (line === null) {
-      // Recovery / never-print state: reset the printed marker on genuine
-      // recovery so the next degradation prints as a state change.
-      if (o.status === 'ok' && h.printed_state && h.printed_state !== 'ok') {
-        h.printed_state = 'ok'
+  const claim = (): string[] => {
+    // Read INSIDE the lock — claiming against a pre-lock snapshot would
+    // reintroduce the lost-update race the lock exists to close.
+    const health = readRemoteHealth(statePath)
+    const lines: string[] = []
+    let dirty = false
+    for (const o of outcomes) {
+      const key = normalizeEndpointUrl(o.host)
+      const h: HostHealth = health.hosts[key] ?? {}
+      health.hosts[key] = h
+      const line = hookRemoteHeaderLine(o)
+      // The suppression key distinguishes plain-ok (never prints) from
+      // ok-with-dropped-scopes (prints like a state).
+      const printKey = o.status === 'ok' && o.dropped_scopes?.length ? 'dropped_scopes' : o.status
+      if (line === null) {
+        // Recovery / never-print state: reset the printed marker on genuine
+        // recovery so the next degradation prints as a state change.
+        if (o.status === 'ok' && h.printed_state && h.printed_state !== 'ok') {
+          h.printed_state = 'ok'
+          h.printed_at = now
+          dirty = true
+        }
+        continue
+      }
+      const changed = h.printed_state !== printKey
+      const stale = now - (h.printed_at ?? 0) > HOOK_HEADER_REPEAT_MS
+      if (changed || stale) {
+        lines.push(line)
+        h.printed_state = printKey
         h.printed_at = now
         dirty = true
       }
-      continue
     }
-    const changed = h.printed_state !== printKey
-    const stale = now - (h.printed_at ?? 0) > HOOK_HEADER_REPEAT_MS
-    if (changed || stale) {
-      lines.push(line)
-      h.printed_state = printKey
-      h.printed_at = now
-      dirty = true
-    }
+    if (dirty) writeRemoteHealth(statePath, health)
+    return lines
   }
-  if (dirty) writeRemoteHealth(statePath, health)
-  return lines
+  // Fallback (lock unavailable): claim unlocked — a rare duplicate header
+  // beats silently dropping a degradation warning.
+  return withRemoteHealthLock(statePath, claim, claim)
 }

--- a/packages/core/src/remote-recall.ts
+++ b/packages/core/src/remote-recall.ts
@@ -1,0 +1,757 @@
+/**
+ * Server-authoritative remote recall (#776, plan A2′).
+ *
+ * One live `POST {host}/api/v1/recall` per configured (url, token) endpoint
+ * group, timeout-bounded, merged by the caller with local results. There is
+ * deliberately NO disk caching of remote engrams — engrams change, so remote
+ * content is always retrieved live; an unreachable host means local-only
+ * results plus loud degradation (plan A4′). The in-memory `RemoteStore` peek
+ * cache keeps only its non-recall duties (stores_list counts, feedback/getById
+ * routing).
+ *
+ * ## Failure semantics (per host)
+ *
+ * | Condition            | State              | Behavior                                    |
+ * |----------------------|--------------------|---------------------------------------------|
+ * | 2xx, valid envelope  | `ok`               | rows validated/namespaced/merged            |
+ * | timeout / abort      | `timeout`          | breaker counts it                           |
+ * | DNS/conn/5xx/bad body| `unreachable`      | breaker counts it                           |
+ * | 401                  | `auth_expired`     | skip + surface re-auth (no breaker)         |
+ * | 403 ×1               | `unreachable`      | unconfirmed — a transient proxy 403 must    |
+ * |                      |                    | not read as revocation (detail: http_403)   |
+ * | 403 ×2 consecutive   | `forbidden`        | treated as auth-level revocation            |
+ * | 404                  | `unsupported`      | host parked for 10 min (NOT process life)   |
+ * | 429                  | `rate_limited`     | honor Retry-After (else 30 s) cooldown      |
+ * | breaker open         | `skipped_cooldown` | 3 straight failures → 5 min cooldown        |
+ *
+ * Breaker / cooldown / unsupported state is PERSISTED across processes in
+ * `<plur root>/cache/remote-health.json` (atomic unique-tmp write): hooks are
+ * one-shot processes at ~86% of recall volume, so in-memory state would reset
+ * every prompt and an off-LAN host would burn the connect budget on every
+ * prompt indefinitely.
+ *
+ * ## Dialing rule (strict scope relevance — user decision, plan rows 39/44)
+ *
+ * A host is dialed only with the subset of its granted scopes relevant to the
+ * current project/work:
+ *   (a) group/project scopes sharing the org segment with the session's
+ *       project scope (org of `project:plur/plur-ai/enterprise` is `plur` →
+ *       all `group:plur/…` + `project:plur/…` scopes for that host);
+ *   (b) the host's `user:*` (personal-family) scopes ONLY when an org context
+ *       exists implicating that host.
+ * No project/work context implicating a remote store → ZERO remote calls. A
+ * host with an empty relevant subset is not dialed. Per-store `dial:
+ * always|never` overrides; the `PLUR_REMOTE_RECALL` env kill-switch
+ * (`off|0|false`) disables the leg entirely. The dialing itself lives in
+ * `Plur._remoteRecallHosts` (index.ts); `scopeOrg` here is the shared org
+ * extraction.
+ */
+
+import * as fs from 'fs'
+import { homedir } from 'os'
+import { join, dirname } from 'path'
+import { z } from 'zod'
+import type { Engram } from './schemas/engram.js'
+import { RemoteRowSchema, normalizeEndpointUrl } from './store/remote-store.js'
+import { isScopeWithin, isSharedScope } from './scope-util.js'
+import { storePrefix } from './engrams.js'
+import { logger } from './logger.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard cap on the query text sent to a remote host — same privacy rationale
+ * as the hook's task truncation (hook-inject.ts): retrieval only needs enough
+ * signal to rank candidates; the rest is privacy bleed of pasted secrets or
+ * proprietary content.
+ */
+export const MAX_REMOTE_QUERY_CHARS = 1000
+
+/** Hard cap on a remote response body — prevents OOM/stall from a
+ *  misconfigured or adversarial server returning multi-megabyte JSON. */
+export const MAX_REMOTE_RESPONSE_BYTES = 128 * 1024
+
+/** Default per-call budget. MCP recall keeps this; the hook passes 1500 ms,
+ *  session_start warm passes 5000 ms. `PLUR_REMOTE_RECALL_TIMEOUT_MS` wins. */
+export const DEFAULT_REMOTE_RECALL_TIMEOUT_MS = 2000
+
+/** Consecutive network-class failures (timeout/unreachable/5xx/bad body)
+ *  before the circuit breaker opens for {@link BREAKER_COOLDOWN_MS}. */
+export const BREAKER_FAILURE_THRESHOLD = 3
+export const BREAKER_COOLDOWN_MS = 5 * 60 * 1000
+
+/** How long a 404 parks a host on `unsupported` — bounded, NOT process
+ *  lifetime: a long-lived MCP server must not park a healthy host on the
+ *  legacy path after one LB hiccup until restart. */
+export const UNSUPPORTED_TTL_MS = 10 * 60 * 1000
+
+/** 429 cooldown when the server sends no usable Retry-After. */
+export const RATE_LIMIT_DEFAULT_COOLDOWN_MS = 30 * 1000
+/** Upper bound on an honored Retry-After — a hostile/buggy header must not
+ *  park a host for a day. */
+export const RATE_LIMIT_MAX_COOLDOWN_MS = 60 * 60 * 1000
+
+/** Hook-header suppression window: after printing (host, state), the same
+ *  pair prints again at most once per this window (plan A4′, default 4h). */
+export const HOOK_HEADER_REPEAT_MS = 4 * 60 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Env knobs
+// ---------------------------------------------------------------------------
+
+/** `PLUR_REMOTE_RECALL=off|0|false` (client convention) kills the remote
+ *  recall leg entirely — zero fetches, zero new latency. */
+export function isRemoteRecallDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.PLUR_REMOTE_RECALL ?? '').trim().toLowerCase()
+  return v === 'off' || v === '0' || v === 'false'
+}
+
+/** Resolve the effective per-call timeout: env override → caller value →
+ *  default. Mirrors the hook's PLUR_HOOK_CEILING_MS env-override precedent. */
+export function resolveRemoteRecallTimeoutMs(
+  callerMs?: number,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const envMs = parseInt(env.PLUR_REMOTE_RECALL_TIMEOUT_MS ?? '', 10)
+  if (Number.isFinite(envMs) && envMs > 0) return envMs
+  if (typeof callerMs === 'number' && callerMs > 0) return callerMs
+  return DEFAULT_REMOTE_RECALL_TIMEOUT_MS
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RemoteHostState =
+  | 'ok'
+  | 'timeout'
+  | 'unreachable'
+  | 'auth_expired'
+  | 'forbidden'
+  | 'rate_limited'
+  | 'unsupported'
+  | 'skipped_cooldown'
+
+export interface HostRecallOutcome {
+  url: string
+  state: RemoteHostState
+  /** Wall time spent on this host (0 when skipped without a fetch). */
+  ms: number
+  /** Rows accepted from this host after validation + scope guard. */
+  count: number
+  /** Server-reported mode that ACTUALLY ran (envelope `mode`). */
+  mode?: string
+  /** Server-reported: the semantic (vector) leg actually ran. */
+  vector?: boolean
+  /** Requested scope selectors the server silently narrowed away (#628). */
+  dropped_scopes?: string[]
+  /** Bounded diagnostic detail (never server-controlled free text). */
+  detail?: string
+}
+
+/** One (url, token) endpoint group to dial, with the RELEVANT granted-scope
+ *  subset (already dialing-filtered by the caller) and the store entries for
+ *  deterministic row→entry namespacing (config order). */
+export interface RemoteRecallHost {
+  url: string
+  token: string
+  /** Scopes to request from this host — the dialed relevant subset. */
+  scopes: string[]
+  /** Store entries (config order) backing those scopes. Rows map to the
+   *  FIRST entry whose scope contains the row's scope; `global` rows map to
+   *  the first-configured entry, mirroring `_loadSecondaryAndPacks`. */
+  entries: Array<{ scope: string }>
+}
+
+export interface RemoteRecallResult {
+  /** Validated, scope-guarded, namespaced rows across all hosts (deduped by
+   *  namespaced id — first host wins, scores max-merged). */
+  engrams: Engram[]
+  /** Per-namespaced-id relevance in [0,1]: the server's per-response score
+   *  when present, else rank-mapped within that host's accepted rows. */
+  scores: Map<string, number>
+  outcomes: HostRecallOutcome[]
+}
+
+export interface RemoteRecallOptions {
+  /** Total per-host budget (headers + body). */
+  timeoutMs?: number
+  /** Connect-phase budget (until response headers). Must be shorter than the
+   *  total budget so a blackholed route fails fast. Default: 2/3 of total. */
+  connectTimeoutMs?: number
+  limit?: number
+  /** Health-state file path (default `<PLUR_PATH|~/.plur>/cache/remote-health.json`). */
+  statePath?: string
+  now?: () => number
+  fetchImpl?: typeof fetch
+  env?: NodeJS.ProcessEnv
+}
+
+// ---------------------------------------------------------------------------
+// Persistent per-host health state
+// ---------------------------------------------------------------------------
+
+interface HostHealth {
+  /** Consecutive network-class failures (timeout/unreachable/5xx/bad body). */
+  failures?: number
+  /** Breaker open until (epoch ms) — `skipped_cooldown` while in force. Also
+   *  set by 429 (Retry-After). */
+  cooldown_until?: number
+  /** 404 TTL — `unsupported` while in force. */
+  unsupported_until?: number
+  /** Consecutive 403s — 2 required before `forbidden` (revocation). */
+  forbidden_count?: number
+  last_state?: RemoteHostState
+  updated_at?: number
+  /** Hook-header suppression bookkeeping (plan A4′). */
+  printed_state?: string
+  printed_at?: number
+}
+
+interface RemoteHealthFile {
+  version: 1
+  hosts: Record<string, HostHealth>
+}
+
+/** Default health-file path. Honors PLUR_PATH like the rest of the CLI. */
+export function remoteHealthPath(env: NodeJS.ProcessEnv = process.env): string {
+  const root = env.PLUR_PATH ?? join(homedir(), '.plur')
+  return join(root, 'cache', 'remote-health.json')
+}
+
+export function readRemoteHealth(path: string): RemoteHealthFile {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path, 'utf8'))
+    if (raw && typeof raw === 'object' && raw.version === 1 && raw.hosts && typeof raw.hosts === 'object') {
+      return raw as RemoteHealthFile
+    }
+  } catch { /* missing or corrupt → fresh state */ }
+  return { version: 1, hosts: {} }
+}
+
+/**
+ * Atomic unique-tmp write: two concurrent one-shot hook processes must never
+ * interleave partial writes. Unique tmp name (pid + random) then rename —
+ * last writer wins wholesale, which is acceptable for advisory health state.
+ */
+function writeRemoteHealth(path: string, file: RemoteHealthFile): void {
+  try {
+    fs.mkdirSync(dirname(path), { recursive: true })
+    const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`
+    fs.writeFileSync(tmp, JSON.stringify(file))
+    fs.renameSync(tmp, path)
+  } catch { /* health persistence is best-effort — never break recall */ }
+}
+
+// ---------------------------------------------------------------------------
+// Org extraction for the dialing rule
+// ---------------------------------------------------------------------------
+
+/**
+ * The org segment of a SHARED scope: `project:plur/plur-ai/enterprise` →
+ * `plur`; `group:acme/eng` → `acme`; `group:test` → `test`. Personal-family
+ * scopes (and `public`, which has no org) → null. Lower-cased for comparison
+ * (scope prefixes are case-folded elsewhere too; stored values untouched).
+ */
+export function scopeOrg(scope: string | undefined): string | null {
+  if (!scope || !isSharedScope(scope)) return null
+  const colon = scope.indexOf(':')
+  if (colon < 0) return null // bare 'public' — no org segment
+  const org = scope.slice(colon + 1).split(/[/:]/)[0]?.trim().toLowerCase()
+  return org || null
+}
+
+// ---------------------------------------------------------------------------
+// Envelope validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Tolerant envelope (#628 contract from enterprise PR #631). Old servers may
+ * return a bare envelope without mode/vector/effective_scopes/dropped_scopes
+ * — every field beyond `results` is optional, and unknown fields pass
+ * through. A bare array body (defensively) coerces to `{results: [...]}`.
+ */
+const RecallEnvelopeSchema = z.object({
+  results: z.array(z.unknown()).default([]),
+  count: z.number().optional(),
+  mode: z.string().optional(),
+  requested_mode: z.string().optional(),
+  vector: z.boolean().optional(),
+  effective_scopes: z.array(z.string()).optional(),
+  dropped_scopes: z.array(z.string()).optional(),
+}).passthrough()
+
+// ---------------------------------------------------------------------------
+// Row post-processing
+// ---------------------------------------------------------------------------
+
+function clamp01(n: number): number {
+  return Math.max(0, Math.min(1, n))
+}
+
+/**
+ * Validate + scope-guard + namespace one host's rows, and derive per-row
+ * scores (server score when present, rank-mapped fallback otherwise).
+ *
+ * Scope guard: a row must fall `isScopeWithin` one of the DIALED scopes —
+ * but `scope === 'global'` rows are ADMITTED and narrowed to the mapped
+ * entry's scope during namespacing, mirroring `_loadSecondaryAndPacks`'s
+ * global clause (index.ts). Dropping global rows would reimplement the #570
+ * server bug client-side and throw away exactly the rows B-T1 restores.
+ *
+ * Deterministic row→store-entry mapping: a row's scope maps to the FIRST
+ * dialed entry (config order) whose scope contains it; `global` maps to the
+ * first-configured dialed entry. Same row → same namespaced id on every
+ * call, or RRF dedup splits and feedback misroutes (pinned by test).
+ *
+ * Activation normalization: `last_accessed = today`,
+ * `retrieval_strength = server value ?? 0.7` — server rows are fresh by
+ * construction; without this they'd enter ranking mid-decay.
+ */
+function processHostRows(
+  rawRows: unknown[],
+  host: RemoteRecallHost,
+  today: string,
+): { engrams: Engram[]; scores: Map<string, number> } {
+  const dialed = new Set(host.scopes)
+  const dialedEntries = host.entries.filter(e => dialed.has(e.scope))
+  const accepted: Array<{ engram: Engram; serverScore: number | undefined }> = []
+
+  for (const raw of rawRows) {
+    if (!raw || typeof raw !== 'object') continue
+    const r = raw as Record<string, unknown>
+    // Rows are top-level engrams per the #628 envelope; tolerate the DB-row
+    // shape {id, scope, status, data} some surfaces emit (same reshape rule
+    // as RemoteStore: authoritative columns win over `data`).
+    const candidate = (r.data && typeof r.data === 'object' && !('statement' in r))
+      ? { ...(r.data as Record<string, unknown>), id: r.id, scope: r.scope, status: r.status }
+      : r
+    const parsed = RemoteRowSchema.safeParse(candidate)
+    if (!parsed.success) {
+      const safeId = String((candidate as Record<string, unknown>).id ?? '').replace(/[^\w:./-]/g, '?').slice(0, 64)
+      logger.debug(`[plur:remote-recall] ${host.url} returned a malformed row (id="${safeId}") — dropped`)
+      continue
+    }
+    const e = parsed.data as unknown as Engram
+    // Scope guard with explicit global admission.
+    const entry = e.scope === 'global'
+      ? dialedEntries[0]
+      : dialedEntries.find(en => isScopeWithin(e.scope, en.scope))
+    if (!entry) {
+      logger.debug(`[plur:remote-recall] ${host.url} row ${e.id} outside dialed scopes (${e.scope}) — dropped`)
+      continue
+    }
+    const cloned = { ...e } as any
+    if (cloned.scope === 'global') cloned.scope = entry.scope
+    const originalId = cloned.id
+    cloned.id = cloned.id.replace(/^(ENG|ABS|META)-/, `$1-${storePrefix(entry.scope)}-`)
+    cloned._originalId = originalId
+    cloned._storeScope = entry.scope
+    // The injection scorer iterates `tags` unguarded — a row without them
+    // must not throw at scoring time.
+    if (!Array.isArray(cloned.tags)) cloned.tags = []
+    // Activation normalization — synthesized-fresh (plan: decay-parity task
+    // dissolved into this).
+    const act = (cloned.activation && typeof cloned.activation === 'object') ? cloned.activation : {}
+    cloned.activation = {
+      storage_strength: typeof act.storage_strength === 'number' ? act.storage_strength : 1.0,
+      frequency: typeof act.frequency === 'number' ? act.frequency : 0,
+      ...act,
+      retrieval_strength: typeof act.retrieval_strength === 'number' ? act.retrieval_strength : 0.7,
+      last_accessed: today,
+    }
+    const serverScore = typeof (r as any).score === 'number' && Number.isFinite((r as any).score)
+      ? clamp01((r as any).score)
+      : undefined
+    // The wire `score` is response metadata, not engram data — don't let it
+    // masquerade as an engram field downstream.
+    delete cloned.score
+    accepted.push({ engram: cloned as Engram, serverScore })
+  }
+
+  const n = accepted.length
+  const scores = new Map<string, number>()
+  const engrams: Engram[] = []
+  for (let i = 0; i < n; i++) {
+    const { engram, serverScore } = accepted[i]
+    // Rank-mapped fallback when the server sent no score: top row → 1.0,
+    // monotonically decreasing, matching the server contract's shape.
+    scores.set(engram.id, serverScore ?? (n - i) / n)
+    engrams.push(engram)
+  }
+  return { engrams, scores }
+}
+
+// ---------------------------------------------------------------------------
+// Body reading with cap
+// ---------------------------------------------------------------------------
+
+async function readBodyCapped(res: Response, cap: number): Promise<string | null> {
+  const len = res.headers.get('content-length')
+  if (len && parseInt(len, 10) > cap) return null
+  const body = (res as { body?: { getReader?: () => { read(): Promise<{ done: boolean; value?: Uint8Array }>; cancel(): Promise<void> } } }).body
+  if (body && typeof body.getReader === 'function') {
+    const reader = body.getReader()
+    const chunks: Buffer[] = []
+    let total = 0
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) {
+        total += value.byteLength
+        if (total > cap) {
+          try { await reader.cancel() } catch { /* already dead */ }
+          return null
+        }
+        chunks.push(Buffer.from(value))
+      }
+    }
+    return Buffer.concat(chunks).toString('utf8')
+  }
+  const text = await res.text()
+  return Buffer.byteLength(text, 'utf8') > cap ? null : text
+}
+
+function parseRetryAfterMs(header: string | null, now: number): number | null {
+  if (!header) return null
+  const secs = parseInt(header, 10)
+  if (Number.isFinite(secs) && String(secs) === header.trim()) return Math.max(0, secs * 1000)
+  const date = Date.parse(header)
+  if (Number.isFinite(date)) return Math.max(0, date - now)
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// remoteRecall
+// ---------------------------------------------------------------------------
+
+/**
+ * Dial every host in parallel (`Promise.allSettled`), each within its own
+ * AbortController budget (connect-phase budget shorter than total), and
+ * return validated/namespaced rows + per-host outcomes. Never throws; never
+ * blocks past the budget. Health state is read once at entry and written
+ * once at exit (atomic).
+ */
+export async function remoteRecall(
+  hosts: RemoteRecallHost[],
+  query: string,
+  opts: RemoteRecallOptions = {},
+): Promise<RemoteRecallResult> {
+  const env = opts.env ?? process.env
+  if (hosts.length === 0 || isRemoteRecallDisabled(env)) {
+    return { engrams: [], scores: new Map(), outcomes: [] }
+  }
+  const timeoutMs = resolveRemoteRecallTimeoutMs(opts.timeoutMs, env)
+  const connectMs = opts.connectTimeoutMs ?? Math.max(1, Math.floor(timeoutMs * 2 / 3))
+  const now = opts.now ?? Date.now
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const statePath = opts.statePath ?? remoteHealthPath(env)
+  const health = readRemoteHealth(statePath)
+  const today = new Date().toISOString().slice(0, 10)
+  const truncatedQuery = query.length > MAX_REMOTE_QUERY_CHARS ? query.slice(0, MAX_REMOTE_QUERY_CHARS) : query
+
+  const dialHost = async (host: RemoteRecallHost): Promise<{
+    outcome: HostRecallOutcome
+    engrams: Engram[]
+    scores: Map<string, number>
+  }> => {
+    const key = normalizeEndpointUrl(host.url)
+    const h: HostHealth = health.hosts[key] ?? {}
+    health.hosts[key] = h
+    const t0 = now()
+    const finish = (state: RemoteHostState, extra: Partial<HostRecallOutcome> = {},
+      rows: { engrams: Engram[]; scores: Map<string, number> } = { engrams: [], scores: new Map() },
+    ) => {
+      h.last_state = state
+      h.updated_at = now()
+      return {
+        outcome: { url: host.url, state, ms: now() - t0, count: rows.engrams.length, ...extra },
+        engrams: rows.engrams,
+        scores: rows.scores,
+      }
+    }
+    const networkFailure = (state: 'timeout' | 'unreachable', detail?: string) => {
+      h.failures = (h.failures ?? 0) + 1
+      if (h.failures >= BREAKER_FAILURE_THRESHOLD) {
+        h.cooldown_until = now() + BREAKER_COOLDOWN_MS
+        h.failures = 0
+      }
+      return finish(state, detail ? { detail } : {})
+    }
+
+    if ((h.cooldown_until ?? 0) > t0) return finish('skipped_cooldown')
+    if ((h.unsupported_until ?? 0) > t0) return finish('unsupported', { detail: 'unsupported_ttl' })
+
+    const ctrl = new AbortController()
+    const overallTimer = setTimeout(() => ctrl.abort(), timeoutMs)
+    let connectTimer: ReturnType<typeof setTimeout> | undefined =
+      setTimeout(() => ctrl.abort(), Math.min(connectMs, timeoutMs))
+    try {
+      const res = await fetchImpl(`${key}/api/v1/recall`, {
+        method: 'POST',
+        signal: ctrl.signal,
+        headers: {
+          Authorization: `Bearer ${host.token}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          query: truncatedQuery,
+          mode: 'hybrid',
+          // Clamp to the server's documented bounds (1..100) — an over-limit
+          // request would 400 and feed the breaker for a client-side mistake.
+          ...(opts.limit != null ? { limit: Math.min(100, Math.max(1, Math.floor(opts.limit))) } : {}),
+          ...(host.scopes.length > 0 ? { scopes: host.scopes } : {}),
+          // B-T7d wire param — the server races its embed() against this and
+          // degrades to keyword rather than blowing the client budget. Old
+          // servers ignore unknown body fields.
+          timeout_ms: timeoutMs,
+        }),
+      })
+      // Headers arrived — connect phase over; the overall timer still bounds
+      // the body read.
+      clearTimeout(connectTimer)
+      connectTimer = undefined
+
+      if (res.status === 401) {
+        h.failures = 0
+        h.forbidden_count = 0
+        return finish('auth_expired')
+      }
+      if (res.status === 403) {
+        h.failures = 0
+        h.forbidden_count = (h.forbidden_count ?? 0) + 1
+        // Require 2 CONSECUTIVE 403s before treating as revocation — a
+        // transient proxy 403 must not read as auth loss (server-side scope
+        // narrowing is silent-with-dropped_scopes, never 403 — B-T7 Q1).
+        if (h.forbidden_count >= 2) return finish('forbidden')
+        return finish('unreachable', { detail: 'http_403_unconfirmed' })
+      }
+      if (res.status === 404) {
+        h.failures = 0
+        h.unsupported_until = now() + UNSUPPORTED_TTL_MS
+        return finish('unsupported', { detail: 'http_404' })
+      }
+      if (res.status === 429) {
+        h.failures = 0
+        const retryMs = parseRetryAfterMs(res.headers.get('retry-after'), now())
+        h.cooldown_until = now() + Math.min(retryMs ?? RATE_LIMIT_DEFAULT_COOLDOWN_MS, RATE_LIMIT_MAX_COOLDOWN_MS)
+        return finish('rate_limited')
+      }
+      if (!res.ok) {
+        return networkFailure('unreachable', `http_${res.status}`)
+      }
+
+      const text = await readBodyCapped(res, MAX_REMOTE_RESPONSE_BYTES)
+      if (text === null) return networkFailure('unreachable', 'oversize')
+      let parsedBody: unknown
+      try {
+        parsedBody = JSON.parse(text)
+      } catch {
+        return networkFailure('unreachable', 'bad_json')
+      }
+      if (Array.isArray(parsedBody)) parsedBody = { results: parsedBody }
+      const envelope = RecallEnvelopeSchema.safeParse(parsedBody)
+      if (!envelope.success) return networkFailure('unreachable', 'bad_envelope')
+
+      h.failures = 0
+      h.forbidden_count = 0
+      h.cooldown_until = 0
+      const rows = processHostRows(envelope.data.results, host, today)
+      const dropped = envelope.data.dropped_scopes
+      return finish('ok', {
+        ...(envelope.data.mode ? { mode: envelope.data.mode } : {}),
+        ...(typeof envelope.data.vector === 'boolean' ? { vector: envelope.data.vector } : {}),
+        ...(dropped && dropped.length > 0 ? { dropped_scopes: dropped } : {}),
+      }, rows)
+    } catch (err) {
+      const isAbort = err instanceof Error && err.name === 'AbortError'
+      return networkFailure(isAbort ? 'timeout' : 'unreachable',
+        isAbort ? undefined : (err instanceof Error ? err.message.slice(0, 120) : undefined))
+    } finally {
+      if (connectTimer) clearTimeout(connectTimer)
+      clearTimeout(overallTimer)
+    }
+  }
+
+  const settled = await Promise.allSettled(hosts.map(dialHost))
+  const outcomes: HostRecallOutcome[] = []
+  const engrams: Engram[] = []
+  const scores = new Map<string, number>()
+  const seen = new Set<string>()
+  for (let i = 0; i < settled.length; i++) {
+    const s = settled[i]
+    if (s.status === 'rejected') {
+      // dialHost never throws by construction; belt-and-braces.
+      outcomes.push({ url: hosts[i].url, state: 'unreachable', ms: 0, count: 0, detail: 'internal_error' })
+      continue
+    }
+    outcomes.push(s.value.outcome)
+    for (const e of s.value.engrams) {
+      const sc = s.value.scores.get(e.id) ?? 0
+      if (seen.has(e.id)) {
+        // Cross-host duplicate (same scope mounted twice) — first host's row
+        // wins; boost collisions max-merge.
+        scores.set(e.id, Math.max(scores.get(e.id) ?? 0, sc))
+        continue
+      }
+      seen.add(e.id)
+      engrams.push(e)
+      scores.set(e.id, sc)
+    }
+  }
+  writeRemoteHealth(statePath, health)
+  return { engrams, scores, outcomes }
+}
+
+// ---------------------------------------------------------------------------
+// A4′ — degradation string table (per state × per surface)
+// ---------------------------------------------------------------------------
+
+export interface RemoteStoreStatusEntry {
+  host: string
+  status: RemoteHostState
+  dropped_scopes?: string[]
+  ms?: number
+  count?: number
+}
+
+/**
+ * Agent-directed strings for MCP response surfaces: consequence + agent
+ * action, because they enter model context ("Admin → Service accounts" is
+ * not an agent action — the agent's action is to relay it). One line per
+ * degraded host, joined by the caller.
+ *
+ * The re-auth string deliberately does NOT reference `plur login` — it
+ * targets device-flow endpoints the enterprise server doesn't have, and the
+ * token it writes has no consumers on the recall path (plan DX finding 1).
+ */
+export function mcpRemoteWarningLine(o: RemoteStoreStatusEntry): string {
+  const host = o.host
+  switch (o.status) {
+    case 'ok':
+      return o.dropped_scopes && o.dropped_scopes.length > 0
+        ? `${host}: scope(s) ${o.dropped_scopes.join(', ')} not granted to your key — results may be missing those team engrams; tell the user to ask an admin (Admin → Service accounts).`
+        : `${host}: ok`
+    case 'timeout':
+      return `${host}: timed out — results may be missing team engrams; serving local only; do not retry; run plur_doctor for detail.`
+    case 'unreachable':
+      return `${host}: unreachable — results may be missing team engrams; serving local only; do not retry; run plur_doctor for detail.`
+    case 'auth_expired':
+      return `${host}: token expired or revoked — team engrams unavailable; serving local only; tell the user to sign in at ${host}/auth and re-add the store via plur_stores_add.`
+    case 'forbidden':
+      return `${host}: access revoked (repeated 403) — team engrams unavailable; serving local only; tell the user to ask an admin (Admin → Service accounts) or re-add via plur_stores_add.`
+    case 'rate_limited':
+      return `${host}: rate limited — cooling down automatically; results may be missing team engrams this call; do not retry.`
+    case 'unsupported':
+      return `${host}: server has no live-recall endpoint (older server) — serving local only; team recall resumes automatically once the server is upgraded.`
+    case 'skipped_cooldown':
+      return `${host}: in cooldown after repeated failures — serving local only; dialing resumes automatically; run plur_doctor if this persists.`
+  }
+}
+
+/**
+ * Human-directed hook-header lines. States `skipped_cooldown` and
+ * `unsupported` NEVER print into a prompt header (they are steady, expected
+ * back-off states — habituation camouflages new degradations). Returns null
+ * for states that never print.
+ */
+export function hookRemoteHeaderLine(o: RemoteStoreStatusEntry): string | null {
+  const host = o.host
+  switch (o.status) {
+    case 'ok':
+      return o.dropped_scopes && o.dropped_scopes.length > 0
+        ? `[PLUR] ${host}: scope(s) ${o.dropped_scopes.join(', ')} not granted to your key — ask an admin (Admin → Service accounts).`
+        : null
+    case 'timeout':
+      return `[PLUR] ${host}: timed out — team memory skipped this prompt (serving local only).`
+    case 'unreachable':
+      return `[PLUR] ${host}: unreachable — team memory skipped this prompt (serving local only).`
+    case 'auth_expired':
+      return `[PLUR] ${host}: token expired or revoked — sign in at ${host}/auth and re-add via plur_stores_add.`
+    case 'forbidden':
+      return `[PLUR] ${host}: access revoked — ask an admin (Admin → Service accounts), or sign in at ${host}/auth and re-add via plur_stores_add.`
+    case 'rate_limited':
+      return `[PLUR] ${host}: rate limited — team memory cooling down, back shortly.`
+    case 'unsupported':
+    case 'skipped_cooldown':
+      return null
+  }
+}
+
+/** Human-directed plur_doctor remediation strings (cause + human fix). */
+export function doctorRemoteRemediation(o: RemoteStoreStatusEntry): string | null {
+  const host = o.host
+  switch (o.status) {
+    case 'ok':
+      return o.dropped_scopes && o.dropped_scopes.length > 0
+        ? `Remote ${host}: scope(s) ${o.dropped_scopes.join(', ')} not granted to your key — the server silently narrowed your recall. Ask an admin (Admin → Service accounts) to grant them.`
+        : null
+    case 'timeout':
+      return `Remote ${host}: live recall timed out — server slow or network path degraded. Check connectivity/VPN; raise PLUR_REMOTE_RECALL_TIMEOUT_MS if the host is genuinely slow.`
+    case 'unreachable':
+      return `Remote ${host}: unreachable — check connectivity/VPN/DNS. Recall serves local results only until it recovers; writes queue in the outbox.`
+    case 'auth_expired':
+      return `Remote ${host}: token expired or revoked — sign in at ${host}/auth and re-add the store via plur_stores_add (see the onboarding doc). Note: \`plur login\` does not work against enterprise servers.`
+    case 'forbidden':
+      return `Remote ${host}: two consecutive 403s — the token's access was revoked. Ask an admin (Admin → Service accounts), or sign in at ${host}/auth and re-add via plur_stores_add.`
+    case 'rate_limited':
+      return `Remote ${host}: server rate limit hit — the client honors Retry-After and cools down automatically. If persistent, ask the operator to raise the per-principal recall limit.`
+    case 'unsupported':
+      return `Remote ${host}: no /api/v1/recall endpoint (older server) — live team recall is parked for ${Math.round(UNSUPPORTED_TTL_MS / 60000)} minutes at a time. Upgrade the enterprise server to enable server-authoritative recall. (An old server also cannot report scope narrowing — absence of a dropped-scopes warning from this host proves nothing.)`
+    case 'skipped_cooldown':
+      return `Remote ${host}: circuit breaker open after ${BREAKER_FAILURE_THRESHOLD} consecutive failures — dialing paused ~${Math.round(BREAKER_COOLDOWN_MS / 60000)} minutes, then retried automatically. Investigate reachability if this persists.`
+  }
+}
+
+/**
+ * Hook-header suppression policy (plan A4′): print on state CHANGE per host,
+ * then at most once per {@link HOOK_HEADER_REPEAT_MS} per (host, state) —
+ * persisted in the same remote-health.json, because hooks are one-shot
+ * processes. `skipped_cooldown` and `unsupported` never print. A recovery to
+ * `ok` resets the printed state (silently) so a recurrence prints again.
+ *
+ * "Claim" semantics: calling this consumes the print budget for the lines it
+ * returns — callers must actually print them.
+ */
+export function claimHookDegradationLines(
+  outcomes: RemoteStoreStatusEntry[],
+  opts: { statePath?: string; now?: () => number; env?: NodeJS.ProcessEnv } = {},
+): string[] {
+  const statePath = opts.statePath ?? remoteHealthPath(opts.env ?? process.env)
+  const now = (opts.now ?? Date.now)()
+  const health = readRemoteHealth(statePath)
+  const lines: string[] = []
+  let dirty = false
+  for (const o of outcomes) {
+    const key = normalizeEndpointUrl(o.host)
+    const h: HostHealth = health.hosts[key] ?? {}
+    health.hosts[key] = h
+    const line = hookRemoteHeaderLine(o)
+    // The suppression key distinguishes plain-ok (never prints) from
+    // ok-with-dropped-scopes (prints like a state).
+    const printKey = o.status === 'ok' && o.dropped_scopes?.length ? 'dropped_scopes' : o.status
+    if (line === null) {
+      // Recovery / never-print state: reset the printed marker on genuine
+      // recovery so the next degradation prints as a state change.
+      if (o.status === 'ok' && h.printed_state && h.printed_state !== 'ok') {
+        h.printed_state = 'ok'
+        h.printed_at = now
+        dirty = true
+      }
+      continue
+    }
+    const changed = h.printed_state !== printKey
+    const stale = now - (h.printed_at ?? 0) > HOOK_HEADER_REPEAT_MS
+    if (changed || stale) {
+      lines.push(line)
+      h.printed_state = printKey
+      h.printed_at = now
+      dirty = true
+    }
+  }
+  if (dirty) writeRemoteHealth(statePath, health)
+  return lines
+}

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -20,6 +20,17 @@ export const StoreEntrySchema = z.object({
   scope: z.string(),
   shared: z.boolean().default(false),
   readonly: z.boolean().default(false),
+  /**
+   * Per-store override for the server-authoritative recall dialing rule
+   * (#776). Optional and backward compatible — absent means the strict
+   * scope-relevance rule decides:
+   *   - `always` — this store's host is dialed on every recall, and this
+   *     store's scope is always in the dialed set, project context or not.
+   *   - `never`  — this store never participates in live remote recall
+   *     (its scope is excluded from dialing; other entries on the same host
+   *     still dial normally).
+   */
+  dial: z.enum(['always', 'never']).optional().catch(undefined),
   description: z.string().optional()
     .describe('Human-readable explanation of what this scope is for (#345). Surfaced in store/scope discovery.'),
   // `covers` and `sensitivity` are shape-tolerant (R2-D #7): a malformed SHAPE

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -12,8 +12,12 @@ import { ScopeMetadataSchema, type ScopeMetadata } from '../schemas/scope-metada
  * malicious remote could spread arbitrary / type-confused data (and instruction-
  * carrying `statement`s) into the local injection pool via `as unknown as Engram`.
  * `.passthrough()` keeps unmodeled fields; the point is to gate the meaningful ones.
+ *
+ * Exported (#776): the server-authoritative recall leg (remote-recall.ts)
+ * validates /api/v1/recall rows through the SAME schema — one trust boundary,
+ * not two that can drift.
  */
-const RemoteRowSchema = z.object({
+export const RemoteRowSchema = z.object({
   id: z.string().regex(/^(ENG|ABS|META)-[A-Za-z0-9-]+$/),
   scope: z.string().min(1),
   status: z.enum(['active', 'dormant', 'retired', 'candidate']),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -124,6 +124,20 @@ export interface RecallBudget {
   ttl_seconds?: number
 }
 
+/**
+ * Project-level remote endpoint from `.plur.yaml` (#776). Its presence IS the
+ * org context for dialing on the hook path: the project explicitly names this
+ * host as part of the current work, so it is dialed even when the org-affinity
+ * heuristic alone would not implicate it. Project config wins over
+ * `config.stores` for the hook path (matching-URL group dials with the
+ * project's token when one is supplied).
+ */
+export interface RemoteProjectConfig {
+  url: string
+  token?: string
+  scopes?: string[]
+}
+
 export interface RecallOptions {
   scope?: string
   /**
@@ -167,6 +181,26 @@ export interface RecallOptions {
    * seconds-scale on CPU — offline/batch). Select via PLUR_RERANKER.
    */
   rerank?: boolean
+  /**
+   * Server-authoritative remote recall leg (#776). Default true: recall dials
+   * every configured remote host implicated by the current project/work (see
+   * the strict scope-relevance dialing rule in remote-recall.ts) in parallel
+   * with the local pipeline and RRF-merges the results.
+   *
+   * INTERNAL CALLERS MUST PASS false: learn-dedup, forget-by-search and
+   * self-eval probes derive queries from statements/prompts — without the
+   * opt-out every plur_learn fires prompt-derived POSTs to all hosts, and a
+   * namespaced remote row can silently suppress a local write as a "dedup
+   * match".
+   */
+  remote?: boolean
+  /** Per-call remote budget in ms (env PLUR_REMOTE_RECALL_TIMEOUT_MS wins).
+   *  Hook path passes 1500; MCP recall defaults to 2000; session_start warm
+   *  passes 5000. */
+  remote_timeout_ms?: number
+  /** `.plur.yaml` remote endpoint — establishes the org context for dialing
+   *  on the hook path (#776). See {@link RemoteProjectConfig}. */
+  remote_project?: RemoteProjectConfig
 }
 
 export interface BoundedRecallResult {
@@ -202,6 +236,17 @@ export interface InjectOptions {
   session_id?: string
   /** Which surface asked for this injection. Recorded on the co_injection event. */
   source?: InjectionSource
+  /**
+   * Server-authoritative remote recall leg for `injectHybrid` (#776).
+   * Default true. Same contract as {@link RecallOptions.remote}; BM25-only
+   * `inject()` NEVER dials regardless of this flag.
+   */
+  remote?: boolean
+  /** Per-call remote budget in ms — see {@link RecallOptions.remote_timeout_ms}. */
+  remote_timeout_ms?: number
+  /** `.plur.yaml` remote endpoint (hook path org context) — see
+   *  {@link RemoteProjectConfig}. */
+  remote_project?: RemoteProjectConfig
 }
 
 export interface InjectionResult {

--- a/packages/core/test/adversarial/guard-fuzz.test.ts
+++ b/packages/core/test/adversarial/guard-fuzz.test.ts
@@ -180,9 +180,10 @@ describe('adversarial leak-guard fuzzer (#353 round-3)', () => {
     }) as any)
   }
 
+  // #776: reads no longer fire a background refresh — warm explicitly, the
+  // same path session_start uses.
   async function primedRemoteId(plur: Plur, serverId: string): Promise<string> {
-    await plur.list()
-    await new Promise(r => setTimeout(r, 50))
+    await plur.warmRemoteCaches()
     const found = (await plur.list()).find(e => (e as any)._originalId === serverId || e.id.endsWith(serverId))
     if (!found) throw new Error(`remote engram ${serverId} not in cache after prime`)
     return found.id

--- a/packages/core/test/guard-remote-boundary.test.ts
+++ b/packages/core/test/guard-remote-boundary.test.ts
@@ -114,10 +114,12 @@ describe('remote-boundary leak guard (#353)', () => {
     }) as any)
   }
 
-  /** Prime the lazy remote cache, then return the namespaced engram id list sees. */
+  /** Prime the lazy remote cache, then return the namespaced engram id list sees.
+   *  #776: reads no longer fire a background refresh (`_loadRemoteCached` lost
+   *  its floating `void driver.load()` when live recall took over) — warming is
+   *  explicit via `warmRemoteCaches()`, the same path session_start uses. */
   async function primedRemoteId(plur: Plur, serverId: string): Promise<string> {
-    await plur.list()                                   // triggers background await load()
-    await new Promise(r => setTimeout(r, 50))     // let the await load() settle
+    await plur.warmRemoteCaches()
     const found = (await plur.list()).find(e => (e as any)._originalId === serverId || e.id.endsWith(serverId))
     if (!found) throw new Error(`remote engram ${serverId} not in cache after prime`)
     return found.id

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -78,6 +78,30 @@ export class StubServer {
    *  echoed row fails RemoteRowSchema validation (#327). */
   badPatchEcho: unknown = null
 
+  // --- POST /api/v1/recall (#776 server-authoritative recall envelope) ---
+  /** Rows served in the envelope's `results` (top-level engram shape, each
+   *  optionally carrying a per-response 0-1 `score`). */
+  recallRows: unknown[] = []
+  /** Force an HTTP status for /recall (401/403/404/429/500...). null = 200. */
+  recallStatus: number | null = null
+  /** Retry-After header value served with a forced 429. */
+  recallRetryAfter: string | null = null
+  /** Raw body override (serialized as JSON) — for invalid-envelope tests. */
+  recallBodyOverride: unknown = null
+  /** Delay before responding, ms — for timeout tests. */
+  recallDelayMs = 0
+  /** Serve an oversize (>128KB) body. */
+  recallOversize = false
+  /** Old-server mode: bare `{results, count}` envelope without
+   *  mode/vector/effective_scopes/dropped_scopes (#628 tolerance). */
+  recallBare = false
+  /** Extra envelope fields (mode/vector/dropped_scopes/...) merged in. */
+  recallEnvelope: Record<string, unknown> = {}
+  /** Number of POST /api/v1/recall requests received (call spy). */
+  recallCalls = 0
+  /** Last POST /api/v1/recall request body (assert scopes/query/timeout_ms). */
+  lastRecallBody: Record<string, unknown> | null = null
+
   constructor(private readonly validToken: string) {}
 
   /** Override the GET /api/v1/me response (authorized scope set, identity).
@@ -141,6 +165,16 @@ export class StubServer {
     this.idCounter = 0
     this.badAppendId = null
     this.badPatchEcho = null
+    this.recallRows = []
+    this.recallStatus = null
+    this.recallRetryAfter = null
+    this.recallBodyOverride = null
+    this.recallDelayMs = 0
+    this.recallOversize = false
+    this.recallBare = false
+    this.recallEnvelope = {}
+    this.recallCalls = 0
+    this.lastRecallBody = null
   }
 
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
@@ -158,6 +192,59 @@ export class StubServer {
     // GET /api/v1/me — resolved identity + authorized scopes (#292)
     if (method === 'GET' && path === '/api/v1/me') {
       this.json(res, 200, this.me)
+      return
+    }
+
+    // POST /api/v1/recall — server-authoritative recall envelope (#776/#628).
+    // Mirrors the enterprise contract: {results (rows with per-response 0-1
+    // score), count, mode, requested_mode, vector, effective_scopes,
+    // dropped_scopes}. Failure-injection knobs above simulate the full
+    // client failure table.
+    if (method === 'POST' && path === '/api/v1/recall') {
+      this.recallCalls++
+      this.readBody(req, (body) => {
+        this.lastRecallBody = body
+        const respond = () => {
+          if (this.recallStatus !== null) {
+            const headers: Record<string, string> = {}
+            if (this.recallStatus === 429 && this.recallRetryAfter !== null) {
+              headers['Retry-After'] = this.recallRetryAfter
+            }
+            const payload = JSON.stringify({ error: `forced ${this.recallStatus}` })
+            res.writeHead(this.recallStatus, {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(payload),
+              ...headers,
+            })
+            res.end(payload)
+            return
+          }
+          if (this.recallOversize) {
+            this.json(res, 200, { results: [], padding: 'x'.repeat(256 * 1024) })
+            return
+          }
+          if (this.recallBodyOverride !== null) {
+            this.json(res, 200, this.recallBodyOverride)
+            return
+          }
+          const requestedScopes = Array.isArray(body.scopes) ? body.scopes as string[] : null
+          const envelope = this.recallBare
+            ? { results: this.recallRows, count: this.recallRows.length }
+            : {
+                results: this.recallRows,
+                count: this.recallRows.length,
+                mode: 'hybrid',
+                requested_mode: (body.mode as string) ?? 'hybrid',
+                vector: true,
+                effective_scopes: requestedScopes ?? this.me.scopes,
+                dropped_scopes: [],
+                ...this.recallEnvelope,
+              }
+          this.json(res, 200, envelope)
+        }
+        if (this.recallDelayMs > 0) setTimeout(respond, this.recallDelayMs)
+        else respond()
+      })
       return
     }
 

--- a/packages/core/test/project-config.test.ts
+++ b/packages/core/test/project-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, realpathSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { tmpdir, homedir } from 'os'
 import { findProjectConfigPath, readProjectConfig } from '../src/project-config.js'
@@ -66,6 +66,53 @@ describe('project-config (#177)', () => {
       // HOME's .plur.yaml by starting the walk AT HOME with no .plur.yaml
       // present — should return null without crashing.
       expect(findProjectConfigPath(homedir())).toBeNull()
+    })
+
+    it('refuses a .plur.yaml directly in an env-overridden HOME that HAS one (#778)', () => {
+      // The real thing this guard exists for: a config file actually present
+      // in HOME must be refused when the walk starts there.
+      const fakeHome = mkdtempSync(join(tmpdir(), 'plur-home-'))
+      writeFileSync(join(fakeHome, '.plur.yaml'), 'scope: project:should-not-load\n')
+      const savedHome = process.env.HOME
+      const savedProfile = process.env.USERPROFILE
+      process.env.HOME = fakeHome
+      process.env.USERPROFILE = fakeHome
+      try {
+        expect(findProjectConfigPath(fakeHome)).toBeNull()
+      } finally {
+        if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome
+        if (savedProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = savedProfile
+        rmSync(fakeHome, { recursive: true, force: true })
+      }
+    })
+
+    it('home refusal survives a symlinked HOME spelling — guard must not fail open (#778)', () => {
+      // process.cwd() is kernel-canonical while $HOME is verbatim env, so on
+      // a symlinked path (macOS /var → /private/var) the same directory
+      // spells two ways. Before canonicalization the equality guard missed,
+      // FAILED OPEN, and a home-level .plur.yaml was silently honored —
+      // which is also exactly why the #776 hook test passed on macOS while
+      // failing on Linux CI. Pin: canonical start dir + symlinked HOME env
+      // still refuse the home-level config.
+      const realHome = realpathSync(mkdtempSync(join(tmpdir(), 'plur-home-real-')))
+      const linkHome = `${realHome}-link`
+      symlinkSync(realHome, linkHome)
+      writeFileSync(join(realHome, '.plur.yaml'), 'scope: project:should-not-load\n')
+      const savedHome = process.env.HOME
+      const savedProfile = process.env.USERPROFILE
+      process.env.HOME = linkHome // symlinked spelling, as a login env may carry
+      process.env.USERPROFILE = linkHome
+      try {
+        // Walk starts at the CANONICAL spelling — the shape process.cwd()
+        // reports. Both spellings are the same directory: refuse.
+        expect(findProjectConfigPath(realHome)).toBeNull()
+        expect(findProjectConfigPath(linkHome)).toBeNull()
+      } finally {
+        if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome
+        if (savedProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = savedProfile
+        unlinkSync(linkHome) // rmSync follows a dir symlink; unlink removes the link itself
+        rmSync(realHome, { recursive: true, force: true })
+      }
     })
 
     it('respects MAX_DEPTH ceiling on path traversal', () => {

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -700,3 +700,115 @@ describe('Remote mutation routing — pin / promote / reportFailure (#185, #86)'
     expect((serverEngram?.data as any)?.pinned).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// #776 — server-authoritative recall merged into recall/inject
+// ---------------------------------------------------------------------------
+
+describe('server-authoritative recall integration (#776)', () => {
+  let dir: string
+  const SCOPE = 'group:test'
+  const PROJECT = 'project:test/app' // org 'test' → implicates the group:test store
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rr-integ-'))
+    server.reset()
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      yaml.dump({
+        embeddings: { enabled: false },
+        stores: [{ url: baseUrl, token: TOKEN, scope: SCOPE, shared: true, readonly: false }],
+        index: false,
+      }, { lineWidth: 120, noRefs: true }),
+    )
+  })
+
+  const row = (id: string, statement: string, extra: Record<string, unknown> = {}) => ({
+    id, scope: SCOPE, status: 'active', statement, ...extra,
+  })
+
+  it('merge ordering: the server-best row beats a weak local match', async () => {
+    const plur = new Plur({ path: dir })
+    await plur.learn('deployment mentioned once in passing', { scope: PROJECT })
+    server.recallRows = [row('ENG-2026-0731-050', 'deployment checklist deployment runbook deployment', { score: 1 })]
+    const results = await plur.recall('deployment checklist', { scope: PROJECT })
+    expect(results.length).toBeGreaterThanOrEqual(2)
+    expect((results[0] as any)._originalId).toBe('ENG-2026-0731-050')
+  })
+
+  it('RRF consensus: a row in BOTH the peek path and the live leg dedups to ONE id and ranks first', async () => {
+    // Same engram reachable via the legacy peek cache (GET /engrams) AND the
+    // live recall leg (POST /recall). The two paths MUST produce identical
+    // namespaced ids — otherwise RRF splits the row and feedback misroutes.
+    server.seedEngram({
+      id: 'ENG-2026-0731-051',
+      scope: SCOPE,
+      status: 'active',
+      data: { statement: 'consensus fact about release automation', tags: [] },
+    })
+    server.recallRows = [row('ENG-2026-0731-051', 'consensus fact about release automation', { score: 1 })]
+
+    const plur = new Plur({ path: dir })
+    await plur.warmRemoteCaches() // fill the peek cache (legacy path)
+    await plur.learn('release automation local note', { scope: PROJECT })
+
+    const results = await plur.recall('release automation consensus', { scope: PROJECT })
+    const consensusRows = results.filter(e => (e as any)._originalId === 'ENG-2026-0731-051')
+    expect(consensusRows).toHaveLength(1) // deduped, not split
+    expect((results[0] as any)._originalId).toBe('ENG-2026-0731-051') // consensus wins
+  })
+
+  it('recallHybrid merges the server leg too (BM25-only local mode)', async () => {
+    const plur = new Plur({ path: dir })
+    server.recallRows = [row('ENG-2026-0731-052', 'hybrid merge target', { score: 0.9 })]
+    const meta = await plur.recallHybridWithMeta('hybrid merge target', { scope: PROJECT })
+    expect(meta.engrams.some(e => (e as any)._originalId === 'ENG-2026-0731-052')).toBe(true)
+  })
+
+  it('injectHybrid: server rows join the pool via the boost channel and inject', async () => {
+    const plur = new Plur({ path: dir })
+    server.recallRows = [row('ENG-2026-0731-053', 'always gate releases behind the canary suite', { score: 1 })]
+    const result = await plur.injectHybrid('preparing a release', { scope: PROJECT })
+    expect(server.recallCalls).toBe(1)
+    expect(result.count).toBeGreaterThan(0)
+    expect(result.injected_ids.some(id => id.endsWith('-2026-0731-053'))).toBe(true)
+  })
+
+  it('ADVERSARIAL: a max-scored out-of-authorization row does NOT inject via the boost channel', async () => {
+    const plur = new Plur({ path: dir })
+    server.recallRows = [row('ENG-2026-0731-054', 'malicious high-score row', { score: 1 })]
+    // options.scopes is the AUTHORIZATION allow-list — the server row's scope
+    // (group:test) is not in it. Without the filter-before-boost rule, the
+    // 0.55+ boost would resurrect it (raw = boost*2 > threshold).
+    const result = await plur.injectHybrid('malicious high-score row', {
+      scope: PROJECT,
+      scopes: [PROJECT],
+    })
+    expect(result.injected_ids.some(id => id.endsWith('-2026-0731-054'))).toBe(false)
+  })
+
+  it('ADVERSARIAL: a max-scored foreign-scope row is dropped by the scope guard before boosts exist', async () => {
+    const plur = new Plur({ path: dir })
+    server.recallRows = [
+      { id: 'ENG-2026-0731-055', scope: 'group:evil/exfil', status: 'active', statement: 'smuggled row', score: 1 },
+    ]
+    const result = await plur.injectHybrid('smuggled row', { scope: PROJECT })
+    expect(result.injected_ids.some(id => id.includes('0731-055'))).toBe(false)
+    const recalled = await plur.recall('smuggled row', { scope: PROJECT })
+    expect(recalled.some(e => (e as any)._originalId === 'ENG-2026-0731-055')).toBe(false)
+  })
+
+  it('learn-dedup makes ZERO remote recall calls (internal-caller opt-out)', async () => {
+    const plur = new Plur({ path: dir })
+    await plur.learnAsync('a brand new fact that must not fan out', { scope: PROJECT })
+    await plur.learnAsync('a brand new fact that must not fan out', { scope: PROJECT }) // dedup hit path
+    expect(server.recallCalls).toBe(0)
+  })
+
+  it('BM25-only inject() never dials', async () => {
+    const plur = new Plur({ path: dir })
+    server.recallRows = [row('ENG-2026-0731-056', 'bm25 inject should stay local', { score: 1 })]
+    await plur.inject('bm25 inject should stay local', { scope: PROJECT })
+    expect(server.recallCalls).toBe(0)
+  })
+})

--- a/packages/core/test/remote-recall.test.ts
+++ b/packages/core/test/remote-recall.test.ts
@@ -1,0 +1,661 @@
+/**
+ * Server-authoritative remote recall (#776, plan A2′/A4′).
+ *
+ * Covers, against a real-HTTP StubServer (no fetch mocking):
+ *   - the full per-host failure table (401/403/404/429/5xx/timeout/bad body)
+ *   - 403 revocation requires 2 CONSECUTIVE 403s
+ *   - 404 → `unsupported` for a bounded TTL, not process lifetime
+ *   - 429 honors Retry-After as a persisted cooldown
+ *   - circuit breaker: 3 straight failures → cooldown → `skipped_cooldown`,
+ *     and the state is READ BY A FRESH CALL (hooks are one-shot processes —
+ *     each remoteRecall() call re-reads the state file, simulating a second
+ *     process)
+ *   - scope guard admits `global` rows (narrowed during namespacing) and
+ *     drops foreign-scope rows
+ *   - deterministic namespacing: same row → same namespaced id, twice
+ *   - server score passthrough + rank-mapped fallback
+ *   - kill-switch (PLUR_REMOTE_RECALL) → zero fetches
+ *   - strict scope-relevance dialing on Plur: org-mismatch not dialed,
+ *     no-context dials nothing, dial:never honored, dial:always forces
+ *   - hook-header suppression policy (state change → line; repeat → silent;
+ *     skipped_cooldown/unsupported never print)
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import {
+  remoteRecall, claimHookDegradationLines, readRemoteHealth,
+  BREAKER_FAILURE_THRESHOLD, HOOK_HEADER_REPEAT_MS, UNSUPPORTED_TTL_MS,
+  scopeOrg,
+  type RemoteRecallHost, type HostRecallOutcome,
+} from '../src/remote-recall.js'
+import { StubServer } from './helpers/stub-server.js'
+
+const TOKEN = 'remote-recall-token'
+const TEAM_SCOPE = 'group:plur/plur-ai/engineering'
+
+let server: StubServer
+let baseUrl: string
+const dirs: string[] = []
+
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+
+function statePath(): string {
+  return join(tmp('plur-rrhealth-'), 'remote-health.json')
+}
+
+function host(overrides: Partial<RemoteRecallHost> = {}): RemoteRecallHost {
+  return {
+    url: baseUrl,
+    token: TOKEN,
+    scopes: [TEAM_SCOPE],
+    entries: [{ scope: TEAM_SCOPE }],
+    ...overrides,
+  }
+}
+
+function serverRow(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    scope: TEAM_SCOPE,
+    status: 'active',
+    statement: `remote statement for ${id}`,
+    ...overrides,
+  }
+}
+
+beforeAll(async () => {
+  server = new StubServer(TOKEN)
+  const info = await server.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => {
+  await server.stop()
+  for (const d of dirs) rmSync(d, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  server.reset()
+})
+
+// ---------------------------------------------------------------------------
+// Happy path + envelope tolerance
+// ---------------------------------------------------------------------------
+
+describe('remoteRecall — ok path', () => {
+  it('returns validated, namespaced rows with outcome ok + envelope metadata', async () => {
+    server.recallRows = [serverRow('ENG-2026-0731-001', { score: 0.9 })]
+    const res = await remoteRecall([host()], 'enterprise recall wiring', { statePath: statePath() })
+    expect(res.outcomes).toHaveLength(1)
+    expect(res.outcomes[0].state).toBe('ok')
+    expect(res.outcomes[0].count).toBe(1)
+    expect(res.outcomes[0].mode).toBe('hybrid')
+    expect(res.outcomes[0].vector).toBe(true)
+    expect(res.engrams).toHaveLength(1)
+    // Namespaced: ENG-<prefix(group:plur/...)>-... with provenance fields.
+    expect(res.engrams[0].id).not.toBe('ENG-2026-0731-001')
+    expect((res.engrams[0] as any)._originalId).toBe('ENG-2026-0731-001')
+    expect((res.engrams[0] as any)._storeScope).toBe(TEAM_SCOPE)
+  })
+
+  it('tolerates an old server serving a bare envelope without mode/vector/dropped_scopes', async () => {
+    server.recallBare = true
+    server.recallRows = [serverRow('ENG-2026-0731-002')]
+    const res = await remoteRecall([host()], 'bare envelope', { statePath: statePath() })
+    expect(res.outcomes[0].state).toBe('ok')
+    expect(res.outcomes[0].mode).toBeUndefined()
+    expect(res.outcomes[0].vector).toBeUndefined()
+    expect(res.outcomes[0].dropped_scopes).toBeUndefined()
+    expect(res.engrams).toHaveLength(1)
+  })
+
+  it('surfaces dropped_scopes from the envelope on an ok outcome', async () => {
+    server.recallEnvelope = { dropped_scopes: ['group:plur/secret'] }
+    const res = await remoteRecall([host()], 'narrowed', { statePath: statePath() })
+    expect(res.outcomes[0].state).toBe('ok')
+    expect(res.outcomes[0].dropped_scopes).toEqual(['group:plur/secret'])
+  })
+
+  it('sends the dialed scopes, hybrid mode and timeout_ms on the wire', async () => {
+    await remoteRecall([host()], 'wire shape', { statePath: statePath(), timeoutMs: 1234 })
+    expect(server.lastRecallBody).not.toBeNull()
+    expect(server.lastRecallBody!.scopes).toEqual([TEAM_SCOPE])
+    expect(server.lastRecallBody!.mode).toBe('hybrid')
+    expect(server.lastRecallBody!.timeout_ms).toBe(1234)
+  })
+
+  it('truncates the query to the privacy cap before it leaves the machine', async () => {
+    const longQuery = 'q'.repeat(5000)
+    await remoteRecall([host()], longQuery, { statePath: statePath() })
+    expect((server.lastRecallBody!.query as string).length).toBe(1000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Failure table
+// ---------------------------------------------------------------------------
+
+describe('remoteRecall — failure table', () => {
+  it('401 → auth_expired (skip + surface, no breaker)', async () => {
+    server.recallStatus = 401
+    const sp = statePath()
+    const res = await remoteRecall([host()], 'x', { statePath: sp })
+    expect(res.outcomes[0].state).toBe('auth_expired')
+    expect(res.engrams).toHaveLength(0)
+    // No breaker contribution: three 401s never open the cooldown.
+    await remoteRecall([host()], 'x', { statePath: sp })
+    await remoteRecall([host()], 'x', { statePath: sp })
+    const again = await remoteRecall([host()], 'x', { statePath: sp })
+    expect(again.outcomes[0].state).toBe('auth_expired')
+  })
+
+  it('403 requires 2 CONSECUTIVE before reading as revocation (forbidden)', async () => {
+    server.recallStatus = 403
+    const sp = statePath()
+    const first = await remoteRecall([host()], 'x', { statePath: sp })
+    expect(first.outcomes[0].state).toBe('unreachable') // unconfirmed
+    expect(first.outcomes[0].detail).toBe('http_403_unconfirmed')
+    const second = await remoteRecall([host()], 'x', { statePath: sp })
+    expect(second.outcomes[0].state).toBe('forbidden')
+  })
+
+  it('a success between two 403s resets the revocation counter', async () => {
+    const sp = statePath()
+    server.recallStatus = 403
+    await remoteRecall([host()], 'x', { statePath: sp })
+    server.recallStatus = null
+    await remoteRecall([host()], 'x', { statePath: sp })
+    server.recallStatus = 403
+    const res = await remoteRecall([host()], 'x', { statePath: sp })
+    expect(res.outcomes[0].state).toBe('unreachable') // count restarted
+  })
+
+  it('404 → unsupported for a TTL, not process lifetime', async () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    server.recallStatus = 404
+    const first = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(first.outcomes[0].state).toBe('unsupported')
+    expect(server.recallCalls).toBe(1)
+
+    // Within the TTL: no fetch at all, still reported unsupported.
+    server.recallStatus = null
+    const second = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(second.outcomes[0].state).toBe('unsupported')
+    expect(server.recallCalls).toBe(1)
+
+    // Past the TTL: the host is probed again and recovers.
+    clock += UNSUPPORTED_TTL_MS + 1
+    server.recallRows = [serverRow('ENG-2026-0731-003')]
+    const third = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(third.outcomes[0].state).toBe('ok')
+    expect(server.recallCalls).toBe(2)
+  })
+
+  it('429 honors Retry-After as a persisted cooldown', async () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    server.recallStatus = 429
+    server.recallRetryAfter = '60'
+    const first = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(first.outcomes[0].state).toBe('rate_limited')
+
+    // 30s later (inside the 60s Retry-After): skipped without a fetch.
+    server.recallStatus = null
+    clock += 30_000
+    const second = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(second.outcomes[0].state).toBe('skipped_cooldown')
+    expect(server.recallCalls).toBe(1)
+
+    // Past the Retry-After: dialed again.
+    clock += 31_000
+    const third = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(third.outcomes[0].state).toBe('ok')
+    expect(server.recallCalls).toBe(2)
+  })
+
+  it('5xx → unreachable', async () => {
+    server.recallStatus = 503
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(res.outcomes[0].state).toBe('unreachable')
+    expect(res.outcomes[0].detail).toBe('http_503')
+  })
+
+  it('slow server → timeout within the budget', async () => {
+    server.recallDelayMs = 400
+    const res = await remoteRecall([host()], 'x', { statePath: statePath(), timeoutMs: 80 })
+    expect(res.outcomes[0].state).toBe('timeout')
+  })
+
+  it('DNS/conn-refused → unreachable', async () => {
+    const dead = host({ url: 'http://127.0.0.1:1' })
+    const res = await remoteRecall([dead], 'x', { statePath: statePath(), timeoutMs: 500 })
+    expect(res.outcomes[0].state).toBe('unreachable')
+  })
+
+  it('oversize body (>128KB) → unreachable (validation class)', async () => {
+    server.recallOversize = true
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(res.outcomes[0].state).toBe('unreachable')
+    expect(res.outcomes[0].detail).toBe('oversize')
+  })
+
+  it('invalid envelope body → unreachable (validation class)', async () => {
+    server.recallBodyOverride = { results: 'not-an-array' }
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(res.outcomes[0].state).toBe('unreachable')
+    expect(res.outcomes[0].detail).toBe('bad_envelope')
+  })
+
+  it('one dead host never sinks a healthy one (parallel isolation)', async () => {
+    server.recallRows = [serverRow('ENG-2026-0731-004')]
+    const res = await remoteRecall(
+      [host(), host({ url: 'http://127.0.0.1:1' })],
+      'x',
+      { statePath: statePath(), timeoutMs: 1000 },
+    )
+    const states = res.outcomes.map(o => o.state).sort()
+    expect(states).toEqual(['ok', 'unreachable'])
+    expect(res.engrams).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Circuit breaker + cross-process persistence
+// ---------------------------------------------------------------------------
+
+describe('remoteRecall — circuit breaker', () => {
+  it('trips after 3 straight failures and a FRESH call reads the persisted state', async () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    server.recallStatus = 500
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) {
+      const r = await remoteRecall([host()], 'x', { statePath: sp, now })
+      expect(r.outcomes[0].state).toBe('unreachable')
+      clock += 1000
+    }
+    expect(server.recallCalls).toBe(3)
+
+    // Every remoteRecall() call reads the state file fresh — this call IS a
+    // second process as far as breaker state is concerned (hooks are
+    // one-shot). Server is healthy again, but the breaker is open.
+    server.recallStatus = null
+    const skipped = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(skipped.outcomes[0].state).toBe('skipped_cooldown')
+    expect(server.recallCalls).toBe(3) // no fetch
+
+    // The file itself carries the cooldown — belt and braces.
+    const persisted = readRemoteHealth(sp)
+    const key = Object.keys(persisted.hosts)[0]
+    expect(persisted.hosts[key].cooldown_until).toBeGreaterThan(clock)
+
+    // After the 5-minute cooldown, dialing resumes.
+    clock += 5 * 60 * 1000 + 1
+    const resumed = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(resumed.outcomes[0].state).toBe('ok')
+    expect(server.recallCalls).toBe(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scope guard + namespacing + scores
+// ---------------------------------------------------------------------------
+
+describe('remoteRecall — row post-processing', () => {
+  it('admits global rows (narrowed to the store scope) and drops foreign-scope rows', async () => {
+    server.recallRows = [
+      serverRow('ENG-2026-0731-010'),                                  // in dialed scope
+      serverRow('ENG-2026-0731-011', { scope: 'global' }),             // admitted + narrowed
+      serverRow('ENG-2026-0731-012', { scope: 'group:evil/exfil' }),   // foreign → dropped
+      serverRow('ENG-2026-0731-013', { scope: 'group:plur/plur-ai' }), // parent ≠ within → dropped
+    ]
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(res.outcomes[0].count).toBe(2)
+    const scopes = res.engrams.map(e => e.scope)
+    expect(scopes).toEqual([TEAM_SCOPE, TEAM_SCOPE]) // global narrowed
+    const originals = res.engrams.map(e => (e as any)._originalId)
+    expect(originals).toEqual(['ENG-2026-0731-010', 'ENG-2026-0731-011'])
+  })
+
+  it('sibling string-prefix scopes do not leak through the guard (#383)', async () => {
+    server.recallRows = [serverRow('ENG-2026-0731-014', { scope: `${TEAM_SCOPE}-private` })]
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(res.outcomes[0].count).toBe(0)
+  })
+
+  it('drops rows that fail RemoteRowSchema validation', async () => {
+    server.recallRows = [
+      serverRow('ENG-2026-0731-015'),
+      { id: 'EVIL\nID', scope: TEAM_SCOPE, status: 'active', statement: 'x' },
+      { id: 'ENG-2026-0731-016', scope: TEAM_SCOPE, status: 'active', statement: '' },
+    ]
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(res.outcomes[0].count).toBe(1)
+  })
+
+  it('namespacing is deterministic: the same row maps to the same id twice', async () => {
+    server.recallRows = [serverRow('ENG-2026-0731-017')]
+    const sp = statePath()
+    const first = await remoteRecall([host()], 'x', { statePath: sp })
+    const second = await remoteRecall([host()], 'x', { statePath: sp })
+    expect(first.engrams[0].id).toBe(second.engrams[0].id)
+  })
+
+  it('passes server scores through and rank-maps rows without scores', async () => {
+    server.recallRows = [
+      serverRow('ENG-2026-0731-018', { score: 0.75 }),
+      serverRow('ENG-2026-0731-019'), // no score → rank fallback
+      serverRow('ENG-2026-0731-020'), // no score → rank fallback
+    ]
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    const [a, b, c] = res.engrams.map(e => res.scores.get(e.id)!)
+    expect(a).toBe(0.75)
+    // rank fallback over 3 accepted rows: (3-1)/3, (3-2)/3
+    expect(b).toBeCloseTo(2 / 3)
+    expect(c).toBeCloseTo(1 / 3)
+    // out-of-range server scores clamp to [0,1]
+    server.reset()
+    server.recallRows = [serverRow('ENG-2026-0731-021', { score: 7 })]
+    const clamped = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(clamped.scores.get(clamped.engrams[0].id)).toBe(1)
+  })
+
+  it('normalizes activation: last_accessed = today, strength = server value ?? 0.7', async () => {
+    const today = new Date().toISOString().slice(0, 10)
+    server.recallRows = [
+      serverRow('ENG-2026-0731-022', { activation: { retrieval_strength: 0.4, last_accessed: '2020-01-01' } }),
+      serverRow('ENG-2026-0731-023'),
+    ]
+    const res = await remoteRecall([host()], 'x', { statePath: statePath() })
+    expect(res.engrams[0].activation.retrieval_strength).toBe(0.4)
+    expect(res.engrams[0].activation.last_accessed).toBe(today)
+    expect(res.engrams[1].activation.retrieval_strength).toBe(0.7)
+    expect(res.engrams[1].activation.last_accessed).toBe(today)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Kill-switch
+// ---------------------------------------------------------------------------
+
+describe('remoteRecall — kill-switch', () => {
+  it.each(['off', '0', 'false'])('PLUR_REMOTE_RECALL=%s → zero fetches', async (v) => {
+    const res = await remoteRecall([host()], 'x', {
+      statePath: statePath(),
+      env: { PLUR_REMOTE_RECALL: v } as NodeJS.ProcessEnv,
+    })
+    expect(res.outcomes).toHaveLength(0)
+    expect(server.recallCalls).toBe(0)
+  })
+
+  it('PLUR_REMOTE_RECALL_TIMEOUT_MS overrides the caller budget', async () => {
+    await remoteRecall([host()], 'x', {
+      statePath: statePath(),
+      timeoutMs: 5000,
+      env: { PLUR_REMOTE_RECALL_TIMEOUT_MS: '777' } as NodeJS.ProcessEnv,
+    })
+    expect(server.lastRecallBody!.timeout_ms).toBe(777)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dialing rule (Plur._remoteRecallHosts) — strict scope relevance
+// ---------------------------------------------------------------------------
+
+describe('dialing — strict scope relevance', () => {
+  function plurWith(storesYaml: string): Plur {
+    const dir = tmp('plur-dial-')
+    writeFileSync(join(dir, 'config.yaml'), `embeddings:\n  enabled: false\nstores:\n${storesYaml}`)
+    return new Plur({ path: dir })
+  }
+  const hostsOf = (plur: Plur, options?: Record<string, unknown>): RemoteRecallHost[] =>
+    (plur as any)._remoteRecallHosts(options)
+
+  it('org-affine host is dialed with shared + user:* scopes; org-mismatch host is NOT dialed', () => {
+    const plur = plurWith(
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "group:plur/plur-ai/engineering"\n` +
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "user:plur:gregor"\n` +
+      `  - url: "https://df.example.com"\n    token: "t2"\n    scope: "group:datafund/igea"\n`,
+    )
+    const hosts = hostsOf(plur, { scope: 'project:plur/plur-ai/enterprise' })
+    expect(hosts).toHaveLength(1)
+    expect(hosts[0].url).toBe('https://plur.example.com')
+    expect(hosts[0].scopes).toEqual(['group:plur/plur-ai/engineering', 'user:plur:gregor'])
+  })
+
+  it('no project/work context → zero hosts dialed (personal-only session)', () => {
+    const plur = plurWith(
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "group:plur/eng"\n` +
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "user:plur:gregor"\n`,
+    )
+    expect(hostsOf(plur)).toHaveLength(0)
+    expect(hostsOf(plur, { scope: 'user:gregor' })).toHaveLength(0)
+  })
+
+  it('a host holding ONLY user:* scopes is not dialed without an org context implicating it', () => {
+    const plur = plurWith(
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "user:plur:gregor"\n`,
+    )
+    expect(hostsOf(plur, { scope: 'project:plur/plur-ai/enterprise' })).toHaveLength(0)
+  })
+
+  it('dial: never excludes the entry; dial: always forces its host even with no context', () => {
+    const plur = plurWith(
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "group:plur/eng"\n    dial: never\n` +
+      `  - url: "https://always.example.com"\n    token: "t3"\n    scope: "group:acme/eng"\n    dial: always\n`,
+    )
+    // No context: only the dial:always host, with only the always entry.
+    const noCtx = hostsOf(plur)
+    expect(noCtx).toHaveLength(1)
+    expect(noCtx[0].url).toBe('https://always.example.com')
+    expect(noCtx[0].scopes).toEqual(['group:acme/eng'])
+    // Org context for plur: the dial:never entry still never dials.
+    const ctx = hostsOf(plur, { scope: 'project:plur/x' })
+    expect(ctx.map(h => h.url)).toEqual(['https://always.example.com'])
+  })
+
+  it('.plur.yaml remote_project implicates its host (project config wins) and stands alone when unmounted', () => {
+    const plur = plurWith(
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "group:other/eng"\n`,
+    )
+    // Mounted host, org-mismatched scope — remote_project still implicates it
+    // and dials ALL its shared scopes with the project token.
+    const mounted = hostsOf(plur, {
+      scope: 'project:plur/x',
+      remote_project: { url: 'https://plur.example.com', token: 'proj-token' },
+    })
+    expect(mounted).toHaveLength(1)
+    expect(mounted[0].token).toBe('proj-token')
+    expect(mounted[0].scopes).toEqual(['group:other/eng'])
+    // Unmounted host: dialed standalone with the project's remote_scopes.
+    const standalone = hostsOf(plur, {
+      remote_project: { url: 'https://solo.example.com', token: 'tk', scopes: ['group:solo/eng'] },
+    })
+    expect(standalone.map(h => h.url)).toContain('https://solo.example.com')
+    const solo = standalone.find(h => h.url === 'https://solo.example.com')!
+    expect(solo.scopes).toEqual(['group:solo/eng'])
+    // Unmounted host WITHOUT remote_scopes: nothing safe to admit → not dialed.
+    const noScopes = hostsOf(plur, {
+      remote_project: { url: 'https://solo.example.com', token: 'tk' },
+    })
+    expect(noScopes.find(h => h.url === 'https://solo.example.com')).toBeUndefined()
+  })
+
+  it('groups by (url, token): two tokens on one endpoint dial twice; conflicts surface for doctor', () => {
+    const plur = plurWith(
+      `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "group:plur/eng"\n` +
+      `  - url: "https://plur.example.com/sse"\n    token: "t2"\n    scope: "group:plur/comms"\n`,
+    )
+    const hosts = hostsOf(plur, { scope: 'project:plur/x' })
+    expect(hosts).toHaveLength(2)
+    expect(new Set(hosts.map(h => h.token))).toEqual(new Set(['t1', 't2']))
+    expect(plur.remoteEndpointTokenConflicts()).toEqual([
+      { url: 'https://plur.example.com', tokens: 2 },
+    ])
+  })
+
+  it('scopeOrg extracts the org segment from shared scopes only', () => {
+    expect(scopeOrg('project:plur/plur-ai/enterprise')).toBe('plur')
+    expect(scopeOrg('group:datafund/igea')).toBe('datafund')
+    expect(scopeOrg('group:test')).toBe('test')
+    expect(scopeOrg('user:plur:gregor')).toBeNull()
+    expect(scopeOrg('global')).toBeNull()
+    expect(scopeOrg(undefined)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-to-end through Plur.recall — merge + outcome tracking + kill switch
+// ---------------------------------------------------------------------------
+
+describe('Plur.recall with a live remote host', () => {
+  function plurFor(scope: string): { plur: Plur; dir: string } {
+    const dir = tmp('plur-rr-e2e-')
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "${baseUrl}"\n    token: "${TOKEN}"\n    scope: "${scope}"\n`,
+    )
+    return { plur: new Plur({ path: dir }), dir }
+  }
+
+  it('merges server rows into recall results and records the outcome', async () => {
+    server.recallRows = [serverRow('ENG-2026-0731-030', { score: 1 })]
+    const { plur } = plurFor(TEAM_SCOPE)
+    const results = await plur.recall('remote statement', { scope: 'project:plur/anything' })
+    expect(results.some(e => (e as any)._originalId === 'ENG-2026-0731-030')).toBe(true)
+    const status = plur.remoteStoreStatus()
+    expect(status).toHaveLength(1)
+    expect(status[0].status).toBe('ok')
+    expect(server.recallCalls).toBe(1)
+  })
+
+  it('no project context → recall makes zero remote calls', async () => {
+    server.recallRows = [serverRow('ENG-2026-0731-031')]
+    const { plur } = plurFor(TEAM_SCOPE)
+    const results = await plur.recall('remote statement')
+    expect(server.recallCalls).toBe(0)
+    expect(results.some(e => (e as any)._originalId === 'ENG-2026-0731-031')).toBe(false)
+    expect(plur.remoteStoreStatus()).toHaveLength(0)
+  })
+
+  it('remote: false (internal caller contract) → zero remote calls', async () => {
+    const { plur } = plurFor(TEAM_SCOPE)
+    await plur.recall('remote statement', { scope: 'project:plur/anything', remote: false })
+    expect(server.recallCalls).toBe(0)
+  })
+
+  it('options.scopes authorization drops server rows outside the allow-list', async () => {
+    server.recallRows = [serverRow('ENG-2026-0731-032')]
+    const { plur } = plurFor(TEAM_SCOPE)
+    const results = await plur.recall('remote statement', {
+      scope: 'project:plur/anything',
+      scopes: ['project:plur/anything'], // team scope NOT in the allow-list
+    })
+    expect(server.recallCalls).toBe(1)
+    expect(results.some(e => (e as any)._originalId === 'ENG-2026-0731-032')).toBe(false)
+  })
+
+  it('host down → local results still served, degradation recorded', async () => {
+    const dir = tmp('plur-rr-down-')
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "http://127.0.0.1:1"\n    token: "t"\n    scope: "${TEAM_SCOPE}"\n`,
+    )
+    const plur = new Plur({ path: dir })
+    await plur.learn('local fact about recall', { scope: 'project:plur/anything' })
+    const results = await plur.recall('local fact about recall', { scope: 'project:plur/anything', remote_timeout_ms: 300 })
+    expect(results.length).toBeGreaterThan(0)
+    const status = plur.remoteStoreStatus()
+    expect(status).toHaveLength(1)
+    expect(['unreachable', 'timeout']).toContain(status[0].status)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A4′ — hook header suppression policy
+// ---------------------------------------------------------------------------
+
+describe('claimHookDegradationLines — suppression policy', () => {
+  const outcome = (state: HostRecallOutcome['state'], extra: Partial<HostRecallOutcome> = {}) => ({
+    host: 'https://plur.example.com',
+    status: state,
+    ...extra,
+  })
+
+  it('prints on first sight, suppresses the same state, prints again on state change', () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    const first = claimHookDegradationLines([outcome('timeout')], { statePath: sp, now })
+    expect(first).toHaveLength(1)
+    expect(first[0]).toMatch(/timed out/)
+
+    clock += 60_000
+    const repeat = claimHookDegradationLines([outcome('timeout')], { statePath: sp, now })
+    expect(repeat).toHaveLength(0) // same (host, state), inside the window
+
+    clock += 60_000
+    const changed = claimHookDegradationLines([outcome('auth_expired')], { statePath: sp, now })
+    expect(changed).toHaveLength(1)
+    expect(changed[0]).toMatch(/token expired or revoked/)
+    // Re-auth copy must NOT reference `plur login` (dead end on enterprise).
+    expect(changed[0]).not.toMatch(/plur login/)
+  })
+
+  it('re-prints the same state after the 4h window', () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    expect(claimHookDegradationLines([outcome('unreachable')], { statePath: sp, now })).toHaveLength(1)
+    clock += HOOK_HEADER_REPEAT_MS + 1
+    expect(claimHookDegradationLines([outcome('unreachable')], { statePath: sp, now })).toHaveLength(1)
+  })
+
+  it('skipped_cooldown and unsupported never print', () => {
+    const sp = statePath()
+    expect(claimHookDegradationLines([outcome('skipped_cooldown')], { statePath: sp })).toHaveLength(0)
+    expect(claimHookDegradationLines([outcome('unsupported')], { statePath: sp })).toHaveLength(0)
+  })
+
+  it('recovery to ok resets the marker so a recurrence prints again', () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    expect(claimHookDegradationLines([outcome('timeout')], { statePath: sp, now })).toHaveLength(1)
+    clock += 1000
+    expect(claimHookDegradationLines([outcome('ok')], { statePath: sp, now })).toHaveLength(0)
+    clock += 1000
+    expect(claimHookDegradationLines([outcome('timeout')], { statePath: sp, now })).toHaveLength(1)
+  })
+
+  it('ok with dropped_scopes prints the scope-narrowing line once', () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    const o = outcome('ok', { dropped_scopes: ['group:plur/secret'] })
+    const first = claimHookDegradationLines([o], { statePath: sp, now })
+    expect(first).toHaveLength(1)
+    expect(first[0]).toMatch(/not granted to your key/)
+    clock += 1000
+    expect(claimHookDegradationLines([o], { statePath: sp, now })).toHaveLength(0)
+  })
+
+  it('survives a corrupt state file (fresh state, still prints)', () => {
+    const sp = statePath()
+    writeFileSync(sp, '{not json')
+    const lines = claimHookDegradationLines([outcome('timeout')], { statePath: sp })
+    expect(lines).toHaveLength(1)
+    // And the rewrite produced a valid file.
+    expect(() => JSON.parse(readFileSync(sp, 'utf8'))).not.toThrow()
+  })
+})

--- a/packages/core/test/remote-recall.test.ts
+++ b/packages/core/test/remote-recall.test.ts
@@ -177,6 +177,52 @@ describe('remoteRecall — failure table', () => {
     expect(res.outcomes[0].state).toBe('unreachable') // count restarted
   })
 
+  it('403 → 404 → 403 does NOT read as revocation — ANY observed non-403 breaks the streak', async () => {
+    const sp = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    server.recallStatus = 403
+    await remoteRecall([host()], 'x', { statePath: sp, now })
+    // A 404 between the two 403s breaks the consecutive-403 streak…
+    server.recallStatus = 404
+    await remoteRecall([host()], 'x', { statePath: sp, now })
+    // …so the next 403 (after the unsupported TTL re-probe) is again
+    // unconfirmed, not a revocation verdict built from non-consecutive 403s.
+    clock += UNSUPPORTED_TTL_MS + 1
+    server.recallStatus = 403
+    const res = await remoteRecall([host()], 'x', { statePath: sp, now })
+    expect(res.outcomes[0].state).toBe('unreachable')
+    expect(res.outcomes[0].detail).toBe('http_403_unconfirmed')
+  })
+
+  it('403 → 5xx → 403 and 403 → 429 → 403 stay unconfirmed too', async () => {
+    // 5xx (network class) breaks the streak.
+    const sp1 = statePath()
+    server.recallStatus = 403
+    await remoteRecall([host()], 'x', { statePath: sp1 })
+    server.recallStatus = 500
+    await remoteRecall([host()], 'x', { statePath: sp1 })
+    server.recallStatus = 403
+    const afterServerError = await remoteRecall([host()], 'x', { statePath: sp1 })
+    expect(afterServerError.outcomes[0].state).toBe('unreachable')
+    expect(afterServerError.outcomes[0].detail).toBe('http_403_unconfirmed')
+
+    // 429 breaks the streak (dial again past its cooldown).
+    const sp2 = statePath()
+    let clock = 1_000_000_000_000
+    const now = () => clock
+    server.recallStatus = 403
+    server.recallRetryAfter = '1'
+    await remoteRecall([host()], 'x', { statePath: sp2, now })
+    server.recallStatus = 429
+    await remoteRecall([host()], 'x', { statePath: sp2, now })
+    clock += 2000
+    server.recallStatus = 403
+    const afterRateLimit = await remoteRecall([host()], 'x', { statePath: sp2, now })
+    expect(afterRateLimit.outcomes[0].state).toBe('unreachable')
+    expect(afterRateLimit.outcomes[0].detail).toBe('http_403_unconfirmed')
+  })
+
   it('404 → unsupported for a TTL, not process lifetime', async () => {
     const sp = statePath()
     let clock = 1_000_000_000_000
@@ -304,6 +350,61 @@ describe('remoteRecall — circuit breaker', () => {
     const resumed = await remoteRecall([host()], 'x', { statePath: sp, now })
     expect(resumed.outcomes[0].state).toBe('ok')
     expect(server.recallCalls).toBe(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// remote-health.json lost-update protection (read-merge-write under lock)
+// ---------------------------------------------------------------------------
+
+describe('remote-health.json — concurrent writers', () => {
+  const URL_A = 'http://127.0.0.1:1'
+  const URL_B = 'http://127.0.0.1:2'
+  const refuse: typeof fetch = async () => { throw new Error('conn refused') }
+
+  it('a writer with a stale entry snapshot does not erase another writer\'s host update', async () => {
+    const sp = statePath()
+    // Writer A reads the (empty) health file at entry, then — while its own
+    // fetch is in flight — writer B runs a COMPLETE recall against another
+    // host and persists a breaker failure for it. Writer A's exit persist is
+    // based on its stale entry snapshot: a whole-file overwrite would erase
+    // B's host entry; the read-merge-write keeps both.
+    let bStarted = false
+    const fetchA: typeof fetch = async (...args) => {
+      if (!bStarted) {
+        bStarted = true
+        await remoteRecall([host({ url: URL_B })], 'x', { statePath: sp, fetchImpl: refuse, timeoutMs: 300 })
+      }
+      return refuse(...args)
+    }
+    await remoteRecall([host({ url: URL_A })], 'x', { statePath: sp, fetchImpl: fetchA, timeoutMs: 500 })
+
+    const persisted = readRemoteHealth(sp)
+    const entries = Object.values(persisted.hosts)
+    expect(Object.keys(persisted.hosts)).toHaveLength(2) // B's entry survived A's persist
+    for (const h of entries) {
+      expect(h.failures).toBe(1)
+      expect(h.last_state).toBe('unreachable')
+    }
+  })
+
+  it('a remoteRecall persist does not erase a concurrent hook-header claim', async () => {
+    const sp = statePath()
+    // The claim happens AFTER the recall's entry snapshot but BEFORE its exit
+    // persist — the exact interleaving that used to lose the suppression
+    // bookkeeping and double-print the header on the next prompt.
+    let claimed: string[] = []
+    const fetchImpl: typeof fetch = async (...args) => {
+      claimed = claimHookDegradationLines([{ host: URL_A, status: 'unreachable' }], { statePath: sp })
+      return refuse(...args)
+    }
+    await remoteRecall([host({ url: URL_A })], 'x', { statePath: sp, fetchImpl, timeoutMs: 500 })
+    expect(claimed).toHaveLength(1) // the mid-flight claim printed
+
+    // The persist finished after the claim; the (host, state) budget it
+    // consumed must still be consumed — same state stays silent.
+    const again = claimHookDegradationLines([{ host: URL_A, status: 'unreachable' }], { statePath: sp })
+    expect(again).toHaveLength(0)
   })
 })
 

--- a/packages/core/test/remote-store-cache.test.ts
+++ b/packages/core/test/remote-store-cache.test.ts
@@ -335,9 +335,9 @@ describe('Plur cold-start with remote store (issues #184, #185)', () => {
       data: { statement: 'seeded engram', scope: 'group:test', status: 'active' },
     })
 
-    // Trigger cache population
-    await plur.list({ scope: 'group:test' })
-    await new Promise(r => setTimeout(r, 2000))
+    // #776: reads no longer fire a background refresh — warm explicitly,
+    // the same path session_start uses.
+    await plur.warmRemoteCaches()
 
     const stores = await plur.listStores()
     const remote = stores.find(s => s.url)
@@ -433,8 +433,8 @@ describe('Plur cold-start with remote store (issues #184, #185)', () => {
       data: { statement: 'seeded engram', scope: 'group:test', status: 'active' },
     })
 
-    await plur.list()
-    await new Promise(r => setTimeout(r, 2000))
+    // #776: reads no longer fire a background refresh — warm explicitly.
+    await plur.warmRemoteCaches()
 
     const found = await plur.getById('ENG-GTE-SEED-001')
     expect(found).toBeTruthy()

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -42,7 +42,7 @@ Next session starts     →  relevant ones injected →  agent remembers
 You rate the result     →  engram strengthens    →  quality improves
 ```
 
-Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant. Search is fully local (BM25 + embeddings), so memory recall costs nothing and works offline. [Benchmark methodology →](https://plur.ai/benchmark.html)
+Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant. Search runs locally (BM25 + embeddings); with a PLUR Enterprise store configured, recall also makes one live, timeout-bounded call per relevant remote host and merges the team's engrams in — and tells you, per host, when that leg is degraded instead of failing silently. Without a remote store it is fully local, costs nothing, and works offline. [Benchmark methodology →](https://plur.ai/benchmark.html)
 
 ## Tools
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -80,11 +80,13 @@ Do not ask permission to use these tools — they are your memory system.
 Setup: If this is a fresh install, suggest the user run: npx @plur-ai/mcp init
 This installs hooks for automatic injection + session management. One-time global setup.`
 
-const GUIDE_RESOURCE = `# PLUR — Agent Guide
+// Exported for the #776 description-honesty test (the guide once claimed
+// "fully local, zero API calls" while the recall path dials enterprise hosts).
+export const GUIDE_RESOURCE = `# PLUR — Agent Guide
 
 ## What is PLUR?
 
-Persistent memory for AI agents. Corrections, preferences, and conventions are stored as **engrams** — small assertions that strengthen with use and decay when irrelevant (ACT-R model). Storage is plain YAML on disk. Search is fully local (BM25 + embeddings). Zero API calls.
+Persistent memory for AI agents. Corrections, preferences, and conventions are stored as **engrams** — small assertions that strengthen with use and decay when irrelevant (ACT-R model). Storage is plain YAML on disk. Search runs locally (BM25 + embeddings); when an enterprise/remote store is configured AND relevant to the current project, recall additionally makes one live timeout-bounded call per remote host and merges the results — degradation is surfaced per host via a \`remote_stores\` block, never silent. With no remote store configured, search is fully local with zero API calls.
 
 ## Quick Start
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,8 +1,8 @@
 import { existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName, SUGGEST_DISPLAY_MIN_CONFIDENCE } from '@plur-ai/core'
-import type { LlmFunction, MetaField, TensionStatus, RerankerEvalResult, HistoryEvent, Receipt } from '@plur-ai/core'
+import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName, SUGGEST_DISPLAY_MIN_CONFIDENCE, mcpRemoteWarningLine, doctorRemoteRemediation } from '@plur-ai/core'
+import type { LlmFunction, MetaField, TensionStatus, RerankerEvalResult, HistoryEvent, Receipt, RemoteStoreStatusEntry } from '@plur-ai/core'
 import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
 import { z } from 'zod'
@@ -47,6 +47,33 @@ export interface ToolDefinition {
 }
 
 /**
+ * A4′ (#776): attach per-host remote degradation to a tool response — ONLY
+ * when a host is non-ok or was silently scope-narrowed (`dropped_scopes`).
+ * Structured block + ONE prose `warning` line (agent-directed strings from
+ * the shared core table — consequence + agent action), mirroring the
+ * hybrid-degraded warning pattern above it. Healthy hosts attach nothing.
+ */
+function attachRemoteStoreDegradation(response: Record<string, unknown>, plur: Plur): void {
+  let status: RemoteStoreStatusEntry[]
+  try {
+    status = plur.remoteStoreStatus()
+  } catch {
+    return // surfacing must never break the tool response
+  }
+  const degraded = status.filter(s => s.status !== 'ok' || (s.dropped_scopes?.length ?? 0) > 0)
+  if (degraded.length === 0) return
+  response.remote_stores = degraded.map(s => ({
+    host: s.host,
+    status: s.status,
+    ...(s.dropped_scopes && s.dropped_scopes.length > 0 ? { dropped_scopes: s.dropped_scopes } : {}),
+  }))
+  const line = `Remote store degradation — ${degraded.map(s => mcpRemoteWarningLine(s)).join(' ')}`
+  response.warning = typeof response.warning === 'string' && response.warning.length > 0
+    ? `${response.warning} ${line}`
+    : line
+}
+
+/**
  * The canonical `plur_recall` handler (#693).
  *
  * Hoisted out of the tool literal so the deprecated `plur_recall_hybrid`
@@ -65,8 +92,9 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
       scope: args.scope as string | undefined,
       domain: args.domain as string | undefined,
       limit: args.limit as number | undefined,
+      remote_timeout_ms: 2000, // MCP recall remote budget (#776)
     })
-    return {
+    const response: Record<string, unknown> = {
       results: results.map(e => {
         const supersededBy = e.relations?.superseded_by
         const annotation = supersededBy?.length ? ` [superseded by ${supersededBy.join(', ')}]` : ''
@@ -82,6 +110,8 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
       count: results.length,
       mode: 'keyword',
     }
+    attachRemoteStoreDegradation(response, plur)
+    return response
   }
   // mode === 'hybrid' (default)
   const budget = args.budget as { max_tokens?: number; max_results?: number; ttl_seconds?: number } | undefined
@@ -95,6 +125,7 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
     scope: args.scope as string | undefined,
     domain: args.domain as string | undefined,
     limit: fetchLimit,
+    remote_timeout_ms: 2000, // MCP recall remote budget (#776)
   })
   // Opt-in, content-free engagement counter (default-off; no query text).
   recordTelemetry('recall')
@@ -162,6 +193,8 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
       response.reranker_warning = `PLUR_RERANKER is set but the reranker did not engage — results are RRF-only (fusion order, no cross-encoder rerank).${corruptNote} Last error: ${rr.lastError}. Run plur_doctor for diagnosis.`
     }
   }
+  // A4′ (#776): per-host remote degradation — attached only when non-ok.
+  attachRemoteStoreDegradation(response, plur)
   return response
 }
 
@@ -925,7 +958,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_recall',
-      description: 'Search engrams by topic. Default mode is hybrid (BM25 + local embeddings via RRF) — set mode:"keyword" for BM25-only. No API calls, fully local. Note: a project-scope filter also returns personal-family engrams (local, global, user:*, agent:*); an explicit scope=global recall returns ALL personal-family engrams — wider than scope=global INJECT, which is targeted to the global namespace only.',
+      description: 'Search engrams by topic. Default mode is hybrid (BM25 + local embeddings via RRF) — set mode:"keyword" for BM25-only. Local search plus, when a configured enterprise store is part of the current project/work, one live timeout-bounded recall per remote host merged in (a `remote_stores` block + warning appears when a host is degraded; no host configured or implicated = fully local). Note: a project-scope filter also returns personal-family engrams (local, global, user:*, agent:*); an explicit scope=global recall returns ALL personal-family engrams — wider than scope=global INJECT, which is targeted to the global namespace only.',
       annotations: { title: 'Recall', readOnlyHint: true, idempotentHint: true },
       inputSchema: {
         type: 'object',
@@ -946,7 +979,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_recall_hybrid',
-      description: '[Deprecated since 0.16 — use plur_recall (mode defaults to hybrid). Alias kept for backwards compatibility; removal earliest 0.18.] Hybrid search — BM25 + local embeddings merged via Reciprocal Rank Fusion. No API calls, fully local.',
+      description: '[Deprecated since 0.16 — use plur_recall (mode defaults to hybrid). Alias kept for backwards compatibility; removal earliest 0.18.] Hybrid search — BM25 + local embeddings merged via Reciprocal Rank Fusion, plus the live enterprise-store recall leg when one is configured and project-relevant.',
       annotations: { title: 'Recall (hybrid) [deprecated alias]', readOnlyHint: true, idempotentHint: true },
       inputSchema: {
         type: 'object',
@@ -1028,7 +1061,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           session_id,
         })
         _recordInjectionTelemetry(session_id, result.injected_packs)
-        return {
+        const response: Record<string, unknown> = {
           directives: result.directives,
           consider: result.consider,
           count: result.count,
@@ -1038,6 +1071,9 @@ function getAllToolDefinitions(): ToolDefinition[] {
           // #181: unresolved-tension warnings — flag contradicted context
           ...(result.warnings ? { warnings: result.warnings } : {}),
         }
+        // A4′ (#776): per-host remote degradation — only when non-ok.
+        attachRemoteStoreDegradation(response, plur)
+        return response
       },
     },
 
@@ -1161,7 +1197,9 @@ function getAllToolDefinitions(): ToolDefinition[] {
           return { success: true, retired: { id: args.id as string } }
         }
         if (args.search) {
-          const matches = await plur.recall(args.search as string, { limit: 100 })
+          // remote:false (#776) — forget-by-search resolves local retirement
+          // targets; it must not fan the search phrase out to remote hosts.
+          const matches = await plur.recall(args.search as string, { limit: 100, remote: false })
           if (matches.length === 0) return { success: false, error: `No active engrams matching "${args.search}"` }
           if (matches.length === 1) {
             await plur.forget(matches[0].id)
@@ -1946,6 +1984,35 @@ function getAllToolDefinitions(): ToolDefinition[] {
             }
           }
         } catch { /* best-effort — never let the remote probe break doctor */ }
+        // #776 A4′: live-recall leg status per host, fed by the last recall
+        // outcomes (not by a fresh probe) — this is what tells the user WHY
+        // recent recalls served local-only, including states /me can't see
+        // (rate_limited, unsupported, circuit-breaker cooldown, silent scope
+        // narrowing via dropped_scopes).
+        try {
+          for (const s of plur.remoteStoreStatus()) {
+            const fix = doctorRemoteRemediation(s)
+            const degraded = s.status !== 'ok' || (s.dropped_scopes?.length ?? 0) > 0
+            checks.push({
+              check: `remote recall: ${s.host}`,
+              ok: !degraded,
+              detail: degraded
+                ? `Last live recall: ${s.status}${s.dropped_scopes?.length ? ` (dropped scopes: ${s.dropped_scopes.join(', ')})` : ''} — recent recalls served local results only.`
+                : `Last live recall ok (${s.count} row(s) in ${s.ms}ms)`,
+            })
+            if (fix) remediation.push(fix)
+          }
+          // (url, token) fan-out sanity: differing tokens per endpoint mean
+          // one POST per token on every recall — a misconfiguration.
+          for (const c of plur.remoteEndpointTokenConflicts()) {
+            checks.push({
+              check: `remote store tokens: ${c.url}`,
+              ok: false,
+              detail: `${c.tokens} distinct tokens configured for this endpoint — recall dials once per (url, token).`,
+            })
+            remediation.push(`Remote ${c.url}: ${c.tokens} distinct tokens are configured across its store entries — consolidate to one token in ~/.plur/config.yaml so recall dials the host once.`)
+          }
+        } catch { /* best-effort — never let recall status break doctor */ }
         return {
           ok: checks.every(c => c.ok),
           checks,
@@ -2071,6 +2138,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
             scope: tags?.length ? `tags:${tags.join(',')}` : undefined,
             session_id, // stamped on the co_injection provenance event (#452)
             source: 'session_start',
+            remote_timeout_ms: 5000, // session_start warm budget (#776)
           })
           _recordInjectionTelemetry(session_id, result.injected_packs)
           if (result.count > 0) {
@@ -2231,7 +2299,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           } catch { /* best-effort */ }
         }
 
-        return {
+        const sessionResponse: Record<string, unknown> = {
           session_id,
           engrams: engrams ?? [],
           store_stats,
@@ -2264,6 +2332,10 @@ function getAllToolDefinitions(): ToolDefinition[] {
           // Version staleness warning (issue #151)
           ...(version_warning ? { version_warning, version: VERSION } : {}),
         }
+        // A4′ (#776): per-host remote recall degradation from the injection
+        // above — attached only when a host is non-ok or scope-narrowed.
+        attachRemoteStoreDegradation(sessionResponse, plur)
+        return sessionResponse
       },
     },
 

--- a/packages/mcp/test/remote-recall-surfacing.test.ts
+++ b/packages/mcp/test/remote-recall-surfacing.test.ts
@@ -1,0 +1,223 @@
+/**
+ * A4′ degradation surfacing on the MCP surfaces (#776).
+ *
+ * The recall/inject/session_start responses attach a structured
+ * `remote_stores` block + ONE prose warning line ONLY when a remote host is
+ * non-ok (or silently scope-narrowed via dropped_scopes) — a healthy host
+ * attaches nothing. plur_doctor renders the human remediation strings,
+ * including the re-auth copy that must NOT reference `plur login` (a dead
+ * end against enterprise servers). Tool descriptions and the agent guide no
+ * longer claim "fully local / no API calls".
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Client } from '@modelcontextprotocol/client'
+import { InMemoryTransport } from '@modelcontextprotocol/server'
+import { Plur } from '@plur-ai/core'
+import { createServer, INSTRUCTIONS, GUIDE_RESOURCE } from '../src/server.js'
+import { getToolDefinitions } from '../src/tools.js'
+import { StubServer } from '../../core/test/helpers/stub-server.js'
+
+const TOKEN = 'surfacing-token'
+const SCOPE = 'group:test'
+const PROJECT = 'project:test/app' // org 'test' → implicates the store
+
+let stub: StubServer
+let baseUrl: string
+const dirs: string[] = []
+let activeClients: Client[] = []
+
+async function makeClient(plurPath: string): Promise<Client> {
+  const plur = new Plur({ path: plurPath })
+  // full profile: plur_inject_hybrid is not directly callable under lean.
+  const server = await createServer(plur, { profile: 'full' })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  const client = new Client({ name: 'test-client', version: '1.0.0' })
+  await client.connect(clientTransport)
+  activeClients.push(client)
+  return client
+}
+
+function callResult(raw: Awaited<ReturnType<Client['callTool']>>): any {
+  return JSON.parse((raw.content as any)[0].text)
+}
+
+function writeConfig(url: string, token = TOKEN): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-mcp-rrs-'))
+  dirs.push(dir)
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    `embeddings:\n  enabled: false\nstores:\n  - url: "${url}"\n    token: "${token}"\n    scope: "${SCOPE}"\n`,
+  )
+  return dir
+}
+
+beforeAll(async () => {
+  stub = new StubServer(TOKEN)
+  const info = await stub.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => {
+  await stub.stop()
+  for (const d of dirs) rmSync(d, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  stub.reset()
+  stub.setMe({ username: 'tester', org_id: 'test', role: 'developer', scopes: [SCOPE] })
+})
+
+afterEach(async () => {
+  await Promise.all(activeClients.map(c => c.close().catch(() => {})))
+  activeClients = []
+})
+
+describe('remote_stores block on plur_recall', () => {
+  it('is ABSENT when the host is healthy', async () => {
+    stub.recallRows = [{ id: 'ENG-2026-0731-080', scope: SCOPE, status: 'active', statement: 'team fact', score: 1 }]
+    const client = await makeClient(writeConfig(baseUrl))
+    const res = callResult(await client.callTool({
+      name: 'plur_recall',
+      arguments: { query: 'team fact', scope: PROJECT },
+    }))
+    expect(res.remote_stores).toBeUndefined()
+    expect(stub.recallCalls).toBe(1)
+    // ...and the server row is actually served.
+    expect(res.results.some((r: any) => String(r.id).includes('2026-0731-080'))).toBe(true)
+  })
+
+  it('is PRESENT with a prose warning when the host is unreachable', async () => {
+    const client = await makeClient(writeConfig('http://127.0.0.1:1'))
+    const res = callResult(await client.callTool({
+      name: 'plur_recall',
+      arguments: { query: 'anything at all', scope: PROJECT },
+    }))
+    expect(res.remote_stores).toBeDefined()
+    expect(res.remote_stores).toHaveLength(1)
+    expect(res.remote_stores[0].host).toBe('http://127.0.0.1:1')
+    expect(['unreachable', 'timeout']).toContain(res.remote_stores[0].status)
+    // Agent-directed prose: consequence + agent action.
+    expect(res.warning).toMatch(/serving local only/)
+    expect(res.warning).toMatch(/plur_doctor/)
+  })
+
+  it('keyword mode surfaces the block too (recall() dials as well)', async () => {
+    const client = await makeClient(writeConfig('http://127.0.0.1:1'))
+    const res = callResult(await client.callTool({
+      name: 'plur_recall',
+      arguments: { query: 'anything', scope: PROJECT, mode: 'keyword' },
+    }))
+    expect(res.remote_stores).toBeDefined()
+  })
+
+  it('surfaces silent scope narrowing (dropped_scopes) even on an ok host', async () => {
+    stub.recallEnvelope = { dropped_scopes: ['group:test/secret'] }
+    const client = await makeClient(writeConfig(baseUrl))
+    const res = callResult(await client.callTool({
+      name: 'plur_recall',
+      arguments: { query: 'anything', scope: PROJECT },
+    }))
+    expect(res.remote_stores).toBeDefined()
+    expect(res.remote_stores[0].status).toBe('ok')
+    expect(res.remote_stores[0].dropped_scopes).toEqual(['group:test/secret'])
+    expect(res.warning).toMatch(/not granted to your key/)
+  })
+})
+
+describe('remote_stores block on plur_inject_hybrid and plur_session_start', () => {
+  it('plur_inject_hybrid attaches the block only when degraded', async () => {
+    const degraded = await makeClient(writeConfig('http://127.0.0.1:1'))
+    const res = callResult(await degraded.callTool({
+      name: 'plur_inject_hybrid',
+      arguments: { task: 'anything at all', scope: PROJECT },
+    }))
+    expect(res.remote_stores).toBeDefined()
+
+    const healthy = await makeClient(writeConfig(baseUrl))
+    const ok = callResult(await healthy.callTool({
+      name: 'plur_inject_hybrid',
+      arguments: { task: 'anything at all', scope: PROJECT },
+    }))
+    expect(ok.remote_stores).toBeUndefined()
+  })
+
+  it('plur_session_start reports a degraded host from its warm injection', async () => {
+    // session_start has no project scope in this harness — give the store a
+    // dial:always override so the warm injection dials it.
+    const dir = mkdtempSync(join(tmpdir(), 'plur-mcp-rrs-'))
+    dirs.push(dir)
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "http://127.0.0.1:1"\n    token: "t"\n    scope: "${SCOPE}"\n    dial: always\n`,
+    )
+    const client = await makeClient(dir)
+    const res = callResult(await client.callTool({
+      name: 'plur_session_start',
+      arguments: { task: 'kick off' },
+    }))
+    expect(res.remote_stores).toBeDefined()
+    expect(['unreachable', 'timeout']).toContain(res.remote_stores[0].status)
+  })
+})
+
+describe('plur_doctor remediation strings (#776)', () => {
+  it('renders the re-auth remediation WITHOUT plur login, and the recall-leg check', async () => {
+    stub.recallStatus = 401
+    const dir = writeConfig(baseUrl)
+    const client = await makeClient(dir)
+    // Prime a recall so the doctor has a last outcome to report.
+    await client.callTool({ name: 'plur_recall', arguments: { query: 'x', scope: PROJECT } })
+    const res = callResult(await client.callTool({ name: 'plur_doctor', arguments: {} }))
+    const recallCheck = res.checks.find((c: any) => String(c.check).startsWith('remote recall:'))
+    expect(recallCheck).toBeDefined()
+    expect(recallCheck.ok).toBe(false)
+    expect(recallCheck.detail).toMatch(/auth_expired/)
+    const remediation: string = res.remediation.join('\n')
+    expect(remediation).toMatch(/token expired or revoked/)
+    expect(remediation).toMatch(/plur_stores_add/)
+    // The dead-end command must not be recommended (DX finding 1): the only
+    // mention allowed is the explicit "does not work" warning.
+    expect(remediation).not.toMatch(/`plur login` (?!does not work)/)
+    expect(remediation).toMatch(/plur login.*does not work/i)
+  })
+
+  it('warns when one endpoint is configured with multiple tokens', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plur-mcp-rrs-'))
+    dirs.push(dir)
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n` +
+      `  - url: "${baseUrl}"\n    token: "${TOKEN}"\n    scope: "group:test"\n` +
+      `  - url: "${baseUrl}/sse"\n    token: "another-token"\n    scope: "group:test/sub"\n`,
+    )
+    const client = await makeClient(dir)
+    const res = callResult(await client.callTool({ name: 'plur_doctor', arguments: {} }))
+    const tokenCheck = res.checks.find((c: any) => String(c.check).startsWith('remote store tokens:'))
+    expect(tokenCheck).toBeDefined()
+    expect(tokenCheck.ok).toBe(false)
+    expect(res.remediation.join('\n')).toMatch(/consolidate to one token/)
+  })
+})
+
+describe('description honesty (#776)', () => {
+  const tools = getToolDefinitions('full')
+
+  it('plur_recall no longer claims "No API calls, fully local"', () => {
+    const recall = tools.find(t => t.name === 'plur_recall')!
+    expect(recall.description).not.toMatch(/No API calls, fully local/)
+    expect(recall.description).toMatch(/remote host|enterprise store/i)
+    const hybrid = tools.find(t => t.name === 'plur_recall_hybrid')!
+    expect(hybrid.description).not.toMatch(/No API calls, fully local/)
+  })
+
+  it('the server instructions/guide no longer claim zero API calls unconditionally', () => {
+    expect(GUIDE_RESOURCE).not.toMatch(/Search is fully local \(BM25 \+ embeddings\)\. Zero API calls\./)
+    expect(GUIDE_RESOURCE).toMatch(/remote_stores/)
+    // INSTRUCTIONS never made the claim — pin that it stays that way.
+    expect(INSTRUCTIONS).not.toMatch(/Zero API calls/)
+  })
+})


### PR DESCRIPTION
Closes #776. Builds on #777 (visibility grants — merge that first; this branch includes it). Server contract: enterprise#631.

## What changes
Recall/inject gains a live server leg: `POST {host}/api/v1/recall` per (url, token) group, timeout-bounded (hook 1500ms / MCP 2000ms), RRF-merged with local results. **No disk caching of remote engrams** (owner decision — engrams change): host unreachable = local-only + loud per-host degradation. **Strict scope-relevance dialing** (owner decision): a host is dialed only with the scope subset relevant to the current project/work; no implicating context → zero remote calls; per-store `dial: always|never` override.

Highlights (full spec in the reviewed plan):
- `remote-recall.ts`: failure table (401 / 2×403→revocation / 404→10-min unsupported / 429 Retry-After / breaker 3→5-min cooldown), **breaker state persisted across one-shot hook processes** (`cache/remote-health.json`), connect-phase budget, 128KB cap, query truncation.
- Scope guard admits `global` rows (does NOT reimplement #570 client-side); deterministic row→store-entry namespacing; server rows pass the visibility predicate BEFORE entering the boost channel (no resurrection of scope-excluded rows); learn-dedup/forget-search/self-eval never dial (`remote:false`).
- `tryRemoteInject` deleted — ≤1 remote call per host per prompt (tested).
- A4′: `remote_stores` degradation block (only when non-ok) on recall/inject/session_start; doctor remediation (re-auth copy does NOT reference `plur login` — it doesn't work against enterprise); hook `[PLUR]` header rate-limited (state change, then 1/4h); stale "fully local / zero API calls" claims fixed in tool descriptions + README.
- Env: `PLUR_REMOTE_RECALL=off|0|false` kill-switch, `PLUR_REMOTE_RECALL_TIMEOUT_MS`.

## Tests
68 new (45 remote-recall, 9 integration, 10 MCP surfacing, 4 CLI hook) incl. the adversarial set from review: global-row survival, boosted out-of-scope non-injection, org-mismatch host not dialed, breaker across two processes, kill-switch. Full workspace: **3318 passed / 0 failed (254 files)**; `pnpm -r build` clean.

Cross-repo e2e against a real enterprise stack (rebuilt from #630+#631): results posted as a PR comment.

Benchmarks (bench:micro): vs main — learn 3.08→3.01ms (−0.07ms), recall BM25 4.03→4.15ms (+0.12ms), recallHybrid 17.57→17.27ms (−0.30ms), inject 0.42→0.45ms (+0.04ms); all within run-to-run noise (bench store has no remote hosts, so the remote leg never dials).
