### PR TITLE
fix(migrate): resolve receiver chains split across lines, anchored at the chain head (#758)

### DIFF
--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -35,13 +35,21 @@ const n = plur.list().length      →  const n = (await plur.list()).length
 awaits `undefined` and yields `undefined`. Getting that wrong produces code
 that runs and returns a plausible value.
 
+Receiver chains are resolved whole, however they are laid out: split across
+lines (`plur\n  .recall(q)`), with comments inside the chain, through calls
+(`getPlur().recall(q)`, `plur.scoped(s).recall(q)`) and optional links
+(`plur?.recall(q)`). The `await` always lands at the head of the chain — the
+only position it may legally occupy.
+
 It reports, but refuses to rewrite:
 
 - **calls inside `Promise.race` / `Promise.all` arrays** — awaiting there
   settles the call *before* the combinator sees it. This silently disabled a 5s
   timeout guard in PLUR's own CLI, and the test suite stayed green.
 - **concise arrow bodies** — the enclosing function has to become `async` first.
-- **calls whose result is consumed across multiple lines.**
+- **calls whose result is consumed across multiple lines** — including a chain
+  whose consumer sits on its own line (`plur\n  .recall(q)\n  .length`): the
+  `(await ...)` wrap there is left to a human.
 
 It never touches string literals or comments. An early version of the codemod
 that migrated PLUR itself rewrote a CLI help string into `hook-await inject`

--- a/packages/migrate/src/index.ts
+++ b/packages/migrate/src/index.ts
@@ -39,7 +39,9 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git', 'coverage', 
  * optimisation — the scanner is authoritative. Built from `NEWLY_ASYNC` so it
  * cannot fall behind it.
  */
-const PREFILTER = new RegExp(String.raw`\.(?:${NEWLY_ASYNC.join('|')})\s*\(`)
+// `\s*` after the dot mirrors the scanner: `plur.\n  recall(q)` is a chain
+// the scanner resolves, so the pre-filter must not skip the file it sits in.
+const PREFILTER = new RegExp(String.raw`\.\s*(?:${NEWLY_ASYNC.join('|')})\s*\(`)
 
 function walk(dir: string, exts: Set<string>, out: string[] = []): string[] {
   let entries

--- a/packages/migrate/src/scan.ts
+++ b/packages/migrate/src/scan.ts
@@ -215,23 +215,51 @@ function spanAt(spans: Array<[number, number]>, idx: number): [number, number] |
 }
 
 /**
- * The last significant character at or before `from`: whitespace is skipped,
- * COMMENT spans are skipped whole, and a string/template literal is
- * significant — its closing quote/backtick is returned, because a string can
- * absorb a following `(` as a call (`'s'(...)` / tagged template), so for the
- * ASI guard it must count as hazardous, not vanish like a comment.
+ * Index of the last significant character at or before `from`: whitespace is
+ * skipped, COMMENT spans are skipped whole, and a string/template literal is
+ * significant — its closing quote/backtick position is returned, because a
+ * string can absorb a following `(` as a call (`'s'(...)` / tagged template),
+ * so for the ASI guard it must count as hazardous, not vanish like a comment.
+ * Callers that need to know they landed inside a literal check `spanAt`.
  */
-function lastSignificantChar(src: string, from: number, spans: Array<[number, number]>): string | null {
+function lastSignificantIndex(src: string, from: number, spans: Array<[number, number]>): number {
   for (let j = from; j >= 0; j--) {
     const span = spanAt(spans, j)
     if (span) {
       if (src[span[0]] === '/') { j = span[0]; continue } // comment — skip whole
-      return src[j] // inside a string/template literal
+      return j // inside a string/template literal
     }
     if (/\s/.test(src[j])) continue
-    return src[j]
+    return j
   }
-  return null
+  return -1
+}
+
+/** The last significant character at or before `from`, or null. See above. */
+function lastSignificantChar(src: string, from: number, spans: Array<[number, number]>): string | null {
+  const j = lastSignificantIndex(src, from, spans)
+  return j < 0 ? null : src[j]
+}
+
+/**
+ * Index of the first significant character at or after `from`: whitespace is
+ * skipped, comment spans are skipped whole. The mirror of
+ * `lastSignificantIndex`, used to see what CONSUMES a call's result — a
+ * comment sitting between the call and its `.length` must not make a consumed
+ * call look bare, because the bare form gets a plain `await`, which for a
+ * consumed result awaits the wrong expression.
+ */
+function nextSignificantIndex(src: string, from: number, spans: Array<[number, number]>): number {
+  for (let j = from; j < src.length; j++) {
+    const span = spanAt(spans, j)
+    if (span) {
+      if (src[span[0]] === '/') { j = span[1] - 1; continue } // comment — skip whole
+      return j
+    }
+    if (/\s/.test(src[j])) continue
+    return j
+  }
+  return -1
 }
 
 /** Index of the line containing `idx`, and the column within it. */
@@ -368,25 +396,166 @@ function isEsm(file: string, src: string): boolean {
   return /^\s*(import\s|export\s|import\()/m.test(src)
 }
 
+const IDENT_CHAR = /[\w$]/
+
+/**
+ * Words that may sit directly before a `(...)` or `[...]` group without
+ * calling or indexing it — prefix operators and statement keywords. They
+ * decide the receiver walk below: `await (getPlur()).recall(q)` must resolve
+ * the GROUP as the receiver head (and then be recognised as already awaited),
+ * not treat `await` as a callee — treating it as one re-anchors the finding
+ * past the `await` and reports (then mangles) already-correct code.
+ * `new` is deliberately absent: it is handled specially, because `await`
+ * cannot be inserted between `new` and its callee.
+ */
+const NON_CALLEE_WORDS = new Set([
+  'await', 'yield', 'return', 'throw', 'typeof', 'void', 'delete',
+  'in', 'of', 'case', 'else', 'instanceof',
+])
+
+/** Index of the `(` matching the `)` at `close`, or -1. Spans skipped whole. */
+function matchBackwardParen(src: string, close: number, spans: Array<[number, number]>): number {
+  let d = 0
+  for (let i = close; i >= 0; i--) {
+    const span = spanAt(spans, i)
+    if (span) { i = span[0]; continue }
+    if (src[i] === ')') d++
+    else if (src[i] === '(') { d--; if (d === 0) return i }
+  }
+  return -1
+}
+
+/** Index of the `[` matching the `]` at `close`, or -1. Spans skipped whole. */
+function matchBackwardBracket(src: string, close: number, spans: Array<[number, number]>): number {
+  let d = 0
+  for (let i = close; i >= 0; i--) {
+    const span = spanAt(spans, i)
+    if (span) { i = span[0]; continue }
+    if (src[i] === ']') d++
+    else if (src[i] === '[') { d--; if (d === 0) return i }
+  }
+  return -1
+}
+
+/**
+ * Resolve the start of the receiver chain whose method dot sits at `dot`, or
+ * null when what precedes the dot is not a receiver this tool understands.
+ *
+ * Walks BACKWARD from the dot through the chain — identifier segments, `?.`
+ * links, bracket indexes (nested ones too — the walk matches brackets with
+ * spans skipped, so `m[a[0]]` and `m["a]b"]` both resolve, two shapes the old
+ * character-class regex documented as misses), call arguments, and
+ * parenthesised heads — skipping whitespace and comments between tokens.
+ *
+ * Two failure classes of the receiver-anchored regex this replaces, both from
+ * the 0.16.0 audit trail (#752 item 6, #758):
+ *
+ *   - It could not span a newline, so `plur\n  .recall(q)` — an ordinary
+ *     fluent chain — scanned CLEAN, and a clean exit is read as "this file is
+ *     done".
+ *   - Worse, it re-anchored MID-chain: `getStore().plur.recall(q)` matched
+ *     with receiver `plur`, and --write emitted
+ *     `getStore().await plur.recall(q)`, which does not parse. The walk
+ *     starts the finding at the true head of the chain, so the insertion
+ *     point is always a position `await` may legally occupy — and an
+ *     `await`/`return`/`void` already in front of the CHAIN is seen, where
+ *     the mid-chain anchor looked past it.
+ *
+ * The walk stops (returns null) at anything it cannot classify — a string or
+ * template receiver, a control-structure header, an unmatched bracket. A miss
+ * is reported by nothing and costs a finding; a mis-anchored rewrite corrupts
+ * user source, which is the one unacceptable outcome.
+ */
+function receiverStart(src: string, dot: number, spans: Array<[number, number]>): number | null {
+  let i = dot - 1
+  if (src[i] === '?') i-- // the `?.` before the method — one token, always adjacent
+  for (;;) {
+    i = lastSignificantIndex(src, i, spans)
+    if (i < 0) return null
+    if (spanAt(spans, i)) return null // a string/template cannot head this chain
+    const c = src[i]
+
+    if (c === ')') {
+      // A call in the chain (`getPlur().recall(q)`, `plur.scoped(s).recall(q)`)
+      // or a parenthesised head (`(store as Plur).recall(q)`). What precedes
+      // the `(` decides which.
+      const open = matchBackwardParen(src, i, spans)
+      if (open < 0) return null
+      const p = lastSignificantIndex(src, open - 1, spans)
+      if (p < 0) return open                 // `(...)` at file start heads the receiver
+      if (spanAt(spans, p)) return null      // tagged-template call — not a chain this tool reads
+      if (IDENT_CHAR.test(src[p])) {
+        let w = p
+        while (w > 0 && IDENT_CHAR.test(src[w - 1])) w--
+        const word = src.slice(w, p + 1)
+        // `new Plur().recall(q)` — the insertion must cover the `new`:
+        // `new await Plur()` does not parse, `await new Plur()...` does.
+        if (word === 'new') return w
+        if (NON_CALLEE_WORDS.has(word)) return open // `await (...)`, `typeof (...)`, …
+        if (CONTROL_KEYWORDS.has(word)) return null // `for (...) (x).recall(q)` — a statement header, not a callee
+        if (/[0-9]/.test(src[w])) return null       // a number is not a callee
+        i = p                                       // ordinary call — the callee continues the chain
+        continue
+      }
+      if (src[p] === ')' || src[p] === ']') { i = p; continue } // f()(…) / arr[0](…)
+      return open // parenthesised expression heads the receiver
+    }
+
+    if (c === ']') {
+      const open = matchBackwardBracket(src, i, spans)
+      if (open < 0) return null
+      const p = lastSignificantIndex(src, open - 1, spans)
+      if (p < 0) return open                 // `[...]` literal at file start
+      if (spanAt(spans, p)) return null      // `'str'[0]` — a string receiver is not this tool's pattern
+      if (src[p] === '.' && src[p - 1] === '?') { i = p - 2; continue } // arr?.[0]
+      if (IDENT_CHAR.test(src[p])) {
+        let w = p
+        while (w > 0 && IDENT_CHAR.test(src[w - 1])) w--
+        const word = src.slice(w, p + 1)
+        // `return [a, b].learn(x)` — the `[` does not index the keyword.
+        if (word === 'new' || NON_CALLEE_WORDS.has(word) || CONTROL_KEYWORDS.has(word)) return open
+        i = p
+        continue
+      }
+      if (src[p] === ')' || src[p] === ']') { i = p; continue } // f()[0] / a[0][1]
+      return open // array literal heads the receiver
+    }
+
+    if (IDENT_CHAR.test(c)) {
+      let s = i
+      while (s > 0 && IDENT_CHAR.test(src[s - 1])) s--
+      if (/[0-9]/.test(src[s])) return null // a number literal, not an identifier
+      const p = lastSignificantIndex(src, s - 1, spans)
+      if (p >= 0 && !spanAt(spans, p) && src[p] === '.') {
+        if (src[p - 1] === '?') { i = p - 2; continue } // x?.y link
+        if (src[p - 1] === '.') return s               // `...plur` — spread dots, the chain starts here
+        i = p - 1                                       // plain member link
+        continue
+      }
+      if (p >= 0 && !spanAt(spans, p) && IDENT_CHAR.test(src[p])) {
+        let w = p
+        while (w > 0 && IDENT_CHAR.test(src[w - 1])) w--
+        if (src.slice(w, p + 1) === 'new') return w // `new Plur().recall(q)` via a bare callee
+      }
+      return s
+    }
+
+    return null // an operator or opener where an element was expected
+  }
+}
+
 /**
  * Scan one file's source for un-awaited calls to newly-async methods.
  *
- * Matches `<receiver>.<method>(` where the receiver is any identifier or member
- * expression — this cannot know that the receiver is a `Plur`, so it reports
- * `db.list()` too. That is the correct trade for a text tool: a false positive
- * costs a glance, a false negative ships a silent bug. The report says which
- * receiver it saw so the reader can dismiss it instantly.
+ * Anchored on the METHOD, not the receiver: the receiver is resolved by
+ * `receiverStart` walking backward from the method's dot, so a chain split
+ * across lines (`plur\n  .recall(q)`), a comment inside the chain, or a call
+ * in the chain all resolve to the same head as their single-line forms.
  *
- * Receiver chains may include single-level bracket indexes — `stores[0]`,
- * `byName['team']`, `pool[i + 1]`, `arr?.[0]` — because arrays/maps of stores
- * are ordinary shapes for this API and a receiver the regex cannot see is a
- * call the user is never told about (the 0.16.0 audit found `arr[0].learn(x)`
- * scanned clean, #752; its second pass found `arr?.[0].learn(x)` still did).
- * Two index shapes remain documented misses: a NESTED index
- * (`m[a[0]].learn(x)`) and an index whose string key contains `]`
- * (`m["a]b"].learn(x)`) — `[^\]]` cannot span the inner `]`, and every
- * partial interpretation fails to reach the method dot, so both are missed —
- * not misreported, and never rewritten at the wrong offset.
+ * This cannot know that the receiver is a `Plur`, so it reports `db.list()`
+ * too. That is the correct trade for a text tool: a false positive costs a
+ * glance, a false negative ships a silent bug. The report says which receiver
+ * it saw so the reader can dismiss it instantly.
  */
 export function scanSource(file: string, src: string, methods: readonly string[] = NEWLY_ASYNC): Finding[] {
   const spans = literalSpans(src)
@@ -394,23 +563,22 @@ export function scanSource(file: string, src: string, methods: readonly string[]
   const alt = methods.join('|')
   // `?.` on either side is the same call with the same hazard: `plur?.learn(x)`
   // and `plur.learn?.(x)` both return a promise nobody awaited. Requiring a
-  // plain `.` missed both.
-  const re = new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*|(?:\?\.)?\[[^\]\n]*\])*)\??\.(${alt})\s*(?:\?\.)?\s*\(`, 'g')
+  // plain `.` missed both. The dot may carry whitespace on either side —
+  // `plur\n  .recall(q)` and `plur.\n  recall(q)` are both ordinary styles.
+  const re = new RegExp(String.raw`\.\s*(${alt})\s*(?:\?\.)?\s*\(`, 'g')
+  // One finding per receiver head: `plur.recall(q).learn(x)` produces two
+  // method matches that resolve to the SAME chain start, and rewriting both
+  // would insert twice at one offset.
+  const seen = new Set<number>()
 
   let m: RegExpExecArray | null
   while ((m = re.exec(src))) {
-    const idx = m.index
-    if (inSpans(spans, idx)) continue
+    const dot = m.index
+    if (inSpans(spans, dot)) continue
 
-    // Already awaited, yielded, or explicitly handled as a promise.
-    const before = src.slice(Math.max(0, idx - 80), idx)
-    if (/\b(await|yield)\s*$/.test(before)) continue
-    if (/\breturn\s*$/.test(before)) continue          // `return p.learn(...)` is fine
-    if (/\bvoid\s*$/.test(before)) continue            // deliberate fire-and-forget
+    const idx = receiverStart(src, dot, spans)
+    if (idx === null || seen.has(idx)) continue
 
-    const after = src.slice(idx)
-    // `.then(` / `.catch(` / `.finally(` immediately after the call: handled.
-    //
     // The call's `(` is the LAST character of the regex match — taken from the
     // match, not from `indexOf('(', idx)`, which finds the first paren after
     // the receiver's start and therefore lands INSIDE a computed index like
@@ -418,8 +586,25 @@ export function scanSource(file: string, src: string, methods: readonly string[]
     // the `.length`-consumption check reads the wrong position, and the
     // rewrite silently awaits the wrong expression — the failure class this
     // tool exists to prevent.
-    const callEnd = matchParen(after, m[0].length - 1, spans, idx)
-    if (callEnd > 0 && /^\s*\.(then|catch|finally)\s*\(/.test(after.slice(callEnd))) continue
+    const parenIdx = dot + m[0].length - 1
+
+    // Already awaited, yielded, or explicitly handled as a promise — checked
+    // at the CHAIN head: `await plur\n  .recall(q)` is awaited however many
+    // lines the chain spans.
+    const before = src.slice(Math.max(0, idx - 80), idx)
+    if (/\b(await|yield)\s*$/.test(before)) continue
+    if (/\breturn\s*$/.test(before)) continue          // `return p.learn(...)` is fine
+    if (/\bvoid\s*$/.test(before)) continue            // deliberate fire-and-forget
+
+    const after = src.slice(idx)
+    const callEnd = matchParen(after, parenIdx - idx, spans, idx)
+    // What consumes the result is the next SIGNIFICANT character after the
+    // call — significant, so a comment between the call and its `.length`
+    // cannot make a consumed call look bare (the bare form gets a plain
+    // `await`, which for a consumed result awaits the wrong expression).
+    const nsi = callEnd > 0 ? nextSignificantIndex(src, idx + callEnd, spans) : -1
+    // `.then(` / `.catch(` / `.finally(` after the call: handled.
+    if (nsi >= 0 && /^(?:\?\.|\.)\s*(?:then|catch|finally)\s*\(/.test(src.slice(nsi, nsi + 80))) continue
 
     const pos = positionOf(src, idx)
 
@@ -445,20 +630,25 @@ export function scanSource(file: string, src: string, methods: readonly string[]
     }
 
     // Does something consume the result directly? Then `await` must wrap the
-    // whole call, not bind looser than the member access.
+    // whole call, not bind looser than the member access. `?.` counts: `await
+    // plur.recall(q)?.length` awaits `.length` OF THE PROMISE exactly as the
+    // plain dot does.
     let wrapTo: number | undefined
     if (callEnd < 0) {
       // Could not find the closing paren, so whether the result is consumed is
       // unknown. Guessing here is what produced the `.length`-of-a-promise bug.
       fixable = false
       reason = 'could not determine where the call ends — add `await` by hand'
-    } else if (callEnd > 0 && /^\s*[.[]/.test(after.slice(callEnd))) {
+    } else if (nsi >= 0 && (src[nsi] === '.' || src[nsi] === '[' || (src[nsi] === '?' && src[nsi + 1] === '.'))) {
       const endIdx = idx + callEnd
       const endPos = positionOf(src, endIdx)
-      // Only when the call starts and ends on the same line — a multi-line call
-      // is reported for a human rather than rewritten blind.
+      // Only when the whole expression — chain head through closing paren —
+      // sits on one line. A consumed call that spans lines (a multi-line
+      // argument list, or a receiver chain split across lines: `plur\n
+      // .recall(q)\n  .length`, audit #752 item 6) is reported for a human
+      // rather than rewritten blind.
       if (endPos.line === pos.line) wrapTo = endPos.column
-      else { fixable = false; reason = 'result is consumed by a multi-line call — needs `(await ...)` by hand' }
+      else { fixable = false; reason = 'result is consumed by a multi-line expression — needs `(await ...)` by hand' }
     }
 
     // ASI hazard — the third failure class in the header comment, and the one
@@ -495,9 +685,26 @@ export function scanSource(file: string, src: string, methods: readonly string[]
           reason = 'previous line has no terminator — a leading `(await ...)` splices onto it (ASI); end it with `;` or add `(await ...)` by hand'
         }
       }
+    } else if (fixable && (src[idx] === '(' || src[idx] === '[')) {
+      // The receiver HEAD is a parenthesised expression or array literal —
+      // the same splice read in the other direction. When that head starts
+      // its line and the previous line never terminated, the head is
+      // currently CONTINUING the previous expression (`let f = function ()
+      // {}` + `(store as Plur).recall(q)` calls f). A plain inserted `await`
+      // would cut that continuation and change what runs, so it is refused
+      // exactly as the leading-`(await ...)` wrap is.
+      const lineStart = idx - (pos.column - 1)
+      if (/^\s*$/.test(src.slice(lineStart, idx))) {
+        const prev = lastSignificantChar(src, lineStart - 1, spans)
+        if (prev !== null && !ASI_SAFE_BEFORE_PAREN.has(prev)) {
+          fixable = false
+          reason = 'previous line has no terminator, so this line continues it (ASI) — inserting `await` would split that; end the previous line with `;` and re-run'
+        }
+      }
     }
 
-    out.push({ file, line: pos.line, column: pos.column, method: m[2], text: pos.text, fixable, reason, wrapTo })
+    seen.add(idx)
+    out.push({ file, line: pos.line, column: pos.column, method: m[1], text: pos.text, fixable, reason, wrapTo })
   }
   return out
 }

--- a/packages/migrate/test/scan-multiline.test.ts
+++ b/packages/migrate/test/scan-multiline.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Multi-line receiver chains — audit #752 item 6, fixed in #758.
+ *
+ * The receiver used to be matched by a regex that could not span a newline,
+ * so `plur\n  .recall(q)` — an ordinary fluent chain — was neither rewritten
+ * nor reported, and the report read as clean on a file that was not. Worse,
+ * on a single line the same regex re-anchored MID-chain:
+ * `getStore().plur.recall(q)` matched with receiver `plur`, and `--write`
+ * emitted `getStore().await plur.recall(q)` — source that does not parse —
+ * while `await getStore().plur.recall(q)`, already correct, was reported and
+ * then mangled the same way.
+ *
+ * The scanner now anchors on the METHOD and resolves the receiver by walking
+ * backward from the dot (see `receiverStart`). These tests pin both halves:
+ * chains split across lines are found, and every finding anchors at the head
+ * of the chain — the only position `await` may legally occupy.
+ */
+import { describe, it, expect } from 'vitest'
+import { scanSource, applyFixes } from '../src/scan.js'
+
+const scan = (src: string) => scanSource('t.ts', src)
+const fix = (src: string) => applyFixes(src, scan(src)).src
+
+describe('multi-line receiver chains are found', () => {
+  it('finds the audit repro — receiver, call, and consumer on three lines — and reports it MANUAL', () => {
+    // The exact site from #752 item 6. It is consumed (`.length`) across
+    // lines, so it must be REPORTED but not rewritten: the single-line wrap
+    // `(await ...)` cannot be placed with line/column arithmetic here.
+    const src = "const n = plur\n  .recall('q')\n  .length\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].method).toBe('recall')
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/multi-line/)
+    // Anchored at the chain head, where the human will add `(await`.
+    expect(f[0].line).toBe(1)
+    expect(f[0].column).toBe(11)
+    expect(applyFixes(src, f).src).toBe(src)
+  })
+
+  it('fixes a bare chain split across lines — await goes in front of the head', () => {
+    const src = "async function g(plur) {\n  plur\n    .learn('x')\n}\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe("async function g(plur) {\n  await plur\n    .learn('x')\n}\n")
+  })
+
+  it('a comment between receiver and call does not hide the chain', () => {
+    const line = "async function g(plur) {\n  plur\n    // engrams\n    .recall('q')\n}\n"
+    expect(fix(line)).toContain('await plur\n')
+    const block = "async function g(plur) {\n  plur /* engrams */.recall('q')\n}\n"
+    expect(fix(block)).toContain("await plur /* engrams */.recall('q')")
+  })
+
+  it('a commented-OUT chain link is skipped, not matched', () => {
+    // The `.recall(` inside the comment is literal text; the real call is
+    // `.learn(`. One finding, and the comment rides along untouched.
+    const src = "async function g(plur) {\n  plur\n    // .recall('old')\n    .learn('x')\n}\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].method).toBe('learn')
+    expect(applyFixes(src, f).src).toBe("async function g(plur) {\n  await plur\n    // .recall('old')\n    .learn('x')\n}\n")
+  })
+
+  it('finds a multi-line optional chain — plur\\n  ?.recall(q)', () => {
+    const src = "async function g(plur) {\n  plur\n    ?.recall('q')\n}\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe("async function g(plur) {\n  await plur\n    ?.recall('q')\n}\n")
+  })
+
+  it('finds a dot-at-line-end chain — plur.\\n  recall(q)', () => {
+    const src = "async function g(plur) {\n  plur.\n    recall('q')\n}\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(applyFixes(src, f).src).toContain('await plur.\n')
+  })
+})
+
+describe('multi-line chains that are already handled stay silent', () => {
+  it('an await in front of the chain head covers the whole chain', () => {
+    expect(scan("async function g(plur) {\n  await plur\n    .recall('q')\n}\n")).toEqual([])
+    expect(scan("async function g(plur) {\n  const x = await plur\n    .recall('q')\n}\n")).toEqual([])
+    expect(scan("async function g() {\n  await getStore().plur\n    .recall('q')\n}\n")).toEqual([])
+  })
+
+  it('a returned or voided chain is fine', () => {
+    expect(scan("async function g(plur) {\n  return plur\n    .sync()\n}\n")).toEqual([])
+    expect(scan("async function g(plur) {\n  void plur\n    .sync()\n}\n")).toEqual([])
+  })
+
+  it('a .then on the next line is a handled promise', () => {
+    expect(scan("async function g(plur) {\n  plur\n    .sync()\n    .then(ok)\n}\n")).toEqual([])
+  })
+
+  it('a chain inside a Promise combinator array is still refused, not rewritten', () => {
+    const src = "const r = await Promise.race([\n  plur\n    .learnRouted(s, ctx),\n  timeout(5000),\n])\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/combinator/)
+  })
+
+  it('a chain inside a non-async function is refused — await there does not parse', () => {
+    const f = scanSource('t.mjs', "function g(plur) {\n  plur\n    .learn('x')\n}\n")
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/not `async`/)
+  })
+})
+
+describe('findings anchor at the head of the chain', () => {
+  it('a call-bearing receiver anchors before the call — the mid-chain anchor emitted unparseable source', () => {
+    // Before #758: finding at `plur`, --write emitted
+    // `getStore().await plur.recall('q')`. The assertion is the exact output.
+    const src = "async function g() { getStore().plur.recall('q') }\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(applyFixes(src, f).src).toBe("async function g() { await getStore().plur.recall('q') }\n")
+  })
+
+  it('an ALREADY-awaited call-bearing receiver is silent — it used to be reported and then mangled', () => {
+    expect(scan("async function g() { await getStore().plur.recall('q') }\n")).toEqual([])
+    expect(scan("async function g() { await (getPlur()).recall('q') }\n")).toEqual([])
+  })
+
+  it('finds a factory-call receiver — getPlur().recall(q)', () => {
+    const src = "async function g() { getPlur().recall('q') }\n"
+    expect(fix(src)).toBe("async function g() { await getPlur().recall('q') }\n")
+  })
+
+  it('finds a fluent chain with a call in the middle — plur.scoped(s).recall(q)', () => {
+    const src = "async function g(plur) { plur.scoped('team').recall('q') }\n"
+    expect(fix(src)).toBe("async function g(plur) { await plur.scoped('team').recall('q') }\n")
+  })
+
+  it('wraps through a call-bearing receiver when the result is consumed', () => {
+    const src = "async function g() { const n = getPlur().recall('q').length }\n"
+    expect(fix(src)).toBe("async function g() { const n = (await getPlur().recall('q')).length }\n")
+  })
+
+  it('a `new` receiver puts the await before the new — `new await` does not parse', () => {
+    const src = "async function g() { new Plur().recall('q') }\n"
+    expect(fix(src)).toBe("async function g() { await new Plur().recall('q') }\n")
+  })
+
+  it('a parenthesised head takes the await in front of the paren', () => {
+    const src = "async function g(store) { (store as Plur).recall('q') }\n"
+    expect(fix(src)).toBe("async function g(store) { await (store as Plur).recall('q') }\n")
+  })
+
+  it('refuses a parenthesised head that ASI-splices onto the previous line', () => {
+    // `let f = function () {}` + `(store).recall(q)` currently CALLS f — a
+    // plain inserted `await` would cut that continuation and change what
+    // runs. Same refusal as the leading-`(await ...)` wrap, other direction.
+    const src = "let f = function () {}\n(store).recall('q')\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(false)
+    expect(f[0].reason).toMatch(/ASI/)
+    expect(applyFixes(src, f).src).toBe(src)
+  })
+
+  it('two newly-async methods on one chain produce ONE finding — two rewrites at one offset would collide', () => {
+    const src = "async function g(plur) { plur.recall('q').learn('x') }\n"
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].method).toBe('recall')
+  })
+})
+
+describe('consumption is read through comments and optional chains', () => {
+  it('`?.` after the call is consumption — the plain form awaits .length of the promise', () => {
+    const src = "async function g(plur) { const n = plur.recall('q')?.length }\n"
+    expect(fix(src)).toBe("async function g(plur) { const n = (await plur.recall('q'))?.length }\n")
+  })
+
+  it('a comment between the call and its consumer does not un-consume it', () => {
+    // Seen as bare, this would get a plain `await` — which awaits `.length`
+    // OF THE PROMISE. The comment must be skipped, the wrap kept.
+    const src = "async function g(plur) { const n = plur.recall('q') /* hits */ .length }\n"
+    expect(fix(src)).toBe("async function g(plur) { const n = (await plur.recall('q')) /* hits */ .length }\n")
+  })
+
+  it('a ?.then across a comment is still a handled promise', () => {
+    expect(scan("async function g(plur) { plur.sync() /* ok */ ?.then(done) }\n")).toEqual([])
+  })
+})
+
+describe('idempotence over the new shapes', () => {
+  it('a second pass over fixed chains finds nothing', () => {
+    const src = [
+      "async function g(plur) {",
+      "  plur",
+      "    .learn('a')",
+      "  getPlur().recall('q')",
+      "  new Plur().recall('r')",
+      "}",
+      "",
+    ].join('\n')
+    const once = applyFixes(src, scan(src)).src
+    const twice = applyFixes(once, scanSource('t.ts', once))
+    expect(twice.applied).toBe(0)
+    expect(twice.src).toBe(once)
+  })
+})

--- a/packages/migrate/test/scan.test.ts
+++ b/packages/migrate/test/scan.test.ts
@@ -65,11 +65,17 @@ describe('scanSource — what it finds', () => {
     )
   })
 
-  it('a NESTED bracket index is missed, never misreported at an inner offset', () => {
-    // `[^\]]` cannot span the inner `]`; every partial interpretation fails to
-    // reach the method dot. A miss is the documented trade — what must never
-    // happen is a finding anchored inside the index (`m[await a[0]].learn`).
-    expect(scan('async function go(m, a) { m[a[0]].learn("x") }')).toEqual([])
+  it('a NESTED bracket index resolves, anchored at the chain head — never an inner offset', () => {
+    // A documented miss until #758: `[^\]]` could not span the inner `]`, so
+    // this scanned clean. The backward receiver walk matches brackets by
+    // depth, so the index resolves — and the invariant that always held still
+    // must: the finding anchors at `m`, never inside the index
+    // (`m[await a[0]].learn` is the misreport that may not happen).
+    const src = 'async function go(m, a) { m[a[0]].learn("x") }'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('async function go(m, a) { await m[a[0]].learn("x") }')
   })
 
   it('finds optional-chain bracket receivers — ?.[ is ordinary modern TS (#752 iteration 2)', () => {
@@ -83,10 +89,15 @@ describe('scanSource — what it finds', () => {
     expect(applyFixes(src, f).src).toBe('async function go(arr) { await arr?.[0].learn("x") }')
   })
 
-  it('an index key containing `]` is missed, never misreported', () => {
-    // Same character-class boundary as the nested case, same invariant: a
-    // clean miss, no finding anchored inside the string key.
-    expect(scan('async function go(m) { m["a]b"].learn("x") }')).toEqual([])
+  it('an index key containing `]` resolves — the walk reads spans, not characters', () => {
+    // The other documented miss until #758. The backward walk skips the
+    // string span whole, so the `]` inside the key cannot end the index —
+    // and the finding anchors at `m`, never inside the string.
+    const src = 'async function go(m) { m["a]b"].learn("x") }'
+    const f = scan(src)
+    expect(f).toHaveLength(1)
+    expect(f[0].fixable).toBe(true)
+    expect(applyFixes(src, f).src).toBe('async function go(m) { await m["a]b"].learn("x") }')
   })
 
   it('reports each occurrence separately', () => {


### PR DESCRIPTION
Closes #758 (audit #752 item 6).

## The gap, and what was under it

`@plur-ai/migrate` matched call sites with a receiver-anchored regex that could not span a newline. An ordinary fluent chain

```ts
const n = plur
  .recall('q')
  .length
```

was neither rewritten nor reported — not even as `MANUAL` — so the report read as clean on a file that was not.

Reproducing the miss exposed a worse failure in the same mechanism: on a single line the regex re-anchored **mid-chain**. `getStore().plur.recall('q')` matched with receiver `plur`, so `--write` emitted

```ts
getStore().await plur.recall('q')   // does not parse
```

and `await getStore().plur.recall('q')` — already correct — was *reported as un-awaited and then mangled the same way*, because the `await` sat in front of the chain while the look-behind check ran from the mid-chain anchor. Emitting source that does not parse is the failure class the package's own header calls strictly worse than doing nothing.

## The fix

No new dependency — the package is deliberately zero-dep and has no AST infrastructure, so this stays a span-aware lexical scanner. The regex now anchors on the **method**, and the receiver is resolved by walking backward from the dot (`receiverStart`): identifier segments, `?.` links, bracket indexes, call arguments, parenthesised heads, a leading `new` — with whitespace and comments skipped between tokens via the existing literal-span machinery. Every finding anchors at the true head of the chain, the only position `await` may legally occupy.

Covered (each pinned in `test/scan-multiline.test.ts`):

- **Multi-line receiver chains** — the audit's exact repro is reported `MANUAL` (`result is consumed by a multi-line expression`), consistent with the existing multi-line handling; a bare chain (`plur\n  .learn(x)`) is fixable, with `await` inserted at the chain head. Dot-leading and dot-trailing styles both resolve.
- **Comments between receiver and call** — line and block comments inside the chain are skipped; a commented-out chain link is not matched.
- **Optional chaining** — `plur\n  ?.recall(q)` resolves; `?.` *after* the call now counts as consumption, so `plur.recall(q)?.length` gets the `(await ...)` wrap instead of a plain `await` that would await `.length` of the promise.
- **Await-wrapped chains** — `await plur\n  .recall(q)`, `return`/`void` chains, and `await getStore().plur.recall(q)` are silent: the look-behind runs at the chain head wherever the chain breaks.

Falls out of the same walk:

- `getPlur().recall(q)`, `plur.scoped(s).recall(q)`, `new Plur().recall(q)` — call-bearing receivers, previously invisible — resolve and rewrite at the head (`await new Plur()...`, never `new await`).
- The two documented bracket-index misses (`m[a[0]].learn(x)` nested, `m["a]b"].learn(x)` string key with `]`) now resolve, still anchored at `m` — the tests that pinned them as misses now pin the rewrite.
- Consumption is read through comments (`plur.recall(q) /* hits */ .length` keeps the wrap).
- A paren/array-literal receiver head that starts its line after an unterminated line is refused as an ASI splice, mirroring the existing leading-`(await ...)` guard.
- One finding per chain head, so two newly-async methods on one chain cannot insert twice at one offset.
- The `PREFILTER` in `index.ts` mirrors the dot-whitespace tolerance so a `plur.\n  recall(q)` file is not skipped before the scanner runs.

## Verification

- `packages/migrate`: 101 tests pass, including the new `scan-multiline.test.ts` (audit repro + anchor cases) and the flipped bracket-index tests.
- `test/method-list.test.ts` (the NEWLY_ASYNC contract test): all 6 pass against the current `Plur` surface, including both git-history assertions against the real `v0.15.0` tag.
- `pnpm typecheck:tests` clean; `pnpm build` clean.
- The rebuilt CLI over `packages/core/src` reports the same three pre-existing concise-arrow sites as before — no new false positives on real source.
- Smoke expectations in `scripts/smoke-release.sh` (section 6b) are unchanged and still hold.
