### PR TITLE
feat(mcp): plur_session_scope — adjust the session default scope mid-session (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Run init from your project root — it sets up Cursor's `.cursor/mcp.json` (plus
 npx @plur-ai/mcp init
 ```
 
-PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 40, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
+PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 41, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
 
 ### OpenClaw
 

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -3,7 +3,12 @@ import { join } from 'path'
 import { createHash } from 'crypto'
 
 export interface HistoryEvent {
-  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome'
+  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome' | 'session_scope_changed'
+  /**
+   * Engram this event belongs to. Session-level events
+   * (`session_scope_changed`) carry no engram — they use `''`, which by
+   * construction never matches a real id in `readHistoryForEngram`.
+   */
   engram_id: string
   timestamp: string // ISO
   data: Record<string, unknown> // event-specific payload

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3074,11 +3074,19 @@ export class Plur {
    * tokens per host mean one POST per token. `remoteEndpointTokenConflicts`
    * feeds the doctor warning for that misconfiguration.
    */
-  private _remoteRecallHosts(options?: { scope?: string; remote_project?: RemoteProjectConfig }): RemoteRecallHost[] {
+  private _remoteRecallHosts(options?: { scope?: string; session?: string; remote_project?: RemoteProjectConfig }): RemoteRecallHost[] {
     const stores = (this.config.stores ?? []).filter(s => s.url)
     const rp = options?.remote_project
     const rpKey = rp ? normalizeEndpointUrl(rp.url) : null
-    const sessionOrg = scopeOrg(options?.scope)
+    // Dialing context (#243): an explicit recall scope wins; otherwise the
+    // SESSION default scope establishes the org context — a session whose
+    // default write scope names org X is doing org-X work, so its recalls
+    // dial org-X hosts. Resolved per-session via the same registry the write
+    // path uses (`options.session` — ADR-0004), so a mid-session scope
+    // switch redirects subsequent recall dialing too. No session scope set
+    // (the pre-#243 state) leaves dialing exactly as before.
+    const dialScope = options?.scope ?? this._sessionScopes.get(options?.session) ?? undefined
+    const sessionOrg = scopeOrg(dialScope)
 
     const groups = new Map<string, { url: string; token?: string; entries: StoreEntry[] }>()
     for (const s of stores) {
@@ -3141,7 +3149,7 @@ export class Plur {
    */
   private _startRemoteRecall(
     query: string,
-    options?: { scope?: string; remote?: boolean; remote_timeout_ms?: number; remote_project?: RemoteProjectConfig; limit?: number },
+    options?: { scope?: string; session?: string; remote?: boolean; remote_timeout_ms?: number; remote_project?: RemoteProjectConfig; limit?: number },
   ): Promise<RemoteRecallResult> | null {
     if (options?.remote === false) return null
     if (isRemoteRecallDisabled()) return null
@@ -3500,6 +3508,11 @@ export class Plur {
     // call per host.
     const remotePromise = this._startRemoteRecall(task, {
       scope: options?.scope,
+      // #243: the inject's session (same id plur_session_start minted for
+      // co_injection provenance) doubles as the dialing-context key — the
+      // session default scope drives org-affinity when no explicit scope is
+      // given, so a mid-session scope switch redials the right org's hosts.
+      session: options?.session_id,
       remote: options?.remote,
       remote_timeout_ms: options?.remote_timeout_ms,
       remote_project: options?.remote_project,
@@ -6478,6 +6491,41 @@ Generate an improved version of the procedure that prevents this failure. Return
    */
   setSessionScope(scope: string | null, opts?: { session?: string }): void {
     this._sessionScopes.set(scope, opts?.session)
+  }
+
+  /**
+   * Adjust the session default scope MID-session (#243) — `setSessionScope`
+   * plus observability: appends a `session_scope_changed` history event so the
+   * scope active at any point in a session can be reconstructed retrospectively
+   * (which scope routed a given engram, whether an agent oscillates scopes).
+   *
+   * `setSessionScope` stays the raw, silent primitive — session bootstrap
+   * (every `plur_session_start`) uses it without flooding history; deliberate
+   * mid-session changes go through here. Same registry, same keying rules:
+   * omit `session` for the process slot, pass it for per-session isolation
+   * (ADR-0004 — one `Plur` serving concurrent sessions MUST key).
+   *
+   * Returns the previous and new effective scope for the targeted slot.
+   */
+  adjustSessionScope(
+    scope: string | null,
+    opts?: { session?: string; reason?: string; trigger?: 'set' | 'clear' },
+  ): { previous: string | null; next: string | null } {
+    const previous = this._sessionScopes.get(opts?.session)
+    this._sessionScopes.set(scope, opts?.session)
+    appendHistory(this.paths.root, {
+      event: 'session_scope_changed',
+      engram_id: '', // session-level event — no engram (see HistoryEvent doc)
+      timestamp: new Date().toISOString(),
+      data: {
+        previous,
+        next: scope,
+        ...(opts?.trigger ? { trigger: opts.trigger } : {}),
+        ...(opts?.reason ? { reason: opts.reason } : {}),
+        ...(opts?.session ? { session_id: opts.session } : {}),
+      },
+    })
+    return { previous, next: scope }
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -201,6 +201,15 @@ export interface RecallOptions {
   /** `.plur.yaml` remote endpoint — establishes the org context for dialing
    *  on the hook path (#776). See {@link RemoteProjectConfig}. */
   remote_project?: RemoteProjectConfig
+  /**
+   * Session key this recall belongs to (#243). Used ONLY to resolve the
+   * session default scope as the dialing context for the remote leg when no
+   * explicit `scope` is passed: a session whose default scope names org X
+   * dials org-X hosts (see `_remoteRecallHosts`). An explicit `scope` always
+   * wins. Same registry key as {@link LearnContext.session} — thread the same
+   * value through both when one `Plur` serves concurrent sessions.
+   */
+  session?: string
 }
 
 export interface BoundedRecallResult {

--- a/packages/core/test/concurrency-session-scope.test.ts
+++ b/packages/core/test/concurrency-session-scope.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { Plur } from '../src/index.js'
 import { SessionScopeRegistry } from '../src/session-scopes.js'
+import { readHistory } from '../src/history.js'
 
 describe('SessionScopeRegistry', () => {
   it('isolates registered sessions from each other and from the process slot', () => {
@@ -172,5 +173,62 @@ describe('Plur — concurrent session scopes', () => {
     expect((e as unknown as Record<string, unknown>).session).toBeUndefined()
     const reloaded = await plur.getById(e.id)
     expect((reloaded as unknown as Record<string, unknown>).session).toBeUndefined()
+  })
+})
+
+// #243: adjustSessionScope = setSessionScope + observability. Same registry,
+// same keying — plus a session_scope_changed history event per change.
+describe('Plur.adjustSessionScope (#243)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-adjust-scope-'))
+    plur = new Plur({ path: dir })
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const events = () => readHistory(dir, new Date().toISOString().slice(0, 7))
+    .filter(e => e.event === 'session_scope_changed')
+
+  it('returns {previous, next} and updates the registry slot it targets', () => {
+    expect(plur.adjustSessionScope('group:plur/eng')).toEqual({ previous: null, next: 'group:plur/eng' })
+    expect(plur.getSessionScope()).toBe('group:plur/eng')
+    expect(plur.adjustSessionScope('project:core')).toEqual({ previous: 'group:plur/eng', next: 'project:core' })
+  })
+
+  it('keyed adjustment isolates sessions and leaves the process slot alone (ADR-0004)', () => {
+    plur.setSessionScope('global')
+    plur.adjustSessionScope('project:alpha', { session: 's1' })
+    plur.adjustSessionScope('project:beta', { session: 's2' })
+    expect(plur.getSessionScope({ session: 's1' })).toBe('project:alpha')
+    expect(plur.getSessionScope({ session: 's2' })).toBe('project:beta')
+    expect(plur.getSessionScope()).toBe('global')
+  })
+
+  it('appends a session_scope_changed history event with previous/next/trigger/reason/session_id', () => {
+    plur.adjustSessionScope('group:plur/eng', { session: 's1', reason: 'pivot to team-wide insight', trigger: 'set' })
+    plur.adjustSessionScope(null, { session: 's1', trigger: 'clear' })
+    const evs = events()
+    expect(evs).toHaveLength(2)
+    // Session-level event — no engram behind it.
+    expect(evs[0].engram_id).toBe('')
+    expect(evs[0].data).toMatchObject({
+      previous: null,
+      next: 'group:plur/eng',
+      trigger: 'set',
+      reason: 'pivot to team-wide insight',
+      session_id: 's1',
+    })
+    expect(evs[1].data).toMatchObject({ previous: 'group:plur/eng', next: null, trigger: 'clear', session_id: 's1' })
+  })
+
+  it('the adjusted scope governs subsequent unscoped writes, exactly like setSessionScope', async () => {
+    plur.adjustSessionScope('project:adjusted', { session: 's1' })
+    const e = await plur.learnRouted('adjust routes the same as set', { session: 's1' })
+    expect(e.scope).toBe('project:adjusted')
   })
 })

--- a/packages/core/test/remote-recall.test.ts
+++ b/packages/core/test/remote-recall.test.ts
@@ -613,6 +613,42 @@ describe('dialing — strict scope relevance', () => {
     expect(scopeOrg('global')).toBeNull()
     expect(scopeOrg(undefined)).toBeNull()
   })
+
+  // #243: the SESSION default scope is the dialing context when no explicit
+  // recall scope is passed — a mid-session scope switch redirects which org's
+  // hosts subsequent recalls dial.
+  const TWO_ORG_STORES =
+    `  - url: "https://plur.example.com"\n    token: "t1"\n    scope: "group:plur/plur-ai/engineering"\n` +
+    `  - url: "https://df.example.com"\n    token: "t2"\n    scope: "group:datafund/igea"\n`
+
+  it('session default scope establishes the dialing org context; switching it redials the other org (#243)', () => {
+    const plur = plurWith(TWO_ORG_STORES)
+    // No session scope, no explicit scope: nothing dialed (pre-#243 behavior).
+    expect(hostsOf(plur)).toHaveLength(0)
+    // Session scoped to plur-org work → plur host only.
+    plur.setSessionScope('project:plur/plur-ai/enterprise')
+    expect(hostsOf(plur).map(h => h.url)).toEqual(['https://plur.example.com'])
+    // Mid-session switch to the other org's project → THAT org's host only.
+    plur.adjustSessionScope('group:datafund/igea', { trigger: 'set' })
+    expect(hostsOf(plur).map(h => h.url)).toEqual(['https://df.example.com'])
+  })
+
+  it('per-session dialing isolation: each keyed session dials its own org (#243, ADR-0004)', () => {
+    const plur = plurWith(TWO_ORG_STORES)
+    plur.setSessionScope('project:plur/plur-ai/enterprise', { session: 's-plur' })
+    plur.setSessionScope('group:datafund/igea', { session: 's-df' })
+    expect(hostsOf(plur, { session: 's-plur' }).map(h => h.url)).toEqual(['https://plur.example.com'])
+    expect(hostsOf(plur, { session: 's-df' }).map(h => h.url)).toEqual(['https://df.example.com'])
+    // A session with no registration inherits the process slot — here unset.
+    expect(hostsOf(plur, { session: 's-ghost' })).toHaveLength(0)
+  })
+
+  it('an explicit recall scope beats the session scope for dialing (#243)', () => {
+    const plur = plurWith(TWO_ORG_STORES)
+    plur.setSessionScope('group:datafund/igea')
+    const hosts = hostsOf(plur, { scope: 'project:plur/x' })
+    expect(hosts.map(h => h.url)).toEqual(['https://plur.example.com'])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -63,7 +63,7 @@ By default (lean profile), your agent gets 12 tools. Everything else is reachabl
 | `plur_tensions_purge` | Clear stale/resolved tensions |
 | `plur_admin` | Dispatch to any other tool: `{ action: "plur_packs_install", args: {...} }` |
 
-Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 40 tools directly.
+Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 41 tools directly.
 
 ## Sync across machines
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -93,6 +93,10 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
       domain: args.domain as string | undefined,
       limit: args.limit as number | undefined,
       remote_timeout_ms: 2000, // MCP recall remote budget (#776)
+      // #243: session default scope (incl. mid-session plur_session_scope
+      // changes) establishes the remote dialing org context when no explicit
+      // scope filter is passed.
+      session: _resolveInjectionSession(args),
     })
     const response: Record<string, unknown> = {
       results: results.map(e => {
@@ -126,6 +130,10 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
     domain: args.domain as string | undefined,
     limit: fetchLimit,
     remote_timeout_ms: 2000, // MCP recall remote budget (#776)
+    // #243: session default scope (incl. mid-session plur_session_scope
+    // changes) establishes the remote dialing org context when no explicit
+    // scope filter is passed.
+    session: _resolveInjectionSession(args),
   })
   // Opt-in, content-free engagement counter (default-off; no query text).
   recordTelemetry('recall')
@@ -425,16 +433,33 @@ interface SessionTelemetry {
   injection_calls: number
   /** ISO timestamp of session_start — used for TTL cleanup. */
   started_at: string
+  /**
+   * Session-start default write scope (#243) — what `plur_session_scope`
+   * op:"clear" reverts to. Recorded here (the existing session-keyed state)
+   * rather than in a new process-global, per ADR-0004.
+   */
+  default_scope?: string | null
+  /** How the session-start default was derived (#243). */
+  default_scope_source?: 'caller' | 'project-config' | 'none'
+  /** True while a mid-session plur_session_scope op:"set" is in effect (#243). */
+  scope_adjusted?: boolean
 }
 const _sessionTelemetry = new Map<string, SessionTelemetry>()
 
 /** TTL for unclosed sessions: 8 hours. Prevents unbounded memory if session_end is never called. */
 const SESSION_TTL_MS = 8 * 60 * 60 * 1000
 
-function _cleanExpiredSessions(): void {
+function _cleanExpiredSessions(plur?: Plur): void {
   const cutoff = Date.now() - SESSION_TTL_MS
   for (const [id, state] of _sessionTelemetry) {
-    if (new Date(state.started_at).getTime() < cutoff) _sessionTelemetry.delete(id)
+    if (new Date(state.started_at).getTime() < cutoff) {
+      _sessionTelemetry.delete(id)
+      // #243: evict the expired session's keyed scope registration alongside
+      // its telemetry (only when a caller with a Plur instance triggered the
+      // sweep — the id-only helpers pass nothing and the entry is cleared on
+      // the next plur-bearing sweep or session_end).
+      try { plur?.clearSessionScope({ session: id }) } catch { /* best-effort */ }
+    }
   }
 }
 
@@ -480,6 +505,29 @@ function _resolveInjectionSession(args: Record<string, unknown>): string | undef
   const explicit = args.session_id
   if (typeof explicit === 'string' && explicit.length > 0) return explicit
   return _implicitSessionId()
+}
+
+/**
+ * Resolve the session a `plur_session_scope` operation targets (#243).
+ *
+ * Same derivation contract as `_implicitSessionId`: explicit `session_id`
+ * always wins; with exactly one session open the implicit answer is
+ * unambiguous; with none the process-default slot is the target (the
+ * pre-session_start / hookless deployment). With SEVERAL open and no
+ * explicit id there is no right answer — `ambiguous` is surfaced so writes
+ * (set/clear) can refuse instead of silently landing in the process slot,
+ * where one session's scope change would decide another session's writes
+ * (the exact ADR-0004 failure).
+ */
+function _resolveScopeSession(args: Record<string, unknown>): { session?: string; ambiguous: boolean; open: number } {
+  const explicit = args.session_id
+  if (typeof explicit === 'string' && explicit.length > 0) {
+    return { session: explicit, ambiguous: false, open: _sessionTelemetry.size }
+  }
+  _cleanExpiredSessions()
+  const open = _sessionTelemetry.size
+  if (open === 1) return { session: _sessionTelemetry.keys().next().value, ambiguous: false, open }
+  return { session: undefined, ambiguous: open > 1, open }
 }
 
 /** Record pack counts from an InjectionResult into the active session's telemetry. */
@@ -690,6 +738,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           valid_from: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge becomes valid — inject/recall skip the engram before this date (#347)' },
           valid_until: { type: 'string', description: 'ISO date (YYYY-MM-DD) the knowledge expires — inject/recall skip the engram after this date. Set this for any time-bound fact (offers, deadlines, temporary endpoints). When omitted, an explicit expiry phrase in the statement ("valid until 31 May 2026") is auto-parsed and echoed back (#347)' },
           supersedes: { type: 'array', items: { type: 'string' }, description: 'Engram IDs this statement intentionally replaces (#240). Writes relations.supersedes on the new engram and the reverse superseded_by edge on each local target. Supersedes-linked pairs are skipped by tension scans — an intentional update is not a contradiction. Use when updating a standing fact (new version, changed rule) rather than contradicting it.' },
+          session_id: { type: 'string', description: 'Session this write belongs to (from plur_session_start). Resolves the session default scope (incl. mid-session plur_session_scope changes) when no explicit scope is passed. Optional when one session is open; pass it when several are (#243).' },
         },
         required: ['statement'],
       },
@@ -714,6 +763,11 @@ function getAllToolDefinitions(): ToolDefinition[] {
           valid_from: args.valid_from as string | undefined,
           valid_until: args.valid_until as string | undefined,
           supersedes: args.supersedes as string[] | undefined,
+          // #243: resolve which session's default scope governs this write —
+          // explicit session_id first, else the lone open session. Never
+          // persisted on the engram (LearnContext.session selects a scope, it
+          // is not part of one).
+          session: _resolveInjectionSession(args),
           llm,
         }
         // Route through learnRouted FIRST so remote-scope writes get
@@ -971,6 +1025,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           budget: { type: 'object', description: 'Budget constraints for sub-agents. Hybrid mode only — ignored when mode:"keyword".', properties: { max_tokens: { type: 'number' }, max_results: { type: 'number' }, ttl_seconds: { type: 'number' } } },
           caller_session_id: { type: 'string', description: 'Session ID of calling agent for budget enforcement. Hybrid mode only — ignored when mode:"keyword".' },
           include_episodes: { type: 'boolean', description: 'If true, include linked episode summaries for each engram (SP2 episodic anchoring). Hybrid mode only — ignored when mode:"keyword".' },
+          session_id: { type: 'string', description: 'Session this recall belongs to (from plur_session_start). Its default scope (incl. mid-session plur_session_scope changes) sets the remote dialing context when no explicit scope filter is passed. Optional when one session is open (#243).' },
         },
         required: ['query'],
       },
@@ -991,6 +1046,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           budget: { type: 'object', description: 'Budget constraints for sub-agents', properties: { max_tokens: { type: 'number' }, max_results: { type: 'number' }, ttl_seconds: { type: 'number' } } },
           caller_session_id: { type: 'string', description: 'Session ID of calling agent for budget enforcement' },
           include_episodes: { type: 'boolean', description: 'If true, include linked episode summaries for each engram (SP2 episodic anchoring)' },
+          session_id: { type: 'string', description: 'Session this recall belongs to (from plur_session_start). Its default scope sets the remote dialing context when no explicit scope filter is passed (#243).' },
         },
         required: ['query'],
       },
@@ -2055,7 +2111,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
         // Initialize session telemetry — tracks per-pack injection counts for
         // activation-rate validation (target: 25-80 sessions/month per user).
         // TTL cleanup runs here to evict any unclosed sessions from prior starts.
-        _cleanExpiredSessions()
+        _cleanExpiredSessions(plur)
         _sessionTelemetry.set(session_id, {
           pack_counts: {},
           injection_calls: 0,
@@ -2118,6 +2174,22 @@ function getAllToolDefinitions(): ToolDefinition[] {
         // without this reset, a default_scope set in session A leaks into every
         // subsequent session that didn't pass its own default_scope.
         plur.setSessionScope(default_scope)
+        // #243: ALSO register the default under this session's own key, so a
+        // caller that threads session_id through plur_learn / plur_recall /
+        // plur_session_scope keeps its scope even when another session starts
+        // later and resets the process slot above (ADR-0004 per-session
+        // isolation). Cleared at plur_session_end / TTL eviction.
+        plur.setSessionScope(default_scope, { session: session_id })
+        {
+          // Record the start default + its provenance in the session-keyed
+          // telemetry record: plur_session_scope op:"clear" reverts to it and
+          // op:"show" reports how the effective scope was derived.
+          const t = _sessionTelemetry.get(session_id)
+          if (t) {
+            t.default_scope = default_scope
+            t.default_scope_source = scope_source as 'caller' | 'project-config' | 'none'
+          }
+        }
 
         // Get store stats for context
         const status = await plur.status()
@@ -2340,6 +2412,137 @@ function getAllToolDefinitions(): ToolDefinition[] {
     },
 
     {
+      name: 'plur_session_scope',
+      description:
+        'Adjust or inspect the session default write scope MID-session — narrow, expand, or switch context without ' +
+        'restarting the session (#243). op:"set" replaces the default scope used by unscoped plur_learn calls for the ' +
+        'rest of the session AND the org context that decides which enterprise hosts plur_recall dials; op:"show" ' +
+        'reports the effective scope and how it was derived (project config, session_start default, or a mid-session ' +
+        'set); op:"clear" reverts to the scope the session started with. Use when the conversation genuinely pivots — ' +
+        'a focused bug fix surfacing a team-wide architecture insight, or switching to another org\'s project. Do NOT ' +
+        'oscillate scope call-by-call: for a one-off write to a different scope, pass scope explicitly on that ' +
+        'plur_learn instead (explicit per-call scope always beats the session default). Every change is logged as a ' +
+        'session_scope_changed history event.',
+      annotations: { title: 'Session scope', destructiveHint: false, idempotentHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          op: {
+            type: 'string',
+            enum: ['set', 'show', 'clear'],
+            description: 'set: replace the session default write scope; show: report the effective scope and its derivation; clear: revert to the session-start default.',
+          },
+          scope: {
+            type: 'string',
+            description: 'New session default scope (op:"set" only), e.g. "project:myapp" or "group:org/team". Must match a configured store scope to route writes to a remote store — other strings stay local under that namespace.',
+          },
+          reason: {
+            type: 'string',
+            description: 'Optional one-line explanation of why the scope is changing — logged on the session_scope_changed event for retrospective debugging.',
+          },
+          session_id: {
+            type: 'string',
+            description: 'Session to target (from plur_session_start). Optional when one session is open; REQUIRED when several are — a scope change must never decide another session\'s writes.',
+          },
+        },
+        required: ['op'],
+      },
+      handler: async (args, plur) => {
+        const op = args.op as string
+        if (op !== 'set' && op !== 'show' && op !== 'clear') {
+          throw new Error(`plur_session_scope: op must be "set", "show" or "clear", got ${JSON.stringify(args.op)}`)
+        }
+        const reason = args.reason as string | undefined
+        const { session, ambiguous, open } = _resolveScopeSession(args)
+        const record = session ? _sessionTelemetry.get(session) : undefined
+        const remote_scopes = plur.getWritableRemoteScopes()
+        const withCommon = (body: Record<string, unknown>): Record<string, unknown> => ({
+          op,
+          ...body,
+          ...(session ? { session_id: session } : {}),
+          ...(remote_scopes.length > 0 ? { remote_scopes } : {}),
+        })
+
+        if (op === 'show') {
+          const scope = plur.getSessionScope({ session })
+          const source = record
+            ? (record.scope_adjusted
+                ? 'session-adjusted'
+                : record.default_scope_source === 'caller'
+                  ? 'session-start'
+                  : record.default_scope_source ?? 'none')
+            : scope == null ? 'none' : 'process-default'
+          return withCommon({
+            scope,
+            source,
+            ...(ambiguous ? {
+              warning: `${open} sessions are open — this is the process-default slot, not a specific session's scope. Pass session_id (from plur_session_start) to inspect one.`,
+            } : {}),
+            guide: scope == null
+              ? 'No session default scope is set: unscoped plur_learn writes auto-route on a confident covers match or land at the unscoped default. Explicit per-call scope always wins.'
+              : `Unscoped plur_learn calls this session default to "${scope}"; recall dialing follows the same org context. Explicit per-call scope always wins.`,
+          })
+        }
+
+        // Writes (set/clear) refuse ambiguity — landing in the process slot
+        // would let this session's change decide another session's writes.
+        if (ambiguous) {
+          throw new Error(
+            `plur_session_scope: ${open} sessions are open on this server — pass session_id (from plur_session_start) ` +
+            `so the scope change targets the right session and cannot bleed into another one.`,
+          )
+        }
+
+        if (op === 'set') {
+          const scope = args.scope
+          if (typeof scope !== 'string' || scope.trim().length === 0) {
+            throw new Error('plur_session_scope: op:"set" requires a non-empty string "scope" (use op:"clear" to revert to the session-start default)')
+          }
+          if (!/^\S+$/.test(scope) || scope.length > 200) {
+            throw new Error(`plur_session_scope: invalid scope ${JSON.stringify(scope)} — a scope is a single token without whitespace (e.g. "project:myapp", "group:org/team"), max 200 chars`)
+          }
+          const { previous, next } = plur.adjustSessionScope(scope, { session, reason, trigger: 'set' })
+          if (record) record.scope_adjusted = true
+          // Guard (#243): a shared/team default means every unscoped write for
+          // the rest of the session carries team-visible scope — say so at the
+          // moment it becomes true, not per-write. The per-write secrets/
+          // sensitivity guard is unchanged and still scans every learn.
+          const remoteEntry = remote_scopes.find(s => s.scope === scope)
+          const warning = isSharedScope(scope)
+            ? (remoteEntry
+                ? `"${scope}" routes to the shared remote store at ${remoteEntry.url}: every unscoped plur_learn for the rest of this session defaults there, visible to everyone with read access to that scope. The per-write secrets/sensitivity guard still scans each write (offending content is demoted to local), but relevance is your call — clear or narrow the scope when the conversation leaves team context.`
+                : `"${scope}" is a shared-family scope but matches no configured remote store scope, so writes stay on this machine under that namespace. The write-time sensitivity guard treats it as shared (scans + demotes offending content). If you expected a team store, check the remote_scopes list.`)
+            : undefined
+          return withCommon({
+            previous_scope: previous,
+            new_scope: next,
+            ...(reason ? { reason } : {}),
+            ...(warning ? { warning } : {}),
+          })
+        }
+
+        // op === 'clear' — revert to the session-start default. With a live
+        // session record that is the recorded default (robust even if another
+        // session_start reset the process slot since); otherwise fall back to
+        // the project config, the same source session_start derives from.
+        const restored = record !== undefined
+          ? (record.default_scope ?? null)
+          : (readProjectConfig().scope ?? null)
+        const restored_source = record !== undefined
+          ? (record.default_scope_source === 'caller' ? 'session-start' : record.default_scope_source ?? 'none')
+          : (restored != null ? 'project-config' : 'none')
+        const { previous, next } = plur.adjustSessionScope(restored, { session, reason, trigger: 'clear' })
+        if (record) record.scope_adjusted = false
+        return withCommon({
+          previous_scope: previous,
+          new_scope: next,
+          restored_source,
+          ...(reason ? { reason } : {}),
+        })
+      },
+    },
+
+    {
       name: 'plur_session_end',
       description: `End a session. BEFORE calling this tool, review the conversation and extract learnings:
 
@@ -2426,6 +2629,10 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
         // Clean up session telemetry
         if (session_id) {
           _sessionTelemetry.delete(session_id)
+          // #243: drop this session's keyed scope registration too — a
+          // long-lived server would otherwise retain one registry entry per
+          // session it has ever served (see SessionScopeRegistry.clear).
+          plur.clearSessionScope({ session: session_id })
         }
 
         // Clean up session checkpoint (#215) — session ended cleanly

--- a/packages/mcp/test/session-scope-tool.test.ts
+++ b/packages/mcp/test/session-scope-tool.test.ts
@@ -1,0 +1,282 @@
+/**
+ * plur_session_scope — dynamic mid-session scope adjustment (#243).
+ *
+ * The session default write scope was fixed at plur_session_start; real
+ * sessions pivot (narrow, expand, switch org). This suite covers the MCP
+ * surface end to end:
+ *
+ *   - set / show / clear roundtrip, with derivation reporting
+ *   - clear reverts to the SESSION-START default, not to null
+ *   - a set scope governs subsequent unscoped plur_learn calls
+ *   - remote routing: learn after set posts to the enterprise store
+ *   - recall dialing follows the session scope's org (#778 interaction)
+ *   - per-session isolation: two sessions adjusting scopes do not bleed
+ *     (ADR-0004), and an ambiguous write refuses instead of guessing
+ *   - invalid input is rejected
+ *   - the session_scope_changed history event is appended
+ *   - session_end drops the session's keyed registration
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, readHistory } from '@plur-ai/core'
+import { getToolDefinitions, _resetSessionTelemetry } from '../src/tools.js'
+
+describe('plur_session_scope (#243)', () => {
+  let plur: Plur
+  let dir: string
+  let tools: ReturnType<typeof getToolDefinitions>
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.find(t => t.name === name)
+    if (!tool) throw new Error(`Unknown tool: ${name}`)
+    return tool.handler(args, plur) as Promise<any>
+  }
+
+  const startSession = async (args: Record<string, unknown> = {}) =>
+    (await callTool('plur_session_start', { task: 'work on the thing', ...args })).session_id as string
+
+  const scopeEvents = () => readHistory(dir, new Date().toISOString().slice(0, 7))
+    .filter(e => e.event === 'session_scope_changed')
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-session-scope-tool-'))
+    plur = new Plur({ path: dir })
+    tools = getToolDefinitions('full')
+    _resetSessionTelemetry()
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('is registered in the full profile with op/scope/reason/session_id inputs', () => {
+    const tool = tools.find(t => t.name === 'plur_session_scope')
+    expect(tool).toBeDefined()
+    const props = (tool!.inputSchema as any).properties
+    expect(props.op.enum).toEqual(['set', 'show', 'clear'])
+    expect(props.scope).toBeDefined()
+    expect(props.reason).toBeDefined()
+    expect(props.session_id).toBeDefined()
+    expect((tool!.inputSchema as any).required).toEqual(['op'])
+    // Anti-oscillation guidance is part of the acceptance criteria.
+    expect(tool!.description).toContain('oscillate')
+  })
+
+  it('set → show → clear roundtrip against a live session', async () => {
+    const session = await startSession()
+
+    const before = await callTool('plur_session_scope', { op: 'show' })
+    expect(before.scope).toBeNull()
+    expect(before.source).toBe('none')
+    expect(before.session_id).toBe(session)
+
+    const set = await callTool('plur_session_scope', {
+      op: 'set', scope: 'group:plur/eng', reason: 'pivot to team-wide insight',
+    })
+    expect(set.previous_scope).toBeNull()
+    expect(set.new_scope).toBe('group:plur/eng')
+    expect(set.reason).toBe('pivot to team-wide insight')
+    expect(set.session_id).toBe(session)
+    // Shared/team scope as session default → warn about write implications;
+    // the per-write guard still applies.
+    expect(set.warning).toMatch(/guard/)
+
+    const after = await callTool('plur_session_scope', { op: 'show' })
+    expect(after.scope).toBe('group:plur/eng')
+    expect(after.source).toBe('session-adjusted')
+
+    const cleared = await callTool('plur_session_scope', { op: 'clear' })
+    expect(cleared.previous_scope).toBe('group:plur/eng')
+    expect(cleared.new_scope).toBeNull()
+    expect(cleared.restored_source).toBe('none')
+
+    const final = await callTool('plur_session_scope', { op: 'show' })
+    expect(final.scope).toBeNull()
+    expect(final.source).toBe('none')
+  })
+
+  it('clear reverts to the session-start default, not to null', async () => {
+    await startSession({ default_scope: 'project:base' })
+
+    await callTool('plur_session_scope', { op: 'set', scope: 'group:elsewhere' })
+    const cleared = await callTool('plur_session_scope', { op: 'clear' })
+    expect(cleared.previous_scope).toBe('group:elsewhere')
+    expect(cleared.new_scope).toBe('project:base')
+    expect(cleared.restored_source).toBe('session-start')
+
+    const engram = await callTool('plur_learn', { statement: 'after clear, writes carry the start default again' })
+    expect(engram.scope).toBe('project:base')
+  })
+
+  it('a mid-session set governs subsequent unscoped plur_learn calls; explicit scope still wins', async () => {
+    await startSession()
+    await callTool('plur_session_scope', { op: 'set', scope: 'project:pivoted' })
+
+    const unscoped = await callTool('plur_learn', { statement: 'routes to the adjusted session scope' })
+    expect(unscoped.scope).toBe('project:pivoted')
+
+    const explicit = await callTool('plur_learn', { statement: 'explicit beats session default', scope: 'project:explicit' })
+    expect(explicit.scope).toBe('project:explicit')
+  })
+
+  it('two sessions adjusting scopes stay isolated (ADR-0004); ambiguous writes refuse', async () => {
+    const a = await startSession({ task: 'org A work' })
+    const b = await startSession({ task: 'org B work' })
+
+    await callTool('plur_session_scope', { op: 'set', scope: 'project:org-a', session_id: a })
+    await callTool('plur_session_scope', { op: 'set', scope: 'project:org-b', session_id: b })
+
+    const showA = await callTool('plur_session_scope', { op: 'show', session_id: a })
+    const showB = await callTool('plur_session_scope', { op: 'show', session_id: b })
+    expect(showA.scope).toBe('project:org-a')
+    expect(showB.scope).toBe('project:org-b')
+
+    const learnA = await callTool('plur_learn', { statement: 'a-side write lands in the a scope', session_id: a })
+    const learnB = await callTool('plur_learn', { statement: 'b-side write lands in the b scope', session_id: b })
+    expect(learnA.scope).toBe('project:org-a')
+    expect(learnB.scope).toBe('project:org-b')
+
+    // With two sessions open and no session_id there is no right target —
+    // landing in the process slot would decide another session's writes.
+    await expect(callTool('plur_session_scope', { op: 'set', scope: 'project:whoever' }))
+      .rejects.toThrow(/session_id/)
+    // show stays answerable but flags the ambiguity.
+    const ambiguousShow = await callTool('plur_session_scope', { op: 'show' })
+    expect(ambiguousShow.warning).toMatch(/sessions are open/)
+  })
+
+  it('rejects invalid input', async () => {
+    await startSession()
+    await expect(callTool('plur_session_scope', { op: 'flip' })).rejects.toThrow(/op must be/)
+    await expect(callTool('plur_session_scope', { op: 'set' })).rejects.toThrow(/non-empty string/)
+    await expect(callTool('plur_session_scope', { op: 'set', scope: '' })).rejects.toThrow(/non-empty string/)
+    await expect(callTool('plur_session_scope', { op: 'set', scope: 'has whitespace' })).rejects.toThrow(/invalid scope/)
+  })
+
+  it('appends a session_scope_changed history event per change', async () => {
+    const session = await startSession()
+    await callTool('plur_session_scope', { op: 'set', scope: 'project:observed', reason: 'observability check' })
+    await callTool('plur_session_scope', { op: 'clear' })
+
+    const evs = scopeEvents()
+    expect(evs).toHaveLength(2)
+    expect(evs[0].data).toMatchObject({
+      previous: null, next: 'project:observed', trigger: 'set',
+      reason: 'observability check', session_id: session,
+    })
+    expect(evs[1].data).toMatchObject({ previous: 'project:observed', next: null, trigger: 'clear', session_id: session })
+  })
+
+  it('plur_session_end drops the session\'s keyed scope registration', async () => {
+    const session = await startSession()
+    await callTool('plur_session_scope', { op: 'set', scope: 'project:short-lived' })
+    expect(plur.trackedSessionScopes()).toContain(session)
+
+    await callTool('plur_session_end', { summary: 'done', session_id: session, engram_suggestions: [] })
+    expect(plur.trackedSessionScopes()).not.toContain(session)
+  })
+})
+
+describe('plur_session_scope — remote routing and dialing (#243 × #778)', () => {
+  let plur: Plur
+  let dir: string
+  let tools: ReturnType<typeof getToolDefinitions>
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.find(t => t.name === name)
+    if (!tool) throw new Error(`Unknown tool: ${name}`)
+    return tool.handler(args, plur) as Promise<any>
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-session-scope-remote-'))
+    tools = getToolDefinitions('full')
+    _resetSessionTelemetry()
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn(async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'POST' && String(url).includes('/api/v1/recall')) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ results: [] }),
+          text: async () => JSON.stringify({ results: [] }),
+        } as Response
+      }
+      if (method === 'POST') {
+        return {
+          ok: true, status: 201,
+          json: async () => ({ id: 'ENG-REMOTE-001' }),
+          text: async () => '',
+        } as Response
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({ rows: [], total_count: 0 }),
+        text: async () => '',
+      } as Response
+    })
+    globalThis.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function configureStores(stores: Array<Record<string, unknown>>) {
+    // JSON is valid YAML — avoids a js-yaml devDependency in this package.
+    writeFileSync(join(dir, 'config.yaml'), JSON.stringify({ stores, index: false }))
+    plur = new Plur({ path: dir })
+  }
+
+  it('learn after a mid-session set routes to the enterprise store for that scope', async () => {
+    configureStores([
+      { url: 'https://enterprise.example.com/sse', token: 'test_token', scope: 'group:plur/eng', shared: true, readonly: false },
+    ])
+
+    const set = await callTool('plur_session_scope', { op: 'set', scope: 'group:plur/eng' })
+    // Remote-backed shared scope → the warning names the store it routes to.
+    expect(set.warning).toContain('enterprise.example.com')
+    expect(set.remote_scopes).toEqual([{ scope: 'group:plur/eng', url: 'https://enterprise.example.com/sse' }])
+
+    const engram = await callTool('plur_learn', { statement: 'routed to the enterprise store via the adjusted scope' })
+    expect(engram.scope).toBe('group:plur/eng')
+    expect(engram.id).toBe('ENG-REMOTE-001')
+    const engramPosts = fetchMock.mock.calls.filter(([u, i]) =>
+      (i as any)?.method === 'POST' && String(u).includes('/api/v1/engrams'))
+    expect(engramPosts.length).toBe(1)
+  })
+
+  it('recall dialing follows the session scope org — and follows it again after a switch', async () => {
+    configureStores([
+      { url: 'https://plur.example.com', token: 't1', scope: 'group:plur/engineering', shared: true, readonly: false },
+      { url: 'https://df.example.com', token: 't2', scope: 'group:datafund/igea', shared: true, readonly: false },
+    ])
+
+    const recallUrls = () => fetchMock.mock.calls
+      .filter(([u, i]) => (i as any)?.method === 'POST' && String(u).includes('/api/v1/recall'))
+      .map(([u]) => String(u))
+
+    // No session scope: recall without an explicit scope implicates no org.
+    await callTool('plur_recall', { query: 'anything at all', mode: 'keyword' })
+    expect(recallUrls()).toEqual([])
+
+    // Session scoped to the plur org → recall dials the plur host only.
+    await callTool('plur_session_scope', { op: 'set', scope: 'project:plur/core' })
+    await callTool('plur_recall', { query: 'anything at all', mode: 'keyword' })
+    expect(recallUrls().some(u => u.startsWith('https://plur.example.com'))).toBe(true)
+    expect(recallUrls().some(u => u.startsWith('https://df.example.com'))).toBe(false)
+
+    // Mid-session switch to the other org → subsequent recalls dial THAT
+    // org's host.
+    fetchMock.mockClear()
+    await callTool('plur_session_scope', { op: 'set', scope: 'group:datafund/igea', reason: 'switching to IGEA work' })
+    await callTool('plur_recall', { query: 'anything at all', mode: 'keyword' })
+    expect(recallUrls().some(u => u.startsWith('https://df.example.com'))).toBe(true)
+    expect(recallUrls().some(u => u.startsWith('https://plur.example.com'))).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #243.

A session's default write scope was fixed at `plur_session_start` (#230); real sessions pivot — narrow, expand, or switch org mid-conversation. This adds the missing mid-session adjustment surface.

## Tool shape

New MCP tool **`plur_session_scope`** (small dedicated tool per the issue's open question 1, with an `op` field rather than the originally sketched `plur_set_scope(null)` — `clear` has revert-to-start semantics, which `set:null` can't express):

| op | effect |
|---|---|
| `set` | Replace the session default scope used by unscoped `plur_learn` calls AND the org context that decides which enterprise hosts `plur_recall` dials. Returns `{previous_scope, new_scope, reason?, remote_scopes, warning?}`. |
| `show` | Effective scope + derivation: `project-config` / `session-start` (caller `default_scope`) / `session-adjusted` / `none` / `process-default`. |
| `clear` | Revert to the session-start default (caller arg or `.plur.yaml`), not to bare null. |

- `reason` is optional (open question 2) and echoed + logged.
- Setting a **shared/team scope warns about write implications** — including the remote store URL when the scope is remote-backed; the per-write secrets/sensitivity guard is unchanged.
- An unregistered scope **warns but is not rejected** (open question 4); genuinely invalid input (unknown op, empty/whitespace scope) is rejected.
- The tool description tells agents **not to oscillate** scope call-by-call (acceptance criterion) — one-off writes should pass explicit per-call scope, which always wins.
- Lean/cursor profiles reach it via `plur_admin` (non-destructive); full profile exposes it directly (now 41 tools).

## Observability

`Plur.adjustSessionScope()` in core = `setSessionScope` + a **`session_scope_changed`** history event `{previous, next, trigger: set|clear, reason?, session_id?}`. Landed in `history/YYYY-MM.jsonl` rather than the episode timeline (open question 3): it's an append-only, greppable log that already answers "which scope was active when engram X was written", without polluting episodic memory used for recall. `setSessionScope` stays the silent bootstrap primitive so `session_start` doesn't flood history.

## Read side (#778 interaction)

The session default scope now establishes the **remote recall dialing org context** when no explicit scope is passed: `_remoteRecallHosts` resolves it from the per-session registry, so switching the session scope to another org's project makes subsequent recalls dial **that** org's hosts (and stop dialing the previous org's). Explicit recall scope still wins; with no session scope set, dialing is byte-for-byte the pre-change behavior.

## Concurrency (ADR-0004)

No new process-global state — the existing session-keyed structures are extended:

- `plur_session_start` now ALSO registers the default under the session's own key (process slot behavior unchanged), so keyed sessions survive another session's start.
- `plur_learn` / `plur_recall` accept `session_id` and thread it through (`LearnContext.session` / new `RecallOptions.session`); the lone-open-session case resolves implicitly, same contract as inject attribution.
- With several sessions open and no `session_id`, `set`/`clear` **refuse** instead of landing in the process slot where one session's change would decide another session's writes.
- Keyed registrations are dropped at `plur_session_end` and TTL eviction.

## Tests

- `packages/mcp/test/session-scope-tool.test.ts` (new, 10): set/show/clear roundtrip + derivation; clear reverts to session-start default; learn-after-set routes to the new scope (incl. remote store POST); recall dialing follows the session org and follows it again after a switch; two sessions adjusting scopes stay isolated + ambiguous writes refuse; invalid input rejected; history event; session_end cleanup.
- `packages/core/test/remote-recall.test.ts` (+3): session-scope dialing fallback, per-session dialing isolation, explicit-scope-wins.
- `packages/core/test/concurrency-session-scope.test.ts` (+4): `adjustSessionScope` return/registry/keying + history event payload.
- Full suite + `tsc` (src and tests) + `pnpm -r build` green.
