### PR TITLE
fix(cli): honour --quiet across all commands via a central output policy

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -102,7 +102,25 @@ export to JSON and use `--from generic` in the meantime.
 | `--json` | Force JSON output (auto-detected when piped) |
 | `--path <dir>` | Override storage path (default: `~/.plur`) |
 | `--fast` | BM25-only search (skip embeddings, faster) |
-| `--quiet` | Suppress non-essential output |
+| `--quiet` | Suppress non-essential output (see below) |
+
+### What `--quiet` suppresses
+
+`--quiet` silences chatter, not answers:
+
+- **Suppressed** — progress lines, confirmations of requested mutations
+  (`Learned: …`, `Feedback recorded`), banners, hints/next-step suggestions,
+  summary footers (`Total: 5`).
+- **Preserved** — the primary output (recall results, listings, status
+  fields, doctor/audit reports), warnings that the outcome differs from what
+  was requested (e.g. a scope demotion, a failed index rebuild), all errors
+  (stderr), exit codes, and `--json` output (unaffected by `--quiet`).
+
+```bash
+plur learn "prefer tabs" --quiet        # exit 0, no output
+plur recall "tabs" --quiet              # results still print
+plur sync --quiet                       # silent unless the index broke
+```
 
 ## JSON Output
 

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 import { readdirSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
@@ -237,9 +237,11 @@ function sharedKeyTerms(a: string, b: string): number {
   return count
 }
 
-function printText(report: AuditReport): void {
-  outputText(`plur audit — content-layer health for ${report.source}`)
-  outputText('')
+function printText(report: AuditReport, flags?: GlobalFlags): void {
+  // --quiet (#730): banner and next-step hints are suppressed; the findings
+  // themselves are the primary output and always print.
+  outputInfo(`plur audit — content-layer health for ${report.source}`, flags)
+  outputInfo('', flags)
   outputText(`Scanned: ${report.scanned} entries`)
   for (const [k, v] of Object.entries(report.counts)) {
     outputText(`  ${k}: ${v}`)
@@ -259,12 +261,12 @@ function printText(report: AuditReport): void {
     }
     outputText('')
   }
-  outputText('Next steps:')
-  outputText('  CONFLICT  → resolve (which is true now?), update or retire engram, fix auto-memory')
-  outputText('  DUPLICATE → delete auto-memory file (engram covers it)')
-  outputText('  SNAPSHOT  → verify against live source (git/gh/package.json), retire if stale')
-  outputText('  ORPHAN    → confirm still relevant, migrate durable rules to engram')
-  outputText('  DURABLE   → leave alone (active project state OR unique to auto-memory)')
+  outputInfo('Next steps:', flags)
+  outputInfo('  CONFLICT  → resolve (which is true now?), update or retire engram, fix auto-memory', flags)
+  outputInfo('  DUPLICATE → delete auto-memory file (engram covers it)', flags)
+  outputInfo('  SNAPSHOT  → verify against live source (git/gh/package.json), retire if stale', flags)
+  outputInfo('  ORPHAN    → confirm still relevant, migrate durable rules to engram', flags)
+  outputInfo('  DURABLE   → leave alone (active project state OR unique to auto-memory)', flags)
 }
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
@@ -325,5 +327,5 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const report: AuditReport = { source, scanned: entries.length, findings, counts }
 
   if (shouldOutputJson(flags)) outputJson(report)
-  else printText(report)
+  else printText(report, flags)
 }

--- a/packages/cli/src/commands/capture.ts
+++ b/packages/cli/src/commands/capture.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -33,8 +33,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson({ id: episode.id, summary: episode.summary, timestamp: episode.timestamp })
   } else {
-    outputText(`Captured episode: ${episode.id}`)
-    outputText(`  Summary: ${episode.summary}`)
-    outputText(`  Timestamp: ${episode.timestamp}`)
+    outputInfo(`Captured episode: ${episode.id}`, flags)
+    outputInfo(`  Summary: ${episode.summary}`, flags)
+    outputInfo(`  Timestamp: ${episode.timestamp}`, flags)
   }
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, realpathSync, statSync, accessSync, constants
 import { join, extname } from 'path'
 import { homedir, platform } from 'os'
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { outputText, outputJson, shouldOutputJson } from '../output.js'
+import { outputText, outputInfo, outputJson, shouldOutputJson } from '../output.js'
 import {
   type ConfigFile,
   buildMcpServerEntry,
@@ -594,11 +594,20 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
   })
 }
 
-function printText(report: DoctorReport): void {
+/**
+ * Render the report. Exported for tests (#730): text mode cannot be exercised
+ * through a spawned CLI (piped stdout auto-selects JSON), and calling run()
+ * in-process would spawn the embedder probe against the test runner's argv.
+ *
+ * --quiet (#730): only the title banner is suppressed — everything else in
+ * this report IS the diagnosis the user asked for, including the ✓ lines
+ * (absence of a ✓ would read as "not checked", not "healthy").
+ */
+export function printText(report: DoctorReport, flags?: GlobalFlags): void {
   const tick = (b: boolean) => (b ? '✓' : '✗')
 
-  outputText('plur doctor — Claude Code / Claude Desktop / Cursor diagnostic')
-  outputText('')
+  outputInfo('plur doctor — Claude Code / Claude Desktop / Cursor diagnostic', flags)
+  outputInfo('', flags)
   outputText('Config files:')
   for (const c of report.configs) {
     if (!c.exists) {
@@ -763,7 +772,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson(report)
   } else {
-    printText(report)
+    printText(report, flags)
   }
 
   process.exit(report.overall === 'ok' ? 0 : 1)

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputInfo, exit } from '../output.js'
 
 const VALID_SIGNALS = ['positive', 'negative', 'neutral'] as const
 type Signal = (typeof VALID_SIGNALS)[number]
@@ -38,7 +38,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (shouldOutputJson(flags)) {
       outputJson({ mode: 'batch', results, summary })
     } else {
-      outputText(`Batch feedback: ${summary.positive} positive, ${summary.negative} negative, ${summary.neutral} neutral`)
+      outputInfo(`Batch feedback: ${summary.positive} positive, ${summary.negative} negative, ${summary.neutral} neutral`, flags)
     }
     return
   }
@@ -68,6 +68,6 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson({ id, signal, status: 'recorded' })
   } else {
-    outputText(`Feedback recorded: ${signal} for ${id}`)
+    outputInfo(`Feedback recorded: ${signal} for ${id}`, flags)
   }
 }

--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -31,7 +31,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: target, statement: engram.statement } })
     } else {
-      outputText(`Retired: [${target}] ${engram.statement}`)
+      outputInfo(`Retired: [${target}] ${engram.statement}`, flags)
     }
     return
   }
@@ -53,7 +53,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, retired: { id: matches[0].id, statement: matches[0].statement } })
     } else {
-      outputText(`Retired: [${matches[0].id}] ${matches[0].statement}`)
+      outputInfo(`Retired: [${matches[0].id}] ${matches[0].statement}`, flags)
     }
     return
   }

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -43,7 +43,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       outputText('No engram candidates found in content.')
       return
     }
-    outputText(`${extractOnly ? 'Extracted' : 'Ingested'} ${candidates.length} engram(s):`)
+    outputInfo(`${extractOnly ? 'Extracted' : 'Ingested'} ${candidates.length} engram(s):`, flags)
     candidates.forEach(c => outputText(`  [${c.type}] ${c.statement}`))
   }
 }

