### PR TITLE
fix(core): make an engram's vector follow its text (#812)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import type { Engram } from './schemas/engram.js'
 
 const STOP_WORDS = new Set([
@@ -48,6 +49,44 @@ export function engramSearchText(engram: Engram): string {
     }
   }
   return parts.join(' ')
+}
+
+/**
+ * Hash of the exact text an engram's embedding was computed from (#812).
+ *
+ * Stored beside the vector so a store can answer "is this vector still the
+ * right one for this engram?" — a question nothing could ask before, because
+ * `engram_embeddings` held only `(engram_id, embedding)`. Without it a dedup
+ * UPDATE/MERGE could rewrite an engram's statement from "cats" to "databases"
+ * and semantic recall would go on ranking it as "cats" forever, since the
+ * backfill's anti-join only asked whether an id had *any* vector.
+ *
+ * Three properties this deliberately has:
+ *
+ * 1. It hashes `ftsTokenize(engramSearchText(e)).join(' ')` — byte-identical
+ *    to the `search_text` column `deriveRow` writes on the Postgres tier. That
+ *    lets that tier compare `content_hash` against `md5(search_text)` inside
+ *    one set-based anti-join instead of probing per id, which is the whole
+ *    reason primary-store auto-embed exists (ADR-0005's 2026-07-28 amendment).
+ *
+ * 2. md5, not the sha256 used by the file-backed cache in `embeddings.ts`.
+ *    Not a security boundary — a change detector that Postgres must be able
+ *    to compute with a builtin. The two hashes never meet.
+ *
+ * 3. The WRITER hashes the text it actually embedded, rather than the store
+ *    re-deriving it at write time. An engram updated between the backfill's
+ *    batch read and its upsert would otherwise get a hash of the NEW text
+ *    attached to a vector of the OLD text — permanently stale while claiming
+ *    to be current. Hashing what we embedded makes that case self-healing:
+ *    the stored hash simply won't match, so the next pass re-embeds.
+ */
+export function embeddingContentHash(engram: Engram): string {
+  return hashEmbeddedText(ftsTokenize(engramSearchText(engram)).join(' '))
+}
+
+/** md5 of an already-derived search text. Exported for stores that hold the derived form. */
+export function hashEmbeddedText(searchText: string): string {
+  return createHash('md5').update(searchText).digest('hex')
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3325,6 +3325,13 @@ export class Plur {
    * probe is also what makes a store migrated in with existing rows converge:
    * the first semantic recall starts the backfill even if nothing was ever
    * written through this instance.
+   *
+   * Deliberately WITHOUT `includeStale` (#812): a stale vector still returns
+   * its engram, merely ranked by older text, so it is not the silent
+   * incompleteness this gate is about. Opening the gate on staleness would put
+   * every semantic recall on the O(N) fallback until the backfill drained —
+   * one edited engram degrading the whole store. Edits kick the backfill from
+   * the write path, so they converge without this gate's help.
    */
   private async _primarySemanticRecall(
     adapter: StorageAdapter,
@@ -5243,12 +5250,17 @@ export class Plur {
       }
       const active = (await this._loadAllEngrams()).filter(e => e.status === 'active' && !(e as any)._originalId && !(e as any)._pack)
       if (active.length === 0) return
-      const { engramSearchText } = await import('./fts.js')
+      const { engramSearchText, embeddingContentHash } = await import('./fts.js')
       for (const engram of active) {
-        if (await adapter.hasEmbedding(engram.id)) continue
+        // #812: skip on "already embedded FROM THIS TEXT", not on "already has
+        // some vector". The latter is what `hasEmbedding` answered, which meant
+        // a dedup UPDATE/MERGE could rewrite an engram and its vector would
+        // never be recomputed — semantic recall kept ranking it by the old text.
+        const hash = embeddingContentHash(engram)
+        if (await adapter.embeddingIsCurrent(engram.id, hash)) continue
         const vec = await embed(engramSearchText(engram))
         if (!vec) return // embedder unavailable — next cycle retries
-        await adapter.upsertEmbedding(engram.id, vec)
+        await adapter.upsertEmbedding(engram.id, vec, hash)
       }
     } catch (err) {
       this._recordIndexError('auto-embed', err)
@@ -5333,11 +5345,29 @@ export class Plur {
         )
         return
       }
-      const { engramSearchText } = await import('./fts.js')
+      const { engramSearchText, embeddingContentHash } = await import('./fts.js')
+      // #812: the loop's exit condition is "the store stops returning rows",
+      // and the store's predicate now includes a hash comparison. If the hash
+      // this side writes ever stopped matching the one the store's SQL derives,
+      // every batch would return the same rows and the pass would spin forever
+      // — a background task pinning a core. The two agree by construction (see
+      // `embeddingContentHash`), and this set makes that a warning instead of a
+      // hang if they ever stop agreeing.
+      const embeddedThisPass = new Set<string>()
       for (;;) {
-        const batch = await adapter.listEngramsMissingEmbeddings(PRIMARY_AUTO_EMBED_BATCH)
+        const batch = await adapter.listEngramsMissingEmbeddings(PRIMARY_AUTO_EMBED_BATCH, { includeStale: true })
         if (batch.length === 0) return
-        for (const engram of batch) {
+        const fresh = batch.filter(e => !embeddedThisPass.has(e.id))
+        if (fresh.length === 0) {
+          logger.warning(
+            `[plur] primary-store auto-embed stopped: ${batch.length} engram(s) still report a stale `
+            + `embedding after being re-embedded in this pass (first: ${batch[0].id}). The stored content `
+            + `hash disagrees with the store's — semantic recall may be ranking stale text. Please report this.`,
+          )
+          return
+        }
+        for (const engram of fresh) {
+          const hash = embeddingContentHash(engram)
           const vec = await embed(engramSearchText(engram))
           if (!vec) {
             // Embedder became unavailable mid-pass — stop; retried on the
@@ -5346,7 +5376,8 @@ export class Plur {
             logger.debug('[plur] primary-store auto-embed paused: embedder unavailable.')
             return
           }
-          await adapter.upsertEmbedding(engram.id, vec)
+          await adapter.upsertEmbedding(engram.id, vec, hash)
+          embeddedThisPass.add(engram.id)
         }
         // A full batch means the anti-join may hold more; a short one is the
         // tail. Progress is guaranteed: every upsert removes a row from the

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -424,11 +424,35 @@ export interface StorageAdapter {
     limit: number,
     opts?: ScopeRestriction & Pick<StorageFilter, 'scope' | 'visibilityGrants'>,
   ): Promise<VectorSearchHit[]>
-  /** Upsert an embedding for a specific engram. */
-  upsertEmbedding(engramId: string, vector: Float32Array): Promise<void>
   /**
-   * Active engrams that have no stored embedding, up to `limit`, as ONE
-   * set-based query (#762). OPTIONAL — and the enabling contract for
+   * Upsert an embedding for a specific engram.
+   *
+   * `contentHash` is `embeddingContentHash(engram)` for the engram the vector
+   * was computed from — the store persists it beside the vector so it can
+   * later tell a current vector from a stale one (#812). Optional only for
+   * back-compatibility with callers that predate staleness tracking; omitting
+   * it stores a NULL hash, which reads as "unknown" and makes the engram a
+   * candidate for one re-embed.
+   */
+  upsertEmbedding(engramId: string, vector: Float32Array, contentHash?: string): Promise<void>
+  /**
+   * Active engrams with no stored embedding, up to `limit`, as ONE set-based
+   * query (#762). With `includeStale`, also those whose stored vector was
+   * computed from text the engram no longer has (#812).
+   *
+   * The two callers want different questions and must not be merged:
+   *
+   *   - the BACKFILL passes `includeStale: true` — a stale vector is work to do.
+   *   - the semantic read path's completeness gate does NOT. It asks whether
+   *     any engram is INVISIBLE to the vector leg, because that is what makes a
+   *     vector search silently partial. A stale vector still returns the engram,
+   *     just ranked by older text. Letting staleness open that gate would drop
+   *     every semantic recall onto the O(N) in-memory path corpus-wide until the
+   *     backfill caught up — one edited engram, whole-store cliff, which is the
+   *     regression this tier exists to avoid (ADR-0005's 2026-07-28 amendment).
+   *     Edits kick the backfill via the write path anyway, so nothing is missed.
+   *
+   * OPTIONAL — and the enabling contract for
    * primary-store auto-embed: core only wires the write-path/backfill
    * embedding pass into an adapter that can answer "which rows lack
    * embeddings" without loading the corpus. The alternative shape — load
@@ -441,7 +465,7 @@ export interface StorageAdapter {
    * Called with `limit: 1` as a completeness probe on the semantic read path,
    * so the implementation should be an indexed anti-join, not a scan-and-diff.
    */
-  listEngramsMissingEmbeddings?(limit: number): Promise<Engram[]>
+  listEngramsMissingEmbeddings?(limit: number, opts?: { includeStale?: boolean }): Promise<Engram[]>
   /** Release resources. */
   close(): Promise<void>
 }

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -263,6 +263,14 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
         );
       `)
     }
+    // #812: the text this vector was computed from, so a changed engram gets a
+    // changed vector. Additive + idempotent, so an existing store gains it on
+    // next open. Deliberately NOT a foreign key to `engrams`: `reindex()`
+    // deletes every engram row and re-inserts it, and ON DELETE CASCADE would
+    // therefore discard the whole embedding table on every reindex — the exact
+    // cache the comment there says is preserved on purpose. Orphans left by
+    // real removals are swept set-wise in `syncFromYaml` instead.
+    await db.exec('ALTER TABLE engram_embeddings ADD COLUMN IF NOT EXISTS content_hash TEXT;')
     // AGE engram graph (#200 lands the actual edges; we just create the
     // graph here so the schema is ready).
     if (this.hasAge) {
@@ -515,6 +523,16 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
         } else {
           await db.exec("DELETE FROM engrams WHERE source = 'primary'")
         }
+        // #812: sweep vectors whose engram is gone. `engram_embeddings` has no
+        // cascading FK on this tier (see the schema comment — a cascade would
+        // empty the table on every `reindex()`), so a removal used to leave the
+        // vector behind indefinitely. That mattered beyond wasted space:
+        // `generateEngramId` mints `max(same-day id) + 1`, so compacting the
+        // highest engram of a day frees that id for the next `learn()`, and the
+        // new, unrelated engram inherited the dead vector — recall ranking it as
+        // whatever the removed engram used to say. Set-based and inside the same
+        // transaction as the deletes above, so it costs one statement per sync.
+        await db.exec('DELETE FROM engram_embeddings WHERE engram_id NOT IN (SELECT id FROM engrams)')
         await db.exec('COMMIT')
       } catch (err) {
         await db.exec('ROLLBACK').catch(() => {})
@@ -650,7 +668,7 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
     return scored.slice(0, limit)
   }
 
-  async upsertEmbedding(engramId: string, vector: Float32Array): Promise<void> {
+  async upsertEmbedding(engramId: string, vector: Float32Array, contentHash?: string): Promise<void> {
     return this.mutex.run(async () => {
       const db = await this.getDb()
       // #335 storage-boundary contract: a wrong-shape vector must never be
@@ -672,18 +690,20 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
         // "[...]" literal and rounds to fp16 on write.
         const literal = vectorLiteral(vector)
         await db.query(
-          `INSERT INTO engram_embeddings (engram_id, embedding)
-           VALUES ($1, $2::${this.activeVecType})
-           ON CONFLICT (engram_id) DO UPDATE SET embedding = EXCLUDED.embedding`,
-          [engramId, literal],
+          `INSERT INTO engram_embeddings (engram_id, embedding, content_hash)
+           VALUES ($1, $2::${this.activeVecType}, $3)
+           ON CONFLICT (engram_id) DO UPDATE
+             SET embedding = EXCLUDED.embedding, content_hash = EXCLUDED.content_hash`,
+          [engramId, literal, contentHash ?? null],
         )
       } else {
         const buf = float32ToBytes(vector)
         await db.query(
-          `INSERT INTO engram_embeddings (engram_id, embedding)
-           VALUES ($1, $2)
-           ON CONFLICT (engram_id) DO UPDATE SET embedding = EXCLUDED.embedding`,
-          [engramId, buf],
+          `INSERT INTO engram_embeddings (engram_id, embedding, content_hash)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (engram_id) DO UPDATE
+             SET embedding = EXCLUDED.embedding, content_hash = EXCLUDED.content_hash`,
+          [engramId, buf, contentHash ?? null],
         )
       }
     })
@@ -695,6 +715,26 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
     const res = await db.query(
       'SELECT 1 FROM engram_embeddings WHERE engram_id = $1 LIMIT 1',
       [engramId],
+    )
+    return res.rows.length > 0
+  }
+
+  /**
+   * True when `engramId` has an embedding computed from exactly `contentHash`
+   * (#812) — the skip condition the auto-embed pass needs instead of
+   * `hasEmbedding`, which only ever asked whether SOME vector existed and so
+   * let an edited engram keep the vector of its previous text indefinitely.
+   *
+   * Both sides are hashed in JS by `embeddingContentHash`, since this tier's
+   * `engrams` table has no `search_text` column for SQL to hash. A row stored
+   * before content hashing carries NULL and reports false, so it is re-embedded
+   * once and correct from then on.
+   */
+  async embeddingIsCurrent(engramId: string, contentHash: string): Promise<boolean> {
+    const db = await this.getDb()
+    const res = await db.query(
+      'SELECT 1 FROM engram_embeddings WHERE engram_id = $1 AND content_hash = $2 LIMIT 1',
+      [engramId, contentHash],
     )
     return res.rows.length > 0
   }

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -592,6 +592,13 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
         embedding ${wantType}(${this.vectorDim}) NOT NULL
       )
     `)
+    // #812: which text this vector was computed from. Additive and idempotent,
+    // exactly like the `tokens` / `search_text` columns above — an existing
+    // deployment gains the column on next connect with no migration step. Rows
+    // written before it existed carry NULL, which the staleness predicate in
+    // `listEngramsMissingEmbeddings` reads as "unknown", so each is re-embedded
+    // once by the background pass and is stable from then on.
+    await this.ddl(client, `ALTER TABLE "${this.schema}".engram_embeddings ADD COLUMN IF NOT EXISTS content_hash TEXT`)
     await this.readEmbeddingColumnInfo(client)
     await this.ensureVectorIndex(client)
   }
@@ -1324,7 +1331,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * embedder and the store disagree — rather than surfacing pgvector's own
    * error.
    */
-  async upsertEmbedding(engramId: string, vector: Float32Array): Promise<void> {
+  async upsertEmbedding(engramId: string, vector: Float32Array, contentHash?: string): Promise<void> {
     const pool = await this.getPool()
     const expectedDim = this.activeVecDim ?? this.vectorDim
     if (vector.length !== expectedDim) {
@@ -1335,15 +1342,31 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       )
     }
     await pool.query(
-      `INSERT INTO "${this.schema}".engram_embeddings (engram_id, embedding)
-       VALUES ($1, $2::${this.activeVecType})
-       ON CONFLICT (engram_id) DO UPDATE SET embedding = EXCLUDED.embedding`,
-      [engramId, vectorLiteral(vector)],
+      `INSERT INTO "${this.schema}".engram_embeddings (engram_id, embedding, content_hash)
+       VALUES ($1, $2::${this.activeVecType}, $3)
+       ON CONFLICT (engram_id) DO UPDATE
+         SET embedding = EXCLUDED.embedding, content_hash = EXCLUDED.content_hash`,
+      [engramId, vectorLiteral(vector), contentHash ?? null],
     )
   }
 
   /**
-   * Active engrams with no row in `engram_embeddings`, up to `limit` (#762).
+   * Active engrams whose embedding is missing or stale, up to `limit` (#762, #812).
+   *
+   * Staleness is `content_hash IS DISTINCT FROM md5(search_text)`. Both sides
+   * are evaluated by Postgres over the same column, and `embeddingContentHash`
+   * — what the writer stores — is md5 over the identical derivation
+   * (`ftsTokenize(engramSearchText(e)).join(' ')`, which is exactly what
+   * `deriveRow` writes to `search_text`). That agreement is load-bearing: this
+   * method is the loop condition of the backfill pass, so a predicate that
+   * never goes false for a row would spin on it forever. `_autoEmbedPrimaryStore`
+   * additionally refuses to revisit an id within one pass, so a future drift
+   * degrades to a logged warning rather than an infinite loop.
+   *
+   * `search_text IS NOT NULL` guards the same hazard from the other side: a row
+   * written before that column existed hashes to NULL, and NULL IS DISTINCT
+   * FROM a real hash is TRUE — permanently. Such rows embed once via the
+   * `em.engram_id IS NULL` arm and are then left alone.
    *
    * ONE set-based anti-join, which is the whole reason primary-store
    * auto-embed exists at all: the PGLite-era shape — load the corpus, probe
@@ -1357,13 +1380,21 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * `ORDER BY e.id` so concurrent auto-embed passes in different processes
    * walk the gap in the same order and converge instead of thrashing.
    */
-  async listEngramsMissingEmbeddings(limit: number): Promise<Engram[]> {
+  async listEngramsMissingEmbeddings(limit: number, opts?: { includeStale?: boolean }): Promise<Engram[]> {
     assertPositiveInt(limit, 'limit')
     const pool = await this.getPool()
+    // `search_text IS NOT NULL` guards a row written before that column
+    // existed: it hashes to NULL, and NULL IS DISTINCT FROM a real hash is
+    // TRUE — permanently. Such a row embeds once through the `IS NULL` arm and
+    // is then left alone, rather than being re-embedded on every pass forever.
+    const staleArm = opts?.includeStale
+      ? `OR (e.search_text IS NOT NULL AND em.content_hash IS DISTINCT FROM md5(e.search_text))`
+      : ''
     const res = await pool.query(
       `SELECT e.data FROM "${this.schema}".engrams e
        LEFT JOIN "${this.schema}".engram_embeddings em ON em.engram_id = e.id
-       WHERE e.status = 'active' AND em.engram_id IS NULL
+       WHERE e.status = 'active'
+         AND (em.engram_id IS NULL ${staleArm})
        ORDER BY e.id
        LIMIT $1`,
       [limit],

--- a/packages/core/test/embedding-staleness-812.test.ts
+++ b/packages/core/test/embedding-staleness-812.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Embedding staleness (#812) — the vector must follow the text.
+ *
+ * Finding 6 of the #811 whole-repository audit. `engram_embeddings` held only
+ * `(engram_id, embedding)`, and the backfill's anti-join asked only whether an
+ * id had ANY vector:
+ *
+ *     LEFT JOIN engram_embeddings em ON em.engram_id = e.id
+ *     WHERE e.status = 'active' AND em.engram_id IS NULL
+ *
+ * So nothing could ever notice that an engram's TEXT had changed. A dedup
+ * UPDATE/MERGE (`learn-async.ts`) could rewrite a statement from "cats" to
+ * "databases" and semantic recall would go on ranking it as "cats" forever.
+ * The engram on disk was correct; the vector answering for it was not. Not
+ * data loss — silently wrong recall, which is harder to notice.
+ *
+ * The fix stores `content_hash` — md5 of the exact text embedded — beside each
+ * vector, and both tiers compare against it. These tests pin the behaviour, and
+ * three of them pin hazards the fix itself introduces:
+ *
+ *   - `reindex()` must NOT lose embeddings. The issue proposed adding a
+ *     cascading FK to PGLite for the orphan problem; that would empty the whole
+ *     table on every reindex, since reindex deletes and re-inserts every engram
+ *     row. The orphan sweep lives in `syncFromYaml` for exactly this reason.
+ *   - the backfill loop's exit condition is now a hash comparison, so a
+ *     writer/selector disagreement would mean every batch returns the same rows
+ *     forever. The pass must refuse to revisit an id and warn instead of spin.
+ *   - a NULL hash (rows written before the column existed) must converge after
+ *     ONE re-embed, not re-embed on every pass.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import { embeddingContentHash, engramSearchText, ftsTokenize, hashEmbeddedText } from '../src/fts.js'
+import { Plur } from '../src/index.js'
+import { logger } from '../src/logger.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+const PGLITE_TIMEOUT = 30_000
+const DIM = 384
+
+function mkEngram(id: string, statement: string, opts: Partial<Engram> = {}): Engram {
+  return {
+    id,
+    statement,
+    type: opts.type ?? 'behavioral',
+    scope: opts.scope ?? 'project:plur',
+    domain: opts.domain ?? 'plur.test',
+    status: opts.status ?? 'active',
+    tags: opts.tags ?? [],
+    activation: {
+      retrieval_strength: 1.0,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-08-03',
+    },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    ...(opts as any),
+  } as Engram
+}
+
+function seedYaml(path: string, engrams: Engram[]): void {
+  writeFileSync(path, yaml.dump({ engrams }), 'utf8')
+}
+
+/** Deterministic unit vector — distinct per text, no model download. */
+function stubVec(text: string): Float32Array {
+  const v = new Float32Array(DIM)
+  for (const t of text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)) {
+    let h = 2166136261
+    for (let i = 0; i < t.length; i++) h = Math.imul(h ^ t.charCodeAt(i), 16777619)
+    v[Math.abs(h) % DIM] += 1
+  }
+  let n = 0
+  for (const x of v) n += x * x
+  n = Math.sqrt(n) || 1
+  for (let i = 0; i < DIM; i++) v[i] /= n
+  return v
+}
+
+describe('#812 — content hash identifies the text a vector was built from', () => {
+  it('changes when the statement changes', () => {
+    const before = embeddingContentHash(mkEngram('ENG-2026-0803-001', 'cats are excellent pets'))
+    const after = embeddingContentHash(mkEngram('ENG-2026-0803-001', 'databases are excellent stores'))
+    expect(before).not.toBe(after)
+  })
+
+  it('is stable for identical content — a re-derivation must not look like an edit', () => {
+    const a = mkEngram('ENG-2026-0803-001', 'cats are excellent pets', { tags: ['x'] })
+    const b = mkEngram('ENG-2026-0803-001', 'cats are excellent pets', { tags: ['x'] })
+    expect(embeddingContentHash(a)).toBe(embeddingContentHash(b))
+  })
+
+  it('tracks every field that feeds the embedding, not just the statement', () => {
+    const base = mkEngram('ENG-2026-0803-001', 'same statement')
+    const withRationale = mkEngram('ENG-2026-0803-001', 'same statement', { rationale: 'a reason that is embedded too' })
+    expect(embeddingContentHash(base)).not.toBe(embeddingContentHash(withRationale))
+  })
+
+  /**
+   * The Postgres tier compares `content_hash` against `md5(search_text)` inside
+   * its anti-join, and `search_text` is written by `deriveRow` as
+   * `ftsTokenize(engramSearchText(e)).join(' ')`. If this equality broke, the
+   * backfill's exit condition would never be satisfiable — every batch would
+   * return the same rows forever. This is that equality, asserted directly.
+   */
+  it('equals md5 of the derived search_text the Postgres tier stores', () => {
+    const e = mkEngram('ENG-2026-0803-001', 'the derived form must agree across tiers')
+    const derivedSearchText = ftsTokenize(engramSearchText(e)).join(' ')
+    expect(embeddingContentHash(e)).toBe(hashEmbeddedText(derivedSearchText))
+  })
+})
+
+describe('#812 — PGLite tracks staleness and sweeps orphans', () => {
+  let dir: string
+  let yamlPath: string
+  let dbPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-812-'))
+    yamlPath = join(dir, 'engrams.yaml')
+    dbPath = join(dir, 'store.pglite')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reports a vector as current only for the text it was built from', async () => {
+    const original = mkEngram('ENG-2026-0803-001', 'cats are excellent pets')
+    seedYaml(yamlPath, [original])
+    const adapter = new PGLiteAdapter(yamlPath, dbPath)
+    await adapter.reindex()
+
+    const originalHash = embeddingContentHash(original)
+    await adapter.upsertEmbedding(original.id, stubVec(original.statement), originalHash)
+    expect(await adapter.embeddingIsCurrent(original.id, originalHash)).toBe(true)
+
+    // The engram is rewritten in place — same id, different meaning. Before the
+    // fix this still reported "has an embedding" and was skipped forever.
+    const edited = mkEngram('ENG-2026-0803-001', 'databases are excellent stores')
+    expect(await adapter.embeddingIsCurrent(edited.id, embeddingContentHash(edited))).toBe(false)
+    expect(await adapter.hasEmbedding(edited.id)).toBe(true) // the old signal, still true — that was the bug
+
+    await adapter.close()
+  }, PGLITE_TIMEOUT)
+
+  it('treats a vector stored without a hash as unknown, then converges after one re-embed', async () => {
+    const e = mkEngram('ENG-2026-0803-001', 'written by a version that had no content_hash')
+    seedYaml(yamlPath, [e])
+    const adapter = new PGLiteAdapter(yamlPath, dbPath)
+    await adapter.reindex()
+
+    await adapter.upsertEmbedding(e.id, stubVec(e.statement)) // legacy write: no hash
+    const hash = embeddingContentHash(e)
+    expect(await adapter.embeddingIsCurrent(e.id, hash)).toBe(false)
+
+    await adapter.upsertEmbedding(e.id, stubVec(e.statement), hash)
+    expect(await adapter.embeddingIsCurrent(e.id, hash)).toBe(true) // converged — not stale forever
+
+    await adapter.close()
+  }, PGLITE_TIMEOUT)
+
+  it('deletes the vector when its engram leaves YAML', async () => {
+    const keep = mkEngram('ENG-2026-0803-001', 'still here')
+    const drop = mkEngram('ENG-2026-0803-002', 'about to be removed')
+    seedYaml(yamlPath, [keep, drop])
+    const adapter = new PGLiteAdapter(yamlPath, dbPath)
+    await adapter.reindex()
+    await adapter.upsertEmbedding(keep.id, stubVec(keep.statement), embeddingContentHash(keep))
+    await adapter.upsertEmbedding(drop.id, stubVec(drop.statement), embeddingContentHash(drop))
+    expect(await adapter.countEmbeddings()).toBe(2)
+
+    seedYaml(yamlPath, [keep])
+    await adapter.syncFromYaml()
+
+    expect(await adapter.hasEmbedding(drop.id)).toBe(false)
+    expect(await adapter.hasEmbedding(keep.id)).toBe(true)
+    await adapter.close()
+  }, PGLITE_TIMEOUT)
+
+  /**
+   * The concrete harm the orphan caused. `generateEngramId` mints
+   * `max(same-day id) + 1`, so removing the highest engram of a day frees its
+   * id for the next `learn()`. With the vector left behind, the new and
+   * unrelated engram inherited it — and semantic recall ranked it as whatever
+   * the deleted engram used to say.
+   */
+  it('does not let a reused id inherit the removed engram\'s vector', async () => {
+    const removed = mkEngram('ENG-2026-0803-001', 'the original meaning of this identifier')
+    seedYaml(yamlPath, [removed])
+    const adapter = new PGLiteAdapter(yamlPath, dbPath)
+    await adapter.reindex()
+    await adapter.upsertEmbedding(removed.id, stubVec(removed.statement), embeddingContentHash(removed))
+
+    seedYaml(yamlPath, [])
+    await adapter.syncFromYaml()
+
+    // Same id minted again for entirely different content.
+    const reused = mkEngram('ENG-2026-0803-001', 'a completely unrelated later assertion')
+    seedYaml(yamlPath, [reused])
+    await adapter.syncFromYaml()
+
+    expect(await adapter.hasEmbedding(reused.id)).toBe(false)
+    expect(await adapter.embeddingIsCurrent(reused.id, embeddingContentHash(reused))).toBe(false)
+    await adapter.close()
+  }, PGLITE_TIMEOUT)
+
+  /**
+   * Regression guard on the fix's own shape. Adding `ON DELETE CASCADE` to
+   * PGLite — which is what #812 originally proposed for the orphan problem —
+   * would discard every vector on each reindex, because reindex deletes all
+   * engram rows and re-inserts them. That turns a cheap index rebuild into a
+   * full re-embed of the corpus.
+   */
+  it('keeps embeddings across a reindex — the rebuild must not force a re-embed', async () => {
+    const e = mkEngram('ENG-2026-0803-001', 'expensive to embed, cheap to reindex')
+    seedYaml(yamlPath, [e])
+    const adapter = new PGLiteAdapter(yamlPath, dbPath)
+    await adapter.reindex()
+    const hash = embeddingContentHash(e)
+    await adapter.upsertEmbedding(e.id, stubVec(e.statement), hash)
+
+    await adapter.reindex()
+
+    expect(await adapter.embeddingIsCurrent(e.id, hash)).toBe(true)
+    await adapter.close()
+  }, PGLITE_TIMEOUT)
+})
+
+describe('#812 — the backfill pass cannot spin', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-812-loop-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /**
+   * The pass loops until the store stops reporting stale rows, and staleness is
+   * now a hash comparison. A store whose predicate never goes false — a
+   * writer/selector hash disagreement, a broken `search_text`, a hostile
+   * adapter — would previously mean an unbounded background loop pinning a CPU
+   * and re-embedding the same engram forever.
+   *
+   * This adapter lies exactly that way: it accepts every upsert and still
+   * reports the rows as stale. The pass must notice it has already handled
+   * them, warn, and stop.
+   *
+   * It must return a FULL batch to reach the hazard. The loop already returns
+   * early on a short batch — the "tail" heuristic — so only a store that keeps
+   * saturating the batch can drive it round again. That is also the realistic
+   * shape of the bug: a systematic hash disagreement makes every row stale, so
+   * every batch comes back full.
+   */
+  it('stops and warns when a store keeps reporting the same engrams as stale', async () => {
+    const BATCH = 100 // must match PRIMARY_AUTO_EMBED_BATCH in index.ts
+    const staleBatch = Array.from({ length: BATCH }, (_, i) =>
+      mkEngram(`ENG-2026-0803-${String(i + 1).padStart(3, '0')}`, `row ${i} will never be admitted as current`))
+    let upserts = 0
+    const lyingAdapter = {
+      listEngramsMissingEmbeddings: async () => staleBatch,
+      upsertEmbedding: async () => { upserts++ },
+      getVectorColumnDim: async () => null,
+    }
+
+    const plur = new Plur({ path: dir })
+    const { _setCachedEmbedder, resetEmbedder } = await import('../src/embeddings.js')
+    _setCachedEmbedder({
+      name: 'stub-812',
+      dim: DIM,
+      embed: async (text: string) => stubVec(text),
+    } as any)
+    // Collect into a local array rather than reading `warn.mock.calls` later:
+    // `mockRestore()` clears the recorded calls, so asserting after the restore
+    // reads an empty history and passes for the wrong reason.
+    const warnings: string[] = []
+    const warn = vi.spyOn(logger, 'warning').mockImplementation((...args: unknown[]) => {
+      warnings.push(String(args[0]))
+    })
+
+    try {
+      await (plur as any)._autoEmbedPrimaryStore(lyingAdapter)
+    } finally {
+      warn.mockRestore()
+      resetEmbedder()
+    }
+
+    // Terminated instead of spinning, having tried each row exactly once.
+    expect(upserts).toBe(BATCH)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain(staleBatch[0].id)
+  }, PGLITE_TIMEOUT)
+})

--- a/packages/core/test/postgres-auto-embed.test.ts
+++ b/packages/core/test/postgres-auto-embed.test.ts
@@ -305,3 +305,82 @@ describe.skipIf(!PG_URL)('Postgres primary-store auto-embed (#762)', () => {
     }
   }, TIMEOUT)
 })
