### PR TITLE
ci: run issue guard on pull_request_target so fork PRs get a write token (#835)

### DIFF
--- a/.github/workflows/pr-issue-guard.yml
+++ b/.github/workflows/pr-issue-guard.yml
@@ -1,7 +1,26 @@
 name: PR Issue Guard
 
+# `pull_request_target`, NOT `pull_request` (#835).
+#
+# On a `pull_request` event raised from a FORK, GitHub forces GITHUB_TOKEN to
+# read-only regardless of the `permissions:` block below — the block can only
+# ever narrow the token, never restore what the fork rule took away. So
+# `addAssignees` returned 403 and this workflow failed on EVERY external
+# contribution, which is precisely the population whose duplicate-effort it
+# exists to prevent. Internal branches are the ones that never needed it.
+#
+# `pull_request_target` runs in the context of the BASE repository, so the token
+# is write-capable for fork PRs too.
+#
+# SECURITY — the rule that makes this safe:
+#   This workflow must NEVER check out, build, or execute the head ref.
+#   `pull_request_target` grants a privileged token to a workflow evaluated
+#   against the base branch; adding `actions/checkout` with the PR's ref would
+#   hand that token to attacker-controlled code. The only untrusted input read
+#   here is the PR body, and it is used solely as a regex source for issue
+#   numbers, each parsed through parseInt before it reaches an API call.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened]
 
 # Only needs to comment on PRs and assign issues — no code access needed.
@@ -43,12 +62,32 @@ jobs:
               const assignees = (issue.assignees || []).map(a => a.login);
 
               if (assignees.length === 0) {
-                await github.rest.issues.addAssignees({
-                  owner, repo,
-                  issue_number: issueNumber,
-                  assignees: [prAuthor],
-                });
-                core.info(`Auto-assigned #${issueNumber} to @${prAuthor}`);
+                // Degrade gracefully rather than failing the run (#835).
+                // Even with a write-capable token, GitHub only permits
+                // assigning users with repo access or prior interaction on the
+                // issue — a brand-new contributor may simply not be assignable.
+                // That is a fact about the account, not a fault in the PR, and
+                // it must not put a red X on someone's first contribution.
+                try {
+                  await github.rest.issues.addAssignees({
+                    owner, repo,
+                    issue_number: issueNumber,
+                    assignees: [prAuthor],
+                  });
+                  core.info(`Auto-assigned #${issueNumber} to @${prAuthor}`);
+                } catch (e) {
+                  core.warning(
+                    `Could not auto-assign #${issueNumber} to @${prAuthor}: ${e.message}. `
+                    + `A maintainer should assign it manually so the claim is recorded.`,
+                  );
+                  await github.rest.issues.createComment({
+                    owner, repo,
+                    issue_number: prNumber,
+                    body: `ℹ️ Could not auto-assign #${issueNumber} to @${prAuthor} — `
+                      + `GitHub only allows assigning users with repo access or prior interaction on the issue. `
+                      + `Maintainer: please assign it manually so the claim is recorded. This is not a problem with the PR.`,
+                  }).catch(err => core.warning(`Fallback comment failed: ${err.message}`));
+                }
               } else if (!assignees.includes(prAuthor)) {
                 const list = assignees.map(a => `@${a}`).join(', ');
                 await github.rest.issues.createComment({


### PR DESCRIPTION
Fixes #835

## Problem

`.github/workflows/pr-issue-guard.yml` failed on **every pull request opened from a fork**, i.e. on every external community contribution. Caught on #782:

```
HttpError: Resource not accessible by integration
POST /repos/plur-ai/plur/issues/780/assignees   →  403
```

For a `pull_request` event raised from a fork, GitHub forces `GITHUB_TOKEN` to read-only *regardless of the declared `permissions:` block*. That block can only ever narrow the token; it cannot restore what the fork rule removed. So the guard could never assign, and the unhandled rejection turned the run red.

The result was the inverse of the guard's purpose: the duplicate-effort protection silently did not exist for external contributors — the only people it was written for — while putting an undiagnosable failing check on their first contribution.

## Change

- **`pull_request` → `pull_request_target`.** Evaluated against the base repository, so the token is write-capable for fork PRs too.
- **Graceful degradation when the author is unassignable.** Even with a write token, GitHub only permits assigning users with repo access or prior interaction on the issue, so a brand-new contributor may simply not be assignable. That is a fact about the account, not a fault in the PR. Warn, and leave a maintainer note on the PR, instead of failing.

## Security

`pull_request_target` hands a privileged token to a workflow evaluated against the base branch, so the standing rule is written into the file as a comment: **this workflow must never check out, build, or execute the head ref.** It doesn't — there is no `actions/checkout` step at all. The only untrusted input is the PR body, used solely as a regex source for issue numbers, each parsed through `parseInt` before reaching an API call.

## Verification

The failure mode is only reproducible from a fork, so this cannot be proven by a same-repo PR — this one will pass either way. The real check is the next external contribution; #782 is the case that surfaced it.