### PR TITLE
feat(core): plur_rescope — move an existing engram to another scope (#676)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Run init from your project root — it sets up Cursor's `.cursor/mcp.json` (plus
 npx @plur-ai/mcp init
 ```
 
-PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 41, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
+PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 42, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
 
 ### OpenClaw
 

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -2,11 +2,21 @@ import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputInfo, exit } from '../output.js'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  // `plur promote <id> --to <scope>` is a scope MOVE, not candidate activation —
+  // delegate to the rescope command so both spellings work (#676). Without
+  // `--to`, promote keeps its historical meaning: activate a candidate engram.
+  if (args.includes('--to')) {
+    const { run: rescopeRun } = await import('./rescope.js')
+    await rescopeRun(args, flags)
+    return
+  }
+
   const plur = createPlur(flags)
 
   const id = args[0]
   if (!id) {
-    exit(1, 'Usage: plur promote <engram-id>')
+    exit(1, 'Usage: plur promote <engram-id>              (activate a candidate)\n' +
+            '       plur promote <engram-id> --to <scope>  (move to another scope — alias of plur rescope)')
   }
 
   const engram = await plur.getById(id)

--- a/packages/cli/src/commands/rescope.ts
+++ b/packages/cli/src/commands/rescope.ts
@@ -1,0 +1,66 @@
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+
+const USAGE =
+  'Usage: plur rescope <engram-id> [<engram-id> ...] --to <scope> [--keep-local] [--dry-run]\n' +
+  '  Moves engram(s) to another scope (#676). Remote target scopes (configured\n' +
+  '  writable stores) receive a pushed copy (server assigns the id) and the local\n' +
+  '  original is retired with a superseded_by link; local targets (local, global,\n' +
+  '  project:*) are rewritten in place, preserving id and activation.\n' +
+  '  --keep-local  keep the local original active after a remote push\n' +
+  '  --dry-run     preview every decision without changing anything'
+
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  const ids: string[] = []
+  let to: string | undefined
+  let keepLocal = false
+  let dryRun = false
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === '--to') {
+      to = args[i + 1]
+      i++
+    } else if (a === '--keep-local') {
+      keepLocal = true
+    } else if (a === '--dry-run') {
+      dryRun = true
+    } else if (a.startsWith('--')) {
+      exit(1, `Unknown flag: ${a}\n${USAGE}`)
+    } else {
+      ids.push(a)
+    }
+  }
+  if (ids.length === 0 || !to) {
+    exit(1, USAGE)
+  }
+
+  const plur = createPlur(flags)
+  const { results, success } = await plur.rescope(ids, to!, { keep_local: keepLocal, dry_run: dryRun })
+
+  if (shouldOutputJson(flags)) {
+    outputJson({ success, dry_run: dryRun || undefined, results })
+  } else {
+    for (const r of results) {
+      const prefix = dryRun ? '[dry-run] ' : ''
+      switch (r.status) {
+        case 'rescoped':
+          outputText(
+            r.action === 'remote_push'
+              ? `${prefix}${r.id}: ${r.from_scope} -> ${r.to_scope}${r.new_id ? ` (server id ${r.new_id})` : ''}${r.kept_local ? ' — local original kept' : ' — local original retired'}`
+              : `${prefix}${r.id}: ${r.from_scope} -> ${r.to_scope} (in place)`,
+          )
+          break
+        case 'deduped':
+          outputText(`${prefix}${r.id}: identical engram already at ${r.to_scope} (${r.new_id}) — idempotent, no duplicate created`)
+          break
+        case 'noop':
+          outputText(`${prefix}${r.id}: already in scope ${r.to_scope}`)
+          break
+        case 'error':
+          outputText(`${prefix}${r.id}: ERROR — ${r.error}`)
+          break
+      }
+    }
+  }
+  if (!success) process.exit(1)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,6 +41,8 @@ Commands:
   packs export <name>     Export engrams as a pack
   similarity-search <q>   Search by cosine similarity with scores
   promote <id>            Promote an engram to active
+  rescope <id...> --to <scope>  Move engram(s) to another scope (#676)
+                          [--keep-local] [--dry-run]; also: promote <id> --to <scope>
   migrate [up|down|status] Run schema migrations
   stores list             List configured stores
   stores add <path>       Add a knowledge store
@@ -104,6 +106,7 @@ const COMMANDS: Record<string, string> = {
   ingest: './commands/ingest.js',
   import: './commands/import.js',
   promote: './commands/promote.js',
+  rescope: './commands/rescope.js',
   'similarity-search': './commands/similarity-search.js',
   stores: './commands/stores.js',
   scopes: './commands/scopes.js',

--- a/packages/cli/test/rescope.test.ts
+++ b/packages/cli/test/rescope.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `plur rescope <id...> --to <scope>` (#676) — CLI surface for scope movement,
+ * plus the `plur promote <id> --to <scope>` spelling that delegates to it
+ * (promote WITHOUT --to keeps its historical candidate-activation meaning).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('plur rescope', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-cli-rescope-')) })
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  function run(args: string): string {
+    return execSync(`node ${CLI} ${args} --path ${dir} --json`, {
+      encoding: 'utf-8',
+      timeout: 15000,
+    }).trim()
+  }
+
+  function learn(statement: string, scope: string): string {
+    const output = run(`learn "${statement}" --scope ${scope}`)
+    return JSON.parse(output).id as string
+  }
+
+  it('moves an engram to another scope and preserves its id', () => {
+    const id = learn('cli rescope statement', 'project:alpha')
+    const output = JSON.parse(run(`rescope ${id} --to global`))
+    expect(output.success).toBe(true)
+    expect(output.results[0]).toMatchObject({ id, status: 'rescoped', to_scope: 'global', new_id: id })
+
+    const listed = JSON.parse(run('list'))
+    const row = (listed.engrams ?? listed).find((e: any) => e.id === id)
+    expect(row.scope).toBe('global')
+  })
+
+  it('--dry-run previews without changing anything', () => {
+    const id = learn('cli dry run statement', 'project:alpha')
+    const output = JSON.parse(run(`rescope ${id} --to global --dry-run`))
+    expect(output.success).toBe(true)
+    expect(output.dry_run).toBe(true)
+    expect(output.results[0]).toMatchObject({ status: 'rescoped', dry_run: true })
+
+    const listed = JSON.parse(run('list'))
+    const row = (listed.engrams ?? listed).find((e: any) => e.id === id)
+    expect(row.scope).toBe('project:alpha')
+  })
+
+  it('accepts multiple ids in one call', () => {
+    const a = learn('cli batch one', 'project:alpha')
+    const b = learn('cli batch two', 'project:alpha')
+    const output = JSON.parse(run(`rescope ${a} ${b} --to global`))
+    expect(output.success).toBe(true)
+    expect(output.results.map((r: any) => r.status)).toEqual(['rescoped', 'rescoped'])
+  })
+
+  it('exits 1 without --to or without ids', () => {
+    expect(() => run('rescope ENG-2026-0101-001')).toThrow()
+    expect(() => run('rescope --to global')).toThrow()
+  })
+
+  it('exits 1 with a structured error for an unconfigured shared target scope', () => {
+    const id = learn('cli typo scope statement', 'local')
+    let failed = false
+    try {
+      run(`rescope ${id} --to group:plur-ai/engineering`)
+    } catch (err: any) {
+      failed = true
+      // With --json the structured error lands on stdout before exit(1).
+      const out = String(err.stdout ?? '')
+      expect(out).toMatch(/no configured store matches/)
+    }
+    expect(failed).toBe(true)
+  })
+
+  it('`plur promote <id> --to <scope>` delegates to rescope', () => {
+    const id = learn('cli promote-to statement', 'project:alpha')
+    const output = JSON.parse(run(`promote ${id} --to global`))
+    expect(output.success).toBe(true)
+    expect(output.results[0]).toMatchObject({ id, status: 'rescoped', to_scope: 'global' })
+  })
+})

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { createHash } from 'crypto'
 
 export interface HistoryEvent {
-  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome' | 'session_scope_changed'
+  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'engram_rescoped' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome' | 'session_scope_changed'
   /**
    * Engram this event belongs to. Session-level events
    * (`session_scope_changed`) carry no engram — they use `''`, which by

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -426,6 +426,50 @@ export interface RegisterDiscoveredResult {
   error?: string
 }
 
+/** Options for {@link Plur.rescope} (#676). */
+export interface RescopeOptions {
+  /**
+   * After a successful REMOTE push, keep the local source engram active
+   * instead of retiring it. Default false: the source is soft-retired with a
+   * `superseded_by` link to the server copy, so it stops injecting and its
+   * content hash cannot resurrect it (`_hashDedup` only matches active rows).
+   * Ignored for local (in-place) rescopes — those move the row, nothing to keep.
+   */
+  keep_local?: boolean
+  /** Report what WOULD happen without mutating anything, local or remote. */
+  dry_run?: boolean
+}
+
+/** Per-engram outcome of {@link Plur.rescope} (#676). */
+export interface RescopeResult {
+  /** Source engram id the caller passed. */
+  id: string
+  /**
+   * 'rescoped'  — moved (or, with dry_run, would move).
+   * 'deduped'   — an identical engram (content-hash + scope match) already
+   *               exists at the target: idempotent success, nothing pushed;
+   *               the source is still retired per keep_local (constraint 5).
+   * 'noop'      — source already carries the target scope.
+   * 'error'     — nothing was changed for this id; see `error`.
+   */
+  status: 'rescoped' | 'deduped' | 'noop' | 'error'
+  /** Which path handled it: push to a configured remote store, or in-place scope rewrite. */
+  action?: 'remote_push' | 'local_rewrite'
+  from_scope?: string
+  to_scope?: string
+  /**
+   * Where the engram lives after the rescope: the SERVER-assigned id for a
+   * remote push, the unchanged id for a local rewrite, or the pre-existing
+   * target engram's id on a dedup hit.
+   */
+  new_id?: string
+  /** True when the local source stayed active (keep_local remote push). */
+  kept_local?: boolean
+  /** Echoed when options.dry_run was set — nothing was mutated. */
+  dry_run?: boolean
+  error?: string
+}
+
 /**
  * Sanitize a remote-served `forbid` list to the known SENSITIVITY_CATEGORIES
  * (scope-audit 2026-07-24). Belt-and-braces behind the /me schema validation:
@@ -4384,6 +4428,297 @@ export class Plur {
       )
     }
     throw new Error(`Engram not found: ${id}`)
+  }
+
+  /**
+   * Move existing engram(s) to `targetScope` (#676) — the missing primitive
+   * between `learn()` (whose content-hash dedup silently no-ops a re-emit
+   * under a new scope) and candidate promotion (`plur_promote` ACTIVATES a
+   * candidate — it never changes scope).
+   *
+   * Routing by target:
+   *  - REMOTE-backed scope (a writable `stores:` url entry): push a copy via
+   *    the routed write path (`appendAndGetServerId` — the server assigns the
+   *    id; its own content-hash dedup is relied on, not fought), with
+   *    provenance stamped in the copy's `source` field ("rescoped from <id>")
+   *    and `structured_data._rescoped_from`. Then, unless `keep_local`,
+   *    soft-retire the local source with a `superseded_by` link so it stops
+   *    injecting; retired rows are invisible to `_hashDedup`, so the source's
+   *    hash cannot resurrect it. Deliberately NO outbox fallback: an explicit
+   *    move either lands or fails loud — on push failure the source stays
+   *    untouched (atomic semantics, #676 constraint 2).
+   *  - LOCAL-family target (`local`, `global`, `project:*`, or the scope of a
+   *    configured path store): rewrite `scope` in place under the store lock —
+   *    the same incremental update path as `updateEngram`'s local branch — so
+   *    id, activation, feedback and history stay attached to the same row.
+   *
+   * Guards:
+   *  - Target validation (#676 constraint 4): a scope that is neither
+   *    local-family nor backed by a configured store fails EARLY with a
+   *    structured error — never a silent success that strands the engram
+   *    un-synced (the `group:plur-ai/engineering` typo case).
+   *  - Authorization: the same client-side rule as the learnRouted write path —
+   *    a readonly store entry is refused.
+   *  - Sensitivity (mirrors `_guardExplicitUpdate`'s remote arm): a rescope to
+   *    a shared/remote scope re-scans the FULL content (statement + context
+   *    fields via `_engramContextFields`). An offending hit BLOCKS that id —
+   *    an explicit move must fail loud, never silently demote.
+   *  - Dedup on target (#676 constraint 5): an identical ACTIVE engram already
+   *    at the target (content-hash AND scope match) is idempotent success —
+   *    nothing pushed, and the source is still retired per `keep_local`, so
+   *    re-running a partially-failed batch converges.
+   *
+   * Batch-first (#676 constraint 3): `idOrIds` accepts one id or an array;
+   * outcomes are per-id and one failure never blocks the rest. `dry_run`
+   * reports every decision without mutating anything, local or remote.
+   */
+  async rescope(
+    idOrIds: string | string[],
+    targetScope: string,
+    options?: RescopeOptions,
+  ): Promise<{ results: RescopeResult[]; success: boolean }> {
+    const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds]
+    if (ids.length === 0) throw new TypeError('plur.rescope: provide at least one engram id')
+    if (typeof targetScope !== 'string' || targetScope.trim() === '') {
+      throw new TypeError('plur.rescope: target scope must be a non-empty string')
+    }
+    const target = targetScope.trim()
+    // Pick up out-of-process config edits (#307) so a store registered after
+    // startup is a valid target without a restart — mirrors _resolveUnscopedScope.
+    this.reloadConfigIfChanged()
+
+    // --- Resolve the target route ONCE, before touching any engram, so an
+    // invalid target fails the whole batch early (#676 constraint 4). ---
+    const remoteDriver = this._resolveRemoteStoreForScope(target)
+    const storeEntry = (this.config.stores ?? []).find(s => s.scope === target)
+    const isLocalFamily = target === 'local' || target === 'global' || target.startsWith('project:')
+    let route: 'remote' | 'local'
+    if (remoteDriver) {
+      route = 'remote'
+    } else if (storeEntry?.url && storeEntry.readonly === true) {
+      // Authorization: same rule the learnRouted write path applies — a
+      // readonly entry never receives writes. Refuse rather than leave the
+      // engram stranded somewhere it can never sync from.
+      throw new Error(
+        `Cannot rescope to "${target}": the configured store for that scope is readonly for this client. `
+        + `Ask for write access or pick another scope.`,
+      )
+    } else if (isLocalFamily || storeEntry) {
+      route = 'local'
+    } else {
+      const configured = (this.config.stores ?? []).map(s => s.scope)
+      throw new Error(
+        `Cannot rescope to "${target}": no configured store matches that scope. `
+        + `Valid targets: local, global, project:*`
+        + (configured.length ? `, or a configured store scope (${configured.join(', ')})` : '')
+        + `. Check for typos — an unmatched shared scope would never reach a team store (#676).`,
+      )
+    }
+
+    const opts = { dryRun: options?.dry_run === true, keepLocal: options?.keep_local === true }
+    const results: RescopeResult[] = []
+    for (const id of ids) {
+      results.push(await this._rescopeOne(id, target, route, remoteDriver, opts))
+    }
+    return { results, success: results.every(r => r.status !== 'error') }
+  }
+
+  /** One engram's rescope — see {@link rescope} for the contract. */
+  private async _rescopeOne(
+    id: string,
+    target: string,
+    route: 'remote' | 'local',
+    remoteDriver: RemoteStore | null,
+    opts: { dryRun: boolean; keepLocal: boolean },
+  ): Promise<RescopeResult> {
+    const action = route === 'remote' ? ('remote_push' as const) : ('local_rewrite' as const)
+    // The source must live in the local primary store: that is where stranded
+    // wrong-scope engrams sit (#676), and the only place this client can
+    // atomically retire from. A namespaced secondary/remote row gets a pointed
+    // error instead of a half-move.
+    const engrams = await this._loadCached(this.paths.engrams)
+    const source = engrams.find(e => e.id === id)
+    if (!source) {
+      const elsewhere = await this.getById(id)
+      return {
+        id, status: 'error', action,
+        error: elsewhere
+          ? `Engram ${id} lives in a secondary/remote store (scope ${elsewhere.scope}) — rescope supports engrams in the local primary store`
+          : `Engram not found: ${id}`,
+      }
+    }
+    if (source.status === 'retired') {
+      return { id, status: 'error', action, from_scope: source.scope, error: `Cannot rescope retired engram ${id}` }
+    }
+    if (source.scope === target) {
+      return { id, status: 'noop', action, from_scope: source.scope, to_scope: target, new_id: id }
+    }
+
+    // Sensitivity guard: a target where content can leave the machine or be
+    // read by others re-scans the FULL content (statement + context fields —
+    // the same surface as _guardExplicitUpdate, LOW-2 #353). Explicit rescope
+    // BLOCKS on a hit — no silent demote.
+    const ctx = this._engramContextFields(source)
+    const scanText = ctx ? `${source.statement}\n${JSON.stringify(ctx)}` : source.statement
+    const offending = this._offendingHitsForScope(scanText, target)
+    if (offending.length > 0) {
+      const patterns = [...new Set(offending.map(h => h.pattern))].join(', ')
+      return {
+        id, status: 'error', action, from_scope: source.scope, to_scope: target,
+        error: `Blocked: sensitive content (${patterns}) must not reach shared scope "${target}". `
+          + `Remove the sensitive material (or allow the category via the scope's sensitivity policy) and retry.`,
+      }
+    }
+
+    // Dedup on target (#676 constraint 5): identical content already AT the
+    // target scope is idempotent success — never a duplicate. _loadAllEngrams
+    // sees the primary store plus the cached remote view; for a cold remote
+    // cache the server's own content-hash dedup is the backstop.
+    const hash = (source as any).content_hash ?? computeContentHash(source.statement)
+    const all = await this._loadAllEngrams()
+    const existing = all.find(e =>
+      e.id !== id && e.status === 'active' && (e as any).content_hash === hash && e.scope === target)
+    if (existing) {
+      const targetId = ((existing as any)._originalId as string | undefined) ?? existing.id
+      const retire = route === 'local' || !opts.keepLocal
+      if (!opts.dryRun && retire) {
+        await this._retireRescopedSource(id, target, targetId)
+      }
+      return {
+        id, status: 'deduped', action, from_scope: source.scope, to_scope: target,
+        new_id: targetId,
+        ...(route === 'remote' ? { kept_local: opts.keepLocal } : {}),
+        ...(opts.dryRun ? { dry_run: true } : {}),
+      }
+    }
+
+    if (opts.dryRun) {
+      return {
+        id, status: 'rescoped', action, from_scope: source.scope, to_scope: target,
+        ...(route === 'remote' ? { kept_local: opts.keepLocal } : { new_id: id }),
+        dry_run: true,
+      }
+    }
+
+    const now = new Date().toISOString()
+    if (route === 'remote') {
+      // Build the pushed copy: scope rewritten, provenance in `source` (rides
+      // the wire — see appendAndGetServerId) and in structured_data, with
+      // PLUR-internal bookkeeping keys (_outbox, _routed, …) stripped.
+      const provenance = `rescoped from ${id} (${source.scope})`
+      const copy: Engram = {
+        ...source,
+        scope: target,
+        source: source.source ? `${source.source} — ${provenance}` : provenance,
+      }
+      const sd = (source as any).structured_data
+      const cleanSd = sd && typeof sd === 'object' && !Array.isArray(sd)
+        ? Object.fromEntries(Object.entries(sd as Record<string, unknown>).filter(([k]) => !k.startsWith('_')))
+        : {}
+      ;(copy as any).structured_data = {
+        ...cleanSd,
+        _rescoped_from: { id, scope: source.scope, at: now },
+      }
+      let serverId: string
+      try {
+        ;({ id: serverId } = await remoteDriver!.appendAndGetServerId(copy))
+      } catch (err) {
+        // Atomic semantics (#676 constraint 2): the push did not land, so the
+        // source stays exactly as it was. Deliberately NO outbox fallback — an
+        // explicit move reports failure instead of becoming a maybe-later.
+        const msg = (err as Error).message
+        const authHint = /\b40[13]\b/.test(msg)
+          ? ' The store token was refused (401/403) — re-authenticate and retry.'
+          : ''
+        return {
+          id, status: 'error', action, from_scope: source.scope, to_scope: target,
+          error: `Remote push failed — source engram left untouched: ${msg}.${authHint}`,
+        }
+      }
+      if (!opts.keepLocal) {
+        await this._retireRescopedSource(id, target, serverId)
+      }
+      appendHistory(this.paths.root, {
+        event: 'engram_rescoped',
+        engram_id: id,
+        timestamp: now,
+        data: { from_scope: source.scope, to_scope: target, new_id: serverId, routed_to: 'remote', kept_local: opts.keepLocal },
+      })
+      return {
+        id, status: 'rescoped', action, from_scope: source.scope, to_scope: target,
+        new_id: serverId, kept_local: opts.keepLocal,
+      }
+    }
+
+    // Local route: rewrite scope IN PLACE under the store lock — the same
+    // incremental update path as updateEngram's local branch. Id, activation,
+    // feedback, relations and history all stay attached to the same row.
+    const rewritten = await this._withStoreLock(this.paths.engrams, async () => {
+      const fresh = await this._primaryStore.load()
+      const t = fresh.find(e => e.id === id)
+      if (!t || t.status === 'retired') return false
+      const from = t.scope
+      t.scope = target
+      const tsd = (t as any).structured_data
+      ;(t as any).structured_data = {
+        ...(tsd && typeof tsd === 'object' && !Array.isArray(tsd) ? tsd : {}),
+        _rescoped: { from_scope: from, at: now },
+      }
+      await this._writeEngrams(this.paths.engrams, fresh)
+      await this._syncIndex()
+      return true
+    })
+    if (!rewritten) {
+      return {
+        id, status: 'error', action, from_scope: source.scope, to_scope: target,
+        error: `Engram ${id} changed underneath the rescope (retired or removed concurrently) — nothing written`,
+      }
+    }
+    appendHistory(this.paths.root, {
+      event: 'engram_rescoped',
+      engram_id: id,
+      timestamp: now,
+      data: { from_scope: source.scope, to_scope: target, new_id: id, routed_to: 'local' },
+    })
+    return { id, status: 'rescoped', action, from_scope: source.scope, to_scope: target, new_id: id }
+  }
+
+  /**
+   * Soft-retire the local source of a successful rescope, with a
+   * supersedes-style link to the copy now living at the target (#676).
+   * UNCONDITIONAL retirement — deliberately NOT the reference-counted
+   * `forget()` path: the engram did not lose one referent, it MOVED, so a
+   * reference_count > 1 must not leave a still-active local duplicate
+   * injecting alongside the team copy. Retired rows are excluded from
+   * `_hashDedup` (the hash cannot resurrect the source) and from every
+   * injection/list surface (status filters).
+   */
+  private async _retireRescopedSource(id: string, toScope: string, newId: string): Promise<void> {
+    const now = new Date().toISOString()
+    await this._withStoreLock(this.paths.engrams, async () => {
+      const fresh = await this._primaryStore.load()
+      const t = fresh.find(e => e.id === id)
+      if (!t) return
+      t.status = 'retired'
+      if (!t.rationale) t.rationale = `Retired: rescoped to ${toScope} as ${newId}`
+      const rel = t.relations ?? { broader: [], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: [] }
+      rel.superseded_by = rel.superseded_by ?? []
+      if (!rel.superseded_by.includes(newId)) rel.superseded_by.push(newId)
+      t.relations = rel
+      const tsd = (t as any).structured_data
+      ;(t as any).structured_data = {
+        ...(tsd && typeof tsd === 'object' && !Array.isArray(tsd) ? tsd : {}),
+        _rescoped: { to_scope: toScope, to_id: newId, at: now },
+      }
+      await this._writeEngrams(this.paths.engrams, fresh)
+      await this._syncIndex()
+    })
+    appendHistory(this.paths.root, {
+      event: 'engram_retired',
+      engram_id: id,
+      timestamp: now,
+      data: { reason: `rescoped to ${toScope}`, rescoped_to: newId, routed_to: 'rescope' },
+    })
   }
 
   /** Remove retired engrams from storage. Returns count of removed and remaining. */

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -335,6 +335,11 @@ export class RemoteStore implements EngramStore {
       ...(valid_until != null               ? { valid_until }                  : {}),
       ...(Array.isArray(supersedes) && supersedes.length > 0 ? { supersedes } : {}),
       ...(e.locked_reason != null           ? { locked_reason: e.locked_reason } : {}),
+      // Provenance rides the wire when present (#676 rescope: the pushed copy
+      // carries "rescoped from <original id>" in `source`). Additive — servers
+      // that don't model `source` ignore the field, and it is omitted entirely
+      // when unset so the historical body is byte-identical without it.
+      ...(e.source != null                  ? { source: e.source }             : {}),
     })
     const r = await fetch(`${this.apiBase}/engrams`, {
       method: 'POST',

--- a/packages/core/test/helpers/stub-server.ts
+++ b/packages/core/test/helpers/stub-server.ts
@@ -257,7 +257,7 @@ export class StubServer {
     if (method === 'POST' && path === '/api/v1/engrams') {
       this.readBody(req, (body) => {
         this.lastAppendBody = body
-        const { statement, scope, domain, type } = body
+        const { statement, scope, domain, type, source } = body
         const id = `ENG-SRV-${String(++this.idCounter).padStart(3, '0')}`
         const now = new Date().toISOString()
         const engram: StoredEngram = {
@@ -266,7 +266,9 @@ export class StubServer {
           // the wire. A non-string scope falls back the same way a missing one does.
           scope: typeof scope === 'string' ? scope : 'global',
           status: 'active',
-          data: { statement, domain, type },
+          // `source` carries rescope provenance over the wire (#676) — keep it
+          // so tests can assert the pushed shape.
+          data: { statement, domain, type, ...(source !== undefined ? { source } : {}) },
           created_at: now,
           updated_at: now,
         }

--- a/packages/core/test/rescope.test.ts
+++ b/packages/core/test/rescope.test.ts
@@ -1,0 +1,358 @@
+/**
+ * plur.rescope() (#676) — move an existing engram to a different scope.
+ *
+ * Covers the accepted design constraints from the issue thread:
+ *  1. content-hash dedup must not intercept a rescope (match by id, move)
+ *  2. atomic semantics — on partial/remote failure the source stays intact
+ *  3. batch support (`ids: string[]`) first-class
+ *  4. target-store validation — unknown scope fails early, structured error
+ *  5. dedup on target — identical engram already there = idempotent success
+ *
+ * Plus: local in-place rescope preserves id/activation, the retired source
+ * cannot be resurrected via its content hash, sensitivity guard blocks a
+ * promote to a shared scope, and dry_run mutates nothing (local or remote).
+ *
+ * Remote legs run against the in-process StubServer (real HTTP, real wire
+ * shapes) — the same harness as remote-integration.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, readdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { StubServer } from './helpers/stub-server.js'
+
+const TOKEN = 'rescope-test-token'
+let server: StubServer
+let baseUrl: string
+
+beforeAll(async () => {
+  server = new StubServer(TOKEN)
+  const info = await server.start()
+  baseUrl = info.url
+})
+
+afterAll(async () => {
+  await server.stop()
+})
+
+function writeConfig(dir: string, stores: Array<Record<string, unknown>>) {
+  writeFileSync(
+    join(dir, 'config.yaml'),
+    yaml.dump({ stores, index: false }, { lineWidth: 120, noRefs: true }),
+  )
+}
+
+function readLocalEngrams(dir: string): any[] {
+  const path = join(dir, 'engrams.yaml')
+  if (!existsSync(path)) return []
+  const data = yaml.load(readFileSync(path, 'utf-8')) as { engrams?: unknown[] } | null
+  return (data?.engrams ?? []) as any[]
+}
+
+function readHistoryEvents(dir: string): any[] {
+  const historyDir = join(dir, 'history')
+  if (!existsSync(historyDir)) return []
+  const events: any[] = []
+  for (const f of readdirSync(historyDir).filter((f: string) => f.endsWith('.jsonl'))) {
+    const lines = readFileSync(join(historyDir, f), 'utf-8').split('\n').filter(l => l.trim())
+    for (const line of lines) events.push(JSON.parse(line))
+  }
+  return events
+}
+
+describe('rescope — local route (in-place scope rewrite)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rescope-local-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('rewrites scope in place, preserving id, activation and feedback', async () => {
+    const e = await plur.learn('Prefer explicit return types on exported functions', { scope: 'project:alpha' })
+    // Accumulate activation state that a move must not reset.
+    await plur.feedback(e.id, 'positive')
+    await plur.feedback(e.id, 'positive')
+    const before = (await plur.getById(e.id))!
+    expect(before.feedback_signals.positive).toBe(2)
+    const strengthBefore = before.activation.retrieval_strength
+    expect(strengthBefore).not.toBe(0.7) // feedback actually moved it
+
+    const { results, success } = await plur.rescope(e.id, 'global')
+    expect(success).toBe(true)
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      id: e.id, status: 'rescoped', action: 'local_rewrite',
+      from_scope: 'project:alpha', to_scope: 'global', new_id: e.id,
+    })
+
+    const after = (await plur.getById(e.id))!
+    expect(after.id).toBe(e.id)                       // same row — not a copy
+    expect(after.scope).toBe('global')
+    expect(after.status).toBe('active')
+    expect(after.activation.retrieval_strength).toBe(strengthBefore)
+    expect(after.feedback_signals.positive).toBe(2)
+    expect((after as any).structured_data._rescoped).toMatchObject({ from_scope: 'project:alpha' })
+
+    // Audited through the normal history mechanism.
+    const events = readHistoryEvents(dir)
+    const rescoped = events.filter(ev => ev.event === 'engram_rescoped' && ev.engram_id === e.id)
+    expect(rescoped).toHaveLength(1)
+    expect(rescoped[0].data).toMatchObject({ from_scope: 'project:alpha', to_scope: 'global', routed_to: 'local' })
+  })
+
+  it('same-scope rescope is a noop, retired source is an error, unknown id is an error', async () => {
+    const e = await plur.learn('Noop test statement', { scope: 'global' })
+    const noop = await plur.rescope(e.id, 'global')
+    expect(noop.results[0].status).toBe('noop')
+    expect(noop.success).toBe(true)
+
+    await plur.forget(e.id)
+    const retired = await plur.rescope(e.id, 'local')
+    expect(retired.results[0].status).toBe('error')
+    expect(retired.results[0].error).toMatch(/retired/)
+    expect(retired.success).toBe(false)
+
+    const missing = await plur.rescope('ENG-9999-0101-999', 'global')
+    expect(missing.results[0].status).toBe('error')
+    expect(missing.results[0].error).toMatch(/not found/i)
+  })
+
+  it('dedup on target (constraint 5): identical engram already at the target is idempotent success', async () => {
+    const e = await plur.learn('Duplicate collapse statement', { scope: 'project:alpha' })
+    // Handcraft an identical active engram already living at the target scope
+    // (learn() can't create it — its cross-scope recurrence path would intercept).
+    const path = join(dir, 'engrams.yaml')
+    const data = yaml.load(readFileSync(path, 'utf-8')) as { engrams: any[] }
+    const src = data.engrams.find(r => r.id === e.id)
+    data.engrams.push({ ...structuredClone(src), id: 'ENG-2020-0101-001', scope: 'global' })
+    writeFileSync(path, yaml.dump(data, { lineWidth: 120, noRefs: true }))
+
+    const plur2 = new Plur({ path: dir })
+    const { results, success } = await plur2.rescope(e.id, 'global')
+    expect(success).toBe(true)
+    expect(results[0]).toMatchObject({ id: e.id, status: 'deduped', new_id: 'ENG-2020-0101-001' })
+
+    // The pair collapsed: source retired with a superseded_by link, target untouched.
+    const rows = readLocalEngrams(dir)
+    const srcRow = rows.find(r => r.id === e.id)
+    const dupRow = rows.find(r => r.id === 'ENG-2020-0101-001')
+    expect(srcRow.status).toBe('retired')
+    expect(srcRow.relations.superseded_by).toContain('ENG-2020-0101-001')
+    expect(dupRow.status).toBe('active')
+    expect(dupRow.scope).toBe('global')
+  })
+
+  it('batch (constraint 3): per-id outcomes, one failure never blocks the rest', async () => {
+    const a = await plur.learn('Batch statement alpha', { scope: 'project:alpha' })
+    const b = await plur.learn('Batch statement beta', { scope: 'project:alpha' })
+    const { results, success } = await plur.rescope([a.id, 'ENG-0000-0000-000', b.id], 'global')
+    expect(success).toBe(false)
+    expect(results.map(r => r.status)).toEqual(['rescoped', 'error', 'rescoped'])
+    expect((await plur.getById(a.id))!.scope).toBe('global')
+    expect((await plur.getById(b.id))!.scope).toBe('global')
+  })
+
+  it('dry_run mutates nothing on the local route', async () => {
+    const e = await plur.learn('Dry run local statement', { scope: 'project:alpha' })
+    const yamlBefore = readFileSync(join(dir, 'engrams.yaml'), 'utf-8')
+
+    const { results, success } = await plur.rescope(e.id, 'global', { dry_run: true })
+    expect(success).toBe(true)
+    expect(results[0]).toMatchObject({ id: e.id, status: 'rescoped', dry_run: true, to_scope: 'global' })
+
+    expect(readFileSync(join(dir, 'engrams.yaml'), 'utf-8')).toBe(yamlBefore)
+    expect((await plur.getById(e.id))!.scope).toBe('project:alpha')
+  })
+
+  it('fails early on a target scope with no configured store (constraint 4 — the typo case)', async () => {
+    const e = await plur.learn('Typo scope statement', { scope: 'local' })
+    await expect(plur.rescope(e.id, 'group:plur-ai/engineering')).rejects.toThrow(/no configured store matches/)
+    // Nothing changed.
+    expect((await plur.getById(e.id))!.scope).toBe('local')
+  })
+})
+
+describe('rescope — remote route (StubServer)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    server.reset()
+    dir = mkdtempSync(join(tmpdir(), 'plur-rescope-remote-'))
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  function remotePlur(token = TOKEN, extra: Record<string, unknown> = {}): Plur {
+    writeConfig(dir, [{ url: baseUrl, token, scope: 'group:test', shared: true, readonly: false, ...extra }])
+    return new Plur({ path: dir })
+  }
+
+  it('pushes the copy over the wire (statement/scope/domain/type/source provenance), retires the local source with a superseded_by link, and no dup injection remains', async () => {
+    const plur = remotePlur()
+    const e = await plur.learn('Team convention: always run vitest before pushing', {
+      scope: 'local', domain: 'plur.testing', type: 'procedural',
+    })
+
+    const { results, success } = await plur.rescope(e.id, 'group:test')
+    expect(success).toBe(true)
+    expect(results[0]).toMatchObject({
+      id: e.id, status: 'rescoped', action: 'remote_push',
+      from_scope: 'local', to_scope: 'group:test',
+      new_id: 'ENG-SRV-001', kept_local: false,
+    })
+
+    // Wire shape: the server-side copy carries the rewritten scope plus the
+    // statement/domain/type and the provenance-bearing source field.
+    expect(server.engramCount).toBe(1)
+    const pushed = server.getEngram('ENG-SRV-001')!
+    expect(pushed.scope).toBe('group:test')
+    expect(pushed.status).toBe('active')
+    expect(pushed.data.statement).toBe('Team convention: always run vitest before pushing')
+    expect(pushed.data.domain).toBe('plur.testing')
+    expect(pushed.data.type).toBe('procedural')
+    expect(pushed.data.source).toContain(`rescoped from ${e.id} (local)`)
+
+    // Local source: soft-retired with the supersedes-style link.
+    const rows = readLocalEngrams(dir)
+    const srcRow = rows.find(r => r.id === e.id)
+    expect(srcRow.status).toBe('retired')
+    expect(srcRow.relations.superseded_by).toContain('ENG-SRV-001')
+    expect(srcRow.structured_data._rescoped).toMatchObject({ to_scope: 'group:test', to_id: 'ENG-SRV-001' })
+
+    // No dup injection: only the team copy is active — the retired source is
+    // invisible to list()/inject() status filters.
+    const active = await plur.list()
+    expect(active.find(x => x.id === e.id)).toBeUndefined()
+    const copies = active.filter(x => x.statement === 'Team convention: always run vitest before pushing')
+    expect(copies).toHaveLength(1)
+    expect(copies[0].scope).toBe('group:test')
+  })
+
+  it('the retired source cannot be resurrected via its content hash', async () => {
+    const plur = remotePlur()
+    const stmt = 'Hash resurrection guard statement'
+    const e = await plur.learn(stmt, { scope: 'local' })
+    await plur.rescope(e.id, 'group:test')
+
+    // Fresh instance (cold remote cache): re-learning the same statement in the
+    // same scope must NOT return the retired row — _hashDedup only matches
+    // active engrams, so this is a fresh engram.
+    const plur2 = new Plur({ path: dir })
+    const relearned = await plur2.learn(stmt, { scope: 'local' })
+    expect(relearned.id).not.toBe(e.id)
+    expect(relearned.status).toBe('active')
+    const srcRow = readLocalEngrams(dir).find(r => r.id === e.id)
+    expect(srcRow.status).toBe('retired')
+  })
+
+  it('keep_local: true keeps the local original active after the push', async () => {
+    const plur = remotePlur()
+    const e = await plur.learn('Keep local original statement', { scope: 'local' })
+    const { results } = await plur.rescope(e.id, 'group:test', { keep_local: true })
+    expect(results[0]).toMatchObject({ status: 'rescoped', kept_local: true, new_id: 'ENG-SRV-001' })
+    expect(server.engramCount).toBe(1)
+
+    const srcRow = readLocalEngrams(dir).find(r => r.id === e.id)
+    expect(srcRow.status).toBe('active')
+    expect(srcRow.scope).toBe('local')
+    expect(srcRow.relations?.superseded_by ?? []).toEqual([])
+  })
+
+  it('authorization denied (401) fails loud and leaves the source untouched — no outbox, no retire (constraint 2)', async () => {
+    const plur = remotePlur('wrong-token')
+    const e = await plur.learn('Auth denied statement', { scope: 'local' })
+    const yamlBefore = readFileSync(join(dir, 'engrams.yaml'), 'utf-8')
+
+    const { results, success } = await plur.rescope(e.id, 'group:test')
+    expect(success).toBe(false)
+    expect(results[0].status).toBe('error')
+    expect(results[0].error).toMatch(/Remote push failed/)
+    expect(results[0].error).toMatch(/401/)
+    expect(results[0].error).toMatch(/re-authenticate/)
+
+    // Atomic: nothing landed, nothing changed locally, nothing queued.
+    expect(server.engramCount).toBe(0)
+    expect(readFileSync(join(dir, 'engrams.yaml'), 'utf-8')).toBe(yamlBefore)
+    const srcRow = readLocalEngrams(dir).find(r => r.id === e.id)
+    expect(srcRow.status).toBe('active')
+    expect(srcRow.structured_data?._outbox).toBeUndefined()
+  })
+
+  it('readonly store entry is refused up-front (authorization, learnRouted parity)', async () => {
+    writeConfig(dir, [{ url: baseUrl, token: TOKEN, scope: 'group:test', shared: true, readonly: true }])
+    const plur = new Plur({ path: dir })
+    const e = await plur.learn('Readonly target statement', { scope: 'local' })
+    await expect(plur.rescope(e.id, 'group:test')).rejects.toThrow(/readonly/)
+    expect(server.engramCount).toBe(0)
+    expect((await plur.getById(e.id))!.scope).toBe('local')
+  })
+
+  it('secrets/sensitivity guard blocks a promote to a shared scope (full-content re-scan)', async () => {
+    const plur = remotePlur()
+    // Infra-sensitive content is legitimate in a local scope (learn accepts it)
+    // but must not cross into a shared/remote store on an explicit rescope.
+    const e = await plur.learn('Staging DB listens on 10.0.0.5:5432 behind the bastion', { scope: 'local' })
+    expect((await plur.getById(e.id))!.scope).toBe('local')
+
+    const { results, success } = await plur.rescope(e.id, 'group:test')
+    expect(success).toBe(false)
+    expect(results[0].status).toBe('error')
+    expect(results[0].error).toMatch(/sensitive content/)
+
+    // Blocked means blocked: nothing pushed, source untouched and still active.
+    expect(server.engramCount).toBe(0)
+    const srcRow = readLocalEngrams(dir).find(r => r.id === e.id)
+    expect(srcRow.status).toBe('active')
+    expect(srcRow.scope).toBe('local')
+  })
+
+  it('sensitive content hiding in context fields (not the statement) is caught too', async () => {
+    const plur = remotePlur()
+    const e = await plur.learn('Connect to the staging database first', {
+      scope: 'local', rationale: 'the box lives at 192.168.4.20:6432',
+    })
+    const { results } = await plur.rescope(e.id, 'group:test')
+    expect(results[0].status).toBe('error')
+    expect(results[0].error).toMatch(/sensitive content/)
+    expect(server.engramCount).toBe(0)
+  })
+
+  it('dry_run mutates nothing on the remote route — no POST, no retire', async () => {
+    const plur = remotePlur()
+    const e = await plur.learn('Dry run remote statement', { scope: 'local' })
+    const yamlBefore = readFileSync(join(dir, 'engrams.yaml'), 'utf-8')
+
+    const { results, success } = await plur.rescope(e.id, 'group:test', { dry_run: true })
+    expect(success).toBe(true)
+    expect(results[0]).toMatchObject({
+      id: e.id, status: 'rescoped', action: 'remote_push',
+      to_scope: 'group:test', dry_run: true,
+    })
+
+    expect(server.engramCount).toBe(0)
+    expect(readFileSync(join(dir, 'engrams.yaml'), 'utf-8')).toBe(yamlBefore)
+  })
+
+  it('batch remote promote — the 35-engram use case in miniature', async () => {
+    const plur = remotePlur()
+    const a = await plur.learn('Team fact one for the batch', { scope: 'local' })
+    const b = await plur.learn('Team fact two for the batch', { scope: 'local' })
+    const c = await plur.learn('Team fact three for the batch', { scope: 'local' })
+
+    const { results, success } = await plur.rescope([a.id, b.id, c.id], 'group:test')
+    expect(success).toBe(true)
+    expect(results.map(r => r.status)).toEqual(['rescoped', 'rescoped', 'rescoped'])
+    expect(new Set(results.map(r => r.new_id)).size).toBe(3) // three server ids
+    expect(server.engramCount).toBe(3)
+
+    const rows = readLocalEngrams(dir)
+    for (const id of [a.id, b.id, c.id]) {
+      expect(rows.find(r => r.id === id).status).toBe('retired')
+    }
+  })
+})

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -63,7 +63,7 @@ By default (lean profile), your agent gets 12 tools. Everything else is reachabl
 | `plur_tensions_purge` | Clear stale/resolved tensions |
 | `plur_admin` | Dispatch to any other tool: `{ action: "plur_packs_install", args: {...} }` |
 
-Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 41 tools directly.
+Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 42 tools directly.
 
 A `plur_*` name missing from `tools/list` means it moved behind the gateway, not that the server is down. `plur_admin { action: "help" }` returns every action with a one-line description and its argument schema; `plur_doctor` reports the same inventory as `tool_surface`.
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -121,7 +121,8 @@ Persistent memory for AI agents. Corrections, preferences, and conventions are s
 - **plur_recall** — hybrid search by default (BM25 + embeddings); pass mode:"keyword" for BM25-only
 - **plur_feedback** — rate an engram (trains relevance)
 - **plur_forget** — retire an outdated engram
-- **plur_promote** — activate a candidate engram
+- **plur_promote** — activate a candidate engram (status only — never changes scope)
+- **plur_rescope** — move an engram to another scope (e.g. promote a local engram into a team store)
 
 ### Context Injection
 - **plur_inject** — select engrams for a task (BM25)

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -3045,7 +3045,7 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
 
     {
       name: 'plur_promote',
-      description: 'Activate candidate engrams so they appear in injection results',
+      description: 'Activate candidate engrams so they appear in injection results. Status change only — it does NOT move an engram to another scope; to promote an engram into a team/shared scope use plur_rescope (#676).',
       annotations: { title: 'Promote', destructiveHint: false, idempotentHint: true },
       inputSchema: {
         type: 'object',
@@ -3076,6 +3076,36 @@ Include at least one engram_suggestion if ANYTHING was learned. An empty suggest
         }
 
         return { promoted, errors, success: errors.length === 0 }
+      },
+    },
+
+    {
+      name: 'plur_rescope',
+      description: 'Move existing engram(s) to a different scope (#676) — e.g. promote a personal/local engram into a team scope so it reaches the shared store. Bypasses the content-hash dedup that makes a plur_learn re-emit a silent no-op: rescope matches by id and moves the engram. Remote targets (a configured writable store scope): a copy is pushed via the routed write path (the server assigns the id, provenance is kept in the copy\'s source field) and the local original is soft-retired with a superseded_by link — set keep_local:true to keep it active. Local targets (local, global, project:*): the scope is rewritten in place, preserving id and activation. The target must be local/global/project:* or a scope with a configured writable store — anything else fails early (typo protection). Content is re-scanned for secrets/sensitive material before any shared/remote target and a hit blocks the move. Batch via ids; dry_run:true previews every decision without mutating anything. NOT candidate activation — that is plur_promote.',
+      annotations: { title: 'Rescope', destructiveHint: false, idempotentHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Single engram ID to move' },
+          ids: { type: 'array', items: { type: 'string' }, description: 'Multiple engram IDs to move to the same target scope (batch)' },
+          target_scope: { type: 'string', description: 'Destination scope: local, global, project:<name>, or a scope with a configured writable store (e.g. group:org/team)' },
+          keep_local: { type: 'boolean', description: 'Remote targets only: keep the local original active after the push (default false — it is retired with a superseded_by link so it stops injecting)' },
+          dry_run: { type: 'boolean', description: 'Preview the per-engram outcome without mutating anything, local or remote' },
+        },
+        required: ['target_scope'],
+      },
+      handler: async (args, plur) => {
+        const targetIds = (args.ids as string[] | undefined) ?? (args.id ? [args.id as string] : [])
+        if (targetIds.length === 0) throw new Error('Provide id or ids')
+        const { results, success } = await plur.rescope(targetIds, args.target_scope as string, {
+          keep_local: args.keep_local as boolean | undefined,
+          dry_run: args.dry_run as boolean | undefined,
+        })
+        return {
+          results,
+          success,
+          ...(args.dry_run === true ? { dry_run: true, note: 'Dry run — nothing was changed.' } : {}),
+        }
       },
     },
 

--- a/packages/mcp/test/rescope-tool.test.ts
+++ b/packages/mcp/test/rescope-tool.test.ts
@@ -1,0 +1,107 @@
+/**
+ * plur_rescope MCP tool (#676) — scope movement, distinct from plur_promote
+ * (candidate activation). Covers: tool surface (full profile + plur_admin
+ * dispatch in lean), local rescope through the tool, dry_run passthrough,
+ * and argument validation.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '@plur-ai/core'
+import { getToolDefinitions, validateToolArgs } from '../src/tools.js'
+
+describe('plur_rescope tool', () => {
+  let plur: Plur
+  let dir: string
+  let tools: ReturnType<typeof getToolDefinitions>
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rescope-tool-'))
+    plur = new Plur({ path: dir })
+    tools = getToolDefinitions('full')
+  })
+  afterEach(() => { rmSync(dir, { recursive: true }) })
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.find(t => t.name === name)
+    if (!tool) throw new Error(`Unknown tool: ${name}`)
+    return tool.handler(args, plur)
+  }
+
+  it('is exposed in the full profile and reachable via plur_admin in the lean profile (not destructive)', () => {
+    const full = getToolDefinitions('full')
+    const rescope = full.find(t => t.name === 'plur_rescope')
+    expect(rescope).toBeDefined()
+    // Soft-retire with a superseded_by link is a move, not a delete — it must
+    // stay dispatchable through plur_admin (destructive tools are refused there).
+    expect(rescope!.annotations?.destructiveHint).toBe(false)
+
+    const lean = getToolDefinitions('lean')
+    expect(lean.find(t => t.name === 'plur_rescope')).toBeUndefined()
+    const admin = lean.find(t => t.name === 'plur_admin')
+    expect(admin).toBeDefined()
+    expect(admin!.description).toContain('plur_rescope')
+  })
+
+  it('moves an engram to a local-family scope, preserving its id', async () => {
+    const e = await plur.learn('Rescope tool statement', { scope: 'project:alpha' })
+    const result = await callTool('plur_rescope', { id: e.id, target_scope: 'global' }) as any
+    expect(result.success).toBe(true)
+    expect(result.results[0]).toMatchObject({
+      id: e.id, status: 'rescoped', to_scope: 'global', new_id: e.id,
+    })
+    expect((await plur.getById(e.id))!.scope).toBe('global')
+  })
+
+  it('dry_run reports the plan and mutates nothing', async () => {
+    const e = await plur.learn('Rescope tool dry run statement', { scope: 'project:alpha' })
+    const result = await callTool('plur_rescope', { id: e.id, target_scope: 'global', dry_run: true }) as any
+    expect(result.success).toBe(true)
+    expect(result.dry_run).toBe(true)
+    expect(result.note).toMatch(/nothing was changed/i)
+    expect(result.results[0]).toMatchObject({ status: 'rescoped', dry_run: true })
+    expect((await plur.getById(e.id))!.scope).toBe('project:alpha')
+  })
+
+  it('accepts batch ids and reports per-id outcomes', async () => {
+    const a = await plur.learn('Batch tool statement one', { scope: 'project:alpha' })
+    const b = await plur.learn('Batch tool statement two', { scope: 'project:alpha' })
+    const result = await callTool('plur_rescope', { ids: [a.id, b.id], target_scope: 'global' }) as any
+    expect(result.success).toBe(true)
+    expect(result.results.map((r: any) => r.status)).toEqual(['rescoped', 'rescoped'])
+  })
+
+  it('requires target_scope (schema) and id/ids (handler)', async () => {
+    const tool = tools.find(t => t.name === 'plur_rescope')!
+    const validated = validateToolArgs(tool, { id: 'ENG-X' })
+    expect(validated.ok).toBe(false)
+
+    await expect(callTool('plur_rescope', { target_scope: 'global' })).rejects.toThrow(/Provide id or ids/)
+  })
+
+  it('an unconfigured shared target scope fails with the structured early error', async () => {
+    const e = await plur.learn('Unknown scope tool statement', { scope: 'local' })
+    await expect(
+      callTool('plur_rescope', { id: e.id, target_scope: 'group:plur-ai/engineering' }),
+    ).rejects.toThrow(/no configured store matches/)
+  })
+
+  it('plur_admin dispatches plur_rescope in the lean profile', async () => {
+    const lean = getToolDefinitions('lean')
+    const admin = lean.find(t => t.name === 'plur_admin')!
+    const e = await plur.learn('Admin dispatch rescope statement', { scope: 'project:alpha' })
+    const result = await admin.handler(
+      { action: 'plur_rescope', args: { id: e.id, target_scope: 'global' } },
+      plur,
+    ) as any
+    expect(result.success).toBe(true)
+    expect((await plur.getById(e.id))!.scope).toBe('global')
+  })
+
+  it('plur_promote still activates candidates and its description points scope moves at plur_rescope', async () => {
+    const promote = tools.find(t => t.name === 'plur_promote')!
+    expect(promote.description).toContain('plur_rescope')
+    expect(promote.description).toMatch(/does NOT move/i)
+  })
+})

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -48,6 +48,9 @@ const ALWAYS_ASYNC = new Set([
   'checkRemoteHealth', 'discoverRemoteScopes', 'registerDiscoveredScopes',
   'registerScope', 'offerableScopes', 'warmRemoteCaches', 'waitForIndex',
   'reportFailure', 'ready',
+  // Born async (#676) — never had a sync form, so there is no pre-0.16
+  // call site for the migrate tool to rewrite.
+  'rescope',
 ])
 
 /** Public methods of `Plur`, mapped to whether they are declared `async`. */


### PR DESCRIPTION
Closes #676.

Implements the accepted `plur_rescope` design from the issue thread — the missing primitive between `plur_learn` (whose content-hash dedup silently no-ops a re-emit under a new scope) and `plur_promote` (candidate activation, which never changes scope).

## What it does

`Plur.rescope(idOrIds, targetScope, { keep_local, dry_run })` — batch-first, per-id outcomes (`rescoped` / `deduped` / `noop` / `error`), one failure never blocks the rest.

**Remote target** (scope with a configured writable `stores:` url entry):
- Pushes a copy via the routed write path (`appendAndGetServerId` — the server assigns the id; its content-hash dedup is relied on, not fought).
- Provenance kept: the pushed copy's `source` field carries `rescoped from <id> (<scope>)` (now rides the POST body — additive wire change) plus `structured_data._rescoped_from`.
- Unless `keep_local:true`, the local source is soft-retired with a `superseded_by` link — it stops injecting, and since `_hashDedup` only matches active rows its hash cannot resurrect it.
- **No outbox fallback**: an explicit move either lands or fails loud. On push failure the source is untouched (atomic semantics — thread constraint 2).

**Local target** (`local`, `global`, `project:*`, or a configured path-store scope): scope is rewritten in place under the store lock — same incremental update path as `updateEngram`'s local branch — preserving id, activation, feedback and history.

## Guards

- **Target validation (constraint 4)**: a scope that is neither local-family nor backed by a configured store fails early with a structured error — the `group:plur-ai/engineering` typo case can no longer strand engrams.
- **Authorization**: readonly store entries are refused up-front (learnRouted write-path parity); a 401/403 on push surfaces with a re-auth hint and leaves the source intact.
- **Sensitivity**: promoting to a shared/remote scope re-scans the full content (statement + context fields, same surface as `_guardExplicitUpdate`) and **blocks** on offending hits — an explicit move fails loud, never silently demotes.
- **Dedup on target (constraint 5)**: an identical active engram already at the target scope is idempotent success — nothing pushed, source still retired per `keep_local`, so re-running a partially-failed batch converges.

## Surfaces

- **MCP**: new `plur_rescope` tool (`id`/`ids`, required `target_scope`, `keep_local`, `dry_run`). `destructiveHint:false` (a move with a link, nothing deleted) so it stays dispatchable via `plur_admin` in the lean profile. `plur_promote`'s description now states it never changes scope and points at `plur_rescope`; guide + README tool counts updated.
- **CLI**: `plur rescope <id...> --to <scope> [--keep-local] [--dry-run]`, and `plur promote <id> --to <scope>` delegates to it (promote without `--to` keeps its historical candidate-activation meaning).
- **Audit**: `engram_rescoped` history events on both routes; retirement recorded through the normal history mechanism.

## Naming decisions

- Tool named `plur_rescope` per the issue-thread design acceptance — `plur_promote` is candidate activation and keeps that meaning (docs clarified).
- CLI canonical command is `rescope`; the `promote --to` spelling is kept as a natural-language bridge.

## Tests

- `packages/core/test/rescope.test.ts` (15): local rescope preserves id/activation/feedback; StubServer wire shape (statement/scope/domain/type/source provenance) + local retire + superseded_by link + no dup injection; retired-source hash non-resurrection; keep_local; 401 auth-denied fails loud with source untouched (no outbox); readonly refused; sensitivity block (statement and context-field hits); dry-run mutates nothing (both routes); batch; target-dedup idempotency; typo-scope early failure.
- `packages/mcp/test/rescope-tool.test.ts` (8): profile surface + plur_admin dispatch, handler behavior, dry-run, validation, promote/rescope docs split.
- `packages/cli/test/rescope.test.ts` (6): rescope, dry-run, batch, arg errors, typo-scope error, `promote --to` delegation.

Full suite + `pnpm -r build` + `tsc -p tsconfig.tests.json` green.
