### PR TITLE
fix(core): index Chinese text as character bigrams so BM25 works for Han script (#780)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -8,11 +8,20 @@ const STOP_WORDS = new Set([
 
 /** Tokenize text into searchable terms */
 export function ftsTokenize(text: string): string[] {
-  return text.toLowerCase()
+  const lower = text.toLowerCase()
+  const tokens = lower
     .replace(/[^\w\s]/g, ' ')
     .split(/\s+/)
     .filter(w => w.length > 2)
     .filter(w => !STOP_WORDS.has(w))
+  // CJK: \w is ASCII-only ([A-Za-z0-9_]), so Han runs are stripped by the
+  // replace above and pure-Chinese text tokenizes to nothing. Chinese has no
+  // whitespace-delimited words — re-extract Han runs from the source and index
+  // them as character bigrams so non-English text survives BM25. (plur-ai#782)
+  for (const run of lower.match(/\p{Script=Han}{2,}/gu) ?? []) {
+    for (let i = 0; i < run.length - 1; i++) tokens.push(run.slice(i, i + 2))
+  }
+  return tokens
 }
 
 /** Build searchable text from all engram fields */

--- a/packages/core/test/fts.test.ts
+++ b/packages/core/test/fts.test.ts
@@ -20,6 +20,30 @@ describe('ftsTokenize', () => {
     expect(tokens).toContain('jumps')
     expect(tokens).not.toContain('the')
   })
+
+  it('keeps ASCII behavior unchanged when text contains no CJK', () => {
+    const tokens = ftsTokenize('docker compose deployment')
+    expect(tokens).toEqual(['docker', 'compose', 'deployment'])
+  })
+
+  it('indexes pure-Chinese text as character bigrams (was: empty tokens)', () => {
+    const tokens = ftsTokenize('测试部署应该用')
+    expect(tokens).toContain('测试')
+    expect(tokens).toContain('试部')
+    expect(tokens).toContain('部署')
+    expect(tokens).toContain('应该')
+    expect(tokens).toContain('该用')
+    // every Han char participates in two bigrams (except run edges)
+    expect(tokens.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('mixed Chinese + English keeps both term kinds', () => {
+    const tokens = ftsTokenize('测试部署应该用 docker compose')
+    expect(tokens).toContain('docker')
+    expect(tokens).toContain('compose')
+    expect(tokens).toContain('部署')
+    expect(tokens).toContain('该用')
+  })
 })
 
 describe('computeIdf', () => {
@@ -167,5 +191,24 @@ describe('BM25 document length normalization', () => {
     const results = searchEngrams(engrams, 'kubernetes')
     // Short doc should rank higher — same term match but normalized by length
     expect(results[0].id).toBe('ENG-2026-0330-001')
+  })
+})
+
+describe('CJK search (Chinese engrams)', () => {
+  const engrams = [
+    makeEngram({ id: 'ENG-2026-0330-001', statement: '测试部署应该用 docker compose' }),
+    makeEngram({ id: 'ENG-2026-0330-002', statement: 'unit tests must run before commit' }),
+  ]
+
+  it('retrieves a Chinese engram for a Chinese query', () => {
+    const results = searchEngrams(engrams, '部署流程')
+    expect(results.length).toBeGreaterThan(0)
+    expect(results[0].id).toBe('ENG-2026-0330-001')
+  })
+
+  it('does not retrieve a Chinese engram for an unrelated Chinese query', () => {
+    const results = searchEngrams(engrams, '单位不要')
+    // zero term overlap → empty result (no noise from unrelated CJK queries)
+    expect(results).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #780 — `ftsTokenize` strips every Han character because JS `\w` is ASCII-only (`[A-Za-z0-9_]`). Pure-Chinese queries tokenize to **zero terms**, so BM25 contributes nothing for non-English stores:

- hybrid recall degenerates to embedding-only (Chinese queries can never achieve a BM25 hit),
- `bm25-only` degradation returns **nothing at all** for pure-Chinese queries.

## Change

- Re-extract Han runs from the source with `\p{Script=Han}` (u flag) and index them as **character bigrams** — the standard n-gram approach for space-less scripts, zero new dependencies.
- ASCII behavior is **unchanged**: English terms still go through the original path, and the fix is a no-op for Latin-only text.

```ts
// before — pure-Chinese text → []
ftsTokenize('测试部署应该用 docker compose')
// → ['docker', 'compose']

// after
ftsTokenize('测试部署应该用 docker compose')
// → ['docker', 'compose', '测试', '试部', '部署', '署应', '应该', '该用']
```

## Tests

- pure-Chinese text tokenizes to bigrams (was: empty)
- mixed Chinese + English keeps both term kinds
- ASCII-only behavior unchanged (regression)
- `searchEngrams` integration: relevant Chinese query retrieves the Chinese engram; unrelated Chinese query returns empty (no noise)

All core tests pass (2420 passed), `pnpm build` green.

## Notes

Character bigrams are a deliberate minimum — no segmenter dependency (jieba / `Intl.Segmenter` can be layered later if precision demands it). Related but separate: default embedding model is English-only (#781), which independently limits non-English semantic recall.