+
+/**
+ * Embedding staleness on the Postgres tier (#812).
+ *
+ * The anti-join used to ask only `em.engram_id IS NULL`, so an engram whose
+ * text changed kept the vector of its previous text forever — the store had no
+ * column that could even express the question. These pin the `content_hash`
+ * comparison end to end against a real Postgres: the PGLite tier answers it in
+ * JS, this one answers it in SQL (`content_hash IS DISTINCT FROM
+ * md5(search_text)`), and the two derivations have to agree or the backfill
+ * loop's exit condition is unsatisfiable.
+ */
+describe.skipIf(!PG_URL)('Postgres embedding staleness (#812)', () => {
+  let adapter: PostgresAdapter
+  let plur: Plur
+  let dir: string
+
+  beforeAll(async () => {
+    process.env.PLUR_INTENT_ROUTING = 'off'
+    installStubEmbedder()
+    dir = mkdtempSync(join(tmpdir(), 'plur-staleness-812-'))
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema: `${SCHEMA}_812`, vectorIndex: 'exact' })
+    await adapter.save([])
+    plur = new Plur({ path: dir, store: adapter })
+    await plur.ready()
+  }, TIMEOUT)
+
+  afterAll(async () => {
+    resetEmbedder()
+    delete process.env.PLUR_INTENT_ROUTING
+    if (adapter) {
+      await adapter.dropSchema().catch(() => { /* best effort */ })
+      await adapter.close().catch(() => { /* best effort */ })
+    }
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }, TIMEOUT)
+
+  it('re-embeds an engram whose text changed, and stops once it has', async () => {
+    const e = await plur.learn('cats are excellent pets', { scope: 'global', type: 'behavioral' })
+    await plur.waitForIndex()
+    expect(await adapter.listEngramsMissingEmbeddings(1)).toEqual([])
+    const before = await adapter.searchVector(await embed('cats are excellent pets', 'query') as Float32Array, 5)
+    const beforeScore = before.find(h => h.engram.id === e.id)!.score
+
+    // Rewrite the statement in place — same id, different meaning. This is the
+    // dedup UPDATE/MERGE shape from learn-async.ts.
+    const stored = (await adapter.load()).find(x => x.id === e.id)!
+    await adapter.updateMany([{ ...stored, statement: 'databases are excellent stores' }])
+
+    // The store must now volunteer it as needing work (the backfill's question:
+    // the read path's completeness gate deliberately does NOT ask about staleness).
+    const stale = await adapter.listEngramsMissingEmbeddings(10, { includeStale: true })
+    expect(stale.map(s => s.id)).toContain(e.id)
+
+    // ...and one pass must clear it, not report it forever.
+    await (plur as any)._autoEmbedPrimaryStore(adapter)
+    expect(await adapter.listEngramsMissingEmbeddings(1, { includeStale: true })).toEqual([])
+
+    // The vector actually moved: it no longer answers to the OLD text as well.
+    const after = await adapter.searchVector(await embed('cats are excellent pets', 'query') as Float32Array, 5)
+    const afterScore = after.find(h => h.engram.id === e.id)?.score ?? 0
+    expect(afterScore).toBeLessThan(beforeScore)
+  }, TIMEOUT)
+
+  it('re-embeds a legacy row stored without a content hash exactly once', async () => {
+    const e = await plur.learn('written before content hashing existed', { scope: 'global' })
+    await plur.waitForIndex()
+
+    // Simulate a row written by a version predating the column.
+    const pool = await (adapter as any).getPool()
+    await pool.query(`UPDATE "${SCHEMA}_812".engram_embeddings SET content_hash = NULL WHERE engram_id = $1`, [e.id])
+    expect((await adapter.listEngramsMissingEmbeddings(50, { includeStale: true })).map(s => s.id)).toContain(e.id)
+
+    await (plur as any)._autoEmbedPrimaryStore(adapter)
+
+    // Converged — a NULL hash must not mean "stale on every pass forever".
+    expect(await adapter.listEngramsMissingEmbeddings(1, { includeStale: true })).toEqual([])
+  }, TIMEOUT)
+})


