### PR TITLE
fix(mcp): correct #772 whole-payload-drop diagnostic and add bounded forensic drop log

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -745,6 +745,17 @@ export class Plur {
   }
 
   /**
+   * Root directory of this instance's store (`~/.plur`, `PLUR_PATH`, or the
+   * explicit constructor `path`). Synchronous mirror of `status().storage_root`
+   * for callers that need the location without an async round-trip — e.g. the
+   * MCP server's payload-drop forensic log (plur-ai/plur#772), which must write
+   * next to the store the dropped call was aimed at.
+   */
+  get storageRoot(): string {
+    return this.paths.root
+  }
+
+  /**
    * Resolve the active storage tier. Order:
    *   1. `PLUR_BACKEND` env var (yaml|sqlite|pglite|postgres)
    *   2. config.yaml `backend` field

--- a/packages/mcp/src/drop-log.ts
+++ b/packages/mcp/src/drop-log.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+
+/**
+ * Forensic log for MCP argument-payload drops (plur-ai/plur#772).
+ *
+ * The #772 failure signature — a tool call arriving with an EMPTY arguments
+ * object (`received_fields: []`) — is intermittent and originates client-side,
+ * before the frame reaches this server (the wire-protocol tests from #297/#301
+ * prove the server handles the same payloads correctly). That makes it
+ * impossible to reproduce on demand; the only way to progress the upstream
+ * report is to record each occurrence as it happens in the wild, with exactly
+ * the wire-level facts the report needs.
+ *
+ * Contract:
+ *  - NO VALUES, ever. Records carry field NAMES and frame metadata only. A
+ *    whole-payload drop has no values by definition; a partial drop does, and
+ *    those never enter this file — engram statements can contain anything.
+ *  - Bounded. The file is trimmed to the newest {@link PAYLOAD_DROP_LOG_MAX_ENTRIES}
+ *    records on every write, so a pathological client cannot grow it unbounded.
+ *  - Best-effort. A diagnostics write must never break the tool call it is
+ *    diagnosing — every failure path is swallowed.
+ */
+
+/** Newest-N cap applied on every write. */
+export const PAYLOAD_DROP_LOG_MAX_ENTRIES = 100
+
+export interface PayloadDropRecord {
+  /** ISO-8601 timestamp of the drop. */
+  ts: string
+  /** Tool the dropped call was addressed to. */
+  tool: string
+  /**
+   * How `params.arguments` looked on the wire — the one bit only this boundary
+   * can observe, and the first thing an upstream client report needs:
+   *  - 'absent'       — the `arguments` key was missing from the frame entirely
+   *  - 'empty_object' — the key arrived, carrying `{}`
+   *  - 'partial'      — some fields arrived, required ones (observed: trailing
+   *                     array-typed ones, #297) did not
+   */
+  arguments_wire: 'absent' | 'empty_object' | 'partial'
+  /** Top-level key NAMES of `request.params` (e.g. name, arguments, _meta). */
+  params_keys: string[]
+  /** Field NAMES that did arrive — never their values. */
+  received_fields: string[]
+  /** Schema-required field NAMES that were missing. */
+  missing_fields: string[]
+  /** JSON-RPC request id, when the SDK exposes it. */
+  request_id?: string | number
+  /** @plur-ai/mcp version that recorded the drop. */
+  server_version: string
+}
+
+export function payloadDropLogPath(storageRoot: string): string {
+  return join(storageRoot, 'logs', 'payload-drops.jsonl')
+}
+
+/**
+ * Append one record, keeping only the newest {@link PAYLOAD_DROP_LOG_MAX_ENTRIES}.
+ * Never throws.
+ */
+export function recordPayloadDrop(storageRoot: string, record: PayloadDropRecord): void {
+  try {
+    const path = payloadDropLogPath(storageRoot)
+    mkdirSync(dirname(path), { recursive: true })
+    let lines: string[] = []
+    if (existsSync(path)) {
+      lines = readFileSync(path, 'utf8').split('\n').filter(l => l.length > 0)
+    }
+    lines.push(JSON.stringify(record))
+    if (lines.length > PAYLOAD_DROP_LOG_MAX_ENTRIES) {
+      lines = lines.slice(-PAYLOAD_DROP_LOG_MAX_ENTRIES)
+    }
+    writeFileSync(path, lines.join('\n') + '\n')
+  } catch {
+    /* diagnostics must never break the tool call being diagnosed */
+  }
+}
+
+/** Read all records (newest last). Missing or corrupt file → []. */
+export function readPayloadDropLog(storageRoot: string): PayloadDropRecord[] {
+  try {
+    const path = payloadDropLogPath(storageRoot)
+    if (!existsSync(path)) return []
+    return readFileSync(path, 'utf8')
+      .split('\n')
+      .filter(l => l.length > 0)
+      .flatMap(l => {
+        try { return [JSON.parse(l) as PayloadDropRecord] } catch { return [] }
+      })
+  } catch {
+    return []
+  }
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { Plur, checkForUpdate } from '@plur-ai/core'
 import { getToolDefinitions, mcpCanary, validateToolArgs, CURSOR_CORE_TOOL_NAMES, type ToolProfile, resolveToolProfile, setActiveToolProfile } from './tools.js'
+import { payloadDropLogPath, recordPayloadDrop } from './drop-log.js'
 import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
 
@@ -236,9 +237,43 @@ export async function createServer(plur?: Plur, options?: { profile?: ToolProfil
     // `threshold` turns without an expected signal flags the capability.
     mcpCanary.tick()
     try {
-      let args = request.params.arguments ?? {}
+      // #772: capture whether the frame carried `arguments` at all BEFORE the
+      // `?? {}` default erases the distinction. "Key absent" vs "arrived as {}"
+      // is the one wire-level fact only this boundary can observe, and it is
+      // the first thing the upstream client report needs.
+      const rawArguments = request.params.arguments
+      let args = rawArguments ?? {}
       const validated = validateToolArgs(tool, args)
       if (!validated.ok) {
+        const drop = validated.errorPayload.drop
+        if (drop) {
+          // Forensic record of the dropped frame (#772) — bounded, field NAMES
+          // only, never values. Written only at this top-level wire boundary:
+          // plur_admin's inner `args` travel INSIDE a delivered payload, so an
+          // inner-validation failure there is not a wire drop.
+          recordPayloadDrop(instance.storageRoot, {
+            ts: new Date().toISOString(),
+            tool: request.params.name,
+            arguments_wire: drop === 'whole_payload'
+              ? (rawArguments === undefined ? 'absent' : 'empty_object')
+              : 'partial',
+            params_keys: Object.keys((request.params ?? {}) as Record<string, unknown>),
+            received_fields: validated.errorPayload.received_fields,
+            missing_fields: validated.errorPayload.missing_fields,
+            request_id: (request as { id?: string | number }).id,
+            server_version: VERSION,
+          })
+          // Guarded sync AND async: a logging failure must never replace the
+          // diagnostic error response with a generic one via the outer catch.
+          try {
+            void Promise.resolve(server.sendLoggingMessage({
+              level: 'warning',
+              data: `Payload drop (#772) on ${request.params.name}: arguments ` +
+                `${rawArguments === undefined ? 'key absent from frame' : `arrived with fields [${validated.errorPayload.received_fields.join(', ')}]`}. ` +
+                `Recorded in ${payloadDropLogPath(instance.storageRoot)}.`,
+            })).catch(() => { /* logging must not break the error response */ })
+          } catch { /* ditto for synchronous throws */ }
+        }
         return {
           content: [{ type: 'text', text: JSON.stringify(validated.errorPayload) }],
           isError: true,

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -273,7 +273,14 @@ export function validateToolArgs(
   rawArgs: Record<string, unknown>,
 ): { ok: true; data: Record<string, unknown> } | {
   ok: false
-  errorPayload: { error: string; success: false; received_fields: string[]; _isError: true }
+  errorPayload: {
+    error: string
+    success: false
+    received_fields: string[]
+    missing_fields: string[]
+    drop?: 'whole_payload' | 'partial'
+    _isError: true
+  }
 } {
   const schema = tool.inputSchema as any
   if (!schema?.properties) return { ok: true, data: rawArgs }
@@ -290,44 +297,74 @@ export function validateToolArgs(
     const hasArrayParam = Object.values((schema.properties ?? {}) as Record<string, any>)
       .some((p: any) => p?.type === 'array')
 
-    // #297 has TWO shapes, not one. The original (total drop) loses the whole
-    // arguments object. The partial drop keeps the early scalar fields and
-    // silently discards trailing ones — observed on a large payload where a
-    // ~700-char `summary` plus a 5-element `engram_suggestions` array arrived
-    // as `{summary}` alone. Gating the hint on `receivedFields.length === 0`
-    // meant the partial case — the one that actually looks like a schema bug
-    // to the caller — got a bare "Required" with no workaround. Fire the hint
-    // whenever a *missing* field is itself array-typed.
-    const missingArrayParams = parsed.error.issues
+    // Field NAMES the schema expected but that did not arrive at all.
+    const missingFields = parsed.error.issues
       .filter((i: any) => i.code === 'invalid_type' && i.received === 'undefined')
       .map((i: any) => String(i.path[0] ?? ''))
+      .filter((k: string) => k.length > 0)
+
+    // The drop has TWO shapes. The partial drop keeps the early scalar fields
+    // and silently discards trailing ones — observed on a large payload where a
+    // ~700-char `summary` plus a 5-element `engram_suggestions` array arrived
+    // as `{summary}` alone (#297); that shape genuinely correlates with
+    // array-typed fields, so the array-workaround hint stays on it.
+    //
+    // The WHOLE-payload drop was reclassified by #772 (refining #297): on
+    // v0.16.1 field evidence it is NOT array-specific — scalar-only calls drop
+    // too, an array-carrying call succeeds moments later, and the strongest
+    // correlation is multiple tool_use blocks batched into one client message.
+    // It is transient: retrying the IDENTICAL call succeeds. So the empty
+    // branch no longer keys on the tool having an array param, and its
+    // guidance is "retry the same payload, alone in the message" — not
+    // "reshape your arrays": the payload was never evaluated, so there is
+    // nothing in it to fix.
+    const missingArrayParams = missingFields
       .filter((k: string) => (schema.properties as any)?.[k]?.type === 'array')
 
-    const totalDrop = receivedFields.length === 0 && hasArrayParam
-    const partialDrop = missingArrayParams.length > 0
+    const wholePayloadDrop = receivedFields.length === 0
+    const partialDrop = !wholePayloadDrop && missingArrayParams.length > 0
 
-    const arrayBugHint = totalDrop || partialDrop
-      ? ' Known client-side bug (plur-ai/plur#297): some MCP clients drop ' +
-        (partialDrop
-          ? `array-typed parameters from a large arguments payload while keeping the earlier fields ` +
-            `(here: ${missingArrayParams.join(', ')}). This is size-sensitive — the same call often ` +
-            `succeeds with a shorter payload, so shrink the other fields (e.g. a briefer summary) as well. `
-          : 'the entire arguments payload when an array-typed parameter is included. ') +
+    let dropHint = ''
+    if (wholePayloadDrop) {
+      dropHint = ' Known intermittent client-side issue (plur-ai/plur#772, refines #297): some MCP ' +
+        'clients transiently drop the ENTIRE arguments payload — most often when several tool calls ' +
+        'are batched into a single message. Nothing was stored or evaluated. Retry the IDENTICAL ' +
+        'call with the full payload, as the ONLY tool call in that message — identical retries ' +
+        'typically succeed. If two identical retries fail the same way, the arguments really are ' +
+        'absent from your call — re-issue it with the intended fields.' +
+        (hasArrayParam
+          ? ' If retries keep failing specifically on array parameters, pass them as a JSON string ' +
+            '(e.g. tags: "[\\"a\\",\\"b\\"]") or a comma-separated string (tags: "a, b") — the server ' +
+            'coerces both back into arrays.'
+          : '')
+    } else if (partialDrop) {
+      dropHint = ' Known client-side bug (plur-ai/plur#297): some MCP clients drop ' +
+        `array-typed parameters from a large arguments payload while keeping the earlier fields ` +
+        `(here: ${missingArrayParams.join(', ')}). This is size-sensitive — the same call often ` +
+        `succeeds with a shorter payload, so shrink the other fields (e.g. a briefer summary) as well. ` +
         'Retry passing array parameters as a JSON string ' +
         '(e.g. tags: "[\\"a\\",\\"b\\"]") or a comma-separated string (tags: "a, b") — the server coerces ' +
         'both back into arrays.'
-      : ''
+    }
+
     const receivedNote = receivedFields.length > 0
       ? `Received fields: [${receivedFields.join(', ')}].`
       : 'Received no fields (the arguments object was empty).'
+    const disposition = wholePayloadDrop
+      ? 'The request reached the server but its arguments did not — do not abandon the call, and do ' +
+        'not rewrite the payload: it was never evaluated.'
+      : 'The call reached the server — this is a malformed-arguments error, not a transport failure. ' +
+        'Fix the field(s) named above and retry; do not abandon the call.'
     return {
       ok: false,
       errorPayload: {
-        error: `Invalid arguments: ${details}. ${receivedNote} ` +
-          'The call reached the server — this is a malformed-arguments error, not a transport failure. ' +
-          'Fix the field(s) named above and retry; do not abandon the call.' + arrayBugHint,
+        error: `Invalid arguments: ${details}. ${receivedNote} ${disposition}${dropHint}`,
         success: false,
         received_fields: receivedFields,
+        missing_fields: missingFields,
+        ...(wholePayloadDrop
+          ? { drop: 'whole_payload' as const }
+          : partialDrop ? { drop: 'partial' as const } : {}),
         _isError: true,
       },
     }

--- a/packages/mcp/test/drop-log.test.ts
+++ b/packages/mcp/test/drop-log.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { tmpdir } from 'os'
+import {
+  PAYLOAD_DROP_LOG_MAX_ENTRIES,
+  payloadDropLogPath,
+  readPayloadDropLog,
+  recordPayloadDrop,
+  type PayloadDropRecord,
+} from '../src/drop-log.js'
+
+// Bounded, values-free forensic log for #772 payload drops. These tests pin
+// the file-level contract; the wire-level behavior (what gets logged when a
+// dropped frame arrives) is pinned in server.test.ts.
+describe('payload drop log (#772)', () => {
+  let dir: string
+
+  const record = (n: number): PayloadDropRecord => ({
+    ts: new Date().toISOString(),
+    tool: 'plur_learn',
+    arguments_wire: 'empty_object',
+    params_keys: ['name', 'arguments'],
+    received_fields: [],
+    missing_fields: ['statement'],
+    request_id: n,
+    server_version: '0.0.0-test',
+  })
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-drop-log-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates logs/payload-drops.jsonl under the storage root', () => {
+    recordPayloadDrop(dir, record(1))
+    expect(payloadDropLogPath(dir)).toBe(join(dir, 'logs', 'payload-drops.jsonl'))
+    const records = readPayloadDropLog(dir)
+    expect(records.length).toBe(1)
+    expect(records[0].tool).toBe('plur_learn')
+    expect(records[0].request_id).toBe(1)
+  })
+
+  it('is bounded: never grows past PAYLOAD_DROP_LOG_MAX_ENTRIES, keeping the newest', () => {
+    const total = PAYLOAD_DROP_LOG_MAX_ENTRIES + 10
+    for (let i = 0; i < total; i++) recordPayloadDrop(dir, record(i))
+    const records = readPayloadDropLog(dir)
+    expect(records.length).toBe(PAYLOAD_DROP_LOG_MAX_ENTRIES)
+    // Oldest 10 trimmed; newest kept in order.
+    expect(records[0].request_id).toBe(10)
+    expect(records[records.length - 1].request_id).toBe(total - 1)
+  })
+
+  it('read tolerates a corrupt line without losing the rest', () => {
+    recordPayloadDrop(dir, record(1))
+    const path = payloadDropLogPath(dir)
+    const intact = readFileSync(path, 'utf8')
+    writeFileSync(path, 'not json at all\n' + intact)
+    const records = readPayloadDropLog(dir)
+    expect(records.length).toBe(1)
+    expect(records[0].request_id).toBe(1)
+  })
+
+  it('read of a missing file returns []', () => {
+    expect(readPayloadDropLog(dir)).toEqual([])
+  })
+
+  it('write failures are swallowed — diagnostics never throw', () => {
+    // Make the logs path unwritable by occupying it with a FILE where the
+    // directory should be.
+    const logsDir = dirname(payloadDropLogPath(dir))
+    writeFileSync(logsDir, 'a file squatting on the logs directory path')
+    expect(() => recordPayloadDrop(dir, record(1))).not.toThrow()
+    expect(readPayloadDropLog(dir)).toEqual([])
+  })
+})

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Client } from '@modelcontextprotocol/client'
 import { InMemoryTransport } from '@modelcontextprotocol/server'
 import { Plur, checkForUpdate, clearVersionCache, settleVersionChecks } from '@plur-ai/core'
 import { createServer } from '../src/server.js'
+import { payloadDropLogPath, readPayloadDropLog } from '../src/drop-log.js'
 
 describe('MCP server (wire protocol)', () => {
   let client: Client
@@ -219,24 +220,143 @@ describe('MCP server (wire protocol)', () => {
       expect(parsed.engrams_created).toBe(2)
     })
 
-    it('empty arguments on a tool with array params names the client bug (#297)', async () => {
+    // #772 reclassified the empty-payload shape: it is NOT array-specific
+    // (scalar-only calls drop too; an array-carrying call succeeds moments
+    // later) and it is transient — the identical call succeeds on retry. The
+    // empty branch therefore points at #772 with retry-identical guidance for
+    // EVERY tool; the array-coercion fallback is appended only where the tool
+    // actually has array params. The dedicated #772 suite below pins the full
+    // contract; these two pin the #297-era split's replacement.
+    it('empty arguments points at #772 with retry-identical guidance, not the array workaround', async () => {
       const result = await client.callTool({ name: 'plur_learn', arguments: {} })
       expect(result.isError).toBe(true)
       const parsed = JSON.parse((result.content as any)[0].text)
       expect(parsed.error).toContain('arguments object was empty')
-      // The targeted hint: names the known client-side array serialization bug
-      // and the coercible retry shapes, so the agent self-corrects.
-      expect(parsed.error).toContain('plur-ai/plur#297')
-      expect(parsed.error).toMatch(/JSON string|comma-separated/)
+      expect(parsed.error).toContain('plur-ai/plur#772')
+      expect(parsed.error).toMatch(/IDENTICAL call/i)
+      // The payload was never evaluated — the agent must NOT be told to fix it.
+      expect(parsed.error).not.toContain('Fix the field(s) named above')
     })
 
-    it('empty arguments on a tool WITHOUT array params does not mention #297', async () => {
-      // plur_recall has no array-typed params — the hint would be noise.
+    it('empty arguments on a tool WITHOUT array params gets #772 but no array-coercion noise', async () => {
+      // plur_recall has no array-typed params — the coercion fallback would be noise.
       const result = await client.callTool({ name: 'plur_recall', arguments: {} })
       expect(result.isError).toBe(true)
       const parsed = JSON.parse((result.content as any)[0].text)
       expect(parsed.error).toContain('arguments object was empty')
-      expect(parsed.error).not.toContain('plur-ai/plur#297')
+      expect(parsed.error).toContain('plur-ai/plur#772')
+      expect(parsed.error).not.toMatch(/JSON string|comma-separated/)
+    })
+  })
+
+  // Issue #772 — intermittent whole-payload drop: the entire arguments object
+  // arrives empty (received_fields: []), not deterministically tied to array
+  // params. Client-side and transient (identical retries succeed; strongest
+  // correlation is multiple tool calls batched in one message), so the server
+  // cannot fix it — but it must (a) fail LOUDLY with retry-with-payload
+  // guidance (never silently store nothing), and (b) record a bounded,
+  // values-free forensic log of each dropped frame for the upstream report.
+  describe('whole-payload drop (#772)', () => {
+    it('rejects an empty-object plur_learn with a structured diagnostic', async () => {
+      const result = await client.callTool({ name: 'plur_learn', arguments: {} })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.success).toBe(false)
+      expect(parsed.received_fields).toEqual([])
+      expect(parsed.missing_fields).toEqual(['statement'])
+      expect(parsed.drop).toBe('whole_payload')
+      // The guidance an agent needs to recover: retry the SAME payload, alone
+      // in the message — batching parallel tool calls is the observed trigger.
+      expect(parsed.error).toContain('plur-ai/plur#772')
+      expect(parsed.error).toMatch(/IDENTICAL call/i)
+      expect(parsed.error).toMatch(/ONLY tool call/i)
+      // Nothing may be stored on this path.
+      const status = await plurInstance.status()
+      expect(status.engram_count).toBe(0)
+    })
+
+    it('records a values-free forensic log entry for an empty-object drop', async () => {
+      await client.callTool({ name: 'plur_learn', arguments: {} })
+      const records = readPayloadDropLog(dir)
+      expect(records.length).toBe(1)
+      expect(records[0].tool).toBe('plur_learn')
+      expect(records[0].arguments_wire).toBe('empty_object')
+      expect(records[0].received_fields).toEqual([])
+      expect(records[0].missing_fields).toEqual(['statement'])
+      expect(records[0].server_version).toBeDefined()
+      expect(records[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('distinguishes an entirely ABSENT arguments key from an empty object', async () => {
+      // callTool passes params through unchanged, so omitting `arguments`
+      // omits the key from the wire frame — the other #772 shape.
+      const result = await client.callTool({ name: 'plur_learn' } as any)
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.drop).toBe('whole_payload')
+      const records = readPayloadDropLog(dir)
+      expect(records.length).toBe(1)
+      expect(records[0].arguments_wire).toBe('absent')
+    })
+
+    it('records a partial drop with field NAMES but never values', async () => {
+      const secretish = 'summary text that must never enter the drop log'
+      const result = await client.callTool({
+        name: 'plur_session_end',
+        arguments: { summary: secretish },
+      })
+      expect(result.isError).toBe(true)
+      const records = readPayloadDropLog(dir)
+      expect(records.length).toBe(1)
+      expect(records[0].arguments_wire).toBe('partial')
+      expect(records[0].received_fields).toEqual(['summary'])
+      expect(records[0].missing_fields).toContain('engram_suggestions')
+      // The raw file must not contain the argument VALUE anywhere.
+      const raw = readFileSync(payloadDropLogPath(dir), 'utf8')
+      expect(raw).not.toContain(secretish)
+    })
+
+    it('a valid call writes no forensic log', async () => {
+      const result = await client.callTool({
+        name: 'plur_learn',
+        arguments: { statement: 'Valid calls leave no drop records' },
+      })
+      expect(result.isError).toBeFalsy()
+      expect(readPayloadDropLog(dir)).toEqual([])
+    })
+
+    it('an ordinary caller error (fields present, non-array missing) is NOT logged as a drop', async () => {
+      const result = await client.callTool({
+        name: 'plur_learn',
+        arguments: { scope: 'global', type: 'behavioral' },
+      })
+      expect(result.isError).toBe(true)
+      const parsed = JSON.parse((result.content as any)[0].text)
+      expect(parsed.drop).toBeUndefined()
+      expect(readPayloadDropLog(dir)).toEqual([])
+    })
+
+    // Server-side exoneration pin: #772's strongest observed correlation is
+    // parallel plur_learn tool_use blocks in one client message. Through this
+    // server's real wire path, concurrent tools/call requests must all be
+    // delivered and stored — if this test ever drops one, the bug is NOT
+    // upstream after all.
+    it('8 concurrent plur_learn calls all persist (no server-side drop)', async () => {
+      const topics = ['tabs', 'vitest', 'zod schemas', 'kebab-case filenames', 'tsup builds', 'pnpm workspaces', 'conventional commits', 'squash merges']
+      const results = await Promise.all(
+        topics.map((topic, i) => client.callTool({
+          name: 'plur_learn',
+          arguments: { statement: `Concurrency pin ${i}: always prefer ${topic} in this repository` },
+        })),
+      )
+      for (const result of results) {
+        expect(result.isError).toBeFalsy()
+        const parsed = JSON.parse((result.content as any)[0].text)
+        expect(parsed.id).toBeDefined()
+      }
+      const status = await plurInstance.status()
+      expect(status.engram_count).toBe(8)
+      expect(readPayloadDropLog(dir)).toEqual([])
     })
   })
 

--- a/packages/mcp/test/tool-profile.test.ts
+++ b/packages/mcp/test/tool-profile.test.ts
@@ -125,15 +125,17 @@ describe('tool profiles', () => {
     })
 
     // Audit fix: a known action with invalid inner args must get the SAME
-    // isError:true + #297 array-bug-hint treatment a direct top-level call to
-    // that tool would get — this is the exact parity gap the original draft
-    // of this plan shipped without a test for.
-    it('surfaces isError:true and the #297 array-bug hint for a known action with bad args', async () => {
+    // isError:true + drop-diagnostic treatment (#297 partial / #772 empty)
+    // a direct top-level call to that tool would get — this is the exact
+    // parity gap the original draft of this plan shipped without a test for.
+    // (No forensic drop LOG is written on this path — plur_admin's inner args
+    // travel inside a delivered payload, so this is not a wire drop.)
+    it('surfaces isError:true and the drop diagnostic for a known action with bad args', async () => {
       const result = await client.callTool({
         name: 'plur_admin',
         // plur_packs_export has a required `name` string field — omit it,
-        // and pass no fields at all, to also trigger the #297 hint path
-        // (array-typed param + empty payload).
+        // and pass no fields at all, to also exercise the empty-payload
+        // (#772) diagnostic branch.
         arguments: { action: 'plur_packs_export', args: {} },
       })
       expect(result.isError).toBe(true)


### PR DESCRIPTION
## Summary

Defensive fix for #772 — the intermittent whole-payload drop (`received_fields: []`) on `plur_learn` and other tools.

## Root-cause investigation

The drop is **not reproducible server-side, by construction**:

- The wire-protocol tests from #297/#301 (and this PR's new concurrency test) deliver the same payloads through a real MCP client and they always arrive intact.
- The MCP SDK v2 beta.4 dispatch path was audited for this PR: both protocol eras define `tools/call` params as `arguments: z.record(z.string(), z.unknown()).optional()`, so a populated arguments object cannot be stripped or partially dropped by the server SDK. A double-serialized (`arguments` as string) frame would fail SDK-level request validation before our handler ever ran — which is *not* the observed signature.
- The observed signature (our Zod layer seeing an empty object) therefore means the arguments were already gone when the frame was deserialized — i.e. the drop happens client-side, before the wire, consistent with #772's field evidence (scalar-only calls drop; array calls succeed; identical retries succeed; parallel `plur_learn` tool_use blocks in one message drop together).

Since the trigger lives in the upstream client, the server's job is (a) never store nothing silently, (b) give the *correct* recovery guidance, and (c) capture the wire-level evidence the upstream report needs — exactly the follow-up #772 asked for.

## Changes

**1. Correct, loud rejection (`packages/mcp/src/tools.ts`)**

Empty-payload calls were already rejected (required fields fail Zod), but the diagnostic still sold the #297 theory: "arrays trigger this — stringify them". #772's evidence contradicts that, and for a whole-payload drop that advice sends the agent off rewriting a payload that was never evaluated. Now:

- The empty-payload branch fires for **every** tool (the drop is not array-specific) and references #772: *retry the IDENTICAL call with the full payload, as the ONLY tool call in the message* — with an escape hatch ("if two identical retries fail the same way, the fields really are absent from your call") so the message is also safe when the caller genuinely sent `{}`.
- Partial drops (early scalars kept, trailing array fields gone — genuinely array-correlated) keep the #297 hint unchanged.
- The error payload gains machine-readable `missing_fields` and `drop: 'whole_payload' | 'partial'`.

**2. Bounded, values-free forensic drop log (`packages/mcp/src/drop-log.ts`, `server.ts`)**

- The tools/call handler now captures whether `params.arguments` was **absent from the frame** vs **arrived as `{}`** *before* the `?? {}` default erases the distinction — the one wire-level fact only this boundary can observe, and the first thing the upstream client report needs.
- Each drop appends a record to `<store>/logs/payload-drops.jsonl`: timestamp, tool, `arguments_wire` (`absent` / `empty_object` / `partial`), params key names, received/missing field **names**, server version. **Never values** — a partial drop's surviving fields (engram statements can contain anything) never enter the file. Trimmed to the newest 100 records on every write; a failed diagnostics write can never break the tool call. An MCP `logging` notification also fires per drop.
- Written only at the top-level wire boundary — `plur_admin`'s inner args travel inside a delivered payload, so inner-validation failures are not wire drops.
- `@plur-ai/core`: `Plur` gains a synchronous `storageRoot` getter (mirror of `status().storage_root`) so the MCP boundary can locate the log.

**3. Tests (`packages/mcp/test/server.test.ts`, `drop-log.test.ts`, `tool-profile.test.ts`)**

- New `whole-payload drop (#772)` suite: structured diagnostic pins (`drop`, `received_fields: []`, `missing_fields`, retry-identical + only-tool-call guidance), nothing stored on the drop path, absent-vs-empty wire distinction, values never entering the log, ordinary caller errors not logged as drops, valid calls logging nothing.
- Server-side exoneration pin: 8 **concurrent** `plur_learn` calls through the real wire path all persist — if this ever drops one, the bug is not upstream after all.
- `drop-log.test.ts`: newest-100 bounding, corrupt-line tolerance, never-throws contract.
- Updated the two #297-era empty-payload pins to the #772 contract (and the misleading "Fix the field(s) named above" no longer appears on the whole-drop path).

## Enterprise path check

The enterprise remote-store write (`RemoteStore.appendAndGetServerId` → `POST /api/v1/engrams`) is a plain sequential HTTPS call from core — no tool_use batching or client argument marshalling — so it does **not** share the #772 client bug. It has its own *deterministic* field-dropping issue (the POST body only carries statement/scope/domain/type), already tracked and claimed in plur#769 (client) + enterprise#627 (server); not duplicated here.

## Test plan

- [x] `pnpm test` — full workspace suite green
- [x] `npx tsc -p tsconfig.tests.json --noEmit` — clean
- [x] `pnpm -r build` — clean

Closes nothing on its own (the upstream client bug remains open in #772); refs #772.
