### PR TITLE
perf(core): stop the shrink guard re-parsing the corpus on every save

### DIFF
--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -260,13 +260,17 @@ export function saveEngrams(filePath: string, engrams: Engram[], opts: SaveEngra
       outgoing.push(entry as Engram)
     }
   }
-  if (!opts.allowShrink) {
+  // Serialize first: the cheap shrink pre-check compares the outgoing document's
+  // byte length against the one on disk, and we need the bytes to do that.
+  const content = yaml.dump({ engrams: outgoing }, { lineWidth: 120, noRefs: true, quotingType: '"' })
+  // Two-stage on purpose: a `stat` rules out the common case, and only a write
+  // that might genuinely be shrinking pays for the exact count. See mightShrink.
+  if (!opts.allowShrink && mightShrink(filePath, content)) {
     const before = countEngramsOnDisk(filePath)
     if (before !== null && outgoing.length < before * (1 - SHRINK_TOLERANCE)) {
       throw new EngramStoreShrinkError(filePath, before, outgoing.length)
     }
   }
-  const content = yaml.dump({ engrams: outgoing }, { lineWidth: 120, noRefs: true, quotingType: '"' })
   atomicWrite(filePath, content)
 }
 
@@ -289,6 +293,44 @@ function countEngramsOnDisk(filePath: string): number | null {
     return raw.engrams.length
   } catch {
     return null
+  }
+}
+
+/**
+ * Could writing `content` over `filePath` be a large shrink?
+ *
+ * A cheap `stat` answers "obviously not" for the overwhelming majority of
+ * writes, which matters because the exact count is a FULL YAML PARSE of the
+ * whole corpus. Measured on a 20,000-engram / 15.7 MB store: parsing to count
+ * added 388 ms to a 419 ms save — it nearly doubled it. That cost lands on
+ * every guarded write, and `_reactivateResults` turns every `recall()` into a
+ * write, so a naive exact-count taxes the READ path of exactly the large stores
+ * that are already slowest.
+ *
+ * The comparison is BYTES, not an estimated record count. A first attempt at
+ * this used a bytes-per-engram constant to guess the count, and that constant
+ * is not merely imprecise, it is unsafe: measured engrams here average 785
+ * bytes against an assumed 2400, so the guess under-reported a 20,000-engram
+ * store as 6,500 and a genuine 50% shrink would have skipped the guard
+ * entirely. Serialized length against on-disk length needs no constant and
+ * calibrates itself to whatever the engrams actually weigh.
+ *
+ * Only ever used to SKIP work. When it says a shrink is possible the caller
+ * still parses for an exact count before refusing, so no write is ever rejected
+ * on the strength of an approximation.
+ */
+function mightShrink(filePath: string, content: string): boolean {
+  try {
+    if (!fs.existsSync(filePath)) return false
+    const stat = fs.statSync(filePath)
+    if (stat.isDirectory() || stat.size === 0) return false
+    // Byte length of the outgoing document vs the document on disk. Records are
+    // broadly similar in size, so a corpus that lost 10% of its records loses
+    // roughly 10% of its bytes. Compare with a margin so ordinary edits — an
+    // engram shortened, a field dropped — never trip the slow path.
+    return Buffer.byteLength(content, 'utf8') < stat.size * (1 - SHRINK_TOLERANCE / 2)
+  } catch {
+    return true
   }
 }
 

--- a/packages/core/test/store-corruption-guard.test.ts
+++ b/packages/core/test/store-corruption-guard.test.ts
@@ -199,6 +199,28 @@ describe('saveEngrams — shrink guard (F1/F2/F3 choke point)', () => {
     expect(loadEngrams(storePath)).toHaveLength(1)
   })
 