### PR DESCRIPTION
Closes #812. Refs #794, #816.

The last open finding from the whole-repo adversarial audit. Not data loss — **silently wrong recall**, which is harder to notice and slower to distrust.

## The bug

`engram_embeddings` held only `(engram_id, embedding)`, and the backfill asked exactly one question:

```sql
WHERE e.status = 'active' AND em.engram_id IS NULL
```

Nothing could notice that an engram's *text* had changed, because the table had no column that could express it. A dedup UPDATE/MERGE could rewrite a statement from "cats" to "databases" and semantic recall would keep ranking it as "cats" — the engram on disk correct, the vector answering for it not.

## The fix

`content_hash` — md5 of the exact text embedded — stored beside each vector on both tiers, added by an idempotent `ADD COLUMN IF NOT EXISTS` in the existing `ensureSchema` path. Same shape as the `tokens` / `search_text` columns already there, so deployments gain it on next connect. **No migration step.**

Postgres compares in SQL (`content_hash IS DISTINCT FROM md5(search_text)`), so the backfill stays one set-based anti-join per batch. PGLite — whose `engrams` table has no `search_text` — compares in JS. `embeddingContentHash` hashes the same derivation `deriveRow` writes into `search_text`, and a unit test pins that equality directly, since the two agreeing is the whole basis of the SQL comparison.

