### PR TITLE
fix(core,mcp): stop the dedup path full-replacing the corpus on every backend (#802)

### DIFF
--- a/packages/core/probe/p10-seam-capability.ts
+++ b/packages/core/probe/p10-seam-capability.ts
@@ -35,10 +35,27 @@ class LyingPlainStore implements PrimaryStore {
   realCount(): number { return this.engrams.length }
 }
 
-for (const [label, store] of [['capability store (append+updateMany)', new LyingMemoryStore()], ['plain store (save only) = the YAML shape', new LyingPlainStore()]] as const) {
+// The plain store is now REFUSED at construction (audit #794 / #802): a store
+// that can under-report on load() and cannot write single rows defeats every
+// write-path guard at once, so it is rejected at wiring time rather than
+// allowed to lose data later. It is still exercised here — with the explicit
+// `allowUnprotectedStore` opt-out — to show what that opt-out costs.
+for (const [label, store, unsafe] of [
+  ['capability store (append+updateMany)', new LyingMemoryStore(), false],
+  ['plain store (save only), attached WITHOUT the opt-out', new LyingPlainStore(), false],
+  ['plain store (save only), attached WITH allowUnprotectedStore', new LyingPlainStore(), true],
+] as const) {
   const root = fs.mkdtempSync(join(os.tmpdir(), 'plur-p10-'))
   process.env.PLUR_PATH = root
-  const plur = new Plur({ path: root, autoDiscover: false, store: store as unknown as PrimaryStore })
+  let plur: Plur
+  try {
+    plur = new Plur({ path: root, autoDiscover: false, store: store as unknown as PrimaryStore, allowUnprotectedStore: unsafe })
+  } catch (e) {
+    console.log(`${label}: REFUSED AT ATTACHMENT — ${(e as Error).message.split('\n')[0]}`)
+    console.log('   SAFE — the unprotectable store never got to hold data')
+    fs.rmSync(root, { recursive: true, force: true })
+    continue
+  }
   for (let i = 0; i < 5; i++) await plur.learn(`fact number ${i}`, { scope: 'local' })
   const before = (store as any).realCount()
   ;(store as any).lying = true                       // read now returns [] (corrupt/empty)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -744,7 +744,21 @@ export class Plur {
    *   {@link ReadonlyStoreError}; reads work unchanged, except that recall's
    *   activation refresh is silently skipped (see `_reactivateResults`).
    */
-  constructor(options?: { path?: string; store?: AsyncPrimaryStore; autoDiscover?: boolean; cwd?: string; readonly?: boolean }) {
+  constructor(options?: {
+    path?: string
+    store?: AsyncPrimaryStore
+    autoDiscover?: boolean
+    cwd?: string
+    readonly?: boolean
+    /**
+     * Attach a store that satisfies neither half of the implementer contract.
+     *
+     * An explicit acceptance that the store can lose data — see the throw in
+     * the constructor. Exists so the check can be a hard failure without
+     * stranding anyone who genuinely knows what their store does.
+     */
+    allowUnprotectedStore?: boolean
+  }) {
     this.paths = detectPlurStorage(options?.path)
     this._readonly = options?.readonly === true
     const baseStore = options?.store ?? new YamlPrimaryStore(this.paths.engrams)
@@ -762,6 +776,36 @@ export class Plur {
     // not the place to turn a performance mistake into an outage.
     if (options?.store) {
       const s = options.store as Partial<AsyncPrimaryStore>
+      // Contract check (audit #794, issue #802). Every write-path guard rests
+      // on SOMETHING the store says being trustworthy. A store that can
+      // under-report on `load()` and offers no per-row write primitive defeats
+      // all of them at once: read-modify-write is the only shape available, the
+      // engine has no second opinion to check the read against, and the
+      // resulting whole-corpus `save()` is indistinguishable from "the corpus
+      // really is this small now". Probe p10 demonstrates it losing rows with
+      // every guard in place.
+      //
+      // This one THROWS where the pair check below only warns, because the two
+      // are different in kind: a split loadByIds/updateMany is a performance
+      // mistake that still writes correctly, while this is an unprotectable
+      // data-loss path. Failing at construction puts it in front of the
+      // implementor, seconds after they wired it, instead of in front of the
+      // user after their corpus is gone.
+      const canWriteRows = typeof s.append === 'function' && typeof s.updateMany === 'function'
+      if (!canWriteRows && !s.refusesUnreadable && !options.allowUnprotectedStore) {
+        throw new Error(
+          `[plur] refusing to attach this primary store: it can neither write single rows ` +
+          `(append + updateMany) nor guarantee that a failed read throws rather than returning a ` +
+          `short array (refusesUnreadable).\n` +
+          `With both absent, every write is a whole-corpus replace derived from a read the engine ` +
+          `cannot verify — so a bad read silently becomes permanent data loss, and no guard can ` +
+          `catch it.\n` +
+          `Fix by implementing append + updateMany (as PostgresAdapter and MemoryPrimaryStore do), ` +
+          `or by making load() throw on an unreadable store and setting refusesUnreadable ` +
+          `(as YamlPrimaryStore does).\n` +
+          `Pass { allowUnprotectedStore: true } only if you accept that this store can lose data.`,
+        )
+      }
       const hasLoadByIds = typeof s.loadByIds === 'function'
       const hasUpdateMany = typeof s.updateMany === 'function'
       if (hasLoadByIds !== hasUpdateMany) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1081,7 +1081,27 @@ export class Plur {
     engrams: Engram[],
     opts?: { allowShrink?: boolean },
   ): Promise<void> {
-    await this._storeAt(path).save(engrams, opts)
+    const store = this._storeAt(path)
+    // Backend-independent floor (audit #794, issue #802). The YAML writer has
+    // its own shrink guard, but that guard lives in `saveEngrams` and so only
+    // covers YAML. `save()` is a whole-corpus replace on EVERY backend, and on
+    // Postgres it ends in `DELETE FROM engrams WHERE id NOT IN (…)` — with an
+    // empty array, an unqualified `DELETE FROM engrams`.
+    //
+    // Emptying the corpus is never an incidental outcome: `compact`, `forget`,
+    // the outbox handoff and pack uninstall all declare `allowShrink`. An
+    // undeclared empty save means the caller read nothing and is about to make
+    // that permanent, which is the whole shape of this audit.
+    if (!opts?.allowShrink && engrams.length === 0) {
+      throw new Error(
+        `[plur] refusing to write an empty corpus to ${path}.\n` +
+        `A store write replaces the whole corpus, so this would delete every engram in it. ` +
+        `Operations that legitimately empty a store declare it; this one did not, which means the ` +
+        `caller most likely read the store as empty when it is not.\n` +
+        `If the store really should be emptied, use the operation that says so (compact/forget).`,
+      )
+    }
+    await store.save(engrams, opts)
   }
 
   /**

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -73,6 +73,35 @@ export interface LearnAsyncDeps {
  * the mutex nor the file. So `learnAsync` and `learnBatch` bypassed the Postgres
  * advisory lock that every other write path takes.
  */
+/**
+ * Persist exactly one changed engram (audit #794 F3 remainder, issue #802).
+ *
+ * The dedup UPDATE and MERGE branches used to call `deps.store.save(engrams)`
+ * directly, which bypasses the incremental write seam and is a WHOLE-CORPUS
+ * REPLACE on every backend. That is a correctness bug, not just a slow path:
+ * `PostgresAdapter.save()` finishes with
+ *
+ *   DELETE FROM engrams WHERE id NOT IN (<the ids being saved>)
+ *
+ * so every row absent from the array this call happened to load is deleted —
+ * and an empty array deletes the table outright. It fires on ordinary
+ * `plur_learn` calls, since UPDATE/MERGE is what LLM dedup returns whenever the
+ * statement resembles something already stored.
+ *
+ * `updateMany` is the seam's "these rows changed, leave the rest alone"
+ * primitive; a store that implements it gets a single-row UPDATE. A store
+ * without it falls back to the whole-corpus save it always had — no worse than
+ * before, and on YAML that save is itself guarded against an unexpected shrink.
+ */
+async function persistOne(deps: LearnAsyncDeps, corpus: Engram[], changed: Engram): Promise<void> {
+  if (deps.store.updateMany) {
+    await deps.store.updateMany([changed])
+    deps.store.invalidate()
+    return
+  }
+  await deps.store.save(corpus)
+}
+
 async function withStoreLock<T>(deps: LearnAsyncDeps, fn: () => Promise<T>): Promise<T> {
   if (deps.store.withExclusiveAccess) return await deps.store.withExclusiveAccess(fn)
   return await withAsyncLock(deps.engramsPath, fn)
@@ -168,7 +197,7 @@ async function executeDedupDecision(
             // into an engram living at a shared scope. Demote before persisting.
             demoteIfSensitive(deps, updated, updated.statement)
             engrams[idx] = updated
-            await deps.store.save(engrams)
+            await persistOne(deps, engrams, updated)
             await deps.syncIndex()
             appendHistory(deps.rootPath, {
               event: 'engram_updated',
@@ -205,7 +234,7 @@ async function executeDedupDecision(
             // a shared scope. Demote before persisting.
             demoteIfSensitive(deps, merged, merged.statement)
             engrams[idx] = merged
-            await deps.store.save(engrams)
+            await persistOne(deps, engrams, merged)
             await deps.syncIndex()
             appendHistory(deps.rootPath, {
               event: 'engram_merged',

--- a/packages/core/src/store/primary-store.ts
+++ b/packages/core/src/store/primary-store.ts
@@ -91,6 +91,25 @@ export interface PrimaryStore {
   readonly kind: PrimaryStoreKind
 
   /**
+   * This store's `load()` FAILS rather than under-reporting.
+   *
+   * Set it only if a read that cannot see the whole corpus throws instead of
+   * returning a short array — `YamlPrimaryStore` qualifies because
+   * `loadEngrams` raises {@link EngramStoreUnreadableError} rather than
+   * treating an unparseable file as empty.
+   *
+   * It is the second of the two ways to satisfy the implementer contract above,
+   * and it is checked at attachment: a store that declares neither this nor the
+   * `append`/`updateMany` pair is refused, because nothing the engine can
+   * observe would distinguish a genuinely small corpus from a bad read.
+   *
+   * Declaring it falsely is worse than not declaring it — it tells the engine a
+   * short read can be trusted, which is precisely the assumption that destroys
+   * corpora.
+   */
+  readonly refusesUnreadable?: boolean
+
+  /**
    * Human-readable location of the store (a file path for YAML, a schema
    * identifier for Postgres). Used for diagnostics and for lock keys while
    * locking is still path-based. `null` when the store has no such location.

--- a/packages/core/src/store/primary-store.ts
+++ b/packages/core/src/store/primary-store.ts
@@ -55,6 +55,37 @@ export interface SaveOptions {
   allowShrink?: boolean
 }
 
+/**
+ * ## Implementer contract: what the engine cannot protect you from
+ *
+ * The engine guards the write path in three places (audit #794): the YAML
+ * loader refuses an unreadable file, `saveEngrams` refuses an undeclared
+ * shrink, and `_writeEngrams` refuses an undeclared *empty* corpus on any
+ * backend. All three rest on the same assumption — that SOMETHING the store
+ * says can be trusted.
+ *
+ * An implementation whose `load()` under-reports (returns `[]`, or a partial
+ * set, for a store that is not actually empty) and which implements neither
+ * `append`/`updateMany` nor a truthful count defeats every one of them by
+ * construction: read-modify-write is the only shape available, the engine has
+ * no second opinion to check the read against, and the resulting `save()`
+ * legitimately looks like "the corpus is now this small". Probe
+ * `probe/p10-seam-capability.ts` demonstrates exactly this with a deliberately
+ * lying store, and it still loses rows — not because a guard is missing, but
+ * because there is nothing left to guard with.
+ *
+ * So an implementation MUST do at least one of:
+ *
+ *   - implement `append` and `updateMany`, so single-engram changes never
+ *     become whole-corpus replaces (what `PostgresAdapter` and
+ *     `MemoryPrimaryStore` do); or
+ *   - make `load()` fail loudly rather than under-report, so the engine can
+ *     refuse instead of persisting a lie (what `YamlPrimaryStore` does via
+ *     `EngramStoreUnreadableError`).
+ *
+ * Every store shipped in this package satisfies one or both. A custom store
+ * that satisfies neither is outside what the engine can defend.
+ */
 export interface PrimaryStore {
   /** Backing medium — for diagnostics and `status()` reporting. */
   readonly kind: PrimaryStoreKind

--- a/packages/core/src/store/readonly-store-guard.ts
+++ b/packages/core/src/store/readonly-store-guard.ts
@@ -41,6 +41,9 @@ export class ReadonlyStoreGuard implements PrimaryStore {
   readonly kind: PrimaryStoreKind
   readonly location: string | null
 
+  /** Mirrors the inner store: wrapping does not change how its reads fail. */
+  readonly refusesUnreadable?: boolean
+
   /** Present only when the inner store implements it — see file header. */
   readonly loadByIds?: (ids: string[]) => Promise<Engram[]>
   /** Present only when the inner store implements it — see file header. */
@@ -53,6 +56,7 @@ export class ReadonlyStoreGuard implements PrimaryStore {
   constructor(private readonly _inner: PrimaryStore) {
     this.kind = _inner.kind
     this.location = _inner.location
+    this.refusesUnreadable = _inner.refusesUnreadable
     if (_inner.loadByIds) this.loadByIds = ids => _inner.loadByIds!(ids)
     if (_inner.estimateCount) this.estimateCount = () => _inner.estimateCount!()
     if (_inner.append) this.append = () => Promise.reject(new ReadonlyStoreError())

--- a/packages/core/src/store/yaml-primary-store.ts
+++ b/packages/core/src/store/yaml-primary-store.ts
@@ -33,6 +33,14 @@ export const AVG_YAML_BYTES_PER_ENGRAM = 2400
 
 export class YamlPrimaryStore implements AsyncPrimaryStore {
   readonly kind: PrimaryStoreKind = 'yaml'
+
+  /**
+   * `loadEngrams` throws `EngramStoreUnreadableError` rather than reporting an
+   * unreadable file as an empty corpus, so a short read from this store is
+   * always a real one. That is what lets a whole-corpus `save()` be safe here
+   * despite the absence of `append`/`updateMany`.
+   */
+  readonly refusesUnreadable = true
   private readonly filePath: string
   private cache: { mtime: bigint; engrams: Engram[] } | null = null
 

--- a/packages/core/test/backend-selection.test.ts
+++ b/packages/core/test/backend-selection.test.ts
@@ -220,7 +220,13 @@ describe('Plur.backendSelection — the instance can say which tier it is on, an
       save: async () => {},
       invalidate: () => {},
     }
-    const tier: BackendTier = new Plur({ path: dir, store: noEstimate }).backendSelection().tier
+    // `allowUnprotectedStore` rather than a `refusesUnreadable` claim, because
+    // this stub genuinely under-reports — `load()` always returns [] — and the
+    // flag must never be declared falsely (audit #794 / #802). Tier selection
+    // is a read-path question; nothing here writes, so accepting the unsafe
+    // store is honest and sufficient.
+    const tier: BackendTier = new Plur({ path: dir, store: noEstimate, allowUnprotectedStore: true })
+      .backendSelection().tier
     expect(tier).toBe('yaml')
   })
 })

--- a/packages/core/test/incremental-write.test.ts
+++ b/packages/core/test/incremental-write.test.ts
@@ -27,6 +27,13 @@ import type { Engram } from '../src/schemas/engram.js'
 /** Delegating wrapper that counts calls without adding any capabilities. */
 class CountingYamlStore implements PrimaryStore {
   readonly kind = 'yaml' as const
+  /**
+   * Delegates every read to a real `YamlPrimaryStore`, so an unreadable store
+   * throws here exactly as it does there. That is what makes a capability-less
+   * whole-corpus save safe, and what the attachment check requires it to
+   * declare (audit #794 / #802).
+   */
+  readonly refusesUnreadable = true
   loads = 0
   cachedLoads = 0
   saves = 0

--- a/packages/core/test/learn-async-seam.test.ts
+++ b/packages/core/test/learn-async-seam.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The dedup UPDATE/MERGE paths must not whole-corpus-replace (issue #802,
+ * audit #794 F3 remainder).
+ *
+ * `deps.store.save(engrams)` is a full replace on every backend. On Postgres it
+ * finishes with
+ *
+ *   DELETE FROM engrams WHERE id NOT IN (<the ids being saved>)
+ *
+ * so every row absent from the array that call happened to load is deleted, and
+ * an empty array deletes the table. It fires on ordinary `plur_learn` calls,
+ * because UPDATE/MERGE is what LLM dedup returns whenever the incoming
+ * statement resembles something already stored — which is the common case, not
+ * an edge one.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+import { MemoryPrimaryStore } from '../src/store/memory-primary-store.js'
+import type { Engram } from '../src/schemas/engram.js'
+import { Plur } from '../src/index.js'
+
+let root: string
+
+/** Records which seam methods the write path actually used. */
+class RecordingStore extends MemoryPrimaryStore {
+  saveCalls: number[] = []
+  updateManyCalls: string[][] = []
+  appendCalls: string[] = []
+
+  override async save(engrams: Engram[]): Promise<void> {
+    this.saveCalls.push(engrams.length)
+    return super.save(engrams)
+  }
+  override async updateMany(engrams: Engram[]): Promise<void> {
+    this.updateManyCalls.push(engrams.map(e => e.id))
+    return super.updateMany(engrams)
+  }
+  override async append(engram: Engram): Promise<void> {
+    this.appendCalls.push(engram.id)
+    return super.append(engram)
+  }
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(join(os.tmpdir(), 'plur-seam-'))
+})
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('dedup writes go through the incremental seam (#802)', () => {
+  it('an ordinary learn appends one row rather than replacing the corpus', async () => {
+    const store = new RecordingStore()
+    const plur = new Plur({ path: root, autoDiscover: false, store })
+    for (let i = 0; i < 5; i++) await plur.learn(`distinct fact number ${i}`, { scope: 'local' })
+
+    expect(store.appendCalls).toHaveLength(5)
+    // The thing that must never happen on a capability store: a whole-corpus
+    // replace on a plain write.
+    expect(store.saveCalls).toEqual([])
+  })
+
+  it('updateMany carries exactly the changed row, never the whole corpus', async () => {
+    const store = new RecordingStore()
+    const plur = new Plur({ path: root, autoDiscover: false, store })
+    const seeded = await plur.learn('the deployment host is example.internal', { scope: 'local' })
+    for (let i = 0; i < 4; i++) await plur.learn(`unrelated fact ${i}`, { scope: 'local' })
+
+    store.updateManyCalls = []
+    store.saveCalls = []
+
+    // feedback() is a seam write on an existing engram — the same shape the
+    // dedup UPDATE path takes after #802.
+    await plur.feedback(seeded.id, 'positive')
+
+    expect(store.saveCalls, 'a single-engram change triggered a whole-corpus replace').toEqual([])
+    expect(store.updateManyCalls.flat()).toContain(seeded.id)
+    // Every engram still present.
+    expect(await plur.list()).toHaveLength(5)
+  })
+})
+
+describe('the seam refuses to empty a corpus it was not told to empty', () => {
+  it('rejects an undeclared empty write on any backend', async () => {
+    // Postgres' save() ends in an unqualified `DELETE FROM engrams` for an
+    // empty array, so this floor is backend-independent by necessity.
+    const store = new RecordingStore()
+    const plur = new Plur({ path: root, autoDiscover: false, store })
+    for (let i = 0; i < 3; i++) await plur.learn(`fact ${i}`, { scope: 'local' })
+
+    await expect(
+      (plur as any)._writeEngrams((plur as any).paths.engrams, []),
+    ).rejects.toThrow(/refusing to write an empty corpus/i)
+
+    expect(await plur.list()).toHaveLength(3)
+  })
+
+  it('allows an empty write when the caller declares it', async () => {
+    const store = new RecordingStore()
+    const plur = new Plur({ path: root, autoDiscover: false, store })
+    await plur.learn('a fact that will be compacted away', { scope: 'local' })
+
+    await expect(
+      (plur as any)._writeEngrams((plur as any).paths.engrams, [], { allowShrink: true }),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -360,7 +360,9 @@ export function validateToolArgs(
       : 'Received no fields (the arguments object was empty).'
     const disposition = wholePayloadDrop
       ? 'The request reached the server but its arguments did not — do not abandon the call, and do ' +
-        'not rewrite the payload: it was never evaluated.'
+        'not rewrite the payload: it was never evaluated. Retry the IDENTICAL call; it usually ' +
+        'succeeds. If you issued several tool calls in one message, send them one per message — ' +
+        'batching is the strongest correlate of this drop (#772).'
       : 'The call reached the server — this is a malformed-arguments error, not a transport failure. ' +
         'Fix the field(s) named above and retry; do not abandon the call.'
     return {


### PR DESCRIPTION
Closes **#802** — the remaining half of audit #794's F3, found by re-running the probes against merged `main` during the 0.17 release audit.

## This is a release blocker for Postgres deployments

The dedup UPDATE and MERGE branches called `deps.store.save(engrams)` directly, bypassing the incremental write seam. `save()` is a **whole-corpus replace on every backend**, and `PostgresAdapter.save()` finishes with:

```sql
DELETE FROM engrams WHERE id NOT IN (<the ids being saved>)
-- and for an empty array:
DELETE FROM engrams
```

So every row absent from whatever array that call happened to load is **deleted**.

This is not an edge path. UPDATE/MERGE is what LLM dedup returns whenever an incoming statement resembles something already stored — i.e. it fires on ordinary `plur_learn` calls, and it fires hardest on the Postgres deployments with the most to lose.

## Fix

**1. Route through the seam.** Both sites now call `persistOne`, which uses `updateMany([changed])` when the store implements it — a single-row UPDATE for a single-engram change — and falls back to the whole-corpus save only for stores offering nothing better. On YAML that fallback is itself shrink-guarded.

**2. Backend-independent floor.** `_writeEngrams` now refuses an undeclared **empty** corpus on any backend. Emptying a store is never incidental: `compact`, `forget`, the outbox handoff and pack uninstall all declare `allowShrink`. An undeclared empty write means the caller read nothing and is about to make that permanent — the shape of every finding in #794.

## The limit this does not remove, stated plainly

Probe `p10-seam-capability` **still loses rows** against its deliberately lying store, and that is not a missing guard.

Every protection in #794 rests on *something* the store says being trustworthy: the YAML loader refuses an unreadable file, `saveEngrams` refuses an undeclared shrink, `_writeEngrams` refuses an undeclared empty write. A store whose `load()` under-reports **and** which implements neither `append`/`updateMany` nor a truthful count defeats all three by construction — read-modify-write is the only shape available, there is no second opinion to check the read against, and the resulting `save()` legitimately looks like "the corpus is now this small".

So `PrimaryStore` now carries an implementer contract: an implementation MUST either implement `append`/`updateMany`, or make `load()` fail loudly rather than under-report. **Every shipped store satisfies at least one** — YAML throws `EngramStoreUnreadableError`; Postgres, Memory and SQLite have the capability methods. A custom store satisfying neither is outside what the engine can defend, and that is now documented rather than left as an unexplained red line in probe output.

## On #772 (not fixed here, and not data loss)

Worth stating since it came up alongside this: #772's whole-payload drop is a **client-side MCP marshalling failure**, upstream of PLUR. Its own evidence records *"no silent data loss — nothing gets written wrong"*; the write never reaches the server and errors loudly, with a forensic drop log added in #779.

The one part in our control is the diagnostic, so it now names the strongest correlate the issue identified: retry the identical call, and send batched tool calls one per message.

## Testing

4 new tests in `learn-async-seam.test.ts` pinning that a single-engram change never becomes a whole-corpus replace, and that the empty-corpus floor holds and honours `allowShrink`.

Full suite: **3652 passed**. One failure — `core-pglite` vector-precision — is unrelated to any file in this diff (it imports `storage-pglite.js` and schemas only) and passes **12/12 in isolation**: flaky under parallel load, same class as #793.

Closes #802
Refs #794, #772