--- a/packages/cli/src/commands/init-remote.ts
+++ b/packages/cli/src/commands/init-remote.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
-import { outputText } from '../output.js'
+import { outputText, outputInfo, outputError } from '../output.js'
 
 /**
  * plur init-remote — opt this project into recall-from-Enterprise.
@@ -314,13 +314,13 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
 
   const parsed = parseArgs(args)
   if ('error' in parsed) {
-    outputText(`Error: ${parsed.error}\n\n${HELP}`, flags)
+    outputError(`Error: ${parsed.error}\n\n${HELP}`)
     process.exit(1)
   }
   const opts = parsed
 
   if (opts.help) {
-    outputText(HELP, flags)
+    outputText(HELP) // explicitly requested — never suppressed
     return
   }
 
@@ -334,16 +334,17 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const verifyPath = findExistingConfigPath() ?? configPath
     const cfg = readRemoteFromConfig(verifyPath)
     if (!cfg.url || !cfg.token) {
-      outputText(`No remote config found (walked upward from ${process.cwd()}). Run \`plur init-remote --url <url> --token <key>\` first.`, flags)
+      outputError(`No remote config found (walked upward from ${process.cwd()}). Run \`plur init-remote --url <url> --token <key>\` first.`)
       process.exit(1)
     }
-    outputText(`Using config at ${verifyPath}`, flags)
+    outputInfo(`Using config at ${verifyPath}`, flags)
     try {
       const me = await verifyConnectivity(cfg.url, cfg.token)
-      outputText(`✓ Connected to ${cfg.url} as ${me.username} (org: ${me.org_id})`, flags)
-      outputText(`  readable scopes: ${me.scopes.length === 0 ? '(none)' : me.scopes.join(', ')}`, flags)
+      // The verify result IS the requested output — never suppressed.
+      outputText(`✓ Connected to ${cfg.url} as ${me.username} (org: ${me.org_id})`)
+      outputText(`  readable scopes: ${me.scopes.length === 0 ? '(none)' : me.scopes.join(', ')}`)
     } catch (err) {
-      outputText(`✗ Connection failed: ${(err as Error).message}`, flags)
+      outputError(`✗ Connection failed: ${(err as Error).message}`)
       process.exit(2)
     }
     return
@@ -351,14 +352,14 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
 
   // Setup mode — validate inputs
   if (!opts.url || !opts.token) {
-    outputText(`Missing required flags.\n${HELP}`, flags)
+    outputError(`Missing required flags.\n${HELP}`)
     process.exit(1)
   }
 
   // Reject control characters in the token — they corrupt the YAML write
   // and silently break the parser (data #EC09).
   if (/[\n\r\t]/.test(opts.token)) {
-    outputText(`Error: token contains newline/tab characters. Refusing to write a corrupt config.`, flags)
+    outputError(`Error: token contains newline/tab characters. Refusing to write a corrupt config.`)
     process.exit(1)
   }
 
@@ -366,24 +367,24 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   try {
     const u = new URL(opts.url)
     if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-      outputText(`Error: remote_url must be http:// or https:// (got ${u.protocol})`, flags)
+      outputError(`Error: remote_url must be http:// or https:// (got ${u.protocol})`)
       process.exit(1)
     }
   } catch {
-    outputText(`Error: remote_url is not a valid URL: ${opts.url}`, flags)
+    outputError(`Error: remote_url is not a valid URL: ${opts.url}`)
     process.exit(1)
   }
 
   // Test connectivity before writing the config — fail-fast saves the user
   // from a confusing "hook is silent" mystery if the token is wrong.
-  outputText(`Testing connectivity to ${opts.url}...`, flags)
+  outputInfo(`Testing connectivity to ${opts.url}...`, flags)
   try {
     const me = await verifyConnectivity(opts.url, opts.token)
-    outputText(`✓ Authenticated as ${me.username} (org: ${me.org_id})`, flags)
-    outputText(`  readable scopes: ${me.scopes.length === 0 ? '(none)' : me.scopes.join(', ')}`, flags)
+    outputInfo(`✓ Authenticated as ${me.username} (org: ${me.org_id})`, flags)
+    outputInfo(`  readable scopes: ${me.scopes.length === 0 ? '(none)' : me.scopes.join(', ')}`, flags)
   } catch (err) {
-    outputText(`✗ Connection failed: ${(err as Error).message}`, flags)
-    outputText(`  Refusing to write a broken config. Fix the URL/token and re-run.`, flags)
+    outputError(`✗ Connection failed: ${(err as Error).message}`)
+    outputError(`  Refusing to write a broken config. Fix the URL/token and re-run.`)
     process.exit(2)
   }
 
@@ -391,33 +392,35 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const existing = existsSync(configPath) ? readFileSync(configPath, 'utf8') : ''
   const next = buildConfigBody(existing, opts.url, opts.token, opts.scopes)
   writeFileSync(configPath, next)
-  outputText(`✓ Wrote ${configPath}`, flags)
+  outputInfo(`✓ Wrote ${configPath}`, flags)
   if (opts.scopes && opts.scopes.length > 0) {
-    outputText(`  scope whitelist: ${opts.scopes.join(', ')}`, flags)
+    outputInfo(`  scope whitelist: ${opts.scopes.join(', ')}`, flags)
   } else {
-    outputText(`  scope whitelist: (none — hook will query all readable scopes)`, flags)
+    outputInfo(`  scope whitelist: (none — hook will query all readable scopes)`, flags)
   }
 
   // Ensure .gitignore
   if (!opts.noGitignore) {
     const gi = ensureGitignore()
-    if (gi.action === 'added') outputText(`✓ Added .plur.yaml to ${gi.path}`, flags)
-    else if (gi.action === 'created') outputText(`✓ Created ${gi.path} with .plur.yaml entry`, flags)
-    else outputText(`✓ ${gi.path} already excludes .plur.yaml`, flags)
+    if (gi.action === 'added') outputInfo(`✓ Added .plur.yaml to ${gi.path}`, flags)
+    else if (gi.action === 'created') outputInfo(`✓ Created ${gi.path} with .plur.yaml entry`, flags)
+    else outputInfo(`✓ ${gi.path} already excludes .plur.yaml`, flags)
   } else {
-    outputText(`⚠ Skipped .gitignore (--no-gitignore). The token in .plur.yaml is sensitive.`, flags)
+    // The token is now committed-able — outcome differs from the safe default;
+    // never suppressed (#730).
+    outputText(`⚠ Skipped .gitignore (--no-gitignore). The token in .plur.yaml is sensitive.`)
   }
 
-  outputText(`\nDone. The UserPromptSubmit hook will now query ${opts.url} on every prompt`, flags)
-  outputText(`from this directory tree (bounded by the nearest .git). Personal/non-project`, flags)
-  outputText(`sessions (without a .plur.yaml in the path) stay local-only.`, flags)
-  outputText(``, flags)
-  outputText(`⚠ Token sensitivity:`, flags)
-  outputText(`  .plur.yaml now contains an API token in plaintext.`, flags)
-  outputText(`  - .gitignore protects against git commits but NOT against cloud sync`, flags)
-  outputText(`    (iCloud Drive, Dropbox, Google Drive). If this project lives in a`, flags)
-  outputText(`    synced folder, the token will leave your machine.`, flags)
-  outputText(`  - Also not protected: \`cp -r\`, \`zip\`, \`rsync\`, archived backups.`, flags)
-  outputText(`  - Consider moving the token to an env var if your project ships with`, flags)
-  outputText(`    others (future: env-var substitution in .plur.yaml).`, flags)
+  outputInfo(`\nDone. The UserPromptSubmit hook will now query ${opts.url} on every prompt`, flags)
+  outputInfo(`from this directory tree (bounded by the nearest .git). Personal/non-project`, flags)
+  outputInfo(`sessions (without a .plur.yaml in the path) stay local-only.`, flags)
+  outputInfo(``, flags)
+  outputInfo(`⚠ Token sensitivity:`, flags)
+  outputInfo(`  .plur.yaml now contains an API token in plaintext.`, flags)
+  outputInfo(`  - .gitignore protects against git commits but NOT against cloud sync`, flags)
+  outputInfo(`    (iCloud Drive, Dropbox, Google Drive). If this project lives in a`, flags)
+  outputInfo(`    synced folder, the token will leave your machine.`, flags)
+  outputInfo(`  - Also not protected: \`cp -r\`, \`zip\`, \`rsync\`, archived backups.`, flags)
+  outputInfo(`  - Consider moving the token to an env var if your project ships with`, flags)
+  outputInfo(`    others (future: env-var substitution in .plur.yaml).`, flags)
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
 import { createInterface } from 'readline'
 import { type GlobalFlags } from '../plur.js'
-import { outputText } from '../output.js'
+import { outputInfo } from '../output.js'
 import {
   buildMcpServerEntry,
   claudeDesktopConfigPath,
@@ -827,36 +827,36 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
 
   const entry = buildMcpServerEntry()
 
-  outputText('PLUR installed for Claude Code.')
-  outputText('')
-  outputText(`Hook binary: ${shim.status}${shim.shimPath ? ` (${shim.shimPath})` : ''}`)
-  outputText(`MCP binary:  ${mcpShim.status}${mcpShim.shimPath ? ` (${mcpShim.shimPath})` : ''}`)
-  outputText('')
-  outputText('Architecture: One global engram store (~/.plur/), enforcement hooks global, injection hooks project-scoped.')
-  outputText('Multi-project scoping via domain/scope fields on engrams, not separate installs.')
-  outputText('')
-  outputText(`MCP server (plur): ${mcpStatus}`)
-  outputText(`  command: ${entry.command} ${entry.args.join(' ')}`)
-  outputText('')
-  outputText(`Enforcement hooks (4, always global): ${enforcementHooksStatus}`)
-  outputText('  SessionStart      — enforce plur_session_start before any work')
-  outputText('  SessionEnd        — auto-close memory lifecycle (captures closing episode)')
-  outputText('  PreToolUse        — session guard (blocks tools until session started)')
-  outputText('  PostToolUse       — session sentinel (marks session as started)')
-  outputText('')
-  outputText(`Injection hooks (9): ${injectionHooksStatus}`)
-  outputText('  UserPromptSubmit  — inject engrams + auto-start session')
-  outputText('  PostCompact       — re-inject engrams after context compaction')
-  outputText('  PreToolUse        — contextual injection (plan mode, skills, agents)')
-  outputText('  PreToolUse        — observation capture for pattern learning')
-  outputText('  PostToolUse       — observation results capture')
-  outputText('  SubagentStart     — inject agent-scoped engrams into subagents')
-  outputText('  Stop              — learning reflection nudge (every 3rd response)')
-  outputText('')
-  outputText(`Enforcement file: ${enforcementPath}`)
-  if (!samePath) outputText(`Injection file:   ${injectionPath}`)
-  outputText(`Claude Desktop:   ${desktopStatus}`)
-  outputText(cursorStatus)
+  outputInfo('PLUR installed for Claude Code.', flags)
+  outputInfo('', flags)
+  outputInfo(`Hook binary: ${shim.status}${shim.shimPath ? ` (${shim.shimPath})` : ''}`, flags)
+  outputInfo(`MCP binary:  ${mcpShim.status}${mcpShim.shimPath ? ` (${mcpShim.shimPath})` : ''}`, flags)
+  outputInfo('', flags)
+  outputInfo('Architecture: One global engram store (~/.plur/), enforcement hooks global, injection hooks project-scoped.', flags)
+  outputInfo('Multi-project scoping via domain/scope fields on engrams, not separate installs.', flags)
+  outputInfo('', flags)
+  outputInfo(`MCP server (plur): ${mcpStatus}`, flags)
+  outputInfo(`  command: ${entry.command} ${entry.args.join(' ')}`, flags)
+  outputInfo('', flags)
+  outputInfo(`Enforcement hooks (4, always global): ${enforcementHooksStatus}`, flags)
+  outputInfo('  SessionStart      — enforce plur_session_start before any work', flags)
+  outputInfo('  SessionEnd        — auto-close memory lifecycle (captures closing episode)', flags)
+  outputInfo('  PreToolUse        — session guard (blocks tools until session started)', flags)
+  outputInfo('  PostToolUse       — session sentinel (marks session as started)', flags)
+  outputInfo('', flags)
+  outputInfo(`Injection hooks (9): ${injectionHooksStatus}`, flags)
+  outputInfo('  UserPromptSubmit  — inject engrams + auto-start session', flags)
+  outputInfo('  PostCompact       — re-inject engrams after context compaction', flags)
+  outputInfo('  PreToolUse        — contextual injection (plan mode, skills, agents)', flags)
+  outputInfo('  PreToolUse        — observation capture for pattern learning', flags)
+  outputInfo('  PostToolUse       — observation results capture', flags)
+  outputInfo('  SubagentStart     — inject agent-scoped engrams into subagents', flags)
+  outputInfo('  Stop              — learning reflection nudge (every 3rd response)', flags)
+  outputInfo('', flags)
+  outputInfo(`Enforcement file: ${enforcementPath}`, flags)
+  if (!samePath) outputInfo(`Injection file:   ${injectionPath}`, flags)
+  outputInfo(`Claude Desktop:   ${desktopStatus}`, flags)
+  outputInfo(cursorStatus, flags)
   if (shouldSetupCursor(args)) {
     // Audit fix (user evaluator): the 11-tools-instead-of-39 tradeoff and
     // plur_admin indirection were previously only discoverable by reading
@@ -867,11 +867,11 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     // Claude Code, both integrations are now active, running independently
     // (separate sentinel directories, separate config files); this plan
     // doesn't test that combination, just documents that it exists.
-    outputText('  Cursor gets a reduced tool set (~11 tools + plur_admin dispatch for the rest) to stay')
-    outputText('  under Cursor\'s ~40-tool-per-workspace limit — call plur_admin with { action, args } for')
-    outputText('  packs/sync/tensions/stores/timeline/etc. Run `plur doctor` any time to see current counts.')
-    outputText('  Note: the Claude Code hooks above are also active in this project — the two integrations')
-    outputText('  run independently and haven\'t been tested together.')
+    outputInfo('  Cursor gets a reduced tool set (~11 tools + plur_admin dispatch for the rest) to stay', flags)
+    outputInfo('  under Cursor\'s ~40-tool-per-workspace limit — call plur_admin with { action, args } for', flags)
+    outputInfo('  packs/sync/tensions/stores/timeline/etc. Run `plur doctor` any time to see current counts.', flags)
+    outputInfo('  Note: the Claude Code hooks above are also active in this project — the two integrations', flags)
+    outputInfo('  run independently and haven\'t been tested together.', flags)
     // Audit fix (evaluator review, 2026-07-08): .cursor/mcp.json and
     // .cursor/hooks.json are intentionally NOT gitignored (unlike the two
     // dynamic .mdc rule files above) so committing .cursor/ lets teammates
@@ -882,39 +882,39 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     // won't start there. `plur doctor` now catches this after the fact
     // (cursorWired checks the command exists); this warns before it bites.
     if (cmd.startsWith('/') || /^[A-Za-z]:\\/.test(cmd)) {
-      outputText('  Committing .cursor/mcp.json / .cursor/hooks.json? Their command is this machine\'s local')
-      outputText(`  path (${cmd}) — it won't exist on a teammate's machine or a fresh Background Agent VM.`)
-      outputText('  Run `plur init --cursor` there too, or edit the command to `npx -y @plur-ai/mcp@latest`.')
+      outputInfo('  Committing .cursor/mcp.json / .cursor/hooks.json? Their command is this machine\'s local', flags)
+      outputInfo(`  path (${cmd}) — it won't exist on a teammate's machine or a fresh Background Agent VM.`, flags)
+      outputInfo('  Run `plur init --cursor` there too, or edit the command to `npx -y @plur-ai/mcp@latest`.', flags)
     }
   }
-  outputText(`CLAUDE.md:        ${claudeMdStatus}`)
+  outputInfo(`CLAUDE.md:        ${claudeMdStatus}`, flags)
   if (projectConfigPath) {
-    outputText(`Project config:   ${projectConfigPath}`)
+    outputInfo(`Project config:   ${projectConfigPath}`, flags)
   }
-  outputText('')
-  outputText('Enforcement hooks fire from any subdirectory; they silent-pass when plur is not configured.')
+  outputInfo('', flags)
+  outputInfo('Enforcement hooks fire from any subdirectory; they silent-pass when plur is not configured.', flags)
   if (projectConfigPath) {
-    outputText('Project scoping configured. Engrams learned in this project will')
-    outputText('be tagged automatically. Run `plur init --domain X --scope Y` in')
-    outputText('other projects to set their defaults.')
-    outputText('')
+    outputInfo('Project scoping configured. Engrams learned in this project will', flags)
+    outputInfo('be tagged automatically. Run `plur init --domain X --scope Y` in', flags)
+    outputInfo('other projects to set their defaults.', flags)
+    outputInfo('', flags)
   }
-  outputText('Restart Claude Code to pick up the changes, then run `plur doctor` to verify.')
+  outputInfo('Restart Claude Code to pick up the changes, then run `plur doctor` to verify.', flags)
 
   // Telemetry opt-in — ask once, never nag. Runs last so it doesn't interrupt the
   // settings-installation summary above. Non-interactive installs silently write
   // enabled:false (opt-out), which ensures they are never opted in without consent.
   const telemetryResult = await promptTelemetryOptIn({ noPrompt })
-  outputText('')
+  outputInfo('', flags)
   if (telemetryResult === 'opted-in') {
-    outputText('Telemetry: enabled (thank you — anonymous counts only, nothing leaves your machine before POST /v1/heartbeat).')
-    outputText('           Disable any time: plur telemetry off  or  set PLUR_TELEMETRY=off')
+    outputInfo('Telemetry: enabled (thank you — anonymous counts only, nothing leaves your machine before POST /v1/heartbeat).', flags)
+    outputInfo('           Disable any time: plur telemetry off  or  set PLUR_TELEMETRY=off', flags)
   } else if (telemetryResult === 'opted-out') {
-    outputText('Telemetry: disabled. Enable any time: plur telemetry on  or  set PLUR_TELEMETRY=on')
-    outputText('           See docs/telemetry-design.md for what is and is not collected.')
+    outputInfo('Telemetry: disabled. Enable any time: plur telemetry on  or  set PLUR_TELEMETRY=on', flags)
+    outputInfo('           See docs/telemetry-design.md for what is and is not collected.', flags)
   } else if (telemetryResult === 'non-interactive') {
-    outputText('Telemetry: disabled (non-interactive install). Enable: set PLUR_TELEMETRY=on')
-    outputText('           See docs/telemetry-design.md for what is collected.')
+    outputInfo('Telemetry: disabled (non-interactive install). Enable: set PLUR_TELEMETRY=on', flags)
+    outputInfo('           See docs/telemetry-design.md for what is collected.', flags)
   }
   // 'already-configured' → silent, user already made a choice
 }

--- a/packages/cli/src/commands/inject.ts
+++ b/packages/cli/src/commands/inject.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 
 // Note: the supersedes rule assumes the consumer has PLUR MCP tools available
 // (plur_learn). Consumers without MCP tooling can opt out via
@@ -65,6 +65,6 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       outputText('## ALSO CONSIDER')
       outputText(result.consider)
     }
-    outputText(`\nInjected ${result.count} engrams (${result.tokens_used} tokens)`)
+    outputInfo(`\nInjected ${result.count} engrams (${result.tokens_used} tokens)`, flags)
   }
 }

--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -198,16 +198,18 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       ...(domainHint ? { domain_hint: domainHint } : {}),
     })
   } else {
-    outputText(`Learned: "${engram.statement}"`)
-    outputText(`  ID: ${engram.id} | Scope: ${engram.scope} | Type: ${engram.type}${engram.domain ? ` | Domain: ${engram.domain}` : ''}`)
+    // Confirmation of a requested mutation → suppressed by --quiet (#730).
+    outputInfo(`Learned: "${engram.statement}"`, flags)
+    outputInfo(`  ID: ${engram.id} | Scope: ${engram.scope} | Type: ${engram.type}${engram.domain ? ` | Domain: ${engram.domain}` : ''}`, flags)
     if (demoted) {
+      // The write landed somewhere OTHER than requested — never suppressed.
       outputText(
         `  Warning: Sensitive content (${demoted.patterns}) detected — stored at ` +
         `${demoted.to}/private instead of ${demoted.from}; re-scope deliberately if false positive.`,
       )
     }
     if (domainHint) {
-      outputText(`  Hint: ${domainHint}`)
+      outputInfo(`  Hint: ${domainHint}`, flags)
     }
   }
 }

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -64,6 +64,6 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
         : e.statement
       outputText(`${e.id.padEnd(20)} ${e.type.padEnd(14)} ${e.scope.padEnd(20)} ${stmt}`)
     }
-    outputText(`\nTotal: ${engrams.length}`)
+    outputInfo(`\nTotal: ${engrams.length}`, flags)
   }
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
-import { outputText } from '../output.js'
+import { outputText, outputInfo, outputError, isQuiet } from '../output.js'
 
 /**
  * plur login <host> — mint an enterprise token via OAuth device flow,
@@ -380,7 +380,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const parsed = parseArgs(args)
 
   if (parsed.error) {
-    outputText(`Error: ${parsed.error}\n\n${HELP}`)
+    outputError(`Error: ${parsed.error}\n\n${HELP}`)
     process.exit(1)
   }
 
@@ -407,7 +407,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   }
 
   if (!parsed.host) {
-    outputText(`Missing required argument: <host>\n\n${HELP}`)
+    outputError(`Missing required argument: <host>\n\n${HELP}`)
     process.exit(1)
   }
 
@@ -415,28 +415,28 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   try {
     origin = normaliseHost(parsed.host)
   } catch (err) {
-    outputText(`Error: ${(err as Error).message}`)
+    outputError(`Error: ${(err as Error).message}`)
     process.exit(1)
   }
 
   const timeoutSecs = parsed.timeoutSecs ?? 300
 
-  outputText(`Authenticating with ${origin}...`)
+  outputInfo(`Authenticating with ${origin}...`, flags)
 
   // Step 1: request device code
   let deviceResp: DeviceCodeResponse
   try {
     deviceResp = await requestDeviceCode(origin)
   } catch (err) {
-    outputText(`Error: ${(err as Error).message}`)
+    outputError(`Error: ${(err as Error).message}`)
     process.exit(1)
   }
 
   // Step 2: present code + URL to user
-  outputText('')
+  outputInfo('', flags)
   outputText(`Your one-time code:  ${deviceResp.user_code}`)
   outputText(`Visit:               ${deviceResp.verification_uri}`)
-  outputText('')
+  outputInfo('', flags)
 
   if (parsed.noOpen) {
     outputText('Open the URL above in your browser, enter the code, and approve the request.')
@@ -448,8 +448,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       outputText('Could not open browser. Visit the URL above manually.')
     }
   }
-  outputText('')
-  outputText(`Waiting for approval (timeout: ${timeoutSecs}s)...`)
+  outputInfo('', flags)
+  outputInfo(`Waiting for approval (timeout: ${timeoutSecs}s)...`, flags)
 
   // Step 3: poll for token
   let tokenResp: TokenResponse
@@ -462,7 +462,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       timeoutSecs,
       () => {
         // Progress indicator — write dots without newlines while polling.
-        // Use process.stdout.write directly (not outputText) to stay on-line.
+        // Raw stdout writes (not outputText) to stay on-line; gated on
+        // --quiet like any other progress output (#730).
+        if (isQuiet(flags)) return
         process.stdout.write('.')
         dots++
         if (dots % 40 === 0) process.stdout.write('\n')
@@ -470,7 +472,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     )
   } catch (err) {
     if (dots > 0) process.stdout.write('\n')
-    outputText(`\nError: ${(err as Error).message}`)
+    outputError(`\nError: ${(err as Error).message}`)
     process.exit(1)
   }
   if (dots > 0) process.stdout.write('\n')
@@ -488,15 +490,15 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     authed_at: new Date().toISOString(),
   }
   writePlurConfig(cfg)
-  outputText(`\nLogged in as ${me.username} — token written to ${plurConfigPath()}`)
+  outputInfo(`\nLogged in as ${me.username} — token written to ${plurConfigPath()}`, flags)
 
   // Step 6: signal hot-reload to running MCP server
   const reloadResult = signalReload()
-  outputText(`Server: ${reloadResult}`)
+  outputInfo(`Server: ${reloadResult}`, flags)
 
-  outputText('')
-  outputText('Done. Your enterprise token is active.')
+  outputInfo('', flags)
+  outputInfo('Done. Your enterprise token is active.', flags)
   if (me.scopes && me.scopes.length > 0) {
-    outputText(`  readable scopes: ${me.scopes.join(', ')}`)
+    outputInfo(`  readable scopes: ${me.scopes.join(', ')}`, flags)
   }
 }

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,6 +1,6 @@
 import { runMigrations, rollbackMigrations, getSchemaVersion, CURRENT_SCHEMA_VERSION } from '@plur-ai/core'
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 import { detectPlurStorage } from '@plur-ai/core'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
@@ -34,16 +34,17 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       if (shouldOutputJson(flags)) {
         outputJson(result)
       } else {
+        // Confirmation of a requested mutation → suppressed by --quiet (#730).
         if (result.applied.length === 0) {
-          outputText('Already up to date.')
+          outputInfo('Already up to date.', flags)
         } else {
-          outputText(`Applied ${result.applied.length} migration(s):`)
+          outputInfo(`Applied ${result.applied.length} migration(s):`, flags)
           for (const id of result.applied) {
-            outputText(`  - ${id}`)
+            outputInfo(`  - ${id}`, flags)
           }
-          outputText(`Schema version: ${result.schema_version}`)
+          outputInfo(`Schema version: ${result.schema_version}`, flags)
           if (result.backup_path) {
-            outputText(`Backup: ${result.backup_path}`)
+            outputInfo(`Backup: ${result.backup_path}`, flags)
           }
         }
       }
@@ -68,13 +69,13 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
         outputJson(result)
       } else {
         if (result.applied.length === 0) {
-          outputText('Nothing to roll back.')
+          outputInfo('Nothing to roll back.', flags)
         } else {
-          outputText(`Rolled back ${result.applied.length} migration(s):`)
+          outputInfo(`Rolled back ${result.applied.length} migration(s):`, flags)
           for (const id of result.applied) {
-            outputText(`  - ${id}`)
+            outputInfo(`  - ${id}`, flags)
           }
-          outputText(`Schema version: ${result.schema_version}`)
+          outputInfo(`Schema version: ${result.schema_version}`, flags)
         }
       }
     } catch (err: any) {

--- a/packages/cli/src/commands/packs.ts
+++ b/packages/cli/src/commands/packs.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { homedir } from 'os'
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -144,11 +144,14 @@ Options:
         name,
       })
     } else {
-      outputText(`Exported pack "${name}":`)
-      outputText(`  Engrams:    ${result.engram_count}`)
-      outputText(`  Path:       ${result.path}`)
-      outputText(`  Integrity:  ${result.integrity}`)
-      outputText(`  Match terms: ${result.match_terms.join(', ') || '(none)'}`)
+      // Export confirmation → suppressed by --quiet; the privacy findings
+      // below (blocked/warned engrams) stay loud — the pack differs from
+      // what was requested (#730).
+      outputInfo(`Exported pack "${name}":`, flags)
+      outputInfo(`  Engrams:    ${result.engram_count}`, flags)
+      outputInfo(`  Path:       ${result.path}`, flags)
+      outputInfo(`  Integrity:  ${result.integrity}`, flags)
+      outputInfo(`  Match terms: ${result.match_terms.join(', ') || '(none)'}`, flags)
 
       if (!result.privacy.clean) {
         const blocked = result.privacy.issues.filter(i => i.type === 'secret' || i.type === 'private_visibility')
@@ -181,9 +184,11 @@ Options:
     if (shouldOutputJson(flags)) {
       outputJson(result)
     } else {
-      outputText(`Installed pack "${result.name}": ${result.installed} engrams`)
+      // Install confirmation → suppressed by --quiet; security warnings and
+      // conflicts below stay loud (#730).
+      outputInfo(`Installed pack "${result.name}": ${result.installed} engrams`, flags)
       if (result.registry) {
-        outputText(`  Integrity: ${result.registry.integrity}`)
+        outputInfo(`  Integrity: ${result.registry.integrity}`, flags)
       }
 
       if (!result.security.clean) {
@@ -224,7 +229,7 @@ Use 'plur packs list' to see installed packs.`)
     if (shouldOutputJson(flags)) {
       outputJson(result)
     } else {
-      outputText(`Uninstalled pack "${result.name}": ${result.engram_count} engrams removed`)
+      outputInfo(`Uninstalled pack "${result.name}": ${result.engram_count} engrams removed`, flags)
     }
     return
   }

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -18,7 +18,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (shouldOutputJson(flags)) {
       outputJson({ success: true, id, status: 'already_active' })
     } else {
-      outputText(`Engram ${id} is already active`)
+      outputInfo(`Engram ${id} is already active`, flags)
     }
     return
   }
@@ -36,6 +36,6 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson({ success: true, id, statement: engram.statement, status: 'promoted' })
   } else {
-    outputText(`Promoted engram: ${id}`)
+    outputInfo(`Promoted engram: ${id}`, flags)
   }
 }

--- a/packages/cli/src/commands/rerank-eval.ts
+++ b/packages/cli/src/commands/rerank-eval.ts
@@ -1,6 +1,6 @@
 import { RERANKER_NAMES, type RerankerName } from '@plur-ai/core'
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { outputText, outputJson, shouldOutputJson, exit } from '../output.js'
+import { outputText, outputInfo, outputJson, shouldOutputJson, exit } from '../output.js'
 
 /**
  * plur rerank-eval — per-store reranker self-eval gate (#451, final task).
@@ -59,8 +59,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     outputJson({ ...result, cached })
   } else {
     const sign = result.delta_mrr >= 0 ? '+' : ''
-    outputText(`plur rerank-eval — per-store reranker self-eval (#451)${cached ? ' [cached]' : ''}`)
-    outputText('')
+    // Banner → suppressed by --quiet; the eval report below is primary (#730).
+    outputInfo(`plur rerank-eval — per-store reranker self-eval (#451)${cached ? ' [cached]' : ''}`, flags)
+    outputInfo('', flags)
     outputText(`  Reranker:   ${result.reranker} (${result.model_id})`)
     outputText(`  Evaluated:  ${result.evaluated_at}`)
     outputText(`  Store:      ${result.engram_count} active engrams, ${result.eligible_count} probe-eligible`)

--- a/packages/cli/src/commands/scopes.ts
+++ b/packages/cli/src/commands/scopes.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 
 /**
  * `plur scopes` (#647) — the user-facing surface for authorized-but-unregistered
@@ -23,9 +23,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     const cleared = plur.getDismissedScopes()
     await plur.reofferScopes()
     if (json) return outputJson({ success: true, action: 'reoffer', cleared })
-    return outputText(cleared.length
+    return outputInfo(cleared.length
       ? `Re-offering ${cleared.length} previously dismissed scope(s): ${cleared.join(', ')}`
-      : 'No dismissed scopes to re-offer.')
+      : 'No dismissed scopes to re-offer.', flags)
   }
 
   const subcommand = args[0]
@@ -37,7 +37,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       const { url, status } = await plur.registerScope(scope)
       if (json) return outputJson({ success: true, action: 'register', scope, url, status })
       const verb = status === 'added' ? 'Registered' : status === 'token_rotated' ? 'Rotated token for' : 'Already registered'
-      return outputText(`${verb} scope "${scope}" (${url}).`)
+      return outputInfo(`${verb} scope "${scope}" (${url}).`, flags)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       if (json) return outputJson({ success: false, action: 'register', scope, error: msg })
@@ -50,7 +50,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     if (!scope) exit(1, 'Usage: plur scopes dismiss <scope>')
     await plur.dismissScope(scope)
     if (json) return outputJson({ success: true, action: 'dismiss', scope })
-    return outputText(`Dismissed "${scope}" — it won't be offered again. Run \`plur scopes --reoffer\` to undo.`)
+    return outputInfo(`Dismissed "${scope}" — it won't be offered again. Run \`plur scopes --reoffer\` to undo.`, flags)
   }
 
   // Default (or `list`): show the offerable set.
@@ -81,6 +81,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (failures.length > 0) {
     outputText(`\n(warning: could not reach ${failures.map(f => f.url).join(', ')} — that store's scopes may be missing above.)`)
   }
-  outputText(`\nRegister one:  plur scopes register <scope>`)
-  outputText(`Dismiss one:   plur scopes dismiss <scope>`)
+  // Next-step hints → suppressed by --quiet (#730); the listing above stays.
+  outputInfo(`\nRegister one:  plur scopes register <scope>`, flags)
+  outputInfo(`Dismiss one:   plur scopes dismiss <scope>`, flags)
 }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo } from '../output.js'
 
 export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -8,8 +8,10 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson(result)
   } else {
-    outputText('Plur Status')
-    outputText('===========')
+    // Banner is decoration → suppressed by --quiet; the fields below are the
+    // primary output and always print (#730).
+    outputInfo('Plur Status', flags)
+    outputInfo('===========', flags)
     outputText(`  Engrams:      ${result.engram_count}`)
     outputText(`  Episodes:     ${result.episode_count}`)
     outputText(`  Packs:        ${result.pack_count}`)

--- a/packages/cli/src/commands/stores.ts
+++ b/packages/cli/src/commands/stores.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -41,7 +41,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
         token_rotated: 'Rotated token for',
         added: 'Added',
       }[result.status] ?? 'Added'
-      outputText(`${verb} store: ${path} (scope: ${result.scope})`)
+      // Confirmation of the requested add → suppressed by --quiet. The
+      // scopeDropped branch above stays loud: the requested scope was NOT added.
+      outputInfo(`${verb} store: ${path} (scope: ${result.scope})`, flags)
     }
     return
   }
@@ -80,7 +82,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       })
     } else {
       const total = discoveries.reduce((n, d) => n + d.unregistered.length, 0)
-      if (total > 0) outputText(`\nRun \`plur stores discover --register\` to register all ${total} unregistered scope(s).`)
+      if (total > 0) outputInfo(`\nRun \`plur stores discover --register\` to register all ${total} unregistered scope(s).`, flags)
     }
     return
   }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,6 +1,6 @@
 import type { IndexSyncError } from '@plur-ai/core'
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo } from '../output.js'
 
 /**
  * `plur sync [remote] [--full]`
@@ -43,11 +43,13 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson({ ...result, full, ...(indexError ? { index_error: indexError } : {}) })
   } else {
-    outputText(`Sync: ${result.action}${full ? ' (full reindex)' : ''}`)
-    if (result.message) outputText(`  ${result.message}`)
-    if (result.files_changed > 0) outputText(`  Files changed: ${result.files_changed}`)
-    if (full) outputText('  Index rebuilt from YAML.')
+    // Status/confirmation lines → suppressed by --quiet (#730)…
+    outputInfo(`Sync: ${result.action}${full ? ' (full reindex)' : ''}`, flags)
+    if (result.message) outputInfo(`  ${result.message}`, flags)
+    if (result.files_changed > 0) outputInfo(`  Files changed: ${result.files_changed}`, flags)
+    if (full) outputInfo('  Index rebuilt from YAML.', flags)
     if (indexError) {
+      // …but a failed index pass is an outcome-differs warning — never suppressed.
       outputText(`  Warning: index ${indexError.op} failed — ${indexError.message}`)
       outputText("  YAML is still the source of truth. Run 'plur sync --full' to rebuild the index.")
     }

--- a/packages/cli/src/commands/tensions.ts
+++ b/packages/cli/src/commands/tensions.ts
@@ -1,5 +1,5 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
-import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 import type { LlmFunction } from '@plur-ai/core'
 
 /** Create an OpenAI-compatible LLM function from base URL + key + model. */
