### PR TITLE
fix(core): TTL re-check for version-behind notification (#760); unify engram id format on ENG-YYYY-MM-DD-NNN (#771)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,12 @@ plur-ai/plur#544) — don't work around it; declare the PRs.
 
 - TypeScript, Vitest, tsup, Zod for validation.
 - YAML for persistent storage (not JSON, not SQLite for primary data; SQLite is used only as an optional read index — YAML is always the source of truth).
+- Engram id grammar is specified in
+  [spec/ENGRAM-STANDARD-v1.md §3](spec/ENGRAM-STANDARD-v1.md): new ids are
+  `ENG-YYYY-MM-DD-NNN` (same shape locally and server-assigned); the legacy
+  compact `ENG-YYYY-MMDD-NNN` stays valid and every parser must accept both;
+  packs use dateless `ENG-PACK-{NAME}-NNN`; merged store ids get a 3-letter
+  prefix (`ENG-XXX-…`). Never write code that assumes only one date shape.
 - No AI attribution in commits, PRs, or issues: do not add `Co-Authored-By:` AI
   lines, `🤖 Generated with` footers, or any other AI-assistant credit to commits,
   PR descriptions, or issue comments.

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -185,11 +185,15 @@ function classify(
 
 /** Extract entity-like tokens: capitalized multi-word phrases, identifiers
  *  with mixed case or underscores, IPs, dotted paths, URLs, version-prefixed
- *  IDs. These are the high-information atoms that drive conflict detection. */
-function extractEntities(s: string): Set<string> {
+ *  IDs. These are the high-information atoms that drive conflict detection.
+ *  Exported for tests (#771 id-format tolerance). */
+export function extractEntities(s: string): Set<string> {
   const out = new Set<string>()
   // Capitalized words and CamelCase/snake_case identifiers
-  const re = /\b(?:[A-Z][a-zA-Z0-9]+(?:[-_/.][A-Za-z0-9]+)*|[a-z0-9]+(?:_[a-z0-9]+)+|ENG-\d{4}-\d{4}-\d+|\d+\.\d+\.\d+\.\d+|[a-z0-9-]+\.(?:org|com|local|io|ai|md|py|ts|js|json|yaml))\b/g
+  // Engram ids: canonical ENG-YYYY-MM-DD-NNN and legacy compact
+  // ENG-YYYY-MMDD-NNN both match (#771 — the `-?` makes the day separator
+  // optional).
+  const re = /\b(?:[A-Z][a-zA-Z0-9]+(?:[-_/.][A-Za-z0-9]+)*|[a-z0-9]+(?:_[a-z0-9]+)+|ENG-\d{4}-\d{2}-?\d{2}-\d+|\d+\.\d+\.\d+\.\d+|[a-z0-9-]+\.(?:org|com|local|io|ai|md|py|ts|js|json|yaml))\b/g
   let m
   while ((m = re.exec(s)) !== null) {
     const tok = m[0]

--- a/packages/cli/test/audit-entities.test.ts
+++ b/packages/cli/test/audit-entities.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { extractEntities } from '../src/commands/audit.js'
+
+// #771: engram ids appear in two date shapes — canonical full-date
+// (ENG-YYYY-MM-DD-NNN, also server-assigned) and legacy compact
+// (ENG-YYYY-MMDD-NNN). Entity extraction must recognize both so audit's
+// conflict detection links statements that reference the same engram.
+describe('audit extractEntities id-format tolerance', () => {
+  it('extracts canonical full-date engram ids', () => {
+    const entities = extractEntities('supersedes ENG-2026-07-26-015 per review')
+    expect(entities.has('ENG-2026-07-26-015')).toBe(true)
+  })
+
+  it('extracts legacy compact engram ids', () => {
+    const entities = extractEntities('supersedes ENG-2026-0726-015 per review')
+    expect(entities.has('ENG-2026-0726-015')).toBe(true)
+  })
+
+  it('extracts store-prefixed ids in either form', () => {
+    const entities = extractEntities('see ENG-GPL-2026-07-30-032 and ENG-DFU-2026-0401-001')
+    expect(entities.has('ENG-GPL-2026-07-30-032')).toBe(true)
+    expect(entities.has('ENG-DFU-2026-0401-001')).toBe(true)
+  })
+})

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -99,7 +99,7 @@ not silently coerced.
 A minimal engram (everything optional defaults applied):
 
 ```yaml
-id: ENG-2026-0506-001
+id: ENG-2026-05-06-001
 statement: "toEqual() in Vitest is strict — use toMatchObject() for partial matching"
 type: behavioral
 status: active

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -172,13 +172,27 @@ export function storePrefix(scope: string): string {
   return (w[0] + (w[1] || w[0]) + (w[2] || w[0])).toUpperCase()
 }
 
+/**
+ * Generate the next local engram id.
+ *
+ * Canonical format (#771): `ENG-YYYY-MM-DD-NNN` — full ISO-8601 date
+ * separators, identical to the id shape the enterprise server assigns, so an
+ * engram gets the same id whether it is minted locally or server-side.
+ * Releases before this minted a compact date (`ENG-YYYY-MMDD-NNN`); those ids
+ * remain valid forever — every parser accepts both forms (see
+ * spec/ENGRAM-STANDARD-v1.md §3.3) — but new ids are no longer minted compact.
+ *
+ * The per-day sequence counts BOTH forms, so a store upgraded mid-day
+ * continues numbering after its compact-form ids instead of restarting at 001.
+ */
 export function generateEngramId(existing: Engram[]): string {
-  const now = new Date()
-  const date = now.toISOString().slice(0, 10).replace(/-/g, '')
-  const prefix = `ENG-${date.slice(0, 4)}-${date.slice(4)}-`
+  const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+  const prefix = `ENG-${day}-`
+  // Legacy compact form minted by earlier releases: ENG-YYYYMMDD → ENG-YYYY-MMDD-
+  const legacyPrefix = `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`
   const existingNums = existing
-    .filter(e => e.id.startsWith(prefix))
-    .map(e => parseInt(e.id.slice(prefix.length), 10))
+    .filter(e => e.id.startsWith(prefix) || e.id.startsWith(legacyPrefix))
+    .map(e => parseInt(e.id.slice(e.id.startsWith(prefix) ? prefix.length : legacyPrefix.length), 10))
     .filter(n => !isNaN(n))
   const next = existingNums.length > 0 ? Math.max(...existingNums) + 1 : 1
   return `${prefix}${String(next).padStart(3, '0')}`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -189,7 +189,7 @@ export {
 } from './reranker-eval.js'
 export type { SimilarityResult } from './embeddings.js'
 export type { SyncResult, SyncStatus, SyncRemoteType } from './sync.js'
-export { checkForUpdate, settleVersionChecks, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, type VersionCheckResult } from './version-check.js'
+export { checkForUpdate, settleVersionChecks, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, VERSION_CHECK_SUCCESS_TTL_MS, VERSION_CHECK_FAILURE_TTL_MS, type VersionCheckResult } from './version-check.js'
 export { scanForTensions, getCandidatePairs, scopesOverlap, domainSegmentsOverlap, subjectsOverlap, statementOverlap, buildContradictionPrompt, parseContradictionResponse, buildBatchContradictionPrompt, parseBatchContradictionResponse, engramDate, daysApart, inTemporalDomain, temporalDiscountFactor, SNAPSHOT_CONFIDENCE_CAP, type ContradictionVerdict, type TensionPair, type TensionScanResult, type TensionScanOptions, type TemporalGateOptions, type CandidatePairOptions, type JudgeStatement } from './tensions.js'
 // Tension lifecycle persistence (#181)
 export { loadTensions, saveTensions, generateTensionId, tensionPairKey, categorizeTension } from './tension-store.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -821,7 +821,8 @@ export class Plur {
    * vanished from `recall()` while `list()` still showed it), and it returned
    * rows RAW — no namespacing, no `global` narrowing, no `isScopeWithin` guard.
    * The namespacing one had teeth beyond cosmetics: both stores mint
-   * `ENG-YYYY-MMDD-NNN` from a per-store daily sequence, so ids collide as the
+   * date-sequenced ids (`ENG-YYYY-MM-DD-NNN`, legacy `ENG-YYYY-MMDD-NNN`)
+   * from a per-store daily sequence, so ids collide as the
    * common case, and `feedback()` / `forget()` resolve by exact id against the
    * primary store first — mutating an unrelated engram.
    *

--- a/packages/core/src/tension-store.ts
+++ b/packages/core/src/tension-store.ts
@@ -60,8 +60,9 @@ const SUPERSEDED_PATTERN = /\(\s*not\s+[^)]+\)/i
 
 /**
  * Recorded date of an engram: `temporal.learned_at`, falling back to the
- * date embedded in canonical ids (ENG-YYYY-MMDD-NNN, ENG-PREFIX-YYYY-MMDD-NNN,
- * server-assigned ENG-YYYY-MM-DD-NNN). Undefined when underivable.
+ * date embedded in the id — canonical ENG-YYYY-MM-DD-NNN (also what servers
+ * assign, #771), legacy compact ENG-YYYY-MMDD-NNN, and either form behind a
+ * store prefix (ENG-{PREFIX}-...). Undefined when underivable.
  */
 function recordedDate(e: Engram): string | undefined {
   const learned = e.temporal?.learned_at

--- a/packages/core/src/tensions.ts
+++ b/packages/core/src/tensions.ts
@@ -32,10 +32,11 @@ export interface JudgeStatement {
 /**
  * Resolve the recorded date of an engram (#240 Layer 3 prompt half).
  *
- * Prefers `temporal.learned_at`; falls back to the date embedded in the
- * canonical id forms `ENG-YYYY-MMDD-NNN`, `ENG-{PREFIX}-YYYY-MMDD-NNN`, and
- * the server-assigned `ENG-YYYY-MM-DD-NNN`. Returns undefined when no date
- * is derivable — callers must degrade gracefully.
+ * Prefers `temporal.learned_at`; falls back to the date embedded in the id.
+ * Accepts the canonical `ENG-YYYY-MM-DD-NNN` (also what servers assign, #771),
+ * the legacy compact `ENG-YYYY-MMDD-NNN`, and either form behind a store
+ * prefix (`ENG-{PREFIX}-...`). Returns undefined when no date is derivable —
+ * callers must degrade gracefully.
  */
 export function engramDate(e: Engram): string | undefined {
   const learned = e.temporal?.learned_at

--- a/packages/core/src/version-check.ts
+++ b/packages/core/src/version-check.ts
@@ -1,7 +1,24 @@
 /**
- * Non-blocking version check against npm registry.
- * Caches result in memory — one fetch per process lifetime.
+ * Non-blocking version check against the npm registry.
  * Never throws or blocks startup.
+ *
+ * Results are cached in memory with a TTL (#760): a successful registry
+ * answer is reused for VERSION_CHECK_SUCCESS_TTL_MS, a failed attempt
+ * (offline, timeout, non-OK response) only for VERSION_CHECK_FAILURE_TTL_MS.
+ * Before the TTLs existed the cache was "one fetch per process lifetime",
+ * which silently disabled the update notification in exactly the two cases
+ * it matters most:
+ *
+ *   1. A long-lived MCP server process that started while current cached
+ *      "no update" forever and never learned about releases published after
+ *      startup — the #760 report: 0.14.0 stayed silent while 0.16.1 shipped.
+ *   2. A process that started offline (laptop resume, network race at boot)
+ *      cached the failed check forever and never retried.
+ *
+ * Reads stay synchronous and zero-cost: an expired entry is returned as-is
+ * while a background refresh is kicked off, so no caller ever waits on the
+ * network. Air-gapped installs pay at most one 3-second attempt per failure
+ * window, always off the hot path.
  */
 
 export interface VersionCheckResult {
@@ -11,11 +28,33 @@ export interface VersionCheckResult {
   checkedAt: number | null
 }
 
-/** Module-level cache: package name → result */
-const cache = new Map<string, VersionCheckResult>()
+/** Reuse a successful registry answer for this long before re-checking. */
+export const VERSION_CHECK_SUCCESS_TTL_MS = 6 * 60 * 60 * 1000 // 6 hours
+
+/** Retry a failed attempt (offline, timeout) after this long. */
+export const VERSION_CHECK_FAILURE_TTL_MS = 30 * 60 * 1000 // 30 minutes
+
+interface CacheEntry {
+  result: VersionCheckResult
+  /** When the fetch attempt finished (success or failure) — drives the TTL. */
+  fetchedAt: number
+  /** Whether the registry answered with a usable version. */
+  ok: boolean
+}
+
+/** Module-level cache: package name → entry */
+const cache = new Map<string, CacheEntry>()
+
+/** In-flight check per package — concurrent refresh requests piggyback. */
+const inflightByPackage = new Map<string, Promise<VersionCheckResult>>()
 
 /** Checks that have been started but have not yet written their result. */
 const inflight = new Set<Promise<VersionCheckResult>>()
+
+function isExpired(entry: CacheEntry, now: number): boolean {
+  const ttl = entry.ok ? VERSION_CHECK_SUCCESS_TTL_MS : VERSION_CHECK_FAILURE_TTL_MS
+  return now - entry.fetchedAt >= ttl
+}
 
 /**
  * Wait for every in-flight check to finish writing to the cache.
@@ -38,7 +77,8 @@ export async function settleVersionChecks(): Promise<void> {
 }
 
 /**
- * Check npm for a newer version. Fetches once, caches forever (process lifetime).
+ * Check npm for a newer version. Returns the cached result while it is within
+ * its TTL; otherwise fetches and refreshes the cache.
  * Fire-and-forget: call at startup, read later via getCachedUpdateCheck().
  */
 export function checkForUpdate(
@@ -46,12 +86,22 @@ export function checkForUpdate(
   currentVersion: string,
   onResult?: (result: VersionCheckResult) => void,
 ): Promise<VersionCheckResult> {
-  const p = runCheck(packageName, currentVersion, onResult)
+  // Piggyback on an already-running check for the same package instead of
+  // issuing a duplicate fetch (refresh-on-read + the periodic re-check can
+  // otherwise race each other).
+  const running = inflightByPackage.get(packageName)
+  const p = running
+    ? running.then((r) => { if (onResult) onResult(r); return r })
+    : runCheck(packageName, currentVersion, onResult)
+  if (!running) inflightByPackage.set(packageName, p)
   inflight.add(p)
   // `runCheck` swallows its own errors, so neither arm can reject here; both are
   // supplied anyway so a future change cannot turn this into an unhandled
   // rejection.
-  const done = () => { inflight.delete(p) }
+  const done = () => {
+    inflight.delete(p)
+    if (inflightByPackage.get(packageName) === p) inflightByPackage.delete(packageName)
+  }
   p.then(done, done)
   return p
 }
@@ -61,14 +111,16 @@ async function runCheck(
   currentVersion: string,
   onResult?: (result: VersionCheckResult) => void,
 ): Promise<VersionCheckResult> {
-  // Return cached result if available
-  const cached = cache.get(packageName)
-  if (cached) {
-    if (onResult) onResult(cached)
-    return cached
+  // Return cached result while fresh (#760: expired entries are re-fetched,
+  // not returned forever)
+  const entry = cache.get(packageName)
+  if (entry && !isExpired(entry, Date.now())) {
+    if (onResult) onResult(entry.result)
+    return entry.result
   }
 
   const result: VersionCheckResult = { current: currentVersion, latest: null, updateAvailable: false, checkedAt: null }
+  let ok = false
   try {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 3_000)
@@ -77,16 +129,21 @@ async function runCheck(
       headers: { Accept: 'application/json' },
     })
     clearTimeout(timeout)
-    if (!res.ok) { cache.set(packageName, result); return result }
-    const data = await res.json() as { version?: string }
-    if (!data.version) { cache.set(packageName, result); return result }
-    result.latest = data.version
-    result.updateAvailable = isNewer(data.version, currentVersion)
-    result.checkedAt = Date.now()
+    if (res.ok) {
+      const data = await res.json() as { version?: string }
+      if (data.version) {
+        result.latest = data.version
+        result.updateAvailable = isNewer(data.version, currentVersion)
+        result.checkedAt = Date.now()
+        ok = true
+      }
+    }
   } catch {
-    // Network error, timeout, offline — cache the negative result
+    // Network error, timeout, offline — cache the negative result briefly
+    // (VERSION_CHECK_FAILURE_TTL_MS) so the next read retries instead of
+    // staying silent for the process lifetime.
   }
-  cache.set(packageName, result)
+  cache.set(packageName, { result, fetchedAt: Date.now(), ok })
   if (onResult) onResult(result)
   return result
 }
@@ -94,14 +151,24 @@ async function runCheck(
 /**
  * Read the cached version check result. Returns null if checkForUpdate() hasn't
  * completed yet. This is the zero-cost read path for assemblers.
+ *
+ * When the cached entry has outlived its TTL a background refresh is started
+ * (#760) so the NEXT read sees fresh data — the current read still returns
+ * synchronously with the stale value and never waits on the network.
  */
 export function getCachedUpdateCheck(packageName: string): VersionCheckResult | null {
-  return cache.get(packageName) ?? null
+  const entry = cache.get(packageName)
+  if (!entry) return null
+  if (isExpired(entry, Date.now()) && !inflightByPackage.has(packageName)) {
+    checkForUpdate(packageName, entry.result.current)
+  }
+  return entry.result
 }
 
 /** Clear cache (for testing). */
 export function clearVersionCache(): void {
   cache.clear()
+  inflightByPackage.clear()
 }
 
 /** Count how many minor versions behind `current` is from `latest`. Returns 0 if current >= latest. */

--- a/packages/core/test/engrams.test.ts
+++ b/packages/core/test/engrams.test.ts
@@ -30,10 +30,16 @@ describe('engrams', () => {
     expect(loaded).toEqual([])
   })
 
+  // #771: new ids use the canonical full-date form, identical to what the
+  // enterprise server assigns: ENG-YYYY-MM-DD-NNN.
+  it('mints canonical full-date IDs (ENG-YYYY-MM-DD-NNN)', () => {
+    const newId = generateEngramId([])
+    expect(newId).toMatch(/^ENG-\d{4}-\d{2}-\d{2}-001$/)
+    expect(newId).toBe(`ENG-${new Date().toISOString().slice(0, 10)}-001`)
+  })
+
   it('generates sequential IDs for same date', () => {
-    const now = new Date()
-    const date = now.toISOString().slice(0, 10).replace(/-/g, '')
-    const prefix = `ENG-${date.slice(0, 4)}-${date.slice(4)}`
+    const prefix = `ENG-${new Date().toISOString().slice(0, 10)}`
     const existing = [
       EngramSchema.parse({ id: `${prefix}-001`, statement: 'a', type: 'behavioral', scope: 'global', status: 'active' }),
       EngramSchema.parse({ id: `${prefix}-002`, statement: 'b', type: 'behavioral', scope: 'global', status: 'active' }),
@@ -42,11 +48,26 @@ describe('engrams', () => {
     expect(newId).toBe(`${prefix}-003`)
   })
 
-  it('starts at 001 when no existing IDs match today', () => {
+  // #771: a store upgraded mid-day already holds legacy compact ids for
+  // today — the sequence continues after them rather than restarting at 001.
+  it('continues the daily sequence across legacy compact IDs', () => {
+    const day = new Date().toISOString().slice(0, 10)
+    const legacyPrefix = `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}`
     const existing = [
-      EngramSchema.parse({ id: 'ENG-2020-0101-001', statement: 'a', type: 'behavioral', scope: 'global', status: 'active' }),
+      EngramSchema.parse({ id: `${legacyPrefix}-007`, statement: 'a', type: 'behavioral', scope: 'global', status: 'active' }),
+      EngramSchema.parse({ id: `ENG-${day}-002`, statement: 'b', type: 'behavioral', scope: 'global', status: 'active' }),
     ]
     const newId = generateEngramId(existing)
-    expect(newId).toMatch(/^ENG-\d{4}-\d{4}-001$/)
+    expect(newId).toBe(`ENG-${day}-008`)
+  })
+
+  it('starts at 001 when no existing IDs match today', () => {
+    const existing = [
+      // Legacy compact and canonical full-date ids from OTHER days are ignored
+      EngramSchema.parse({ id: 'ENG-2020-0101-001', statement: 'a', type: 'behavioral', scope: 'global', status: 'active' }),
+      EngramSchema.parse({ id: 'ENG-2020-01-02-004', statement: 'b', type: 'behavioral', scope: 'global', status: 'active' }),
+    ]
+    const newId = generateEngramId(existing)
+    expect(newId).toMatch(/^ENG-\d{4}-\d{2}-\d{2}-001$/)
   })
 })

--- a/packages/core/test/multi-store.test.ts
+++ b/packages/core/test/multi-store.test.ts
@@ -159,6 +159,27 @@ describe('Multi-store', () => {
     expect(found!.id).toBe(NS_ID)
   })
 
+  // #771: store namespacing must be id-format agnostic — server-assigned
+  // full-date ids (ENG-YYYY-MM-DD-NNN) and legacy compact ids
+  // (ENG-YYYY-MMDD-NNN, the makeEngram default used across this file) both
+  // get the same `ENG-{PREFIX}-` head and stay resolvable.
+  it('namespaces server-assigned full-date IDs identically to compact IDs (#771)', async () => {
+    writeStoreEngrams([
+      makeEngram({ id: 'ENG-2026-07-30-032', statement: 'Server-assigned full-date id' }),
+      makeEngram({ statement: 'Legacy compact id' }), // ENG-2026-0401-001
+    ])
+    writeConfig([{ path: storePath, scope: 'datafund' }])
+    const plur = createPlur()
+
+    const full = await plur.getById('ENG-DFD-2026-07-30-032')
+    expect(full).not.toBeNull()
+    expect(full!.statement).toBe('Server-assigned full-date id')
+
+    const compact = await plur.getById(NS_ID)
+    expect(compact).not.toBeNull()
+    expect(compact!.statement).toBe('Legacy compact id')
+  })
+
   it('status counts across stores', async () => {
     // 2 primary engrams
     const plur0 = new Plur({ path: primaryDir })

--- a/packages/core/test/plur.test.ts
+++ b/packages/core/test/plur.test.ts
@@ -23,6 +23,35 @@ describe('Plur', () => {
     expect(results[0].statement).toContain('snake_case')
   })
 
+  // #771: existing stores hold legacy compact ids (ENG-YYYY-MMDD-NNN). They
+  // need no migration — recall/feedback/forget keep working on them while new
+  // learns mint the canonical full-date form (ENG-YYYY-MM-DD-NNN).
+  it('legacy compact IDs stay valid alongside canonical full-date IDs (#771)', async () => {
+    const engramsPath = join(dir, 'engrams.yaml')
+    writeFileSync(engramsPath, yaml.dump({
+      engrams: [{
+        id: 'ENG-2026-0720-026',
+        statement: 'Legacy engram about widget calibration',
+        type: 'behavioral',
+        scope: 'global',
+        status: 'active',
+        activation: { retrieval_strength: 0.7, storage_strength: 1.0, frequency: 0, last_accessed: '2026-07-20' },
+      }],
+    }))
+
+    // New learns mint the canonical server-shaped id
+    const fresh = await plur.learn('Canonical engram about sprocket alignment', { scope: 'global' })
+    expect(fresh.id).toMatch(/^ENG-\d{4}-\d{2}-\d{2}-\d{3}$/)
+
+    // The legacy engram is still recallable and mutable by its old id
+    const recalled = await plur.recall('widget calibration')
+    expect(recalled.some(e => e.id === 'ENG-2026-0720-026')).toBe(true)
+    await plur.feedback('ENG-2026-0720-026', 'positive')
+    await plur.forget('ENG-2026-0720-026', 'test cleanup')
+    const after = yaml.load(readFileSync(engramsPath, 'utf8')) as any
+    expect(after.engrams.find((e: any) => e.id === 'ENG-2026-0720-026').status).toBe('retired')
+  })
+
   it('inject returns scored engrams within budget', async () => {
     await plur.learn('Always use blue-green deploy strategies', { scope: 'global' })
     await plur.learn('Database for myapp is PostgreSQL', { scope: 'project:myapp' })

--- a/packages/core/test/tensions.test.ts
+++ b/packages/core/test/tensions.test.ts
@@ -265,8 +265,27 @@ describe('engramDate', () => {
     expect(engramDate(e)).toBe('2026-06-15')
   })
 
+  // #771: the legacy compact local form must keep parsing forever — existing
+  // stores are not migrated.
+  it('falls back to legacy compact ID pattern ENG-YYYY-MMDD-NNN', () => {
+    const e = makeEngram({ id: 'ENG-2026-0615-001', statement: 'x' })
+    expect(engramDate(e)).toBe('2026-06-15')
+  })
+
+  it('parses store-prefixed IDs in both date forms (#771)', () => {
+    const full = makeEngram({ id: 'ENG-GPL-2026-07-30-032', statement: 'x' })
+    expect(engramDate(full)).toBe('2026-07-30')
+    const compact = makeEngram({ id: 'ENG-DFU-2026-0401-001', statement: 'x' })
+    expect(engramDate(compact)).toBe('2026-04-01')
+  })
+
   it('returns undefined for IDs with no date pattern', () => {
     const e = makeEngram({ id: 'E1', statement: 'x' })
+    expect(engramDate(e)).toBeUndefined()
+  })
+
+  it('returns undefined for dateless pack IDs', () => {
+    const e = makeEngram({ id: 'ENG-PACK-EM-006', statement: 'x' })
     expect(engramDate(e)).toBeUndefined()
   })
 })

--- a/packages/core/test/version-check.test.ts
+++ b/packages/core/test/version-check.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { checkForUpdate, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind } from '../src/version-check.js'
+import {
+  checkForUpdate,
+  getCachedUpdateCheck,
+  clearVersionCache,
+  minorVersionsBehind,
+  settleVersionChecks,
+  VERSION_CHECK_SUCCESS_TTL_MS,
+  VERSION_CHECK_FAILURE_TTL_MS,
+} from '../src/version-check.js'
 
 describe('version-check', () => {
   const originalFetch = globalThis.fetch
@@ -133,6 +141,97 @@ describe('version-check', () => {
       expect(cached).not.toBeNull()
       expect(cached!.updateAvailable).toBe(true)
       expect(cached!.latest).toBe('5.0.0')
+    })
+
+    // #760: before the TTL existed, the cache was "one fetch per process
+    // lifetime" — a long-lived server that started while current (or offline)
+    // never re-checked and stayed silent about every later release.
+    describe('TTL refresh (#760)', () => {
+      afterEach(() => {
+        vi.restoreAllMocks()
+      })
+
+      it('re-checks after the success TTL expires and sees a later release', async () => {
+        const mockFetch = vi.fn()
+          .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ version: '1.0.0' }) })
+          .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ version: '2.0.0' }) })
+        globalThis.fetch = mockFetch as any
+
+        // Process starts current — check caches "no update"
+        const first = await checkForUpdate('pkg-ttl', '1.0.0')
+        expect(first.updateAvailable).toBe(false)
+
+        // Within the TTL the cache is served — no second fetch
+        await checkForUpdate('pkg-ttl', '1.0.0')
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+
+        // Beyond the TTL the check re-fetches and finds the new release
+        const base = Date.now()
+        vi.spyOn(Date, 'now').mockImplementation(() => base + VERSION_CHECK_SUCCESS_TTL_MS + 1)
+        const second = await checkForUpdate('pkg-ttl', '1.0.0')
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+        expect(second.updateAvailable).toBe(true)
+        expect(second.latest).toBe('2.0.0')
+      })
+
+      it('retries a failed check after the failure TTL (offline at startup)', async () => {
+        const mockFetch = vi.fn()
+          .mockRejectedValueOnce(new Error('offline'))
+          .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ version: '2.0.0' }) })
+        globalThis.fetch = mockFetch as any
+
+        const first = await checkForUpdate('pkg-fail', '1.0.0')
+        expect(first.latest).toBeNull()
+
+        // Still inside the failure TTL — negative result served from cache
+        await checkForUpdate('pkg-fail', '1.0.0')
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+
+        // After the failure TTL the check retries instead of staying silent
+        const base = Date.now()
+        vi.spyOn(Date, 'now').mockImplementation(() => base + VERSION_CHECK_FAILURE_TTL_MS + 1)
+        const second = await checkForUpdate('pkg-fail', '1.0.0')
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+        expect(second.updateAvailable).toBe(true)
+        expect(second.latest).toBe('2.0.0')
+      })
+
+      it('getCachedUpdateCheck serves stale synchronously and refreshes in background', async () => {
+        const mockFetch = vi.fn()
+          .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ version: '1.0.0' }) })
+          .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ version: '2.0.0' }) })
+        globalThis.fetch = mockFetch as any
+        await checkForUpdate('pkg-read', '1.0.0')
+
+        const base = Date.now()
+        vi.spyOn(Date, 'now').mockImplementation(() => base + VERSION_CHECK_SUCCESS_TTL_MS + 1)
+
+        // Stale read returns the old answer immediately — never blocks —
+        // and kicks off a background refresh
+        const stale = getCachedUpdateCheck('pkg-read')
+        expect(stale).not.toBeNull()
+        expect(stale!.updateAvailable).toBe(false)
+
+        await settleVersionChecks()
+        const fresh = getCachedUpdateCheck('pkg-read')
+        expect(fresh!.updateAvailable).toBe(true)
+        expect(fresh!.latest).toBe('2.0.0')
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+      })
+
+      it('concurrent checks for the same package share one fetch', async () => {
+        let resolveFetch: ((v: unknown) => void) | undefined
+        const mockFetch = vi.fn().mockImplementation(() => new Promise((r) => { resolveFetch = r }))
+        globalThis.fetch = mockFetch as any
+
+        const p1 = checkForUpdate('pkg-dedupe', '1.0.0')
+        const p2 = checkForUpdate('pkg-dedupe', '1.0.0')
+        resolveFetch!({ ok: true, json: () => Promise.resolve({ version: '2.0.0' }) })
+        const [r1, r2] = await Promise.all([p1, p2])
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        expect(r1.latest).toBe('2.0.0')
+        expect(r2.latest).toBe('2.0.0')
+      })
     })
 
     it('clearVersionCache resets everything', async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/server/stdio'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { Plur, checkForUpdate } from '@plur-ai/core'
+import { Plur, checkForUpdate, VERSION_CHECK_SUCCESS_TTL_MS } from '@plur-ai/core'
 import { getToolDefinitions, mcpCanary, validateToolArgs, CURSOR_CORE_TOOL_NAMES, type ToolProfile, resolveToolProfile, setActiveToolProfile } from './tools.js'
 import { registerFlushOnExit } from './telemetry.js'
 import { VERSION } from './version.js'
@@ -167,6 +167,10 @@ Use \`scope\` to namespace engrams per project:
 Override with \`PLUR_PATH\` environment variable.
 `
 
+// One periodic version re-check per process, however many servers are created
+// (tests create one per case — stacking an interval per server would leak).
+let versionRecheckTimer: ReturnType<typeof setInterval> | undefined
+
 export async function createServer(plur?: Plur, options?: { profile?: ToolProfile }): Promise<Server> {
   const instance = plur ?? new Plur()
   const profile = options?.profile ?? 'lean'
@@ -176,12 +180,25 @@ export async function createServer(plur?: Plur, options?: { profile?: ToolProfil
   setActiveToolProfile(profile)
   const tools = getToolDefinitions(profile)
 
-  // Non-blocking version check — fire and forget
-  checkForUpdate('@plur-ai/mcp', VERSION, (r) => {
+  // Non-blocking version check — fire and forget at startup, then re-checked
+  // periodically (#760). Without the periodic re-check a long-lived server
+  // process that started while current would cache "no update" for its entire
+  // lifetime and never surface releases published after startup — which is
+  // exactly how the 0.14.x regression report happened. The timer is unref'd so
+  // it never keeps the process alive, and the TTL-driven refresh-on-read in
+  // version-check.ts covers processes whose timers are throttled.
+  const announceUpdate = (r: { updateAvailable: boolean; current: string; latest: string | null }) => {
     if (r.updateAvailable) {
       console.error(`[plur] Update available: ${r.current} → ${r.latest}. Run: npx @plur-ai/mcp@latest`)
     }
-  })
+  }
+  checkForUpdate('@plur-ai/mcp', VERSION, announceUpdate)
+  if (!versionRecheckTimer) {
+    versionRecheckTimer = setInterval(() => {
+      checkForUpdate('@plur-ai/mcp', VERSION, announceUpdate)
+    }, VERSION_CHECK_SUCCESS_TTL_MS)
+    versionRecheckTimer.unref?.()
+  }
 
   const server = new Server(
     { name: 'plur-mcp', version: VERSION },

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { Client } from '@modelcontextprotocol/client'
 import { InMemoryTransport } from '@modelcontextprotocol/server'
-import { Plur, checkForUpdate, clearVersionCache, settleVersionChecks } from '@plur-ai/core'
+import { Plur, checkForUpdate, clearVersionCache, settleVersionChecks, VERSION_CHECK_SUCCESS_TTL_MS } from '@plur-ai/core'
 import { createServer } from '../src/server.js'
 
 describe('MCP server (wire protocol)', () => {
@@ -540,6 +540,51 @@ describe('MCP server (wire protocol)', () => {
       const result = await client.callTool({ name: 'plur_status', arguments: {} })
       const data = JSON.parse((result.content as any)[0].text)
       expect(data.update_available).toBeUndefined()
+    })
+
+    // Regression test for #760: the process started while current, cached
+    // "no update", and a newer version was published while it kept running.
+    // Before the cache TTL, that process stayed silent forever — 0.14.0
+    // installs never surfaced 0.15/0.16.
+    it('surfaces a release published after a long-lived process started (#760)', async () => {
+      // Startup: current version IS the latest — check caches "no update"
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: '0.9.8' }),
+      }) as any
+      await checkForUpdate('@plur-ai/mcp', '0.9.8')
+
+      let result = await client.callTool({ name: 'plur_status', arguments: {} })
+      let data = JSON.parse((result.content as any)[0].text)
+      expect(data.update_available).toBeUndefined()
+
+      // A newer version is published while the process keeps running,
+      // and the success TTL elapses
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: '99.0.0' }),
+      }) as any
+      const base = Date.now()
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => base + VERSION_CHECK_SUCCESS_TTL_MS + 1)
+      try {
+        // First read after expiry stays zero-cost (may still serve the stale
+        // answer) but triggers the background refresh
+        await client.callTool({ name: 'plur_status', arguments: {} })
+        await settleVersionChecks()
+
+        // The next read sees the new release on both surfaces
+        result = await client.callTool({ name: 'plur_status', arguments: {} })
+        data = JSON.parse((result.content as any)[0].text)
+        expect(data.update_available).toBeDefined()
+        expect(data.update_available.latest).toBe('99.0.0')
+
+        const session = await client.callTool({ name: 'plur_session_start', arguments: { task: 'test' } })
+        const sessionData = JSON.parse((session.content as any)[0].text)
+        expect(sessionData.version_warning).toBeDefined()
+        expect(sessionData.version_warning).toContain('99.0.0')
+      } finally {
+        nowSpy.mockRestore()
+      }
     })
   })
 })

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -108,7 +108,7 @@ sequence of engram objects:
 
 ```yaml
 engrams:
-  - id: ENG-2026-0506-001
+  - id: ENG-2026-05-06-001
     statement: "toEqual() in Vitest is strict — use toMatchObject() for partial matching"
     type: behavioral
     status: active
@@ -175,30 +175,70 @@ As a regular expression (the reference validator):
 ### 3.3 Canonical concrete form
 
 While the grammar permits any `[A-Za-z0-9-]+` body, the RECOMMENDED canonical
-form for a freshly minted concrete engram is date-sequenced:
+form for a freshly minted concrete engram is date-sequenced with full ISO-8601
+date separators — the SAME form whether the id is minted locally or assigned
+by a server (plur-ai/plur#771):
 
 ```
