### PR TITLE
feat(mcp): make the plur_admin gateway visible to clients (#761)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -65,6 +65,8 @@ By default (lean profile), your agent gets 12 tools. Everything else is reachabl
 
 Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 40 tools directly.
 
+A `plur_*` name missing from `tools/list` means it moved behind the gateway, not that the server is down. `plur_admin { action: "help" }` returns every action with a one-line description and its argument schema; `plur_doctor` reports the same inventory as `tool_surface`.
+
 ## Sync across machines
 
 Your agent can sync memory to any git remote:

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -47,7 +47,7 @@ export const INSTRUCTIONS = `PLUR is your persistent memory. Corrections, prefer
 
 PLUR is a GLOBAL tool — one MCP server, one engram store (~/.plur/), available in every project. Multi-project scoping uses domain/scope fields on engrams, not separate installations.
 
-TOOL PROFILE: by default only the core session tools are exposed directly (lean profile). Every other plur_* operation is reachable via plur_admin: { action: "<tool name>", args: {...} } — same arguments and validation as a direct call. PLUR_TOOL_PROFILE=full exposes everything directly.
+TOOL PROFILE: by default only the core session tools are exposed directly (lean profile). Every other plur_* operation is reachable via plur_admin: { action: "<tool name>", args: {...} } — same arguments and validation as a direct call. A plur_* name missing from tools/list means it MOVED behind plur_admin, not that the MCP is down — never conclude the server is unavailable from a name-lookup miss. Discover the live surface with plur_admin { action: "help" } (every action with description + argument schema) or plur_doctor (tool_surface). PLUR_TOOL_PROFILE=full exposes everything directly.
 
 SESSION LIFECYCLE:
 - With hooks installed (plur init): engrams are injected automatically on first message. You do NOT need to call plur_session_start — it happens via hooks. Just call plur_session_end before the conversation ends.

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -552,17 +552,68 @@ export const CURSOR_CORE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'plur_tensions_purge',
 ])
 
+/**
+ * One line of a tool's description, for plur_admin's `help` action (#761).
+ * Cuts at the first newline, then backs off to a sentence boundary when the
+ * line runs long — the full detail stays on the tool definition itself.
+ */
+function summarizeToolDescription(description: string): string {
+  const line = description.split('\n', 1)[0].trim()
+  if (line.length <= 200) return line
+  const cut = line.lastIndexOf('. ', 200)
+  return cut > 40 ? line.slice(0, cut + 1) : `${line.slice(0, 199)}…`
+}
+
+/**
+ * The action inventory clause for plur_admin's tool description, grouped by
+ * name family (the token after `plur_`) so ~30 names scan as a categorized
+ * list instead of a wall. GENERATED from the same action list the dispatcher
+ * routes on — never hand-maintained (#761): hand-kept text is exactly what
+ * drifts silently the moment a tool is added or renamed, and this description
+ * is the one place a client that only reads tools/list can learn the surface.
+ *
+ * If the registry ever outgrows what a description can reasonably carry, the
+ * clause degrades to family names + counts and points at `help` — a truncated
+ * enumeration reads as complete, which is worse than an honest summary.
+ */
+function describeActionInventory(actions: string[]): string {
+  const families = new Map<string, string[]>()
+  for (const name of actions) {
+    const family = name.replace(/^plur_/, '').split('_', 1)[0]
+    families.set(family, [...(families.get(family) ?? []), name])
+  }
+  const sorted = [...families.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  const grouped: string[] = []
+  const misc: string[] = []
+  for (const [family, members] of sorted) {
+    if (members.length > 1) grouped.push(`${family}: ${members.join(', ')}`)
+    else misc.push(members[0])
+  }
+  if (misc.length > 0) grouped.push(`other: ${misc.join(', ')}`)
+  const full = `Actions, grouped — ${grouped.join(' · ')}.`
+  if (full.length <= 1500) return full
+  const counted = sorted.map(([family, members]) => `${family} (${members.length})`).join(', ')
+  return `${actions.length} actions in groups ${counted} — the full list is in { action: "help" }.`
+}
+
 function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
   const byName = new Map(all.map(t => [t.name, t] as const))
   const adminActions = all.map(t => t.name).filter(n => !CURSOR_CORE_TOOL_NAMES.has(n)).sort()
+  // The example an agent copies must be a real, currently-dispatchable action —
+  // prefer the one from the #761 incident report, fall back to whatever exists.
+  const exampleAction = adminActions.includes('plur_recall_hybrid') ? 'plur_recall_hybrid' : adminActions[0]
+  const exampleArgs = exampleAction === 'plur_recall_hybrid' ? '{ query: "deploy checklist" }' : '{}'
 
   return {
     name: 'plur_admin',
     description:
-      'Dispatch for less-common PLUR operations (packs, sync, tensions, stores, timeline, ' +
-      "ingest, and more), collapsed into one tool so Cursor's ~40-tool-per-workspace limit " +
-      'is not exhausted by PLUR alone. Set "action" to the underlying tool name and "args" ' +
-      `to that tool's normal arguments. Valid actions: ${adminActions.join(', ')}.`,
+      `Gateway to the ${adminActions.length} PLUR operations that are not top-level tools under the ` +
+      "current profile (collapsed into one dispatch tool so Cursor's ~40-tool-per-workspace limit is " +
+      'not exhausted by PLUR alone). A plur_* name missing from tools/list means it moved HERE — not ' +
+      'that the MCP is unavailable. Calling convention: { action: "<tool name>", args: { ...that ' +
+      "tool's normal arguments } } — same arguments, same validation, same result as a direct call. " +
+      `Example: { action: "${exampleAction}", args: ${exampleArgs} }. Send { action: "help" } for ` +
+      `every action's one-line description and argument schema. ${describeActionInventory(adminActions)}`,
     annotations: { title: 'Admin dispatch', readOnlyHint: false },
     inputSchema: {
       type: 'object',
@@ -574,16 +625,37 @@ function buildAdminDispatchTool(all: ToolDefinition[]): ToolDefinition {
         // CallToolRequestSchema handler's Zod validation would reject
         // unknown actions before this handler's `if (!target)` branch ever
         // ran.
-        action: { type: 'string', description: 'Which underlying plur_* tool to invoke' },
+        action: { type: 'string', description: 'Which underlying plur_* tool to invoke, or "help" to list every action with its description and argument schema' },
         args: { type: 'object', description: "Arguments for the chosen action, matching that tool's normal input schema", additionalProperties: true },
       },
       required: ['action'],
     },
     handler: async (args, plur) => {
       const action = args.action as string
+      // #761: the runtime discovery surface. The tool description carries the
+      // action NAMES; this returns what each one does and what it takes, so an
+      // agent that only knows "plur_admin exists" can learn the whole surface
+      // in one call instead of guessing names against the Unknown-action error.
+      if (action === 'help') {
+        return {
+          calling_convention:
+            'plur_admin { action: "<tool name>", args: { ... } } — same arguments, same validation, ' +
+            'same result as calling that tool directly. A tools/list miss on one of these names means ' +
+            'it is consolidated here, NOT that the MCP is unavailable.',
+          actions: adminActions.map(name => {
+            const t = byName.get(name)!
+            return { action: name, description: summarizeToolDescription(t.description), args_schema: t.inputSchema }
+          }),
+          standalone_tools: all.map(t => t.name).filter(n => CURSOR_CORE_TOOL_NAMES.has(n)).sort(),
+          standalone_note:
+            'standalone_tools are exposed as top-level tools in every profile — call them directly, ' +
+            'never through plur_admin (destructive ones are refused here so their risk annotations ' +
+            'stay visible to your client).',
+        }
+      }
       const target = byName.get(action)
       if (!target) {
-        return { error: `Unknown action "${action}". Valid actions: ${adminActions.join(', ')}`, success: false, _isError: true }
+        return { error: `Unknown action "${action}". Valid actions: help, ${adminActions.join(', ')}`, success: false, _isError: true }
       }
       // #625 audit: ENFORCE the annotation-visibility guarantee the module
       // comment documents. Destructive tools must never execute through this
@@ -696,7 +768,7 @@ export function describeToolSurface(profile: ToolProfile = activeToolProfile()):
     admin_actions,
     note: admin_actions.length === 0
       ? 'All tools are exposed directly under this profile.'
-      : `Only the ${standalone.length} tools in "standalone" are callable by name. Everything in "admin_actions" is reachable as plur_admin { action: "<name>", args: {...} } — same arguments, same validation, same result. A name-lookup miss on one of those means it moved, NOT that the MCP is unavailable. Set PLUR_TOOL_PROFILE=full to expose all tools directly.`,
+      : `Only the ${standalone.length} tools in "standalone" are callable by name. Everything in "admin_actions" is reachable as plur_admin { action: "<name>", args: {...} } — same arguments, same validation, same result. A name-lookup miss on one of those means it moved, NOT that the MCP is unavailable. Call plur_admin { action: "help" } for each action's description and argument schema. Set PLUR_TOOL_PROFILE=full to expose all tools directly.`,
   }
 }
 