@@ -111,13 +111,13 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       if (action === 'confirm') {
         const record = plur.confirmTension(tensionId)
         if (shouldOutputJson(flags)) { outputJson({ record }) } else {
-          outputText(`Confirmed ${record.id} as a real conflict.`)
-          outputText(`Resolve it with: plur tensions resolve ${record.id} --winner <engram-id>`)
+          outputInfo(`Confirmed ${record.id} as a real conflict.`, flags)
+          outputInfo(`Resolve it with: plur tensions resolve ${record.id} --winner <engram-id>`, flags)
         }
       } else if (action === 'dismiss') {
         const record = plur.dismissTension(tensionId)
         if (shouldOutputJson(flags)) { outputJson({ record }) } else {
-          outputText(`Dismissed ${record.id} — the pair is suppressed from future scans.`)
+          outputInfo(`Dismissed ${record.id} — the pair is suppressed from future scans.`, flags)
         }
       } else {
         if (!winner) {
@@ -126,7 +126,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
         }
         const { record, retired_id } = await plur.resolveTension(tensionId, winner)
         if (shouldOutputJson(flags)) { outputJson({ record, retired: retired_id }) } else {
-          outputText(`Resolved ${record.id}: ${winner} wins, ${retired_id} retired.`)
+          outputInfo(`Resolved ${record.id}: ${winner} wins, ${retired_id} retired.`, flags)
         }
       }
     } catch (err) {
@@ -153,11 +153,12 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     }
 
     if (!shouldOutputJson(flags)) {
-      outputText(`Scanning ${engrams.length} engrams for contradictions…`)
-      if (scope) outputText(`  scope: ${scope}`)
-      if (domain) outputText(`  domain: ${domain}`)
-      outputText(`  min-confidence: ${minConfidence}  max-pairs: ${maxPairs}  batch-size: ${batchSize}`)
-      outputText('')
+      // Progress banner → suppressed by --quiet (#730).
+      outputInfo(`Scanning ${engrams.length} engrams for contradictions…`, flags)
+      if (scope) outputInfo(`  scope: ${scope}`, flags)
+      if (domain) outputInfo(`  domain: ${domain}`, flags)
+      outputInfo(`  min-confidence: ${minConfidence}  max-pairs: ${maxPairs}  batch-size: ${batchSize}`, flags)
+      outputInfo('', flags)
     }
 
     const { scanForTensions } = await import('@plur-ai/core')
