### PR TITLE
fix(core): ten defects from an independent whole-repository audit (#811)

### DIFF
--- a/docs/audits/2026-08-02-store-write-path-data-loss.md
+++ b/docs/audits/2026-08-02-store-write-path-data-loss.md
@@ -187,6 +187,35 @@ it worse, but only a backup restores them. Note also that snapshots are DAILY: e
 a given day's snapshot are not in it. `plur restore` therefore reads the append-only history log and
 NAMES the engrams a restore cannot recover, rather than rolling the user back silently.
 
+
+## Follow-up: what this audit missed (2026-08-03)
+
+An independent whole-repository adversarial audit (gpt-5.6-sol via Codex CLI), run as the 0.17
+release gate, reported 21 findings. Ten were fixed in #811/PR #814; the rest are tracked in #812 and
+#813.
+
+The two CRITICAL ones were in paths **this report never examined**:
+
+- `uninstallPack(packsDir, '..')` resolved to the PLUR root and `fs.rmSync`'d it recursively —
+  demonstrated deleting `engrams.yaml`, `config.yaml` and the whole root while returning
+  `{removed: true}`. Reachable from the CLI and from the `plur_packs_uninstall` MCP tool.
+- `Plur.sync()` called `gitSync` with no lock while `git pull --rebase` replaces `engrams.yaml`,
+  racing the write path in a way the count-based shrink guard cannot detect.
+
+**The scope framing was the blind spot.** This report swept *every writer of engrams* —
+`saveEngrams`, `_writeEngrams`, `atomicWrite` callers. A recursive delete reached through a path
+component is not a writer. Neither is git sync. Neither is `restore`, which turned out to be
+unlocked and non-atomic — the recovery path itself.
+
+Two findings were worse than a miss. The per-writer sweep above **lists** `captureEpisode` and
+`recordTensions` as `corrupt → [] → wipe`. The remediation fixed only the episodes *locking* (F8)
+and then reported the corrupt-read class closed. Shared sync had the same shape: F5 was fixed for
+`engrams.yaml` while the sibling artifacts kept pushing corrupt, private-derived text verbatim.
+
+**Lesson for the next audit of this kind:** enumerate the OPERATIONS that can cause the failure —
+write, delete, replace, restore, sync — not the functions that look like writers. And audit the
+recovery path, because a broken restore turns a survivable incident into a permanent one.
+
 ## Provenance
 
 Audit run 2026-08-02 against merged 0.17 main (`4b815ed`) in a detached scratch worktree; the main

--- a/packages/core/src/backup.ts
+++ b/packages/core/src/backup.ts
@@ -52,6 +52,7 @@ import { createHash } from 'crypto'
 import * as yaml from 'js-yaml'
 import { EngramSchemaPassthrough } from './schemas/engram.js'
 import { logger } from './logger.js'
+import { atomicWrite, withLock } from './sync.js'
 
 /** Directory under the plur root holding snapshots and their state. */
 export const BACKUP_DIR = 'backups'
@@ -309,6 +310,21 @@ export function maybeDailyBackup(root: string, storePath: string, now = new Date
   }
 }
 
