### PR TITLE
feat(cli): plur login --status shows enterprise token validity, not raw config (#587)

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,13 +1,27 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { type GlobalFlags } from '../plur.js'
-import { outputText, outputInfo, outputError, isQuiet } from '../output.js'
+import { doctorRemoteRemediation, normalizeEndpointUrl, type RemoteHealth } from '@plur-ai/core'
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { outputText, outputInfo, outputError, outputJson, shouldOutputJson, isQuiet } from '../output.js'
 
 /**
- * plur login <host> — mint an enterprise token via OAuth device flow,
- * write it to ~/.plur/config.json, and signal the running MCP server
- * to hot-reload its configuration.
+ * plur login — enterprise token status (#587) and the (gated) OAuth device flow.
+ *
+ * `plur login --status` reports each configured enterprise credential's
+ * validity instead of dumping raw config: one row per DISTINCT (url, token)
+ * group in `~/.plur/config.yaml` stores (core's `remoteEndpointTokenGroups`,
+ * the #776 grouping), each with the JWT's display-only subject/org + expiry,
+ * a live `/api/v1/me` probe (via core's `checkRemoteHealth` — the same probe
+ * `plur_doctor` uses), and the locally mounted scopes. Token values are never
+ * printed. Exit 0 when every credential is valid; 1 when any is EXPIRED or
+ * INVALID (script-friendly).
+ *
+ * The device flow below is GATED (see #300/#532): enterprise servers do not
+ * expose the device-flow endpoints yet, and the token it writes has no
+ * consumers on the recall path — so attempting `plur login <host>` prints the
+ * supported path (sign in at <host>/auth, add the store via plur_stores_add)
+ * and exits 1. The implementation is kept for when B-T9 lands server-side.
  *
  * OAuth device flow:
  *   1. POST /api/v1/auth/device — request a device code
@@ -34,27 +48,26 @@ import { outputText, outputInfo, outputError, isQuiet } from '../output.js'
  *   written — the server picks it up on next start.
  */
 
-const HELP = `plur login — mint an enterprise token and configure the MCP server
+const HELP = `plur login — enterprise token status (device-flow sign-in not yet available)
 
 USAGE
-  plur login <host>               Authenticate against the enterprise server
-  plur login <host> --no-open    Print the URL instead of opening a browser
-  plur login <host> --timeout N  Poll window in seconds (default: 300)
-  plur login --status            Show current auth status from ~/.plur/config.json
+  plur login --status            Show enterprise token validity per host
+  plur login --status --json     Machine-readable status report
 
-ARGS
-  host    Enterprise server URL, e.g. https://plur.datafund.io
+WHAT --status DOES
+  For every distinct (url, token) credential in ~/.plur/config.yaml stores:
+    - decodes the JWT (display only, unverified): subject, org, expiry
+    - live-probes GET <host>/api/v1/me with a short timeout
+    - reports VALID / EXPIRING SOON (<7d) / EXPIRED / UNREACHABLE / INVALID
+    - lists the scopes mounted locally for that host
+  Token values are never printed. Exit code: 0 when all credentials are
+  valid, 1 when any is EXPIRED or INVALID (or none are configured).
 
-WHAT THIS DOES
-  Uses the OAuth 2.0 Device Authorization Grant (RFC 8628) to authenticate:
-    1. Fetches a device code from <host>/api/v1/auth/device
-    2. Opens the verification URL in your default browser
-    3. Polls for the token until you approve (or the code expires)
-    4. Writes the token to ~/.plur/config.json
-    5. Signals the running MCP server to hot-reload (SIGUSR1 on POSIX,
-       reload-marker file on Windows)
-
-  If no MCP server is running the token is saved and picked up on next start.
+SIGNING IN
+  \`plur login <host>\` (OAuth device flow) is not available yet — enterprise
+  servers do not expose the device-flow endpoints. To connect:
+    1. Sign in at <host>/auth in your browser
+    2. Add the store via plur_stores_add (MCP) or \`plur stores add\`
 `
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -333,6 +346,209 @@ async function openBrowser(url: string): Promise<boolean> {
   })
 }
 