@@ -217,10 +218,11 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       outputText('')
     })
 
-    outputText('Next steps:')
-    outputText('  plur tensions confirm <T-id>                       # real conflict')
-    outputText('  plur tensions dismiss <T-id>                       # false positive, suppress')
-    outputText('  plur tensions resolve <T-id> --winner <engram-id>  # keep winner, retire loser')
+    // Next-step hints → suppressed by --quiet; the findings above stay (#730).
+    outputInfo('Next steps:', flags)
+    outputInfo('  plur tensions confirm <T-id>                       # real conflict', flags)
+    outputInfo('  plur tensions dismiss <T-id>                       # false positive, suppress', flags)
+    outputInfo('  plur tensions resolve <T-id> --winner <engram-id>  # keep winner, retire loser', flags)
     return
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { shouldOutputJson, outputJson, exit } from './output.js'
+import { shouldOutputJson, outputJson, setQuiet, exit } from './output.js'
 import { parseGlobalFlags, createPlur } from './plur.js'
 
 export type { GlobalFlags } from './plur.js'
@@ -71,13 +71,19 @@ Global flags:
   --json       Force JSON output (auto-detected when piped)
   --path <dir> Override storage path (default: ~/.plur)
   --fast       Use BM25-only search (skip embeddings)
-  --quiet      Suppress non-essential output
+  --quiet      Suppress non-essential output (progress, confirmations, hints;
+               results, warnings and errors still print)
   --version    Print version
   --help       Show this help`)
   process.exit(0)
 }
 
 const { flags, args } = parseGlobalFlags(argv)
+// Arm --quiet globally (#730) so no output site can forget it. Commands still
+// pass `flags` to outputInfo where available; this covers the ones that don't.
+// hook-* commands are unaffected: their stdout is protocol JSON written
+// directly, never through outputInfo.
+setQuiet(flags.quiet === true)
 const command = args[0]
 const commandArgs = args.slice(1)
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -99,16 +99,50 @@ export function outputJson(data: unknown): void {
   process.stdout.write(JSON.stringify(redactSecrets(data)) + '\n')
 }
 
-/** Write human-readable text to stdout. */
+// ── --quiet policy (#730) ───────────────────────────────────────────────────
+//
+// `--quiet` means "suppress non-essential output". "Non-essential" is defined
+// here, once, not per command:
+//
+//   SUPPRESSED  progress lines ("Testing connectivity…"), confirmations of a
+//               mutation the user explicitly requested ("Learned: …",
+//               "Feedback recorded"), banners/titles, hints and next-step
+//               suggestions, summary footers ("Total: 5").
+//   PRESERVED   the primary output — the thing the user asked for (recall
+//               results, listings, status fields, reports); warnings that the
+//               outcome DIFFERS from what was requested (scope demotion,
+//               index failure, partial results); errors (stderr, always);
+//               exit codes; all `--json` output; hook-* protocol stdout.
+//
+// Mechanics: the entry point calls {@link setQuiet} once from the parsed
+// global flags, so quiet cannot be forgotten by a command that never threads
+// options (the failure mode of the pre-#730 design, where only init-remote
+// passed flags and the other ~350 call sites silently ignored the flag).
+// Call sites still pass `flags` explicitly where available — that keeps
+// commands testable in-process without touching module state, and the
+// per-call value overrides the global one.
+//
+// Ambiguous lines default to {@link outputText} (printing): a too-chatty
+// `--quiet` is an annoyance, a suppressed result is data loss.
+
+let globalQuiet = false
+
+/** Set once by the CLI entry point from `parseGlobalFlags` (see policy above). */
+export function setQuiet(quiet: boolean): void {
+  globalQuiet = quiet
+}
+
+/** Whether informational output is currently suppressed. Per-call `options.quiet` overrides the global flag. */
+export function isQuiet(options?: OutputOptions): boolean {
+  return options?.quiet ?? globalQuiet
+}
+
 /**
- * Write a line of human-readable output, honouring `--quiet`.
+ * Write a line of PRIMARY human-readable output to stdout.
  *
- * The `options` parameter is not decorative. `init-remote` has been calling
- * `outputText(text, flags)` at 35 sites since it was written, believing that was
- * how output got routed; the one-parameter signature silently discarded the
- * second argument, so `--quiet` did nothing there. Nothing caught it: esbuild
- * strips types without checking them, and the test suites were not typechecked
- * at all until `tsconfig.tests.json` was added.
+ * Never suppressed — this is the thing the user asked for (see the --quiet
+ * policy above). For progress/confirmation/decoration lines use
+ * {@link outputInfo}; for errors use {@link outputError} or {@link exit}.
  *
  * `--json` is deliberately NOT handled here. There is no correct automatic
  * translation from a line of prose to a machine-readable record, and inventing
@@ -117,9 +151,30 @@ export function outputJson(data: unknown): void {
  * one that cannot should say so rather than emit prose to a caller that asked
  * for JSON.
  */
-export function outputText(text: string, options?: OutputOptions): void {
-  if (options?.quiet) return
+export function outputText(text: string): void {
   process.stdout.write(text + '\n')
+}
+
+/**
+ * Write an INFORMATIONAL line to stdout — suppressed by `--quiet`.
+ *
+ * Use for progress, confirmations of requested mutations, banners, hints,
+ * and summary footers (see the --quiet policy above). Pass the command's
+ * `flags` when in scope so behaviour is explicit and testable in-process;
+ * the global flag set by the entry point covers call sites that don't.
+ */
+export function outputInfo(text: string, options?: OutputOptions): void {
+  if (isQuiet(options)) return
+  process.stdout.write(text + '\n')
+}
+
+/**
+ * Write an error line to stderr. NEVER suppressed — `--quiet` silences
+ * chatter, not failures. Prefer {@link exit} when the command terminates
+ * immediately; use this when it reports and continues (or exits later).
+ */
+export function outputError(text: string): void {
+  process.stderr.write(text + '\n')
 }
 
 /** Exit with code. 0 = success, 1 = error, 2 = no results. */

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest'
-import { shouldOutputJson, type OutputOptions } from '../src/output.js'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  shouldOutputJson,
+  outputText,
+  outputInfo,
+  outputError,
+  setQuiet,
+  isQuiet,
+  type OutputOptions,
+} from '../src/output.js'
 
 describe('output', () => {
   it('returns true when json flag is set', () => {
@@ -8,5 +16,82 @@ describe('output', () => {
 
   it('returns false when json flag is explicitly false', () => {
     expect(shouldOutputJson({ json: false })).toBe(false)
+  })
+})
+
+// #730 — the --quiet plumbing. outputText is primary output (never
+// suppressed), outputInfo is informational (suppressed by quiet, per-call or
+// global), outputError always reaches stderr.
+describe('output --quiet (#730)', () => {
+  let out: string[]
+  let err: string[]
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    out = []
+    err = []
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      out.push(String(chunk))
+      return true
+    }) as never)
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      err.push(String(chunk))
+      return true
+    }) as never)
+  })
+
+  afterEach(() => {
+    setQuiet(false) // never leak global state into other tests
+    stdoutSpy.mockRestore()
+    stderrSpy.mockRestore()
+  })
+
+  it('outputText always writes, even under global quiet', () => {
+    setQuiet(true)
+    outputText('primary result')
+    expect(out.join('')).toBe('primary result\n')
+  })
+
+  it('outputInfo writes by default', () => {
+    outputInfo('progress line')
+    expect(out.join('')).toBe('progress line\n')
+  })
+
+  it('outputInfo is suppressed by per-call quiet', () => {
+    outputInfo('progress line', { quiet: true })
+    expect(out).toHaveLength(0)
+  })
+
+  it('outputInfo is suppressed by global quiet set at the entry point', () => {
+    setQuiet(true)
+    outputInfo('progress line')
+    expect(out).toHaveLength(0)
+  })
+
+  it('per-call options override the global flag in both directions', () => {
+    setQuiet(true)
+    outputInfo('explicitly loud', { quiet: false })
+    expect(out.join('')).toBe('explicitly loud\n')
+
+    setQuiet(false)
+    outputInfo('explicitly quiet', { quiet: true })
+    expect(out.join('')).toBe('explicitly loud\n') // unchanged
+  })
+
+  it('isQuiet reflects the per-call override, else the global flag', () => {
+    expect(isQuiet()).toBe(false)
+    setQuiet(true)
+    expect(isQuiet()).toBe(true)
+    expect(isQuiet({ quiet: false } as OutputOptions)).toBe(false)
+    setQuiet(false)
+    expect(isQuiet({ quiet: true } as OutputOptions)).toBe(true)
+  })
+
+  it('outputError writes to stderr and ignores quiet entirely', () => {
+    setQuiet(true)
+    outputError('something broke')
+    expect(err.join('')).toBe('something broke\n')
+    expect(out).toHaveLength(0)
   })
 })

--- a/packages/cli/test/quiet-sync.test.ts
+++ b/packages/cli/test/quiet-sync.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `plur sync --quiet` (#730) — status lines are suppressed, but a background
+ * index failure is an outcome-differs warning and must survive --quiet
+ * (suppressing it would regress #272's whole point: a broken index silently
+ * reporting success).
+ *
+ * Same createPlur mock harness as sync-index-error.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { IndexSyncError } from '@plur-ai/core'
+
+const mockPlur = {
+  sync: vi.fn(),
+  waitForIndex: vi.fn(async () => undefined),
+  lastIndexError: vi.fn((): IndexSyncError | null => null),
+}
+
+vi.mock('../src/plur.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/plur.js')>()
+  return { ...mod, createPlur: () => mockPlur as never }
+})
+
+import { run } from '../src/commands/sync.js'
+
+describe('plur sync --quiet (#730)', () => {
+  let writes: string[]
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    writes = []
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk))
+      return true
+    }) as never)
+    mockPlur.sync.mockReturnValue({ action: 'up-to-date', message: 'all good', remote: null, files_changed: 2 })
+    mockPlur.lastIndexError.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+    vi.clearAllMocks()
+  })
+
+  it('suppresses the status lines under --quiet', async () => {
+    await run([], { json: false, quiet: true })
+    expect(writes.join('')).toBe('')
+  })
+
+  it('prints the status lines without --quiet', async () => {
+    await run([], { json: false })
+    const text = writes.join('')
+    expect(text).toContain('Sync: up-to-date')
+    expect(text).toContain('all good')
+    expect(text).toContain('Files changed: 2')
+  })
+
+  it('still prints the index-failure warning under --quiet', async () => {
+    mockPlur.lastIndexError.mockReturnValue({
+      op: 'sync-from-yaml',
+      message: 'disk on fire',
+      at: '2026-07-02T00:00:00.000Z',
+    })
+    await run([], { json: false, quiet: true })
+    const text = writes.join('')
+    expect(text).not.toContain('Sync: up-to-date')
+    expect(text).toContain('Warning: index sync-from-yaml failed — disk on fire')
+  })
+
+  it('--quiet does not touch JSON output', async () => {
+    await run([], { json: true, quiet: true })
+    const parsed = JSON.parse(writes.join(''))
+    expect(parsed.action).toBe('up-to-date')
+  })
+})

--- a/packages/cli/test/quiet.test.ts
+++ b/packages/cli/test/quiet.test.ts
@@ -1,0 +1,201 @@
+/**
+ * --quiet behaviour per command (#730).
+ *
+ * Policy under test (defined in src/output.ts):
+ *   - suppressed:  progress, confirmations of requested mutations, banners,
+ *                  hints, summary footers
+ *   - preserved:   primary output (the thing the user asked for), warnings
+ *                  that the outcome differs from the request, stderr errors,
+ *                  exit codes, --json output
+ *
+ * Text mode cannot be exercised through a spawned CLI (a piped stdout makes
+ * shouldOutputJson auto-select JSON), so commands run in-process with
+ * explicit `json: false` and spied stdout/stderr — the same pattern as
+ * status.test.ts and sync-index-error.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+describe('--quiet per command (#730)', () => {
+  let dir: string
+  let out: string[]
+  let err: string[]
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-quiet-test-'))
+    out = []
+    err = []
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      out.push(String(chunk))
+      return true
+    }) as never)
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      err.push(String(chunk))
+      return true
+    }) as never)
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+    stderrSpy.mockRestore()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const stdout = () => out.join('')
+  const stderr = () => err.join('')
+
+  // ── learn — confirmation suppressed, demotion warning preserved ──────────
+
+  it('learn --quiet suppresses the confirmation lines', async () => {
+    const { run } = await import('../src/commands/learn.js')
+    await run(['a quiet learn statement'], { path: dir, json: false, quiet: true })
+    expect(stdout()).toBe('')
+  })
+
+  it('learn without --quiet prints the confirmation', async () => {
+    const { run } = await import('../src/commands/learn.js')
+    await run(['a loud learn statement'], { path: dir, json: false })
+    expect(stdout()).toContain('Learned: "a loud learn statement"')
+    expect(stdout()).toContain('ID: ENG-')
+  })
+
+  it('learn --quiet still prints the scope-demotion warning (outcome differs from request)', async () => {
+    const { run } = await import('../src/commands/learn.js')
+    // A public IP in a shared scope triggers core's sensitive-content demotion.
+    await run(
+      ['deploy target is 139.59.155.82', '--scope', 'group:plur/core'],
+      { path: dir, json: false, quiet: true },
+    )
+    expect(stdout()).toContain('Warning: Sensitive content')
+    expect(stdout()).not.toContain('Learned:')
+  })
+
+  // ── recall — results are primary output, never suppressed ────────────────
+
+  it('recall --quiet still prints the results', async () => {
+    const { run: learn } = await import('../src/commands/learn.js')
+    const { run: recall } = await import('../src/commands/recall.js')
+    await learn(['always use TypeScript for new projects'], { path: dir, json: false, quiet: true })
+    await recall(['TypeScript'], { path: dir, json: false, quiet: true, fast: true })
+    expect(stdout()).toContain('always use TypeScript for new projects')
+    expect(stdout()).toContain('[ENG-')
+  })
+
+  // ── status — banner suppressed, fields preserved ─────────────────────────
+
+  it('status --quiet drops the banner but keeps the fields', async () => {
+    const { run } = await import('../src/commands/status.js')
+    await run([], { path: dir, json: false, quiet: true })
+    expect(stdout()).not.toContain('Plur Status')
+    expect(stdout()).toContain('Engrams:')
+    expect(stdout()).toContain('Storage root:')
+  })
+
+  // ── list — table preserved, Total footer suppressed ──────────────────────
+
+  it('list --quiet keeps the rows and drops the Total footer', async () => {
+    const { run: learn } = await import('../src/commands/learn.js')
+    const { run: list } = await import('../src/commands/list.js')
+    await learn(['a listed statement'], { path: dir, json: false, quiet: true })
+    await list([], { path: dir, json: false, quiet: true })
+    expect(stdout()).toContain('a listed statement')
+    expect(stdout()).not.toContain('Total:')
+  })
+
+  // ── errors — stderr and exit codes are never silenced ────────────────────
+
+  it('feedback --quiet still reports an invalid signal on stderr with exit 1', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`)
+    }) as never)
+    try {
+      const { run } = await import('../src/commands/feedback.js')
+      await expect(run(['ENG-1', 'bogus'], { path: dir, json: false, quiet: true }))
+        .rejects.toThrow('exit:1')
+      expect(stderr()).toContain('Invalid signal')
+      expect(stdout()).toBe('')
+    } finally {
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('init-remote --quiet still reports a parse error on stderr with exit 1', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`)
+    }) as never)
+    try {
+      const { run } = await import('../src/commands/init-remote.js')
+      await expect(run(['--url'], { json: false, quiet: true })).rejects.toThrow('exit:1')
+      expect(stderr()).toContain('--url requires a value')
+      expect(stdout()).toBe('')
+    } finally {
+      exitSpy.mockRestore()
+    }
+  })
+})
+
+// ── doctor — report preserved, banner suppressed ───────────────────────────
+// printText is exercised directly: run() would spawn the embedder probe
+// against the test runner's argv (see the export note in doctor.ts).
+describe('doctor --quiet (#730)', () => {
+  let out: string[]
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    out = []
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      out.push(String(chunk))
+      return true
+    }) as never)
+  })
+
+  afterEach(() => stdoutSpy.mockRestore())
+
+  async function report(): Promise<Parameters<typeof import('../src/commands/doctor.js')['printText']>[0]> {
+    return {
+      configs: [{
+        label: 'Claude Code (global)',
+        path: '/tmp/settings.json',
+        exists: true,
+        hasPlurMcp: true,
+        hasDatacoreMcp: false,
+        hasPlurHooks: false,
+      }],
+      hooksInstalled: false,
+      mcpRegistered: true,
+      datacoreCollision: false,
+      staleNpxHooks: false,
+      staleNpxMcp: false,
+      hookShim: { valid: false, shimPath: '/tmp/shim', error: 'shim not found — run `plur init` to create it' },
+      mcpShim: { valid: true, shimPath: '/tmp/mcp-shim' },
+      handshake: { ok: false, error: 'skipped (--no-handshake)' },
+      cursorHandshake: null,
+      embedder: { available: true, loaded: true, lastError: null, modelLoaded: true, disabled: false, disabledReason: null },
+      cursorProjectDetected: false,
+      cursorWired: false,
+      pgliteGemmaReembedNeeded: false,
+      overall: 'fail',
+    }
+  }
+
+  it('suppresses only the banner; every finding still prints', async () => {
+    const { printText } = await import('../src/commands/doctor.js')
+    printText(await report(), { quiet: true })
+    const text = out.join('')
+    expect(text).not.toContain('plur doctor — Claude Code / Claude Desktop / Cursor diagnostic')
+    expect(text).toContain('✗ Hooks installed')
+    expect(text).toContain('✓ plur MCP server registered')
+    expect(text).toContain('✗ Hook shim: shim not found')
+    expect(text).toContain('✗ Issues detected.')
+  })
+
+  it('prints the banner without --quiet', async () => {
+    const { printText } = await import('../src/commands/doctor.js')
+    printText(await report(), { quiet: false })
+    expect(out.join('')).toContain('plur doctor — Claude Code / Claude Desktop / Cursor diagnostic')
+  })
+})


### PR DESCRIPTION
Closes #730.

`--quiet` was parsed by `parseGlobalFlags` and then ignored by ~352 of the CLI's ~388 `outputText` sites — only `init-remote` passed options, and until #728 even those were silently discarded. This makes the flag real, with the meaning of "non-essential" defined once in `src/output.ts` instead of per command.

## Approach

The issue offered two options: thread options through every call site, or suppress globally in `outputText`. Neither is right on its own — global suppression would swallow exactly the output the issue flags as the open question (`plur recall`, `plur status` results). This PR combines them: the suppression decision is global (option 2's "cannot be forgotten" property), but each line is classified into a channel (option 1's explicitness), with the classification policy centralized.

- **`outputText(text)`** — primary output, never suppressed: the thing the user asked for (recall results, listings, status fields, doctor/audit/receipt reports), plus warnings that the outcome differs from the request (scope demotion on `learn`, index failure on `sync`, `--no-gitignore` on `init-remote`).
- **`outputInfo(text, flags?)`** — suppressed by `--quiet`: progress lines, confirmations of requested mutations (`Learned: …`, `Feedback recorded`, `Applied N migration(s)`, the whole `init` report), banners, hints/next-steps, summary footers (`Total: N`).
- **`outputError(text)`** — stderr, never suppressed. `init-remote` and `login` error paths that printed errors to **stdout** before `process.exit(1)` now use it (under the old code, `--quiet` on `init-remote` would have suppressed the error text and exited 1 silently).
- The entry point calls `setQuiet(flags.quiet)` once, so a future command that forgets to thread flags still honours `--quiet`; call sites pass `flags` anyway, which keeps commands testable in-process and lets a per-call value override the global.

## Suppress / preserve policy

| | `--quiet` |
|---|---|
| Progress, confirmations, banners, hints, footers | suppressed |
| Primary command output (results, listings, reports) | preserved |
| Outcome-differs warnings (demotion, index failure, …) | preserved |
| Errors | preserved, on **stderr** |
| Exit codes | unchanged |
| `--json` output | unaffected |
| `hook-*` protocol stdout (e.g. `hook-inject` additionalContext JSON) | untouched — written directly, never through the info channel |

Ambiguous lines default to printing: a chatty `--quiet` is an annoyance, a suppressed result is data loss.

## Migration

All 26 command files audited and migrated per-command: 157 sites → `outputInfo`, 15 error sites → `outputError` (stdout→stderr), 224 sites stay `outputText` as primary output. `doctor`/`audit` render helpers now take `flags`; `login`'s polling dots are gated on quiet too. `--help`/`--version` are exempt (explicitly requested output). README and `--help` now state what `--quiet` does and does not suppress.

## Tests

- `output.test.ts` — unit tests for the module: `outputText` immune to quiet, `outputInfo` per-call/global suppression + override precedence, `outputError` → stderr.
- `quiet.test.ts` — per-command smoke tests (in-process, since a piped CLI auto-selects JSON): `learn` (silent on success, demotion warning survives quiet), `recall` (results survive), `status` (banner dropped, fields kept), `list` (rows kept, footer dropped), `doctor` (banner dropped, findings kept), `feedback`/`init-remote` (stderr + exit 1 survive quiet).
- `quiet-sync.test.ts` — `sync` status lines suppressed, #272's index-failure warning preserved, JSON untouched.
- Full suite green; no existing assertions weakened (existing tests spawn the CLI with piped stdout → JSON mode, which `--quiet` does not touch).