-ENG-YYYY-MMDD-NNN
+ENG-YYYY-MM-DD-NNN
 ```
 
-- `YYYY` four-digit year, `MMDD` month+day, `NNN` a zero-padded per-day
-  sequence number starting at `001`.
-- Example: `ENG-2026-0506-003`.
+- `YYYY-MM-DD` ISO-8601 calendar date (UTC at mint time), `NNN` a zero-padded
+  per-day sequence number starting at `001`.
+- Example: `ENG-2026-05-06-003`.
+
+#### 3.3.1 Legacy compact form
+
+Reference releases before the #771 convergence minted *local* ids with a
+compact date while servers assigned the full-date form above, producing two
+shapes for the same logical scheme:
+
+```
+ENG-YYYY-MMDD-NNN                 e.g.  ENG-2026-0506-003   (legacy, local)
+```
+
+Compact ids remain VALID forever — they match the §3.1 grammar, existing
+stores containing them need NO migration, and consumers MUST accept both the
+full-date and compact forms wherever a date-sequenced id is parsed (e.g. the
+reference's `engramDate()` treats the day separator as optional).
+Implementations MUST NOT mint new compact ids.
+
+#### 3.3.2 Pack form
+
+Engrams shipped in curated packs use a dateless, human-assigned form:
+
+```
+ENG-PACK-{NAME}-NNN               e.g.  ENG-PACK-EM-006
+```
+
+where `{NAME}` is a short uppercase abbreviation of the pack name. This is an
+INTENTIONAL exemption from the date-sequenced scheme: pack content is
+versioned by the pack manifest, not by mint date, and ids must stay stable
+across pack releases so installs and upgrades can be diffed. Pack ids match
+the §3.1 grammar. The `ABS-` and `META-` class prefixes (§3.2) combine with
+every form in this section the same way (e.g. `ABS-PACK-EM-001`,
+`META-2026-05-06-001`).
 
 ### 3.4 Store-namespaced form
 
 When engrams from multiple stores are merged, an implementation MAY namespace an
-ID with a short store **PREFIX** to avoid collisions:
+ID with a short store **PREFIX** to avoid collisions. The prefix is inserted
+directly after the class prefix; the rest of the id — whichever §3.3 form the
+source store minted — is preserved verbatim:
 
 ```
