### PR TITLE
feat(core): wire Postgres primary-store auto-embed — engram_embeddings tracks the corpus, semantic recall uses the vector index (#762)

### DIFF
--- a/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
+++ b/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
@@ -1,7 +1,8 @@
 # ADR-0005: The Postgres tier, and what happens to exact search
 
 Status: **Accepted** — implemented in 0.16; amended 2026-07-28, see
-[Update — Phases 2 and 4 have landed](#what-this-phase-does-not-do-and-why)
+[Update — Phases 2 and 4 have landed](#what-this-phase-does-not-do-and-why);
+the amendment's embeddings gap is closed by #762 (see its Closure note)
 Date: 2026-07-26
 Authors: convergence programme, Phase 5
 Related: ADR-0001 ([#226](https://github.com/plur-ai/plur/issues/226)), ADR-0003,
@@ -340,3 +341,31 @@ a serious regression at the 50,000-engram threshold that selects Postgres. It
 needs a set-based "which active ids have no embedding" query, and a decision
 about whether a server tier should pay embedding cost on the write path at all —
 which is a deployment question, not just an implementation one.
+
+### Closure — #762
+
+The gap above is closed, on exactly the terms this amendment demanded:
+
+- **The set-based query exists.** `PostgresAdapter.listEngramsMissingEmbeddings`
+  is one bounded anti-join between the two tables' primary keys (active rows
+  with no embedding row, `ORDER BY id LIMIT n`). Cost scales with the gap, not
+  the corpus; the `LIMIT 1` shape doubles as a completeness probe.
+- **The write path does NOT pay embedding cost.** Every primary-store write
+  kicks a fire-and-track background pass (`_syncIndex` → the coalescing
+  `_kickPrimaryAutoEmbed`) that drains the anti-join in bounded batches.
+  Back-to-back writes coalesce into one follow-up sweep instead of stacking
+  passes. Failures land in `lastIndexError()` / `status().index_error`, never
+  in the write.
+- **Backfill needs no operator step.** The first semantic recall probes
+  completeness; a store migrated in with rows but no embeddings starts the
+  backfill from the read side and converges without a single write.
+- **`recallSemantic` reads the table** — `_primarySemanticRecall` pushes the
+  k-NN into `searchVector` (scope allow-list, visibility scope, and mounted
+  grants all inside the query) once the table is complete, and degrades to the
+  in-memory path while it fills — partial vector answers are never served.
+- **Opt-outs hold.** `PLUR_DISABLE_EMBEDDINGS` / `embeddings.enabled: false`
+  skips the pass before any query (one loud notice per instance), and an
+  embedder/column dimension mismatch skips rather than persist wrong-shape
+  vectors (#335). The schema-init warning this amendment introduced is gone —
+  the condition it warned about no longer exists when the engine drives the
+  adapter.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -573,6 +573,15 @@ const PUSHDOWN_OVERFETCH = 3
  */
 const PUSHDOWN_MAX_ROUNDS = 3
 
+/**
+ * Rows per `listEngramsMissingEmbeddings` batch in the primary-store
+ * auto-embed pass (#762). Bounds how much of the corpus is ever held in
+ * memory by the pass — the pass itself runs to convergence, one batch at a
+ * time, in the background. Each batch is a fresh anti-join, so concurrent
+ * writers and a mid-pass crash both converge on the next pass.
+ */
+const PRIMARY_AUTO_EMBED_BATCH = 100
+
 export class Plur {
   private paths: PlurPaths
   private config: PlurConfig
@@ -589,6 +598,16 @@ export class Plur {
    */
   private pgliteAdapter: PGLiteAdapter | null = null
   private _pgliteInitPromise: Promise<void> | null = null
+  /**
+   * In-flight primary-store auto-embed pass (#762), or null. One pass at a
+   * time: a write landing while a pass runs sets `_primaryEmbedRerun` instead
+   * of starting a second pass, so back-to-back writes coalesce into one
+   * follow-up sweep rather than N overlapping ones re-embedding the same gap.
+   */
+  private _primaryEmbedPass: Promise<void> | null = null
+  private _primaryEmbedRerun = false
+  /** One-shot latch for the embeddings-disabled notice on the primary-store auto-embed path. */
+  private _primaryEmbedDisabledNoticeDone = false
   /**
    * Last background index failure (#272). Set by the .catch of the
    * fire-and-forget index chains (initial sync, syncFromYaml, reindex,
@@ -2752,9 +2771,8 @@ export class Plur {
     return results
   }
 
-  /** Search engrams using local embeddings. Async, no API calls. Routes through PGLite/pgvector when active (#226), with optional intent routing (#224) + cross-encoder rerank (#220). */
+  /** Search engrams using local embeddings. Async, no API calls. Routes through PGLite/pgvector when active (#226) or a Postgres primary store's vector index (#762), with optional intent routing (#224) + cross-encoder rerank (#220). */
   async recallSemantic(query: string, options?: Omit<RecallOptions, 'mode' | 'llm'>): Promise<Engram[]> {
-    const filtered = await this._filterEngrams(options)
     const limit = options?.limit ?? 20
     const rerank = await this._resolveRerankOptions(options?.rerank)
     const intent = this._resolveIntentProfile(query, options?.intentOverride)
@@ -2765,9 +2783,14 @@ export class Plur {
     const rerankFetch = rerank ? Math.max(limit, rerank.topK ?? 50) : limit
     const fetchLimit = Math.max(intentFetch, rerankFetch)
     let results: Engram[]
+    const primaryAdapter = this._primaryQueryAdapter()
     if (this.pgliteAdapter) {
+      const filtered = await this._filterEngrams(options)
       results = await this._pgliteSemanticRecall(query, fetchLimit, filtered, options)
+    } else if (primaryAdapter) {
+      results = await this._primarySemanticRecall(primaryAdapter, query, fetchLimit, options)
     } else {
+      const filtered = await this._filterEngrams(options)
       results = await embeddingSearch(filtered, query, fetchLimit, this.paths.root)
     }
     if (intent) {
@@ -3100,6 +3123,80 @@ export class Plur {
     } catch (err) {
       logger.warning(`[plur] PGLite searchVector failed: ${(err as Error).message}. Falling back to JSON cache.`)
       return embeddingSearch(filtered, query, limit, this.paths.root)
+    }
+  }
+
+  /**
+   * Semantic recall pushed into a primary query store's vector index (#762) —
+   * the `recall()` pushdown's vector twin. Until this existed the Postgres
+   * tier answered `recallSemantic` by loading the corpus and embedding it in
+   * memory: the O(N) path the tier exists to escape, silently, because
+   * nothing populated `engram_embeddings` and nothing read it.
+   *
+   * Shape mirrors `recall()`'s BM25 pushdown:
+   *   - scope/scopes/visibilityGrants go INTO the k-NN query (dilution guard —
+   *     see `_pgliteSemanticRecall`'s comment; same reasoning).
+   *   - residual filters (expiry, min_strength) run here on the rows that
+   *     came back — SQL cannot evaluate them.
+   *   - secondary-store and pack engrams cannot be in the store's table, so
+   *     they are scored in memory (they are small and already file-backed)
+   *     and merged BY SCORE: both sides are cosine similarity from the same
+   *     embedder — the store computes `1 - cosine_distance`, clamped here to
+   *     [0,1] exactly as `embeddingSearchWithScores` clamps its side — so the
+   *     merge is the same metric, not an approximation.
+   *
+   * Completeness gate: one `listEngramsMissingEmbeddings(1)` anti-join probe
+   * per call. While ANY active engram lacks an embedding, vector hits would
+   * be drawn from whatever subset happens to be embedded — correct-looking,
+   * silently incomplete — so this degrades to the in-memory path for THIS
+   * query and kicks the background backfill instead of waiting for it. The
+   * probe is also what makes a store migrated in with existing rows converge:
+   * the first semantic recall starts the backfill even if nothing was ever
+   * written through this instance.
+   */
+  private async _primarySemanticRecall(
+    adapter: StorageAdapter,
+    query: string,
+    limit: number,
+    options?: Omit<RecallOptions, 'mode' | 'llm'>,
+  ): Promise<Engram[]> {
+    const fallback = async () =>
+      embeddingSearch(await this._filterEngrams(options), query, limit, this.paths.root)
+    const { embed } = await import('./embeddings.js')
+    const queryVec = await embed(query, 'query')
+    // Embedder disabled or unavailable: exactly the degraded path this method
+    // replaced — embeddingSearch reports [] without an embedder, never throws.
+    if (!queryVec) return fallback()
+    try {
+      if (typeof adapter.listEngramsMissingEmbeddings === 'function') {
+        const gap = await adapter.listEngramsMissingEmbeddings(1)
+        if (gap.length > 0) {
+          this._kickPrimaryAutoEmbed(adapter)
+          return fallback()
+        }
+      }
+      const hits = await adapter.searchVector(queryVec, Math.max(limit * 3, 50), {
+        scopes: options?.scopes,
+        scope: options?.scope,
+        visibilityGrants: this._grantedScopes(),
+      })
+      const surviving = new Set(this._applyResidualFilters(hits.map(h => h.engram), options).map(e => e.id))
+      const primaryScored: SimilarityResult[] = hits
+        .filter(h => surviving.has(h.engram.id))
+        .map(h => ({ engram: h.engram, score: Math.max(0, Math.min(1, h.score)) }))
+      const outsiders = this._applyResidualFilters(await this._engramsOutsidePrimaryStore(options), options)
+      const outsiderScored = outsiders.length > 0
+        ? await embeddingSearchWithScores(outsiders, query, limit, this.paths.root)
+        : []
+      return [...primaryScored, ...outsiderScored]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit)
+        .map(s => s.engram)
+    } catch (err) {
+      logger.warning(
+        `[plur] primary-store searchVector failed: ${(err as Error).message}. Falling back to in-memory semantic recall.`,
+      )
+      return fallback()
     }
   }
 
@@ -4968,6 +5065,109 @@ export class Plur {
     }
   }
 
+  /**
+   * Kick (or coalesce into) the background primary-store auto-embed pass
+   * (#762). Fire-and-track: callers never await it — a write must not pay
+   * embedding latency, and a semantic recall must not block on a backfill.
+   * The pass is tracked on `_pgliteInitPromise` so `waitForIndex()` covers it
+   * exactly like the PGLite background chains.
+   */
+  private _kickPrimaryAutoEmbed(adapter: StorageAdapter): void {
+    if (this._primaryEmbedPass) {
+      // A pass is mid-flight. It re-queries the anti-join per batch, but a
+      // write landing after its final query would be missed — request one
+      // follow-up sweep instead of stacking a second concurrent pass.
+      this._primaryEmbedRerun = true
+      return
+    }
+    const pass = (async () => {
+      do {
+        this._primaryEmbedRerun = false
+        await this._autoEmbedPrimaryStore(adapter) // never throws — errors land in lastIndexError()
+      } while (this._primaryEmbedRerun)
+    })().finally(() => {
+      if (this._primaryEmbedPass === pass) this._primaryEmbedPass = null
+    })
+    this._primaryEmbedPass = pass
+    this._pgliteInitPromise = pass
+  }
+
+  /**
+   * Embed active engrams missing a row in the primary store's embedding table
+   * (#762) — the Postgres-primary counterpart of `_autoEmbedNewEngrams`.
+   *
+   * Deliberately NOT that method: `_autoEmbedNewEngrams` loads the whole
+   * corpus and probes `hasEmbedding` per id, which is fine for a local PGLite
+   * index and a serious per-write regression at the corpus size that selects
+   * a server tier. This pass asks the store the set-based question instead —
+   * `listEngramsMissingEmbeddings` is one anti-join per batch — so its cost
+   * scales with the GAP, not with the corpus.
+   *
+   * Failure posture, in order:
+   *   - embeddings disabled (PLUR_DISABLE_EMBEDDINGS / config): skip before
+   *     touching the database, with a once-per-instance notice — the table
+   *     staying empty is then a configuration choice, not a silent gap.
+   *   - embedder dim ≠ the store's embedding column: skip (debug log), same
+   *     as the PGLite pass — writing wrong-dim vectors is worse than none.
+   *   - embedder unavailable mid-pass: stop quietly; the next write or
+   *     semantic recall retries.
+   *   - anything else: recorded via `lastIndexError()` and logged. Never
+   *     thrown — a background embed must not be able to fail a write.
+   */
+  private async _autoEmbedPrimaryStore(adapter: StorageAdapter): Promise<void> {
+    if (typeof adapter.listEngramsMissingEmbeddings !== 'function') return
+    try {
+      const { embed, embedderStatus } = await import('./embeddings.js')
+      const status = embedderStatus()
+      if (status.disabled) {
+        if (!this._primaryEmbedDisabledNoticeDone) {
+          this._primaryEmbedDisabledNoticeDone = true
+          logger.info(
+            `[plur] embeddings are disabled (${status.disabledReason}) — the primary store's embedding table `
+            + `will not be populated and semantic recall stays on the non-vector fallback path.`,
+          )
+        }
+        return
+      }
+      // #335 dim guard, mirroring _autoEmbedNewEngrams: an embedder/column
+      // mismatch must skip, not persist wrong-shape vectors.
+      const withDim = adapter as Partial<{ getVectorColumnDim(): Promise<number | null> }>
+      const indexedDim = typeof withDim.getVectorColumnDim === 'function'
+        ? await withDim.getVectorColumnDim()
+        : null
+      if (indexedDim !== null && getEmbedder(resolveEmbedderName()).dim !== indexedDim) {
+        logger.debug(
+          `[plur] primary-store auto-embed skip: active embedder dim differs from the store's embedding `
+          + `column (${indexedDim}). Re-create the store's embedding column or switch PLUR_EMBEDDER to migrate.`,
+        )
+        return
+      }
+      const { engramSearchText } = await import('./fts.js')
+      for (;;) {
+        const batch = await adapter.listEngramsMissingEmbeddings(PRIMARY_AUTO_EMBED_BATCH)
+        if (batch.length === 0) return
+        for (const engram of batch) {
+          const vec = await embed(engramSearchText(engram))
+          if (!vec) {
+            // Embedder became unavailable mid-pass — stop; retried on the
+            // next write or semantic recall. Debug, not warning: the embed
+            // failure itself is already surfaced via embedderStatus().
+            logger.debug('[plur] primary-store auto-embed paused: embedder unavailable.')
+            return
+          }
+          await adapter.upsertEmbedding(engram.id, vec)
+        }
+        // A full batch means the anti-join may hold more; a short one is the
+        // tail. Progress is guaranteed: every upsert removes a row from the
+        // next batch's answer, so this cannot loop on the same gap.
+        if (batch.length < PRIMARY_AUTO_EMBED_BATCH) return
+      }
+    } catch (err) {
+      this._recordIndexError('auto-embed', err)
+      logger.warning(`[plur] primary-store auto-embed failed: ${(err as Error).message}`)
+    }
+  }
+
   /** Record a background index failure for later surfacing (#272). */
   private _recordIndexError(op: IndexSyncError['op'], err: unknown): void {
     this._lastIndexError = {
@@ -5012,6 +5212,17 @@ export class Plur {
           this._recordIndexError('sync-from-yaml', err)
           logger.warning(`[plur] PGLite syncFromYaml failed (YAML is still source of truth): ${(err as Error).message}`)
         })
+      return
+    }
+    // Primary query store (#762): the write already landed in the engine that
+    // answers queries — no index delta — but its EMBEDDING has not. Kick the
+    // background auto-embed pass so `engram_embeddings` tracks the corpus and
+    // semantic recall gets to use the vector index instead of falling back to
+    // the O(N) in-memory path. Fire-and-track: the write path never waits.
+    const primary = this._primaryQueryAdapter()
+    if (primary && typeof primary.listEngramsMissingEmbeddings === 'function') {
+      this._lastIndexError = null // new pass — stale failures cleared on success
+      this._kickPrimaryAutoEmbed(primary)
       return
     }
     if (this.indexedStorage) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -582,6 +582,33 @@ const PUSHDOWN_MAX_ROUNDS = 3
  */
 const PRIMARY_AUTO_EMBED_BATCH = 100
 
+/**
+ * True when a background-pass error means "the store was torn down under
+ * us", not "something is wrong" (#762 follow-up, caught by smoke-packaged).
+ *
+ * The auto-embed pass is fire-and-track, so a short-lived process — the
+ * packaged smoke, a CLI invocation, any script that closes or drops its
+ * store when its work is done — can legitimately tear the store down while
+ * a pass is mid-flight. That is a benign cancellation: there is nothing to
+ * fix, nothing to retry, and the next engine over a live store converges.
+ * Reporting it as a background FAILURE (warning + `lastIndexError`) is
+ * noise at best; at worst the stray warning lands after the process's real
+ * output, which is exactly how the release smoke's last-line gate caught it.
+ *
+ * Patterns, each tied to a specific teardown path:
+ *   - Postgres `42P01` (undefined_table) / `3F000` (invalid_schema_name):
+ *     `dropSchema()` won the race against the pass's next query.
+ *   - "adapter is closed": `close()` beat the pass's next `getPool()`.
+ *   - "after calling end": node-postgres's "Cannot use a pool after calling
+ *     end on the pool" — same race, seen from a checkout already in flight.
+ */
+function isStoreTeardownError(err: unknown): boolean {
+  const code = (err as { code?: string }).code
+  if (code === '42P01' || code === '3F000') return true
+  const msg = (err as Error)?.message ?? ''
+  return msg.includes('adapter is closed') || msg.includes('after calling end')
+}
+
 export class Plur {
   private paths: PlurPaths
   private config: PlurConfig
@@ -5163,6 +5190,14 @@ export class Plur {
         if (batch.length < PRIMARY_AUTO_EMBED_BATCH) return
       }
     } catch (err) {
+      // A store torn down mid-pass (close()/dropSchema() in a short-lived
+      // process) is a cancellation, not a failure — stay quiet and do NOT
+      // record it, or the stray warning outlives the process's real output
+      // (the release smoke's last-line gate caught exactly that).
+      if (isStoreTeardownError(err)) {
+        logger.debug('[plur] primary-store auto-embed stopped: the store was closed or dropped mid-pass.')
+        return
+      }
       this._recordIndexError('auto-embed', err)
       logger.warning(`[plur] primary-store auto-embed failed: ${(err as Error).message}`)
     }

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -414,11 +414,34 @@ export interface StorageAdapter {
    * `opts.scopes` must be applied IN the query (as part of the k-NN
    * predicate), not to the returned rows — otherwise `limit` is measured
    * against the unrestricted neighbour list and in-scope results are diluted
-   * away. See {@link ScopeRestriction}.
+   * away. See {@link ScopeRestriction}. The `scope` visibility filter and
+   * `visibilityGrants` (#775) ride the same rule for the same reason: a
+   * caller that honours them post-hoc spends `limit` on rows it is about to
+   * discard, and a granted team engram never surfaces through the vector leg.
    */
-  searchVector(query: Float32Array, limit: number, opts?: ScopeRestriction): Promise<VectorSearchHit[]>
+  searchVector(
+    query: Float32Array,
+    limit: number,
+    opts?: ScopeRestriction & Pick<StorageFilter, 'scope' | 'visibilityGrants'>,
+  ): Promise<VectorSearchHit[]>
   /** Upsert an embedding for a specific engram. */
   upsertEmbedding(engramId: string, vector: Float32Array): Promise<void>
+  /**
+   * Active engrams that have no stored embedding, up to `limit`, as ONE
+   * set-based query (#762). OPTIONAL — and the enabling contract for
+   * primary-store auto-embed: core only wires the write-path/backfill
+   * embedding pass into an adapter that can answer "which rows lack
+   * embeddings" without loading the corpus. The alternative shape — load
+   * everything, probe `hasEmbedding` per id — is O(N) round trips on every
+   * write, which at the corpus size that selects a server tier is a worse
+   * regression than the missing embeddings (see ADR-0005's 2026-07-28
+   * amendment). An adapter that cannot answer this as a set must leave the
+   * method undefined; core then skips auto-embed rather than degrade writes.
+   *
+   * Called with `limit: 1` as a completeness probe on the semantic read path,
+   * so the implementation should be an indexed anti-join, not a scan-and-diff.
+   */
+  listEngramsMissingEmbeddings?(limit: number): Promise<Engram[]>
   /** Release resources. */
   close(): Promise<void>
 }

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -37,10 +37,12 @@
  * by driving the adapter directly. `test/postgres-recall-quality.test.ts`
  * exercises them through `Plur.recall()`.
  *
- * What IS still open: nothing in core writes embeddings to a Postgres primary
- * store, so the vector half of this adapter is inert unless a deployment fills
- * `engram_embeddings` itself. See `ensureVectorIndex` and ADR-0005's 2026-07-28
- * amendment.
+ * The last half of that story closed in #762: core now populates
+ * `engram_embeddings` on this tier. Every primary-store write kicks a
+ * background auto-embed pass that finds un-embedded rows with the set-based
+ * {@link listEngramsMissingEmbeddings} anti-join (never a per-id probe), and
+ * the first semantic recall backfills a store migrated in with existing rows.
+ * See ADR-0005's 2026-07-28 amendment and its #762 closure note.
  *
  * ## Vector search is the one place behaviour can differ
  *
@@ -251,8 +253,6 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * the answer exists.
    */
   private trigramAvailable: boolean | undefined
-  /** One-shot latch for the embedding-gap warning — see ensureVectorIndex. */
-  private embeddingGapWarned = false
   /**
    * Every client currently checked out of either pool.
    *
@@ -628,32 +628,13 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * failed.
    */
   private async ensureVectorIndex(q: any = this.pool): Promise<void> {
-    // Say plainly that nothing in core populates this table.
-    //
-    // `upsertEmbedding` and `searchVector` are implemented here and work, but
-    // the engine's only caller of `upsertEmbedding` is `_autoEmbedNewEngrams`,
-    // which runs for the PGLite DERIVED index and never for a primary store.
-    // Measured: 5 engrams learned through `Plur` against this adapter leave
-    // `engram_embeddings` with 0 rows.
-    //
-    // So `vectorIndex: 'hnsw'` on this tier asks for an ANN index over an empty
-    // table, and semantic recall silently falls back to loading engrams and
-    // scoring in memory — correct, but the O(N) path this tier exists to avoid.
-    // A deployment that wants vectors here has to write them itself.
-    //
-    // Wiring the engine to populate them is deliberately NOT done as a
-    // late-release patch: `_autoEmbedNewEngrams` loads the whole corpus and
-    // probes `hasEmbedding` per id on every write, which at the 50,000-engram
-    // threshold that selects this tier would be a worse regression than the gap
-    // it closes. It needs a set-based "which ids lack embeddings" query first.
-    if (!this.embeddingGapWarned && this.indexMode !== 'exact') {
-      this.embeddingGapWarned = true
-      logger.warning(
-        `[postgres] vectorIndex='${this.indexMode}' is configured, but core does not write embeddings to a `
-        + `Postgres primary store — 'engram_embeddings' stays empty unless your deployment populates it, and `
-        + `semantic recall falls back to in-memory scoring. Set vectorIndex:'exact' to silence this.`,
-      )
-    }
+    // Until #762 this method warned that nothing in core populated
+    // `engram_embeddings` on a primary store. That gap is closed: `Plur` runs
+    // a background auto-embed pass after every primary-store write and a
+    // backfill on the first semantic recall, both fed by the set-based
+    // `listEngramsMissingEmbeddings` anti-join below — never a per-id probe.
+    // A deployment driving this adapter WITHOUT the engine still has to write
+    // embeddings itself; that is a deployment choice, not a core gap.
     let want: boolean
     if (this.indexMode === 'exact') {
       want = false
@@ -1277,40 +1258,53 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * `SET LOCAL` scopes the setting to the transaction, so a pooled connection
    * is never left with another query's tuning on it.
    */
-  async searchVector(query: Float32Array, limit: number, opts?: ScopeRestriction): Promise<VectorSearchHit[]> {
+  async searchVector(
+    query: Float32Array,
+    limit: number,
+    opts?: ScopeRestriction & Pick<StorageFilter, 'scope' | 'visibilityGrants'>,
+  ): Promise<VectorSearchHit[]> {
     const pool = await this.getPool()
     const t = this.activeVecType
     const literal = vectorLiteral(query)
+    // EVERY restriction goes IN the k-NN predicate, never on the rows that
+    // come back. Post-filtering measures LIMIT against the unrestricted
+    // neighbour list, so a principal permitted a small share of the corpus
+    // asks for N and silently gets far fewer, with permitted rows sitting
+    // just below the cut.
+    //
+    // This method previously omitted the `opts` parameter entirely. TypeScript
+    // accepts a narrower arity than the interface declares, so a caller
+    // passing `scopes` compiled, ran, and got an unrestricted search with no
+    // error — on an authorization filter.
+    //
+    // `scope` + `visibilityGrants` (#775) joined `scopes` when the semantic
+    // pushdown landed (#762), for the dilution reason above — and through
+    // `buildFilterClause`, the ONE copy of the scope rules, rather than a
+    // hand-rolled second WHERE. The filter's columns are unambiguous in this
+    // join: `engram_embeddings` carries only `engram_id` and `embedding`.
+    const { where, params } = buildFilterClause({
+      status: 'active',
+      scopes: opts?.scopes,
+      scope: opts?.scope,
+      visibilityGrants: opts?.visibilityGrants,
+    })
+    const vecIdx = params.length + 1
+    const limitIdx = params.length + 2
+    // #751: every checkout goes through acquire() so close() can destroy it.
     const client = await this.acquire(pool)
     try {
       await client.query('BEGIN')
       if (this.hnswActive) {
         await client.query(`SET LOCAL hnsw.ef_search = ${this.efSearchForLimit(limit)}`)
       }
-      // The scope restriction goes IN the k-NN predicate, never on the rows
-      // that come back. Post-filtering measures LIMIT against the unrestricted
-      // neighbour list, so a principal permitted a small share of the corpus
-      // asks for N and silently gets far fewer, with permitted rows sitting
-      // just below the cut.
-      //
-      // This method previously omitted the `opts` parameter entirely. TypeScript
-      // accepts a narrower arity than the interface declares, so a caller
-      // passing `scopes` compiled, ran, and got an unrestricted search with no
-      // error — on an authorization filter.
-      const params: unknown[] = [literal, limit]
-      let scopeClause = ''
-      if (opts?.scopes !== undefined) {
-        params.push(opts.scopes)
-        scopeClause = ` AND e.scope = ANY($${params.length}::text[])`
-      }
       const res = await client.query(
-        `SELECT e.data, 1 - (em.embedding <=> $1::${t}) AS score
+        `SELECT e.data, 1 - (em.embedding <=> $${vecIdx}::${t}) AS score
          FROM "${this.schema}".engram_embeddings em
          JOIN "${this.schema}".engrams e ON e.id = em.engram_id
-         WHERE e.status = 'active'${scopeClause}
-         ORDER BY em.embedding <=> $1::${t}
-         LIMIT $2`,
-        params,
+         ${where}
+         ORDER BY em.embedding <=> $${vecIdx}::${t}
+         LIMIT $${limitIdx}`,
+        [...params, literal, limit],
       )
       await client.query('COMMIT')
       return res.rows.map((r: any) => ({ engram: parseRow(r), score: Number(r.score) }))
@@ -1346,6 +1340,35 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
        ON CONFLICT (engram_id) DO UPDATE SET embedding = EXCLUDED.embedding`,
       [engramId, vectorLiteral(vector)],
     )
+  }
+
+  /**
+   * Active engrams with no row in `engram_embeddings`, up to `limit` (#762).
+   *
+   * ONE set-based anti-join, which is the whole reason primary-store
+   * auto-embed exists at all: the PGLite-era shape — load the corpus, probe
+   * `hasEmbedding` per id — is O(N) round trips on every write, and at the
+   * 50,000-engram threshold that selects this tier that would be a worse
+   * regression than the missing embeddings (ADR-0005 amendment). Both sides
+   * of the join are the tables' primary keys, so `LIMIT 1` — the completeness
+   * probe the semantic read path issues — is an index-only anti-join, the
+   * same probe shape `corpusStats` uses for NULL-token rows.
+   *
+   * `ORDER BY e.id` so concurrent auto-embed passes in different processes
+   * walk the gap in the same order and converge instead of thrashing.
+   */
+  async listEngramsMissingEmbeddings(limit: number): Promise<Engram[]> {
+    assertPositiveInt(limit, 'limit')
+    const pool = await this.getPool()
+    const res = await pool.query(
+      `SELECT e.data FROM "${this.schema}".engrams e
+       LEFT JOIN "${this.schema}".engram_embeddings em ON em.engram_id = e.id
+       WHERE e.status = 'active' AND em.engram_id IS NULL
+       ORDER BY e.id
+       LIMIT $1`,
+      [limit],
+    )
+    return res.rows.map((r: any) => parseRow(r))
   }
 
   // ------------------------------------------------------------- diagnostics

--- a/packages/core/test/postgres-adapter.test.ts
+++ b/packages/core/test/postgres-adapter.test.ts
@@ -19,7 +19,7 @@
  * Everything runs inside a per-run schema which is dropped in teardown, so this
  * can share a database with anything else without colliding.
  */
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -27,7 +27,6 @@ import yaml from 'js-yaml'
 import { PostgresAdapter, HNSW_RECALL_TARGET } from '../src/storage-postgres.js'
 import { PGLiteAdapter } from '../src/storage-pglite.js'
 import { requiresIndexSync, asDerivedIndex, efSearchFor, PGVECTOR_DEFAULT_EF_SEARCH } from '../src/storage-adapter.js'
-import { logger } from '../src/logger.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 const DSN = process.env.PLUR_TEST_POSTGRES_URL
@@ -477,39 +476,57 @@ describe.skipIf(!DSN)('PGLite and Postgres answer the same filter identically', 
   }
 })
 
-describe.skipIf(!DSN)('the embeddings-gap warning at schema init (#752)', () => {
-  // The 0.16.0 release ships the Postgres tier WITHOUT core writing
-  // embeddings (ADR-0005 amendment): `engram_embeddings` stays empty and
-  // semantic recall silently falls back to in-memory scoring. The stated
-  // mitigation is a one-shot warning at schema init. That warning had zero
-  // test coverage — a refactor deleting it would strip the only runtime
-  // disclosure of the gap and nothing in CI would notice.
-  it('fires once for a non-exact vectorIndex, and not at all for exact', async () => {
-    const spy = vi.spyOn(logger, 'warning').mockImplementation(() => {})
-    const gapCalls = () => spy.mock.calls.filter(c => String(c[0]).includes('does not write embeddings'))
-    const auto = new PostgresAdapter({
-      connectionString: DSN!, schema: `${SCHEMA}_egap_a`, vectorDim: VECTOR_DIM,
-    })
-    const exact = new PostgresAdapter({
-      connectionString: DSN!, schema: `${SCHEMA}_egap_e`, vectorDim: VECTOR_DIM, vectorIndex: 'exact',
-    })
-    try {
-      await auto.save([])           // first schema init — warns
-      expect(gapCalls()).toHaveLength(1)
-      expect(String(gapCalls()[0][0])).toContain("vectorIndex:'exact' to silence")
-      await auto.load()             // second operation — no repeat
-      await auto.refreshVectorIndex()
-      expect(gapCalls()).toHaveLength(1)
+describe.skipIf(!DSN)('listEngramsMissingEmbeddings — the set-based auto-embed query (#762)', () => {
+  // The reason the embeddings gap shipped in 0.16.0 at all was the absence of
+  // this query: the only auto-embed pass loaded the corpus and probed
+  // `hasEmbedding` per id, which at the corpus size that selects this tier is
+  // a worse regression than the gap. The engine's write-path auto-embed and
+  // the semantic-recall completeness probe both stand on this method, so its
+  // semantics — active-only, bounded, shrinks as embeddings land — are pinned
+  // here at the adapter level.
+  const MSCHEMA = `${SCHEMA}_missing_762`
+  let adapter: PostgresAdapter
 
-      await exact.save([])          // documented escape hatch — silent
-      await exact.load()
-      expect(gapCalls()).toHaveLength(1)
-    } finally {
-      await auto.dropSchema().catch(() => {})
-      await exact.dropSchema().catch(() => {})
-      await auto.close().catch(() => {})
-      await exact.close().catch(() => {})
-      spy.mockRestore()
-    }
+  beforeAll(async () => {
+    adapter = new PostgresAdapter({
+      connectionString: DSN!, schema: MSCHEMA, vectorDim: VECTOR_DIM, vectorIndex: 'exact',
+    })
+    await adapter.save([
+      mkEngram('ENG-762-A', 'alpha statement'),
+      mkEngram('ENG-762-B', 'beta statement'),
+      mkEngram('ENG-762-C', 'gamma statement'),
+      mkEngram('ENG-762-R', 'retired statement', { status: 'retired' }),
+    ])
+  }, TIMEOUT)
+
+  afterAll(async () => {
+    await adapter?.dropSchema().catch(() => {})
+    await adapter?.close().catch(() => {})
+  }, TIMEOUT)
+
+  it('reports every un-embedded ACTIVE engram, and never a retired one', async () => {
+    const missing = await adapter.listEngramsMissingEmbeddings(10)
+    expect(missing.map(e => e.id).sort()).toEqual(['ENG-762-A', 'ENG-762-B', 'ENG-762-C'])
+  }, TIMEOUT)
+
+  it('is bounded by limit, in stable id order', async () => {
+    const one = await adapter.listEngramsMissingEmbeddings(1)
+    expect(one.map(e => e.id)).toEqual(['ENG-762-A'])
+    const two = await adapter.listEngramsMissingEmbeddings(2)
+    expect(two.map(e => e.id)).toEqual(['ENG-762-A', 'ENG-762-B'])
+  }, TIMEOUT)
+
+  it('shrinks as embeddings land, and empties when the gap is closed', async () => {
+    await adapter.upsertEmbedding('ENG-762-A', vec(1))
+    expect((await adapter.listEngramsMissingEmbeddings(10)).map(e => e.id).sort())
+      .toEqual(['ENG-762-B', 'ENG-762-C'])
+    await adapter.upsertEmbedding('ENG-762-B', vec(2))
+    await adapter.upsertEmbedding('ENG-762-C', vec(3))
+    // The LIMIT-1 shape is exactly the completeness probe recallSemantic runs.
+    expect(await adapter.listEngramsMissingEmbeddings(1)).toEqual([])
+  }, TIMEOUT)
+
+  it('rejects a non-positive limit rather than quietly returning everything', async () => {
+    await expect(adapter.listEngramsMissingEmbeddings(0)).rejects.toThrow(/positive integer/)
   }, TIMEOUT)
 })

--- a/packages/core/test/postgres-auto-embed.test.ts
+++ b/packages/core/test/postgres-auto-embed.test.ts
@@ -30,13 +30,14 @@
  * Gate follows the house rule: skip when PLUR_TEST_POSTGRES_URL is unset,
  * fail loudly when it is set and the database is broken.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Plur } from '../src/index.js'
 import { PostgresAdapter } from '../src/storage-postgres.js'
 import { _setCachedEmbedder, resetEmbedder, setEmbeddingsEnabled, embed } from '../src/embeddings.js'
+import { logger } from '../src/logger.js'
 
 const PG_URL = process.env.PLUR_TEST_POSTGRES_URL
 const SCHEMA = 'plur_auto_embed_762'
@@ -255,5 +256,52 @@ describe.skipIf(!PG_URL)('Postgres primary-store auto-embed (#762)', () => {
     expect(await plur.recallSemantic('solar panel cooling', { limit: 5, scopes: [] })).toEqual([])
     const scoped = await plur.recallSemantic('solar panel cooling', { limit: 5, scopes: ['global'] })
     expect(scoped.every(e => e.scope === 'global')).toBe(true)
+  }, TIMEOUT)
+
+  it('a store torn down mid-pass is a cancellation, not a failure — smoke-packaged regression', async () => {
+    // The release smoke caught this: its pg step drops the schema and closes
+    // the adapter when its work is done, and the still-in-flight auto-embed
+    // pass then failed LOUDLY — a stray "auto-embed failed: relation ...
+    // does not exist" warning after the process's real output, which broke
+    // the smoke's last-line gate. Teardown-under-a-background-pass must be
+    // classified as benign: no warning, no lastIndexError.
+    const SCHEMA2 = `${SCHEMA}_teardown`
+    const a3 = new PostgresAdapter({ connectionString: PG_URL!, schema: SCHEMA2, vectorIndex: 'exact' })
+    await a3.save([])
+    const dir3 = mkdtempSync(join(tmpdir(), 'plur-auto-embed-td-'))
+    const plur3 = new Plur({ path: dir3, store: a3 })
+    await plur3.ready()
+
+    // Gate the embedder so the pass is PROVABLY mid-flight when the store is
+    // dropped: embed() signals arrival, then blocks until released. Without
+    // the gate the pass usually wins the race and the test proves nothing.
+    let arrived!: () => void
+    const arrival = new Promise<void>(r => { arrived = r })
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    _setCachedEmbedder({
+      name: 'bge-small-en-v1.5',
+      dim: DIM,
+      modelId: 'stub-762-gate',
+      embed: async t => { arrived(); await gate; return stubVec(t) },
+      embedBatch: async ts => ts.map(stubVec),
+    })
+    const warnSpy = vi.spyOn(logger, 'warning')
+    try {
+      await plur3.learn('teardown race probe', { scope: 'global' }) // kicks the pass
+      await arrival                                                 // pass is inside embed()
+      await a3.dropSchema()                                         // teardown wins the race
+      release()                                                     // pass resumes into a dropped schema (42P01)
+      await plur3.waitForIndex()                                    // resolves — the pass never rejects
+
+      expect(plur3.lastIndexError(), 'teardown was recorded as a background failure').toBeNull()
+      const loud = warnSpy.mock.calls.filter(c => String(c[0]).includes('auto-embed failed'))
+      expect(loud, 'teardown produced a loud auto-embed warning').toEqual([])
+    } finally {
+      warnSpy.mockRestore()
+      installStubEmbedder() // drop the gated stub before any other test embeds
+      await a3.close().catch(() => { /* best effort */ })
+      rmSync(dir3, { recursive: true, force: true })
+    }
   }, TIMEOUT)
 })

--- a/packages/core/test/postgres-auto-embed.test.ts
+++ b/packages/core/test/postgres-auto-embed.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Postgres primary-store auto-embed (#762).
+ *
+ * The 0.16.0 audit (#752, item 4) measured the gap this file closes: five
+ * engrams learned through `Plur` against a `PostgresAdapter` left
+ * `engram_embeddings` at ZERO rows, so `vectorIndex: 'hnsw'` indexed an empty
+ * table and `recallSemantic` silently fell back to loading the corpus and
+ * scoring it in memory — the O(N) path the tier exists to escape. Correct
+ * results, wrong performance, no error.
+ *
+ * These tests pin the closure end to end, through the engine, against a real
+ * Postgres:
+ *
+ *   1. a write through `Plur.learn()` populates `engram_embeddings`;
+ *   2. a store migrated in WITH rows but WITHOUT embeddings is backfilled,
+ *      kicked by the first semantic recall — which must degrade to the
+ *      in-memory path while the table fills, never block, never miss rows;
+ *   3. `PLUR_DISABLE_EMBEDDINGS`-style opt-out: writes still land, nothing
+ *      crashes, recall falls back — and re-enabling converges the gap;
+ *   4. `recallSemantic` actually READS the table once it is complete — proven
+ *      behaviourally, not just by call-counting: a stored embedding is
+ *      poisoned with the query's own vector, and the poisoned engram tops the
+ *      ranking even though its TEXT is unrelated to the query. Only a path
+ *      that trusts the stored vectors can produce that ordering.
+ *
+ * Embeddings use the deterministic stub adapter (`_setCachedEmbedder`, the
+ * #335 test seam) so nothing here depends on a model download — the point is
+ * the plumbing between engine and store, not embedding quality.
+ *
+ * Gate follows the house rule: skip when PLUR_TEST_POSTGRES_URL is unset,
+ * fail loudly when it is set and the database is broken.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Plur } from '../src/index.js'
+import { PostgresAdapter } from '../src/storage-postgres.js'
+import { _setCachedEmbedder, resetEmbedder, setEmbeddingsEnabled, embed } from '../src/embeddings.js'
+
+const PG_URL = process.env.PLUR_TEST_POSTGRES_URL
+const SCHEMA = 'plur_auto_embed_762'
+const TIMEOUT = 120_000
+/** Must match the default vectorDim the adapter sizes its column to (and the
+ *  bge-small dim the engine's #335 guard resolves for the active embedder). */
+const DIM = 384
+
+/**
+ * Deterministic bag-of-tokens embedding: each token hashes to one of DIM
+ * buckets, vector is L2-normalized. Similar texts share tokens, share
+ * buckets, and score high cosine — enough signal for ranking assertions
+ * without a model load.
+ */
+function stubVec(text: string): Float32Array {
+  const v = new Float32Array(DIM)
+  const tokens = text.toLowerCase().split(/[^a-z0-9]+/).filter(t => t.length >= 3)
+  for (const t of tokens) {
+    let h = 2166136261
+    for (let i = 0; i < t.length; i++) h = Math.imul(h ^ t.charCodeAt(i), 16777619)
+    v[Math.abs(h) % DIM] += 1
+  }
+  let norm = 0
+  for (let i = 0; i < DIM; i++) norm += v[i] * v[i]
+  norm = Math.sqrt(norm)
+  if (norm === 0) { v[0] = 1; return v }
+  for (let i = 0; i < DIM; i++) v[i] /= norm
+  return v
+}
+
+/** (Re)install the deterministic stub as the active embedder. Needed again
+ *  after `setEmbeddingsEnabled(false)`, which drops the cached pipeline —
+ *  without this, re-enabling would make the next embed() load the real model. */
+function installStubEmbedder(): void {
+  _setCachedEmbedder({
+    name: 'bge-small-en-v1.5',
+    dim: DIM,
+    modelId: 'stub-762',
+    embed: async t => stubVec(t),
+    embedBatch: async ts => ts.map(stubVec),
+  })
+}
+
+describe.skipIf(!PG_URL)('Postgres primary-store auto-embed (#762)', () => {
+  let adapter: PostgresAdapter
+  let plur: Plur
+  let dir: string
+
+  beforeAll(async () => {
+    // Intent routing keys off query phrasing; pin it off so ranking
+    // assertions cannot be reordered by the classifier.
+    process.env.PLUR_INTENT_ROUTING = 'off'
+    installStubEmbedder()
+    dir = mkdtempSync(join(tmpdir(), 'plur-auto-embed-'))
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema: SCHEMA, vectorIndex: 'exact' })
+    await adapter.save([]) // known-empty store; fails loudly on a broken database
+    plur = new Plur({ path: dir, store: adapter })
+    await plur.ready()
+  }, TIMEOUT)
+
+  afterAll(async () => {
+    setEmbeddingsEnabled(true)
+    resetEmbedder()
+    delete process.env.PLUR_INTENT_ROUTING
+    if (adapter) {
+      await adapter.dropSchema().catch(() => { /* best effort */ })
+      await adapter.close().catch(() => { /* best effort */ })
+    }
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }, TIMEOUT)
+
+  it('learn() populates engram_embeddings — the audit-measured gap (#752 item 4)', async () => {
+    const e = await plur.learn('solar panel efficiency improves with active cooling', {
+      scope: 'global', type: 'behavioral',
+    })
+    // The embed pass is fire-and-track — the write itself must not wait on it.
+    await plur.waitForIndex()
+    expect(await adapter.hasEmbedding(e.id), 'learned engram has no embedding row').toBe(true)
+    expect(await adapter.countEmbeddings()).toBeGreaterThan(0)
+    expect(plur.lastIndexError()).toBeNull()
+  }, TIMEOUT)
+
+  it('a second write converges the whole gap, not just its own row', async () => {
+    const a = await plur.learn('kubernetes deploys use rolling updates', { scope: 'global' })
+    const b = await plur.learn('espresso extraction takes thirty seconds', { scope: 'global' })
+    await plur.waitForIndex()
+    expect(await adapter.hasEmbedding(a.id)).toBe(true)
+    expect(await adapter.hasEmbedding(b.id)).toBe(true)
+    // Set-based invariant: nothing active is left behind.
+    expect(await adapter.listEngramsMissingEmbeddings(1)).toEqual([])
+  }, TIMEOUT)
+
+  it('recallSemantic READS the table when it is complete — poisoned-vector proof', async () => {
+    await plur.waitForIndex()
+    const query = 'solar panel cooling'
+    // Find the engram whose TEXT is unrelated to the query...
+    const all = await adapter.load()
+    const espresso = all.find(e => e.statement.includes('espresso'))!
+    // ...and poison its STORED vector with the query's own embedding.
+    const queryVec = await embed(query, 'query')
+    await adapter.upsertEmbedding(espresso.id, queryVec!)
+
+    // Count real k-NN queries too, so a silent fallback cannot pass.
+    let vectorCalls = 0
+    const real = adapter.searchVector.bind(adapter)
+    ;(adapter as unknown as { searchVector: typeof adapter.searchVector }).searchVector = async (q, l, o) => {
+      vectorCalls++
+      return await real(q, l, o)
+    }
+    try {
+      const hits = await plur.recallSemantic(query, { limit: 3 })
+      expect(vectorCalls, 'recallSemantic did not query the vector index').toBe(1)
+      // Only a path trusting STORED vectors ranks the espresso engram first —
+      // the in-memory path re-embeds its text and would bury it.
+      expect(hits[0]?.id, 'ranking ignored the stored vectors').toBe(espresso.id)
+    } finally {
+      ;(adapter as unknown as { searchVector: typeof adapter.searchVector }).searchVector = real
+      // Heal the poisoned row for the tests that follow.
+      const { engramSearchText } = await import('../src/fts.js')
+      await adapter.upsertEmbedding(espresso.id, (await embed(engramSearchText(espresso)))!)
+    }
+  }, TIMEOUT)
+
+  it('backfills a store that has rows but no embeddings, kicked by the first semantic recall', async () => {
+    // Simulate a corpus migrated in from outside the engine: rows exist,
+    // embeddings do not. `save()` through the adapter writes no vectors.
+    const corpus = await adapter.load()
+    await adapter.dropSchema()
+    await adapter.close().catch(() => { /* superseded below */ })
+    const adapter2 = new PostgresAdapter({ connectionString: PG_URL!, schema: SCHEMA, vectorIndex: 'exact' })
+    await adapter2.save(corpus)
+    expect(await adapter2.countEmbeddings()).toBe(0)
+
+    const dir2 = mkdtempSync(join(tmpdir(), 'plur-auto-embed-bf-'))
+    try {
+      const plur2 = new Plur({ path: dir2, store: adapter2 })
+      await plur2.ready()
+
+      let vectorCalls = 0
+      const real = adapter2.searchVector.bind(adapter2)
+      ;(adapter2 as unknown as { searchVector: typeof adapter2.searchVector }).searchVector = async (q, l, o) => {
+        vectorCalls++
+        return await real(q, l, o)
+      }
+      try {
+        // While the table is incomplete the vector index would return results
+        // drawn from whatever subset happens to be embedded — correct-looking,
+        // silently incomplete. The read must degrade to the in-memory path...
+        const during = await plur2.recallSemantic('solar panel cooling', { limit: 3 })
+        expect(vectorCalls, 'used a half-filled vector index').toBe(0)
+        expect(during.length).toBeGreaterThan(0)
+        expect(during[0].statement).toContain('solar panel')
+
+        // ...while kicking the backfill in the background.
+        await plur2.waitForIndex()
+        expect(await adapter2.listEngramsMissingEmbeddings(1)).toEqual([])
+        expect(await adapter2.countEmbeddings()).toBe(corpus.filter(e => e.status === 'active').length)
+
+        // Once complete, the same call routes through the vector index.
+        const after = await plur2.recallSemantic('solar panel cooling', { limit: 3 })
+        expect(vectorCalls, 'complete table was not used').toBe(1)
+        expect(after[0].statement).toContain('solar panel')
+      } finally {
+        ;(adapter2 as unknown as { searchVector: typeof adapter2.searchVector }).searchVector = real
+      }
+      // Hand the (now embedded) store back to the outer fixtures.
+      adapter = adapter2
+      plur = new Plur({ path: dir, store: adapter2 })
+      await plur.ready()
+    } finally {
+      rmSync(dir2, { recursive: true, force: true })
+    }
+  }, TIMEOUT)
+
+  it('embedder disabled: writes still land, nothing crashes, recall falls back', async () => {
+    setEmbeddingsEnabled(false, 'test: simulating PLUR_DISABLE_EMBEDDINGS')
+    let disabledEngramId = ''
+    try {
+      const before = await adapter.countEmbeddings()
+      const e = await plur.learn('written while embeddings are disabled', { scope: 'global' })
+      disabledEngramId = e.id
+      await plur.waitForIndex()
+      // The write landed; the embedding deliberately did not.
+      expect((await adapter.load()).map(x => x.id)).toContain(e.id)
+      expect(await adapter.countEmbeddings()).toBe(before)
+      expect(plur.lastIndexError()).toBeNull()
+
+      // Semantic recall must not throw and must not touch the vector index.
+      let vectorCalls = 0
+      const real = adapter.searchVector.bind(adapter)
+      ;(adapter as unknown as { searchVector: typeof adapter.searchVector }).searchVector = async (q, l, o) => {
+        vectorCalls++
+        return await real(q, l, o)
+      }
+      try {
+        const hits = await plur.recallSemantic('solar panel cooling', { limit: 3 })
+        expect(Array.isArray(hits)).toBe(true)
+        expect(vectorCalls).toBe(0)
+      } finally {
+        ;(adapter as unknown as { searchVector: typeof adapter.searchVector }).searchVector = real
+      }
+    } finally {
+      setEmbeddingsEnabled(true)
+      installStubEmbedder() // disabling dropped the cached stub pipeline
+    }
+
+    // Re-enabled: the next write sweeps up the engram written while disabled.
+    await plur.learn('written after embeddings were re-enabled', { scope: 'global' })
+    await plur.waitForIndex()
+    expect(await adapter.hasEmbedding(disabledEngramId), 'disabled-era engram was never backfilled').toBe(true)
+    expect(await adapter.listEngramsMissingEmbeddings(1)).toEqual([])
+  }, TIMEOUT)
+
+  it('scope restrictions ride the semantic pushdown — an empty allow-list returns nothing', async () => {
+    await plur.waitForIndex()
+    expect(await plur.recallSemantic('solar panel cooling', { limit: 5, scopes: [] })).toEqual([])
+    const scoped = await plur.recallSemantic('solar panel cooling', { limit: 5, scopes: ['global'] })
+    expect(scoped.every(e => e.scope === 'global')).toBe(true)
+  }, TIMEOUT)
+})


### PR DESCRIPTION
Closes #762 (audit #752, item 4).

On a Postgres **primary** store nothing populated `engram_embeddings`: `vectorIndex: 'hnsw'` built an ANN index over an empty table and `recallSemantic` silently fell back to loading the corpus and scoring it in memory — the O(N) path the tier exists to escape. Measured in the audit: five engrams learned through `Plur` left the table at 0 rows. This closes the gap on both sides, on the terms the ADR-0005 amendment demanded.

## Design

**The set-based query the issue asked for.** `PostgresAdapter.listEngramsMissingEmbeddings(limit)` is one bounded anti-join between the two tables' primary keys (`active` rows with no embedding row, `ORDER BY id LIMIT n`). Cost scales with the *gap*, not the corpus — the per-id `hasEmbedding` probe shape that made `_autoEmbedNewEngrams` unshippable at 50k rows is never used. It is declared as an optional `StorageAdapter` method: an adapter that cannot answer the question as a set leaves it undefined and core skips auto-embed rather than degrade writes.

**Write path — fire-and-track, coalescing.** `_syncIndex()` (already called after every primary-store write) now kicks `_kickPrimaryAutoEmbed` when the primary store is a query adapter with the anti-join. The write never waits on embedding. A write landing mid-pass sets a rerun flag instead of stacking a second pass, so bursts coalesce into one follow-up sweep. The pass drains the anti-join in batches of 100 (bounds memory; each batch is a fresh query, so concurrent writers and mid-pass crashes converge). Failures land in `lastIndexError()` / `status().index_error`, never in the write. The pass is tracked on the same promise `waitForIndex()` awaits, like the PGLite chains.

**Read side — `recallSemantic` actually uses the table.** Verified the issue's suspicion the hard way: the read path was *not* already correct — only `pgliteAdapter` ever routed to `searchVector`; a Postgres primary always took the in-memory `embeddingSearch` path. New `_primarySemanticRecall` mirrors `recall()`'s BM25 pushdown: k-NN into `searchVector` with `scopes`, the `scope` visibility filter, and mounted-scope `visibilityGrants` all **inside the query** (`PostgresAdapter.searchVector` now pushes all three down via the shared `buildFilterClause`; previously it honoured only `scopes`, so the semantic pushdown would have re-created the #775 dilution failure). Residual filters (expiry, `min_strength`) run on the returned rows; secondary-store/pack engrams are scored in memory and merged by the same clamped-cosine metric — same embedder, same measure, not an approximation.

**Completeness gate — partial vector answers are never served.** One `listEngramsMissingEmbeddings(1)` probe per semantic call. While *any* active engram lacks an embedding, hits would be drawn from whichever subset happens to be embedded — correct-looking, silently incomplete — so the call degrades to the in-memory path for that query and kicks the backfill in the background. This is also the migration story: a store imported with rows but no embeddings converges from the **first semantic recall**, no operator step, no write required.

**Opt-outs hold.** `PLUR_DISABLE_EMBEDDINGS` / `embeddings.enabled: false` skips the pass before any DB query (one loud notice per instance — the empty table is then a configuration choice, not a silent gap); an embedder/column dim mismatch skips rather than persist wrong-shape vectors (#335); an embedder that dies mid-pass pauses the sweep and never fails a write.

**Removed:** the schema-init embeddings-gap warning and its test — the condition they disclosed no longer exists when the engine drives the adapter. ADR-0005 gains a closure note under its 2026-07-28 amendment.

## Files

- `packages/core/src/storage-postgres.ts` — `listEngramsMissingEmbeddings` anti-join; `searchVector` pushes `scope`/`visibilityGrants` down via `buildFilterClause`; gap warning removed; docs updated
- `packages/core/src/storage-adapter.ts` — optional `listEngramsMissingEmbeddings` on the interface; `searchVector` opts widened to match what both implementations already honour
- `packages/core/src/index.ts` — `_kickPrimaryAutoEmbed` / `_autoEmbedPrimaryStore` (write path + backfill), `_primarySemanticRecall` (read path), `_syncIndex` wiring
- `packages/core/test/postgres-auto-embed.test.ts` — new engine-level suite (below)
- `packages/core/test/postgres-adapter.test.ts` — adapter-level anti-join semantics; obsolete gap-warning test removed
- `docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md` — closure note

## Tests

Postgres-gated (`PLUR_TEST_POSTGRES_URL`, real PostgreSQL 16 + pgvector), engine level:

- `learn()` populates `engram_embeddings` — the exact audit measurement, inverted
- a second write converges the whole gap, not just its own row
- **poisoned-vector proof** that `recallSemantic` READS the table: one stored embedding is overwritten with the query's own vector, and that engram tops the ranking despite unrelated text — an ordering only a path trusting stored vectors can produce (plus a call-count spy on `searchVector`)
- backfill: a corpus `save()`d in with 0 embeddings → first semantic recall returns correct results via the fallback (spy proves the half-filled index is *not* used), kicks the backfill, converges; the next call routes through the vector index
- embedder disabled: writes land, no rows added, recall falls back without touching the index, nothing crashes — and re-enabling sweeps up the disabled-era engram on the next write
- scope restrictions ride the pushdown (`scopes: []` returns nothing)

Adapter level: anti-join is active-only, bounded, stable-ordered, shrinks as embeddings land, rejects non-positive limits.

Verification: all 8 Postgres suites green (98 tests) + the new suite (6 tests); `pnpm typecheck:tests` and `pnpm build` clean. Full suite: 3402 passed; 28 failures in 14 files were all 5s/30s **timeouts** (CLI process-spawn and WASM-Postgres boots) during a run that overlapped two concurrent suites plus another agent session on the same machine — the contention class `vitest.config.ts` documents. All 14 files re-run green in isolation (81/81, 42s).

## Bench (`pnpm bench:micro`, 50 iters, YAML store — the default tier this bench exercises)

| Operation | main | pr762 | Δ mean |
|---|---|---|---|
| learn | 3.30ms (p95 4.39) | 3.55ms (p95 6.36) | +0.24ms (+7.4%) |
| recall_bm25 | 4.61ms (p95 5.78) | 4.28ms (p95 5.43) | −0.33ms (−7.2%) |
| recall_hybrid | 33.86ms (p95 26.99) | 11.31ms (p95 11.86) | −22.55ms (−66.6%) |
| inject | 0.72ms (p95 1.52) | 0.42ms (p95 0.55) | −0.30ms (−41.9%) |

Read the deltas honestly: run-to-run variance dominates. A second branch run measured learn **2.78ms** — faster than main — so the +0.24ms is noise, not a regression; the hybrid/inject "wins" are warm-cache artifacts, not claims. That is the expected shape: on the YAML tier the entire cost of this change is one method-existence check in `_syncIndex`, and the Postgres tier's new work is background-only by construction.

## Known limits / follow-ups

- An engram whose **statement changes** under an existing id keeps its old embedding (the anti-join only sees missing rows). Exact parity with the PGLite pass, which skips any id with an embedding — pre-existing behaviour, not introduced here.
- `recallHybrid`'s vector leg on the Postgres tier still runs in memory; wiring it through the same pushdown is a natural follow-up but a larger change (BM25 + vector + RRF coordination), out of #762's scope.

## CI follow-up (second commit)

The first push failed `smoke-packaged`: the smoke's pg step drops its schema and closes the adapter when done, and the still-in-flight background auto-embed pass then failed loudly — a stray `auto-embed failed: relation ... does not exist` warning around the process's real output broke the smoke's last-line `pg-ok` gate. Exactly the kind of short-lived-process race the smoke exists to catch, and it would bite any CLI invocation or script that closes its store.

Fix (`52a3d6a`): the pass classifies store teardown — Postgres `42P01`/`3F000` (schema/table dropped), "adapter is closed", node-postgres pool-ended — as a benign cancellation: debug log, no warning, not recorded in `lastIndexError()`. Every other failure stays loud. The smoke script is untouched. Regression test gates the stub embedder so the pass is provably mid-flight at drop time, and was verified non-vacuous (fails pre-fix with the smoke's exact error). `smoke-packaged` and the full unit matrix are green on the second push.