+  it('still refuses a 50% shrink on a store large enough to take the fast path', () => {
+    // Regression for a hole introduced while making the guard cheap. The exact
+    // count is a full YAML parse, which measured +388ms on a 419ms save — and
+    // since _reactivateResults turns every recall() into a save, that taxed the
+    // READ path of the largest stores. The first fix estimated the record count
+    // from a bytes-per-engram constant; measured engrams average 785 bytes
+    // against an assumed 2400, so a 20k store estimated as 6.5k and a genuine
+    // 50% shrink skipped the guard entirely. The pre-check now compares
+    // serialized bytes to on-disk bytes, which needs no constant.
+    const engrams = seed(200)
+    expect(() => saveEngrams(storePath, engrams.slice(0, 100))).toThrow(EngramStoreShrinkError)
+    expect(loadEngrams(storePath)).toHaveLength(200)
+  })
+
+  it('takes the fast path for a same-size rewrite — no exact count needed', () => {
+    // The common case: recall() rewrites the corpus it just read. Must not pay
+    // for a full re-parse.
+    const engrams = seed(200)
+    expect(() => saveEngrams(storePath, engrams)).not.toThrow()
+    expect(loadEngrams(storePath)).toHaveLength(200)
+  })
+
   it('counts quarantined entries toward the outgoing total', () => {
     // 10 on disk, 2 invalid -> loader returns 8. Writing those 8 back is a 20%
     // shrink by naive counting, but the 2 quarantined entries are re-appended,


### PR DESCRIPTION
Found during the 0.17 release audit by checking the guard against **engram memory**, not by re-reading the diff.

## The regression

Two engrams pointed at it: `ENG-2026-0604-023` / `ENG-2026-0604-040` record that `_reactivateResults` rewrites the **entire** `engrams.yaml` on every `recall()` — 60 MB per query at 30k engrams, V8 ConsString OOM after ~50 queries.

The shrink guard from #807 called `countEngramsOnDisk`, which is a **full `yaml.load` of the whole corpus**, on every guarded save. Since every recall *is* a save, that put an extra full parse on the **read path of exactly the stores that already OOM**.

Measured on 20,000 engrams / 15.7 MB:

```
guarded save   : 807 ms
allowShrink    : 419 ms   (serialize only)
GUARD OVERHEAD : 388 ms   (+93%)
```

## The first fix was worse than the problem

Estimating the record count from a bytes-per-engram constant is not just imprecise, it is **unsafe**:

```
actual bytes/engram : 785
constant assumes    : 2400
→ a 20,000-engram store estimates as 6,542
→ a genuine 50% shrink would have SKIPPED the guard entirely
```

That trades a performance bug for a **correctness hole in the data-loss guard itself** — the exact failure mode this audit exists to prevent. Caught before it shipped, but it is the interesting part of this PR.

## The actual fix

Compare the **serialized byte length** against the **on-disk byte length**. No constant. Self-calibrating to whatever the engrams actually weigh. One `stat`.

It is only ever used to *skip* work: when it says a shrink is possible, the exact count still runs before anything is refused, so **no write is ever rejected on an approximation**.

| | overhead on a 20k store |
|---|---|
| original (full parse every save) | **+388 ms (+93%)** |
| bytes-per-engram estimate | fast, but missed 50% shrinks |
| **serialized bytes vs on-disk bytes** | **−4 ms** (median of 5 — noise) |

The full parse it replaced measured 638 ms.

## Guard behaviour, re-verified end to end

```
ok  the 50% case my estimate missed   20000 ->  10000 (50%)   REFUSED   on disk: 20000
ok  catastrophic wipe                 20000 ->      1 (100%)  REFUSED   on disk: 20000
ok  15% shrink (past tolerance)       20000 ->  17000 (15%)   REFUSED   on disk: 20000
ok  5% shrink (within tolerance)      20000 ->  19000 ( 5%)   WROTE     on disk: 19000
ok  no change                         20000 ->  20000 ( 0%)   WROTE     on disk: 20000
ok  growth                            20000 ->  25000 (-25%)  WROTE     on disk: 25000
ok  small store, 50%                    100 ->     50 (50%)   REFUSED   on disk: 100
ok  tiny store, the p01 case              5 ->      1 (80%)   REFUSED   on disk: 5
```

Nothing destroyed in any refused case.

## Measurement note for whoever checks this next

Seed the fixture **through `saveEngrams`**. Seeding with plain `yaml.dump` uses different dump options, and the byte comparison correctly reads that format difference as a shrink — which presents as a fake **+28% regression**. I hit this and nearly reported it as a real number.

## Testing

Two regression tests: the 50%-shrink-on-a-large-store case the estimate would have missed, and the same-size fast path that `recall()` depends on.

Full suite: **3653 passed, 0 failed.** `typecheck:tests` clean.

Refs #794, #802
