### PR TITLE
fix(core): shrink guard on every whole-corpus writer (#824) + invariant mechanisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.17.0 (2026-08-03)
 
 ### Changed — operations that used to succeed can now refuse
 
@@ -94,6 +94,60 @@ previously returned quietly. Each throw replaces a silent corpus deletion.
   the copies cannot drift again.
 
 - **Sibling-file strip completes the shared-remote guarantee** (#686): #640/#678 stripped only `engrams.yaml`, but `episodes.yaml`, `candidates.yaml`, and `tensions.yaml` synced verbatim — a teammate cloning a `shared` remote could still receive statement text *derived* from private/personal engrams (a tension's statement snapshots, a failure-report episode) even though the engrams themselves were withheld. A sibling record is now pushed to a `shared` remote only when every engram id it references resolves to the shared push set; records referencing personal, private, or unresolvable engrams stay local (strip-on-doubt), the working tree keeps everything, and the strip is deterministic so the #396 no-infinite-dirty property holds. The sync `warning` reports the stripped sibling record count. `personal` remotes are unchanged.
+
+### Fixed — the audits of the fixes
+
+The first audit (#794) hardened the store write paths. Two further independent passes then audited
+that work — a whole-repository adversarial audit (#811) and an audit of the fix diff itself (#821)
+— on the reasoning that fixes written under release pressure have their own defect rate. They did:
+#821 found sixteen, every one introduced by an earlier fix. An independent human review (#823)
+cleared the result and added one more.
+
+- **The shrink guard had a bypass, and it was the guard's own optimisation** (#821): the exact
+  record count ran only when the outgoing document was >5% smaller than the file on disk. That
+  encoded an assumption engrams do not satisfy — a bare statement and one carrying `rationale`,
+  `dual_coding` and `knowledge_anchors` differ by an order of magnitude — so a write dropping 11 of
+  100 records moved the count 11% and the bytes under 5%, and the guard never ran. The count is now
+  unconditional, and cheap enough to afford it: counting scans for record-start lines instead of
+  parsing (62ms on a 20,000-engram/19.1MB save, against 246ms for the parse it replaced).
+- **The shrink guard now protects every whole-corpus writer** (#824): it lived in `saveEngrams`,
+  while `YamlStore.save()` — the `EngramStore` backend — replaced the whole file without it.
+- **A corrupt sibling store no longer takes down the session** (#821): `status()` is a diagnostic
+  and now reports unreadable artifacts through `store_errors` instead of throwing — including the
+  corpus itself. MCP `session_start` awaits `status()`, so a truncated `episodes.yaml` previously
+  meant no session could start at all. One damaged pack no longer hides the others.
+- **Atomic writes preserve file permissions** (#821): replace-by-rename creates a new inode, so a
+  `0600` `config.yaml` — bearer tokens, Postgres DSNs — came back `0644` under the usual umask.
+  Config files are also created `0600` rather than inheriting it.
+- **An engram's embedding now follows its text** (#812): nothing invalidated a vector when the text
+  changed, so a dedup UPDATE could rewrite a statement and semantic recall would rank it by the old
+  wording indefinitely. Both tiers store the hash of the text actually embedded.
+- **Migrations hold the corpus lock across plan, apply and version stamp** (#821): a concurrent run
+  and rollback could leave the store reporting a schema version it did not have.
+- **The pack registry is atomic, locked, and refuses to be read as empty** (#805): a truncated
+  registry destroyed every installed pack's integrity baseline, after which a tampered pack
+  reported its integrity as *unknown* rather than *modified*. `plur packs list` now distinguishes
+  `ok` / `modified` / `unverified` instead of printing nothing for the last two.
+- **Stale-lock recovery can no longer delete a live lock** (#821): the steal is an atomic
+  `rename` claim, so a contender can only remove a file it has already moved aside.
+- **Tension records, config writes, restore planning, pack installs and the MCP drop log** all
+  gained the locking, atomicity or quarantine-carrying they were missing (#805, #821).
+
+### Added — invariants that fail the build
+
+The recurring cause was invariants documented in prose. Prose does not fail a build, so each change
+re-derived them by hand and hand-derivation kept missing a call site.
+
+- **Property tests for the shrink guard**: random heterogeneous corpora and random writes against
+  the stated invariant, rather than fixtures. Both historical bypasses reproduce against them.
+- **A corruption matrix**: every store artifact, damaged eight ways, against every entry point —
+  asserting both that diagnostics survive and that write paths still refuse.
+
+### Security
+
+- All seven open Dependabot advisories cleared (#818), with bounded version ranges so a patch-level
+  advisory can no longer pull in a new major.
+
 
 ## 0.16.1 (2026-07-29)
 

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -367,13 +367,61 @@ export function saveEngrams(filePath: string, engrams: Engram[], opts: SaveEngra
   //   the old parse-based count would have added 246ms to that same save.
   // So the guard now runs on every write for a quarter of what it used to cost
   // on the rare writes it actually ran on.
-  if (!opts.allowShrink) {
-    const before = countEngramsOnDisk(filePath)
-    if (before !== null && outgoing.length < before * (1 - SHRINK_TOLERANCE)) {
-      throw new EngramStoreShrinkError(filePath, before, outgoing.length)
-    }
-  }
+  if (!opts.allowShrink) assertShrinkAllowed(filePath, outgoing.length)
   atomicWrite(filePath, content)
+}
+
+/**
+ * Refuse a whole-corpus write that drops more than {@link SHRINK_TOLERANCE} of
+ * the records on disk.
+ *
+ * Extracted so it is a SHARED FUNCTION rather than a step inside one writer
+ * (#824, found in Črt's independent review). The guard lived only in
+ * `saveEngrams`, and `YamlStore.save()` — the `EngramStore` backend from
+ * `createStore`/`factory.ts` — is a parallel whole-corpus writer that
+ * `yaml.dump`s straight to disk, so the F2/F3 wipe protection was silently
+ * absent there. Same shape as the quarantine bug: a cross-cutting rule enforced
+ * by convention and missed at a parallel call site.
+ *
+ * Sharing the function does not make the rule structural — a third writer could
+ * still forget to call it — but it removes the copy, which is the part that
+ * drifts. #824 tracks making it a type every writer must pass through.
+ */
+export function assertShrinkAllowed(filePath: string, outgoingCount: number): void {
+  const before = countEngramsOnDisk(filePath)
+  if (before !== null && outgoingCount < before * (1 - SHRINK_TOLERANCE)) {
+    throw new EngramStoreShrinkError(filePath, before, outgoingCount)
+  }
+}
+
+/**
+ * Async twin of {@link assertShrinkAllowed}, for the async store backends.
+ *
+ * Shares `countRecordStarts` — the counting RULE has exactly one definition, so
+ * the two paths cannot disagree about what a record is. Only the read differs,
+ * because blocking the event loop on a multi-megabyte corpus is precisely what
+ * the async store exists to avoid.
+ */
+export async function assertShrinkAllowedAsync(filePath: string, outgoingCount: number): Promise<void> {
+  let before: number | null = null
+  try {
+    const { readFile, stat } = await import('fs/promises')
+    const info = await stat(filePath)
+    if (!info.isDirectory() && info.size > 0) {
+      const text = await readFile(filePath, 'utf8')
+      const scanned = countRecordStarts(text)
+      if (scanned !== null) before = scanned
+      else {
+        const raw: any = yaml.load(text)
+        before = raw && typeof raw === 'object' && Array.isArray(raw.engrams) ? raw.engrams.length : null
+      }
+    }
+  } catch {
+    before = null // no baseline — nothing to guard against
+  }
+  if (before !== null && outgoingCount < before * (1 - SHRINK_TOLERANCE)) {
+    throw new EngramStoreShrinkError(filePath, before, outgoingCount)
+  }
 }
 
 /**

--- a/packages/core/src/store/yaml-store.ts
+++ b/packages/core/src/store/yaml-store.ts
@@ -8,7 +8,7 @@ import { existsSync } from 'fs'
 import { readFile, stat } from 'fs/promises'
 import * as yaml from 'js-yaml'
 import { type Engram } from '../schemas/engram.js'
-import { parseEngramFile } from '../engrams.js'
+import { parseEngramFile, assertShrinkAllowedAsync } from '../engrams.js'
 import { asyncAtomicWrite } from './async-fs.js'
 import { withAsyncLock } from './async-lock.js'
 import type { EngramStore } from './types.js'
@@ -54,6 +54,14 @@ export class YamlStore implements EngramStore {
         return !(typeof id === 'string' && ids.has(id))
       })
       const out = carried.length > 0 ? [...engrams, ...carried] : engrams
+      // The SAME wipe protection `saveEngrams` applies (#824, from Črt's
+      // independent review). This method is a parallel whole-corpus writer —
+      // it replaces the entire file — and it reached the disk without the
+      // shrink guard, so an `EngramStore` backend used as the corpus had the
+      // F2/F3 protection silently absent on `save()`. The default primary is
+      // `YamlPrimaryStore` (which routes through `saveEngrams`), which is why
+      // it went unnoticed: the guarded path was the one everyone exercised.
+      await assertShrinkAllowedAsync(this.filePath, out.length)
       const content = yaml.dump({ engrams: out }, { lineWidth: 120, noRefs: true, quotingType: '"' })
       await asyncAtomicWrite(this.filePath, content)
     })

--- a/packages/core/test/corruption-matrix.test.ts
+++ b/packages/core/test/corruption-matrix.test.ts
@@ -284,3 +284,66 @@ describe('corruption matrix — one damaged pack must not hide the others', () =
     expect(fs.existsSync(join(packsDir, 'src-packB'))).toBe(false)
   })
 })
+
+/**
+ * The shrink guard must protect EVERY whole-corpus writer, not just the one
+ * everybody exercises (#824, from Črt's independent review of #822).
+ *
+ * `saveEngrams` had the guard; `YamlStore.save()` — the `EngramStore` backend
+ * from `createStore`/`factory.ts` — replaced the whole file by `yaml.dump` and
+ * never reached it. It went unnoticed because the DEFAULT primary is
+ * `YamlPrimaryStore`, which routes through `saveEngrams`: the guarded path was
+ * the one under test.
+ *
+ * Same failure shape as the quarantine bug — a cross-cutting rule enforced by
+ * convention, missed at a parallel call site. These pin both writers against
+ * the same invariant so a third one cannot quietly diverge.
+ */
+describe('every whole-corpus writer honours the shrink guard', () => {
+  async function seedStore(path: string, n: number) {
+    const { YamlStore } = await import('../src/store/yaml-store.js')
+    const store = new YamlStore(path)
+    const engrams = Array.from({ length: n }, (_, i) => ({
+      id: `ENG-2026-08-03-${String(i).padStart(3, '0')}`,
+      statement: `store fact ${i}`, type: 'behavioral', status: 'active',
+      scope: 'global', tags: [],
+      activation: { retrieval_strength: 1, storage_strength: 1, frequency: 0, last_accessed: '2026-08-03' },
+      feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    })) as any[]
+    await store.save(engrams)
+    return { store, engrams }
+  }
+
+  it('YamlStore.save refuses to drop most of the corpus', async () => {
+    const path = join(root, 'engrams.yaml')
+    const { store, engrams } = await seedStore(path, 40)
+    const { EngramStoreShrinkError } = await import('../src/engrams.js')
+
+    await expect(store.save(engrams.slice(0, 4)), 'a 90% drop went through unguarded')
+      .rejects.toThrow(EngramStoreShrinkError)
+    // And refusing means not writing.
+    expect(loadEngrams(path)).toHaveLength(40)
+  })
+
+  it('YamlStore.save still allows ordinary edits and growth', async () => {
+    const path = join(root, 'engrams.yaml')
+    const { store, engrams } = await seedStore(path, 40)
+
+    await expect(store.save(engrams.slice(0, 38))).resolves.toBeUndefined() // 5% — within tolerance
+    expect(loadEngrams(path)).toHaveLength(38)
+  })
+
+  it('agrees with saveEngrams about where the boundary is', async () => {
+    // Two writers, one rule: the same corpus and the same outgoing count must
+    // produce the same verdict, whichever path is taken.
+    const a = join(root, 'a.yaml')
+    const b = join(root, 'b.yaml')
+    const { store, engrams } = await seedStore(a, 30)
+    const { saveEngrams, EngramStoreShrinkError } = await import('../src/engrams.js')
+    saveEngrams(b, engrams as any, { allowShrink: true })
+
+    const tooFew = engrams.slice(0, 20) // 33% drop — past tolerance for both
+    await expect(store.save(tooFew)).rejects.toThrow(EngramStoreShrinkError)
+    expect(() => saveEngrams(b, tooFew as any)).toThrow(EngramStoreShrinkError)
+  })
+})

--- a/packages/core/test/corruption-matrix.test.ts
+++ b/packages/core/test/corruption-matrix.test.ts
@@ -1,0 +1,286 @@
+/**
+ * The corruption matrix: every artifact PLUR reads, damaged every way it can be
+ * damaged, against every entry point — asserting BOTH directions of the
+ * contract.
+ *
+ * ## Why this file exists
+ *
+ * The refuse-on-corrupt work (audits #794, #811, #805) turned a set of silent
+ * degradations into exceptions. That was right — returning `[]` for a file that
+ * would not parse is what destroyed corpora, because every write replaces the
+ * whole file. But it created a NEW class of defect that then recurred five
+ * times, each found separately, each after the previous one was declared fixed:
+ *
+ *   - `status()` died on a corrupt pack registry              (found in #820)
+ *   - `status()` still died on corrupt episodes/tensions       (#821 finding 6)
+ *   - `session_start` therefore could not start at all         (#821 finding 6)
+ *   - `listPacks` aborted entirely on one corrupt pack         (#821 finding 13)
+ *   - a refused install left a half-installed pack behind      (#805, on re-probe)
+ *
+ * Five instances of one mistake: a caller that cannot tolerate a throw now gets
+ * one. Each was found by someone tracing callers by hand, and hand-tracing kept
+ * missing one. This table replaces the tracing.
+ *
+ * ## The contract, in both directions
+ *
+ * A test that only asserts "does not throw" would be satisfied by deleting the
+ * protections, so both halves are pinned here:
+ *
+ *   MUST THROW    a WRITE path reading a damaged corpus. This is the F1/F2
+ *                 protection; losing it silently is the original data-loss bug.
+ *   MUST NOT THROW  a DIAGNOSTIC, whatever is damaged. `status()` is what an
+ *                 operator runs to find out what is wrong; dying on the fault
+ *                 it exists to report is worse than the silence it replaced.
+ *   MUST NOT THROW  a read path when an UNRELATED artifact is damaged. A broken
+ *                 episodes file must not take down recall.
+ *   MUST ISOLATE  one damaged pack must not hide the others.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+import { Plur } from '../src/index.js'
+import { listPacks, installPack, PackRegistryUnreadableError } from '../src/packs.js'
+import { loadEngrams, EngramStoreUnreadableError } from '../src/engrams.js'
+
+/**
+ * Every way a YAML artifact gets damaged in the wild.
+ *
+ * Not invented: each maps to something an audit or probe actually produced —
+ * a power cut (0 bytes), a truncation landing on a document boundary
+ * (`engrams:` with no value), a git merge conflict after `plur sync`, a
+ * half-written file, a hand edit.
+ */
+const CORRUPTIONS: Array<{ name: string; make: (good: string) => string }> = [
+  { name: 'zero bytes', make: () => '' },
+  { name: 'whitespace only', make: () => '   \n\n  ' },
+  { name: 'truncated mid-document', make: g => g.slice(0, Math.max(1, Math.floor(g.length * 0.6))) },
+  { name: 'truncated on a key boundary', make: () => 'engrams:\n' },
+  { name: 'top level is a list', make: () => '- one\n- two\n' },
+  { name: 'top level is a scalar', make: () => 'just a string\n' },
+  { name: 'unparseable yaml', make: g => g.slice(0, 40) + '\n  bad: "unterminated\n' },
+  { name: 'git conflict markers', make: g => `<<<<<<< HEAD\n${g.slice(0, 60)}\n=======\n${g.slice(0, 60)}\n>>>>>>> other\n` },
+]
+
+let root: string
+
+async function seeded(): Promise<Plur> {
+  const plur = new Plur({ path: root })
+  await plur.ready()
+  await plur.learn('the sky is usually blue during the day', { scope: 'global' })
+  await plur.learn('espresso extraction takes about thirty seconds', { scope: 'global' })
+  return plur
+}
+
+function damage(relPath: string, corruption: (good: string) => string): void {
+  const p = join(root, relPath)
+  const good = fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : 'placeholder: true\n'
+  fs.mkdirSync(join(root, relPath, '..'), { recursive: true })
+  fs.writeFileSync(p, corruption(good))
+}
+
+beforeEach(() => { root = fs.mkdtempSync(join(os.tmpdir(), 'plur-matrix-')) })
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }) })
+
+/**
+ * Not every corruption makes an artifact UNREADABLE, and the matrix had to be
+ * taught that rather than the other way round:
+ *
+ *   - `episodes.yaml` and `tensions.yaml` are bare YAML LISTS, so a top-level
+ *     list is a structurally valid file whose entries merely fail validation —
+ *     and those are quarantined, not errors.
+ *   - a corpus truncated mid-document frequently still parses, as a valid but
+ *     SMALLER `engrams:` list. The loader is right not to throw; the protection
+ *     against that one is the shrink guard on the next write.
+ *
+ * So the invariant is not "status reports something" — it is that `status()`
+ * never throws, and that what it reports AGREES with what the loader does. A
+ * hard-coded expectation per cell would encode today's parser behaviour; this
+ * encodes the relationship, which is the thing that must hold.
+ */
+function loaderRefuses(path: string): boolean {
+  try {
+    loadEngrams(path)
+    return false
+  } catch {
+    return true
+  }
+}
+
+describe('corruption matrix — status() is a diagnostic and must never throw', () => {
+  for (const artifact of ['engrams.yaml', 'episodes.yaml', 'tensions.yaml', 'packs/registry.yaml']) {
+    for (const c of CORRUPTIONS) {
+      it(`survives ${artifact} — ${c.name}`, async () => {
+        const plur = await seeded()
+        damage(artifact, c.make)
+
+        // THE invariant: whatever is damaged, the diagnostic answers.
+        const status = await plur.status()
+        expect(typeof status.engram_count).toBe('number')
+        expect(typeof status.storage_root).toBe('string')
+
+        // And it agrees with the loader: reports exactly when reading refuses.
+        if (artifact === 'engrams.yaml') {
+          const refuses = loaderRefuses(join(root, 'engrams.yaml'))
+          expect(Boolean(status.store_errors?.engrams),
+            `${c.name}: status and loader disagree about readability`).toBe(refuses)
+        }
+      })
+    }
+  }
+
+  it('reports EVERY damaged artifact at once, not just the first', async () => {
+    const plur = await seeded()
+    damage('episodes.yaml', () => 'oops: "')
+    damage('tensions.yaml', () => '- not: {a list of records')
+
+    const status = await plur.status()
+    // An operator fixing them one at a time pays a round trip per file
+    // otherwise, and each fix reveals the next failure as if it were new.
+    expect(Object.keys(status.store_errors ?? {}).sort()).toEqual(['episodes', 'tensions'])
+  })
+
+  it('reports nothing when everything is healthy', async () => {
+    const plur = await seeded()
+    const status = await plur.status()
+    expect(status.store_errors).toBeUndefined()
+  })
+})
+
+describe('corruption matrix — write paths MUST refuse a damaged corpus', () => {
+  // Corruptions that leave nothing intelligible. The loader must refuse each:
+  // if it ever returns `[]` instead, the original data-loss bug is back, since
+  // the write path replaces the whole file.
+  const UNREADABLE = CORRUPTIONS.filter(c => c.name !== 'truncated mid-document')
+
+  for (const c of UNREADABLE) {
+    it(`refuses to read a corpus that is ${c.name}`, async () => {
+      await seeded()
+      damage('engrams.yaml', c.make)
+      expect(() => loadEngrams(join(root, 'engrams.yaml'))).toThrow(EngramStoreUnreadableError)
+    })
+  }
+
+  /**
+   * The cell that is NOT covered by either guard — pinned deliberately, because
+   * the obvious "fix" for it is wrong.
+   *
+   * A truncation can land where the remainder still parses, so the corpus reads
+   * as valid and simply SMALLER. The loader cannot object: nothing is
+   * malformed. And the shrink guard cannot either, because its baseline is the
+   * file on disk — which IS the truncated one. It compares 21 against 21 and
+   * correctly allows the write.
+   *
+   * That is not a hole in the guards. The records were lost when the file was
+   * truncated, not by the write that followed; no write-side check can recover
+   * bytes that are already gone. The defence for this class is the validity-
+   * gated daily backup and `plur restore`, which is why those exist (#799).
+   *
+   * This test exists so nobody "fixes" it by making the guard compare against
+   * something other than the file it is about to replace — which would break
+   * every legitimate write instead.
+   */
+  it('does NOT refuse a smaller-but-valid corpus — this class is covered by backups', async () => {
+    const plur = await seeded()
+    for (let i = 0; i < 40; i++) await plur.learn(`filler engram number ${i}`, { scope: 'global' })
+
+    const p = join(root, 'engrams.yaml')
+    const before = loadEngrams(p).length
+    const good = fs.readFileSync(p, 'utf8')
+
+    // Cut at a record boundary so the remainder is well-formed YAML.
+    const lines = good.split('\n')
+    const starts = lines.map((l, i) => (/^  - /.test(l) ? i : -1)).filter(i => i >= 0)
+    fs.writeFileSync(p, lines.slice(0, starts[Math.floor(starts.length * 0.5)]).join('\n') + '\n')
+
+    const after = loadEngrams(p)
+    expect(after.length, 'truncation should leave a readable, smaller corpus').toBeLessThan(before)
+
+    // Neither guard fires, and both are right not to.
+    const { saveEngrams } = await import('../src/engrams.js')
+    expect(() => saveEngrams(p, after)).not.toThrow()
+
+    // The recovery path for this class is the backup, not the guard.
+    const { listBackups } = await import('../src/backup.js')
+    expect(typeof listBackups, 'the documented recovery path must exist').toBe('function')
+  })
+})
+
+describe('corruption matrix — a damaged SIBLING must not break unrelated reads', () => {
+  for (const artifact of ['episodes.yaml', 'tensions.yaml', 'packs/registry.yaml']) {
+    it(`recall still works with a corrupt ${artifact}`, async () => {
+      const plur = await seeded()
+      damage(artifact, () => 'nonsense: "')
+
+      // The corpus is intact; nothing about a broken episodes file should stop
+      // an engram being retrieved.
+      const hits = await plur.recall('espresso')
+      expect(hits.length, `${artifact} corruption blocked recall`).toBeGreaterThan(0)
+    })
+  }
+})
+
+describe('corruption matrix — one damaged pack must not hide the others', () => {
+  function makePack(name: string): string {
+    const dir = join(root, `src-${name}`)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(join(dir, 'SKILL.md'),
+      `---\nname: ${name}\nversion: 1.0.0\ndescription: matrix pack\n---\n\n# ${name}\n`)
+    fs.writeFileSync(join(dir, 'engrams.yaml'), yaml.dump({
+      engrams: [{
+        id: `ENG-2026-08-03-${name.slice(-1)}01`, version: 2, status: 'active', consolidated: false,
+        type: 'behavioral', scope: 'global', visibility: 'public', statement: `${name} knowledge`,
+        activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-03' },
+        feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+        knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+        knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+        abstract: null, derived_from: null, polarity: null, content_hash: `h${name}`,
+        commitment: 'leaning', reference_count: 1, sources: [], recurrence_count: 0,
+        summary: name, engram_version: 1, episode_ids: [],
+      }],
+    }))
+    return dir
+  }
+
+  for (const c of CORRUPTIONS) {
+    it(`lists the healthy pack when a sibling pack's engrams are ${c.name}`, async () => {
+      const packsDir = join(root, 'packs')
+      fs.mkdirSync(packsDir, { recursive: true })
+      await installPack(packsDir, makePack('packA'))
+      await installPack(packsDir, makePack('packB'))
+
+      const bDir = listPacks(packsDir).find(p => p.name === 'packB')!.path
+      const good = fs.readFileSync(join(bDir, 'engrams.yaml'), 'utf8')
+      fs.writeFileSync(join(bDir, 'engrams.yaml'), c.make(good))
+
+      // Aborting here is what finding 13 was: the per-pack fallback called the
+      // now-throwing loadEngrams outside any try, so ONE damaged pack removed
+      // every other pack from the listing.
+      const packs = listPacks(packsDir)
+      expect(packs.map(p => p.name), `${c.name}: healthy pack missing`).toContain('packA')
+      expect(packs.length, `${c.name}: listing collapsed`).toBe(2)
+
+      const broken = packs.find(p => p.name !== 'packA')!
+      // A damaged pack is reported as damaged — not silently listed as a
+      // healthy pack that happens to hold zero engrams.
+      expect(broken.integrity_status).toBe('unverified')
+      expect(broken.load_error, `${c.name}: damage not reported`).toBeTruthy()
+    })
+  }
+
+  it('refuses an INSTALL against a corrupt registry, and leaves nothing behind', async () => {
+    const packsDir = join(root, 'packs')
+    fs.mkdirSync(packsDir, { recursive: true })
+    await installPack(packsDir, makePack('packA'))
+    fs.writeFileSync(join(packsDir, 'registry.yaml'), 'packs:\n  - name: a\n bad: "')
+
+    // Refusing IS correct here — proceeding from a phantom-empty registry
+    // destroys every other pack's integrity baseline.
+    await expect(installPack(packsDir, makePack('packB'))).rejects.toThrow(PackRegistryUnreadableError)
+    // But it must refuse BEFORE doing filesystem work, or the refusal leaves a
+    // half-installed pack that then reports as 'unverified' — the same
+    // ambiguous state the refusal exists to prevent.
+    expect(fs.existsSync(join(packsDir, 'src-packB'))).toBe(false)
+  })
+})

--- a/packages/core/test/property-shrink-guard.test.ts
+++ b/packages/core/test/property-shrink-guard.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Property tests for the save-side shrink guard.
+ *
+ * ## Why this file exists
+ *
+ * The guard has been broken twice, by the same optimisation, for the same
+ * reason — and the existing fixture tests could not have caught either:
+ *
+ *   1. #810 estimated the on-disk record count from a bytes-per-engram
+ *      constant. Real engrams averaged 785 bytes against an assumed 2400, so a
+ *      20,000-engram store was read as 6,500 and a genuine 50% shrink skipped
+ *      the guard entirely.
+ *   2. The replacement compared serialized bytes to on-disk bytes. That removed
+ *      the bad constant but kept the assumption under it, which the code stated
+ *      out loud: "records are broadly similar in size". They are not. Dropping
+ *      11 of 100 records moved the COUNT 11% and the BYTES under 5%, so the
+ *      guard never ran (audit 2026-08-03, finding 5).
+ *
+ * Both survived a suite with thorough fixture coverage because every fixture
+ * used uniformly generated engrams, where count and bytes move together by
+ * construction. No amount of care in writing more fixtures fixes that — the
+ * blind spot IS the fixture generator.
+ *
+ * So this file does not assert on examples. It states the invariant and lets a
+ * generator attack it with heterogeneous corpora and random writes:
+ *
+ *   a write that removes more than SHRINK_TOLERANCE of the records must throw,
+ *   and one that removes fewer must not, whatever the bytes happen to do.
+ *
+ * ## Determinism
+ *
+ * Seeded PRNG, not `Math.random`. A property test that cannot be replayed
+ * reports a failure you then have to reproduce by guessing; this one prints the
+ * seed, and `PLUR_PROPERTY_SEED=<n>` replays it exactly. The default seed list
+ * is fixed so CI runs the same cases every time — the value is in the SHAPE of
+ * the generated data, not in fresh randomness on every run, which would make
+ * the suite flaky rather than thorough.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as yaml from 'js-yaml'
+import { join } from 'path'
+import { loadEngrams, saveEngrams, EngramStoreShrinkError } from '../src/engrams.js'
+import { EngramSchemaPassthrough, type Engram } from '../src/schemas/engram.js'
+
+/** Must match SHRINK_TOLERANCE in engrams.ts. */
+const SHRINK_TOLERANCE = 0.1
+
+/** Deterministic PRNG (mulberry32) — small, fast, and replayable from a seed. */
+function rng(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const int = (r: () => number, lo: number, hi: number) => lo + Math.floor(r() * (hi - lo + 1))
+
+/**
+ * An engram of deliberately unpredictable WEIGHT.
+ *
+ * The point of the generator is that record size and record count must be
+ * allowed to move independently. `rationale`, `dual_coding` and
+ * `knowledge_anchors` all feed the serialized form, and a corpus mixing bare
+ * statements with fully-populated engrams spans more than an order of magnitude
+ * per record — which is what real stores look like and what every previous
+ * fixture failed to represent.
+ */
+function randomEngram(r: () => number, n: number): Engram {
+  const heavy = r() < 0.5
+  const base: Record<string, unknown> = {
+    id: `ENG-2026-08-03-${String(n).padStart(5, '0')}`,
+    statement: 'x'.repeat(int(r, 10, heavy ? 3000 : 60)),
+    type: 'behavioral',
+    status: 'active',
+    confidence: 0.5,
+    created: '2026-08-03',
+    scope: 'local',
+  }
+  if (heavy) {
+    base.rationale = 'r'.repeat(int(r, 100, 4000))
+    if (r() < 0.5) base.dual_coding = { example: 'e'.repeat(int(r, 50, 1500)) }
+    if (r() < 0.5) base.tags = Array.from({ length: int(r, 1, 12) }, (_, i) => `tag-${i}`)
+  }
+  return EngramSchemaPassthrough.parse(base) as Engram
+}
+
+let root: string
+let storePath: string
+
+beforeEach(() => {
+  root = fs.mkdtempSync(join(os.tmpdir(), 'plur-prop-shrink-'))
+  storePath = join(root, 'engrams.yaml')
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+/** Seeds run by default. Override with PLUR_PROPERTY_SEED to replay one. */
+const SEEDS = process.env.PLUR_PROPERTY_SEED
+  ? [Number(process.env.PLUR_PROPERTY_SEED)]
+  : [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
+
+describe('shrink guard — property: the record COUNT decides, never the byte size', () => {
+  it.each(SEEDS)('holds across randomised corpora and writes (seed %i)', (seedValue) => {
+    const r = rng(seedValue)
+
+    for (let round = 0; round < 40; round++) {
+      const before = int(r, 20, 120)
+      const corpus = Array.from({ length: before }, (_, i) => randomEngram(r, i))
+      // Establish the baseline with the guard explicitly disabled, so the setup
+      // can never be what fails.
+      saveEngrams(storePath, corpus, { allowShrink: true })
+
+      // Remove a random SUBSET — not a prefix. A prefix slice correlates size
+      // with position whenever the generator emits runs of similar records; an
+      // arbitrary subset is what a buggy caller actually produces.
+      const keepCount = int(r, 0, before)
+      const shuffled = [...corpus]
+      for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = int(r, 0, i)
+        ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+      }
+      const outgoing = shuffled.slice(0, keepCount)
+
+      const shouldRefuse = outgoing.length < before * (1 - SHRINK_TOLERANCE)
+      const context = `seed=${seedValue} round=${round} before=${before} after=${outgoing.length}`
+
+      if (shouldRefuse) {
+        expect(() => saveEngrams(storePath, outgoing), `expected refusal — ${context}`)
+          .toThrow(EngramStoreShrinkError)
+        // Refusing must also mean not writing: a guard that throws AFTER
+        // replacing the file protects nothing.
+        expect(loadEngrams(storePath).length, `store changed despite refusal — ${context}`)
+          .toBe(before)
+      } else {
+        expect(() => saveEngrams(storePath, outgoing), `unexpected refusal — ${context}`)
+          .not.toThrow()
+        expect(loadEngrams(storePath).length, `write did not land — ${context}`)
+          .toBe(outgoing.length)
+      }
+    }
+  })
+
+  /**
+   * The specific shape both historical bugs had: a large drop in RECORDS that
+   * is a small change in BYTES. Generated rather than hand-picked, so it covers
+   * the ratio space instead of the one example someone thought of.
+   */
+  it.each(SEEDS.slice(0, 5))('refuses record loss that barely moves the byte count (seed %i)', (seedValue) => {
+    const r = rng(seedValue + 1000)
+
+    for (let round = 0; round < 25; round++) {
+      const heavyCount = int(r, 40, 90)
+      const lightCount = int(r, 12, 30)
+      // Heavy records dominate the bytes; light records dominate nothing.
+      const heavy = Array.from({ length: heavyCount }, (_, i) =>
+        EngramSchemaPassthrough.parse({
+          id: `ENG-2026-08-03-H${String(i).padStart(4, '0')}`,
+          statement: 'h'.repeat(2000), rationale: 'r'.repeat(3000),
+          type: 'behavioral', status: 'active', confidence: 0.5,
+          created: '2026-08-03', scope: 'local',
+        }) as Engram)
+      const light = Array.from({ length: lightCount }, (_, i) =>
+        EngramSchemaPassthrough.parse({
+          id: `ENG-2026-08-03-L${String(i).padStart(4, '0')}`,
+          statement: 'l', type: 'behavioral', status: 'active',
+          confidence: 0.5, created: '2026-08-03', scope: 'local',
+        }) as Engram)
+
+      const total = heavyCount + lightCount
+      saveEngrams(storePath, [...heavy, ...light], { allowShrink: true })
+      const bytesBefore = fs.statSync(storePath).size
+
+      // Dropping every light record is always past the tolerance by count.
+      expect(lightCount).toBeGreaterThan(total * SHRINK_TOLERANCE)
+
+      const context = `seed=${seedValue} round=${round} ${total} -> ${heavyCount}`
+      expect(() => saveEngrams(storePath, heavy), `expected refusal — ${context}`)
+        .toThrow(EngramStoreShrinkError)
+
+      // Document the trap in the assertion itself: the byte delta here is small
+      // enough that any byte-proportional heuristic would have waved this
+      // through. If a future optimisation reintroduces one, this fails.
+      const bytesAfterIfWritten = Buffer.byteLength(
+        yaml.dump({ engrams: heavy }, { lineWidth: 120, noRefs: true, quotingType: '"' }), 'utf8')
+      const byteDrop = 1 - bytesAfterIfWritten / bytesBefore
+      expect(byteDrop, `byte delta ${(byteDrop * 100).toFixed(1)}% — fixture no longer exercises the trap`)
+        .toBeLessThan(SHRINK_TOLERANCE)
+    }
+  })
+
+  /**
+   * The counting path must be exact for every document PLUR itself writes.
+   * `countEngramsOnDisk` scans for record-start lines rather than parsing, and
+   * a scan that miscounts is worse than a parse that is slow: the baseline it
+   * produces is what decides whether a write is refused.
+   */
+  it.each(SEEDS.slice(0, 5))('counts a written store exactly, whatever it contains (seed %i)', (seedValue) => {
+    const r = rng(seedValue + 2000)
+
+    for (let round = 0; round < 20; round++) {
+      const n = int(r, 1, 60)
+      const corpus = Array.from({ length: n }, (_, i) => {
+        const e = randomEngram(r, i) as any
+        // Multi-line scalars whose bodies contain sequence-looking lines are
+        // the case a line scan can plausibly get wrong.
+        if (r() < 0.4) e.rationale = 'first line\n- looks like an item\n- and another\n'
+        return EngramSchemaPassthrough.parse(e) as Engram
+      })
+      saveEngrams(storePath, corpus, { allowShrink: true })
+
+      // If the on-disk count were wrong by even one, the tolerance boundary
+      // moves and one of these two assertions fails.
+      const justInside = Math.ceil(n * (1 - SHRINK_TOLERANCE))
+      const justOutside = justInside - 1
+      const ctx = `seed=${seedValue} round=${round} n=${n}`
+
+      if (justOutside >= 0 && justOutside < n * (1 - SHRINK_TOLERANCE)) {
+        expect(() => saveEngrams(storePath, corpus.slice(0, justOutside)), `${ctx} justOutside`)
+          .toThrow(EngramStoreShrinkError)
+      }
+      expect(() => saveEngrams(storePath, corpus.slice(0, justInside)), `${ctx} justInside`)
+        .not.toThrow()
+      // Restore the baseline for the next round.
+      saveEngrams(storePath, corpus, { allowShrink: true })
+    }
+  })
+})


### PR DESCRIPTION
Closes #824. Refs #823, #821.

Three things, all of which should land before 0.17.0 ships.

## 1. The #824 fix — Črt's finding

`saveEngrams` carried the F2/F3 wipe protection. `YamlStore.save()` — the `EngramStore` backend from `createStore`/`factory.ts` — is *also* a whole-corpus writer, and went straight from `yaml.dump` to `asyncAtomicWrite` without it.

The detail worth noting: that method **did** carry quarantined entries — #811 finding 8 was fixed at that exact call site — but not the shrink guard. Same file, same method, one cross-cutting rule present and the other absent. That is what a convention decays into: each rule applied wherever someone remembered it.

Unnoticed because the default primary is `YamlPrimaryStore`, which routes through `saveEngrams`. The guarded path was the one everybody exercised.

The guard is now a shared function (`assertShrinkAllowed` + an async twin) over one `countRecordStarts`, so the counting *rule* has a single definition. **That removes the copy, not the convention** — a third writer could still forget to call it, which is why #824 stays open for the structural fix.

## 2. Property tests for the shrink guard

The guard has been broken twice by its own optimisation, and the fixture tests could not have caught either: every fixture used uniformly generated engrams, where record count and byte size move together by construction. The blind spot *was* the generator, so more fixtures would not have helped.

These assert the invariant instead — *a write dropping more than `SHRINK_TOLERANCE` of the **records** must be refused, whatever the bytes do* — and attack it with heterogeneous corpora and random subset removals. Seeded mulberry32, so a failure prints a replayable seed.

**Verified against the historical bug: reintroducing the byte pre-check makes 9 of them fail.**

## 3. A corruption matrix

"A caller that cannot tolerate a throw now gets one" recurred **five** times, each found separately, each after the previous was declared fixed. Four artifacts × eight corruptions, asserting both halves — diagnostics must survive, write paths must still refuse.

**Verified: reintroducing finding 13 makes 8 of them fail.**

The matrix corrected me three times while I wrote it, which is the useful part. `episodes.yaml`/`tensions.yaml` genuinely *are* bare lists. And a truncated corpus usually still parses — **the shrink guard cannot catch that either**, because its baseline is the truncated file: it compares 21 to 21 and correctly allows the write. That cell is pinned as explicitly *not* caught, with its real defence named (validity-gated backups), so nobody later "fixes" it by making the guard compare against something other than the file it is about to replace.

## Verification

Full suite with Postgres: **3903 passed, 0 failed**. Cherry-picked onto current `main` (post-#822) and re-run there.