-ENG-{PREFIX}-YYYY-MMDD-NNN        e.g.  ENG-DF-2026-0401-001
+ENG-{PREFIX}-YYYY-MM-DD-NNN       e.g.  ENG-GPL-2026-07-30-032
+ENG-{PREFIX}-YYYY-MMDD-NNN        e.g.  ENG-DF-2026-0401-001   (legacy source id)
 ```
 
-`PREFIX` is a SHORT uppercase token derived from the source scope. The
-namespaced form still matches the grammar in §3.1. Implementations MUST treat
-the namespaced and bare forms as referring to *different* logical engrams once
-namespacing has been applied (the prefix is part of the identity in a merged
-view). Pack producers SHOULD export *bare* IDs.
+`PREFIX` is a SHORT uppercase token derived from the source scope (the
+reference derives exactly three characters via `storePrefix()`, e.g.
+`group:plur/engineering` → `GPL`-style abbreviations, and detects namespaced
+ids with `^(ENG|ABS|META)-[A-Z]{3}-`). The namespaced form still matches the
+grammar in §3.1. Implementations MUST treat the namespaced and bare forms as
+referring to *different* logical engrams once namespacing has been applied
+(the prefix is part of the identity in a merged view). Pack producers SHOULD
+export *bare* IDs.
 
 ### 3.5 Uniqueness
 
@@ -382,7 +422,7 @@ ignore the values.
 A minimally conformant engram is exactly:
 
 ```yaml
