### PR TITLE
fix(core): give the sync lock the liveness that pays for its raised threshold

### DIFF
--- a/packages/core/src/store/async-lock.ts
+++ b/packages/core/src/store/async-lock.ts
@@ -124,7 +124,7 @@ let tokenCounter = 0
  * on the machine that owns it, and `~/.plur` on a synced or networked volume can
  * hold a lock written by a different host.
  */
-function makeToken(): string {
+export function makeToken(): string {
   return `${hostname()}:${process.pid}:${Date.now()}:${tokenCounter++}`
 }
 
@@ -136,7 +136,7 @@ function makeToken(): string {
  * "dead" would steal a lock from a live writer, which is the corpus-corruption
  * outcome the whole mechanism exists to prevent.
  */
-function holderIsAlive(token: string): boolean | undefined {
+export function holderIsAlive(token: string): boolean | undefined {
   const parts = token.split(':')
   if (parts.length < 2) return undefined
   const [host, pidRaw] = parts

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkS
 import { join, dirname, relative } from 'path'
 import * as yaml from 'js-yaml'
 import { isSharedScope } from './scope-util.js'
-import { DEFAULT_STALE_THRESHOLD } from './store/async-lock.js'
+import { DEFAULT_STALE_THRESHOLD, holderIsAlive, makeToken } from './store/async-lock.js'
 
 export interface SyncStatus {
   initialized: boolean
@@ -729,15 +729,29 @@ export function withLock<T>(
   const baseDelay = options?.baseDelay ?? 100
   const staleThreshold = options?.staleThreshold ?? DEFAULT_STALE_THRESHOLD
 
+  const token = makeToken()
+
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      writeFileSync(lockPath, `${process.pid}`, { flag: 'wx' })
+      writeFileSync(lockPath, token, { flag: 'wx' })
       break
     } catch (err: any) {
       if (err.code !== 'EEXIST') throw err
       try {
         const stat = statSync(lockPath)
-        if (Date.now() - stat.mtimeMs > staleThreshold) {
+        // Liveness is what pays for the raised stale threshold, and it has to
+        // be here as well as on the async lock. Raising the threshold to 60s
+        // without it would take crash recovery on THESE paths (episodes,
+        // tensions, config) from 10s to 60s — a regression introduced by the
+        // F9 fix if only half of it is applied.
+        //
+        // `undefined` means "cannot tell" — a token from another host, or the
+        // bare pid an older client wrote — and must be read as "assume alive",
+        // falling back to the mtime threshold. Guessing "dead" would steal a
+        // lock from a live writer.
+        const holder = readFileSync(lockPath, 'utf8').trim()
+        const dead = holderIsAlive(holder) === false
+        if (dead || Date.now() - stat.mtimeMs > staleThreshold) {
           unlinkSync(lockPath)
           continue
         }
@@ -756,7 +770,12 @@ export function withLock<T>(
   try {
     return fn()
   } finally {
-    try { unlinkSync(lockPath) } catch { /* lock already gone */ }
+    // Only ours to remove. Without the token comparison, a holder whose lock
+    // was stolen deletes the THIEF's lock on its way out and a third writer
+    // walks in mid-write — the cascade fixed on the async lock (audit #794 F9).
+    try {
+      if (readFileSync(lockPath, 'utf8').trim() === token) unlinkSync(lockPath)
+    } catch { /* already gone */ }
   }
 }
 


### PR DESCRIPTION
**A regression I introduced in #806 and missed.** Caught by re-running probe `p05-stale-lock` during the 0.17 release audit — a probe I had claimed was green without having re-run it.

## What went wrong

#806 raised the stale-lock threshold **10s → 60s in both lock implementations**, because a 50,000-engram store legitimately holds the lock ~4.3s (re-measured here: save 2536ms + load 1733ms) and 10s left almost no margin before a live writer gets its lock stolen.

On the **async** lock that raise is paid for by a pid+host liveness check: a dead holder's lock is stolen immediately, so crash recovery did not get slower.

The **synchronous** `withLock` got the raised threshold and **not** the liveness. So on the paths that use it — `episodes.yaml`, `tensions.yaml`, `config.yaml` — a **crashed** holder went from blocking other writers for 10s to blocking them for **60s**.

That is a 6× recovery regression, and it is precisely the trade the async lock's own comment warns about, applied to only half the code:

> *The cost of a high threshold is slow recovery after a crash, and that is paid for separately by the liveness check below.*

I wrote that sentence and then didn't apply it to the sync twin.

## Fix

Both halves now match:

- **Liveness** — a lock whose owning process is gone is stolen at once. Host-scoped, since a pid means nothing on another machine and `~/.plur` can live on a synced volume. "Cannot tell" (another host, or the bare pid an older client wrote) reads as **assume alive** and falls back to the mtime threshold; guessing "dead" would steal from a live writer.
- **Token-guarded release** — the holder removes the lock only if it still carries its own token, so a holder whose lock was stolen no longer deletes the *thief's* lock on its way out. Same cascade already fixed on the async side.

## Deliberately unchanged

The retry budget stays short here. This implementation busy-waits on `Date.now()`, so waiting longer blocks the event loop (**F10**, still open) rather than improving correctness. Callers who need to wait out a slow holder belong on `withAsyncLock`; this variant serves short holds.

## Testing

Lock, sync and episode suites: **76 passed**. Full suite: **3653 passed, 0 failed**. `typecheck:tests` clean.

Refs #794, #804