The writer hashes **the text it actually embedded** rather than letting the store re-derive it. An engram updated between the batch read and the upsert would otherwise get a hash of the new text attached to a vector of the old — permanently stale while claiming to be current. Hashing what we embedded makes that case self-healing.

## Three hazards the fix itself introduced

These are the interesting part of the review.

**Staleness must not open the read path's completeness gate.** That gate shares this method and exists to catch engrams *invisible* to the vector leg; a stale vector still returns its engram, just ranked by older text. My first version wired staleness into it — which put every semantic recall on the O(N) in-memory fallback until the backfill drained. One edited engram, whole-store performance cliff, exactly the regression this tier exists to avoid. **The existing poisoned-vector test caught it.** The question is now explicit: the backfill passes `includeStale`, the gate does not, and edits kick the backfill from the write path anyway.

**PGLite must not get the cascading FK the issue proposed.** `reindex()` deletes every engram row and re-inserts it, deliberately leaving embeddings intact. `ON DELETE CASCADE` would empty the table on every reindex, turning a cheap index rebuild into a full re-embed. Orphans are swept set-wise in `syncFromYaml` instead — which also closes the concrete harm, since `generateEngramId` mints `max(same-day id) + 1`, so compacting the highest engram of a day frees its ID and the next unrelated `learn()` used to inherit the dead vector.

**The backfill loop now exits on a hash comparison**, so a writer/selector disagreement would return the same rows forever — an unbounded background pass pinning a core. The pass refuses to revisit an ID within one run and warns instead. Reaching that guard needs a *full* batch, since the loop already returns early on a short one; the test drives it that way.

Plus: a row written before the column existed hashes to NULL, and `NULL IS DISTINCT FROM` a real hash is TRUE — permanently. Guarded on both tiers, so such rows embed **once** rather than on every pass.

## Verification

Full suite with `PLUR_TEST_POSTGRES_URL` against a real pgvector Postgres:

**3789 passed, 0 failed** (36 skipped — versus 145 skipped without a database, so this run covered materially more than a default CI run). `typecheck:tests` clean.

Ten new PGLite/unit tests and two Postgres-tier tests, including a regression guard for each hazard above.

## Carved out

The ID-reuse hazard #812 also raised is filed as **#816**. It corrupts history records, backup diffs and `supersedes` edges, has nothing to do with embeddings, and needs a store-format decision rather than a patch. The embedding-specific symptom is closed here by the orphan sweep.