-id: ENG-2026-0506-001         # §3 grammar
+id: ENG-2026-05-06-001         # §3 grammar
 statement: "…"                # non-empty
 type: behavioral              # enum §4.2
 status: active                # enum §4.2


### PR DESCRIPTION
Closes #758 (audit #752 item 6).

## The gap, and what was under it

`@plur-ai/migrate` matched call sites with a receiver-anchored regex that could not span a newline. An ordinary fluent chain

```ts
const n = plur
  .recall('q')
  .length
```

was neither rewritten nor reported — not even as `MANUAL` — so the report read as clean on a file that was not.

Reproducing the miss exposed a worse failure in the same mechanism: on a single line the regex re-anchored **mid-chain**. `getStore().plur.recall('q')` matched with receiver `plur`, so `--write` emitted

```ts
getStore().await plur.recall('q')   // does not parse
```

and `await getStore().plur.recall('q')` — already correct — was *reported as un-awaited and then mangled the same way*, because the `await` sat in front of the chain while the look-behind check ran from the mid-chain anchor. Emitting source that does not parse is the failure class the package's own header calls strictly worse than doing nothing.

## The fix

No new dependency — the package is deliberately zero-dep and has no AST infrastructure, so this stays a span-aware lexical scanner. The regex now anchors on the **method**, and the receiver is resolved by walking backward from the dot (`receiverStart`): identifier segments, `?.` links, bracket indexes, call arguments, parenthesised heads, a leading `new` — with whitespace and comments skipped between tokens via the existing literal-span machinery. Every finding anchors at the true head of the chain, the only position `await` may legally occupy.