+/** fsync a file written by a non-atomic helper (copyFileSync). Best-effort. */
+function flushFileAt(filePath: string): void {
+  let fd: number | undefined
+  try {
+    fd = fs.openSync(filePath, 'r+')
+    fs.fsyncSync(fd)
+  } catch {
+    /* nothing actionable — the copy itself succeeded */
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd) } catch { /* ignore */ }
+    }
+  }
+}
+
 /**
  * Write and fsync — a backup that is only in the page cache is not a backup,
  * which is the same reasoning as the store's own atomicWrite (audit #794, F4).
@@ -529,9 +545,29 @@ export function restoreBackup(
     }
   }
 
+  // Under the store lock, and atomic (#811 audit, finding 10).
+  //
+  // Restoring is a whole-corpus overwrite — the exact operation the rest of
+  // this audit constrains — and it was doing it unlocked, through a truncating
+  // open on the LIVE file. Two consequences:
+  //
+  //   - a writer committing between the superseded copy and the overwrite left
+  //     its engram in NEITHER file, with both calls reporting success
+  //   - a crash mid-write left the live corpus partial, which is precisely the
+  //     input the loader now refuses
+  //
+  // `withLock` here is the synchronous variant, which shares the `<path>.lock`
+  // file protocol with `withAsyncLock` — so a restore run from the CLI waits
+  // for an MCP server mid-write, which is the case that matters.
   const superseded = `${storePath}.superseded-${Date.now()}`
-  if (fs.existsSync(storePath)) fs.copyFileSync(storePath, superseded)
-  writeFileDurable(storePath, fs.readFileSync(plan.backup.path))
+  withLock(storePath, () => {
+    if (fs.existsSync(storePath)) {
+      fs.copyFileSync(storePath, superseded)
+      flushFileAt(superseded)
+    }
+    // tmp + fsync + rename, rather than truncating the live file in place.
+    atomicWrite(storePath, fs.readFileSync(plan.backup.path, 'utf8'))
+  })
 
   if (plan.wouldLose.length > 0) {
     logger.warning(

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -119,7 +119,21 @@ export function parseEngramFile(
       new Error('mapping has no "engrams" key — the file is not an engram store, or is truncated'),
     )
   }
-  if (raw.engrams == null) return { valid: [], quarantined: [] }
+  // `engrams:` with a null value is NOT an empty store. PLUR only ever writes
+  // `engrams: []` — initFilesystemStore included — so a null-valued key is a
+  // hand-edit or, far more likely, a truncation that happened to stop right
+  // after the key. Accepting it as empty normalises the corruption: the next
+  // write turns a truncated 5,000-engram store into a valid 1-engram one, which
+  // then syncs and can replace subsequent backups. Demonstrated: 5 engrams,
+  // file truncated to `engrams:\n`, one learn -> 1 engram on disk (#811 audit,
+  // finding 4). An earlier version of this parser accepted it, and a test
+  // blessed the behaviour.
+  if (raw.engrams == null) {
+    throw new EngramStoreUnreadableError(
+      filePath,
+      new Error('"engrams" key is present but has no value — an empty store is written as `engrams: []`'),
+    )
+  }
   if (!Array.isArray(raw.engrams)) {
     throw new EngramStoreUnreadableError(filePath, new Error('"engrams" is present but is not a list'))
   }
@@ -134,6 +148,74 @@ export function parseEngramFile(
     logger.warning(
       `Quarantined ${quarantined.length} invalid engram(s) in ${filePath} — ` +
       `they are excluded from recall but PRESERVED in the file. Run 'plur doctor' to inspect them.`,
+    )
+  }
+  return { valid, quarantined }
+}
+
+/**
+ * Error thrown when a sibling record file (episodes, tensions) is unreadable.
+ *
+ * Same doctrine as {@link EngramStoreUnreadableError}, for the artifacts that
+ * are a bare YAML array rather than an `engrams:` mapping.
+ */
+export class RecordStoreUnreadableError extends Error {
+  constructor(readonly filePath: string, readonly cause: unknown) {
+    super(
+      `[plur] refusing to read ${filePath}: ${cause}\n` +
+      `The file exists but is not a valid record list, so PLUR cannot tell how many records it holds. ` +
+      `It is NOT being treated as empty: these files are rewritten whole, so a write against an ` +
+      `"empty" store would destroy every record in it.\n` +
+      `Fix the file (or restore it) and retry.`,
+    )
+    this.name = 'RecordStoreUnreadableError'
+  }
+}
+
+/**
+ * Read a bare-array record file (episodes.yaml, tensions.yaml), or throw.
+ *
+ * These carried the same defect the engram store did (audit #794 F1/F2, still
+ * live after the first remediation and re-found by the #811 audit): an
+ * unparseable or wrongly-shaped file returned `[]`, and since every writer
+ * rewrites the whole array, the next capture persisted that emptiness. A
+ * corrupt episodes.yaml became a one-episode file; a tensions.yaml with
+ * schema-invalid entries silently lost them.
+ *
+ * Missing file is still `[]` — that is a genuinely empty store. An EXISTING
+ * file that says nothing intelligible is an error. Individually invalid entries
+ * are QUARANTINED and handed back to the caller so they can be written out
+ * again, never dropped.
+ */
+export function parseRecordArrayFile<T>(
+  filePath: string,
+  validate: (entry: unknown) => T | null,
+): { valid: T[]; quarantined: unknown[] } {
+  if (!fs.existsSync(filePath)) return { valid: [], quarantined: [] }
+  const stat = fs.statSync(filePath)
+  if (stat.isDirectory()) return { valid: [], quarantined: [] }
+  if (stat.size === 0) throw new RecordStoreUnreadableError(filePath, new Error('file is empty (0 bytes)'))
+  let raw: unknown
+  try {
+    raw = yaml.load(fs.readFileSync(filePath, 'utf8'))
+  } catch (err) {
+    throw new RecordStoreUnreadableError(filePath, err)
+  }
+  // An empty list serialises as `[]`, so `null` here means the bytes said
+  // nothing — a truncation, not an empty store.
+  if (raw == null) throw new RecordStoreUnreadableError(filePath, new Error('file has content but parses to nothing'))
+  if (!Array.isArray(raw)) throw new RecordStoreUnreadableError(filePath, new Error('top-level value is not a list'))
+  const valid: T[] = []
+  const quarantined: unknown[] = []
+  for (const entry of raw) {
+    const ok = validate(entry)
+    if (ok !== null) valid.push(ok)
+    else quarantined.push(entry)
+  }
+  if (quarantined.length > 0) {
+    logger.warning(
+      `Quarantined ${quarantined.length} invalid record(s) in ${filePath} — ` +
+      `excluded from queries but PRESERVED in the file.`,
     )
   }
   return { valid, quarantined }

--- a/packages/core/src/episodes.ts
+++ b/packages/core/src/episodes.ts
@@ -3,6 +3,7 @@ import yaml from 'js-yaml'
 import type { Episode } from './schemas/episode.js'
 import type { CaptureContext, TimelineQuery } from './types.js'
 import { atomicWrite, withLock } from './sync.js'
+import { parseRecordArrayFile } from './engrams.js'
 
 function generateEpisodeId(): string {
   const ts = Date.now()
@@ -43,9 +44,11 @@ export function captureEpisode(path: string, summary: string, context?: CaptureC
     timestamp: new Date().toISOString(),
   }
   withLock(path, () => {
-    const episodes = loadEpisodes(path)
-    episodes.push(episode)
-    atomicWrite(path, yaml.dump(episodes, { lineWidth: 120, noRefs: true }))
+    // Quarantined records ride along so a malformed episode is withheld from
+    // queries without being deleted by the next capture.
+    const { valid, quarantined } = loadEpisodesWithQuarantine(path)
+    const out = [...valid, episode, ...(quarantined as Episode[])]
+    atomicWrite(path, yaml.dump(out, { lineWidth: 120, noRefs: true }))
   })
   return episode
 }
@@ -63,12 +66,23 @@ export function queryTimeline(path: string, query?: TimelineQuery): Episode[] {
   return episodes
 }
 
+/**
+ * Read the episode log, or throw when it is unreadable.
+ *
+ * Returned `[]` for a corrupt or wrongly-shaped file until the #811 audit —
+ * and since `captureEpisode` rewrites the whole array, the next capture then
+ * wrote a one-episode file over everything. Same shape as the engram-store
+ * wipe (#794 F1), in an artifact the original sweep listed but never fixed.
+ */
+function loadEpisodesWithQuarantine(path: string): { valid: Episode[]; quarantined: unknown[] } {
+  return parseRecordArrayFile<Episode>(path, entry =>
+    // Episodes have no Zod schema; the shape contract is an object with an id.
+    entry !== null && typeof entry === 'object' && typeof (entry as Episode).id === 'string'
+      ? entry as Episode
+      : null,
+  )
+}
+
 function loadEpisodes(path: string): Episode[] {
-  if (!existsSync(path)) return []
-  try {
-    const raw = yaml.load(readFileSync(path, 'utf8'))
-    return Array.isArray(raw) ? raw : []
-  } catch {
-    return []
-  }
+  return loadEpisodesWithQuarantine(path).valid
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5530,7 +5530,36 @@ export class Plur {
     // mirror-everything default — `shared` is an explicit opt-in that filters
     // the push set to shared-scope, non-private engrams).
     const remoteType = options?.remoteType ?? this.config.sync?.remote_type ?? 'personal'
-    const result = gitSync(this.paths.root, remote, { remoteType })
+    // Git sync REPLACES engrams.yaml on the pull/rebase path, so it has to
+    // serialize against the write path or it races it (#811 audit, finding 2):
+    //
+    //   1. writer A takes the store lock and reads corpus N
+    //   2. sync B, holding nothing, pulls remote engram R -> the file is N+R
+    //   3. writer A appends L to its stale N and saves N+L
+    //   4. the shrink guard sees the same COUNT before and after, so it passes
+    //   5. the next sync commits and pushes the deletion of R
+    //
+    // Both operations report success and R is gone. The count-based guard
+    // cannot catch this by construction — one row arrived while one row was
+    // added — which is why the fix has to be mutual exclusion rather than
+    // another validity check.
+    //
+    // `gitSync` takes no lock of its own (nothing in sync.ts calls withLock),
+    // so this cannot self-deadlock against a non-reentrant lock. Held across
+    // the network calls deliberately: a waiter blocked for the duration of a
+    // fetch is a delay, while a lost engram is permanent. Liveness keeps this
+    // lock from being stolen while we hold it, however long the fetch takes.
+    //
+    // CALLER CONTRACT: `sync()` now acquires the store lock, so it must NOT be
+    // called from inside `_withStoreLock`. The in-process queue is FIFO with no
+    // timeout — unlike the file lock, which has `acquireTimeout` — so nesting
+    // hangs the process rather than erroring. Today's only callers are the
+    // `plur_sync` MCP tool and the `plur sync` CLI command, both top-level.
+    // (Found by writing this fix's first regression test as a nested call and
+    // watching it hang; see async-lock's "NOT REENTRANT" header.)
+    const result = await this._withStoreLock(this.paths.engrams, async () => {
+      return gitSync(this.paths.root, remote, { remoteType })
+    })
     // `git pull --rebase` may have REPLACED engrams.yaml underneath us, so any
     // cached snapshot the store is holding now describes a file that no longer
     // exists in that form. `invalidate()` exists precisely for this and had no

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -330,7 +330,7 @@ function _installPackDir(
   }
 
   const sourceName = path.basename(source)
-  const destDir = path.join(packsDir, sourceName)
+  const destDir = resolveInside(packsDir, sourceName, 'install')
 
   // Copy pack directory
   if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true })
@@ -423,6 +423,41 @@ export async function installPack(
   return _installPackDir(packsDir, source, existingEngrams, opts)
 }
 
+/**
+ * Resolve `name` as a direct child of `packsDir`, or throw.
+ *
+ * A pack name is a caller-supplied string that reaches here from `plur packs
+ * uninstall <name>` and from the `plur_packs_uninstall` MCP tool. It used to be
+ * joined straight onto `packsDir`, which made `..` resolve to the PLUR ROOT —
+ * and `uninstallPack` ends in `fs.rmSync(packDir, { recursive: true })`.
+ *
+ * Demonstrated before this guard: `uninstallPack(packsDir, '..')` deleted
+ * engrams.yaml, config.yaml and the whole root, and returned `{removed: true}`.
+ * `../..` reached the parent. The install path had the mirror flaw, since a
+ * source ending in `/..` has basename `..`, so pack files were copied over a
+ * live engrams.yaml before any write guard could see them (#811).
+ *
+ * Containment is checked on the RESOLVED path rather than by pattern-matching
+ * the name: `a/../..`, an absolute path, and a name with embedded separators
+ * all normalise away, and a denylist of shapes would have to enumerate them.
+ * Resolution answers the only question that matters — does this end up inside
+ * the packs directory.
+ */
+function resolveInside(packsDir: string, name: string, op: string): string {
+  const base = path.resolve(packsDir)
+  const candidate = path.resolve(base, name)
+  const contained = candidate !== base && candidate.startsWith(base + path.sep)
+  if (!contained || name.includes('/') || name.includes('\\')) {
+    throw new Error(
+      `[plur] refusing to ${op} pack "${name}": a pack name must be a single directory ` +
+      `inside ${packsDir}, and this one resolves to ${candidate}.\n` +
+      `Names containing path separators or ".." are rejected — they would let this operation ` +
+      `read or delete outside the packs directory.`,
+    )
+  }
+  return candidate
+}
+
 // --- Uninstall ---
 
 export interface UninstallResult {
@@ -433,7 +468,7 @@ export interface UninstallResult {
 
 export function uninstallPack(packsDir: string, name: string): UninstallResult {
   // Find the pack — try exact name, then case-insensitive
-  let packDir = path.join(packsDir, name)
+  let packDir = resolveInside(packsDir, name, 'uninstall')
   if (!fs.existsSync(packDir)) {
     // Try case-insensitive scan
     const entries = fs.existsSync(packsDir) ? fs.readdirSync(packsDir) : []

--- a/packages/core/src/store/async-lock.ts
+++ b/packages/core/src/store/async-lock.ts
@@ -221,13 +221,21 @@ async function withFileLock<T>(
           readFile(lockPath, 'utf8').catch(() => ''),
         ])
         holder = contents.trim()
+        const alive = holderIsAlive(holder)
         // (1) The holder's process is gone. Definitive, and immediate — this is
         //     what keeps crash recovery fast despite the long stale threshold.
-        if (holderIsAlive(holder) === false) abandoned = true
-        // (2) Nothing has touched it for longer than any legitimate hold. The
-        //     fallback for holders we cannot probe: another host, or a pid we
-        //     cannot reason about.
-        else if (Date.now() - s.mtimeMs > staleThreshold) abandoned = true
+        if (alive === false) abandoned = true
+        // (2) We cannot probe this holder — another host, or a pid we cannot
+        //     reason about — so age is the only signal left.
+        //
+        //     Age is deliberately NOT consulted when liveness came back TRUE.
+        //     An `else if` here would steal from a writer we have just
+        //     confirmed is running, purely for being slow, and a 50k-engram
+        //     save legitimately holds the lock for seconds. Stealing from a
+        //     live writer corrupts the corpus; waiting on a wedged one is a
+        //     visible error after `acquireTimeout` that names the lock file.
+        //     A loud stall beats silent corruption.
+        else if (alive === undefined && Date.now() - s.mtimeMs > staleThreshold) abandoned = true
       } catch {
         // Vanished between the EEXIST and the check — the holder released.
         // Retry immediately; there is nothing to steal.

--- a/packages/core/src/store/yaml-store.ts
+++ b/packages/core/src/store/yaml-store.ts
@@ -26,7 +26,21 @@ export class YamlStore implements EngramStore {
 
   async save(engrams: Engram[]): Promise<void> {
     await withAsyncLock(this.filePath, async () => {
-      const content = yaml.dump({ engrams }, { lineWidth: 120, noRefs: true, quotingType: '"' })
+      // Carry quarantined entries through, exactly as append/remove do.
+      // Without this, `save(await load())` — the most natural way to use this
+      // class — permanently deletes every schema-invalid record, because
+      // `load()` withholds them by design. The preservation claim in the class
+      // docs was true of append/remove and false here (#811 audit, finding 8).
+      const { quarantined } = await this._read()
+      const ids = new Set(engrams.map(e => e.id))
+      const carried = (quarantined as Engram[]).filter(q => {
+        const id = (q as { id?: unknown })?.id
+        // A record the caller has since re-added properly must not come back
+        // as a malformed duplicate.
+        return !(typeof id === 'string' && ids.has(id))
+      })
+      const out = carried.length > 0 ? [...engrams, ...carried] : engrams
+      const content = yaml.dump({ engrams: out }, { lineWidth: 120, noRefs: true, quotingType: '"' })
       await asyncAtomicWrite(this.filePath, content)
     })
   }

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -731,9 +731,23 @@ export function withLock<T>(
 
   const token = makeToken()
 
+  // Whether we actually took the lock.
+  //
+  // Without this the loop can simply RUN OUT: both `continue` branches below —
+  // a stale lock stolen, and a stat that fails because the holder released
+  // between the EEXIST and the check — skip the give-up throw. If either lands
+  // on the FINAL attempt the loop ends normally, `fn()` runs holding nothing,
+  // and the `finally` deletes a lock belonging to whoever does hold it. The
+  // async implementation has carried this guard (and a regression test) since
+  // the F9 work; porting the liveness check here without it left the sync twin
+  // exposed. Reachable through public options — `maxRetries: 0` makes the first
+  // attempt the final one.
+  let acquired = false
+
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       writeFileSync(lockPath, token, { flag: 'wx' })
+      acquired = true
       break
     } catch (err: any) {
       if (err.code !== 'EEXIST') throw err
@@ -742,17 +756,23 @@ export function withLock<T>(
         // Liveness is what pays for the raised stale threshold, and it has to
         // be here as well as on the async lock. Raising the threshold to 60s
         // without it would take crash recovery on THESE paths (episodes,
-        // tensions, config) from 10s to 60s — a regression introduced by the
-        // F9 fix if only half of it is applied.
-        //
-        // `undefined` means "cannot tell" — a token from another host, or the
-        // bare pid an older client wrote — and must be read as "assume alive",
-        // falling back to the mtime threshold. Guessing "dead" would steal a
-        // lock from a live writer.
+        // tensions, config) from 10s to 60s.
         const holder = readFileSync(lockPath, 'utf8').trim()
-        const dead = holderIsAlive(holder) === false
-        if (dead || Date.now() - stat.mtimeMs > staleThreshold) {
-          unlinkSync(lockPath)
+        const alive = holderIsAlive(holder)
+        // Age is consulted ONLY when liveness is unknown — another host, or the
+        // bare pid an older client wrote. A confirmed-live holder is never
+        // stolen from for being slow: that corrupts the artifact it is midway
+        // through writing, whereas waiting on a wedged holder surfaces as a
+        // loud failure the operator can act on.
+        const steal = alive === false
+          || (alive === undefined && Date.now() - stat.mtimeMs > staleThreshold)
+        if (steal) {
+          // Re-read and compare before unlinking: between the inspection above
+          // and this call the holder may have released and a THIRD party
+          // acquired, and deleting by pathname would take the newcomer's lock.
+          try {
+            if (readFileSync(lockPath, 'utf8').trim() === holder) unlinkSync(lockPath)
+          } catch { /* already gone — nothing to steal */ }
           continue
         }
       } catch {
@@ -765,6 +785,12 @@ export function withLock<T>(
       const end = Date.now() + delay
       while (Date.now() < end) { /* busy wait — sync context */ }
     }
+  }
+
+  if (!acquired) {
+    throw new Error(
+      `Failed to acquire lock on ${filePath} after ${maxRetries} retries (contended throughout)`,
+    )
   }
 
   try {

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -372,13 +372,27 @@ function sharedPushIds(root: string): Set<string> {
  */
 function readSiblingList(root: string, file: string): unknown[] | null {
   const path = join(root, file)
+  // ABSENT is the only "nothing to strip" answer. Unparseable and wrongly
+  // shaped are refusals, matching what readEngramList does.
+  //
+  // These used to collapse into the same `null`, and `stageStrippedSiblings`
+  // responded by skipping the filter and leaving the already force-staged blob
+  // untouched — so a malformed episodes.yaml carrying text DERIVED from private
+  // engrams was pushed verbatim to a shared remote. That is the F5 leak in the
+  // sibling artifacts (#811 audit, finding 9). The old comment here claimed it
+  // matched the engrams posture; that stopped being true when unreadable
+  // engrams began aborting the sync, and nothing updated the siblings to match.
   if (!existsSync(path)) return null
+  let raw: unknown
   try {
-    const raw = yaml.load(readFileSync(path, 'utf8'))
-    return Array.isArray(raw) ? raw : null
+    raw = yaml.load(readFileSync(path, 'utf8'))
   } catch {
-    return null
+    throw new SyncStoreUnreadableError(path)
   }
+  // An empty list serialises as `[]`; null means the bytes said nothing.
+  if (raw == null) throw new SyncStoreUnreadableError(path)
+  if (!Array.isArray(raw)) throw new SyncStoreUnreadableError(path)
+  return raw
 }
 
 /**

--- a/packages/core/src/tension-store.ts
+++ b/packages/core/src/tension-store.ts
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync } from 'fs'
 import yaml from 'js-yaml'
 import { atomicWrite } from './sync.js'
+import { parseRecordArrayFile } from './engrams.js'
 import { TensionRecordSchema, type TensionRecord, type TensionCategory } from './schemas/tension.js'
 import type { Engram } from './schemas/engram.js'
 
@@ -17,25 +18,37 @@ export function tensionPairKey(idA: string, idB: string): string {
   return [idA, idB].sort().join(':')
 }
 
-export function loadTensions(path: string): TensionRecord[] {
-  if (!existsSync(path)) return []
-  try {
-    const raw = yaml.load(readFileSync(path, 'utf8'))
-    if (!Array.isArray(raw)) return []
-    const records: TensionRecord[] = []
-    for (const entry of raw) {
-      const parsed = TensionRecordSchema.safeParse(entry)
-      if (parsed.success) records.push(parsed.data)
-      // Malformed entries are skipped, not fatal — same posture as episodes.
-    }
-    return records
-  } catch {
-    return []
-  }
+/**
+ * Read tension records, or throw when the file is unreadable.
+ *
+ * Both halves of the engram-store defect lived here too (#794 F1/F2, still
+ * live after the first remediation and re-found by the #811 audit): a corrupt
+ * or wrongly-shaped file returned `[]`, and schema-invalid entries were
+ * silently skipped. Since `saveTensions` rewrites the whole array, the next
+ * `recordTensions` persisted only the survivors — a silent permanent delete.
+ */
+export function loadTensionsWithQuarantine(path: string): { valid: TensionRecord[]; quarantined: unknown[] } {
+  return parseRecordArrayFile<TensionRecord>(path, entry => {
+    const parsed = TensionRecordSchema.safeParse(entry)
+    return parsed.success ? parsed.data : null
+  })
 }
 
-export function saveTensions(path: string, records: TensionRecord[]): void {
-  atomicWrite(path, yaml.dump(records, { lineWidth: 120, noRefs: true }))
+export function loadTensions(path: string): TensionRecord[] {
+  return loadTensionsWithQuarantine(path).valid
+}
+
+/**
+ * Write the tension list.
+ *
+ * `quarantined` is the set withheld by {@link loadTensionsWithQuarantine};
+ * passing it back is what stops a malformed record being deleted by an
+ * unrelated write. Callers that loaded through the quarantine helper should
+ * always hand it back.
+ */
+export function saveTensions(path: string, records: TensionRecord[], quarantined: unknown[] = []): void {
+  const out = quarantined.length > 0 ? [...records, ...(quarantined as TensionRecord[])] : records
+  atomicWrite(path, yaml.dump(out, { lineWidth: 120, noRefs: true }))
 }
 
 /**

--- a/packages/core/test/lock.test.ts
+++ b/packages/core/test/lock.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { writeFileSync, existsSync, unlinkSync, utimesSync, mkdtempSync, rmSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { tmpdir } from 'os'
+import { tmpdir, hostname } from 'os'
 import { execSync } from 'child_process'
 import { withLock } from '../src/sync.js'
 import { DEFAULT_STALE_THRESHOLD } from '../src/store/async-lock.js'
@@ -98,5 +98,58 @@ describe('withLock', () => {
     // All 10 increments should have been applied in order
     expect(results).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     expect(readFileSync(counterPath, 'utf8')).toBe('10')
+  })
+})
+
+describe('withLock never runs the body without the lock (#811 audit, finding 3)', () => {
+  let dir2: string
+  let target: string
+  beforeEach(() => {
+    dir2 = mkdtempSync(join(tmpdir(), 'plur-lock-acq-'))
+    target = join(dir2, 'engrams.yaml')
+    writeFileSync(target, 'engrams: []\n')
+  })
+  afterEach(() => { rmSync(dir2, { recursive: true, force: true }) })
+
+  it('throws rather than running fn() when a stale cleanup lands on the final attempt', () => {
+    // The hole: both `continue` branches skip the give-up throw, so a stale
+    // steal on the LAST attempt fell out of the loop and ran the body holding
+    // nothing — then the `finally` deleted whatever lock did exist. maxRetries:0
+    // makes the first attempt the final one, and it is a public option.
+    const lockPath = target + '.lock'
+    writeFileSync(lockPath, 'someone-else')
+    const old = new Date(Date.now() - DEFAULT_STALE_THRESHOLD - 5_000)
+    utimesSync(lockPath, old, old)
+
+    let ran = false
+    expect(() => withLock(target, () => { ran = true }, { maxRetries: 0, baseDelay: 1 }))
+      .toThrow(/Failed to acquire lock/)
+    expect(ran, 'ran the protected body without ever acquiring the lock').toBe(false)
+  })
+
+  it('does not steal from a holder confirmed to be alive, however old the lock', () => {
+    // Age is only a signal when liveness is UNKNOWN. Stealing from a writer we
+    // just confirmed is running corrupts whatever it is midway through writing;
+    // a 50k-engram save legitimately holds the lock for seconds.
+    const lockPath = target + '.lock'
+    writeFileSync(lockPath, `${hostname()}:${process.pid}:${Date.now()}:0`)  // OUR pid — provably alive
+    const ancient = new Date(Date.now() - DEFAULT_STALE_THRESHOLD * 10)
+    utimesSync(lockPath, ancient, ancient)
+
+    let ran = false
+    expect(() => withLock(target, () => { ran = true }, { maxRetries: 1, baseDelay: 5 })).toThrow(/lock/)
+    expect(ran, 'ran the body after stealing from a live holder').toBe(false)
+    expect(existsSync(lockPath), "a live holder's lock was stolen").toBe(true)
+    unlinkSync(lockPath)
+  })
+
+  it('steals immediately from a dead holder regardless of age', () => {
+    const lockPath = target + '.lock'
+    writeFileSync(lockPath, `${hostname()}:2147483646:${Date.now()}:0`)  // pid cannot exist
+    const now = new Date()
+    utimesSync(lockPath, now, now)
+    const started = Date.now()
+    expect(withLock(target, () => 'recovered', { maxRetries: 3, baseDelay: 5 })).toBe('recovered')
+    expect(Date.now() - started).toBeLessThan(2_000)
   })
 })

--- a/packages/core/test/packs.test.ts
+++ b/packages/core/test/packs.test.ts
@@ -661,3 +661,50 @@ describe('pack management', () => {
     expect((exported[0] as any).commitment).not.toBe('locked')
   })
 })
+
+describe('pack names are constrained to the packs directory (#811)', () => {
+  let root: string
+  let packsDir: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'plur-pack-traversal-'))
+    packsDir = join(root, 'packs')
+    mkdirSync(join(packsDir, 'real-pack'), { recursive: true })
+    // The things a traversal would destroy.
+    writeFileSync(join(root, 'engrams.yaml'), 'engrams: []\n')
+    writeFileSync(join(root, 'config.yaml'), 'stores: []\n')
+  })
+  afterEach(() => { rmSync(root, { recursive: true, force: true }) })
+
+  // Demonstrated before the guard: uninstallPack(packsDir, '..') resolved to
+  // the PLUR root and `fs.rmSync(packDir, { recursive: true })` deleted
+  // engrams.yaml, config.yaml and the whole root — returning {removed: true}.
+  // Reachable from `plur packs uninstall <name>` and the plur_packs_uninstall
+  // MCP tool, so any agent with MCP access could trigger it.
+  for (const name of ['..', '../..', 'a/../..', 'real-pack/../..']) {
+    it(`refuses to uninstall ${JSON.stringify(name)} and destroys nothing`, () => {
+      expect(() => uninstallPack(packsDir, name)).toThrow(/refusing to uninstall/i)
+      expect(existsSync(join(root, 'engrams.yaml')), 'engrams.yaml was deleted').toBe(true)
+      expect(existsSync(join(root, 'config.yaml')), 'config.yaml was deleted').toBe(true)
+      expect(existsSync(packsDir)).toBe(true)
+    })
+  }
+
+  it('refuses an absolute path as a pack name', () => {
+    expect(() => uninstallPack(packsDir, '/etc')).toThrow(/refusing to uninstall/i)
+  })
+
+  it('still reports a genuinely missing pack as not found, not as a traversal', () => {
+    expect(() => uninstallPack(packsDir, 'no-such-pack')).toThrow(/Pack not found/i)
+  })
+
+  it('refuses to install from a source whose basename escapes the packs dir', async () => {
+    // basename('/some/path/..') === '..', which made the destination the PLUR
+    // root — so pack files were copied over a live engrams.yaml before any
+    // write guard could see them.
+    const escaping = join(root, 'somewhere', '..')
+    mkdirSync(join(root, 'somewhere'), { recursive: true })
+    await expect(installPack(packsDir, escaping)).rejects.toThrow()
+    expect(readFileSync(join(root, 'engrams.yaml'), 'utf8')).toBe('engrams: []\n')
+  })
+})

--- a/packages/core/test/store-corruption-guard.test.ts
+++ b/packages/core/test/store-corruption-guard.test.ts
@@ -108,10 +108,15 @@ describe('loadEngrams — refuses unreadable stores instead of reporting empty (
     expect(loadEngrams(storePath)).toEqual([])
   })
 
-  it('accepts a null engrams key as empty rather than throwing', () => {
-    // `engrams:` with nothing after it is what a hand-edited file looks like.
+  it('refuses a null engrams key — only `engrams: []` is an empty store', () => {
+    // This test used to assert the opposite, on the reasoning that `engrams:`
+    // is what a hand-edited file looks like. That was wrong and it blessed a
+    // hole: PLUR only ever writes `engrams: []`, so a null-valued key is a
+    // truncation that stopped after the key. Demonstrated with the old
+    // behaviour: 5 engrams, truncate to `engrams:\n`, one learn -> 1 engram on
+    // disk, corruption normalised into a valid file (#811 audit, finding 4).
     fs.writeFileSync(storePath, 'engrams:\n')
-    expect(loadEngrams(storePath)).toEqual([])
+    expect(() => loadEngrams(storePath)).toThrow(EngramStoreUnreadableError)
   })
 })
 

--- a/packages/core/test/sync-corrupt-push-guard.test.ts
+++ b/packages/core/test/sync-corrupt-push-guard.test.ts
@@ -21,6 +21,8 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import * as yaml from 'js-yaml'
 import { sync, SyncStoreUnreadableError } from '../src/sync.js'
+import { Plur } from '../src/index.js'
+import { withAsyncLock } from '../src/store/async-lock.js'
 
 let root: string
 let remote: string
@@ -175,4 +177,33 @@ describe('sync tells the truth about what it backs up (F7)', () => {
     const result = sync(root, remote)
     expect(result.warning).toBeUndefined()
   })
+})
+
+describe('sync serializes against the store lock (#811 audit, finding 2)', () => {
+  it('waits for a writer holding the store lock instead of racing it', async () => {
+    // git pull --rebase REPLACES engrams.yaml, so an unlocked sync races the
+    // write path and the race is invisible to the shrink guard:
+    //   writer reads N -> sync pulls R (file is N+R) -> writer saves N+L
+    //   the guard sees the same COUNT before and after, so it passes
+    //   the next sync commits and pushes the deletion of R
+    // Both report success and R is gone. Measured before the fix, this test
+    // produced "sync-done -> writer-released"; it now produces the reverse.
+    const dir = mkdtempSync(join(tmpdir(), 'plur-sync-serialize-'))
+    try {
+      const plur = new Plur({ path: dir, autoDiscover: false })
+      await plur.learn('a seed engram so the store exists', { scope: 'local' })
+
+      const order: string[] = []
+      const holder = withAsyncLock(join(dir, 'engrams.yaml'), async () => {
+        await new Promise(r => setTimeout(r, 400))
+        order.push('writer-released')
+      })
+      const syncing = plur.sync().then(() => order.push('sync-done'), () => order.push('sync-failed'))
+      await Promise.all([holder, syncing])
+
+      expect(order[0], 'sync ran while a writer held the store lock').toBe('writer-released')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }, 30_000)
 })


### PR DESCRIPTION
Closes **#811**. Ten defects found by an independent adversarial **whole-repository** audit (gpt-5.6-sol via Codex CLI, 9.1M tokens) run as the 0.17 release gate.

Every one was **reproduced against the code before being fixed**. The lock and sync fixes were additionally checked against the *unfixed* source to confirm the new tests actually catch the bug rather than merely passing.

## Critical

### 1. A pack name could delete the entire PLUR root

```
before  : { root: true, engrams: true }
uninstallPack(packsDir, "..") -> completed without error
after   : { root: false, engrams: false, config: false }
```

`uninstallPack` joined the caller's `name` onto `packsDir` and then `fs.rmSync(..., {recursive: true})`. `".."` is the PLUR root; `"../.."` its parent. The name is passed through unchanged by the CLI **and** the `plur_packs_uninstall` MCP tool, so any agent with MCP access could trigger it — and it returned `{removed: true}`.

`installPack` had the mirror flaw: `basename` of a source ending in `/..` is `..`, so pack files copied **into the PLUR root, over a live `engrams.yaml`**, before any write guard could see them.

Fixed by resolving the candidate and requiring strict containment — checked on the *resolved* path, because `a/../..`, absolute paths and embedded separators all normalise away and a denylist would have to enumerate them. All six attack shapes refused; a genuine "not found" still behaves.

### 2. Git sync raced the write path, and the shrink guard could not see it

```
1. writer A takes the store lock, reads corpus N
2. sync B, holding nothing, pulls remote engram R  -> file is N+R
3. writer A appends L to its stale N, saves N+L
4. the shrink guard sees the same COUNT before and after -> passes
5. the next sync commits and pushes the deletion of R
```

Both report success; R is gone. The count guard cannot catch this by construction — one row arrived while one row was added — so the fix is mutual exclusion, not another validity check. `gitSync` now runs inside `_withStoreLock`.

```
before: ORDER: sync-done -> writer-released      (RACE)
after : ORDER: writer-released -> sync-done      (SAFE)
```

**Caller contract, now in the code:** `sync()` acquires the store lock and must not be called from inside one. The in-process queue is FIFO with *no* timeout (unlike the file lock), so nesting **hangs** rather than erroring. Both current callers are top-level. Found by writing this fix's first test as a nested call and watching it wedge.

## High

**3. The locks, three ways.** The synchronous `withLock` ran `fn()` **without ever acquiring** when a stale cleanup landed on the final attempt — reachable via the public `maxRetries: 0`; the async twin has had that guard since the F9 work and porting liveness across without it left the sync side exposed. **Both** implementations stole from *confirmed-live* holders, because the age check sat behind an `else if` still reached when `holderIsAlive()` returned `true` — a 50k save legitimately holds the lock for seconds. And the sync lock unlinked **by pathname** after inspecting the holder, so a holder that released in between lost its successor's lock.

**4. `engrams:` with a null value normalised corruption.** PLUR only ever writes `engrams: []`, so a null-valued key is a truncation that stopped after the key. Accepting it as empty meant: 5 engrams → truncate → one learn → **1 engram on disk**. The F1 shape, in a case one of my own tests explicitly blessed. That test now asserts the refusal; the bytes survive for restore.

**7. Episodes and tensions still wiped on corrupt read.** Both returned `[]` for unparseable input and rewrote the whole array; tensions silently dropped schema-invalid records. The #794 per-writer table *listed* both as `corrupt -> [] -> wipe` — only the episodes locking was fixed, so the class was reported closed while these stayed open. Both now share one `parseRecordArrayFile`: refuse on unreadable, quarantine invalid entries, write them back.

**8. `YamlStore.save()` discarded quarantined entries.** `append`/`remove` preserved them; `save` did not — so `store.save(await store.load())`, the most natural use of the class, permanently deleted every schema-invalid record.

**9. Shared sync pushed corrupt siblings verbatim.** `readSiblingList` collapsed absent / unparseable / wrong-shape into one `null`, and the stripper answered `continue` — leaving the force-staged blob untouched. A malformed `episodes.yaml` carrying text **derived from private engrams** went to a shared remote. The F5 fix covered `engrams.yaml` only, and the comment claiming parity stopped being true the moment engrams began aborting the sync.

**10. Restore was unlocked and non-atomic.** A whole-corpus overwrite that took no lock and truncated the live file in place, with `atomicWrite` sitting in the same module. A writer committing between the superseded copy and the overwrite left its engram in **neither** file, both reporting success; a crash mid-write left the corpus partial — exactly the input the loader now refuses.

## Not fixed here — filed with the analysis

- **#812** stale embeddings: nothing invalidates a vector when text changes, the backfill query is ID-only, PGLite lacks the FK Postgres has, and `generateEngramId` reuses IDs freed by `compact()`. Not a one-liner: `recall()` calls `updateMany` on every query, so unconditional invalidation would re-embed the result set per query. Needs a hash column and a migration.
- **#813** the remaining ten, verified and specified.

## What this says about the original audit

The two Critical findings and most of the High ones live in paths **#794 never examined**: a deleter taking a path component, git sync as a writer, sibling artifacts, restore itself. That audit swept "every writer of engrams", and the framing that made it thorough is what made it blind.

Findings 7 and 9 are worse than a miss — the report *documented* those holes and the remediation closed only part of them while calling the class done.

## Testing

Full suite: **3664 passed, 0 failed.** `typecheck:tests` clean. New regression tests for pack containment, lock acquisition, live-holder protection, `engrams:` refusal, quarantine preservation, and sync serialisation — the lock and sync ones verified to fail against the pre-fix source.

Closes #811
Refs #794
