### PR TITLE
feat(core): targeted write-path seams for row stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.17.1 (2026-08-03)
+
+Learning something no longer reads your whole memory first.
+
+### Changed — performance
+
+- **`learn()` and `feedback()` stop loading the whole corpus** (#827, #828, (#829)): `learn()` read every
+  engram twice before writing one — once to check for a duplicate statement, once to work out the
+  next id — and `feedback()` read every engram to fetch the single one you rated. On a plain YAML
+  store that costs nothing, because the file is parsed either way; on a database-backed store it is
+  a full table scan standing in for an index lookup, on every write. Two optional store methods
+  (`findActiveByContentHash`, `nextEngramId`) let a store answer both questions directly, and the
+  same targeted-read treatment now covers `updateEngram`, `setPinned`, `forget` and `rescope`.
+  Nothing changes for the default YAML store, which keeps the behaviour it had.
+
+  One deliberate trade-off for stores that opt in: the dedup lookup is scope-**bound**, so it cannot
+  see — and must not disclose — a matching statement in a *different* scope. Cross-scope recurrence
+  (the rule that re-learning the same sentence under a second scope graduates the original toward
+  `global`) is therefore skipped on such stores, and the statement becomes its own engram instead.
+  This is the point rather than a side effect: where scopes are a permission boundary, one tenant's
+  engram must not be broadened because another tenant learned the same sentence. See
+  [ADR-0003](docs/adr/ADR-0003-primary-store-capability.md).
+
 ## 0.17.0 (2026-08-03)
 
 Your memory now backs itself up.

--- a/benchmark/micro.ts
+++ b/benchmark/micro.ts
@@ -95,8 +95,12 @@ async function runBench(label: string, iterations: number) {
   console.log(`${'='.repeat(60)}\n`)
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-micro-'))
-  fs.writeFileSync(path.join(tmpDir, 'engrams.yaml'), '[]')
-  fs.writeFileSync(path.join(tmpDir, 'episodes.yaml'), '[]')
+  // A MAPPING with an `engrams` list, not a bare `[]`. Since audit #794 the
+  // loader refuses a file it cannot interpret rather than treating it as an
+  // empty store — a bare list now raises EngramStoreUnreadableError on the
+  // first learn(), which took this benchmark out entirely.
+  fs.writeFileSync(path.join(tmpDir, 'engrams.yaml'), 'engrams: []\n')
+  fs.writeFileSync(path.join(tmpDir, 'episodes.yaml'), 'episodes: []\n')
   fs.writeFileSync(path.join(tmpDir, 'config.yaml'), 'auto_learn: true\nindex: false\n')
 
   const plur = new Plur({ path: tmpDir })

--- a/docs/adr/ADR-0003-primary-store-capability.md
+++ b/docs/adr/ADR-0003-primary-store-capability.md
@@ -226,3 +226,74 @@ built for.
 The cost is a hard breaking change for `@plur-ai/core` consumers, since async is
 contagious across roughly twenty public `Plur` methods. `npx @plur-ai/migrate`
 exists to absorb it. The block above shows the interface as shipped.
+
+## Amendment — 2026-08-03: the write path gets the same seams ([#827](https://github.com/plur-ai/plur/issues/827), [#828](https://github.com/plur-ai/plur/issues/828))
+
+0.16 and 0.17 gave a row store everything it needed on the **read** side —
+`role: 'primary'` + `searchBM25` to answer queries from its own indexes,
+`loadByIds` + `updateMany` to write back only the rows a recall touched. The
+write path kept the shape this ADR set out to remove: `learn()` materialised the
+corpus twice (once to look for a duplicate statement, once to derive the next
+id) and `feedback()` materialised it to fetch one row by primary key. A store
+could serve reads entirely from its indexes and then pay a full corpus load the
+moment anyone learned something — `updateMany`'s own note puts that at 252ms at
+2,000 engrams and ~6.3s at 50,000, which is the tier where a row store is
+selected at all.
+
+Two optional methods close it, in the same additive shape as the rest:
+
+```ts
+findActiveByContentHash?(hash: string, scope: string): Promise<Engram | null>
+nextEngramId?(datePrefix: string): Promise<string>
+```
+
+Both are read off the same materialised corpus today, so they are jointly
+required: delegating one still pays the full load for the other. They are gated
+together with the 0.17 write seams (`append` + `updateMany` + `loadByIds`),
+because every fallback in `learn()` takes "the corpus in hand" and turns it into
+a whole-corpus `save()` when no row-level write exists — a targeted read without
+a targeted write would hand a one-row array to a full replace, which is the #749
+defect from the other side. `YamlPrimaryStore` and `MemoryPrimaryStore`
+deliberately implement neither: their `load()` is free, so the seam would buy
+nothing and cost the trade-off below.
+
+### Two decisions worth stating rather than leaving to be discovered
+
+**1. Cross-scope recurrence is skipped when dedup is delegated.**
+`findActiveByContentHash` is scope-bound by contract — a hash match in another
+scope is a different engram, and returning it would disclose it. That is exactly
+the query cross-scope recurrence (#176) asks, so the seam cannot answer it and
+the primary-store half of that check is not performed. The statement becomes its
+own engram in its own scope instead of graduating an existing one toward
+`global` + `locked`. Secondary stores and packs are unaffected; they are scanned
+in memory either way.
+
+This is the intended outcome rather than a tolerated loss. A store that wants
+the seam is one where scopes are a permission boundary, and silently broadening
+one scope's engram to `global` because another scope learned the same sentence
+is what such a store must not do. A deployment that wants graduation declines
+the seam and keeps the corpus scan. Pinned by test, not just by prose:
+`test/write-path-seams.test.ts` asserts the graduation on the corpus-scanning
+path and its absence on the delegated one.
+
+**2. Id allocation and `append`'s collision check are one concern from two
+ends.** `generateEngramId` derives a suffix from a snapshot and the engine then
+calls `append`, whose contract says an implementation *SHOULD surface an id
+collision as an error rather than absorb it* — the last line of defence for an
+id that was already stale when minted. A store whose `append` is an upsert has
+no such defence and silently overwrites the loser of a race; the engine's store
+lock contains this within one process but not across two sharing a database.
+`nextEngramId` moves allocation to the party that can make it atomic.
+
+### Also folded in
+
+The same `load()`-then-`find(id)` shape existed at seven other sites
+(`feedback`, `updateEngram`, `updateEngramAsync`, `setPinned`, `setPinnedAsync`,
+`forget`, `rescope`'s local branch, `_retireRescopedSource`, and the outbox
+failure bookkeeping). All now go through one `_loadTargeted(ids)` helper that
+checks `loadByIds` and `updateMany` as a pair, so the subset it returns is only
+ever produced when the write consuming it is itself targeted. The one site left
+alone is the outbox's local-copy REMOVAL: the only removal primitive
+`PrimaryStore` has is a whole-corpus save of the array without the row, so a
+targeted read there would be a full replace by an empty array. It stays a full
+load until there is a `remove`/`deleteMany` seam.

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -622,6 +622,19 @@ export function storePrefix(scope: string): string {
  * The per-day sequence counts BOTH forms, so a store upgraded mid-day
  * continues numbering after its compact-form ids instead of restarting at 001.
  */
+/**
+ * The canonical id prefix for today, `ENG-YYYY-MM-DD-`.
+ *
+ * Exported so the one place that mints ids from a corpus
+ * ({@link generateEngramId}) and the one that delegates minting to the store
+ * (`PrimaryStore.nextEngramId`) cannot drift apart on the format — a store
+ * queried with a prefix the engine does not itself use would allocate ids in a
+ * namespace nothing else counts.
+ */
+export function engramIdDatePrefix(now: Date = new Date()): string {
+  return `ENG-${now.toISOString().slice(0, 10)}-`
+}
+
 export function generateEngramId(existing: Engram[]): string {
   const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
   const prefix = `ENG-${day}-`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ import { detectPlurStorage, type PlurPaths } from './storage.js'
 import { IndexedStorage } from './storage-indexed.js'
 import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
-import { generateEngramId, loadAllPacks, storePrefix, initFilesystemStore } from './engrams.js'
+import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, initFilesystemStore } from './engrams.js'
 import { maybeDailyBackup } from './backup.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats } from './fts.js'
@@ -844,6 +844,27 @@ export class Plur {
           + `whole-corpus reactivation. Implement both to enable targeted reads/writes.`,
         )
       }
+      // The `learn()` seams (#828) are a SET, and a partial set is silent:
+      // `canDelegate` in `learn()` is a single boolean, so a store missing one
+      // member keeps paying two full corpus loads per write with nothing to
+      // indicate why. Say so where the implementor is looking. A warning, not a
+      // throw — a partial set is a performance mistake, not a data-loss one.
+      const hasFindByHash = typeof s.findActiveByContentHash === 'function'
+      const hasNextId = typeof s.nextEngramId === 'function'
+      if (hasFindByHash !== hasNextId) {
+        logger.warning(
+          `[plur] the supplied primary store implements ${hasFindByHash ? 'findActiveByContentHash' : 'nextEngramId'} `
+          + `but not ${hasFindByHash ? 'nextEngramId' : 'findActiveByContentHash'} — learn() needs both to skip the `
+          + `whole-corpus load, so it still loads the corpus. Implement both.`,
+        )
+      } else if (hasFindByHash && !(canWriteRows && hasLoadByIds)) {
+        logger.warning(
+          `[plur] the supplied primary store implements the learn() derive seams `
+          + `(findActiveByContentHash + nextEngramId) but not the targeted-write seams `
+          + `(append + updateMany + loadByIds) — learn() still loads the corpus, because a whole-corpus `
+          + `save() is the only write available. Implement all five to enable targeted learns.`,
+        )
+      }
     }
     this.config = loadConfig(this.paths.config)
     this._autoDiscover = Plur.resolveAutoDiscover(options?.autoDiscover)
@@ -1217,6 +1238,37 @@ export class Plur {
    * call site would have to remember to check (and #745's `update(): false`
    * showed they don't) is worse than semantics that cannot lose the write.
    */
+  /**
+   * Read the primary-store rows for `ids` — targeted when the store can, a
+   * whole-corpus load when it cannot (#827).
+   *
+   * Every caller is the same shape: load, find one row by id, mutate it, hand
+   * it to {@link _updateEngrams}. The WRITE has been targeted since 0.17; the
+   * READ was not, so a store that implements the 0.17 pair still paid a full
+   * table scan to fetch a row by primary key on every feedback signal, pin
+   * toggle, update and forget. `_reactivateResults` already took the targeted
+   * branch for exactly this shape — these call sites were simply missed.
+   *
+   * `loadByIds` and `updateMany` are checked as a PAIR, and the pair is what
+   * makes the return value safe to use as "the corpus in hand". Callers pass
+   * the array straight on to `_updateEngrams`, which falls back to a FULL
+   * REPLACE of whatever it is given when `updateMany` is absent. Taking the
+   * targeted read alone would therefore hand a one-row array to a whole-corpus
+   * save and delete everything else — the #749 defect, from the write side.
+   * Requiring both means the subset is only ever produced when the write that
+   * consumes it is itself targeted.
+   *
+   * Ids absent from the store are simply not returned, so a caller's
+   * `find(...)` miss keeps its existing meaning and its existing fall-through
+   * to the secondary stores.
+   */
+  private async _loadTargeted(ids: string[]): Promise<Engram[]> {
+    const store = this._primaryStore
+    return store.loadByIds && store.updateMany
+      ? await store.loadByIds(ids)
+      : await store.load()
+  }
+
   private async _updateEngrams(corpus: Engram[], changed: Engram[]): Promise<void> {
     if (changed.length === 0) return
     if (this._primaryStore.updateMany) {
@@ -2221,24 +2273,83 @@ export class Plur {
     // into an existing engram below.
     const validity = resolveValidity(statement, context)
     return await this._withStoreLock(this.paths.engrams, async () => {
-      const engrams = await this._primaryStore.load()
-      const allEngrams = await this._loadAllEngrams()
-
       const scope = guarded.scope
+      const ps = this._primaryStore
+      // Can the store answer BOTH derived facts `learn()` needs — "is this
+      // statement already here in this scope" and "what is the next id" —
+      // without the corpus, AND take every write `learn()` performs as a
+      // targeted row operation? (#828)
+      //
+      // It is a capability SET, not a pair, and every member is load-bearing.
+      // The derive seams are jointly required because each of the two facts is
+      // otherwise read off the SAME materialised corpus — delegating one still
+      // pays the full load for the other. The write seams are required because
+      // every fallback below (`_appendEngram`, `_updateEngrams`,
+      // `_writeSupersededByEdges`) takes "the corpus in hand" and, absent a
+      // row-level write, turns it into a whole-corpus `save()`. Taking the
+      // targeted READ without the targeted WRITE would hand a stand-in array
+      // of one or two rows to a FULL REPLACE — the #749 shape that deleted a
+      // corpus on an ordinary recall, and the reason `_reactivateResults`
+      // checks its pair rather than each half.
+      const canDelegate = Boolean(
+        ps.findActiveByContentHash && ps.nextEngramId
+        && ps.append && ps.updateMany && ps.loadByIds,
+      )
+      // The primary corpus, or an empty stand-in when nothing below will read
+      // or rewrite it. Safe ONLY under `canDelegate` — see above.
+      const engrams = canDelegate ? [] : await ps.load()
+      // Secondary stores and packs are NOT the primary corpus. They are small,
+      // separately loaded, and no seam speaks for them, so they are scanned in
+      // memory in both modes; only the primary half moves into the store.
+      const allEngrams = canDelegate
+        ? await this._loadSecondaryAndPacks()
+        : await this._loadAllEngrams()
 
       // Idea 29: Content hash fast-path dedup (scope-aware — issue #136).
       // On dedup hit, mutate: increment reference_count, append source (#107).
-      const hashMatch = this._hashDedup(statement, allEngrams, scope)
-      if (hashMatch) return await this._recordDuplicate(hashMatch, engrams, scope, context)
+      //
+      // The store is asked first, matching the corpus order it replaces
+      // (`_loadAllEngrams` puts primary rows ahead of secondary ones, so a
+      // primary match has always won).
+      const primaryHashMatch = canDelegate
+        ? await ps.findActiveByContentHash!(computeContentHash(statement), scope)
+        : null
+      const hashMatch = primaryHashMatch ?? this._hashDedup(statement, allEngrams, scope)
+      if (hashMatch) {
+        // `_recordDuplicate` persists only when the hit is IN the array it is
+        // given — a match from a secondary store or a pack is counted in
+        // memory and not written, which is the documented v1 behaviour. The
+        // store-served hit is a freshly-read row under this same lock, so it
+        // is the corpus in hand for exactly one row.
+        const corpusInHand = primaryHashMatch ? [primaryHashMatch] : engrams
+        return await this._recordDuplicate(hashMatch, corpusInHand, scope, context)
+      }
 
       // #176: cross-scope recurrence — same statement, different scope.
       // Treated as evidence of universal applicability: graduates the
       // existing engram toward 'global' + 'locked' commitment instead of
       // creating a new scope-bound duplicate.
+      //
+      // Under `canDelegate` this sees secondary stores and packs but NOT the
+      // primary store, and that is deliberate rather than an oversight of the
+      // seam: `findActiveByContentHash` is scope-bound by contract precisely so
+      // it cannot disclose another scope's engram, which is the same query
+      // cross-scope recurrence needs. A store that opts into the seam is one
+      // where scopes are a permission boundary, and broadening one scope's
+      // engram to `global` because another scope learned the same sentence is
+      // what such a store must not do. So the primary half is skipped, the new
+      // statement becomes its own engram, and a deployment that wants
+      // graduation declines the seam and keeps the corpus scan.
+      // See `PrimaryStore.findActiveByContentHash`.
       const crossMatch = this._crossScopeRecurrenceDetect(statement, allEngrams, scope)
+      // `engrams` is empty under delegation, so `_recordCrossScopeRecurrence`
+      // takes its secondary-store branch — which is where every match it can
+      // still see actually lives.
       if (crossMatch) return await this._recordCrossScopeRecurrence(crossMatch, engrams, scope, context)
 
-      const id = generateEngramId(allEngrams)
+      const id = canDelegate
+        ? await ps.nextEngramId!(engramIdDatePrefix())
+        : generateEngramId(allEngrams)
       const now = new Date().toISOString()
       const type = context?.type ?? 'behavioral'
       const cogLevel = TYPE_TO_COGNITIVE[type] ?? 'remember'
@@ -2331,8 +2442,18 @@ export class Plur {
       // the incremental write path below can persist them explicitly — on a
       // store with `append`, writing only the new engram would silently drop
       // these back-edges (the CI failure ffe04e0 fixed on #745).
+      //
+      // Under delegation `engrams` is empty, so the targets are fetched by id.
+      // Dropping the back-edges instead would be the quiet kind of regression:
+      // `supersedes` would still be recorded on the new engram and the reverse
+      // edge would simply never appear, which reads as data corruption rather
+      // than as a disabled feature.
       const supersededTargets = context?.supersedes?.length
-        ? this._writeSupersededByEdges(engrams, context.supersedes, id)
+        ? this._writeSupersededByEdges(
+            canDelegate ? await ps.loadByIds!(context.supersedes) : engrams,
+            context.supersedes,
+            id,
+          )
         : []
 
       // Stamp the extraction marker (#347) so the plur_learn MCP response can
@@ -2434,7 +2555,8 @@ export class Plur {
             // Already saved locally with outbox metadata — will be retried.
             logger.warning(`[plur:outbox] immediate push failed for ${engram.id}, queued for retry: ${(err as Error).message}`)
             await this._withStoreLock(this.paths.engrams, async () => {
-              const fresh = await this._primaryStore.load()
+              // Targeted read (#827): only this engram's outbox bookkeeping.
+              const fresh = await this._loadTargeted([engram.id])
               const target = fresh.find(e => e.id === engram.id) as any
               if (target?.structured_data?._outbox) {
                 target.structured_data._outbox.last_error = (err as Error).message
@@ -2451,6 +2573,11 @@ export class Plur {
           // rather than re-queueing something already accepted.
           try {
             await this._withStoreLock(this.paths.engrams, async () => {
+              // NOT `_loadTargeted` (#827): this REMOVES a row, and the only
+              // removal primitive `PrimaryStore` has is a whole-corpus save of
+              // the array without it. A one-row targeted read here would be a
+              // full replace by an empty array — the corpus, deleted. It stays
+              // a full load until there is a `remove`/`deleteMany` seam.
               const fresh = await this._primaryStore.load()
               const idx = fresh.findIndex(e => e.id === engram.id)
               if (idx !== -1) {
@@ -4300,7 +4427,10 @@ export class Plur {
     this._assertWritable()
     // Try primary engrams first
     const found = await this._withStoreLock(this.paths.engrams, async () => {
-      const engrams = await this._primaryStore.load()
+      // Targeted read (#827): rating one engram is a lookup by primary key,
+      // not a reason to materialise the corpus. A miss still means "not in the
+      // primary store" and still falls through to the secondary stores below.
+      const engrams = await this._loadTargeted([id])
       const engram = engrams.find(e => e.id === id)
       if (!engram) return false
 
@@ -4517,7 +4647,8 @@ export class Plur {
     this._assertWritable()
     // Local primary first.
     const localResult = await this._withStoreLock(this.paths.engrams, async () => {
-      const engrams = await this._primaryStore.load()
+      // Targeted read (#827): resolving one engram by id.
+      const engrams = await this._loadTargeted([updated.id])
       const idx = engrams.findIndex(e => e.id === updated.id)
       if (idx === -1) return false
       // Leak guard (#353): local-resident → demote a sensitive update in place.
@@ -4586,7 +4717,8 @@ export class Plur {
     this._assertWritable()
     // Local primary first.
     const localResult = await this._withStoreLock(this.paths.engrams, async () => {
-      const engrams = await this._primaryStore.load()
+      // Targeted read (#827): resolving one engram by id.
+      const engrams = await this._loadTargeted([updated.id])
       const idx = engrams.findIndex(e => e.id === updated.id)
       if (idx === -1) return null
       // Leak guard (#353): local-resident → demote a sensitive update in place.
@@ -4632,7 +4764,8 @@ export class Plur {
     this._assertWritable()
     // Local primary first.
     const localResult = await this._withStoreLock(this.paths.engrams, async () => {
-      const engrams = await this._primaryStore.load()
+      // Targeted read (#827): resolving one engram by id.
+      const engrams = await this._loadTargeted([id])
       const idx = engrams.findIndex(e => e.id === id)
       if (idx === -1) return null
       const e = engrams[idx]
@@ -4681,7 +4814,8 @@ export class Plur {
     this._assertWritable()
     // Local primary first.
     const localResult = await this._withStoreLock(this.paths.engrams, async () => {
-      const engrams = await this._primaryStore.load()
+      // Targeted read (#827): resolving one engram by id.
+      const engrams = await this._loadTargeted([id])
       const idx = engrams.findIndex(e => e.id === id)
       if (idx === -1) return null
       const e = engrams[idx]
@@ -4728,7 +4862,9 @@ export class Plur {
     // engram stays active with a lower count.
     // options.force=true overrides this: retires immediately (#766).
     const foundInPrimary = await this._withStoreLock(this.paths.engrams, async () => {
-      const engrams = await this._primaryStore.load()
+      // Targeted read (#827): a miss still means "not in the primary store"
+      // and still falls through to the secondary stores below.
+      const engrams = await this._loadTargeted([id])
       const engram = engrams.find(e => e.id === id)
       if (!engram) return false
 
@@ -5114,7 +5250,8 @@ export class Plur {
     // incremental update path as updateEngram's local branch. Id, activation,
     // feedback, relations and history all stay attached to the same row.
     const rewritten = await this._withStoreLock(this.paths.engrams, async () => {
-      const fresh = await this._primaryStore.load()
+      // Targeted read (#827): resolving one engram by id.
+      const fresh = await this._loadTargeted([id])
       const t = fresh.find(e => e.id === id)
       if (!t || t.status === 'retired') return false
       const from = t.scope
@@ -5157,7 +5294,8 @@ export class Plur {
   private async _retireRescopedSource(id: string, toScope: string, newId: string): Promise<void> {
     const now = new Date().toISOString()
     await this._withStoreLock(this.paths.engrams, async () => {
-      const fresh = await this._primaryStore.load()
+      // Targeted read (#827): resolving one engram by id.
+      const fresh = await this._loadTargeted([id])
       const t = fresh.find(e => e.id === id)
       if (!t) return
       t.status = 'retired'

--- a/packages/core/src/store/primary-store.ts
+++ b/packages/core/src/store/primary-store.ts
@@ -235,6 +235,94 @@ export interface PrimaryStore {
   loadByIds?(ids: string[]): Promise<Engram[]>
 
   /**
+   * The engram carrying this content hash IN THIS SCOPE with
+   * `status === 'active'`, or `null`. Optional; when absent the caller falls
+   * back to scanning the loaded corpus.
+   *
+   * The status filter is the predicate, not a nicety: re-learning a RETIRED
+   * statement must create a fresh engram rather than resurrect the retired one
+   * (#107), and the local half of a completed rescope is retired precisely so
+   * its hash cannot pull the statement back (#676). An implementation that
+   * matches retired rows undoes both.
+   *
+   * `learn()` asks one question before it writes anything: "do we already have
+   * this exact statement in this scope?" On a single YAML file, answering it by
+   * scanning the parsed corpus is free — the file was parsed either way. On a
+   * row store it is a full table scan standing in for an index lookup on
+   * `(content_hash, scope)`, paid on every learn, at the corpus size where a row
+   * store gets selected in the first place (see {@link updateMany}: 252ms at
+   * 2,000 engrams, ~6.3s at 50,000).
+   *
+   * ### Scope-bound, deliberately
+   *
+   * A hash match in ANOTHER scope is a different engram, and returning it would
+   * disclose it. Implementations MUST restrict the lookup to `scope` exactly —
+   * not a prefix, not a parent, not "any scope this caller could read".
+   *
+   * That has a consequence worth stating plainly rather than discovering:
+   * `learn()`'s CROSS-scope recurrence check (#176 — the same statement
+   * re-learned under a different scope graduates the existing engram toward
+   * `global` + `locked` instead of creating a second row) asks the opposite
+   * question, and this seam is defined so it cannot answer it. So when a store
+   * implements this method, the primary-store half of cross-scope recurrence is
+   * SKIPPED: a same-hash engram in another scope is not found, and the new
+   * statement becomes a new engram in its own scope. Secondary stores and packs
+   * are unaffected — they are scanned in memory either way.
+   *
+   * That is the intended outcome, not a tolerated loss. A store that wants this
+   * seam is one where scopes are a permission boundary; silently broadening one
+   * tenant's engram to `global` because another tenant learned the same
+   * sentence is precisely what such a store must not do. A store that wants
+   * cross-scope graduation should not implement this method, and pays the
+   * corpus scan that makes it possible.
+   *
+   * @see nextEngramId — the other half of the `learn()` seam; both are required
+   *   before the engine will skip the corpus load.
+   */
+  findActiveByContentHash?(hash: string, scope: string): Promise<Engram | null>
+
+  /**
+   * The next unused engram id for `datePrefix` (e.g. `'ENG-2026-08-03-'`).
+   * Optional; when absent the caller falls back to deriving it from the loaded
+   * corpus.
+   *
+   * The performance half is the obvious one — `generateEngramId` scans the
+   * whole corpus for the maximum suffix, which a row store answers with
+   * `SELECT MAX(...) WHERE id LIKE '<datePrefix>%'`.
+   *
+   * ### The sharper half is collision safety
+   *
+   * `generateEngramId` derives its suffix from a SNAPSHOT and the engine then
+   * calls {@link append}. Those are the same concern from opposite ends:
+   * `append` says an implementation *SHOULD surface an id collision as an error
+   * rather than absorb it*, which is the last line of defence for an id that
+   * was already stale when it was minted. A store whose `append` is really an
+   * upsert has no such defence and silently overwrites the loser of a race.
+   * The engine's store lock contains this within one process; it is not a
+   * property callers should have to rely on, and it does not survive two
+   * processes sharing one database.
+   *
+   * `nextEngramId` moves allocation to the party that can make it atomic —
+   * for a row store, a sequence or an `INSERT ... RETURNING` in the same
+   * transaction. Implementations SHOULD make allocation collision-safe under
+   * concurrency rather than returning a value derived from a stale read.
+   *
+   * ### Contract
+   *
+   * - The returned id MUST begin with `datePrefix` and MUST be unused in this
+   *   store.
+   * - The engine passes the canonical `ENG-YYYY-MM-DD-` form. A store also
+   *   holding legacy `ENG-YYYY-MMDD-` ids may account for them but need not:
+   *   the two forms cannot collide as strings.
+   * - Allocation is scoped to the PRIMARY store. Unlike the fallback, ids held
+   *   by installed packs are not consulted — `append`'s collision check is the
+   *   backstop.
+   *
+   * @see findActiveByContentHash — the other half of the `learn()` seam.
+   */
+  nextEngramId?(datePrefix: string): Promise<string>
+
+  /**
    * Cheap, approximate size of the store — for choosing a backend, never for
    * reporting a count to a user.
    *

--- a/packages/core/src/store/readonly-store-guard.ts
+++ b/packages/core/src/store/readonly-store-guard.ts
@@ -15,9 +15,9 @@
  *   guard must not invent an estimate of 0 for a store that declined to give
  *   one (backend selection has its own "treat as small" fallback and must see
  *   the absence, not a fabricated number). Likewise the write capabilities
- *   `append`/`updateMany` are only declared when the inner store declares
- *   them, so capability probes (`store.updateMany && store.loadByIds`) see
- *   the same shape as the unwrapped store.
+ *   `append`/`updateMany`/`nextEngramId` are only declared when the inner store
+ *   declares them, so capability probes (`store.updateMany && store.loadByIds`)
+ *   see the same shape as the unwrapped store.
  * - **`withExclusiveAccess` runs the callback WITHOUT acquiring anything.**
  *   Exclusive access exists to serialize read-modify-write cycles; on a store
  *   that cannot be written there is no write to serialize, and acquiring the
@@ -52,6 +52,20 @@ export class ReadonlyStoreGuard implements PrimaryStore {
   readonly append?: (engram: Engram) => Promise<void>
   /** Present (and rejecting) only when the inner store implements it. */
   readonly updateMany?: (engrams: Engram[]) => Promise<void>
+  /**
+   * A READ — present and delegating, like `loadByIds`. It answers "is this
+   * statement already stored here", which a read-only instance may ask.
+   */
+  readonly findActiveByContentHash?: (hash: string, scope: string) => Promise<Engram | null>
+  /**
+   * Present (and rejecting) only when the inner store implements it.
+   *
+   * Unlike `findActiveByContentHash` this is NOT a read: an implementation that
+   * makes allocation collision-safe does so by CONSUMING the id (a sequence
+   * bump, a reservation row), which is a mutation of the store. Delegating it
+   * from a read-only guard would burn ids on a path that can never write one.
+   */
+  readonly nextEngramId?: (datePrefix: string) => Promise<string>
 
   constructor(private readonly _inner: PrimaryStore) {
     this.kind = _inner.kind
@@ -61,6 +75,10 @@ export class ReadonlyStoreGuard implements PrimaryStore {
     if (_inner.estimateCount) this.estimateCount = () => _inner.estimateCount!()
     if (_inner.append) this.append = () => Promise.reject(new ReadonlyStoreError())
     if (_inner.updateMany) this.updateMany = () => Promise.reject(new ReadonlyStoreError())
+    if (_inner.findActiveByContentHash) {
+      this.findActiveByContentHash = (hash, scope) => _inner.findActiveByContentHash!(hash, scope)
+    }
+    if (_inner.nextEngramId) this.nextEngramId = () => Promise.reject(new ReadonlyStoreError())
   }
 
   load(): Promise<Engram[]> { return this._inner.load() }

--- a/packages/core/test/write-path-seams.test.ts
+++ b/packages/core/test/write-path-seams.test.ts
@@ -383,7 +383,7 @@ describe('#827 feedback() fetches by id', () => {
     const raw = structuredClone(store.peek().find(e => e.id === teamEngram.id)!)
     writeFileSync(teamPath, dump({ engrams: [raw] }), 'utf8')
     await plur.forget(teamEngram.id, undefined, { force: true })
-    plur.config.stores = [{ scope: 'group:team', path: teamPath }]
+    plur.addStore(teamPath, 'group:team', { shared: true, readonly: false })
 
     const all = await plur.list()
     const namespaced = all.find(e => (e as any)._originalId === raw.id)!

--- a/packages/core/test/write-path-seams.test.ts
+++ b/packages/core/test/write-path-seams.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Targeted write-path seams (#827, #828).
+ *
+ * 0.16 and 0.17 gave a row store seams to serve READS from its own indexes
+ * (`role: 'primary'` + `searchBM25`) and to write back only the rows that
+ * changed (`loadByIds` + `updateMany`). The write path never got the same
+ * treatment: `learn()` materialised the corpus twice — once to look for a
+ * duplicate statement, once to derive the next id — and `feedback()`
+ * materialised it to fetch a single row by primary key.
+ *
+ * These tests pin the two properties that make the fix meaningful:
+ *
+ *   1. With the capabilities present, the engine performs ZERO full-corpus
+ *      loads. Asserted with a counting store, never with timing — "fast
+ *      enough" is not a property, "did not call load()" is.
+ *   2. With them absent, behaviour is exactly what it was, and no partial
+ *      implementation can be talked into destroying the corpus.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { dump } from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { YamlPrimaryStore } from '../src/store/yaml-primary-store.js'
+import { logger } from '../src/logger.js'
+import type { Engram } from '../src/schemas/engram.js'
+import type { PrimaryStore, PrimaryStoreKind } from '../src/store/primary-store.js'
+
+/**
+ * A row-store stand-in that COUNTS whole-corpus reads.
+ *
+ * Deliberately not built on `MemoryPrimaryStore` or `YamlPrimaryStore`: the
+ * targeted methods here read `this.rows` directly rather than going through
+ * `load()`, so the counter measures exactly one thing — how many times the
+ * ENGINE asked for the whole corpus. A spy whose own `loadByIds` called
+ * `load()` internally would report a full load for every targeted query and
+ * measure nothing at all.
+ */
+class CountingStore implements PrimaryStore {
+  readonly kind: PrimaryStoreKind = 'memory'
+  readonly location: string | null = null
+
+  /** Whole-corpus reads (`load` + `loadCached`) requested by the engine. */
+  fullLoads = 0
+  findByHashCalls = 0
+  nextIdCalls = 0
+  appendCalls = 0
+  updateManyCalls = 0
+  loadByIdsCalls = 0
+
+  protected rows: Engram[] = []
+
+  async load(): Promise<Engram[]> {
+    this.fullLoads++
+    return this.rows.map(e => structuredClone(e))
+  }
+
+  async loadCached(): Promise<Engram[]> {
+    return this.load()
+  }
+
+  async save(engrams: Engram[]): Promise<void> {
+    this.rows = engrams.map(e => structuredClone(e))
+  }
+
+  invalidate(): void {
+    // Nothing is cached — the store IS the memory.
+  }
+
+  async append(engram: Engram): Promise<void> {
+    this.appendCalls++
+    if (this.rows.some(e => e.id === engram.id)) {
+      throw new Error(`append: engram ${engram.id} already exists`)
+    }
+    this.rows.push(structuredClone(engram))
+  }
+
+  async updateMany(engrams: Engram[]): Promise<void> {
+    this.updateManyCalls++
+    for (const engram of engrams) {
+      const idx = this.rows.findIndex(e => e.id === engram.id)
+      if (idx === -1) this.rows.push(structuredClone(engram))
+      else this.rows[idx] = structuredClone(engram)
+    }
+  }
+
+  async loadByIds(ids: string[]): Promise<Engram[]> {
+    this.loadByIdsCalls++
+    const wanted = new Set(ids)
+    return this.rows.filter(e => wanted.has(e.id)).map(e => structuredClone(e))
+  }
+
+  async findActiveByContentHash(hash: string, scope: string): Promise<Engram | null> {
+    this.findByHashCalls++
+    const hit = this.rows.find(
+      e => e.status === 'active' && (e as any).content_hash === hash && e.scope === scope,
+    )
+    return hit ? structuredClone(hit) : null
+  }
+
+  async nextEngramId(datePrefix: string): Promise<string> {
+    this.nextIdCalls++
+    const used = this.rows
+      .filter(e => e.id.startsWith(datePrefix))
+      .map(e => parseInt(e.id.slice(datePrefix.length), 10))
+      .filter(n => !isNaN(n))
+    const next = used.length > 0 ? Math.max(...used) + 1 : 1
+    return `${datePrefix}${String(next).padStart(3, '0')}`
+  }
+
+  /** Read the rows WITHOUT counting a load — for assertions only. */
+  peek(): Engram[] {
+    return this.rows
+  }
+
+  resetCounts(): void {
+    this.fullLoads = 0
+    this.findByHashCalls = 0
+    this.nextIdCalls = 0
+    this.appendCalls = 0
+    this.updateManyCalls = 0
+    this.loadByIdsCalls = 0
+  }
+}
+
+/**
+ * The derive seams WITHOUT the targeted-write seams — the half-implemented
+ * shape the optional-method interface permits, and the one that would be
+ * catastrophic if the engine took the targeted READ and then wrote a
+ * whole-corpus `save()` of the stand-in array.
+ */
+class DeriveOnlyStore extends CountingStore {
+  readonly refusesUnreadable = true
+  // append / updateMany / loadByIds deliberately absent.
+  append = undefined as any
+  updateMany = undefined as any
+  loadByIds = undefined as any
+}
+
+const TEMP_DIRS: string[] = []
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-write-seams-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length) rmSync(TEMP_DIRS.pop()!, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// #828 — learn()
+// ---------------------------------------------------------------------------
+
+describe('#828 learn() write-path seams', () => {
+  it('performs no full-corpus load when the store implements the seams', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    // Seed through the public API, then measure only the learn under test.
+    for (let i = 0; i < 5; i++) {
+      await plur.learn(`seeded engram ${i} about deployment rollout`, { scope: 'global' })
+    }
+    store.resetCounts()
+
+    const engram = await plur.learn('a brand new statement nobody has learned yet', { scope: 'global' })
+
+    expect(store.fullLoads).toBe(0)
+    expect(store.findByHashCalls).toBe(1)
+    expect(store.nextIdCalls).toBe(1)
+    expect(store.appendCalls).toBe(1)
+    expect(store.peek().some(e => e.id === engram.id)).toBe(true)
+  })
+
+  it('uses the store id allocator for the new engram id', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    const day = new Date().toISOString().slice(0, 10)
+    const first = await plur.learn('the first statement of the day', { scope: 'global' })
+    const second = await plur.learn('the second statement of the day', { scope: 'global' })
+
+    expect(first.id).toBe(`ENG-${day}-001`)
+    expect(second.id).toBe(`ENG-${day}-002`)
+    expect(store.nextIdCalls).toBe(2)
+  })
+
+  it('deduplicates through the store and persists the reference_count increment', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    const original = await plur.learn('always run pnpm build before publishing', { scope: 'global' })
+    store.resetCounts()
+
+    const again = await plur.learn('always run pnpm build before publishing', { scope: 'global' })
+
+    expect(again.id).toBe(original.id)
+    expect(store.fullLoads).toBe(0)
+    expect(store.findByHashCalls).toBe(1)
+    // The increment landed on the row, not just on the returned object.
+    const stored = store.peek().find(e => e.id === original.id)!
+    expect((stored as any).reference_count).toBe(2)
+    expect(store.peek().filter(e => e.status === 'active')).toHaveLength(1)
+    // No new id was allocated for a duplicate.
+    expect(store.nextIdCalls).toBe(0)
+    expect(store.appendCalls).toBe(0)
+  })
+
+  /**
+   * The documented consequence of a scope-BOUND dedup seam, pinned so it can
+   * only change deliberately.
+   *
+   * On the corpus-scanning path the second learn is a cross-scope recurrence:
+   * it graduates the existing engram (#176) instead of creating a row. The
+   * seam is contractually unable to answer "same hash, ANY other scope" —
+   * that is the disclosure it exists to prevent — so under delegation the
+   * primary half of that check is skipped and the statement becomes its own
+   * engram in its own scope. See `PrimaryStore.findActiveByContentHash`.
+   */
+  it('does not graduate a cross-scope recurrence — the dedup seam is scope-bound', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    const a = await plur.learn('deploys go out on Tuesdays', { scope: 'global' })
+    const b = await plur.learn('deploys go out on Tuesdays', { scope: 'project:widget' })
+
+    expect(b.id).not.toBe(a.id)
+    expect(b.scope).toBe('project:widget')
+    expect(store.peek()).toHaveLength(2)
+    // The other scope's engram was neither broadened nor escalated.
+    const untouched = store.peek().find(e => e.id === a.id)!
+    expect(untouched.scope).toBe('global')
+    expect((untouched as any).recurrence_count).toBe(0)
+  })
+
+  it('still writes superseded_by back-edges without loading the corpus', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    const old = await plur.learn('the old way of configuring the linter', { scope: 'global' })
+    store.resetCounts()
+
+    const fresh = await plur.learn('the new way of configuring the linter', {
+      scope: 'global',
+      supersedes: [old.id],
+    })
+
+    expect(store.fullLoads).toBe(0)
+    const stored = store.peek().find(e => e.id === old.id)!
+    expect(stored.relations?.superseded_by).toContain(fresh.id)
+  })
+
+  it('does not lose the corpus when the derive seams arrive without the write seams', async () => {
+    const store = new DeriveOnlyStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    for (let i = 0; i < 8; i++) {
+      await plur.learn(`corpus engram ${i} about incident response`, { scope: 'global' })
+    }
+    expect(store.peek()).toHaveLength(8)
+
+    await plur.learn('a ninth statement that must not eat the other eight', { scope: 'global' })
+
+    expect(store.peek()).toHaveLength(9)
+    // Delegation is OFF without the targeted-write seams: the engine still
+    // loads the corpus, because the whole-corpus save is the only write it has.
+    expect(store.fullLoads).toBeGreaterThan(0)
+  })
+
+  it('warns at attachment when only one of the derive seams is implemented', () => {
+    const spy = vi.spyOn(logger, 'warning').mockImplementation(() => {})
+    try {
+      class HalfDerive extends CountingStore {
+        findActiveByContentHash = undefined as any
+      }
+      // eslint-disable-next-line no-new
+      new Plur({ path: tempDir(), store: new HalfDerive(), autoDiscover: false })
+      const hits = spy.mock.calls.filter(c => String(c[0]).includes('nextEngramId'))
+      expect(hits.length).toBeGreaterThan(0)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})
+
+describe('#828 YamlPrimaryStore behaviour is unchanged', () => {
+  let dir: string
+  beforeEach(() => { dir = tempDir() })
+
+  it('deduplicates, allocates sequential ids, and graduates cross-scope recurrence', async () => {
+    const store = new YamlPrimaryStore(join(dir, 'engrams.yaml'))
+    const plur = new Plur({ path: dir, store, autoDiscover: false })
+    await plur.ready()
+
+    const day = new Date().toISOString().slice(0, 10)
+    const first = await plur.learn('rollbacks are always announced in the channel', { scope: 'global' })
+    expect(first.id).toBe(`ENG-${day}-001`)
+
+    // Exact dedup in the same scope.
+    const dup = await plur.learn('rollbacks are always announced in the channel', { scope: 'global' })
+    expect(dup.id).toBe(first.id)
+    expect((dup as any).reference_count).toBe(2)
+
+    // Sequential allocation continues from the corpus.
+    const second = await plur.learn('a different statement entirely', { scope: 'global' })
+    expect(second.id).toBe(`ENG-${day}-002`)
+  })
+
+  it('graduates a cross-scope recurrence on the corpus-scanning path', async () => {
+    const store = new YamlPrimaryStore(join(dir, 'engrams.yaml'))
+    const plur = new Plur({ path: dir, store, autoDiscover: false })
+    await plur.ready()
+
+    const a = await plur.learn('secrets never go in the repo', { scope: 'project:alpha' })
+    const b = await plur.learn('secrets never go in the repo', { scope: 'project:beta' })
+
+    // Same engram, escalated — not a second row.
+    expect(b.id).toBe(a.id)
+    expect((b as any).recurrence_count).toBe(1)
+    expect((await plur.list()).filter(e => e.status === 'active')).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #827 — feedback()
+// ---------------------------------------------------------------------------
+
+describe('#827 feedback() fetches by id', () => {
+  it('performs no full-corpus load when the store implements loadByIds', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    const engram = await plur.learn('prefer explicit imports over barrel files', { scope: 'global' })
+    for (let i = 0; i < 5; i++) {
+      await plur.learn(`filler engram ${i} about code style`, { scope: 'global' })
+    }
+    store.resetCounts()
+
+    await plur.feedback(engram.id, 'positive')
+
+    expect(store.fullLoads).toBe(0)
+    expect(store.loadByIdsCalls).toBe(1)
+    const stored = store.peek().find(e => e.id === engram.id)!
+    expect(stored.feedback_signals.positive).toBe(1)
+  })
+
+  it('leaves the rest of the corpus intact', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false })
+    await plur.ready()
+
+    const ids: string[] = []
+    for (let i = 0; i < 6; i++) {
+      ids.push((await plur.learn(`engram ${i} about observability`, { scope: 'global' })).id)
+    }
+    await plur.feedback(ids[2], 'negative')
+
+    expect(store.peek()).toHaveLength(6)
+    expect(store.peek().find(e => e.id === ids[2])!.feedback_signals.negative).toBe(1)
+  })
+
+  it('still falls through to a secondary store for an id the primary does not hold', async () => {
+    const dir = tempDir()
+    const storeDir = join(dir, 'stores')
+    mkdirSync(storeDir, { recursive: true })
+    const teamPath = join(storeDir, 'team.yaml')
+
+    const store = new CountingStore()
+    const plur = new Plur({ path: dir, store, autoDiscover: false })
+    await plur.ready()
+
+    // A secondary store engram, written directly so it does not pass through
+    // the primary store at all.
+    const teamEngram = await plur.learn('a statement that will move to the team store', { scope: 'group:team' })
+    const raw = structuredClone(store.peek().find(e => e.id === teamEngram.id)!)
+    writeFileSync(teamPath, dump({ engrams: [raw] }), 'utf8')
+    await plur.forget(teamEngram.id, undefined, { force: true })
+    plur.config.stores = [{ scope: 'group:team', path: teamPath }]
+
+    const all = await plur.list()
+    const namespaced = all.find(e => (e as any)._originalId === raw.id)!
+    expect(namespaced).toBeDefined()
+
+    await plur.feedback(namespaced.id, 'positive')
+
+    // The primary store was consulted first and missed; the secondary took it.
+    const reloaded = await plur.list()
+    const after = reloaded.find(e => (e as any)._originalId === raw.id)!
+    expect(after.feedback_signals.positive).toBe(1)
+  })
+
+  it('behaves identically on YamlPrimaryStore', async () => {
+    const dir = tempDir()
+    const store = new YamlPrimaryStore(join(dir, 'engrams.yaml'))
+    const plur = new Plur({ path: dir, store, autoDiscover: false })
+    await plur.ready()
+
+    const engram = await plur.learn('run the smoke tests after publishing', { scope: 'global' })
+    await plur.feedback(engram.id, 'positive')
+    await plur.feedback(engram.id, 'negative')
+
+    const stored = (await plur.list()).find(e => e.id === engram.id)!
+    expect(stored.feedback_signals.positive).toBe(1)
+    expect(stored.feedback_signals.negative).toBe(1)
+  })
+
+  it('does not delete the corpus on a store with loadByIds but no updateMany', async () => {
+    const dir = tempDir()
+    class HalfTargeted extends YamlPrimaryStore {
+      async loadByIds(ids: string[]): Promise<Engram[]> {
+        const all = await this.load()
+        return all.filter(e => ids.includes(e.id))
+      }
+      // updateMany deliberately absent.
+    }
+    const store = new HalfTargeted(join(dir, 'engrams.yaml'))
+    const plur = new Plur({ path: dir, store, autoDiscover: false })
+    await plur.ready()
+
+    const ids: string[] = []
+    for (let i = 0; i < 7; i++) {
+      ids.push((await plur.learn(`half-targeted engram ${i} about caching`, { scope: 'global' })).id)
+    }
+
+    await plur.feedback(ids[0], 'positive')
+
+    expect((await plur.list())).toHaveLength(7)
+  })
+})


### PR DESCRIPTION
Closes #827, closes #828.

## The gap

0.16 and 0.17 gave a row store everything it needed on the **read** side — `role: 'primary'` + `searchBM25` to answer queries from its own indexes, `loadByIds` + `updateMany` to write back only the rows a recall touched. The write path kept the original shape:

- `learn()` materialised the corpus **twice** — once to look for a duplicate statement, once to derive the next id.
- `feedback()` materialised it to fetch **one row by primary key**.

So a store could serve every read from an index and then pay a full corpus load the moment anyone learned something. Core's own `updateMany` docs put that at 252ms at 2,000 engrams and ~6.3s at 50,000 — the tier where a row store is selected at all.

## The fix

Two optional `PrimaryStore` methods, in the same additive, capability-checked shape as `loadByIds`/`updateMany`. No existing implementation changes; `YamlPrimaryStore` is byte-identical in behaviour.

```ts
findActiveByContentHash?(hash: string, scope: string): Promise<Engram | null>
nextEngramId?(datePrefix: string): Promise<string>
```

`learn()` gates on the **set** `findActiveByContentHash + nextEngramId + append + updateMany + loadByIds`, not on a pair, and both halves of that are load-bearing:

- The two derive seams are jointly required because each fact is otherwise read off the **same** materialised corpus — delegating one still pays the full load for the other.
- The write seams are required because every fallback in `learn()` (`_appendEngram`, `_updateEngrams`, `_writeSupersededByEdges`) takes "the corpus in hand" and turns it into a whole-corpus `save()` when no row-level write exists. Taking the targeted READ without the targeted WRITE would hand a one- or two-row stand-in array to a FULL REPLACE — the #749 shape that deleted a corpus on an ordinary recall, and the reason `_reactivateResults` checks its pair rather than each half.

A partial set now **warns at attachment**, next to the existing `loadByIds`/`updateMany` warning, so a store that implements three of five gets told why nothing got faster instead of discovering it in a profile.

## The three things decided deliberately

### 1. `_crossScopeRecurrenceDetect` is not delegable — and is skipped, not silently kept

`findActiveByContentHash` is scope-**bound** by contract: a hash match in another scope is a different engram, and returning it would disclose it. That is precisely the query cross-scope recurrence (#176) asks, so the seam cannot answer it. When a store implements the seam, the **primary-store half of cross-scope recurrence is skipped**: the statement becomes its own engram in its own scope instead of graduating an existing one toward `global` + `locked`. Secondary stores and packs are unaffected — they are scanned in memory either way.

This is the intended outcome, not a tolerated loss. A store that wants this seam is one where scopes are a permission boundary, and silently broadening one scope's engram to `global` because another scope learned the same sentence is exactly what such a store must not do. A deployment that wants graduation declines the seam and keeps the corpus scan.

Documented in the interface JSDoc, at the `learn()` call site, in ADR-0003, and in the CHANGELOG — and pinned by **two** tests, one asserting graduation on the corpus-scanning path and one asserting its absence on the delegated path.

> Note on the issue text: #828 describes the cross-scope check as "a fuzzy cross-scope similarity scan". It is not — it is the same exact `content_hash` comparison as `_hashDedup`, just filtered to `e.scope !== currentScope`. That makes the conclusion *stronger*, not weaker: it is not undelegable because it is fuzzy, but because the seam is contractually forbidden from answering across scopes.

### 2. Id allocation is collision safety

`generateEngramId` derives a suffix from a snapshot and the engine then calls `append`, whose contract says an implementation *SHOULD surface an id collision as an error rather than absorb it* — the last line of defence for an id that was already stale when minted. A store whose `append` is an upsert has no such defence and silently overwrites the loser of a race; the store lock contains this within one process but not across two sharing a database. `nextEngramId` moves allocation to the party that can make it atomic. The `nextEngramId` docs state the `append` expectation explicitly, since the two are the same concern from opposite ends.

Contract pinned in the JSDoc: the returned id MUST start with `datePrefix` and MUST be unused; the legacy `ENG-YYYY-MMDD-` form cannot collide with the canonical one as a string; allocation is scoped to the primary store, so pack-held ids are not consulted (unlike the fallback) and `append`'s check is the backstop.

### 3. Counting store, not timing

`test/write-path-seams.test.ts` asserts `fullLoads === 0`. The spy is deliberately **not** built on `MemoryPrimaryStore` or `YamlPrimaryStore`: its targeted methods read the backing array directly rather than through `load()`, so the counter measures exactly one thing — how many times the *engine* asked for the whole corpus. A spy whose `loadByIds` called `load()` internally would report a full load per targeted query and measure nothing.

## Also in scope (#827's last criterion)

`feedback()` and seven sibling `load()`-then-`find(id)` sites — `updateEngram`, `updateEngramAsync`, `setPinned`, `setPinnedAsync`, `forget`, `rescope`'s local branch, `_retireRescopedSource`, and the outbox failure bookkeeping — now go through one `_loadTargeted(ids)` helper that checks `loadByIds` and `updateMany` **as a pair**, so the subset it returns is only ever produced when the write consuming it is itself targeted.

One site deliberately left alone: the outbox's local-copy **removal**. The only removal primitive `PrimaryStore` has is a whole-corpus save of the array without the row, so a targeted read there would be a full replace by an empty array. It keeps its full load, with a comment saying so, until there is a `remove`/`deleteMany` seam.

## Verification

- Full monorepo suite: **3805 passed, 0 failed** (14 new tests).
- `pnpm bench:micro`, `mainbase` vs `seams`, 100 iterations:

  | op | mainbase | seams | Δ |
  |---|---|---|---|
  | learn | 12.19ms (p95 14.47) | 12.14ms (p95 15.77) | −0.3% |
  | recall_bm25 | 11.30ms (p95 13.20) | 11.88ms (p95 13.29) | +5.2% |
  | recall_hybrid | 26.35ms (p95 31.92) | 25.81ms (p95 24.34) | −2.0% |
  | inject | 3.83ms (p95 6.01) | 3.87ms (p95 5.05) | +1.0% |

  All noise — the benchmark runs `YamlPrimaryStore`, which takes the unchanged branch. The gain this PR exists for is on a store whose `load()` is not free, and is asserted structurally (`fullLoads === 0`) rather than by timing.

  Separately: `benchmark/micro.ts` had been failing on `main` since audit #794 hardened the loader — it seeded `engrams.yaml` with a bare `[]`, which is no longer readable as an empty store. Fixed in its own `chore(bench)` commit; that is why numbers exist at all.

## Downstream

This is the remaining core-side gap for retiring the parallel memory-engine implementation tracked in the private enterprise repo. Reads could already converge; writes could not until these land.

---

**Survey completeness note.** `learnRouted`'s *local* route delegates to `learn()`, so it inherits the seam for free. Its *remote* route keeps its own corpus scan deliberately: it dedups against the merged local + cached-remote view (semantics no primary-store seam speaks for), and its cost is dominated by the HTTP POST, not the load. Not changed here.