Covered (each pinned in `test/scan-multiline.test.ts`):

- **Multi-line receiver chains** — the audit's exact repro is reported `MANUAL` (`result is consumed by a multi-line expression`), consistent with the existing multi-line handling; a bare chain (`plur\n  .learn(x)`) is fixable, with `await` inserted at the chain head. Dot-leading and dot-trailing styles both resolve.
- **Comments between receiver and call** — line and block comments inside the chain are skipped; a commented-out chain link is not matched.
- **Optional chaining** — `plur\n  ?.recall(q)` resolves; `?.` *after* the call now counts as consumption, so `plur.recall(q)?.length` gets the `(await ...)` wrap instead of a plain `await` that would await `.length` of the promise.
- **Await-wrapped chains** — `await plur\n  .recall(q)`, `return`/`void` chains, and `await getStore().plur.recall(q)` are silent: the look-behind runs at the chain head wherever the chain breaks.

Falls out of the same walk:

- `getPlur().recall(q)`, `plur.scoped(s).recall(q)`, `new Plur().recall(q)` — call-bearing receivers, previously invisible — resolve and rewrite at the head (`await new Plur()...`, never `new await`).
- The two documented bracket-index misses (`m[a[0]].learn(x)` nested, `m["a]b"].learn(x)` string key with `]`) now resolve, still anchored at `m` — the tests that pinned them as misses now pin the rewrite.
- Consumption is read through comments (`plur.recall(q) /* hits */ .length` keeps the wrap).
- A paren/array-literal receiver head that starts its line after an unterminated line is refused as an ASI splice, mirroring the existing leading-`(await ...)` guard.
- One finding per chain head, so two newly-async methods on one chain cannot insert twice at one offset.
- The `PREFILTER` in `index.ts` mirrors the dot-whitespace tolerance so a `plur.\n  recall(q)` file is not skipped before the scanner runs.

## Verification

- `packages/migrate`: 101 tests pass, including the new `scan-multiline.test.ts` (audit repro + anchor cases) and the flipped bracket-index tests.
- `test/method-list.test.ts` (the NEWLY_ASYNC contract test): all 6 pass against the current `Plur` surface, including both git-history assertions against the real `v0.15.0` tag.
- `pnpm typecheck:tests` clean; `pnpm build` clean.
- The rebuilt CLI over `packages/core/src` reports the same three pre-existing concise-arrow sites as before — no new false positives on real source.
- Smoke expectations in `scripts/smoke-release.sh` (section 6b) are unchanged and still hold.