@@ -1767,8 +1839,21 @@ function getAllToolDefinitions(): ToolDefinition[] {
           created_after: args.created_after as string | undefined,
         })
         const versionCheck = getCachedUpdateCheck('@plur-ai/mcp')
+        // #761: name the profile + gateway in the other name-stable diagnostic
+        // door. status is where agents look when "tools seem missing" — one
+        // line here turns a lookup miss into a plur_admin call instead of a
+        // false "MCP is down" conclusion. Full inventory: plur_doctor's
+        // tool_surface, or plur_admin { action: "help" }.
+        const tool_profile = activeToolProfile()
         return {
           version: VERSION,
+          tool_profile,
+          ...(tool_profile !== 'full' ? {
+            tool_surface_note:
+              `Tool profile "${tool_profile}": most plur_* operations are not top-level tools — call them ` +
+              'as plur_admin { action: "<name>", args: {...} }; send { action: "help" } for the list. ' +
+              'A name-lookup miss means a tool moved there, not that the MCP is down.',
+          } : {}),
           engram_count: status.engram_count,
           episode_count: status.episode_count,
           pack_count: status.pack_count,
@@ -2376,6 +2461,17 @@ function getAllToolDefinitions(): ToolDefinition[] {
               }
             }
           } catch { /* best-effort */ }
