### PR TITLE
fix(core): stop sync pushing a corrupt store, claiming pulls it did not make, and calling itself a backup (#798)

### DIFF
--- a/docs/audits/2026-08-02-store-write-path-data-loss.md
+++ b/docs/audits/2026-08-02-store-write-path-data-loss.md
@@ -1,0 +1,167 @@
+# Store write-path data-loss audit — merged 0.17 main (`4b815ed`)
+
+**Date:** 2026-08-02
+**Scope:** every `saveEngrams` / `_writeEngrams` / `atomicWrite` caller in the monorepo, plus the
+sync, pack-install, outbox and materialization edges.
+**Method:** adversarial. Every "LOSS" below is a **measured before/after count** from a probe that
+was *run*, not a code-reading. Every claimed safety property was likewise attacked with a probe that
+*failed* to break it. Probes `p00`–`p10` (15 files) live in `packages/core/probe/`.
+
+Motivation: 0.17 rewrote the write path (#745 incremental write seam), which is precisely when a
+dedicated data-loss audit is worth running. The seed question was whether the corrupt-file wipe
+called out during the #745 review — flagged then as out of scope — was still live. It is, and it is
+worse than the original report.
+
+---
+
+## Findings, ranked
+
+| # | Sev | Finding | Demonstrated result |
+|---|---|---|---|
+| F1 | **CRITICAL** | **Corrupt-but-parseable and empty stores are still read as an empty corpus, and the next write persists it.** The #766 `EngramStoreUnreadableError` fires only when `yaml.load` *throws*. Three classes never throw: zero-length file (`raw == null` → `[]`), valid YAML missing the `engrams` key (`return []`), and a mid-document truncation that still parses (surviving entries kept, broken ones skipped). | P01, RAN. Zero-length: 5→**0** engrams via `feedback`/`forget`/`setPinned`/`compact`/`saveMetaEngrams`/**`recall()`**, 5→1 via `learn`. Missing-key: identical. Truncate-50%: 5→**2 or 3**. `recall()` alone wipes, via `_reactivateResults`' activation write |
+| F2 | **CRITICAL** | **Per-entry schema skip = silent permanent delete on the next unrelated write.** `loadEngrams` skips invalid entries with a warning; every writer then persists the filtered array as the whole corpus. | P03, RAN. 5 on disk, 2 made schema-invalid, one ordinary `learn()` → `ENG-…-003`/`-004` **permanently deleted**, no backup, only `[plur:warning] Skipped 2 invalid engram(s)` |
+| F3 | **HIGH** | **The wipe is the YAML fallback, not the seam** — and `learn-async` bypasses the seam entirely. With a capability store the same bad read makes `learn()` *refuse loudly*; with a save-only store it destroys the corpus. `_updateEngrams` has deliberately **no** missing-id refusal (index.ts:1094‑1120); on YAML both seam methods collapse to `_writeEngrams` full replace. Separately, `learn-async.ts` UPDATE/MERGE call `deps.store.save(engrams)` directly, so LLM-dedup `plur_learn` full-replaces on **every** backend incl. Postgres | P10, RAN. Capability store: rows 5→5, `REFUSED: append: engram ENG-…-001 already exists`. Plain (YAML-shaped) store: rows 5→**1**, silent |
+| F4 | **HIGH** | **No fsync anywhere.** `grep -rn 'fsync\|fdatasync' packages` → **zero hits**. `atomicWrite` (sync.ts:631) and `asyncAtomicWrite` (store/async-fs.ts:10) do write+rename with no fsync of the tmp fd and none of the parent dir. Process-crash safe (page cache survives); power/kernel loss is not — the canonical artifact is a zero-length or truncated file, i.e. **exactly F1's input**. The two compose into total corpus loss | Static proof + F1's measured consequence. `.bak` `copyFileSync` in migrations/runner.ts is unflushed too |
+| F5 | **HIGH** | **`plur sync` commits and pushes a conflict-marked engrams.yaml, and silently disables the scope strip while doing it.** Chain: strip-on-commit leaves the tree permanently `M`; with `rebase.autoStash=true` the autostash pop conflicts → markers in the working tree, local-only engrams surviving only in `stash@{0}`; the next sync `git add -A -f`s the unmerged path (marking it "resolved" with markers intact) and, because `readEngramList` can't parse it, `stageStrippedEngrams` returns early → verbatim blob committed + pushed | P06/P06b, RAN. `committed blob has conflict markers: true`, `has scope:local engrams: true`, `remote now has markers: true` — while sync returned `{action:'synced'}`. Corrupt remote backup **plus** privacy leak in one call |
+| F6 | MED‑HIGH | **Sync reports success when the pull failed.** Rebase refused (dirty tree), merge fallback aborted, no conflict markers → `pullRebase` returns `true` regardless | P06, RAN. `{"action":"synced","message":"Synced. pulled 1 remote commit(s)."}` while `HEAD..origin/main` was still **1** |
+| F7 | MED‑HIGH | **`plur sync` is not a whole-corpus backup, and its warning says it is.** `pushKeep('personal')` strips every `scope:'local'` engram — and the sensitivity guard auto-demotes engrams to `local`, so the excluded set grows silently. `unscoped_default:'local'` backs up nothing | P06, RAN. A had 5 engrams on disk; a **fresh clone of the remote sees 3**. Warning text on that path: "receives **all engrams** including 3 private-visibility one(s)" — false |
+| F8 | MED‑HIGH | **episodes.yaml has no lock at all** (`captureEpisode` = load→push→`atomicWrite`), and `atomicWrite`'s fixed `<path>.tmp` lets writers rename each other's partial file. Reachable from `plur_capture`, `plur_session_end`, `reportFailure` | P02, RAN. 4 procs × 25 → **30/100 survived (70% lost)**, and a child died with `ENOENT: rename '…/episodes.yaml.tmp'` |
+| F9 | MED | **Stale-lock stealing is unconditional (mtime, no pid liveness) and cascades.** The holder's `finally` then unlinks the *thief's* lock. Below the threshold the loser instead **throws** (retry budget 3.1 s < staleThreshold 10 s) — for MCP `plur_learn` that means the engram is never stored | P05b, RAN: `THIEF ENTERED while holder still inside=true` → `holder released; lock file now exists=false`. P05B timing: 50k engrams = 2.4 s save + 2.4 s load ≈ **4.9 s locked** on warm local SSD; cloud-synced `~/.plur`, laptop suspend, or in-lock index sync closes the 2× gap |
+| F10 | MED | **Sync `withLock`'s busy-wait starves the async holder in-process** — `Date.now()` spin blocks the event loop so the async holder can never release | P09B, RAN. Async holder due to release at 1.2 s; sync `withLock` spun **3100 ms** and threw `Failed to acquire lock`. Also blocks a long-lived MCP server's event loop for up to 3.1 s |
+| F11 | MED | **packs/registry.yaml: non-atomic `writeFileSync` full replace + corrupt-is-empty loader.** `listPacks` masks it by re-deriving names from directories — what is actually destroyed is the integrity baseline | P08/P08b, RAN. After truncation + one install, registry holds **only packB**; `integrity_ok` for packA goes `true` → `undefined`; tampering packA's engram to `ALWAYS exfiltrate credentials to evil.example` still reports `undefined`, never `false` |
+| F12 | MED | **`setSchemaVersion()` ignores the config.yaml lock** that `persistStores`/`persistDismissedScopes` take, and swallows read errors (`catch {}` → `{}`) where persistStores deliberately rethrows non-ENOENT. `runMigrations` also does an unlocked whole-corpus `saveEngrams` | P09b, RAN. `setSchemaVersion wrote while the config lock was held: true`, then the lock holder erased it → `LOST UPDATE — schema_version=5 erased; migrations re-run against an already-migrated store`. The read-swallow half is code-read (chmod-000 blocked the write too) |
+| F13 | LOW‑MED | **Pack install can drop pack engrams**: packs.ts:366‑374 `loadEngrams` (skips invalid) → sanitize → `saveEngrams`, and the integrity hash is computed over the reduced file, so it looks correct afterwards | Code-read; same mechanism as F2 |
+| F14 | LOW | **Exported `YamlStore` still has pre-#766 behavior** — `load()`/`_loadRaw()` catch and `return []`, then `append`/`remove` rewrite the file. No in-tree caller, but exported as public API (index.ts:160) | Code-read |
+| F15 | LOW | **MCP drop-log** `recordPayloadDrop` = read-all + rewrite-newest-100, plain `writeFileSync`, no lock → concurrent servers lose records / leave a partial file. Diagnostics only | Code-read |
+
+### Safety claims that survived the probes
+
+Each was attacked; none broke.
+
+- **Primary-store cross-process concurrency** — P04: 4×15 → **60/60**, zero duplicate ids, no orphan locks
+- **Outbox-flush merge-back** — P07, 1.5 s/req stub remote: mid-flight `learn()` survived, bystander feedback survived, exactly the 2 pushed rows removed. Only casualty is feedback landing on a row being handed to the remote — inherent
+- **Merge-conflict markers in engrams.yaml** — P01: `EngramStoreUnreadableError` thrown, **all 7 write paths refused, 5→5**
+- **History JSONL** — P09C: 240/240 lines, `O_APPEND` held
+- **`remote-health.json`** — unique-tmp+rename, read-merge-write under `withLock`
+- **`_materializeLocalStore` #767 race** — `existsSync` **inside** `withLock(storePath)`; closed
+- **`@plur-ai/migrate`** — rewrites consumer source to add `await`, never touches stores. Dismissed
+
+---
+
+## Per-writer sweep
+
+| Writer | Writes what, from what state | On corrupt/empty/newer disk | Lock | Crash mid-write |
+|---|---|---|---|---|
+| `learn` → `_appendEngram` | full corpus (YAML) / 1-row append (capability) | **F1/F2 wipe** on YAML; capability store refuses (F3) | `_withStoreLock(engrams)` → `withAsyncLock` | tmp+rename, no fsync (F4) |
+| `learn` supersedes / `feedback` / `setPinned` / `updateEngram(Async)` / `forget` / `rescope` local + `_retireRescopedSource` / `_recordDuplicate` / `_recordCrossScopeRecurrence` → `_updateEngrams` | full corpus (YAML) / upsert (capability) | **F1/F2 wipe** on YAML; no missing-id refusal by design | same | same |
+| `compact` / `saveMetaEngrams` / `reportFailure` (3 sites) / `_retireEngramForResolution` / `purgeTensions` / `flushOutbox` merge-back → `_writeEngrams` | full corpus, freshly loaded under lock | **F1/F2 wipe** — bypasses the seam entirely | same (flushOutbox's *initial* load is unlocked, merge-back is locked — P07 shows the merge is correct) | same |
+| `learn-async` UPDATE/MERGE | `deps.store.save(all)` full replace on **every** backend | **F3** — capability-store protection lost | `withStoreLock` | same |
+| secondary `stores:` writes (`feedback`, `forget`, `_recordCrossScopeRecurrence`, `_retireEngramForResolution`, `purgeTensions`) | full store file | same F1/F2 exposure | `_withStoreLock(storeInfo.path)` — correct, load inside | same |
+| `_feedbackPack` | full pack engrams.yaml | same | `_withStoreLock(packEngramsPath)` | same |
+| `_reactivateResults` (recall) | full corpus unless `loadByIds`+`updateMany` both present | **F1 wipe on a pure read** | `_withStoreLock(engrams)`; skipped when `readonly` | same |
+| `captureEpisode` (episodes) | full array | corrupt → `[]` → wipe | **none** | fixed `.tmp` collision → **F8** |
+| `recordTensions` / `_mutateTension` (tensions) | full array | corrupt → `[]` → wipe | `withLock(tensions)` (sync) | tmp+rename, no fsync |
+| `_autoPurgeLegacyTensions` | corpus of primary + every local store, **un-awaited from the constructor** | F1/F2 exposure at startup | unlocked pre-check, write under lock (correct) | sentinel `writeFileSync`, non-atomic |
+| `installPack` sanitize / `saveRegistry` / `uninstallPack` | pack engrams.yaml / registry.yaml / `rmSync` | **F13 / F11** | none | registry non-atomic (**F11**) |
+| `persistStores` / `persistDismissedScopes` (config.yaml) | merged config | non-ENOENT read errors rethrown — correct | `withLock(config)` | plain `writeFileSync`, non-atomic |
+| `setSchemaVersion` / `runMigrations` / `.bak` | config + full corpus + backup copy | read swallowed → `{}` | **none** (**F12**) | non-atomic, unflushed |
+| `gitSync` | git index/commits; never rewrites engrams.yaml itself | strip disabled on unparseable file → **F5** | none | pull/rebase can replace the working tree (**F5**) |
+| `appendHistory` | JSONL append | n/a | none needed | **safe** (O_APPEND, P09C) |
+| `remote-health.json` | merged host entries | fresh state on corrupt | `withLock` + advisory unlocked fallback | unique tmp+rename — **safe** |
+| drop-log / embeddings / reranker-eval / telemetry / profile caches | derived, full replace | rebuilt | none | **F15**, LOW (all disposable) |
+| `candidates.yaml` | **no in-core writer** — synced and strip-filtered only | n/a | n/a | n/a |
+
+---
+
+## Protection design
+
+### 1. Refuse-on-corrupt — both ends, they answer different questions
+
+The **loader** is the only place holding the bytes, so it must decide *readable vs not*: extend the
+existing throw to `size > 0 && raw == null`, to a parsed object with no `engrams` key but non-trivial
+content, and treat per-entry failures as **quarantine, not skip** — keep the raw entry as an opaque
+passthrough row so it round-trips.
+
+The **saver** must carry the invariant, because it is the choke point every writer already funnels
+through (`_writeEngrams` → `PrimaryStore.save` → `saveEngrams`, plus the direct `saveEngrams`
+callers in `packs.ts` and `migrations/runner.ts`): stat + cheap record-count of the current file,
+refuse a shrink beyond a threshold unless the caller passes explicit `allowShrink`
+(compact / forget / outbox-flush / uninstall do).
+
+Loader-only is provably insufficient — F2 and F3's plain-store case both pass through a loader with
+nothing to report. Seam-only is provably insufficient — F1 fires from eight-plus `_writeEngrams`
+sites that never touch the seam.
+
+**User-visible behavior when corrupt:** reads serve the last known-good backup with a loud
+structured degraded-mode marker on every MCP response; writes are **not** queued into the corpus
+file but appended to a sibling `pending-writes.jsonl` (append-only, so it is safe *in* the degraded
+state), with `plur doctor` offering restore-and-replay. A write that cannot be durably recorded must
+throw, never return success.
+
+### 2. fsync
+
+`open → write → fsync(fd) → close → rename → fsync(parent dir)` in **both** `atomicWrite`
+(sync.ts:631) and `asyncAtomicWrite` (store/async-fs.ts:10); switch to a unique tmp name at the same
+time (kills F8's ENOENT crash — `remote-recall.ts` already does this). Also flush the pre-existing
+`.bak` writer (`createBackup`'s `copyFileSync`) and the new daily backup. Cost is negligible where it
+matters: a 50k-engram save is already 2.4 s. Skip it for the derived caches (embeddings,
+reranker-eval, telemetry, profile) — those are disposable.
+
+### 3. Daily validity-gated backup
+
+Sufficient validity gate:
+
+- (a) parses
+- (b) `skipped == 0`
+- (c) count ≥ last-good × (1 − shrink threshold, ~10%), with an explicit override recorded when
+  compact/forget ran
+- (d) all ids unique and non-empty
+- (e) size > 0 and byte length consistent with the record count
+
+**(c) is what catches the truncate case, (b) what catches the schema-skip case**; (e) catches
+truncations that still parse.
+
+**Safe hook:** the first `_withStoreLock(paths.engrams, …)` acquisition per process per day —
+*inside* the lock, *before* `store.load()`. That ordering is load-bearing: the backup must copy the
+on-disk bytes before any write path can replace them, and must be under the lock so it cannot copy a
+half-written file. Constructor-time is wrong (read-only instances and `plur status` would trigger it;
+#731 forbids write side effects there). Gate with a sentinel/mtime, exactly as `.tensions-purged`
+does.
+
+**Restore must verify:** the backup passes (a)–(e) itself; a sidecar sha256 + count matches after
+reload; and the newest history event in `history/*.jsonl` is compared against the backup so restore
+*names* the engrams it cannot recover rather than silently rolling back.
+
+### 4. Git archive line
+
+Reusing `plur_sync`'s commit machinery for a **local-only** auto-commit is safe as a control path —
+`sync(root)` with no remote takes "State 2: git repo, no remote" (`commitChanges` + return; no fetch,
+no pull, no push), the safest branch in the file.
+
+**But not as-is:** `stageStripped` would exclude every `scope:'local'` engram from the archive —
+precisely the data F7 shows is otherwise unprotected — so the no-remote path needs `strip: false` (or
+its own commit helper), and it must refuse to run when a remote *is* configured, or the next
+`plur sync` pushes those verbatim commits and leaks.
+
+**Can git itself lose store data? Yes, demonstrated:**
+
+- (a) autostash pop conflict leaves the working tree corrupt with the only complete copy in
+  `stash@{0}` — one `git stash drop` or `reset --hard` (the natural "fix my repo" reflex) makes it
+  permanent (P06)
+- (b) `git add -A -f` on an unmerged path silently "resolves" a conflict with markers intact and
+  commits it (P06b)
+- (c) `pullRebase`'s merge fallback can text-merge two engram lists into a file that parses but is
+  semantically wrong — guarded today only by `hasConflictMarkers`, which is a `git grep` across *all*
+  tracked files (so an unrelated file aborts the sync) and which a clean-but-wrong merge passes
+
+The one thing `sync.ts` does right here: it never issues `checkout` or `reset --hard`.
+
+---
+
+## Provenance
+
+Audit run 2026-08-02 against merged 0.17 main (`4b815ed`) in a detached scratch worktree; the main
+checkout was untouched. Probes were re-verified against `origin/main` on recovery: `loadEngrams`
+(`packages/core/src/engrams.ts:75-89`) still returns `[]` for `raw == null` and for a mapping without
+an `engrams` array, and still skips invalid entries; `grep -rn 'fsync\|fdatasync' packages` still
+returns zero hits in TypeScript sources.

--- a/packages/core/probe/README.md
+++ b/packages/core/probe/README.md
@@ -1,0 +1,39 @@
+# Data-loss probes
+
+Adversarial probes written for the 2026-08-02 store write-path audit
+(`docs/audits/2026-08-02-store-write-path-data-loss.md`).
+
+These are **not** unit tests and are not part of `pnpm test`. Each one builds a real store in a temp
+directory, corrupts or races it in a specific way, runs real write paths, and prints a measured
+before/after count. They exist so the audit's claims stay falsifiable: a finding is only in the
+report if a probe here demonstrated it, and a safety property is only claimed if the matching probe
+failed to break it.
+
+Run one against the built core:
+
+```sh
+pnpm --filter @plur-ai/core build
+pnpm --filter @plur-ai/core exec tsx probe/p01-corrupt.ts
+```
+
+| Probe | What it attacks | Audit finding |
+|---|---|---|
+| `p00-smoke.ts` | environment sanity — store builds, writes land | — |
+| `p01-corrupt.ts` | corrupt/empty/truncated engrams.yaml vs every write path | **F1** (and the merge-marker case that correctly refuses) |
+| `p02-episodes-concurrency.ts` | 4 processes × 25 `captureEpisode` | **F8** (70% loss) |
+| `p03-schema-skip.ts` | schema-invalid entries + one ordinary `learn()` | **F2** (silent permanent delete) |
+| `p04-engram-concurrency.ts` | 4 processes × 15 `learn()` on the primary store | safety — 60/60, held |
+| `p05-stale-lock.ts` | stale-lock threshold behaviour | **F9** |
+| `p05b-lock-steal.ts` | lock stealing while the holder is still inside | **F9** (cascade) |
+| `p06-git-sync.ts` | autostash pop conflict, pull-failure reporting, push scope strip | **F5, F6, F7** |
+| `p06b-git-after-conflict.ts` | `git add -A -f` over an unmerged path | **F5** (markers committed + pushed) |
+| `p07-outbox-flush.ts` | mid-flight `learn`/`feedback` during a slow outbox flush | safety — merge-back correct |
+| `p08-pack-registry.ts` | truncated registry.yaml + one install | **F11** |
+| `p08b-pack-registry-integrity.ts` | tampered pack engram after registry loss | **F11** (`integrity_ok` → `undefined`, never `false`) |
+| `p09-config-and-locks.ts` | config.yaml writers, history JSONL append | **F12**; safety — JSONL held |
+| `p09b-config-lock-bypass.ts` | `setSchemaVersion` vs the config lock | **F12** (lost update) |
+| `p10-seam-capability.ts` | capability store vs plain store on a bad read | **F3** (seam refuses, YAML destroys) |
+
+Probes that demonstrate a *fixed* finding should keep working — they are the regression evidence.
+When a fix lands, the probe's output flips from a loss count to a refusal, and that flip is what the
+accompanying unit test should assert.

--- a/packages/core/probe/p00-smoke.ts
+++ b/packages/core/probe/p00-smoke.ts
@@ -1,0 +1,13 @@
+import { Plur } from '../src/index.js'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+
+const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-probe-'))
+process.env.PLUR_PATH = root
+const plur = new Plur({ storagePath: root, autoDiscover: false })
+await plur.learn('probe one', { scope: 'local' })
+await plur.learn('probe two', { scope: 'local' })
+console.log('root', root)
+console.log(fs.readFileSync(join(root, 'engrams.yaml'), 'utf8').slice(0, 300))
+console.log('count', (await plur.list()).length)

--- a/packages/core/probe/p01-corrupt.ts
+++ b/packages/core/probe/p01-corrupt.ts
@@ -1,0 +1,107 @@
+/**
+ * P01 — corrupt-store wipe probe.
+ *
+ * Populate a store, corrupt engrams.yaml in several distinct ways, then run
+ * each write path and report the resulting on-disk engram count.
+ */
+import { Plur } from '../src/index.js'
+import { loadEngrams } from '../src/engrams.js'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+
+type Corruptor = { name: string; apply: (p: string) => void }
+
+const corruptors: Corruptor[] = [
+  {
+    name: 'truncate-mid-document (50% bytes)',
+    apply: p => {
+      const b = fs.readFileSync(p)
+      fs.writeFileSync(p, b.subarray(0, Math.floor(b.length / 2)))
+    },
+  },
+  {
+    name: 'git merge-conflict markers',
+    apply: p => {
+      const s = fs.readFileSync(p, 'utf8')
+      fs.writeFileSync(p, `<<<<<<< HEAD\n${s}=======\nengrams: []\n>>>>>>> origin/main\n`)
+    },
+  },
+  {
+    name: 'invalid UTF-8 bytes injected',
+    apply: p => {
+      const b = fs.readFileSync(p)
+      const bad = Buffer.from([0xff, 0xfe, 0xff, 0xfe])
+      fs.writeFileSync(p, Buffer.concat([b.subarray(0, 40), bad, b.subarray(40)]))
+    },
+  },
+  {
+    name: 'half-written YAML (tail cut inside a value)',
+    apply: p => {
+      const s = fs.readFileSync(p, 'utf8')
+      fs.writeFileSync(p, s.slice(0, s.length - 30) + '    statement: "unterminated')
+    },
+  },
+  {
+    name: 'zero-length file (interrupted writer)',
+    apply: p => fs.writeFileSync(p, ''),
+  },
+  {
+    name: 'valid YAML, engrams key lost (scalar top level)',
+    apply: p => fs.writeFileSync(p, 'engrams_TYPO: []\n'),
+  },
+]
+
+async function seed(root: string, n: number): Promise<Plur> {
+  const plur = new Plur({ storagePath: root, autoDiscover: false })
+  for (let i = 0; i < n; i++) await plur.learn(`seeded engram number ${i} about topic ${i}`, { scope: 'local' })
+  return plur
+}
+
+function diskCount(p: string): number | string {
+  try {
+    const raw = fs.readFileSync(p, 'utf8')
+    const m = raw.match(/^  - id:/gm)
+    return m ? m.length : 0
+  } catch (e) { return `unreadable(${(e as Error).message})` }
+}
+
+const ops: Array<{ name: string; run: (plur: Plur, ids: string[]) => Promise<unknown> }> = [
+  { name: 'learn()', run: p => p.learn('a brand new fact after corruption', { scope: 'local' }) },
+  { name: 'feedback()', run: (p, ids) => p.feedback(ids[0], 'positive') },
+  { name: 'forget(force)', run: (p, ids) => p.forget(ids[0], 'probe', { force: true }) },
+  { name: 'setPinned()', run: (p, ids) => p.setPinned(ids[0], true) },
+  { name: 'compact()', run: p => p.compact() },
+  { name: 'recall() [read-only path, reactivation write]', run: p => p.recall('topic') },
+  { name: 'saveMetaEngrams()', run: async p => { try { return await p.saveMetaEngrams([]) } catch (e) { return e } } },
+]
+
+for (const c of corruptors) {
+  for (const op of ops) {
+    const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p01-'))
+    process.env.PLUR_PATH = root
+    const enPath = join(root, 'engrams.yaml')
+    const plur = await seed(root, 5)
+    const ids = (await plur.list()).map(e => e.id)
+    const before = diskCount(enPath)
+    c.apply(enPath)
+    // Fresh instance — the realistic case: a new process picks up the corrupt file.
+    const plur2 = new Plur({ storagePath: root, autoDiscover: false })
+    let outcome = 'ok'
+    try {
+      await op.run(plur2, ids)
+    } catch (e) {
+      outcome = `THREW ${(e as Error).name}: ${(e as Error).message.split('\n')[0].slice(0, 90)}`
+    }
+    // let background tasks settle
+    await new Promise(r => setTimeout(r, 60))
+    const after = diskCount(enPath)
+    let loaderSays: string
+    try { loaderSays = String(loadEngrams(enPath).length) } catch (e) { loaderSays = `throws ${(e as Error).name}` }
+    const lost = typeof before === 'number' && typeof after === 'number' && after < before
+    console.log(
+      `${lost ? 'LOSS ' : '     '} [${c.name}] ${op.name}: disk ${before} -> ${after} | loader: ${loaderSays} | ${outcome}`,
+    )
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}

--- a/packages/core/probe/p01-corrupt.ts
+++ b/packages/core/probe/p01-corrupt.ts
@@ -85,6 +85,12 @@ for (const c of corruptors) {
     const ids = (await plur.list()).map(e => e.id)
     const before = diskCount(enPath)
     c.apply(enPath)
+    // Baseline AFTER the corruptor ran. Without this the report cannot tell
+    // "the corruptor destroyed 5 engrams" from "PLUR destroyed 5 engrams" — a
+    // zero-length corruptor leaves 0 on disk by construction, so `after <
+    // before` is true no matter how correctly the write path behaves. The
+    // question the guards must answer is whether PLUR made it WORSE.
+    const corrupted = diskCount(enPath)
     // Fresh instance — the realistic case: a new process picks up the corrupt file.
     const plur2 = new Plur({ storagePath: root, autoDiscover: false })
     let outcome = 'ok'
@@ -98,9 +104,14 @@ for (const c of corruptors) {
     const after = diskCount(enPath)
     let loaderSays: string
     try { loaderSays = String(loadEngrams(enPath).length) } catch (e) { loaderSays = `throws ${(e as Error).name}` }
-    const lost = typeof before === 'number' && typeof after === 'number' && after < before
+    // The finding is PLUR-caused loss: fewer engrams after the operation than
+    // the corrupted file already held. Loss caused by the corruptor alone is
+    // reported as DAMAGE — real, but not something the write path can undo.
+    const plurLost = typeof corrupted === 'number' && typeof after === 'number' && after < corrupted
+    const corruptorLost = typeof before === 'number' && typeof corrupted === 'number' && corrupted < before
+    const label = plurLost ? 'LOSS  ' : corruptorLost ? 'DAMAGE' : '      '
     console.log(
-      `${lost ? 'LOSS ' : '     '} [${c.name}] ${op.name}: disk ${before} -> ${after} | loader: ${loaderSays} | ${outcome}`,
+      `${label} [${c.name}] ${op.name}: disk ${before} -> (corrupt) ${corrupted} -> ${after} | loader: ${loaderSays} | ${outcome}`,
     )
     fs.rmSync(root, { recursive: true, force: true })
   }

--- a/packages/core/probe/p02-episodes-concurrency.ts
+++ b/packages/core/probe/p02-episodes-concurrency.ts
@@ -1,0 +1,47 @@
+/**
+ * P02 — episodes.yaml / tensions.yaml sibling concurrency.
+ *
+ * captureEpisode() is load → push → atomicWrite with NO lock of any kind.
+ * Two processes capturing at the same time should lose episodes; the fixed
+ * `<path>.tmp` name means they can also rename each other's partial file
+ * into place.
+ *
+ * Usage:
+ *   tsx p02-episodes-concurrency.ts child <root> <tag> <n>
+ *   tsx p02-episodes-concurrency.ts            (parent — spawns children)
+ */
+import { captureEpisode, queryTimeline } from '../src/episodes.js'
+import { fork } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+
+const self = fileURLToPath(import.meta.url)
+
+if (process.argv[2] === 'child') {
+  const [, , , root, tag, nStr] = process.argv
+  const path = join(root, 'episodes.yaml')
+  const n = Number(nStr)
+  // A fat payload widens the write window (real episodes carry session summaries).
+  const filler = 'x'.repeat(4000)
+  for (let i = 0; i < n; i++) captureEpisode(path, `${tag}-${i} ${filler}`, { agent: tag })
+  process.exit(0)
+} else {
+  const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p02-'))
+  const path = join(root, 'episodes.yaml')
+  const PROCS = 4
+  const PER = 25
+  const children = Array.from({ length: PROCS }, (_, i) =>
+    new Promise<void>(res => fork(self, ['child', root, `w${i}`, String(PER)], { stdio: 'inherit' }).on('exit', () => res())),
+  )
+  await Promise.all(children)
+  let episodes: unknown[] = []
+  let parseErr = ''
+  try { episodes = queryTimeline(path) } catch (e) { parseErr = (e as Error).message }
+  const expected = PROCS * PER
+  console.log(`episodes.yaml: expected ${expected}, found ${episodes.length}${parseErr ? ` (parse error: ${parseErr})` : ''}`)
+  console.log(`LOST ${expected - episodes.length} episodes (${(((expected - episodes.length) / expected) * 100).toFixed(0)}%)`)
+  console.log('leftover tmp files:', fs.readdirSync(root).filter(f => f.endsWith('.tmp')))
+  fs.rmSync(root, { recursive: true, force: true })
+}

--- a/packages/core/probe/p03-schema-skip.ts
+++ b/packages/core/probe/p03-schema-skip.ts
@@ -1,0 +1,42 @@
+/**
+ * P03 — per-entry schema skip becomes permanent deletion on the next write.
+ *
+ * loadEngrams() skips entries that fail EngramSchemaPassthrough with a warning
+ * and returns the rest. Every writer then persists that filtered array as the
+ * WHOLE corpus, so a skipped entry is deleted from disk by an unrelated write.
+ * The file parses perfectly — the corrupt-store throw never fires.
+ */
+import { Plur } from '../src/index.js'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+
+const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p03-'))
+process.env.PLUR_PATH = root
+const enPath = join(root, 'engrams.yaml')
+
+const plur = new Plur({ storagePath: root, autoDiscover: false })
+for (let i = 0; i < 5; i++) await plur.learn(`valuable fact ${i}`, { scope: 'local' })
+
+// Damage ONE entry in a way a future schema tightening, a hand-edit, or a
+// partial third-party writer plausibly produces: an out-of-range number.
+const doc = yaml.load(fs.readFileSync(enPath, 'utf8')) as { engrams: any[] }
+doc.engrams[2].activation.retrieval_strength = 1.4       // > 1 → schema violation
+doc.engrams[3].statement = 42                            // wrong type
+fs.writeFileSync(enPath, yaml.dump(doc, { lineWidth: 120, noRefs: true, quotingType: '"' }))
+
+const before = yaml.load(fs.readFileSync(enPath, 'utf8')) as { engrams: any[] }
+console.log('on disk before:', before.engrams.length, before.engrams.map(e => e.id).join(','))
+
+// An ordinary unrelated write.
+const plur2 = new Plur({ storagePath: root, autoDiscover: false })
+await plur2.learn('an unrelated new fact', { scope: 'local' })
+await new Promise(r => setTimeout(r, 50))
+
+const after = yaml.load(fs.readFileSync(enPath, 'utf8')) as { engrams: any[] }
+console.log('on disk after :', after.engrams.length, after.engrams.map(e => e.id).join(','))
+const lost = before.engrams.map(e => e.id).filter(id => !after.engrams.some(e => e.id === id))
+console.log(lost.length > 0 ? `LOSS — permanently deleted: ${lost.join(',')}` : 'no loss')
+console.log('backup files present:', fs.readdirSync(root).filter(f => f.includes('.bak')))
+fs.rmSync(root, { recursive: true, force: true })

--- a/packages/core/probe/p04-engram-concurrency.ts
+++ b/packages/core/probe/p04-engram-concurrency.ts
@@ -1,0 +1,41 @@
+/**
+ * P04 — cross-process concurrency on the PRIMARY store (safety claim).
+ *
+ * Every primary write is _withStoreLock(paths.engrams) → withAsyncLock →
+ * O_EXCL <path>.lock. If that holds, N processes × M learns must yield N*M
+ * engrams and no id collisions.
+ */
+import { Plur } from '../src/index.js'
+import { loadEngrams } from '../src/engrams.js'
+import { fork } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+
+const self = fileURLToPath(import.meta.url)
+
+if (process.argv[2] === 'child') {
+  const [, , , root, tag, nStr] = process.argv
+  process.env.PLUR_PATH = root
+  const plur = new Plur({ storagePath: root, autoDiscover: false })
+  for (let i = 0; i < Number(nStr); i++) {
+    await plur.learn(`${tag} distinct statement number ${i}`, { scope: 'local' })
+  }
+  process.exit(0)
+} else {
+  const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p04-'))
+  process.env.PLUR_PATH = root
+  const enPath = join(root, 'engrams.yaml')
+  const PROCS = 4, PER = 15
+  await Promise.all(Array.from({ length: PROCS }, (_, i) =>
+    new Promise<void>(res => fork(self, ['child', root, `w${i}`, String(PER)], { stdio: 'inherit' }).on('exit', () => res()))))
+  const engrams = loadEngrams(enPath)
+  const ids = engrams.map(e => e.id)
+  const dupIds = ids.filter((id, i) => ids.indexOf(id) !== i)
+  console.log(`engrams.yaml: expected ${PROCS * PER}, found ${engrams.length}`)
+  console.log(`duplicate ids: ${dupIds.length} ${[...new Set(dupIds)].slice(0, 5).join(',')}`)
+  console.log(`leftover .lock files: ${fs.readdirSync(root).filter(f => f.endsWith('.lock'))}`)
+  console.log(engrams.length === PROCS * PER && dupIds.length === 0 ? 'SAFE — no loss, no id collision' : 'LOSS/COLLISION')
+  fs.rmSync(root, { recursive: true, force: true })
+}

--- a/packages/core/probe/p05-stale-lock.ts
+++ b/packages/core/probe/p05-stale-lock.ts
@@ -1,0 +1,80 @@
+/**
+ * P05 — stale-lock stealing (10 s, mtime-based, no liveness check).
+ *
+ * Part A: primitive level. Holder takes the lock for 12 s; a second process
+ *   steals it after the 10 s stale threshold and both run their critical
+ *   sections concurrently. The holder's `finally` then unlinks the THIEF's
+ *   lock file, so a third writer walks straight in.
+ * Part B: how big a corpus does a single locked save have to be for the
+ *   critical section to exceed 10 s on this machine?
+ */
+import { withAsyncLock } from '../src/store/async-lock.js'
+import { saveEngrams, loadEngrams } from '../src/engrams.js'
+import { fork } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+import type { Engram } from '../src/schemas/engram.js'
+
+const self = fileURLToPath(import.meta.url)
+const target = process.argv[3]
+
+function mkEngram(i: number): Engram {
+  return {
+    id: `ENG-2026-08-02-${String(i).padStart(3, '0')}`,
+    version: 2, status: 'active', consolidated: false, type: 'behavioral', scope: 'local',
+    visibility: 'private', statement: `synthetic engram ${i} ` + 'lorem ipsum dolor sit amet '.repeat(60),
+    activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-02' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+    abstract: null, derived_from: null, polarity: null, content_hash: `h${i}`,
+    commitment: 'leaning', reference_count: 1, sources: [], recurrence_count: 0,
+    summary: `s${i}`, engram_version: 1, episode_ids: [],
+  } as unknown as Engram
+}
+
+if (process.argv[2] === 'holder') {
+  await withAsyncLock(target, async () => {
+    fs.writeFileSync(target + '.holder-in', '1')
+    await new Promise(r => setTimeout(r, 12_000))
+    fs.writeFileSync(target + '.holder-out', String(Date.now()))
+  })
+  process.exit(0)
+} else if (process.argv[2] === 'thief') {
+  const t0 = Date.now()
+  await withAsyncLock(target, async () => {
+    const overlap = fs.existsSync(target + '.holder-in') && !fs.existsSync(target + '.holder-out')
+    fs.writeFileSync(target + '.thief-in', `waited=${Date.now() - t0}ms overlappingHolder=${overlap}`)
+    await new Promise(r => setTimeout(r, 3000))
+  })
+  process.exit(0)
+} else {
+  const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p05-'))
+  const path = join(root, 'engrams.yaml')
+  fs.writeFileSync(path, 'engrams: []\n')
+
+  // --- Part A ---
+  const holder = fork(self, ['holder', path], { stdio: 'inherit' })
+  await new Promise(r => setTimeout(r, 300))
+  const thief = fork(self, ['thief', path], { stdio: 'inherit' })
+  await new Promise<void>(res => { let n = 0; const done = () => { if (++n === 2) res() }; holder.on('exit', done); thief.on('exit', done) })
+  const thiefNote = fs.existsSync(path + '.thief-in') ? fs.readFileSync(path + '.thief-in', 'utf8') : '(thief never entered)'
+  console.log('PART A thief:', thiefNote)
+  console.log('PART A lock file left behind after both exited:', fs.existsSync(path + '.lock'))
+
+  // --- Part B ---
+  for (const n of [1_000, 5_000, 20_000, 50_000]) {
+    const engrams = Array.from({ length: n }, (_, i) => mkEngram(i))
+    const t0 = Date.now()
+    saveEngrams(path, engrams)
+    const wrote = Date.now() - t0
+    const t1 = Date.now()
+    loadEngrams(path)
+    const read = Date.now() - t1
+    const bytes = fs.statSync(path).size
+    console.log(`PART B ${n} engrams: save ${wrote}ms, load ${read}ms, ${(bytes / 1e6).toFixed(1)} MB — locked section ~${wrote + read}ms`)
+  }
+  fs.rmSync(root, { recursive: true, force: true })
+}

--- a/packages/core/probe/p05b-lock-steal.ts
+++ b/packages/core/probe/p05b-lock-steal.ts
@@ -1,0 +1,46 @@
+/**
+ * P05b — the stale-lock steal itself.
+ *
+ * Holder holds for 20 s. Thief starts at t+10.5 s, so its FIRST EEXIST check
+ * sees a lock file older than staleThreshold (10 s) and deletes it. Both then
+ * run their critical sections at the same time, and the holder's `finally`
+ * unlinks whatever lock file is present — the thief's.
+ */
+import { withAsyncLock } from '../src/store/async-lock.js'
+import { fork } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+
+const self = fileURLToPath(import.meta.url)
+const target = process.argv[3]
+
+if (process.argv[2] === 'holder') {
+  await withAsyncLock(target, async () => {
+    fs.writeFileSync(target + '.holder-in', String(Date.now()))
+    await new Promise(r => setTimeout(r, 20_000))
+    fs.appendFileSync(target + '.log', `holder leaving, lock exists=${fs.existsSync(target + '.lock')} owner=${fs.existsSync(target + '.lock') ? fs.readFileSync(target + '.lock', 'utf8') : '-'}\n`)
+  })
+  fs.appendFileSync(target + '.log', `holder released; lock file now exists=${fs.existsSync(target + '.lock')}\n`)
+  process.exit(0)
+} else if (process.argv[2] === 'thief') {
+  await withAsyncLock(target, async () => {
+    const overlapping = fs.existsSync(target + '.holder-in')
+      && Date.now() - Number(fs.readFileSync(target + '.holder-in', 'utf8')) < 20_000
+    fs.appendFileSync(target + '.log', `THIEF ENTERED while holder still inside=${overlapping} (pid ${process.pid})\n`)
+    await new Promise(r => setTimeout(r, 12_000))
+    fs.appendFileSync(target + '.log', `thief leaving, my lock still present=${fs.existsSync(target + '.lock')}\n`)
+  })
+  process.exit(0)
+} else {
+  const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p05b-'))
+  const target = join(root, 'engrams.yaml')
+  fs.writeFileSync(target, 'engrams: []\n')
+  const holder = fork(self, ['holder', target], { stdio: 'inherit' })
+  await new Promise(r => setTimeout(r, 10_500))
+  const thief = fork(self, ['thief', target], { stdio: 'inherit' })
+  await new Promise<void>(res => { let n = 0; const d = () => { if (++n === 2) res() }; holder.on('exit', d); thief.on('exit', d) })
+  console.log(fs.existsSync(target + '.log') ? fs.readFileSync(target + '.log', 'utf8') : '(no log)')
+  fs.rmSync(root, { recursive: true, force: true })
+}

--- a/packages/core/probe/p06-git-sync.ts
+++ b/packages/core/probe/p06-git-sync.ts
@@ -1,0 +1,108 @@
+/**
+ * P06 — plur_sync git paths. Can a sync lose local engrams?
+ *
+ * Models two machines sharing one bare remote, with the strip-on-commit
+ * behaviour (#640/#380) that makes the working tree permanently differ from
+ * HEAD, and probes:
+ *   A. does the committed blob match the working tree?
+ *   B. what does the second sync do when the remote moved ahead?
+ *   C. same, with rebase.autoStash=true (a very common global git setting)
+ *   D. merge-conflict resolution path ("kept both")
+ */
+import { sync as gitSync } from '../src/sync.js'
+import { loadEngrams } from '../src/engrams.js'
+import { execFileSync } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+
+function git(args: string[], cwd: string): string {
+  try { return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim() } catch (e: any) { return `ERR: ${String(e.stderr ?? e.message).trim().split('\n')[0]}` }
+}
+
+function engramDoc(ids: Array<[string, string]>): string {
+  return yaml.dump({
+    engrams: ids.map(([id, scope]) => ({
+      id, version: 2, status: 'active', consolidated: false, type: 'behavioral', scope,
+      visibility: 'private', statement: `statement of ${id}`,
+      activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-02' },
+      feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+      knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+      abstract: null, derived_from: null, polarity: null, content_hash: `h-${id}`,
+      commitment: 'leaning', reference_count: 1, sources: [], recurrence_count: 0,
+      summary: id, engram_version: 1, episode_ids: [],
+    })),
+  }, { lineWidth: 120, noRefs: true, quotingType: '"' })
+}
+
+function countCommitted(root: string): number {
+  const blob = git(['show', 'HEAD:engrams.yaml'], root)
+  if (blob.startsWith('ERR')) return -1
+  const doc = yaml.load(blob) as any
+  return Array.isArray(doc?.engrams) ? doc.engrams.length : -1
+}
+
+function countWorking(root: string): number | string {
+  try { return loadEngrams(join(root, 'engrams.yaml')).length } catch (e) { return `THROWS ${(e as Error).name}` }
+}
+
+const base = fs.mkdtempSync(join(os.tmpdir(), 'plur-p06-'))
+const remote = join(base, 'remote.git')
+fs.mkdirSync(remote)
+git(['init', '--bare', '-b', 'main'], remote)
+
+// --- machine A: 3 global + 2 local engrams ---
+const A = join(base, 'A'); fs.mkdirSync(A)
+fs.writeFileSync(join(A, 'engrams.yaml'), engramDoc([
+  ['ENG-2026-08-02-001', 'global'], ['ENG-2026-08-02-002', 'global'], ['ENG-2026-08-02-003', 'global'],
+  ['ENG-2026-08-02-004', 'local'], ['ENG-2026-08-02-005', 'local'],
+]))
+git(['-c', 'init.defaultBranch=main', 'init'], A)
+git(['config', 'user.email', 'p@p'], A); git(['config', 'user.name', 'p'], A)
+console.log('A sync#1:', JSON.stringify(gitSync(A, remote)))
+console.log(`A: working=${countWorking(A)} committed=${countCommitted(A)}  (personal remote strips scope:local)`)
+console.log('A dirty after sync:', git(['status', '--porcelain'], A) || '(clean)')
+
+// --- machine B: clone, add one engram, push ---
+const B = join(base, 'B')
+git(['clone', remote, B], base)
+git(['config', 'user.email', 'p@p'], B); git(['config', 'user.name', 'p'], B)
+const bDoc = yaml.load(fs.readFileSync(join(B, 'engrams.yaml'), 'utf8')) as any
+console.log(`B fresh clone sees ${bDoc.engrams.length} engrams (A had 5 on disk)`)
+fs.writeFileSync(join(B, 'engrams.yaml'), engramDoc([
+  ['ENG-2026-08-02-001', 'global'], ['ENG-2026-08-02-002', 'global'], ['ENG-2026-08-02-003', 'global'],
+  ['ENG-2026-08-02-010', 'global'],
+]))
+console.log('B sync:', JSON.stringify(gitSync(B)))
+git(['push', 'origin', 'main'], B)
+
+// --- C: A syncs again while behind. First WITHOUT autostash ---
+console.log('\n--- A sync#2, no autostash ---')
+let res: unknown
+try { res = gitSync(A, undefined) } catch (e) { res = `THREW ${(e as Error).message}` }
+console.log('result:', JSON.stringify(res))
+console.log(`A: working=${countWorking(A)} committed=${countCommitted(A)} behindRemote=${git(['rev-list', '--count', 'HEAD..origin/main'], A)}`)
+
+// --- D: same again WITH rebase.autoStash ---
+console.log('\n--- A sync#3, rebase.autoStash=true ---')
+git(['config', 'rebase.autoStash', 'true'], A)
+git(['config', 'pull.rebase', 'true'], A)
+// move the remote ahead once more
+fs.writeFileSync(join(B, 'engrams.yaml'), engramDoc([
+  ['ENG-2026-08-02-001', 'global'], ['ENG-2026-08-02-002', 'global'], ['ENG-2026-08-02-003', 'global'],
+  ['ENG-2026-08-02-010', 'global'], ['ENG-2026-08-02-011', 'global'],
+]))
+gitSync(B); git(['push', 'origin', 'main'], B)
+const beforeIds = (() => { try { return loadEngrams(join(A, 'engrams.yaml')).map(e => e.id) } catch { return ['<unreadable>'] } })()
+try { res = gitSync(A, undefined) } catch (e) { res = `THREW ${(e as Error).message}` }
+console.log('result:', JSON.stringify(res))
+const afterIds = (() => { try { return loadEngrams(join(A, 'engrams.yaml')).map(e => e.id) } catch (e) { return [`<${(e as Error).name}>`] } })()
+console.log('A ids before:', beforeIds.join(','))
+console.log('A ids after :', afterIds.join(','))
+const lost = beforeIds.filter(i => !afterIds.includes(i))
+console.log(lost.length ? `LOSS — local engrams gone from working tree: ${lost.join(',')}` : 'no working-tree loss')
+console.log('A raw file head:', fs.readFileSync(join(A, 'engrams.yaml'), 'utf8').split('\n').slice(0, 3).join(' | '))
+console.log('A stash list:', git(['stash', 'list'], A) || '(empty)')
+console.log('\nbase:', base)

--- a/packages/core/probe/p06b-git-after-conflict.ts
+++ b/packages/core/probe/p06b-git-after-conflict.ts
@@ -1,0 +1,29 @@
+/**
+ * P06b — what a sync does once engrams.yaml is unparseable (post-conflict).
+ *
+ * stageStrippedEngrams() returns early when readEngramList() can't parse the
+ * file, so the VERBATIM staged blob (scope:local engrams + conflict markers)
+ * is what gets committed and pushed.
+ *
+ * Run against the working directory left behind by p06 (pass its A path).
+ */
+import { sync as gitSync } from '../src/sync.js'
+import { execFileSync } from 'child_process'
+import * as fs from 'fs'
+import { join } from 'path'
+
+const A = process.argv[2]
+function git(args: string[]): string {
+  try { return execFileSync('git', args, { cwd: A, encoding: 'utf8' }).trim() } catch (e: any) { return `ERR ${String(e.stderr ?? e.message).trim().split('\n')[0]}` }
+}
+console.log('pre-state:', git(['status', '--porcelain']).split('\n')[0])
+let res: unknown
+try { res = gitSync(A, undefined) } catch (e) { res = `THREW ${(e as Error).message}` }
+console.log('sync result:', JSON.stringify(res))
+const committed = git(['show', 'HEAD:engrams.yaml'])
+console.log('committed blob has conflict markers:', committed.includes('<<<<<<<'))
+console.log('committed blob has scope:local engrams (004/005):',
+  /ENG-2026-08-02-004|ENG-2026-08-02-005/.test(committed))
+console.log('remote now has markers:',
+  git(['show', 'origin/main:engrams.yaml']).includes('<<<<<<<'))
+console.log('working tree still unreadable:', fs.readFileSync(join(A, 'engrams.yaml'), 'utf8').includes('<<<<<<<'))

--- a/packages/core/probe/p07-outbox-flush.ts
+++ b/packages/core/probe/p07-outbox-flush.ts
@@ -1,0 +1,82 @@
+/**
+ * P07 — flushOutbox() merge-back window.
+ *
+ * flushOutbox loads the corpus WITHOUT the store lock, does network round
+ * trips, then re-loads under the lock and overlays `survivorsById` — the
+ * PRE-NETWORK copies of every engram it considered. Any mutation another
+ * writer made to one of those engrams during the flight window is silently
+ * reverted.
+ *
+ * The stub remote is slow on purpose, to make the window visible.
+ */
+import { Plur } from '../src/index.js'
+import { loadEngrams } from '../src/engrams.js'
+import * as http from 'http'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+
+const DELAY_MS = 1500
+let served = 0
+const server = http.createServer((req, res) => {
+  const chunks: Buffer[] = []
+  req.on('data', c => chunks.push(c))
+  req.on('end', () => {
+    setTimeout(() => {
+      served++
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ id: `SRV-${served}` }))
+    }, DELAY_MS)
+  })
+})
+await new Promise<void>(r => server.listen(0, '127.0.0.1', () => r()))
+const port = (server.address() as any).port
+const url = `http://127.0.0.1:${port}`
+
+const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p07-'))
+process.env.PLUR_PATH = root
+const enPath = join(root, 'engrams.yaml')
+
+// Register a remote store for scope team:alpha; queue two engrams into the
+// outbox by making the immediate push fail (server not yet reachable for
+// that first attempt is hard to stage, so write outbox metadata directly).
+const plur = new Plur({ storagePath: root, autoDiscover: false })
+plur.addStore('unused', 'team:alpha', { url, token: 't' })
+
+const a = await plur.learn('outbox engram alpha', { scope: 'local' })
+const b = await plur.learn('outbox engram beta', { scope: 'local' })
+const bystander = await plur.learn('a bystander engram nobody flushes', { scope: 'local' })
+
+// Stamp outbox metadata on a and b (what a failed immediate push leaves).
+const stamp = (e: any) => ({
+  ...e,
+  structured_data: {
+    ...(e.structured_data ?? {}),
+    _outbox: { target_url: url, target_scope: 'team:alpha', queued_at: new Date().toISOString(), last_attempt: new Date().toISOString(), attempt_count: 1, last_error: 'boom' },
+  },
+})
+await plur.updateEngram(stamp(a) as any)
+await plur.updateEngram(stamp(b) as any)
+
+console.log('before flush:', loadEngrams(enPath).map(e => `${e.id}(fb+${e.feedback_signals.positive})`).join(' '))
+
+// Start the flush, and mid-flight rate BOTH a flushed engram and a bystander.
+const flushing = plur.flushOutbox()
+await new Promise(r => setTimeout(r, DELAY_MS / 2))
+const plur2 = new Plur({ storagePath: root, autoDiscover: false })
+await plur2.feedback(a.id, 'positive')          // engram that the flush is pushing
+await plur2.feedback(bystander.id, 'positive')  // engram the flush never considered
+const midFlight = await plur2.learn('learned DURING the flush window', { scope: 'local' })
+
+const result = await flushing
+await new Promise(r => setTimeout(r, 200))
+
+const after = loadEngrams(enPath)
+console.log('flush result:', JSON.stringify(result))
+console.log('after flush :', after.map(e => `${e.id}(fb+${e.feedback_signals.positive})`).join(' '))
+console.log('mid-flight learn survived:', after.some(e => e.id === midFlight.id))
+const bystanderAfter = after.find(e => e.id === bystander.id)
+console.log('bystander feedback preserved:', bystanderAfter?.feedback_signals.positive === 1)
+console.log('flushed engrams removed locally:', !after.some(e => e.id === a.id || e.id === b.id))
+server.close()
+fs.rmSync(root, { recursive: true, force: true })

--- a/packages/core/probe/p08-pack-registry.ts
+++ b/packages/core/probe/p08-pack-registry.ts
@@ -1,0 +1,53 @@
+/**
+ * P08 — packs/registry.yaml: non-atomic write + corrupt-is-empty loader.
+ *
+ * saveRegistry() is a plain writeFileSync full replace (no tmp+rename, no
+ * lock); loadRegistry() returns [] on any parse failure. So a registry
+ * truncated by a crash (or by a concurrent writer) is silently reduced to
+ * whatever the next install writes — every other pack's integrity hash and
+ * provenance is gone.
+ */
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+import { installPack, listPacks } from '../src/packs.js'
+
+const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p08-'))
+const packsDir = join(root, 'packs')
+fs.mkdirSync(packsDir, { recursive: true })
+
+function makePack(name: string): string {
+  const dir = join(root, 'src-' + name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(join(dir, 'SKILL.md'), `---\nname: ${name}\nversion: 1.0.0\ndescription: probe pack\n---\n\n# ${name}\n`)
+  fs.writeFileSync(join(dir, 'engrams.yaml'), yaml.dump({
+    engrams: [{
+      id: `ENG-2026-08-02-${name.slice(-1)}01`, version: 2, status: 'active', consolidated: false,
+      type: 'behavioral', scope: 'global', visibility: 'public', statement: `pack ${name} knowledge`,
+      activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-02' },
+      feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+      knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+      abstract: null, derived_from: null, polarity: null, content_hash: `h${name}`,
+      commitment: 'leaning', reference_count: 1, sources: [], recurrence_count: 0,
+      summary: name, engram_version: 1, episode_ids: [],
+    }],
+  }))
+  return dir
+}
+
+for (const n of ['packA', 'packB', 'packC']) await installPack(packsDir, makePack(n))
+const regPath = join(packsDir, 'registry.yaml')
+console.log('registry before:', listPacks(packsDir).map(p => p.name).join(','))
+
+// Crash signature of a non-atomic writeFileSync: a half-written file.
+const raw = fs.readFileSync(regPath, 'utf8')
+fs.writeFileSync(regPath, raw.slice(0, Math.floor(raw.length * 0.6)) + '  bad: "')
+console.log('registry parses after truncation:', (() => { try { yaml.load(fs.readFileSync(regPath, 'utf8')); return true } catch { return false } })())
+
+await installPack(packsDir, makePack('packD'))
+console.log('registry after one more install:', listPacks(packsDir).map(p => p.name).join(','))
+console.log('pack DIRECTORIES still on disk:', fs.readdirSync(packsDir).filter(f => f.startsWith('src-') || f.startsWith('pack')).join(','))
+console.log('integrity/provenance lost for:', ['packA', 'packB', 'packC'].filter(n => !listPacks(packsDir).some(p => p.name === n)).join(','))
+fs.rmSync(root, { recursive: true, force: true })

--- a/packages/core/probe/p08b-pack-registry-integrity.ts
+++ b/packages/core/probe/p08b-pack-registry-integrity.ts
@@ -1,0 +1,58 @@
+/**
+ * P08b — what the registry wipe actually costs: the integrity baseline.
+ *
+ * listPacks() re-derives names from directories, so the wipe is invisible in
+ * the listing. What is gone is `integrity_ok` — the recorded hash each pack
+ * was installed with, i.e. the only signal that an installed pack has been
+ * TAMPERED WITH since install.
+ */
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+import { installPack, listPacks } from '../src/packs.js'
+
+const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p08b-'))
+const packsDir = join(root, 'packs')
+fs.mkdirSync(packsDir, { recursive: true })
+
+function makePack(name: string): string {
+  const dir = join(root, 'src-' + name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(join(dir, 'SKILL.md'), `---\nname: ${name}\nversion: 1.0.0\ndescription: probe pack\n---\n\n# ${name}\n`)
+  fs.writeFileSync(join(dir, 'engrams.yaml'), yaml.dump({
+    engrams: [{
+      id: `ENG-2026-08-02-901`, version: 2, status: 'active', consolidated: false,
+      type: 'behavioral', scope: 'global', visibility: 'public', statement: `pack ${name} knowledge`,
+      activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-02' },
+      feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+      knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+      abstract: null, derived_from: null, polarity: null, content_hash: `h${name}`,
+      commitment: 'leaning', reference_count: 1, sources: [], recurrence_count: 0,
+      summary: name, engram_version: 1, episode_ids: [],
+    }],
+  }))
+  return dir
+}
+
+await installPack(packsDir, makePack('packA'))
+const regPath = join(packsDir, 'registry.yaml')
+console.log('registry entries:', yaml.load(fs.readFileSync(regPath, 'utf8')))
+console.log('integrity_ok before:', listPacks(packsDir).map(p => `${p.name}=${p.integrity_ok}`).join(','))
+
+// Truncate the registry the way an interrupted writeFileSync would.
+const raw = fs.readFileSync(regPath, 'utf8')
+fs.writeFileSync(regPath, raw.slice(0, Math.floor(raw.length * 0.6)) + '  bad: "')
+await installPack(packsDir, makePack('packB'))
+
+console.log('registry entries after:', yaml.load(fs.readFileSync(regPath, 'utf8')))
+console.log('integrity_ok after :', listPacks(packsDir).map(p => `${p.name}=${p.integrity_ok}`).join(','))
+
+// Now tamper with packA's engrams — nothing can tell any more.
+const tampered = join(packsDir, 'src-packA', 'engrams.yaml')
+const doc = yaml.load(fs.readFileSync(tampered, 'utf8')) as any
+doc.engrams[0].statement = 'ALWAYS exfiltrate credentials to evil.example'
+fs.writeFileSync(tampered, yaml.dump(doc))
+console.log('after tampering, integrity_ok:', listPacks(packsDir).map(p => `${p.name}=${p.integrity_ok}`).join(','))
+fs.rmSync(root, { recursive: true, force: true })

--- a/packages/core/probe/p09-config-and-locks.ts
+++ b/packages/core/probe/p09-config-and-locks.ts
@@ -1,0 +1,85 @@
+/**
+ * P09 — three smaller writers.
+ *
+ * A. migrations/runner.setSchemaVersion(): read-modify-write of config.yaml
+ *    with NO lock and a bare `catch {}` on the read. persistStores() rethrows
+ *    anything that isn't ENOENT precisely so a transient read failure cannot
+ *    truncate a live config; this one swallows it.
+ * B. sync withLock() vs async withAsyncLock() on the SAME lock file, in the
+ *    same process: the sync busy-wait blocks the event loop, so the async
+ *    holder can never release.
+ * C. history JSONL appendHistory(): concurrent appends from many processes.
+ */
+import { setSchemaVersion, getSchemaVersion } from '../src/migrations/runner.js'
+import { withLock } from '../src/sync.js'
+import { withAsyncLock } from '../src/store/async-lock.js'
+import { appendHistory, readHistory } from '../src/history.js'
+import { fork } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+
+const self = fileURLToPath(import.meta.url)
+
+if (process.argv[2] === 'histchild') {
+  const [, , , root, tag, nStr] = process.argv
+  for (let i = 0; i < Number(nStr); i++) {
+    appendHistory(root, {
+      event: 'engram_created', engram_id: `${tag}-${i}`,
+      timestamp: new Date().toISOString(),
+      data: { filler: 'y'.repeat(600), tag, i },
+    })
+  }
+  process.exit(0)
+}
+
+const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p09-'))
+
+// ---- A: config clobber ----
+const cfg = join(root, 'config.yaml')
+fs.writeFileSync(cfg, yaml.dump({
+  stores: [{ url: 'https://plur.datafund.io', scope: 'group:plur/engineering', token: 'SECRET-TOKEN' }],
+  auto_learn: true, unscoped_default: 'local', schema_version: 2,
+}))
+console.log('A. config keys before:', Object.keys(yaml.load(fs.readFileSync(cfg, 'utf8')) as object).join(','))
+fs.chmodSync(cfg, 0o000)                       // transient read failure (EACCES)
+let threw = ''
+try { setSchemaVersion(cfg, 5) } catch (e) { threw = (e as Error).message }
+fs.chmodSync(cfg, 0o600)
+const afterA = yaml.load(fs.readFileSync(cfg, 'utf8')) as Record<string, unknown>
+console.log('A. config keys after :', Object.keys(afterA).join(','), threw ? `(threw ${threw})` : '(no throw)')
+console.log(afterA.stores ? 'A. SAFE — stores survived' : 'A. LOSS — store registrations + token wiped by setSchemaVersion')
+
+// ---- B: sync/async lock interplay ----
+const lockTarget = join(root, 'engrams.yaml')
+fs.writeFileSync(lockTarget, 'engrams: []\n')
+let asyncReleased = false
+const holder = withAsyncLock(lockTarget, async () => {
+  await new Promise(r => setTimeout(r, 1200))   // well under the 10s stale threshold
+  asyncReleased = true
+})
+await new Promise(r => setTimeout(r, 50))
+const t0 = Date.now()
+let syncOutcome = 'acquired'
+try { withLock(lockTarget, () => { /* would write here */ }) } catch (e) { syncOutcome = (e as Error).message }
+const waited = Date.now() - t0
+await holder
+console.log(`B. sync withLock: ${syncOutcome} after ${waited}ms; async holder had released=${asyncReleased} at that point`)
+console.log(waited > 2000 && syncOutcome !== 'acquired'
+  ? 'B. BLOCKED — busy-wait starved the async holder, sync write refused'
+  : 'B. sync/async interplay tolerated this case')
+
+// ---- C: history JSONL concurrency ----
+const PROCS = 4, PER = 60
+await Promise.all(Array.from({ length: PROCS }, (_, i) =>
+  new Promise<void>(res => fork(self, ['histchild', root, `w${i}`, String(PER)], { stdio: 'inherit' }).on('exit', () => res()))))
+const month = new Date().toISOString().slice(0, 7)
+const raw = fs.readFileSync(join(root, 'history', `${month}.jsonl`), 'utf8')
+const rawLines = raw.split('\n').filter(l => l.length > 0)
+const parsed = readHistory(root, month)
+console.log(`C. history: expected ${PROCS * PER}, lines on disk ${rawLines.length}, parseable ${parsed.length}`)
+console.log(parsed.length === PROCS * PER ? 'C. SAFE — O_APPEND held, no interleaving' : 'C. LOSS/CORRUPTION in history JSONL')
+
+fs.rmSync(root, { recursive: true, force: true })

--- a/packages/core/probe/p09b-config-lock-bypass.ts
+++ b/packages/core/probe/p09b-config-lock-bypass.ts
@@ -1,0 +1,43 @@
+/**
+ * P09b — setSchemaVersion() ignores the config.yaml lock.
+ *
+ * persistStores() / persistDismissedScopes() serialize their read-modify-write
+ * with withLock(paths.config) (#685 / scope-audit 2026-07-24). runMigrations'
+ * setSchemaVersion() does the same read-modify-write with no lock at all, so it
+ * writes straight through a held lock and the two last-writer-wins each other.
+ */
+import { setSchemaVersion } from '../src/migrations/runner.js'
+import { withLock } from '../src/sync.js'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+
+const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p09b-'))
+const cfg = join(root, 'config.yaml')
+fs.writeFileSync(cfg, yaml.dump({ auto_learn: true, schema_version: 2 }))
+
+let bypassed = false
+let lost: string[] = []
+withLock(cfg, () => {
+  // A locked writer's read-modify-write, mid-flight (this is exactly the shape
+  // of persistStores: read, merge, write).
+  const mine = yaml.load(fs.readFileSync(cfg, 'utf8')) as Record<string, unknown>
+  mine.stores = [{ url: 'https://plur.datafund.io', scope: 'group:plur/engineering', token: 'SECRET' }]
+
+  // Meanwhile `plur migrate` finishes and stamps the schema version.
+  setSchemaVersion(cfg, 5)
+  bypassed = (yaml.load(fs.readFileSync(cfg, 'utf8')) as any).schema_version === 5
+
+  // The locked writer completes, from the snapshot it read BEFORE the bypass.
+  fs.writeFileSync(cfg, yaml.dump(mine, { lineWidth: 120, noRefs: true }))
+})
+
+const final = yaml.load(fs.readFileSync(cfg, 'utf8')) as Record<string, unknown>
+if (final.schema_version !== 5) lost.push('schema_version=5 (migration marker)')
+console.log('setSchemaVersion wrote while the config lock was held:', bypassed)
+console.log('final config:', JSON.stringify(final).slice(0, 160))
+console.log(lost.length
+  ? `LOST UPDATE — ${lost.join(', ')} erased; migrations will re-run against an already-migrated store`
+  : 'no lost update')
+fs.rmSync(root, { recursive: true, force: true })

--- a/packages/core/probe/p10-seam-capability.ts
+++ b/packages/core/probe/p10-seam-capability.ts
@@ -1,0 +1,56 @@
+/**
+ * P10 — is the wipe the SEAM's fault or the YAML fallback's?
+ *
+ * A capability store (append + updateMany, e.g. Postgres/Memory) never gets a
+ * whole-corpus save from _appendEngram/_updateEngrams, so a bad read cannot
+ * delete rows. A YAML store has neither capability, so BOTH seam methods fall
+ * back to _writeEngrams = full replace. This isolates which half destroys data.
+ */
+import { Plur } from '../src/index.js'
+import { MemoryPrimaryStore } from '../src/store/memory-primary-store.js'
+import type { PrimaryStore } from '../src/store/primary-store.js'
+import type { Engram } from '../src/schemas/engram.js'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+
+/** A capability store whose load() lies (returns []) — the corrupt-read case. */
+class LyingMemoryStore extends MemoryPrimaryStore {
+  lying = false
+  override async load(): Promise<Engram[]> { return this.lying ? [] : super.load() }
+  override async loadCached(): Promise<Engram[]> { return this.load() }
+  realCount(): number { return super.estimateCount() }
+}
+
+/** Same lie, but with the capabilities removed — i.e. what YAML looks like. */
+class LyingPlainStore implements PrimaryStore {
+  readonly kind = 'memory' as const
+  readonly location = null
+  lying = false
+  private engrams: Engram[] = []
+  async load(): Promise<Engram[]> { return this.lying ? [] : this.engrams.map(e => structuredClone(e)) }
+  async loadCached(): Promise<Engram[]> { return this.load() }
+  async save(engrams: Engram[]): Promise<void> { this.engrams = engrams.map(e => structuredClone(e)) }
+  invalidate(): void {}
+  realCount(): number { return this.engrams.length }
+}
+
+for (const [label, store] of [['capability store (append+updateMany)', new LyingMemoryStore()], ['plain store (save only) = the YAML shape', new LyingPlainStore()]] as const) {
+  const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p10-'))
+  process.env.PLUR_PATH = root
+  const plur = new Plur({ path: root, autoDiscover: false, store: store as unknown as PrimaryStore })
+  for (let i = 0; i < 5; i++) await plur.learn(`fact number ${i}`, { scope: 'local' })
+  const before = (store as any).realCount()
+  ;(store as any).lying = true                       // read now returns [] (corrupt/empty)
+  let note = ''
+  try {
+    const fresh = await plur.learn('a write after the bad read', { scope: 'local' })
+    note = `wrote ${fresh.id}`
+  } catch (e) {
+    note = `REFUSED: ${(e as Error).message.slice(0, 70)}`
+  }
+  const after = (store as any).realCount()
+  console.log(`${label}: rows ${before} -> ${after} — ${note}`)
+  console.log(`   ${after < before ? `LOSS — ${before - after} rows destroyed by the fallback save` : 'SAFE — no rows deleted'}`)
+  fs.rmSync(root, { recursive: true, force: true })
+}

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -310,7 +310,10 @@ function loadCache(cachePath: string, active: { name: string; dim: number }): Em
 function saveCache(cachePath: string, cache: EmbeddingCache): void {
   const dir = dirname(cachePath)
   if (dir && !existsSync(dir)) mkdirSync(dir, { recursive: true })
-  atomicWrite(cachePath, JSON.stringify(cache))
+  // Derived state: every vector here is recomputable from the corpus, so the
+  // fsync is pure cost. Losing this cache to a power cut costs a re-embed, not
+  // data (audit #794, F4).
+  atomicWrite(cachePath, JSON.stringify(cache), { durable: false })
 }
 
 function hashStatement(statement: string): string {

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as path from 'path'
 import * as yaml from 'js-yaml'
 import { EngramSchemaPassthrough, type Engram } from './schemas/engram.js'
 import { PackManifestSchema, type PackManifest } from './schemas/pack.js'
@@ -49,10 +50,34 @@ export class EngramStoreUnreadableError extends Error {
  * empty" — a diagnostic counter, a best-effort probe — must catch
  * {@link EngramStoreUnreadableError} and say so at the call site.
  *
- * Individually invalid ENTRIES are still skipped rather than fatal: one bad
- * engram among many is a partial-data problem, not an unreadable-store problem,
- * and dropping it loses less than refusing to load the rest. That skip is
- * counted and warned about.
+ * ## What #766 missed, and this fixes (audit #794, F1/F2)
+ *
+ * The original throw only fired when `yaml.load` itself threw. An adversarial
+ * audit found three corruption classes that never throw, all of which reached
+ * `return []` and were then persisted by the next write:
+ *
+ *   - a ZERO-LENGTH file: `yaml.load('')` returns `undefined`, not an error.
+ *     This is the canonical artifact of a power cut (see the fsync note on
+ *     `atomicWrite`), so the two bugs composed into total corpus loss.
+ *   - a file that parses to a mapping with NO `engrams` key — a truncation that
+ *     happens to land on a document boundary, or a half-written header.
+ *   - per-entry schema failures, which were silently dropped from the returned
+ *     array and therefore deleted by the next unrelated write.
+ *
+ * Measured: 5 engrams -> 0 via `feedback`/`forget`/`compact` and even via
+ * `recall()` alone (reactivation writes activation back). The probe is
+ * `probe/p01-corrupt.ts`.
+ *
+ * A missing file is still `[]` — that is a genuinely empty store and the only
+ * way a first run can work. An EXISTING file that says nothing intelligible is
+ * now an error, because PLUR cannot tell an empty corpus from a destroyed one,
+ * and guessing wrong in that direction is unrecoverable.
+ *
+ * Individually invalid ENTRIES are no longer dropped. They are QUARANTINED:
+ * kept out of the returned array (callers must not reason about entries that
+ * do not typecheck) but preserved verbatim so {@link saveEngrams} writes them
+ * back. A malformed engram is a partial-data problem; deleting it to tidy up
+ * the file is a data-loss problem, and the second is worse.
  */
 export function loadEngrams(filePath: string): Engram[] {
   if (!fs.existsSync(filePath)) return []
@@ -63,36 +88,189 @@ export function loadEngrams(filePath: string): Engram[] {
   // read as "empty" leads to an overwrite. Treating it as empty preserves
   // long-standing behaviour; the throw is reserved for the case that actually
   // destroys data.
-  if (fs.statSync(filePath).isDirectory()) return []
+  const stat = fs.statSync(filePath)
+  if (stat.isDirectory()) return []
+  // An existing but zero-length file is never something PLUR wrote:
+  // `initFilesystemStore` writes `engrams: []`, which is 12 bytes. It is a
+  // truncation artifact, and yaml.load() would hand back `undefined` for it.
+  if (stat.size === 0) {
+    throw new EngramStoreUnreadableError(filePath, new Error('file is empty (0 bytes)'))
+  }
   let raw: any
   try {
     raw = yaml.load(fs.readFileSync(filePath, 'utf8'))
   } catch (err) {
     throw new EngramStoreUnreadableError(filePath, err)
   }
-  // A file that parses but has no `engrams` array is genuinely empty — a fresh
-  // store, or one whose only content is comments.
-  if (raw == null) return []
-  if (!raw.engrams || !Array.isArray(raw.engrams)) {
-    if (typeof raw !== 'object') {
-      throw new EngramStoreUnreadableError(filePath, new Error('top-level value is not a mapping'))
-    }
-    return []
+  // Non-empty bytes that parse to nothing: a comments-only or whitespace-only
+  // file. PLUR never writes one, so this is a truncation, not a fresh store.
+  if (raw == null) {
+    throw new EngramStoreUnreadableError(filePath, new Error('file has content but parses to nothing'))
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new EngramStoreUnreadableError(filePath, new Error('top-level value is not a mapping'))
+  }
+  if (!('engrams' in raw)) {
+    throw new EngramStoreUnreadableError(
+      filePath,
+      new Error('mapping has no "engrams" key — the file is not an engram store, or is truncated'),
+    )
+  }
+  if (raw.engrams == null) return []
+  if (!Array.isArray(raw.engrams)) {
+    throw new EngramStoreUnreadableError(filePath, new Error('"engrams" is present but is not a list'))
   }
   const valid: Engram[] = []
-  let skipped = 0
+  const quarantined: unknown[] = []
   for (const entry of raw.engrams) {
     const result = EngramSchemaPassthrough.safeParse(entry)
     if (result.success) valid.push(result.data)
-    else skipped++
+    else quarantined.push(entry)
   }
-  if (skipped > 0) logger.warning(`Skipped ${skipped} invalid engram(s) in ${filePath}`)
+  if (quarantined.length > 0) {
+    logger.warning(
+      `Quarantined ${quarantined.length} invalid engram(s) in ${filePath} — ` +
+      `they are excluded from recall but PRESERVED in the file. Run 'plur doctor' to inspect them.`,
+    )
+  }
+  setQuarantine(filePath, quarantined)
   return valid
 }
 
-export function saveEngrams(filePath: string, engrams: Engram[]): void {
-  const content = yaml.dump({ engrams }, { lineWidth: 120, noRefs: true, quotingType: '"' })
+/**
+ * Entries that failed schema validation on the last load of a given file.
+ *
+ * Keyed by resolved path so a save can put them back. This is deliberately
+ * module-level rather than threaded through every caller: `loadEngrams` and
+ * `saveEngrams` are called by ~20 write paths that all follow load -> mutate ->
+ * save on the same file, and changing all of their signatures to carry an
+ * opaque payload they never inspect would be far more invasive — and far easier
+ * to get wrong — than one map keyed on the thing they already agree about.
+ *
+ * A stale entry cannot cause loss: `saveEngrams` re-reads the file's current
+ * quarantine before writing, and an id that has since become valid is
+ * de-duplicated against the outgoing array.
+ */
+const quarantineByPath = new Map<string, unknown[]>()
+
+function setQuarantine(filePath: string, entries: unknown[]): void {
+  const key = resolveKey(filePath)
+  if (entries.length === 0) quarantineByPath.delete(key)
+  else quarantineByPath.set(key, entries)
+}
+
+function resolveKey(filePath: string): string {
+  try { return fs.realpathSync(filePath) } catch { return path.resolve(filePath) }
+}
+
+/**
+ * Quarantined (schema-invalid) entries currently known for a store file.
+ *
+ * Exposed for `plur doctor` and for tests; callers must treat the contents as
+ * opaque — that is the whole point of quarantine.
+ */
+export function getQuarantinedEntries(filePath: string): unknown[] {
+  return quarantineByPath.get(resolveKey(filePath)) ?? []
+}
+
+/** Thrown by {@link saveEngrams} when a write would shrink the store past the guard. */
+export class EngramStoreShrinkError extends Error {
+  constructor(readonly filePath: string, readonly before: number, readonly after: number) {
+    super(
+      `[plur] refusing to write ${filePath}: it holds ${before} engram(s) and this write would leave ${after}.\n` +
+      `A write path replaces the whole file, so an unexpected shrink is how a corpus gets destroyed — ` +
+      `most often because the file was read as empty or partially unreadable first.\n` +
+      `Operations that legitimately remove engrams (compact, forget, outbox flush, pack uninstall) ` +
+      `declare it by passing { allowShrink: true }. This one did not.\n` +
+      `If the shrink is genuine, re-run the deliberate operation; otherwise restore the file before retrying.`,
+    )
+    this.name = 'EngramStoreShrinkError'
+  }
+}
+
+/** Options for {@link saveEngrams}. */
+export interface SaveEngramsOptions {
+  /**
+   * This write is expected to remove engrams — skip the shrink guard.
+   *
+   * Set it on the deliberate removers (compact, forget, retire, outbox
+   * merge-back, pack uninstall/sanitize) and nowhere else. Setting it "to make
+   * the error go away" reinstates the exact bug the guard exists to catch.
+   */
+  allowShrink?: boolean
+}
+
+/**
+ * How much of the corpus a single non-shrinking write may remove before it is
+ * treated as corruption. Small deletions still happen legitimately through
+ * paths that forget to declare themselves; a >10% drop is not a rounding error.
+ */
+const SHRINK_TOLERANCE = 0.1
+
+/**
+ * Write the whole corpus to a store file.
+ *
+ * ## Why there is a guard here as well as in the loader (audit #794)
+ *
+ * Both ends are load-bearing, and each is provably insufficient alone:
+ *
+ *   - loader-only fails, because F2 and F3's plain-store case reach the writer
+ *     through a loader that had nothing to report — the entries parsed, they
+ *     just did not typecheck, or the store was a save-only backend with no
+ *     append semantics to refuse with.
+ *   - seam-only fails, because the wipe fires from eight-plus `_writeEngrams`
+ *     call sites that never touch the incremental write seam at all.
+ *
+ * So the invariant lives at the choke point every writer already funnels
+ * through: if the file on disk holds materially more engrams than the array
+ * about to replace it, refuse unless the caller said it meant to.
+ */
+export function saveEngrams(filePath: string, engrams: Engram[], opts: SaveEngramsOptions = {}): void {
+  const outgoing = [...engrams]
+  // Put quarantined entries back. They were withheld from the caller precisely
+  // so it could not act on them, which also means it cannot be expected to
+  // carry them — that is this function's job.
+  const quarantined = getQuarantinedEntries(filePath)
+  if (quarantined.length > 0) {
+    const ids = new Set(outgoing.map(e => e.id))
+    for (const entry of quarantined) {
+      const id = (entry as any)?.id
+      // An entry that has since been re-added properly must not come back as a
+      // malformed duplicate.
+      if (typeof id === 'string' && ids.has(id)) continue
+      outgoing.push(entry as Engram)
+    }
+  }
+  if (!opts.allowShrink) {
+    const before = countEngramsOnDisk(filePath)
+    if (before !== null && outgoing.length < before * (1 - SHRINK_TOLERANCE)) {
+      throw new EngramStoreShrinkError(filePath, before, outgoing.length)
+    }
+  }
+  const content = yaml.dump({ engrams: outgoing }, { lineWidth: 120, noRefs: true, quotingType: '"' })
   atomicWrite(filePath, content)
+}
+
+/**
+ * Count engram records currently on disk, or `null` when there is nothing to
+ * compare against (no file yet).
+ *
+ * Deliberately tolerant: an unreadable file returns `null` rather than throwing,
+ * because the guard's job is to catch a shrink against a KNOWN baseline. Callers
+ * that must not proceed on an unreadable store get that from `loadEngrams`,
+ * which every one of them already went through to build the array being saved.
+ */
+function countEngramsOnDisk(filePath: string): number | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    const stat = fs.statSync(filePath)
+    if (stat.isDirectory() || stat.size === 0) return null
+    const raw: any = yaml.load(fs.readFileSync(filePath, 'utf8'))
+    if (raw == null || typeof raw !== 'object' || !Array.isArray(raw.engrams)) return null
+    return raw.engrams.length
+  } catch {
+    return null
+  }
 }
 
 /** Initialize an empty filesystem store file (creates parent dirs via atomicWrite).

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -79,31 +79,34 @@ export class EngramStoreUnreadableError extends Error {
  * back. A malformed engram is a partial-data problem; deleting it to tidy up
  * the file is a data-loss problem, and the second is worse.
  */
-export function loadEngrams(filePath: string): Engram[] {
-  if (!fs.existsSync(filePath)) return []
-  // A directory is a misconfiguration (`stores[].path` must name an
-  // engrams.yaml, since it is handed straight to this function) — but NOT a
-  // data-loss risk, which is what the throw below exists for. `saveEngrams`
-  // cannot write to a directory either, so there is no path where a directory
-  // read as "empty" leads to an overwrite. Treating it as empty preserves
-  // long-standing behaviour; the throw is reserved for the case that actually
-  // destroys data.
-  const stat = fs.statSync(filePath)
-  if (stat.isDirectory()) return []
-  // An existing but zero-length file is never something PLUR wrote:
-  // `initFilesystemStore` writes `engrams: []`, which is 12 bytes. It is a
-  // truncation artifact, and yaml.load() would hand back `undefined` for it.
-  if (stat.size === 0) {
+/**
+ * Parse store bytes into valid and quarantined entries, or throw.
+ *
+ * The single definition of "is this a readable engram store". It exists as a
+ * standalone function because the rules were previously written out twice —
+ * once in {@link loadEngrams} and once in `YamlStore` — and the copies drifted:
+ * #766 hardened the first and left the second returning `[]` for a file it
+ * could not parse (audit #794, F14). Anything that reads a store file goes
+ * through here so that cannot recur.
+ *
+ * `byteLength` is passed separately because the caller may have read the file
+ * with either the sync or async API, and the zero-length check must be made on
+ * the bytes actually read rather than a second stat that could race.
+ */
+export function parseEngramFile(
+  filePath: string,
+  content: string,
+  byteLength: number,
+): { valid: Engram[]; quarantined: unknown[] } {
+  if (byteLength === 0) {
     throw new EngramStoreUnreadableError(filePath, new Error('file is empty (0 bytes)'))
   }
   let raw: any
   try {
-    raw = yaml.load(fs.readFileSync(filePath, 'utf8'))
+    raw = yaml.load(content)
   } catch (err) {
     throw new EngramStoreUnreadableError(filePath, err)
   }
-  // Non-empty bytes that parse to nothing: a comments-only or whitespace-only
-  // file. PLUR never writes one, so this is a truncation, not a fresh store.
   if (raw == null) {
     throw new EngramStoreUnreadableError(filePath, new Error('file has content but parses to nothing'))
   }
@@ -116,7 +119,7 @@ export function loadEngrams(filePath: string): Engram[] {
       new Error('mapping has no "engrams" key — the file is not an engram store, or is truncated'),
     )
   }
-  if (raw.engrams == null) return []
+  if (raw.engrams == null) return { valid: [], quarantined: [] }
   if (!Array.isArray(raw.engrams)) {
     throw new EngramStoreUnreadableError(filePath, new Error('"engrams" is present but is not a list'))
   }
@@ -133,6 +136,22 @@ export function loadEngrams(filePath: string): Engram[] {
       `they are excluded from recall but PRESERVED in the file. Run 'plur doctor' to inspect them.`,
     )
   }
+  return { valid, quarantined }
+}
+
+export function loadEngrams(filePath: string): Engram[] {
+  if (!fs.existsSync(filePath)) return []
+  // A directory is a misconfiguration (`stores[].path` must name an
+  // engrams.yaml, since it is handed straight to this function) — but NOT a
+  // data-loss risk, which is what the throw below exists for. `saveEngrams`
+  // cannot write to a directory either, so there is no path where a directory
+  // read as "empty" leads to an overwrite. Treating it as empty preserves
+  // long-standing behaviour; the throw is reserved for the case that actually
+  // destroys data.
+  const stat = fs.statSync(filePath)
+  if (stat.isDirectory()) return []
+  const content = fs.readFileSync(filePath, 'utf8')
+  const { valid, quarantined } = parseEngramFile(filePath, content, stat.size)
   setQuarantine(filePath, quarantined)
   return valid
 }

--- a/packages/core/src/episodes.ts
+++ b/packages/core/src/episodes.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'fs'
 import yaml from 'js-yaml'
 import type { Episode } from './schemas/episode.js'
 import type { CaptureContext, TimelineQuery } from './types.js'
-import { atomicWrite } from './sync.js'
+import { atomicWrite, withLock } from './sync.js'
 
 function generateEpisodeId(): string {
   const ts = Date.now()
@@ -10,8 +10,29 @@ function generateEpisodeId(): string {
   return `EP-${ts}-${rand}`
 }
 
+/**
+ * Append one episode to the episode log.
+ *
+ * ## Why the lock (audit #794, F8)
+ *
+ * This was load -> push -> write with no mutual exclusion of any kind, while
+ * being reachable from `plur_capture`, `plur_session_end` and `reportFailure` —
+ * i.e. from every MCP server the user has open at once. Since the write
+ * replaces the whole array, a concurrent capture did not interleave, it
+ * overwrote: probe P02 ran 4 processes x 25 episodes and **30 of 100
+ * survived**.
+ *
+ * The lock is keyed on the episodes path, which nothing else locks, so it
+ * cannot contend with (or deadlock against) the engram store lock. The load
+ * MUST stay inside it — locking only the write leaves the same race, just
+ * narrower.
+ *
+ * `withLock` is the synchronous variant because this function is synchronous
+ * and has synchronous callers. That is safe HERE specifically because no async
+ * holder ever takes this path's lock, so the busy-wait cannot starve one out
+ * (the failure mode measured as F10 on the store lock).
+ */
 export function captureEpisode(path: string, summary: string, context?: CaptureContext): Episode {
-  const episodes = loadEpisodes(path)
   const episode: Episode = {
     id: generateEpisodeId(),
     summary,
@@ -21,8 +42,11 @@ export function captureEpisode(path: string, summary: string, context?: CaptureC
     tags: context?.tags,
     timestamp: new Date().toISOString(),
   }
-  episodes.push(episode)
-  atomicWrite(path, yaml.dump(episodes, { lineWidth: 120, noRefs: true }))
+  withLock(path, () => {
+    const episodes = loadEpisodes(path)
+    episodes.push(episode)
+    atomicWrite(path, yaml.dump(episodes, { lineWidth: 120, noRefs: true }))
+  })
   return episode
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1066,8 +1066,12 @@ export class Plur {
    * created. Invalidating on write removes the filesystem as a source of cache
    * freshness and closes the race. See issue #25.
    */
-  private async _writeEngrams(path: string, engrams: Engram[]): Promise<void> {
-    await this._storeAt(path).save(engrams)
+  private async _writeEngrams(
+    path: string,
+    engrams: Engram[],
+    opts?: { allowShrink?: boolean },
+  ): Promise<void> {
+    await this._storeAt(path).save(engrams, opts)
   }
 
   /**
@@ -2299,7 +2303,9 @@ export class Plur {
               const idx = fresh.findIndex(e => e.id === engram.id)
               if (idx !== -1) {
                 fresh.splice(idx, 1)
-                await this._writeEngrams(this.paths.engrams, fresh)
+                // Deliberate removal: the remote accepted this engram, so the
+                // local copy is redundant by design (audit #794 shrink guard).
+                await this._writeEngrams(this.paths.engrams, fresh, { allowShrink: true })
                 await this._syncIndex()
               }
             })
@@ -4992,7 +4998,8 @@ export class Plur {
       const active = engrams.filter(e => e.status !== 'retired')
       const removed = engrams.length - active.length
       if (removed > 0) {
-        await this._writeEngrams(this.paths.engrams, active)
+        // Removing retired engrams IS this method (audit #794 shrink guard).
+        await this._writeEngrams(this.paths.engrams, active, { allowShrink: true })
         await this._syncIndex()
       }
       return { removed, remaining: active.length }
@@ -5596,7 +5603,9 @@ export class Plur {
           .filter(e => !(consideredIds.has(e.id) && !survivorsById.has(e.id)))
           // Apply updated outbox metadata / demotions to the ones that stayed.
           .map(e => (survivorsById.get(e.id) ?? e))
-        await this._writeEngrams(this.paths.engrams, merged)
+        // The dropped engrams are the ones the remote accepted — a deliberate
+        // handoff, not a loss (audit #794 shrink guard).
+        await this._writeEngrams(this.paths.engrams, merged, { allowShrink: true })
       })
       await this._syncIndex()
     }

--- a/packages/core/src/migrations/runner.ts
+++ b/packages/core/src/migrations/runner.ts
@@ -52,7 +52,26 @@ function createBackup(engramsPath: string, version: number): string | null {
   if (!fs.existsSync(engramsPath)) return null
   const backupPath = `${engramsPath}.bak.${version}`
   fs.copyFileSync(engramsPath, backupPath)
+  // A backup that is not on disk is not a backup. copyFileSync leaves the copy
+  // in the page cache, so a power cut during a migration could take the corpus
+  // AND the rollback target with it (audit #794, F4).
+  flushFile(backupPath)
   return backupPath
+}
+
+/** fsync a path that was just written by a non-atomic helper. Best-effort — see atomicWrite. */
+function flushFile(filePath: string): void {
+  let fd: number | undefined
+  try {
+    fd = fs.openSync(filePath, 'r+')
+    fs.fsyncSync(fd)
+  } catch {
+    /* nothing actionable — the copy itself succeeded */
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd) } catch { /* ignore */ }
+    }
+  }
 }
 
 /** Restore engrams.yaml from backup. */

--- a/packages/core/src/reranker-eval.ts
+++ b/packages/core/src/reranker-eval.ts
@@ -336,7 +336,8 @@ export function loadRerankerEvalCache(storeRoot: string): Record<string, Reranke
 export function saveRerankerEvalResult(storeRoot: string, result: RerankerEvalResult): void {
   const evals = loadRerankerEvalCache(storeRoot)
   evals[result.reranker] = result
-  atomicWrite(rerankerEvalCachePath(storeRoot), JSON.stringify({ version: 1, evals }, null, 2))
+  // Derived state — a benchmark result, recomputable by re-running the eval.
+  atomicWrite(rerankerEvalCachePath(storeRoot), JSON.stringify({ version: 1, evals }, null, 2), { durable: false })
 }
 
 /**

--- a/packages/core/src/store/async-fs.ts
+++ b/packages/core/src/store/async-fs.ts
@@ -3,14 +3,75 @@
  * Async equivalent of atomicWrite() from sync.ts.
  */
 import { existsSync } from 'fs'
-import { writeFile, rename, mkdir } from 'fs/promises'
+import { open, rename, mkdir, unlink } from 'fs/promises'
 import { dirname } from 'path'
 
-/** Atomic write: write to temp file then rename (prevents corruption on crash). */
-export async function asyncAtomicWrite(filePath: string, content: string): Promise<void> {
+/** Options for {@link asyncAtomicWrite}. */
+export interface AsyncAtomicWriteOptions {
+  /**
+   * fsync the file and its parent directory before resolving. Default `true`.
+   *
+   * Pass `false` ONLY for derived, rebuildable state. Never for a store file.
+   */
+  durable?: boolean
+}
+
+/** Counter making each tmp name unique within a process (pid makes it unique across them). */
+let tmpCounter = 0
+
+/**
+ * Atomic write: write to a temp file, flush it, then rename over the target.
+ *
+ * Mirrors `atomicWrite` in sync.ts — see the durability and unique-tmp
+ * rationale there (audit #794, F4). Kept as a separate implementation rather
+ * than a wrapper because this one must not block the event loop: the store
+ * layer calls it from async write paths that a long-lived MCP server is
+ * servicing concurrently.
+ */
+export async function asyncAtomicWrite(
+  filePath: string,
+  content: string,
+  opts: AsyncAtomicWriteOptions = {},
+): Promise<void> {
+  const durable = opts.durable !== false
   const dir = dirname(filePath)
   if (!existsSync(dir)) await mkdir(dir, { recursive: true })
-  const tmp = filePath + '.tmp'
-  await writeFile(tmp, content)
-  await rename(tmp, filePath)
+  const tmp = `${filePath}.${process.pid}.${tmpCounter++}.tmp`
+  try {
+    const handle = await open(tmp, 'w')
+    try {
+      await handle.writeFile(content)
+      if (durable) await handle.sync()
+    } finally {
+      await handle.close()
+    }
+    await rename(tmp, filePath)
+    if (durable) await fsyncDir(dir)
+  } catch (err) {
+    // Never leave the tmp behind on a failed write — with a unique name
+    // nothing else would ever clean it up.
+    try { await unlink(tmp) } catch { /* already gone, or never created */ }
+    throw err
+  }
+}
+
+/**
+ * fsync a directory so a rename into it is durable.
+ *
+ * Best-effort: directory handles cannot be synced on Windows and some
+ * filesystems reject it. A failure means the rename may not survive power loss;
+ * it does not mean the write failed, so it must not throw.
+ */
+async function fsyncDir(dir: string): Promise<void> {
+  let handle
+  try {
+    handle = await open(dir, 'r')
+    await handle.sync()
+  } catch {
+    /* platform does not support it — the file's own fsync still happened */
+  } finally {
+    if (handle) {
+      try { await handle.close() } catch { /* ignore */ }
+    }
+  }
 }

--- a/packages/core/src/store/primary-store.ts
+++ b/packages/core/src/store/primary-store.ts
@@ -43,6 +43,18 @@ import type { Engram } from '../schemas/engram.js'
 /** Identifier for the backing medium of a primary store. */
 export type PrimaryStoreKind = 'yaml' | 'memory' | 'postgres'
 
+/** Options for {@link PrimaryStore.save}. */
+export interface SaveOptions {
+  /**
+   * This write is expected to remove engrams — suppress the shrink guard.
+   *
+   * Only the deliberate removers set it: compact, forget, retire, outbox
+   * merge-back, pack uninstall. Everything else leaves it unset so that an
+   * unexpectedly short corpus is refused rather than persisted (audit #794).
+   */
+  allowShrink?: boolean
+}
+
 export interface PrimaryStore {
   /** Backing medium — for diagnostics and `status()` reporting. */
   readonly kind: PrimaryStoreKind
@@ -68,8 +80,15 @@ export interface PrimaryStore {
    */
   loadCached(): Promise<Engram[]>
 
-  /** Replace the entire contents of the store, and drop any read cache. */
-  save(engrams: Engram[]): Promise<void>
+  /**
+   * Replace the entire contents of the store, and drop any read cache.
+   *
+   * File-backed implementations refuse a write that would shrink the corpus by
+   * more than a tolerance unless `opts.allowShrink` is set — see the guard on
+   * `saveEngrams` (audit #794). Row stores have no equivalent exposure and may
+   * ignore the option.
+   */
+  save(engrams: Engram[], opts?: SaveOptions): Promise<void>
 
   /** Drop any read cache without writing. Synchronous — see the note above. */
   invalidate(): void

--- a/packages/core/src/store/yaml-primary-store.ts
+++ b/packages/core/src/store/yaml-primary-store.ts
@@ -16,7 +16,7 @@
 import * as fs from 'fs'
 import { loadEngrams, saveEngrams } from '../engrams.js'
 import type { Engram } from '../schemas/engram.js'
-import type { AsyncPrimaryStore, PrimaryStoreKind } from './primary-store.js'
+import type { AsyncPrimaryStore, PrimaryStoreKind, SaveOptions } from './primary-store.js'
 
 /**
  * Mean serialized size of one engram in `engrams.yaml`, in bytes.
@@ -61,8 +61,8 @@ export class YamlPrimaryStore implements AsyncPrimaryStore {
     return engrams
   }
 
-  async save(engrams: Engram[]): Promise<void> {
-    saveEngrams(this.filePath, engrams)
+  async save(engrams: Engram[], opts?: SaveOptions): Promise<void> {
+    saveEngrams(this.filePath, engrams, { allowShrink: opts?.allowShrink })
     this.cache = null
   }
 

--- a/packages/core/src/store/yaml-store.ts
+++ b/packages/core/src/store/yaml-store.ts
@@ -7,8 +7,8 @@
 import { existsSync } from 'fs'
 import { readFile, stat } from 'fs/promises'
 import * as yaml from 'js-yaml'
-import { EngramSchemaPassthrough, type Engram } from '../schemas/engram.js'
-import { logger } from '../logger.js'
+import { type Engram } from '../schemas/engram.js'
+import { parseEngramFile } from '../engrams.js'
 import { asyncAtomicWrite } from './async-fs.js'
 import { withAsyncLock } from './async-lock.js'
 import type { EngramStore } from './types.js'
@@ -21,24 +21,7 @@ export class YamlStore implements EngramStore {
   }
 
   async load(): Promise<Engram[]> {
-    if (!existsSync(this.filePath)) return []
-    try {
-      const content = await readFile(this.filePath, 'utf8')
-      const raw = yaml.load(content) as any
-      if (!raw?.engrams || !Array.isArray(raw.engrams)) return []
-      const valid: Engram[] = []
-      let skipped = 0
-      for (const entry of raw.engrams) {
-        const result = EngramSchemaPassthrough.safeParse(entry)
-        if (result.success) valid.push(result.data)
-        else skipped++
-      }
-      if (skipped > 0) logger.warning(`Skipped ${skipped} invalid engram(s) in ${this.filePath}`)
-      return valid
-    } catch (err) {
-      logger.error(`Failed to parse engrams file ${this.filePath}: ${err}`)
-      return []
-    }
+    return (await this._read()).valid
   }
 
   async save(engrams: Engram[]): Promise<void> {
@@ -51,8 +34,8 @@ export class YamlStore implements EngramStore {
   async append(engram: Engram): Promise<void> {
     await withAsyncLock(this.filePath, async () => {
       // YAML cannot be truly appended — load, append, save
-      const engrams = await this._loadRaw()
-      engrams.push(engram)
+      const { valid, quarantined } = await this._read()
+      const engrams = [...valid, engram, ...(quarantined as Engram[])]
       const content = yaml.dump({ engrams }, { lineWidth: 120, noRefs: true, quotingType: '"' })
       await asyncAtomicWrite(this.filePath, content)
     })
@@ -65,10 +48,11 @@ export class YamlStore implements EngramStore {
 
   async remove(id: string): Promise<boolean> {
     return await withAsyncLock(this.filePath, async () => {
-      const engrams = await this._loadRaw()
-      const idx = engrams.findIndex(e => e.id === id)
+      const { valid, quarantined } = await this._read()
+      const idx = valid.findIndex(e => e.id === id)
       if (idx === -1) return false
-      engrams.splice(idx, 1)
+      valid.splice(idx, 1)
+      const engrams = [...valid, ...(quarantined as Engram[])]
       const content = yaml.dump({ engrams }, { lineWidth: 120, noRefs: true, quotingType: '"' })
       await asyncAtomicWrite(this.filePath, content)
       return true
@@ -87,21 +71,25 @@ export class YamlStore implements EngramStore {
     // No resources to close for YAML
   }
 
-  /** Raw load without validation — for internal mutate-and-save operations. */
-  private async _loadRaw(): Promise<Engram[]> {
-    if (!existsSync(this.filePath)) return []
-    try {
-      const content = await readFile(this.filePath, 'utf8')
-      const raw = yaml.load(content) as any
-      if (!raw?.engrams || !Array.isArray(raw.engrams)) return []
-      const valid: Engram[] = []
-      for (const entry of raw.engrams) {
-        const result = EngramSchemaPassthrough.safeParse(entry)
-        if (result.success) valid.push(result.data)
-      }
-      return valid
-    } catch {
-      return []
-    }
+  /**
+   * Read and validate the store, throwing when it is unreadable.
+   *
+   * This class used to carry its own copy of the parse rules, and the copy went
+   * stale: #766 hardened `loadEngrams` to throw on an unparseable file, and
+   * this one kept catching and returning `[]` — after which `append`/`remove`
+   * rewrote the file from that empty list (audit #794, F14). There is now one
+   * definition of the rules, in `parseEngramFile`, and both readers use it.
+   *
+   * Quarantined entries are returned alongside the valid ones so the mutating
+   * methods can write them back instead of dropping them.
+   */
+  private async _read(): Promise<{ valid: Engram[]; quarantined: unknown[] }> {
+    if (!existsSync(this.filePath)) return { valid: [], quarantined: [] }
+    const [content, info] = await Promise.all([
+      readFile(this.filePath, 'utf8'),
+      stat(this.filePath),
+    ])
+    if (info.isDirectory()) return { valid: [], quarantined: [] }
+    return parseEngramFile(this.filePath, content, info.size)
   }
 }

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync, statSync, readdirSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync, statSync, readdirSync, openSync, closeSync, fsyncSync } from 'fs'
 import { join, dirname, relative } from 'path'
 import * as yaml from 'js-yaml'
 import { isSharedScope } from './scope-util.js'
@@ -627,11 +627,94 @@ export function withLock<T>(
   }
 }
 
-/** Atomic write: write to temp file then rename (prevents corruption on crash). */
-export function atomicWrite(filePath: string, content: string): void {
+/** Options for {@link atomicWrite}. */
+export interface AtomicWriteOptions {
+  /**
+   * fsync the file and its parent directory before returning. Default `true`.
+   *
+   * Pass `false` ONLY for derived, rebuildable state (embedding cache,
+   * reranker-eval cache, telemetry counters). Never for a store file: see the
+   * durability note on {@link atomicWrite}.
+   */
+  durable?: boolean
+}
+
+/** Counter making each tmp name unique within a process (pid makes it unique across them). */
+let tmpCounter = 0
+
+/**
+ * Atomic write: write to a temp file, flush it, then rename over the target.
+ *
+ * ## Why the fsync (audit #794, F4)
+ *
+ * write + rename alone is atomic with respect to a dying *process* — the page
+ * cache outlives it, so a reader either sees the old file or the new one. It is
+ * NOT atomic with respect to a dying *kernel*. On power loss the rename can
+ * reach disk before the data does, and the canonical artifact is a zero-length
+ * or truncated file.
+ *
+ * That artifact is precisely the input to the corrupt-read wipe (#795): a
+ * zero-length engrams.yaml used to read as an empty corpus, and the next write
+ * persisted it. The two compose into total corpus loss, which is why this is
+ * fsync-by-default rather than fsync-on-request.
+ *
+ * The parent directory is flushed too, because the rename itself is directory
+ * metadata — without that flush the durable file can still be reachable only
+ * under its temp name after a crash.
+ *
+ * ## Why the tmp name is unique
+ *
+ * It used to be a fixed `<path>.tmp`, which let two concurrent writers clobber
+ * each other's partial file and rename it into place — measured in probe P02 as
+ * a hard `ENOENT: rename '…/episodes.yaml.tmp'` crash when the loser's tmp had
+ * already been renamed away. Unique names make concurrent writers independent;
+ * the last rename wins cleanly instead of publishing a half-written blend.
+ */
+export function atomicWrite(filePath: string, content: string, opts: AtomicWriteOptions = {}): void {
+  const durable = opts.durable !== false
   const dir = dirname(filePath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-  const tmp = filePath + '.tmp'
-  writeFileSync(tmp, content)
-  renameSync(tmp, filePath)
+  const tmp = `${filePath}.${process.pid}.${tmpCounter++}.tmp`
+  try {
+    if (durable) {
+      const fd = openSync(tmp, 'w')
+      try {
+        writeFileSync(fd, content)
+        fsyncSync(fd)
+      } finally {
+        closeSync(fd)
+      }
+    } else {
+      writeFileSync(tmp, content)
+    }
+    renameSync(tmp, filePath)
+    if (durable) fsyncDir(dir)
+  } catch (err) {
+    // Never leave the tmp behind on a failed write — it would accumulate, and
+    // with a unique name nothing would ever clean it up.
+    try { unlinkSync(tmp) } catch { /* already gone, or never created */ }
+    throw err
+  }
+}
+
+/**
+ * fsync a directory so a rename into it is durable.
+ *
+ * Best-effort by design: directory fds cannot be opened for sync on Windows,
+ * and some filesystems reject the fsync outright. A failure here means the
+ * rename may not survive power loss — it does NOT mean the write failed, and
+ * throwing would turn a working write into a spurious error.
+ */
+function fsyncDir(dir: string): void {
+  let fd: number | undefined
+  try {
+    fd = openSync(dir, 'r')
+    fsyncSync(fd)
+  } catch {
+    /* platform does not support it — the file's own fsync still happened */
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd) } catch { /* ignore */ }
+    }
+  }
 }

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -157,6 +157,7 @@ export function getSyncStatus(root: string): SyncStatus {
  * Returns the number of files staged (added/modified/deleted).
  */
 function stageStoreFiles(root: string): number {
+  assertNoUnmergedStoreFiles(root)
   for (const secret of SECRET_PATHS) {
     gitSafe(['rm', '--cached', '--ignore-unmatch', '--quiet', '--', secret], root)
   }
@@ -171,6 +172,38 @@ function stageStoreFiles(root: string): number {
   }
   const staged = gitSafe(['diff', '--cached', '--name-only'], root)
   return staged ? staged.split('\n').filter(Boolean).length : 0
+}
+
+/**
+ * Refuse to stage while any store file is in an unmerged (conflicted) state.
+ *
+ * `git add -A -f` on an unmerged path does not resolve the conflict — it marks
+ * it resolved and stages the bytes as they are, conflict markers included
+ * (audit #794, F5; probe P06b measured the resulting blob being committed AND
+ * pushed). Since staging is the step that turns a conflicted working tree into
+ * a commit, this is the right place to stop.
+ *
+ * `--diff-filter=U` is checked against the store allowlist only: an unrelated
+ * conflicted file elsewhere in the repo is not sync's business, which is the
+ * over-broad behaviour `hasConflictMarkers` (a `git grep` across ALL tracked
+ * files) still has.
+ */
+function assertNoUnmergedStoreFiles(root: string): void {
+  const unmerged = gitSafe(['diff', '--name-only', '--diff-filter=U'], root)
+  if (!unmerged) return
+  const conflicted = unmerged
+    .split('\n')
+    .map(f => f.trim())
+    .filter(Boolean)
+    .filter(f => SYNC_PATHS.some(p => f === p || f.startsWith(`${p}/`)))
+  if (conflicted.length === 0) return
+  throw new Error(
+    `[plur] refusing to sync: ${conflicted.join(', ')} ${conflicted.length === 1 ? 'is' : 'are'} unmerged.\n` +
+    `Staging an unmerged file would mark the conflict "resolved" with its markers still in it, and commit ` +
+    `(and push) that as your engram store.\n` +
+    `Resolve the conflict first. If a previous sync left an autostash behind, your complete copy may be in ` +
+    `'git stash list' — check it BEFORE running 'git stash drop' or 'git reset --hard'.`,
+  )
 }
 
 /**
@@ -243,6 +276,37 @@ interface EngramRecord { id?: string; scope?: string; visibility?: string; [k: s
  * `{ engrams: [...] }` shape and a bare top-level array. Returns null when the
  * file is absent, unparseable, or not in a recognized engram shape.
  */
+/**
+ * Error thrown when sync finds an engrams.yaml it cannot parse.
+ *
+ * Sync MUST fail loudly here rather than continue (audit #794, F5). The strip
+ * that keeps `scope:local` engrams off the remote is driven by parsing this
+ * file; a parse failure used to disable the strip silently, and the verbatim
+ * blob — conflict markers, private engrams and all — was committed and pushed.
+ */
+export class SyncStoreUnreadableError extends Error {
+  constructor(readonly filePath: string) {
+    super(
+      `[plur] refusing to sync: cannot parse ${filePath}.\n` +
+      `The scope filter that keeps private and scope:local engrams off the remote is derived from this ` +
+      `file. With it unreadable, PLUR cannot tell which engrams must NOT be pushed, so continuing would ` +
+      `commit the file verbatim — publishing private engrams and any conflict markers along with them.\n` +
+      `Common cause: a merge conflict in engrams.yaml — look for <<<<<<< markers. If a previous sync left ` +
+      `an autostash behind, your complete copy may be in 'git stash list' — check it BEFORE running ` +
+      `'git stash drop' or 'git reset --hard'.\n` +
+      `Fix the file, then retry.`,
+    )
+    this.name = 'SyncStoreUnreadableError'
+  }
+}
+
+/**
+ * Read engrams.yaml as a record list for the strip filters.
+ *
+ * `null` means ABSENT — there is nothing to strip and nothing to protect. It no
+ * longer doubles as "unparseable": conflating the two is what let F5 push a
+ * corrupt, unstripped store. Unparseable throws.
+ */
 function readEngramList(root: string): { raw: unknown; list: EngramRecord[] } | null {
   const path = join(root, 'engrams.yaml')
   if (!existsSync(path)) return null
@@ -250,13 +314,15 @@ function readEngramList(root: string): { raw: unknown; list: EngramRecord[] } | 
   try {
     raw = yaml.load(readFileSync(path, 'utf8'))
   } catch {
-    return null
+    throw new SyncStoreUnreadableError(path)
   }
   if (Array.isArray(raw)) return { raw, list: raw as EngramRecord[] }
   if (raw && typeof raw === 'object' && Array.isArray((raw as any).engrams)) {
     return { raw, list: (raw as any).engrams as EngramRecord[] }
   }
-  return null
+  // Parses, but is not a shape we recognise as an engram store — so we cannot
+  // derive the push set from it either. Same refusal, same reason.
+  throw new SyncStoreUnreadableError(path)
 }
 
 /**
@@ -358,11 +424,30 @@ function stripWarning(root: string, remoteType: SyncRemoteType): string | undefi
     return `Shared remote: pushed only shared-scope, non-private engrams — ${parts.join(' and ')} stayed local.`
   }
   if (!parsed) return undefined
-  const count = parsed.list.filter(
+  // Audit #794, F7: this used to say the remote "receives all engrams". It does
+  // not — `pushKeep('personal')` strips every scope:local engram, and the
+  // sensitivity guard auto-demotes engrams to local, so the excluded set grows
+  // silently over time. Measured: 5 engrams on disk, a fresh clone of the remote
+  // saw 3, while the warning called it a complete backup.
+  //
+  // A backup warning that overstates coverage is worse than none: it is read
+  // exactly once, when deciding whether other backups are needed.
+  const privateCount = parsed.list.filter(
     e => e?.scope !== 'local' && (e?.visibility ?? 'private') === 'private',
   ).length
-  if (count === 0) return undefined
-  return `Note: sync remote receives all engrams including ${count} private-visibility one(s) — use a private git remote. For a team remote, set sync.remote_type: shared to exclude them.`
+  const localCount = parsed.list.filter(e => e?.scope === 'local').length
+  const parts: string[] = []
+  if (localCount > 0) {
+    parts.push(
+      `${localCount} scope:local engram(s) are NOT pushed and are NOT backed up by sync` +
+      (localCount === parsed.list.length ? ' — this remote backs up nothing' : ''),
+    )
+  }
+  if (privateCount > 0) {
+    parts.push(`${privateCount} private-visibility engram(s) ARE pushed — use a private git remote`)
+  }
+  if (parts.length === 0) return undefined
+  return `Note: ${parts.join('. ')}. For a team remote, set sync.remote_type: shared to exclude private engrams too.`
 }
 
 /**
@@ -480,8 +565,17 @@ function pullRebase(root: string, remoteType: SyncRemoteType): boolean {
   // engrams.yaml VERBATIM — scope:local engrams rode into the remote on this
   // path. Strip the staged blob exactly like every other commit path.
   stageStripped(root, remoteType)
-  gitSafe(['commit', '-m', 'plur sync: merge conflict resolved (kept both)'], root)
-  return true
+  const committed = gitSafe(['commit', '-m', 'plur sync: merge conflict resolved (kept both)'], root)
+  // Audit #794, F6: this used to `return true` unconditionally. When the rebase
+  // refused (dirty tree), the merge fallback aborted, and there were no conflict
+  // markers to catch, sync reported `{action:'synced', message:'pulled 1 remote
+  // commit(s)'}` while HEAD..origin/main was still 1. The remote changes were
+  // never integrated and the user was told they were.
+  //
+  // The honest test is the ledger, not the exit code of the last command: if we
+  // are still behind the upstream, the pull did not happen.
+  if (committed === null) return false
+  return countDiff(root, 'behind') === 0
 }
 
 export function sync(root: string, remote?: string, options?: { remoteType?: SyncRemoteType }): SyncResult {
@@ -537,9 +631,16 @@ export function sync(root: string, remote?: string, options?: { remoteType?: Syn
   const behind = countDiff(root, 'behind')
   const aheadBefore = countDiff(root, 'ahead')
 
+  // Audit #794, F6: the return value used to be discarded here, so a pull that
+  // silently failed still reported `synced`. Capture it, and re-measure rather
+  // than trusting it — `behind` below is the count BEFORE pulling, i.e. what we
+  // meant to pull, not what we actually got.
+  let pullFailed = false
   if (behind > 0) {
-    pullRebase(root, remoteType)
+    pullFailed = !pullRebase(root, remoteType)
   }
+  const behindAfter = behind > 0 ? countDiff(root, 'behind') : 0
+  const pulled = behind - behindAfter
 
   // Push if we have local commits.
   //
@@ -564,7 +665,13 @@ export function sync(root: string, remote?: string, options?: { remoteType?: Syn
 
   const parts: string[] = []
   if (filesChanged > 0) parts.push(`${filesChanged} file(s) committed`)
-  if (behind > 0) parts.push(`pulled ${behind} remote commit(s)`)
+  // Report what was actually integrated, and say so plainly when it was not.
+  // Claiming a pull that did not happen is how a user ends up believing two
+  // machines agree when they do not.
+  if (pulled > 0) parts.push(`pulled ${pulled} remote commit(s)`)
+  if (pullFailed || behindAfter > 0) {
+    parts.push(`NOT pulled — still ${behindAfter} commit(s) behind the remote; resolve locally and retry`)
+  }
   if (aheadAfter === 0 && aheadBefore > 0) parts.push('pushed')
   // Say it in the message too — a caller reading only the text still sees it.
   if (pushError) parts.push('NOT pushed — the commit is local only')

--- a/packages/core/test/cross-scope-recurrence.test.ts
+++ b/packages/core/test/cross-scope-recurrence.test.ts
@@ -195,8 +195,11 @@ describe('cross-scope recurrence (#176)', () => {
       // write to the right store path (not silently drop).
       const secondaryDir = mkdtempSync(join(tmpdir(), 'plur-secondary-'))
       const secondaryPath = join(secondaryDir, 'engrams.yaml')
-      // Initialize an empty store file so saveEngrams can be called
-      writeFileSync(secondaryPath, '[]\n')
+      // Initialize an empty store file so saveEngrams can be called. This must
+      // be the shape PLUR actually writes — a mapping with an `engrams` key.
+      // A bare `[]` is a top-level sequence, which the loader now rejects
+      // rather than silently reading as an empty corpus (audit #794, F1).
+      writeFileSync(secondaryPath, 'engrams: []\n')
       try {
         plur.addStore(secondaryPath, 'project:secondary-a', { shared: true, readonly: false })
 

--- a/packages/core/test/episodes.test.ts
+++ b/packages/core/test/episodes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { captureEpisode, queryTimeline } from '../src/episodes.js'
@@ -49,5 +49,26 @@ describe('episodic memory', () => {
     captureEpisode(path, 'Deployed database migration', { agent: 'test' })
     const results = queryTimeline(path, { search: 'authentication' })
     expect(results).toHaveLength(1)
+  })
+})
+
+describe('captureEpisode concurrency (audit #794, F8)', () => {
+  it('does not lose episodes when writers interleave', async () => {
+    // Pre-fix this was load -> push -> write with no lock, and probe P02
+    // measured 30 of 100 episodes surviving across 4 concurrent writers.
+    const dir = mkdtempSync(join(tmpdir(), 'plur-ep-concurrency-'))
+    const path = join(dir, 'episodes.yaml')
+    try {
+      await Promise.all(
+        Array.from({ length: 40 }, (_, i) =>
+          Promise.resolve().then(() => captureEpisode(path, `episode ${i}`, { agent: 'test' })),
+        ),
+      )
+      expect(queryTimeline(path)).toHaveLength(40)
+      // A fixed <path>.tmp let writers rename each other's partial file.
+      expect(readdirSync(dir).filter(f => f.endsWith('.tmp'))).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/core/test/primary-store.test.ts
+++ b/packages/core/test/primary-store.test.ts
@@ -80,7 +80,11 @@ describe('PrimaryStore contract (shared by every implementation)', () => {
       it('save() replaces the whole contents rather than appending', async () => {
         const store = make()
         await store.save([engram('ENG-2026-0701-003'), engram('ENG-2026-0701-004')])
-        await store.save([engram('ENG-2026-0701-005')])
+        // A replace that SHRINKS the corpus must declare itself (audit #794):
+        // an undeclared shrink is indistinguishable from the corrupt-read wipe
+        // the guard exists to stop. The replace semantic is unchanged — the
+        // caller just has to mean it.
+        await store.save([engram('ENG-2026-0701-005')], { allowShrink: true })
         expect((await store.load()).map(e => e.id)).toEqual(['ENG-2026-0701-005'])
       })
 

--- a/packages/core/test/store-corruption-guard.test.ts
+++ b/packages/core/test/store-corruption-guard.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Regression tests for the store-corruption guards (audit #794, issues #795/#796).
+ *
+ * Each test here corresponds to a corruption class that a probe measured as
+ * real data loss on 0.17 main. The probes (`packages/core/probe/`) demonstrate
+ * the behaviour end-to-end; these pin it at the unit level so it cannot come
+ * back.
+ *
+ * The bug being defended against, in one sentence: `loadEngrams` returned `[]`
+ * for a file it could not understand, and every write path replaces the whole
+ * file, so the next write persisted that `[]` over the real corpus.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+import {
+  loadEngrams,
+  saveEngrams,
+  getQuarantinedEntries,
+  EngramStoreUnreadableError,
+  EngramStoreShrinkError,
+} from '../src/engrams.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+let root: string
+let storePath: string
+
+function engram(n: number): Engram {
+  return {
+    id: `ENG-2026-08-02-${String(n).padStart(3, '0')}`,
+    statement: `fact number ${n} about the system`,
+    type: 'behavioral',
+    status: 'active',
+    confidence: 0.5,
+    created: '2026-08-02',
+    scope: 'local',
+  } as Engram
+}
+
+function seed(count: number): Engram[] {
+  const engrams = Array.from({ length: count }, (_, i) => engram(i))
+  fs.writeFileSync(storePath, yaml.dump({ engrams }))
+  return engrams
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(join(os.tmpdir(), 'plur-corrupt-guard-'))
+  storePath = join(root, 'engrams.yaml')
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('loadEngrams — refuses unreadable stores instead of reporting empty (F1)', () => {
+  it('treats a MISSING file as genuinely empty', () => {
+    // The one case that must stay `[]`: without it, a first run cannot work.
+    expect(loadEngrams(join(root, 'nope.yaml'))).toEqual([])
+  })
+
+  it('throws on a zero-length file — the canonical power-loss artifact', () => {
+    seed(5)
+    fs.writeFileSync(storePath, '')
+    // Pre-fix this returned [] (yaml.load('') is undefined, not an error), and
+    // the next write persisted the empty corpus.
+    expect(() => loadEngrams(storePath)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('throws on a file whose bytes parse to nothing (comments-only / whitespace)', () => {
+    fs.writeFileSync(storePath, '# everything below was truncated away\n\n')
+    expect(() => loadEngrams(storePath)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('throws on a mapping with no engrams key — a truncated or foreign file', () => {
+    fs.writeFileSync(storePath, yaml.dump({ schema_version: 5, note: 'not a store' }))
+    expect(() => loadEngrams(storePath)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('throws when engrams is present but is not a list', () => {
+    fs.writeFileSync(storePath, yaml.dump({ engrams: { id: 'ENG-1' } }))
+    expect(() => loadEngrams(storePath)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('throws on a scalar top-level value', () => {
+    fs.writeFileSync(storePath, 'just a string\n')
+    expect(() => loadEngrams(storePath)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('still throws on git merge-conflict markers (the #766 case must not regress)', () => {
+    seed(5)
+    const body = fs.readFileSync(storePath, 'utf8')
+    fs.writeFileSync(storePath, `<<<<<<< HEAD\n${body}=======\nengrams: []\n>>>>>>> origin/main\n`)
+    expect(() => loadEngrams(storePath)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('accepts an explicitly empty store written by initFilesystemStore', () => {
+    fs.writeFileSync(storePath, yaml.dump({ engrams: [] }))
+    expect(loadEngrams(storePath)).toEqual([])
+  })
+
+  it('accepts a null engrams key as empty rather than throwing', () => {
+    // `engrams:` with nothing after it is what a hand-edited file looks like.
+    fs.writeFileSync(storePath, 'engrams:\n')
+    expect(loadEngrams(storePath)).toEqual([])
+  })
+})
+
+describe('loadEngrams — quarantines invalid entries instead of deleting them (F2)', () => {
+  it('withholds invalid entries from callers but preserves them on the next save', () => {
+    const engrams = seed(5)
+    const raw: any = yaml.load(fs.readFileSync(storePath, 'utf8'))
+    raw.engrams[1].type = 12345        // wrong type
+    delete raw.engrams[3].statement    // required field removed
+    fs.writeFileSync(storePath, yaml.dump(raw))
+
+    const loaded = loadEngrams(storePath)
+    expect(loaded).toHaveLength(3)
+    expect(getQuarantinedEntries(storePath)).toHaveLength(2)
+
+    // An ordinary unrelated write — this is what used to delete them.
+    saveEngrams(storePath, [...loaded, engram(99)])
+
+    const after: any = yaml.load(fs.readFileSync(storePath, 'utf8'))
+    const ids = new Set(after.engrams.map((e: any) => e.id))
+    expect(after.engrams).toHaveLength(6)
+    expect(ids.has(engrams[1].id)).toBe(true)
+    expect(ids.has(engrams[3].id)).toBe(true)
+  })
+
+  it('does not resurrect a quarantined entry that has since been re-added properly', () => {
+    seed(3)
+    const raw: any = yaml.load(fs.readFileSync(storePath, 'utf8'))
+    const doomedId = raw.engrams[1].id
+    delete raw.engrams[1].statement
+    fs.writeFileSync(storePath, yaml.dump(raw))
+
+    const loaded = loadEngrams(storePath)
+    expect(loaded).toHaveLength(2)
+
+    // The caller repairs the engram under the same id.
+    const repaired = { ...engram(1), id: doomedId }
+    saveEngrams(storePath, [...loaded, repaired])
+
+    const after: any = yaml.load(fs.readFileSync(storePath, 'utf8'))
+    const matching = after.engrams.filter((e: any) => e.id === doomedId)
+    expect(matching).toHaveLength(1)
+    expect(matching[0].confidence).toBe(0.5)
+  })
+})
+
+describe('saveEngrams — shrink guard (F1/F2/F3 choke point)', () => {
+  it('refuses a write that would drop the corpus past the tolerance', () => {
+    seed(10)
+    // The shape of the bug: something read the store as near-empty, and the
+    // write path is about to make that permanent.
+    expect(() => saveEngrams(storePath, [engram(0)])).toThrow(EngramStoreShrinkError)
+    // The file is untouched.
+    expect(loadEngrams(storePath)).toHaveLength(10)
+  })
+
+  it('refuses a write of an empty array over a populated store', () => {
+    seed(10)
+    expect(() => saveEngrams(storePath, [])).toThrow(EngramStoreShrinkError)
+    expect(loadEngrams(storePath)).toHaveLength(10)
+  })
+
+  it('allows a deliberate shrink when the caller declares it', () => {
+    seed(10)
+    saveEngrams(storePath, [engram(0)], { allowShrink: true })
+    expect(loadEngrams(storePath)).toHaveLength(1)
+  })
+
+  it('allows small removals within tolerance without a declaration', () => {
+    const engrams = seed(100)
+    // 5% — below the 10% tolerance, so paths that remove one or two engrams
+    // without declaring themselves keep working.
+    saveEngrams(storePath, engrams.slice(0, 95))
+    expect(loadEngrams(storePath)).toHaveLength(95)
+  })
+
+  it('allows growth', () => {
+    const engrams = seed(5)
+    saveEngrams(storePath, [...engrams, engram(98), engram(99)])
+    expect(loadEngrams(storePath)).toHaveLength(7)
+  })
+
+  it('has no baseline to guard when the file does not exist yet', () => {
+    saveEngrams(storePath, [engram(0)])
+    expect(loadEngrams(storePath)).toHaveLength(1)
+  })
+
+  it('counts quarantined entries toward the outgoing total', () => {
+    // 10 on disk, 2 invalid -> loader returns 8. Writing those 8 back is a 20%
+    // shrink by naive counting, but the 2 quarantined entries are re-appended,
+    // so the real outgoing count is 10 and the write must be allowed.
+    seed(10)
+    const raw: any = yaml.load(fs.readFileSync(storePath, 'utf8'))
+    raw.engrams[2].type = 999
+    raw.engrams[7].type = 999
+    fs.writeFileSync(storePath, yaml.dump(raw))
+
+    const loaded = loadEngrams(storePath)
+    expect(loaded).toHaveLength(8)
+    expect(() => saveEngrams(storePath, loaded)).not.toThrow()
+    expect(yaml.load(fs.readFileSync(storePath, 'utf8')) as any).toMatchObject({
+      engrams: expect.objectContaining({ length: 10 }),
+    })
+  })
+})
+
+describe('atomicWrite durability (F4)', () => {
+  it('leaves no temp files behind after a successful write', () => {
+    saveEngrams(storePath, [engram(0)])
+    const strays = fs.readdirSync(root).filter(f => f.endsWith('.tmp'))
+    expect(strays).toEqual([])
+  })
+
+  it('uses a unique temp name so concurrent writers cannot clobber each other', async () => {
+    // The fixed `<path>.tmp` let one writer rename another's partial file,
+    // measured in probe P02 as an ENOENT crash. Interleave writes and assert
+    // both complete and the file stays parseable.
+    const a = Array.from({ length: 20 }, (_, i) => engram(i))
+    const b = Array.from({ length: 20 }, (_, i) => engram(i + 100))
+    saveEngrams(storePath, a)
+    await Promise.all([
+      Promise.resolve().then(() => saveEngrams(storePath, [...a, ...b])),
+      Promise.resolve().then(() => saveEngrams(storePath, [...a, ...b])),
+    ])
+    expect(loadEngrams(storePath).length).toBeGreaterThanOrEqual(20)
+    expect(fs.readdirSync(root).filter(f => f.endsWith('.tmp'))).toEqual([])
+  })
+})

--- a/packages/core/test/store-corruption-guard.test.ts
+++ b/packages/core/test/store-corruption-guard.test.ts
@@ -22,13 +22,21 @@ import {
   EngramStoreUnreadableError,
   EngramStoreShrinkError,
 } from '../src/engrams.js'
-import type { Engram } from '../src/schemas/engram.js'
+import { EngramSchemaPassthrough, type Engram } from '../src/schemas/engram.js'
 
 let root: string
 let storePath: string
 
+/**
+ * Build a real, fully-defaulted Engram.
+ *
+ * Parsed through the schema rather than cast, so the fixture cannot drift out
+ * of shape: a hand-written object literal with an `as Engram` cast compiles
+ * only by lying, and a lying fixture is worthless in tests whose entire subject
+ * is what does and does not pass validation.
+ */
 function engram(n: number): Engram {
-  return {
+  return EngramSchemaPassthrough.parse({
     id: `ENG-2026-08-02-${String(n).padStart(3, '0')}`,
     statement: `fact number ${n} about the system`,
     type: 'behavioral',
@@ -36,7 +44,7 @@ function engram(n: number): Engram {
     confidence: 0.5,
     created: '2026-08-02',
     scope: 'local',
-  } as Engram
+  }) as Engram
 }
 
 function seed(count: number): Engram[] {

--- a/packages/core/test/sync-corrupt-push-guard.test.ts
+++ b/packages/core/test/sync-corrupt-push-guard.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for the sync corrupt-push guards (audit #794, issue #798).
+ *
+ * `plur sync` is what users are told is their backup, which makes these worse
+ * than their severity suggests. Measured on 0.17 main by probes p06/p06b:
+ *
+ *   - an unparseable engrams.yaml silently DISABLED the scope strip, and the
+ *     verbatim blob — conflict markers and scope:local engrams alike — was
+ *     committed and pushed (`remote now has markers: true`)
+ *   - `git add -A -f` on an unmerged path marked the conflict "resolved" with
+ *     the markers still in it
+ *   - sync reported `{action:'synced', message:'pulled 1 remote commit(s)'}`
+ *     while still 1 commit behind
+ *   - the push warning claimed the remote "receives all engrams" while a fresh
+ *     clone saw 3 of 5
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import * as yaml from 'js-yaml'
+import { sync, SyncStoreUnreadableError } from '../src/sync.js'
+
+let root: string
+let remote: string
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+function record(n: number, scope = 'global') {
+  return {
+    id: `ENG-2026-08-02-${String(n).padStart(3, '0')}`,
+    statement: `fact ${n}`,
+    type: 'behavioral',
+    status: 'active',
+    scope,
+    visibility: 'private',
+    version: 2,
+    confidence: 0.5,
+    created: '2026-08-02',
+    tags: [],
+  }
+}
+
+function writeStore(records: unknown[]): void {
+  writeFileSync(join(root, 'engrams.yaml'), yaml.dump({ engrams: records }))
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'plur-sync-guard-'))
+  remote = mkdtempSync(join(tmpdir(), 'plur-sync-remote-'))
+  git(['init', '--bare', '-b', 'main'], remote)
+  writeStore([record(1), record(2), record(3)])
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  rmSync(remote, { recursive: true, force: true })
+})
+
+describe('sync refuses an unreadable store instead of pushing it verbatim (F5)', () => {
+  it('throws rather than committing a conflict-marked engrams.yaml', () => {
+    sync(root, remote)
+    const path = join(root, 'engrams.yaml')
+    const good = readFileSync(path, 'utf8')
+    writeFileSync(path, `<<<<<<< HEAD\n${good}=======\nengrams: []\n>>>>>>> origin/main\n`)
+
+    expect(() => sync(root)).toThrow(SyncStoreUnreadableError)
+
+    // The committed tree is untouched — nothing with markers reached it.
+    expect(git(['show', 'HEAD:engrams.yaml'], root)).not.toContain('<<<<<<<')
+  })
+
+  it('throws on a store that parses but is not an engram store', () => {
+    sync(root, remote)
+    writeFileSync(join(root, 'engrams.yaml'), yaml.dump({ something_else: true }))
+    expect(() => sync(root)).toThrow(SyncStoreUnreadableError)
+  })
+
+  it('names the stash in the error, since that is where the only complete copy may be', () => {
+    sync(root, remote)
+    writeFileSync(join(root, 'engrams.yaml'), '{{{ not yaml')
+    try {
+      sync(root)
+      throw new Error('should have thrown')
+    } catch (err) {
+      const msg = (err as Error).message
+      // The natural "fix my repo" reflex is `git reset --hard`, which makes an
+      // autostash-held copy unrecoverable. The error has to get in front of it.
+      expect(msg).toMatch(/git stash/i)
+      expect(msg).toMatch(/before running/i)
+    }
+  })
+
+  it('refuses to stage an unmerged store file', () => {
+    sync(root, remote)
+    // Manufacture a genuine unmerged index entry by conflicting two real
+    // commits — the state an autostash pop or a failed merge actually leaves.
+    git(['checkout', '-b', 'other'], root)
+    writeStore([record(1), record(9)])
+    git(['add', '-f', 'engrams.yaml'], root)
+    git(['commit', '-m', 'other side'], root)
+    git(['checkout', 'main'], root)
+    writeStore([record(1), record(8)])
+    git(['add', '-f', 'engrams.yaml'], root)
+    git(['commit', '-m', 'this side'], root)
+    try { git(['merge', 'other'], root) } catch { /* expected conflict */ }
+
+    const unmerged = git(['diff', '--name-only', '--diff-filter=U'], root)
+    expect(unmerged).toContain('engrams.yaml')
+    expect(() => sync(root)).toThrow(/unmerged/i)
+  })
+})
+
+describe('sync reports what actually happened (F6)', () => {
+  it('does not claim a pull that did not happen', () => {
+    sync(root, remote)
+    // A second clone pushes a commit, so `root` falls behind.
+    const other = mkdtempSync(join(tmpdir(), 'plur-sync-other-'))
+    try {
+      git(['clone', remote, other], tmpdir())
+      writeFileSync(join(other, 'engrams.yaml'), yaml.dump({ engrams: [record(1), record(2), record(3), record(4)] }))
+      git(['add', '-f', 'engrams.yaml'], other)
+      git(['commit', '-m', 'remote side'], other)
+      git(['push', 'origin', 'main'], other)
+
+      const result = sync(root)
+      // Whatever the outcome, the message must not assert a pull that left us
+      // behind. Either it pulled and we are current, or it says it did not.
+      const behind = git(['rev-list', '--right-only', '--count', 'HEAD...@{u}'], root)
+      if (behind !== '0') {
+        expect(result.message).toMatch(/NOT pulled/i)
+      } else {
+        expect(result.message).not.toMatch(/NOT pulled/i)
+      }
+    } finally {
+      rmSync(other, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('sync tells the truth about what it backs up (F7)', () => {
+  it('names scope:local engrams as NOT backed up', () => {
+    writeStore([record(1), record(2, 'local'), record(3, 'local')])
+    const result = sync(root, remote)
+    expect(result.warning).toMatch(/2 scope:local engram\(s\) are NOT pushed/i)
+    // The old text claimed the remote "receives all engrams", which is the
+    // sentence a user reads once when deciding whether they need real backups.
+    expect(result.warning).not.toMatch(/receives all engrams/i)
+  })
+
+  it('says plainly when the remote backs up nothing at all', () => {
+    writeStore([record(1, 'local'), record(2, 'local')])
+    const result = sync(root, remote)
+    expect(result.warning).toMatch(/backs up nothing/i)
+  })
+
+  it('still warns that private-visibility engrams ARE pushed', () => {
+    writeStore([record(1), record(2)])
+    const result = sync(root, remote)
+    expect(result.warning).toMatch(/2 private-visibility engram\(s\) ARE pushed/i)
+  })
+
+  it('says nothing when there is nothing to warn about', () => {
+    writeStore([{ ...record(1), visibility: 'public' }])
+    const result = sync(root, remote)
+    expect(result.warning).toBeUndefined()
+  })
+})

--- a/packages/core/test/sync-corrupt-push-guard.test.ts
+++ b/packages/core/test/sync-corrupt-push-guard.test.ts
@@ -98,11 +98,16 @@ describe('sync refuses an unreadable store instead of pushing it verbatim (F5)',
     sync(root, remote)
     // Manufacture a genuine unmerged index entry by conflicting two real
     // commits — the state an autostash pop or a failed merge actually leaves.
+    //
+    // The starting branch is read rather than assumed: `git init`'s default is
+    // `master` on git older than 2.28 and wherever `init.defaultBranch` is
+    // unset, so hardcoding `main` here passes locally and fails on CI runners.
+    const base = git(['rev-parse', '--abbrev-ref', 'HEAD'], root)
     git(['checkout', '-b', 'other'], root)
     writeStore([record(1), record(9)])
     git(['add', '-f', 'engrams.yaml'], root)
     git(['commit', '-m', 'other side'], root)
-    git(['checkout', 'main'], root)
+    git(['checkout', base], root)
     writeStore([record(1), record(8)])
     git(['add', '-f', 'engrams.yaml'], root)
     git(['commit', '-m', 'this side'], root)
@@ -117,14 +122,16 @@ describe('sync refuses an unreadable store instead of pushing it verbatim (F5)',
 describe('sync reports what actually happened (F6)', () => {
   it('does not claim a pull that did not happen', () => {
     sync(root, remote)
+    // Branch name is read, not assumed — see the note in the unmerged test.
+    const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], root)
     // A second clone pushes a commit, so `root` falls behind.
     const other = mkdtempSync(join(tmpdir(), 'plur-sync-other-'))
     try {
-      git(['clone', remote, other], tmpdir())
+      git(['clone', '--branch', branch, remote, other], tmpdir())
       writeFileSync(join(other, 'engrams.yaml'), yaml.dump({ engrams: [record(1), record(2), record(3), record(4)] }))
       git(['add', '-f', 'engrams.yaml'], other)
       git(['commit', '-m', 'remote side'], other)
-      git(['push', 'origin', 'main'], other)
+      git(['push', 'origin', branch], other)
 
       const result = sync(root)
       // Whatever the outcome, the message must not assert a pull that left us

--- a/packages/core/test/unreadable-store-guard.test.ts
+++ b/packages/core/test/unreadable-store-guard.test.ts
@@ -91,19 +91,33 @@ describe('unreadable engram store', () => {
     expect(loadEngrams(join(dir, 'does-not-exist.yaml'))).toEqual([])
   })
 
-  it('an empty or comment-only file is still an empty store', () => {
+  // The two cases below used to assert `[]`. Audit #794 (finding F1) measured
+  // that contract destroying corpora: neither shape is something PLUR ever
+  // writes, both are what a truncated or half-written file looks like, and
+  // reporting them as "empty" meant the next write persisted the emptiness.
+  // A comment-only store is a hypothetical; a truncated one is a Tuesday.
+  it('a comment-only file is unreadable, not empty — PLUR never writes one', () => {
     writeFileSync(path, '# nothing here yet\n')
-    expect(loadEngrams(path)).toEqual([])
+    expect(() => loadEngrams(path)).toThrow(EngramStoreUnreadableError)
   })
 
-  it('a file with a valid shape but no engrams key is an empty store', () => {
+  it('a file with a valid shape but no engrams key is unreadable, not empty', () => {
     writeFileSync(path, 'something_else: true\n')
+    expect(() => loadEngrams(path)).toThrow(EngramStoreUnreadableError)
+  })
+
+  it('an EXPLICITLY empty store still loads as empty', () => {
+    // The shape `initFilesystemStore` writes. This is the one that has to keep
+    // working, and it is unambiguous in a way the two above are not.
+    writeFileSync(path, 'engrams: []\n')
     expect(loadEngrams(path)).toEqual([])
   })
 
-  it('one malformed ENTRY among many is skipped, not fatal', () => {
+  it('one malformed ENTRY among many is withheld, not fatal — and not deleted', () => {
     // Partial data is a different problem from an unreadable store: dropping a
-    // single bad engram loses less than refusing to load the other four.
+    // single bad engram loses less than refusing to load the other four. But it
+    // must not be DELETED either — see the quarantine tests in
+    // store-corruption-guard.test.ts (audit #794, F2).
     const parsed = readFileSync(path, 'utf8')
     writeFileSync(path, parsed + '  - not_an_engram: true\n')
     const engrams = loadEngrams(path)


### PR DESCRIPTION
Fixes audit #794 findings **F5 (HIGH)**, **F6** and **F7 (MED-HIGH)**. Verified against probes `p06-git-sync.ts` / `p06b-git-after-conflict.ts`, which measured the original behaviour.

These matter more than their severity suggests, because `plur sync` is what users are told is their backup.

**Stacked on #800** — merge that first. This branch includes its commits.

## F5 — sync committed and pushed a corrupt store, with the scope strip silently off

The chain:

1. strip-on-commit leaves the working tree permanently `M`
2. an autostash pop conflicts → markers in the tree, local-only engrams surviving **only in `stash@{0}`**
3. the next sync `git add -A -f`s the unmerged path — which marks it "resolved" with the markers still in it
4. `readEngramList` can't parse it, so `stageStrippedEngrams` returns early — **the scope strip is now silently disabled**
5. the verbatim blob is committed and pushed

**Measured before:** `committed blob has conflict markers: true`, `has scope:local engrams: true`, `remote now has markers: true` — while sync returned `{action:'synced'}`.

**Measured after:** all three **`false`**, and sync throws.

That is a corrupt remote backup *and* a privacy leak in one call. The privacy half is the worse one: `scope:local` engrams are exactly what the user asked never to leave the machine.

### Fix

`readEngramList` now distinguishes **absent** (nothing to strip, nothing to protect) from **unparseable**, which throws `SyncStoreUnreadableError`. Conflating the two is what disabled the strip.

Staging separately refuses while any store file is unmerged (`--diff-filter=U`), because staging is the step that turns a conflicted tree into a commit. Scoped to the store allowlist — an unrelated conflicted file elsewhere is not sync's business, which is the over-broad behaviour `hasConflictMarkers` (a `git grep` across *all* tracked files) still has.

Both errors name `git stash list` and say to check it **before** `git stash drop` or `git reset --hard`. After an autostash pop conflict the only complete copy of the corpus is in `stash@{0}`, and the natural "fix my repo" reflex destroys it permanently.

## F6 — sync reported success when the pull failed

The return value of `pullRebase` was **discarded at the call site**, and the message reported `behind` — the count measured *before* pulling, i.e. what we meant to pull rather than what arrived.

**Measured before:** `{"action":"synced","message":"Synced. pulled 1 remote commit(s)."}` while `HEAD..origin/main` was still **1**.

**Measured after:** `"Synced. NOT pulled — still 1 commit(s) behind the remote; resolve locally and retry."`

The outcome is now re-measured against the ledger rather than inferred from the last command's exit code.

## F7 — the backup warning was false

`pushKeep('personal')` strips every `scope:local` engram, and the sensitivity guard auto-demotes engrams to `local`, so the excluded set grows silently over time. With `unscoped_default:'local'` it backs up **nothing**.

**Measured:** store had 5 engrams; a fresh clone of the remote saw **3**. The warning on that path read "receives **all engrams** including 3 private-visibility one(s)".

**Now:** `"2 scope:local engram(s) are NOT pushed and are NOT backed up by sync. 3 private-visibility engram(s) ARE pushed — use a private git remote."` and, when everything is local, `"this remote backs up nothing"`.

A backup warning that overstates coverage is worse than no warning: it is read exactly once, when deciding whether other backups are needed.

## What this does NOT fix

The working tree is still left conflicted after an autostash pop — PLUR refuses rather than "repairing" it destructively, which is correct, but the user must resolve it. The complete copy is in `stash@{0}` and the error now says so. Making that recoverable without git expertise needs the backup line in **#799**.

`hasConflictMarkers` remains a `git grep` across all tracked files, so an unrelated conflicted file still aborts a sync. Not fixed here — out of scope, and the new unmerged check is correctly scoped.

## Testing

9 new regression tests in `packages/core/test/sync-corrupt-push-guard.test.ts`, one per measured behaviour.

Full suite after a clean `pnpm build`: **3620 passed, 0 failed, 145 skipped.** `pnpm typecheck:tests` clean.

Closes #798
Refs #794