+// ── Token status (#587) ───────────────────────────────────────────────────────
+
+/** Live `/me` probe budget for --status — short: a status readout must not hang. */
+export const STATUS_PROBE_TIMEOUT_MS = 3000
+
+/** Days-to-expiry below which a valid token is flagged EXPIRING SOON. */
+export const EXPIRING_SOON_DAYS = 7
+
+export type TokenStatusLabel = 'VALID' | 'EXPIRING SOON' | 'EXPIRED' | 'UNREACHABLE' | 'INVALID'
+
+export interface HostTokenStatus {
+  url: string
+  status: TokenStatusLabel
+  /** JWT `sub` (unverified) or, when the probe succeeded, the server's username. */
+  subject?: string
+  /** JWT org claim (unverified) or the server's org_id. */
+  org?: string
+  tokenExpiresAt?: string
+  tokenExpiresInDays?: number | null
+  /** Human-readable relative expiry: "expires in 23d" / "EXPIRED 3d ago". */
+  expiry: string
+  probe: {
+    /** False when the probe was skipped (token already expired locally). */
+    probed: boolean
+    reachable?: boolean
+    /** Scopes the server reports granted to this token (probe ok only). */
+    grantedScopes?: number
+    reason?: string
+  }
+  /** Scopes mounted locally (config.yaml stores) for this (url, token) group. */
+  mountedScopes: string[]
+  remediation?: string
+}
+
+export interface LoginStatusReport {
+  hosts: HostTokenStatus[]
+  /** A `plur login`-written ~/.plur/config.json token not mounted as a store —
+   *  it has no consumers on the recall path, so flag it instead of probing it. */
+  legacyLogin?: { url: string; mounted: boolean }
+  /** True when at least one credential is configured and none is EXPIRED/INVALID. */
+  ok: boolean
+}
+
+/**
+ * Classify one probed credential. EXPIRED means the JWT itself is past its
+ * `exp` (locally decodable — the strongest signal); INVALID means the server
+ * rejected a token that is not visibly expired (revoked, wrong, or opaque);
+ * UNREACHABLE is a network-class failure and deliberately NOT an auth verdict.
+ */
+export function classifyTokenStatus(h: Pick<RemoteHealth, 'status' | 'tokenExpiresInDays'>): TokenStatusLabel {
+  if (h.status === 'ok') {
+    const d = h.tokenExpiresInDays
+    return typeof d === 'number' && d >= 0 && d < EXPIRING_SOON_DAYS ? 'EXPIRING SOON' : 'VALID'
+  }
+  if (h.status === 'auth_expired') {
+    return typeof h.tokenExpiresInDays === 'number' && h.tokenExpiresInDays < 0 ? 'EXPIRED' : 'INVALID'
+  }
+  return 'UNREACHABLE'
+}
+
+/** "expires in 23d" / "EXPIRED 3d ago" / opaque-key fallback. */
+export function formatRelativeExpiry(days: number | null | undefined): string {
+  if (typeof days !== 'number') return 'no expiry claim (not a JWT)'
+  if (days < 0) return `EXPIRED ${-days}d ago`
+  if (days === 0) return 'expires in <1d'
+  return `expires in ${days}d`
+}
+
+/**
+ * Remediation per label — REUSES the A4′ doctor strings (remote-recall.ts) so
+ * every surface gives the same instruction: sign in at <host>/auth and re-add
+ * via plur_stores_add. Never suggests running `plur login` — enterprise
+ * servers have no device-flow endpoints (the A4′ strings say so explicitly).
+ */
+function remediationFor(label: TokenStatusLabel, url: string, expiresInDays?: number | null): string | undefined {
+  const host = normalizeEndpointUrl(url)
+  switch (label) {
+    case 'EXPIRED':
+    case 'INVALID':
+      return doctorRemoteRemediation({ host, status: 'auth_expired' }) ?? undefined
+    case 'UNREACHABLE':
+      return doctorRemoteRemediation({ host, status: 'unreachable' }) ?? undefined
+    case 'EXPIRING SOON':
+      return `Token for ${host} expires in ${expiresInDays}d — sign in at ${host}/auth and re-add the store via plur_stores_add before it expires.`
+    case 'VALID':
+      return undefined
+  }
+}
+
+/** Build the full --status report from checkRemoteHealth results. Pure. */
+export function buildStatusReport(
+  health: RemoteHealth[],
+  legacyLogin?: { url: string; mounted: boolean },
+): LoginStatusReport {
+  const hosts: HostTokenStatus[] = health.map(h => {
+    const status = classifyTokenStatus(h)
+    const locallyExpired = typeof h.tokenExpiresInDays === 'number' && h.tokenExpiresInDays < 0
+    const probe: HostTokenStatus['probe'] =
+      h.status === 'ok'
+        ? { probed: true, reachable: true, ...(h.grantedScopes !== undefined ? { grantedScopes: h.grantedScopes } : {}) }
+        : h.status === 'auth_expired' && locallyExpired
+          ? { probed: false, reason: 'skipped — token already expired' }
+          : h.status === 'auth_expired'
+            ? { probed: true, reachable: true, ...(h.reason ? { reason: h.reason } : {}) }
+            : { probed: true, reachable: false, ...(h.reason ? { reason: h.reason } : {}) }
+    const remediation = remediationFor(status, h.url, h.tokenExpiresInDays)
+    return {
+      url: h.url,
+      status,
+      ...(h.tokenSubject ?? h.username ? { subject: h.tokenSubject ?? h.username } : {}),
+      ...(h.tokenOrg ?? h.orgId ? { org: h.tokenOrg ?? h.orgId } : {}),
+      ...(h.tokenExpiresAt ? { tokenExpiresAt: h.tokenExpiresAt } : {}),
+      tokenExpiresInDays: h.tokenExpiresInDays ?? null,
+      expiry: formatRelativeExpiry(h.tokenExpiresInDays),
+      probe,
+      mountedScopes: h.scopes,
+      ...(remediation ? { remediation } : {}),
+    }
+  })
+  return {
+    hosts,
+    ...(legacyLogin ? { legacyLogin } : {}),
+    ok: hosts.length > 0 && hosts.every(h => h.status !== 'EXPIRED' && h.status !== 'INVALID'),
+  }
+}
+
+const STATUS_MARK: Record<TokenStatusLabel, string> = {
+  'VALID': '✓',
+  'EXPIRING SOON': '!',
+  'UNREACHABLE': '?',
+  'EXPIRED': '✗',
+  'INVALID': '✗',
+}
+
+/** Human-readable --status lines. Pure (testable); never includes token values. */
+export function formatStatusLines(report: LoginStatusReport): string[] {
+  const lines: string[] = []
+  if (report.hosts.length === 0) {
+    lines.push('No enterprise tokens configured (no remote stores in ~/.plur/config.yaml).')
+    lines.push('To connect: sign in at your enterprise server\'s /auth page and add the store via plur_stores_add.')
+  } else {
+    lines.push(`Enterprise token status — ${report.hosts.length} credential(s)`)
+    for (const h of report.hosts) {
+      lines.push('')
+      lines.push(`${STATUS_MARK[h.status]} ${h.url} — ${h.status}`)
+      if (h.subject || h.org) {
+        lines.push(`    identity: ${h.subject ?? '(unknown)'}${h.org ? ` (org: ${h.org})` : ''}`)
+      }
+      lines.push(`    token:    ${h.expiry}${h.tokenExpiresAt ? ` (${h.tokenExpiresAt.slice(0, 10)})` : ''}`)
+      if (!h.probe.probed) {
+        lines.push(`    server:   not probed — token already expired`)
+      } else if (h.probe.reachable && (h.status === 'VALID' || h.status === 'EXPIRING SOON')) {
+        lines.push(`    server:   reachable — ${h.probe.grantedScopes ?? 0} scope(s) granted`)
+      } else if (h.probe.reachable) {
+        lines.push(`    server:   reachable — token rejected${h.probe.reason ? ` (${h.probe.reason})` : ''}`)
+      } else {
+        lines.push(`    server:   unreachable${h.probe.reason ? ` (${h.probe.reason})` : ''}`)
+      }
+      lines.push(`    mounted:  ${h.mountedScopes.length > 0 ? h.mountedScopes.join(', ') : '(none)'}`)
+      if (h.remediation) lines.push(`    fix:      ${h.remediation}`)
+    }
+  }
+  if (report.legacyLogin && !report.legacyLogin.mounted) {
+    lines.push('')
+    lines.push(`Note: ~/.plur/config.json holds a legacy \`plur login\` token for ${report.legacyLogin.url} that is`)
+    lines.push('not mounted as a store — nothing reads it. Sign in at the server\'s /auth page and add the')
+    lines.push('store via plur_stores_add instead.')
+  }
+  return lines
+}
+
+/** `plur login --status` — build, print, and exit (0 all valid / 1 otherwise). */
+async function runStatus(flags: GlobalFlags): Promise<never> {
+  const plur = createPlur(flags)
+  let health: RemoteHealth[] = []
+  try {
+    health = await plur.checkRemoteHealth({ timeoutMs: STATUS_PROBE_TIMEOUT_MS })
+  } catch { /* belt-and-braces: checkRemoteHealth captures per-endpoint failures itself */ }
+
+  // Legacy `plur login`-written token (config.json): note-only — it is not on
+  // the recall path, so it is flagged rather than probed.
+  let legacyLogin: { url: string; mounted: boolean } | undefined
+  const ent = readPlurConfig().enterprise
+  if (ent?.url && ent?.token) {
+    let mounted = false
+    try {
+      const key = normalizeEndpointUrl(ent.url)
+      mounted = plur.remoteEndpointTokenGroups()
+        .some(g => normalizeEndpointUrl(g.url) === key && (g.token ?? '') === ent.token)
+    } catch { /* unparseable legacy URL → report as unmounted */ }
+    legacyLogin = { url: ent.url, mounted }
+  }
+
+  const report = buildStatusReport(health, legacyLogin)
+  if (shouldOutputJson(flags)) {
+    outputJson(report)
+  } else {
+    // Primary output of --status — never suppressed by --quiet (#784 policy).
+    for (const line of formatStatusLines(report)) outputText(line)
+  }
+  process.exit(report.ok ? 0 : 1)
+}
+
 // ── Args parser ───────────────────────────────────────────────────────────────
 
 interface ParsedArgs {
@@ -389,21 +605,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
 
-  // --status: display current auth state
+  // --status: token validity per configured (url, token) credential (#587)
   if (parsed.status) {
-    const cfg = readPlurConfig()
-    const ent = cfg.enterprise
-    if (!ent?.url || !ent?.token) {
-      outputText('Not logged in. Run `plur login <host>` to authenticate.')
-      process.exit(1)
-    }
-    outputText(`Logged in to ${ent.url}`)
-    if (ent.username) outputText(`  as ${ent.username}`)
-    if (ent.authed_at) outputText(`  authenticated at ${ent.authed_at}`)
-    if (ent.scopes && ent.scopes.length > 0) {
-      outputText(`  scopes: ${ent.scopes.join(', ')}`)
-    }
-    return
+    await runStatus(flags)
   }
 
   if (!parsed.host) {
@@ -416,6 +620,27 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     origin = normaliseHost(parsed.host)
   } catch (err) {
     outputError(`Error: ${(err as Error).message}`)
+    process.exit(1)
+  }
+
+  // Device-flow gate (#300/#532): enterprise servers do not expose the
+  // device-flow endpoints yet, and the token this flow writes has no consumers
+  // on the recall path — attempting it would only produce a confusing HTTP 404.
+  // Point at the supported path instead. The flow below stays implemented
+  // (and unit-tested) for when server-side support (B-T9) lands; flip this
+  // constant to re-enable it.
+  const DEVICE_FLOW_AVAILABLE = false as boolean
+  if (!DEVICE_FLOW_AVAILABLE) {
+    // Error-class output (#784 policy): the command cannot do what was asked
+    // and exits 1, so the explanation + next steps go to stderr, unsuppressed.
+    outputError('plur login (OAuth device flow) is not available yet — enterprise servers')
+    outputError('do not expose the device-flow endpoints.')
+    outputError('')
+    outputError(`To connect to ${origin}:`)
+    outputError(`  1. Sign in at ${origin}/auth in your browser`)
+    outputError('  2. Add the store via plur_stores_add (MCP) or `plur stores add`')
+    outputError('')
+    outputError('Check existing tokens with: plur login --status')
     process.exit(1)
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,6 +48,7 @@ Commands:
   scopes register <scope> Register one; scopes dismiss <scope>; scopes --reoffer
   init                    Install Claude Code hooks + register plur MCP server
   init-remote             Opt this project into recall from a PLUR Enterprise server
+  login --status          Enterprise token validity per host (probe + expiry) (#587)
   doctor                  Diagnose Claude Code / Claude Desktop integration
   rerank-eval             Per-store reranker self-eval gate (advisory, #451)
                           [--reranker <name>] [--sample N] [--seed N] [--force]
@@ -109,11 +110,12 @@ const COMMANDS: Record<string, string> = {
   migrate: './commands/migrate.js',
   init: './commands/init.js',
   'init-remote': './commands/init-remote.js',
-  // `login` (enterprise OAuth device flow, #532) is intentionally NOT registered
-  // yet — the implementation in ./commands/login.js is complete but happy-path
-  // only (no paste-token fallback, hard dependency on server device-flow
-  // endpoints, no refresh tokens). Deactivated pending that hardening; re-add
-  // this line to activate. See #300.
+  // `login` is registered for `--status` (#587: token validity per host). The
+  // OAuth device flow itself (#532) stays GATED INSIDE the command — it is
+  // happy-path only (no paste-token fallback, no refresh tokens) and targets
+  // device-flow endpoints enterprise servers don't expose yet; attempting it
+  // prints the sign-in-URL + plur_stores_add path instead. See #300.
+  login: './commands/login.js',
   doctor: './commands/doctor.js',
   'rerank-eval': './commands/rerank-eval.js',
   tensions: './commands/tensions.js',

--- a/packages/cli/test/login.test.ts
+++ b/packages/cli/test/login.test.ts
@@ -1,8 +1,14 @@
 /**
- * Tests for `plur login` — config write, reload signal, and arg parsing.
+ * Tests for `plur login` — token status (#587), config write, reload signal,
+ * and arg parsing.
  *
- * Pure unit tests: no spawned CLI processes, no real HTTP. The OAuth device
- * flow itself is tested via a local stub server. Browser-open is not tested
+ * The `--status` path is covered at two levels: pure unit tests over the
+ * exported classification/report helpers (JWT expiry classification, grouping
+ * fan-in via buildStatusReport, remediation strings), and process-level tests
+ * spawning the real CLI against the core StubServer (real HTTP) for exit
+ * codes, --json shape, and the unreachable-host path. The OAuth device flow
+ * helpers are tested via a local stub server; the flow itself is GATED in the
+ * command (#300/#532) and the gate is pinned here. Browser-open is not tested
  * (it shells out to `open`/`xdg-open`/`start`; those are OS calls we don't
  * control). Signal delivery is tested by asserting the signalReload() return
  * value rather than actually sending a kill, which would require a real process.
@@ -14,8 +20,20 @@ import { tmpdir } from 'os'
 import { createServer, type Server } from 'http'
 import type { AddressInfo } from 'net'
 import { spawn } from 'child_process'
+import { StubServer } from '../../core/test/helpers/stub-server.js'
+// Warm the module graph at collection time: login.js now pulls in the full
+// @plur-ai/core barrel (checkRemoteHealth reuse, #587), and paying that import
+// inside the FIRST per-test dynamic import blows the 5s test timeout.
+import '../src/commands/login.js'
 
 const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+const b64url = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+const makeJwt = (payload: object) =>
+  `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url(payload)}.sig`
+/** JWT expiring `days` whole days from now (+1h slack so day math is stable). */
+const jwtExpiringIn = (days: number, claims: object = {}) =>
+  makeJwt({ sub: 'gregor', orgId: 'igea', exp: Math.floor(Date.now() / 1000) + days * 86_400 + 3_600, ...claims })
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -251,15 +269,186 @@ describe('pollForToken', () => {
   })
 })
 
-// ── CLI process-level smoke tests ─────────────────────────────────────────────
-// SKIPPED: `plur login` is deactivated — the command is intentionally not
-// registered in the CLI dispatcher (packages/cli/src/index.ts) pending the
-// hardening in #300 (paste-token fallback, refresh tokens, live-server
-// verification). These process-level tests invoke `plur login` via the
-// dispatcher, so they can only pass once the command is re-registered. The
-// helper unit tests above still run — they exercise the (dormant) login.ts
-// functions directly. Re-enable this block when login is reactivated.
-describe.skip('plur login CLI', () => {
+// ── Token-status helpers (#587) — pure unit tests ─────────────────────────────
+
+describe('classifyTokenStatus (#587)', () => {
+  it('probe ok + far-future expiry → VALID', async () => {
+    const { classifyTokenStatus } = await import('../src/commands/login.js')
+    expect(classifyTokenStatus({ status: 'ok', tokenExpiresInDays: 23 })).toBe('VALID')
+  })
+
+  it('probe ok + opaque key (no expiry claim) → VALID', async () => {
+    const { classifyTokenStatus } = await import('../src/commands/login.js')
+    expect(classifyTokenStatus({ status: 'ok', tokenExpiresInDays: null })).toBe('VALID')
+  })
+
+  it('probe ok + <7d to expiry → EXPIRING SOON (boundary: 6 yes, 7 no)', async () => {
+    const { classifyTokenStatus } = await import('../src/commands/login.js')
+    expect(classifyTokenStatus({ status: 'ok', tokenExpiresInDays: 6 })).toBe('EXPIRING SOON')
+    expect(classifyTokenStatus({ status: 'ok', tokenExpiresInDays: 0 })).toBe('EXPIRING SOON')
+    expect(classifyTokenStatus({ status: 'ok', tokenExpiresInDays: 7 })).toBe('VALID')
+  })
+
+  it('auth failure + locally-expired JWT → EXPIRED', async () => {
+    const { classifyTokenStatus } = await import('../src/commands/login.js')
+    expect(classifyTokenStatus({ status: 'auth_expired', tokenExpiresInDays: -3 })).toBe('EXPIRED')
+  })
+
+  it('auth failure + non-expired or opaque token → INVALID (revoked/wrong)', async () => {
+    const { classifyTokenStatus } = await import('../src/commands/login.js')
+    expect(classifyTokenStatus({ status: 'auth_expired', tokenExpiresInDays: 20 })).toBe('INVALID')
+    expect(classifyTokenStatus({ status: 'auth_expired', tokenExpiresInDays: null })).toBe('INVALID')
+  })
+
+  it('network failure → UNREACHABLE (not an auth verdict)', async () => {
+    const { classifyTokenStatus } = await import('../src/commands/login.js')
+    expect(classifyTokenStatus({ status: 'unreachable', tokenExpiresInDays: 23 })).toBe('UNREACHABLE')
+  })
+})
+
+describe('formatRelativeExpiry (#587)', () => {
+  it('formats future, past, same-day, and opaque expiries', async () => {
+    const { formatRelativeExpiry } = await import('../src/commands/login.js')
+    expect(formatRelativeExpiry(23)).toBe('expires in 23d')
+    expect(formatRelativeExpiry(-3)).toBe('EXPIRED 3d ago')
+    expect(formatRelativeExpiry(0)).toBe('expires in <1d')
+    expect(formatRelativeExpiry(null)).toMatch(/no expiry claim/)
+    expect(formatRelativeExpiry(undefined)).toMatch(/no expiry claim/)
+  })
+})
+
+describe('buildStatusReport (#587)', () => {
+  it('maps a healthy probe to VALID with granted-scope count and mounted scopes', async () => {
+    const { buildStatusReport } = await import('../src/commands/login.js')
+    const report = buildStatusReport([{
+      url: 'https://plur.example.com', scopes: ['group:igea/gis'], status: 'ok', ok: true,
+      tokenExpiresAt: '2026-08-23T00:00:00.000Z', tokenExpiresInDays: 23,
+      tokenSubject: 'gregor', tokenOrg: 'igea', username: 'gregor', orgId: 'igea', grantedScopes: 5,
+    }])
+    expect(report.ok).toBe(true)
+    const h = report.hosts[0]
+    expect(h.status).toBe('VALID')
+    expect(h.subject).toBe('gregor')
+    expect(h.org).toBe('igea')
+    expect(h.expiry).toBe('expires in 23d')
+    expect(h.probe).toEqual({ probed: true, reachable: true, grantedScopes: 5 })
+    expect(h.mountedScopes).toEqual(['group:igea/gis'])
+    expect(h.remediation).toBeUndefined()
+  })
+
+  it('marks a locally-expired token EXPIRED with probe skipped, and fails the report', async () => {
+    const { buildStatusReport } = await import('../src/commands/login.js')
+    const report = buildStatusReport([{
+      url: 'https://plur.example.com', scopes: ['group:igea/gis'], status: 'auth_expired', ok: false,
+      reason: 'token expired 2026-07-28T00:00:00.000Z',
+      tokenExpiresAt: '2026-07-28T00:00:00.000Z', tokenExpiresInDays: -3, tokenSubject: 'gregor',
+    }])
+    expect(report.ok).toBe(false)
+    const h = report.hosts[0]
+    expect(h.status).toBe('EXPIRED')
+    expect(h.expiry).toBe('EXPIRED 3d ago')
+    expect(h.probe.probed).toBe(false)
+    expect(h.remediation).toBeTruthy()
+  })
+
+  it('EXPIRED/INVALID remediation gives the sign-in-URL + plur_stores_add flow and never suggests running plur login', async () => {
+    const { buildStatusReport } = await import('../src/commands/login.js')
+    const report = buildStatusReport([
+      { url: 'https://plur.example.com', scopes: ['group:a'], status: 'auth_expired', ok: false, tokenExpiresInDays: -3 },
+      { url: 'https://other.example.com', scopes: ['group:b'], status: 'auth_expired', ok: false, tokenExpiresInDays: null, reason: 'Remote /me failed: 401' },
+    ])
+    for (const h of report.hosts) {
+      const fix = h.remediation!
+      // A4′ flow: sign in at <host>/auth, re-add via plur_stores_add.
+      expect(fix).toContain('/auth')
+      expect(fix).toContain('plur_stores_add')
+      // `plur login` must never be SUGGESTED — enterprise servers have no
+      // device-flow endpoints. The A4′ string may only mention it to say it
+      // does NOT work.
+      expect(fix).not.toMatch(/run\s+`?plur login/i)
+      for (const m of fix.matchAll(/`?plur login`?/g)) {
+        expect(fix.slice(m.index)).toMatch(/^`?plur login`? does not work/)
+      }
+    }
+  })
+
+  it('UNREACHABLE does not fail the report (network is not an auth verdict)', async () => {
+    const { buildStatusReport } = await import('../src/commands/login.js')
+    const report = buildStatusReport([{
+      url: 'https://plur.example.com', scopes: ['group:a'], status: 'unreachable', ok: false,
+      reason: 'fetch failed', tokenExpiresInDays: 23,
+    }])
+    expect(report.hosts[0].status).toBe('UNREACHABLE')
+    expect(report.hosts[0].probe).toEqual({ probed: true, reachable: false, reason: 'fetch failed' })
+    expect(report.ok).toBe(true)
+  })
+
+  it('an empty credential set is not ok, and an unmounted legacy login token is flagged', async () => {
+    const { buildStatusReport } = await import('../src/commands/login.js')
+    const report = buildStatusReport([], { url: 'https://plur.example.com', mounted: false })
+    expect(report.ok).toBe(false)
+    expect(report.hosts).toEqual([])
+    expect(report.legacyLogin).toEqual({ url: 'https://plur.example.com', mounted: false })
+  })
+})
+
+describe('formatStatusLines (#587)', () => {
+  it('renders one block per credential with status, expiry, probe, and mounted scopes', async () => {
+    const { buildStatusReport, formatStatusLines } = await import('../src/commands/login.js')
+    const report = buildStatusReport([
+      { url: 'https://a.example.com', scopes: ['group:a'], status: 'ok', ok: true, tokenExpiresInDays: 23, tokenExpiresAt: '2026-08-23T00:00:00.000Z', tokenSubject: 'gregor', tokenOrg: 'igea', grantedScopes: 5 },
+      { url: 'https://b.example.com', scopes: ['group:b'], status: 'auth_expired', ok: false, tokenExpiresInDays: -3 },
+    ])
+    const text = formatStatusLines(report).join('\n')
+    expect(text).toContain('✓ https://a.example.com — VALID')
+    expect(text).toContain('identity: gregor (org: igea)')
+    expect(text).toContain('5 scope(s) granted')
+    expect(text).toContain('mounted:  group:a')
+    expect(text).toContain('✗ https://b.example.com — EXPIRED')
+    expect(text).toContain('not probed — token already expired')
+  })
+
+  it('with no credentials, points at the /auth + plur_stores_add flow (never `plur login`)', async () => {
+    const { buildStatusReport, formatStatusLines } = await import('../src/commands/login.js')
+    const text = formatStatusLines(buildStatusReport([])).join('\n')
+    expect(text).toContain('No enterprise tokens configured')
+    expect(text).toContain('plur_stores_add')
+    expect(text).not.toMatch(/run\s+`?plur login/i)
+  })
+
+  it('flags an unmounted legacy config.json token as unused', async () => {
+    const { buildStatusReport, formatStatusLines } = await import('../src/commands/login.js')
+    const text = formatStatusLines(buildStatusReport([], { url: 'https://plur.example.com', mounted: false })).join('\n')
+    expect(text).toContain('legacy `plur login` token')
+    expect(text).toContain('nothing reads it')
+  })
+})
+
+// ── CLI process-level tests ───────────────────────────────────────────────────
+// `login` is registered in the dispatcher for `--status` (#587); the device
+// flow itself is gated inside the command (#300/#532) — pinned below.
+
+/** Write a plur root (config.yaml) and return its --path value. */
+function writePlurRoot(stores: Array<Record<string, unknown>>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-login-root-'))
+  const storeYaml = stores.map(s =>
+    `  - ${Object.entries(s).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join('\n    ')}`,
+  ).join('\n')
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    `embeddings:\n  enabled: false\nindex: false\nstores:\n${storeYaml}\n`,
+  )
+  return dir
+}
+
+/** Parse the JSON object line from combined CLI output (ignores log noise). */
+function parseJsonOut(stdout: string): any {
+  const line = stdout.split('\n').map(l => l.trim()).filter(l => l.startsWith('{')).pop()
+  expect(line, `no JSON line in output:\n${stdout}`).toBeTruthy()
+  return JSON.parse(line!)
+}
+
+describe('plur login CLI (gated device flow + arg errors)', () => {
   let home: string
   let cwd: string
 
@@ -291,33 +480,159 @@ describe.skip('plur login CLI', () => {
     expect(r.stdout).toMatch(/--timeout requires a value/)
   })
 
-  it('exits 1 when --timeout value is not a positive integer', async () => {
-    const r = await runCli('login https://plur.example.com --timeout abc', cwd, home)
-    expect(r.status).toBe(1)
-    expect(r.stdout).toMatch(/--timeout must be a positive integer/)
-  })
-
-  it('--help prints usage and exits 0', async () => {
+  it('--help prints usage (global help intercepts) and exits 0, listing login --status', async () => {
     const r = await runCli('login --help', cwd, home)
     expect(r.status).toBe(0)
-    expect(r.stdout).toMatch(/OAuth|device flow|USAGE/i)
+    // The dispatcher's global --help intercept answers before command dispatch;
+    // it must list the new status surface.
+    expect(r.stdout).toMatch(/Usage/i)
+    expect(r.stdout).toMatch(/login --status/)
   })
 
-  it('--status exits 1 when not logged in', async () => {
-    const r = await runCli('login --status', cwd, home)
+  it('device flow is gated: `plur login <host>` exits 1 with the /auth + plur_stores_add path', async () => {
+    const r = await runCli('login https://plur.example.com', cwd, home)
     expect(r.status).toBe(1)
-    expect(r.stdout).toMatch(/Not logged in/)
+    expect(r.stdout).toMatch(/not available yet/)
+    expect(r.stdout).toContain('https://plur.example.com/auth')
+    expect(r.stdout).toContain('plur_stores_add')
+    // The flow must not have started — no device code prompt.
+    expect(r.stdout).not.toMatch(/one-time code/)
+  })
+})
+
+describe('plur login --status (#587) — exit codes and --json shape', () => {
+  const TOKEN = 'status-test-token'
+  let server: StubServer
+  let baseUrl: string
+  let home: string
+  let cwd: string
+  const roots: string[] = []
+
+  beforeEach(async () => {
+    server = new StubServer(TOKEN)
+    const info = await server.start()
+    baseUrl = info.url
+    server.setMe({ username: 'gregor', org_id: 'igea', role: 'developer', scopes: ['group:igea/gis', 'group:igea/eng', 'user:igea:gregor'] })
+    home = mkdtempSync(join(tmpdir(), 'plur-status-home-'))
+    cwd  = mkdtempSync(join(tmpdir(), 'plur-status-proj-'))
   })
 
-  it.skip('--status prints auth info when config.json is present [requires real HOME]', async () => {
-    // This test would require writing to the real ~/.plur/config.json.
-    // Skipped — covered by the unit test above (writePlurConfig + readPlurConfig).
+  afterEach(async () => {
+    await server.stop()
+    rmSync(home, { recursive: true, force: true })
+    rmSync(cwd, { recursive: true, force: true })
+    while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true })
   })
 
-  it('exits non-zero when the device code endpoint is unreachable', async () => {
-    // Port 1 is reserved and will refuse connections on any OS
-    const r = await runCli('login http://127.0.0.1:1 --no-open --timeout 5', cwd, home)
-    expect(r.status).not.toBe(0)
-    expect(r.stdout).toMatch(/Error|failed|ECONNREFUSED/i)
+  const root = (stores: Array<Record<string, unknown>>): string => {
+    const dir = writePlurRoot(stores)
+    roots.push(dir)
+    return dir
+  }
+
+  it('exits 1 with an empty report when nothing is configured', async () => {
+    const r = await runCli('login --status --json', cwd, home)
+    expect(r.status).toBe(1)
+    const report = parseJsonOut(r.stdout)
+    expect(report.hosts).toEqual([])
+    expect(report.ok).toBe(false)
+  })
+
+  it('VALID: reachable host + accepted opaque token → exit 0, full JSON row, no token leaked', async () => {
+    const dir = root([{ url: baseUrl, token: TOKEN, scope: 'group:igea/gis' }])
+    const r = await runCli(`login --status --json --path ${dir}`, cwd, home)
+    expect(r.status).toBe(0)
+    const report = parseJsonOut(r.stdout)
+    expect(report.ok).toBe(true)
+    expect(report.hosts).toHaveLength(1)
+    const h = report.hosts[0]
+    expect(h.url).toBe(baseUrl)
+    expect(h.status).toBe('VALID')
+    expect(h.subject).toBe('gregor')
+    expect(h.org).toBe('igea')
+    expect(h.probe).toEqual({ probed: true, reachable: true, grantedScopes: 3 })
+    expect(h.mountedScopes).toEqual(['group:igea/gis'])
+    // The token value itself must never appear anywhere in the output.
+    expect(r.stdout).not.toContain(TOKEN)
+  })
+
+  it('EXPIRED: locally-expired JWT → exit 1, remediation is /auth + plur_stores_add', async () => {
+    const expired = jwtExpiringIn(-3)
+    const dir = root([{ url: baseUrl, token: expired, scope: 'group:igea/gis' }])
+    const r = await runCli(`login --status --json --path ${dir}`, cwd, home)
+    expect(r.status).toBe(1)
+    const h = parseJsonOut(r.stdout).hosts[0]
+    expect(h.status).toBe('EXPIRED')
+    expect(h.subject).toBe('gregor')
+    expect(h.expiry).toMatch(/^EXPIRED \dd ago$/)
+    expect(h.probe.probed).toBe(false)
+    expect(h.remediation).toContain('/auth')
+    expect(h.remediation).toContain('plur_stores_add')
+    expect(r.stdout).not.toContain(expired)
+  })
+
+  it('INVALID: server rejects a non-expired token (401) → exit 1', async () => {
+    const dir = root([{ url: baseUrl, token: 'wrong-token', scope: 'group:igea/gis' }])
+    const r = await runCli(`login --status --json --path ${dir}`, cwd, home)
+    expect(r.status).toBe(1)
+    const h = parseJsonOut(r.stdout).hosts[0]
+    expect(h.status).toBe('INVALID')
+    expect(h.probe.probed).toBe(true)
+    expect(h.probe.reachable).toBe(true)
+  })
+
+  it('EXPIRING SOON: valid JWT with <7d left → exit 0 but flagged', async () => {
+    const soonJwt = jwtExpiringIn(3)
+    const soonServer = new StubServer(soonJwt) // server accepts exactly this JWT
+    const info = await soonServer.start()
+    try {
+      const dir = root([{ url: info.url, token: soonJwt, scope: 'group:igea/gis' }])
+      const r = await runCli(`login --status --json --path ${dir}`, cwd, home)
+      expect(r.status).toBe(0)
+      const h = parseJsonOut(r.stdout).hosts[0]
+      expect(h.status).toBe('EXPIRING SOON')
+      expect(h.expiry).toMatch(/^expires in \dd$/)
+      expect(h.remediation).toContain('plur_stores_add')
+    } finally {
+      await soonServer.stop()
+    }
+  })
+
+  it('UNREACHABLE: host down → exit 0 (network is not an auth verdict)', async () => {
+    const down = new StubServer(TOKEN)
+    const info = await down.start()
+    await down.stop() // port now closed
+    const dir = root([{ url: info.url, token: TOKEN, scope: 'group:igea/gis' }])
+    const r = await runCli(`login --status --json --path ${dir}`, cwd, home)
+    expect(r.status).toBe(0)
+    const h = parseJsonOut(r.stdout).hosts[0]
+    expect(h.status).toBe('UNREACHABLE')
+    expect(h.probe.reachable).toBe(false)
+  })
+
+  it('groups by distinct (url, token): one dead second token fails the whole status', async () => {
+    const dir = root([
+      { url: baseUrl, token: TOKEN, scope: 'group:igea/gis' },
+      { url: baseUrl, token: 'dead-second-token', scope: 'group:igea/eng' },
+    ])
+    const r = await runCli(`login --status --json --path ${dir}`, cwd, home)
+    expect(r.status).toBe(1)
+    const report = parseJsonOut(r.stdout)
+    expect(report.hosts).toHaveLength(2)
+    const statuses = report.hosts.map((h: any) => h.status).sort()
+    expect(statuses).toEqual(['INVALID', 'VALID'])
+  })
+
+  it('flags an unmounted legacy config.json token instead of probing it', async () => {
+    mkdirSync(join(home, '.plur'), { recursive: true })
+    writeFileSync(
+      join(home, '.plur', 'config.json'),
+      JSON.stringify({ enterprise: { url: 'https://legacy.example.com', token: 'legacy-token' } }),
+    )
+    const r = await runCli('login --status --json', cwd, home)
+    expect(r.status).toBe(1) // no mounted credentials → not ok
+    const report = parseJsonOut(r.stdout)
+    expect(report.legacyLogin).toEqual({ url: 'https://legacy.example.com', mounted: false })
+    expect(r.stdout).not.toContain('legacy-token')
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,7 @@ import type { TensionRecord, TensionStatus } from './schemas/tension.js'
 import type { TensionPair } from './tensions.js'
 import { engramDate } from './tensions.js'
 import { resolveValidity, buildTemporal } from './expiry.js'
-import { decodeJwtExpiry } from './jwt.js'
+import { decodeJwtExpiry, decodeJwtPayload } from './jwt.js'
 import { RemoteStore, normalizeEndpointUrl } from './store/remote-store.js'
 import {
   remoteRecall, isRemoteRecallDisabled, resolveRemoteRecallTimeoutMs, scopeOrg,
@@ -279,6 +279,11 @@ export {
   POSITIVE_STRENGTH_DELTA, NEGATIVE_STRENGTH_DELTA,
   type FeedbackSignal,
 } from './feedback.js'
+// Client-side token inspection (#295/#587) — expiry + display-only payload
+// claims, no signature verification — and the endpoint-identity normalizer,
+// so CLI surfaces (login --status) compare hosts the same way the core does.
+export { decodeJwtExpiry, decodeJwtPayload, type JwtExpiry } from './jwt.js'
+export { normalizeEndpointUrl } from './store/remote-store.js'
 
 export * from './types.js'
 
@@ -384,7 +389,7 @@ export interface RemoteScopeDiscovery {
  */
 export interface RemoteHealth {
   url: string
-  /** Scopes registered locally for this URL (for the report). */
+  /** Scopes registered locally for this (url, token) group (for the report). */
   scopes: string[]
   /** 'ok' = /me succeeded; 'auth_expired' = 401/403 or JWT exp passed; 'unreachable' = network/timeout/5xx. */
   status: 'ok' | 'auth_expired' | 'unreachable'
@@ -396,6 +401,16 @@ export interface RemoteHealth {
   tokenExpiresAt?: string
   /** Whole days until token expiry (negative if past), or null if unknown. */
   tokenExpiresInDays?: number | null
+  /** JWT `sub` claim — UNVERIFIED, display only (#587). Absent for opaque keys. */
+  tokenSubject?: string
+  /** JWT org claim (`orgId`/`org_id`/`org`) — UNVERIFIED, display only (#587). */
+  tokenOrg?: string
+  /** Server-confirmed identity from the live `/me` probe (status 'ok' only). */
+  username?: string
+  /** Server-confirmed org from the live `/me` probe (status 'ok' only). */
+  orgId?: string
+  /** Number of scopes the server reports granted to this token (status 'ok' only). */
+  grantedScopes?: number
 }
 
 /** Outcome of registering discovered scopes for one URL (#292). */
@@ -6132,6 +6147,28 @@ Generate an improved version of the procedure that prevents this failure. Return
   }
 
   /**
+   * Distinct (url, token) groups among the configured remote stores (#587) —
+   * the AUTH-identity counterpart of {@link _distinctRemoteEndpoints}. Same
+   * `::` composite key as `_remoteRecallHosts` (#776): two entries on one URL
+   * with DIFFERENT tokens are two distinct credentials with independent
+   * validity, so token-status surfaces must report them separately rather
+   * than letting first-token-wins mask a dead second token. URL identity is
+   * normalized ({@link normalizeEndpointUrl}); the first-configured spelling
+   * is reported. `scopes` lists the group's registered scopes in config order.
+   */
+  remoteEndpointTokenGroups(): Array<{ url: string; token?: string; scopes: string[] }> {
+    const groups = new Map<string, { url: string; token?: string; scopes: string[] }>()
+    for (const s of this.config.stores ?? []) {
+      if (!s.url) continue
+      const key = `${normalizeEndpointUrl(s.url)}::${s.token ?? ''}`
+      let g = groups.get(key)
+      if (!g) { g = { url: s.url, token: s.token, scopes: [] }; groups.set(key, g) }
+      if (!g.scopes.includes(s.scope)) g.scopes.push(s.scope)
+    }
+    return [...groups.values()]
+  }
+
+  /**
    * Discover which scopes each configured remote token is authorized for, via
    * `GET /api/v1/me` (#292). For each distinct remote URL, reports the
    * server-authorized scope set and which of those are not yet registered
@@ -6214,22 +6251,35 @@ Generate an improved version of the procedure that prevents this failure. Return
   }
 
   /**
-   * Probe each configured remote endpoint's auth/reachability (#295) by calling
-   * `GET /api/v1/me` (raced against a timeout), combined with a local JWT-expiry
-   * read. Distinguishes 'auth_expired' (token rejected or JWT exp passed →
-   * reauth) from 'unreachable' (network/timeout/5xx). Read-only; one bad
-   * endpoint never affects the others. Powers `plur_doctor`'s remote check so
-   * the doctor stops reporting "healthy" when the remote auth is dead.
+   * Probe each configured remote credential's auth/reachability (#295) by
+   * calling `GET /api/v1/me` (raced against a timeout), combined with a local
+   * JWT-expiry read. Distinguishes 'auth_expired' (token rejected or JWT exp
+   * passed → reauth) from 'unreachable' (network/timeout/5xx). Read-only; one
+   * bad endpoint never affects the others. Powers `plur_doctor`'s remote check
+   * and `plur login --status` (#587), so neither reports "healthy" when the
+   * remote auth is dead.
+   *
+   * Probes per distinct (url, token) group ({@link remoteEndpointTokenGroups}),
+   * not per URL (#587): each token's validity is independent, and the old
+   * first-token-wins collapse reported a URL as ok while its second configured
+   * token was expired. Also surfaces display-only JWT claims (`tokenSubject`,
+   * `tokenOrg` — unverified) and, on a successful probe, the server-confirmed
+   * `username`/`orgId`/`grantedScopes` from `/me`.
    */
   async checkRemoteHealth(opts?: { timeoutMs?: number }): Promise<RemoteHealth[]> {
     const timeoutMs = opts?.timeoutMs ?? 5000
-    const endpoints = this._distinctRemoteEndpoints()
-    return Promise.all(endpoints.map(async ({ url, token }) => {
-      const scopes = this._storesForEndpoint(url).map(s => s.scope)
+    const groups = this.remoteEndpointTokenGroups()
+    return Promise.all(groups.map(async ({ url, token, scopes }) => {
       const exp = decodeJwtExpiry(token)
+      const payload = decodeJwtPayload(token)
+      const subject = typeof payload?.sub === 'string' ? payload.sub : undefined
+      const orgClaim = [payload?.orgId, payload?.org_id, payload?.org]
+        .find((v): v is string => typeof v === 'string')
       const expiryFields = {
         tokenExpiresAt: exp.expiresAt ? exp.expiresAt.toISOString() : undefined,
         tokenExpiresInDays: exp.expiresInDays,
+        ...(subject !== undefined ? { tokenSubject: subject } : {}),
+        ...(orgClaim !== undefined ? { tokenOrg: orgClaim } : {}),
       }
       // A JWT we can already see is expired → don't bother probing; it's auth_expired.
       if (exp.expired) {
@@ -6239,13 +6289,17 @@ Generate an improved version of the procedure that prevents this failure. Return
       try {
         const driver = this._getRemoteDriver({ url, token, scope: scopes[0] ?? '' })
         let timeoutHandle: ReturnType<typeof setTimeout> | undefined
-        await Promise.race([
+        const me = await Promise.race([
           driver.me().finally(() => { if (timeoutHandle) clearTimeout(timeoutHandle) }),
           new Promise<never>((_, reject) => {
             timeoutHandle = setTimeout(() => reject(new Error(`/me timeout (${timeoutMs}ms)`)), timeoutMs)
           }),
         ])
-        return { url, scopes, status: 'ok' as const, ok: true, ...expiryFields }
+        return { url, scopes, status: 'ok' as const, ok: true,
+          ...(me.username ? { username: me.username } : {}),
+          ...(me.org_id ? { orgId: me.org_id } : {}),
+          grantedScopes: me.scopes.length,
+          ...expiryFields }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         const isAuth = /\b40[13]\b/.test(msg)

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -32,6 +32,29 @@ function base64UrlDecode(segment: string): string | null {
 }
 
 /**
+ * Decode a JWT's payload WITHOUT verifying the signature — display-only
+ * identity hints (`sub`, `orgId`, …) for status readouts (#587). Returns null
+ * for anything that is not a three-part JWT with a JSON object payload (e.g.
+ * opaque `plur_sk_…` API keys). Never trust these claims for authorization;
+ * the server verifies — this is purely "whose token does this LOOK like".
+ */
+export function decodeJwtPayload(token: string | undefined | null): Record<string, unknown> | null {
+  if (!token || typeof token !== 'string') return null
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  const json = base64UrlDecode(parts[1])
+  if (!json) return null
+  try {
+    const payload: unknown = JSON.parse(json)
+    return payload !== null && typeof payload === 'object' && !Array.isArray(payload)
+      ? payload as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Read the `exp` claim from a JWT without verifying it. Returns all-null for
  * anything that is not a three-part JWT carrying a numeric `exp` (e.g. opaque
  * API keys), so callers can cleanly skip expiry reasoning for those.
@@ -39,18 +62,8 @@ function base64UrlDecode(segment: string): string | null {
  * @param now epoch millis to compare against (injectable for tests; defaults to Date.now()).
  */
 export function decodeJwtExpiry(token: string | undefined | null, now: number = Date.now()): JwtExpiry {
-  if (!token || typeof token !== 'string') return UNKNOWN
-  const parts = token.split('.')
-  if (parts.length !== 3) return UNKNOWN
-  const json = base64UrlDecode(parts[1])
-  if (!json) return UNKNOWN
-  let payload: { exp?: unknown }
-  try {
-    payload = JSON.parse(json)
-  } catch {
-    return UNKNOWN
-  }
-  if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) return UNKNOWN
+  const payload = decodeJwtPayload(token)
+  if (!payload || typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) return UNKNOWN
   const expiresAt = new Date(payload.exp * 1000)
   const msLeft = expiresAt.getTime() - now
   return {

--- a/packages/core/test/jwt.test.ts
+++ b/packages/core/test/jwt.test.ts
@@ -3,7 +3,7 @@
  * No signature verification; we only read the `exp` claim to warn the user.
  */
 import { describe, it, expect } from 'vitest'
-import { decodeJwtExpiry } from '../src/jwt.js'
+import { decodeJwtExpiry, decodeJwtPayload } from '../src/jwt.js'
 
 const b64url = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
 const makeJwt = (payload: object) =>
@@ -45,5 +45,30 @@ describe('decodeJwtExpiry', () => {
     expect(decodeJwtExpiry('', NOW).expiresAt).toBeNull()
     expect(decodeJwtExpiry('not.a.jwt.with.too.many.parts', NOW).expiresAt).toBeNull()
     expect(decodeJwtExpiry('two.parts', NOW).expiresAt).toBeNull()
+  })
+})
+
+describe('decodeJwtPayload (#587 — display-only claims)', () => {
+  it('returns the payload claims of a decodable JWT', () => {
+    const p = decodeJwtPayload(makeJwt({ sub: 'gregor', orgId: 'igea', role: 'developer', exp: 123 }))
+    expect(p).not.toBeNull()
+    expect(p!.sub).toBe('gregor')
+    expect(p!.orgId).toBe('igea')
+    expect(p!.exp).toBe(123)
+  })
+
+  it('returns null for opaque keys, garbage, and empty input', () => {
+    expect(decodeJwtPayload('plur_sk_abc123def456')).toBeNull()
+    expect(decodeJwtPayload('two.parts')).toBeNull()
+    expect(decodeJwtPayload('not.a.jwt.with.too.many.parts')).toBeNull()
+    expect(decodeJwtPayload('')).toBeNull()
+    expect(decodeJwtPayload(undefined)).toBeNull()
+  })
+
+  it('returns null when the payload segment is not a JSON object', () => {
+    const b64 = (s: string) => Buffer.from(s).toString('base64url')
+    expect(decodeJwtPayload(`${b64('{"alg":"HS256"}')}.${b64('not json')}.sig`)).toBeNull()
+    expect(decodeJwtPayload(`${b64('{"alg":"HS256"}')}.${b64('[1,2,3]')}.sig`)).toBeNull()
+    expect(decodeJwtPayload(`${b64('{"alg":"HS256"}')}.${b64('"str"')}.sig`)).toBeNull()
   })
 })

--- a/packages/core/test/remote-health.test.ts
+++ b/packages/core/test/remote-health.test.ts
@@ -84,6 +84,75 @@ describe('Plur.checkRemoteHealth()', () => {
     const plur = writeConfig([])
     expect(await plur.checkRemoteHealth()).toEqual([])
   })
+
+  it('probes each distinct (url, token) group separately (#587)', async () => {
+    // Two credentials on ONE host: the old per-URL first-token-wins collapse
+    // reported this config healthy while the second token was dead.
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:test', shared: true, readonly: false },
+      { url: baseUrl, token: 'dead-second-token', scope: 'group:other', shared: true, readonly: false },
+    ])
+    const rows = await plur.checkRemoteHealth()
+    expect(rows).toHaveLength(2)
+    const ok = rows.find(r => r.status === 'ok')
+    const dead = rows.find(r => r.status === 'auth_expired')
+    expect(ok?.scopes).toEqual(['group:test'])
+    expect(dead?.scopes).toEqual(['group:other'])
+    expect(dead?.reason).toMatch(/401/)
+  })
+
+  it('collapses same (url, token) across scopes and URL spellings into one probe (#587)', async () => {
+    const plur = writeConfig([
+      { url: baseUrl, token: TOKEN, scope: 'group:test', shared: true, readonly: false },
+      { url: `${baseUrl}/`, token: TOKEN, scope: 'group:second', shared: true, readonly: false },
+    ])
+    const rows = await plur.checkRemoteHealth()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].scopes).toEqual(['group:test', 'group:second'])
+  })
+
+  it('reports server-confirmed identity + granted scope count on ok (#587)', async () => {
+    server.setMe({ username: 'crtahlin', org_id: 'plur', role: 'developer', scopes: ['group:a', 'group:b', 'group:c'] })
+    const plur = writeConfig([{ url: baseUrl, token: TOKEN, scope: 'group:a', shared: true, readonly: false }])
+    const [h] = await plur.checkRemoteHealth()
+    expect(h.status).toBe('ok')
+    expect(h.username).toBe('crtahlin')
+    expect(h.orgId).toBe('plur')
+    expect(h.grantedScopes).toBe(3)
+  })
+
+  it('surfaces display-only JWT subject/org claims even when the server rejects the token (#587)', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 20 * 86_400
+    const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+    const revokedJwt = `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 'gregor', orgId: 'igea', exp })}.sig`
+    const plur = writeConfig([{ url: baseUrl, token: revokedJwt, scope: 'group:igea/gis', shared: true, readonly: false }])
+    const [h] = await plur.checkRemoteHealth()
+    expect(h.status).toBe('auth_expired') // stub 401s any token it did not mint
+    expect(h.tokenSubject).toBe('gregor')
+    expect(h.tokenOrg).toBe('igea')
+    expect(h.tokenExpiresInDays).toBeGreaterThan(18)
+  })
+})
+
+describe('Plur.remoteEndpointTokenGroups() (#587)', () => {
+  it('groups by (normalized url, token) preserving config order of scopes', () => {
+    const plur = writeConfig([
+      { url: 'https://x.example.com', token: 't1', scope: 'group:a', shared: true, readonly: false },
+      { url: 'https://x.example.com/', token: 't1', scope: 'group:b', shared: true, readonly: false },
+      { url: 'https://x.example.com', token: 't2', scope: 'group:c', shared: true, readonly: false },
+      { url: 'https://y.example.com', token: 't1', scope: 'group:d', shared: true, readonly: false },
+    ])
+    const groups = plur.remoteEndpointTokenGroups()
+    expect(groups).toHaveLength(3)
+    expect(groups[0]).toEqual({ url: 'https://x.example.com', token: 't1', scopes: ['group:a', 'group:b'] })
+    expect(groups[1]).toEqual({ url: 'https://x.example.com', token: 't2', scopes: ['group:c'] })
+    expect(groups[2]).toEqual({ url: 'https://y.example.com', token: 't1', scopes: ['group:d'] })
+  })
+
+  it('ignores filesystem stores', () => {
+    const plur = writeConfig([{ path: '/tmp/some-store', scope: 'user:me', shared: false, readonly: false }])
+    expect(plur.remoteEndpointTokenGroups()).toEqual([])
+  })
 })
 
 describe('Plur.remoteTokenExpiries()', () => {


### PR DESCRIPTION
Closes #587.

`plur login --status` now reports whether each configured enterprise credential actually works, instead of dumping raw `~/.plur/config.json`.

## What it does

For every **distinct (url, token)** group among `~/.plur/config.yaml` stores (same composite-key grouping as the #776 recall dialing), `--status` shows:

- **host** and the JWT's display-only **subject/org** (unverified payload decode — enterprise claims `sub`/`orgId`; falls back to the live `/me` identity)
- **expiry**, absolute + relative: `expires in 23d` / `EXPIRED 3d ago` / opaque-key fallback
- **live probe** of `GET /api/v1/me` (3 s budget) with the server's granted-scope count
- the **scopes mounted locally** for that credential
- a clear status: `VALID` / `EXPIRING SOON` (<7d) / `EXPIRED` / `UNREACHABLE` / `INVALID`

Exit code is script-friendly: **0** when every credential is valid (UNREACHABLE is a network condition, not an auth verdict), **1** when any is EXPIRED/INVALID or none are configured. `--json` emits the full report as one machine-readable object; `--quiet` is honoured on the text path. Token values are never printed (and `outputJson`'s redaction layer backstops that).

A `plur login`-written legacy `config.json` token that is **not** mounted as a store is flagged as unused rather than probed — nothing on the recall path reads it.

## Reuse, not reimplementation

- The probe is core's `checkRemoteHealth` (the same `/me` probe + local JWT-expiry decode `plur_doctor` uses), now grouped per **(url, token)** via a new public `Plur.remoteEndpointTokenGroups()` instead of per-URL first-token-wins — so a dead second token on the same host can no longer hide behind a healthy first one. `RemoteHealth` gains additive fields (`tokenSubject`, `tokenOrg`, `username`, `orgId`, `grantedScopes`); the MCP doctor consumer is unchanged.
- `decodeJwtPayload` is factored out of `decodeJwtExpiry` in core's `jwt.ts` (still zero-dependency, still display-only).
- Remediation strings **reuse the A4′ table** (`doctorRemoteRemediation`): sign in at `<host>/auth` + re-add via `plur_stores_add`. `plur login` is never *suggested* — enterprise servers have no device-flow endpoints (B-T9 pending); the only mention is the A4′ "does not work" note, and a test pins that.

## Device-flow gate

Registering `login` in the dispatcher was required to make `--status` reachable, but the OAuth device flow itself stays deactivated per the #300/#532 decision: `plur login <host>` now prints the supported sign-in path (`<host>/auth` + `plur_stores_add`) and exits 1. The flow implementation is kept (and still unit-tested) for when server-side support lands.

## Tests

- **core** — `decodeJwtPayload` fixtures (valid / opaque / malformed / non-object payloads); `checkRemoteHealth` per-(url, token) fan-out against the StubServer (ok + dead second token), same-(url, token) collapse across scopes and URL spellings, `/me` identity + granted-scope count, JWT claim surfacing on a rejected token; `remoteEndpointTokenGroups` grouping/order.
- **cli** — unit: status classification matrix (incl. the 6/7-day boundary and EXPIRED-vs-INVALID split), relative-expiry formatting, report building, remediation-string pinning (no `plur login` suggestion), text rendering. Process-level (spawned CLI × StubServer): exit codes for empty config / VALID / EXPIRED / INVALID / EXPIRING SOON / UNREACHABLE (StubServer stopped), `--json` shape, (url, token) grouping, legacy-token flagging, device-flow gate — plus no-token-leak assertions on every output.

`typecheck:tests` and `pnpm -r build` are clean. Full suite on the rebased branch: 3377 passed, 1 failed — the known spawn-heavy `hook-learn-check` 5s-timeout flake under machine load; it passes solo (5/5 in 2.6s) and is untouched by this diff.