+        }
+
+        // #761: the lean surface is invisible in tools/list, and session_start
+        // is the first tool an agent calls — one line here tells it the
+        // gateway exists BEFORE it ever misses a name and concludes the MCP
+        // is down. Silent under 'full', where nothing is hidden.
+        const session_tool_profile = activeToolProfile()
+        if (session_tool_profile !== 'full') {
+          guide += `\n\nTool profile "${session_tool_profile}": most plur_* tools are not exposed by name — ` +
+            'call them via plur_admin { action: "<tool name>", args: {...} } ' +
+            '(send { action: "help" } for the full action list).'
         }
 
         const sessionResponse: Record<string, unknown> = {

--- a/packages/mcp/test/admin-gateway.test.ts
+++ b/packages/mcp/test/admin-gateway.test.ts
@@ -1,0 +1,189 @@
+/**
+ * plur_admin has to advertise itself as the gateway (#761) — the client half.
+ *
+ * #763 made the surface answerable in-band via plur_doctor's `tool_surface`,
+ * which covers the agent that already suspects something is wrong. These tests
+ * cover the agent that never gets that far: the only things it reliably reads
+ * are tools/list descriptions, the session_start/status responses it calls
+ * anyway, and — once it knows the gateway exists — plur_admin itself. Each of
+ * those surfaces must (a) name the gateway and (b) be GENERATED from the same
+ * registry the dispatcher routes on, because hand-maintained text drifts the
+ * moment a tool is added or renamed, and a stale inventory an agent trusts is
+ * worse than none.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Client } from '@modelcontextprotocol/client'
+import { InMemoryTransport } from '@modelcontextprotocol/server'
+import { Plur, settleVersionChecks, clearVersionCache } from '@plur-ai/core'
+import { createServer } from '../src/server.js'
+import {
+  getToolDefinitions, CURSOR_CORE_TOOL_NAMES,
+  setActiveToolProfile, _resetActiveToolProfile, _resetSessionTelemetry,
+} from '../src/tools.js'
+
+/** The dispatchable set, computed from the registry the way the dispatcher does. */
+const adminActions = () =>
+  getToolDefinitions('full').map(t => t.name).filter(n => !CURSOR_CORE_TOOL_NAMES.has(n)).sort()
+
+describe('plur_admin tool description is the gateway sign (#761)', () => {
+  const admin = () => getToolDefinitions('lean').find(t => t.name === 'plur_admin')!
+
+  it('enumerates every dispatchable action — add or remove a tool and this regenerates', () => {
+    // The drift guard. The description is the ONE thing a client that only
+    // reads tools/list sees, so it must be derived from the same list the
+    // handler routes on. If someone replaces the generated inventory with
+    // hand-typed text, the next registry change breaks this test instead of
+    // silently shipping a wrong inventory.
+    const description = admin().description
+    for (const action of adminActions()) {
+      expect(description, `action "${action}" missing from plur_admin's description`).toContain(action)
+    }
+  })
+
+  it('states the true action count, computed not hardcoded', () => {
+    expect(admin().description).toContain(`Gateway to the ${adminActions().length} PLUR operations`)
+  })
+
+  it('shows the calling convention with an example that is a real action', () => {
+    const description = admin().description
+    expect(description).toContain('{ action: "<tool name>", args: {')
+    const example = description.match(/Example: \{ action: "([a-z_]+)"/)
+    expect(example, 'description must carry a copyable example call').not.toBeNull()
+    expect(adminActions(), `example action "${example![1]}" is not dispatchable`).toContain(example![1])
+  })
+
+  it('says a tools/list miss means moved, not gone — the #761 inference', () => {
+    expect(admin().description).toMatch(/moved HERE — not that the MCP is unavailable/i)
+  })
+
+  it('points at { action: "help" } for the full runtime inventory', () => {
+    expect(admin().description).toContain('{ action: "help" }')
+  })
+
+  it('stays within a sane description length for tool-list budgets', () => {
+    expect(admin().description.length).toBeLessThanOrEqual(2500)
+  })
+})
+
+describe('plur_admin { action: "help" } — the runtime discovery surface (#761)', () => {
+  let client: Client
+  let dir: string
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-admin-help-'))
+    // Hermetic per the server.test.ts pattern: temp-dir Plur, stubbed fetch so
+    // createServer's fire-and-forget version check never leaves the process.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }))
+    const server = await createServer(new Plur({ path: dir }), { profile: 'lean' })
+    await settleVersionChecks()
+    clearVersionCache()
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await server.connect(serverTransport)
+    client = new Client({ name: 'test-client', version: '1.0.0' })
+    await client.connect(clientTransport)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    _resetActiveToolProfile()
+    rmSync(dir, { recursive: true })
+  })
+
+  const callHelp = async () => {
+    const result = await client.callTool({ name: 'plur_admin', arguments: { action: 'help' } })
+    expect(result.isError).toBeFalsy()
+    return JSON.parse((result.content as any)[0].text)
+  }
+
+  it('lists every dispatchable action with a one-line description and its argument schema', async () => {
+    const data = await callHelp()
+    expect(data.actions.map((a: any) => a.action)).toEqual(adminActions())
+    for (const entry of data.actions) {
+      expect(typeof entry.description, `${entry.action} has no description`).toBe('string')
+      expect(entry.description.length, `${entry.action} has an empty description`).toBeGreaterThan(0)
+      expect(entry.description, `${entry.action} description is not one line`).not.toContain('\n')
+      expect(entry.args_schema?.type, `${entry.action} is missing its argument schema`).toBe('object')
+    }
+  })
+
+  it('states the calling convention and the moved-not-gone rule', async () => {
+    const data = await callHelp()
+    expect(data.calling_convention).toContain('plur_admin { action: "<tool name>", args: { ... } }')
+    expect(data.calling_convention).toMatch(/NOT that the MCP is unavailable/)
+  })
+
+  it('names the standalone tools so an agent does not route them through the gateway', async () => {
+    const data = await callHelp()
+    const standalone = getToolDefinitions('full').map(t => t.name).filter(n => CURSOR_CORE_TOOL_NAMES.has(n)).sort()
+    expect(data.standalone_tools).toEqual(standalone)
+    expect(data.standalone_note).toContain('call them directly')
+  })
+
+  it('help does not shadow a real tool name', () => {
+    expect(getToolDefinitions('full').some(t => t.name === 'help')).toBe(false)
+  })
+
+  it('the unknown-action error offers help, so a lost agent recovers in one step', async () => {
+    const result = await client.callTool({ name: 'plur_admin', arguments: { action: 'plur_nonexistent' } })
+    const data = JSON.parse((result.content as any)[0].text)
+    expect(data.success).toBe(false)
+    expect(data.error).toContain('Unknown action')
+    expect(data.error).toContain('help')
+  })
+})
+
+describe('session_start and status name the profile + gateway (#761)', () => {
+  let plur: Plur
+  let dir: string
+  let tools: ReturnType<typeof getToolDefinitions>
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-gateway-note-'))
+    plur = new Plur({ path: dir })
+    tools = getToolDefinitions('full')
+    _resetSessionTelemetry()
+  })
+
+  afterEach(() => {
+    _resetActiveToolProfile()
+    rmSync(dir, { recursive: true })
+  })
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.find(t => t.name === name)!
+    return tool.handler(args, plur) as Promise<any>
+  }
+
+  it('plur_status reports the active profile and a gateway one-liner under lean', async () => {
+    setActiveToolProfile('lean')
+    const status = await callTool('plur_status')
+    expect(status.tool_profile).toBe('lean')
+    expect(status.tool_surface_note).toContain('plur_admin { action: "<name>", args: {...} }')
+    expect(status.tool_surface_note).toContain('help')
+    expect(status.tool_surface_note).toMatch(/moved there, not that the MCP is down/)
+  })
+
+  it('plur_status omits the note under full — nothing is hidden there', async () => {
+    setActiveToolProfile('full')
+    const status = await callTool('plur_status')
+    expect(status.tool_profile).toBe('full')
+    expect(status.tool_surface_note).toBeUndefined()
+  })
+
+  it('session_start guide carries the profile + gateway line under lean', async () => {
+    setActiveToolProfile('lean')
+    const result = await callTool('plur_session_start', { task: 'anything at all' })
+    expect(result.guide).toContain('Tool profile "lean"')
+    expect(result.guide).toContain('plur_admin { action: "<tool name>", args: {...} }')
+    expect(result.guide).toContain('{ action: "help" }')
+  })
+
+  it('session_start guide stays quiet about the gateway under full', async () => {
+    setActiveToolProfile('full')
+    const result = await callTool('plur_session_start', { task: 'anything at all' })
+    expect(result.guide).not.toContain('Tool profile "')
+  })
+})

--- a/packages/mcp/test/instructions.test.ts
+++ b/packages/mcp/test/instructions.test.ts
@@ -19,3 +19,26 @@ describe('server INSTRUCTIONS — scope selection (#296)', () => {
     expect(INSTRUCTIONS).toMatch(/never reaches the team store/i)
   })
 })
+
+/**
+ * The instructions block is the ONE surface every MCP client receives on
+ * connect, before any tool call — so it is where the plur_admin gateway must
+ * be documented (#761). An agent that reads a 12-tool tools/list under the
+ * lean profile otherwise concludes the missing tools don't exist.
+ */
+describe('server INSTRUCTIONS — plur_admin gateway (#761)', () => {
+  it('documents the gateway calling convention', () => {
+    expect(INSTRUCTIONS).toContain('plur_admin')
+    expect(INSTRUCTIONS).toContain('{ action: "<tool name>", args: {...} }')
+  })
+
+  it('says a missing name means moved, not that the MCP is down', () => {
+    expect(INSTRUCTIONS).toMatch(/MOVED behind plur_admin/)
+    expect(INSTRUCTIONS).toMatch(/never conclude the server is unavailable/i)
+  })
+
+  it('points at both runtime discovery surfaces — help and tool_surface', () => {
+    expect(INSTRUCTIONS).toContain('{ action: "help" }')
+    expect(INSTRUCTIONS).toContain('tool_surface')
+  })
+})


### PR DESCRIPTION
Closes #761 (client-visible half; the diagnosability half shipped in #763).

## Problem

Under the lean profile (the default), 29 of 40 `plur_*` operations are reachable only as actions on `plur_admin` — but nothing a client reads *before* getting suspicious says so. An agent carrying pre-lean tool names looks one up in `tools/list`, misses, and concludes the MCP is down (observed 2026-07-29: healthy server, full HTTP-fallback switch). #763 gave the *already-suspicious* agent an answer via `plur_doctor`'s `tool_surface`; this PR fixes the surfaces an agent reads first, so the false conclusion never forms.

## What changed

- **`plur_admin` description is now the gateway sign** — action count, the moved-not-gone rule, the calling convention with a copyable example (`{ action: "plur_recall_hybrid", args: { query: ... } }`), and the full action inventory grouped by name family. All **generated** from the same action list the dispatcher routes on, never hand-maintained. If the registry ever outgrows a sane description length (guard at 1500 chars for the inventory clause), it degrades to family counts + a pointer at `help` instead of a truncated list that reads as complete. Current length: 1177 chars.
- **New `help` action** — `plur_admin { action: "help" }` returns every dispatchable action with a one-line description and its argument schema, plus the standalone tools that must *not* be routed through the gateway (destructive tools keep their annotations by staying direct). The unknown-action error now offers `help` too, so a lost agent recovers in one step.
- **Server `instructions` block** states the moved-not-gone rule outright and names both discovery doors (`help` and `tool_surface`).
- **`plur_session_start` guide + `plur_status`** each gain one line naming the active profile and the gateway — silent under `full`, where nothing is hidden. Both use the #763 `activeToolProfile()` (the profile the server was actually built with), not the environment.
- **`describeToolSurface` note** and the mcp README point at `help` as well.
- Direct calls to hidden tools already return an actionable `plur_admin` hint (#625) — verified interceptable, no change needed.

## Tests

New `packages/mcp/test/admin-gateway.test.ts` (15 tests) + 3 in `instructions.test.ts`:

- **Drift guard**: the description must contain every registry-derived action name — replacing the generated inventory with hand-kept text breaks the suite on the next tool add/rename.
- Description contract: true computed count, real copyable example, moved-not-gone phrasing, `help` pointer, length cap.
- `help` shape over the wire: exact action set, one-line descriptions, `args_schema.type === 'object'` for every entry, standalone-tools list, calling convention.
- Unknown-action error offers `help`.
- Profile notes present under `lean` and absent under `full` for both `plur_status` and `session_start`.
- INSTRUCTIONS content assertions.

328 mcp tests, 3359 across the monorepo, `typecheck:tests` and `pnpm build` clean.