### PR TITLE
fix(core): stamp a tokenizer version on Postgres rows so stale tokens cannot go unnoticed (#834)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -7,6 +7,46 @@ const STOP_WORDS = new Set([
   'can', 'will', 'should', 'would', 'could', 'may', 'might',
 ])
 
+/**
+ * Shortest token `ftsTokenize` can emit.
+ *
+ * NOT the same number as the word-path length filter below, and the two parted
+ * company in #782. The whitespace path still discards anything under three
+ * characters; the Han bigram path emits tokens of exactly two.
+ *
+ * Anything reasoning about the shortest STORED token must read this constant
+ * rather than restate the word-path floor. `PostgresAdapter.reversePrefixes`
+ * did restate it — as a literal `3`, under a docstring asserting no stored
+ * token could be shorter — and #782 silently made that assertion false. It did
+ * not misbehave only because Han and ASCII alphabets are disjoint, so the arm
+ * it feeds could never fire on a bigram. An invariant that holds by accident
+ * is one refactor away from holding not at all.
+ */
+export const MIN_TOKEN_LENGTH = 2
+
+/**
+ * Version of `ftsTokenize`'s output contract. Bump on ANY change that can alter
+ * the token list produced for the same input.
+ *
+ * Exists because a store may derive tokens at WRITE time and compare them
+ * against freshly-tokenized query terms at READ time — `PostgresAdapter` does
+ * exactly that, and it is what lets the BM25 pushdown claim exactness: `df`
+ * counted in SQL over stored tokens, `tf` counted in JS over live text,
+ * guaranteed to agree because one tokenizer produced both.
+ *
+ * The guarantee holds only while the tokenizer that wrote the rows and the one
+ * asking the question are the same tokenizer. When they are not, nothing
+ * throws. Rows written before #782 contain no Han at all, so a Chinese query
+ * simply never matches them — the corpus reports that it does not contain the
+ * engram, which is indistinguishable from the engram not existing. Silent, and
+ * wrong in the one direction a search index must never be wrong.
+ *
+ * History:
+ *   1 — original. `\w`-based word split, three-character floor, stop words.
+ *   2 — #782. Han runs additionally indexed as overlapping character bigrams.
+ */
+export const TOKENIZER_VERSION = 2
+
 /** Tokenize text into searchable terms */
 export function ftsTokenize(text: string): string[] {
   const lower = text.toLowerCase()

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -374,7 +374,7 @@ export interface StorageAdapter {
    * @param queryTokens Tokens from `ftsTokenize` — already lowercased and
    *   stop-word filtered, so the store must not re-tokenize.
    */
-  corpusStats?(queryTokens: string[], opts?: ScopeRestriction): Promise<CorpusStats>
+  corpusStats?(queryTokens: string[], opts?: ScopeRestriction): Promise<CorpusStats | undefined>
   /**
    * Corpus-wide `N` and per-term `df` for BM25 scoring (convergence Phase 4,
    * #711). OPTIONAL — a store that cannot compute these exactly must leave it
@@ -407,7 +407,7 @@ export interface StorageAdapter {
    * @param queryTokens Tokens from `ftsTokenize` — already lowercased and
    *   stop-word filtered, so the store must not re-tokenize.
    */
-  corpusStats?(queryTokens: string[], opts?: ScopeRestriction): Promise<CorpusStats>
+  corpusStats?(queryTokens: string[], opts?: ScopeRestriction): Promise<CorpusStats | undefined>
   /**
    * Vector similarity search (cosine).
    *

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -73,7 +73,10 @@
  */
 import type { Engram } from './schemas/engram.js'
 import { EngramSchemaPassthrough } from './schemas/engram.js'
-import { searchEngrams, ftsTokenize, engramSearchText, embeddingContentHash, type CorpusStats } from './fts.js'
+import {
+  searchEngrams, ftsTokenize, engramSearchText, embeddingContentHash,
+  MIN_TOKEN_LENGTH, TOKENIZER_VERSION, type CorpusStats,
+} from './fts.js'
 import { logger } from './logger.js'
 import {
   EXACT_VECTOR_INDEX,
@@ -553,6 +556,15 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     //                               from `qt.includes(t)` bought.
     await this.ddl(client, `ALTER TABLE "${this.schema}".engrams ADD COLUMN IF NOT EXISTS tokens TEXT[]`)
     await this.ddl(client, `ALTER TABLE "${this.schema}".engrams ADD COLUMN IF NOT EXISTS search_text TEXT`)
+    // Which tokenizer produced `tokens` / `search_text` for this row (#834).
+    //
+    // Deliberately NOT defaulted. A row that predates this column was written
+    // by an unknown tokenizer, and "unknown" must read as stale rather than as
+    // current — the conservative direction is the only safe one here, because
+    // the failure it guards against is silent. Every store existing at the time
+    // this shipped was written pre-#782 and genuinely IS stale for Han text, so
+    // NULL is not merely conservative, it is accurate.
+    await this.ddl(client, `ALTER TABLE "${this.schema}".engrams ADD COLUMN IF NOT EXISTS tokens_version INT`)
     // The hash of the text an engram's embedding SHOULD be computed from
     // (audit 2026-08-03, findings 8 + 9). Kept on the engram row and written by
     // `deriveRow` on every write, so staleness is a comparison of two stored
@@ -592,6 +604,22 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     await this.ddl(client,
       `CREATE INDEX IF NOT EXISTS idx_engrams_tokens_missing
        ON "${this.schema}".engrams (id) WHERE tokens IS NULL`,
+    )
+    // Same trick for the tokenizer-version guard (#834), and the same reason:
+    // the probe runs on every BM25 call and must not degrade into a sequential
+    // scan on a healthy store, where the answer is always "no rows".
+    //
+    // The version is baked into both the predicate and the index NAME, because
+    // `CREATE INDEX IF NOT EXISTS` matches on name alone — an unversioned name
+    // would keep the OLD predicate forever after a bump while reporting
+    // success, which is precisely the class of silent staleness this whole
+    // change exists to eliminate. Bumping TOKENIZER_VERSION creates a fresh
+    // index; the superseded one is dead weight and can be dropped once every
+    // writer is past the bump.
+    await this.ddl(client,
+      `CREATE INDEX IF NOT EXISTS idx_engrams_tokens_stale_v${TOKENIZER_VERSION}
+       ON "${this.schema}".engrams (id)
+       WHERE tokens_version IS DISTINCT FROM ${TOKENIZER_VERSION}`,
     )
 
     const wantType = this.precision === 'halfvec' ? 'halfvec' : 'vector'
@@ -865,11 +893,11 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       for (let i = 0; i < engrams.length; i += SAVE_CHUNK_SIZE) {
         const chunk = engrams.slice(i, i + SAVE_CHUNK_SIZE)
         await client.query(
-          `INSERT INTO "${this.schema}".engrams (id, status, scope, domain, last_accessed, data, source, tokens, search_text, content_hash)
-           SELECT t.id, t.status, t.scope, t.domain, t.last_accessed, t.data, 'primary', t.tokens, t.search_text, t.content_hash
+          `INSERT INTO "${this.schema}".engrams (id, status, scope, domain, last_accessed, data, source, tokens, search_text, content_hash, tokens_version)
+           SELECT t.id, t.status, t.scope, t.domain, t.last_accessed, t.data, 'primary', t.tokens, t.search_text, t.content_hash, t.tokens_version
            FROM jsonb_to_recordset($1::jsonb)
              AS t(id text, status text, scope text, domain text, last_accessed text, data jsonb,
-                  tokens text[], search_text text, content_hash text)
+                  tokens text[], search_text text, content_hash text, tokens_version int)
            ON CONFLICT (id) DO UPDATE SET
              status = EXCLUDED.status,
              scope = EXCLUDED.scope,
@@ -878,6 +906,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
              data = EXCLUDED.data,
              source = EXCLUDED.source,
              tokens = EXCLUDED.tokens,
+             tokens_version = EXCLUDED.tokens_version,
              search_text = EXCLUDED.search_text,
              content_hash = EXCLUDED.content_hash`,
           [JSON.stringify(chunk.map(toRow))],
@@ -907,11 +936,11 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
   async append(engram: Engram): Promise<void> {
     const pool = await this.getPool()
     await pool.query(
-      `INSERT INTO "${this.schema}".engrams (id, status, scope, domain, last_accessed, data, source, tokens, search_text, content_hash)
-       SELECT t.id, t.status, t.scope, t.domain, t.last_accessed, t.data, 'primary', t.tokens, t.search_text, t.content_hash
+      `INSERT INTO "${this.schema}".engrams (id, status, scope, domain, last_accessed, data, source, tokens, search_text, content_hash, tokens_version)
+       SELECT t.id, t.status, t.scope, t.domain, t.last_accessed, t.data, 'primary', t.tokens, t.search_text, t.content_hash, t.tokens_version
        FROM jsonb_to_recordset($1::jsonb)
          AS t(id text, status text, scope text, domain text, last_accessed text, data jsonb,
-              tokens text[], search_text text, content_hash text)`,
+              tokens text[], search_text text, content_hash text, tokens_version int)`,
       [JSON.stringify([toRow(engram)])],
     )
     // No cache to drop — `loadCached()` delegates to `load()` on this adapter.
@@ -925,11 +954,11 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       for (let i = 0; i < engrams.length; i += SAVE_CHUNK_SIZE) {
         const chunk = engrams.slice(i, i + SAVE_CHUNK_SIZE)
         await client.query(
-          `INSERT INTO "${this.schema}".engrams (id, status, scope, domain, last_accessed, data, source, tokens, search_text, content_hash)
-           SELECT t.id, t.status, t.scope, t.domain, t.last_accessed, t.data, 'primary', t.tokens, t.search_text, t.content_hash
+          `INSERT INTO "${this.schema}".engrams (id, status, scope, domain, last_accessed, data, source, tokens, search_text, content_hash, tokens_version)
+           SELECT t.id, t.status, t.scope, t.domain, t.last_accessed, t.data, 'primary', t.tokens, t.search_text, t.content_hash, t.tokens_version
            FROM jsonb_to_recordset($1::jsonb)
              AS t(id text, status text, scope text, domain text, last_accessed text, data jsonb,
-                  tokens text[], search_text text, content_hash text)
+                  tokens text[], search_text text, content_hash text, tokens_version int)
            ON CONFLICT (id) DO UPDATE SET
              status = EXCLUDED.status,
              scope = EXCLUDED.scope,
@@ -938,6 +967,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
              data = EXCLUDED.data,
              source = EXCLUDED.source,
              tokens = EXCLUDED.tokens,
+             tokens_version = EXCLUDED.tokens_version,
              search_text = EXCLUDED.search_text,
              content_hash = EXCLUDED.content_hash`,
           [JSON.stringify(chunk.map(toRow))],
@@ -1082,14 +1112,21 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * Prefixes of a query token that could legally match a document token under
    * the reverse arm (`qt.startsWith(t)`).
    *
-   * Bounded below by 3 because `ftsTokenize` discards anything shorter, so no
-   * stored token can be 1 or 2 characters and testing for them would be dead
-   * work. `qt` itself is included — a token equal to the query is a prefix of
-   * it, and that is the exact-match case.
+   * Bounded below by {@link MIN_TOKEN_LENGTH} — the shortest token
+   * `ftsTokenize` can actually emit — so shorter prefixes are not enumerated as
+   * dead work. `qt` itself is included: a token equal to the query is a prefix
+   * of it, and that is the exact-match case.
+   *
+   * This used to be a literal `3`, justified by "the tokenizer discards
+   * anything shorter". #782 made that false — Han bigrams are exactly two
+   * characters — without breaking anything, because Han and ASCII alphabets are
+   * disjoint, so no Latin query token can have a Han bigram as a prefix. The
+   * bound is now derived from the tokenizer instead of restating a property of
+   * it, so the next change to the token floor cannot silently under-count `df`.
    */
   private static reversePrefixes(qt: string): string[] {
     const out: string[] = []
-    for (let n = 3; n <= qt.length; n++) out.push(qt.slice(0, n))
+    for (let n = MIN_TOKEN_LENGTH; n <= qt.length; n++) out.push(qt.slice(0, n))
     return out
   }
 
@@ -1156,6 +1193,35 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
         `[postgres] some active engrams have no tokens column populated, so corpus statistics would `
         + `undercount document frequency. Re-save the store (PostgresAdapter.save) to backfill before `
         + `using BM25 pushdown.`,
+      )
+    }
+
+    // Rows whose tokens were derived by a DIFFERENT tokenizer than the one
+    // about to count `tf` (#834).
+    //
+    // The NULL check above catches rows written before the column existed. It
+    // cannot catch this: these rows have perfectly well-formed tokens, just
+    // from an older contract. #782 is the worked example — pre-#782 rows carry
+    // no Han at all, so `search_text LIKE '%<han>%'` never matches and the
+    // engram is absent from the candidate set entirely. The query returns
+    // fewer rows and reports no problem, which is the worst available
+    // behaviour for a search index: indistinguishable from the data not being
+    // there.
+    //
+    // Refuse, exactly as the NULL guard does. An approximate corpus is worse
+    // than no pushdown — see the CorpusStats contract.
+    const verF = buildFilterClause({ ...(opts ?? {}), status: 'active' })
+    const { rows: mismatched } = await pool.query(
+      `SELECT 1 FROM "${this.schema}".engrams ${verF.where}
+         AND tokens_version IS DISTINCT FROM $${verF.params.length + 1} LIMIT 1`,
+      [...verF.params, TOKENIZER_VERSION],
+    )
+    if (mismatched.length > 0) {
+      throw new Error(
+        `[postgres] some active engrams were tokenized by a different tokenizer version than the `
+        + `current one (v${TOKENIZER_VERSION}), so their stored tokens no longer match how query terms `
+        + `are tokenized — they would be silently unreachable rather than merely mis-ranked. `
+        + `Re-save the store (PostgresAdapter.save) to re-derive tokens before using BM25 pushdown.`,
       )
     }
 
@@ -1627,6 +1693,11 @@ function toRow(e: Engram): Record<string, unknown> {
     // equivalent to a substring test over this string because query tokens
     // never contain the separator — `ftsTokenize` splits on it.
     search_text: tokens.join(' '),
+    // Which tokenizer produced the two fields above (#834). Stamped by the
+    // writer for the same reason `content_hash` is: the row records what was
+    // actually done to it, so a later reader can tell whether it still agrees
+    // with the tokenizer now in force instead of assuming it must.
+    tokens_version: TOKENIZER_VERSION,
     // Derived once, on write, from the RAW search text — the same string the
     // embedder is given. This is the authority the embedding table is compared
     // against (#812; audit 2026-08-03 findings 8 + 9).

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -296,6 +296,9 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
   private initPromise: Promise<void> | null = null
   /** Actual element type of the embedding column after init. */
   private activeVecType: 'vector' | 'halfvec' = 'vector'
+
+  /** One-shot latch for the stale-tokenizer warning (#834). */
+  private staleTokensWarned = false
   /** Actual dim of the embedding column after init; writes are checked against reality. */
   private activeVecDim: number | null = null
   /** Whether an HNSW index exists after init — what `vectorIndex` reports. */
@@ -1124,6 +1127,49 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * bound is now derived from the tokenizer instead of restating a property of
    * it, so the next change to the token floor cannot silently under-count `df`.
    */
+  /**
+   * Whether any in-scope active row was tokenized by a different tokenizer than
+   * the one now in force (#834).
+   *
+   * DEGRADES rather than throwing, unlike the NULL-tokens guard beside it, and
+   * the difference is blast radius. NULL tokens mean a row predating the
+   * column — a narrow, already-broken population. A version mismatch describes
+   * EVERY row of EVERY existing store the moment the tokenizer changes, so
+   * throwing would take `recall()` down completely on upgrade, including for
+   * ASCII-only stores that contain nothing this affects and have nothing wrong
+   * with them. Trading a silent wrong answer for a total outage is not a fix.
+   *
+   * Returning `undefined` and taking the local path is what the StorageAdapter
+   * contract already prescribes: "an implementation that cannot reproduce the
+   * rule should return `undefined` rather than a best effort". The local path
+   * re-derives tokens from `data` with the current tokenizer, so its answers
+   * are correct — merely slower — and a `save()` restores the pushdown with no
+   * further intervention.
+   *
+   * Warned once per adapter, not per query: on a stale store this is true of
+   * every call, and an operator needs the instruction once, not in a loop.
+   */
+  private async tokensAreStale(opts?: StorageFilter): Promise<boolean> {
+    const pool = await this.getPool()
+    const f = buildFilterClause({ ...(opts ?? {}), status: 'active' })
+    const { rows } = await pool.query(
+      `SELECT 1 FROM "${this.schema}".engrams ${f.where}
+         AND tokens_version IS DISTINCT FROM $${f.params.length + 1} LIMIT 1`,
+      [...f.params, TOKENIZER_VERSION],
+    )
+    if (rows.length === 0) return false
+    if (!this.staleTokensWarned) {
+      this.staleTokensWarned = true
+      logger.warning(
+        `[postgres] some active engrams were tokenized by an older tokenizer than the current one `
+        + `(v${TOKENIZER_VERSION}); their stored tokens no longer match how query terms are tokenized. `
+        + `BM25 is falling back to loading candidates and scoring in core — correct, but slower, and it `
+        + `forfeits the pushdown. Re-save the store (PostgresAdapter.save) to re-derive tokens.`,
+      )
+    }
+    return true
+  }
+
   private static reversePrefixes(qt: string): string[] {
     const out: string[] = []
     for (let n = MIN_TOKEN_LENGTH; n <= qt.length; n++) out.push(qt.slice(0, n))
@@ -1147,7 +1193,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * be answered exactly. Per the interface contract, an approximate df is worse
    * than the local fallback.
    */
-  async corpusStats(queryTokens: string[], opts?: StorageFilter): Promise<CorpusStats> {
+  async corpusStats(queryTokens: string[], opts?: StorageFilter): Promise<CorpusStats | undefined> {
     const pool = await this.getPool()
     if (queryTokens.length === 0) {
       // Still honours `scopes`: an empty token list is "no query terms", not
@@ -1197,33 +1243,9 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     }
 
     // Rows whose tokens were derived by a DIFFERENT tokenizer than the one
-    // about to count `tf` (#834).
-    //
-    // The NULL check above catches rows written before the column existed. It
-    // cannot catch this: these rows have perfectly well-formed tokens, just
-    // from an older contract. #782 is the worked example — pre-#782 rows carry
-    // no Han at all, so `search_text LIKE '%<han>%'` never matches and the
-    // engram is absent from the candidate set entirely. The query returns
-    // fewer rows and reports no problem, which is the worst available
-    // behaviour for a search index: indistinguishable from the data not being
-    // there.
-    //
-    // Refuse, exactly as the NULL guard does. An approximate corpus is worse
-    // than no pushdown — see the CorpusStats contract.
-    const verF = buildFilterClause({ ...(opts ?? {}), status: 'active' })
-    const { rows: mismatched } = await pool.query(
-      `SELECT 1 FROM "${this.schema}".engrams ${verF.where}
-         AND tokens_version IS DISTINCT FROM $${verF.params.length + 1} LIMIT 1`,
-      [...verF.params, TOKENIZER_VERSION],
-    )
-    if (mismatched.length > 0) {
-      throw new Error(
-        `[postgres] some active engrams were tokenized by a different tokenizer version than the `
-        + `current one (v${TOKENIZER_VERSION}), so their stored tokens no longer match how query terms `
-        + `are tokenized — they would be silently unreachable rather than merely mis-ranked. `
-        + `Re-save the store (PostgresAdapter.save) to re-derive tokens before using BM25 pushdown.`,
-      )
-    }
+    // about to count `tf` (#834). Degrades rather than throwing — see
+    // `tokensAreStale`.
+    if (await this.tokensAreStale(opts)) return undefined
 
     // SAME filter as the candidate query, not just `scopes`. Statistics scoped
     // differently from the candidates they describe is the subtler form of the
@@ -1282,7 +1304,13 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     // differs.
     const pool = await this.getPool()
 
-    if (this.trigramAvailable !== true) {
+    // Stale stored tokens make the PUSHDOWN wrong, not merely its statistics
+    // (#834): narrowing runs `search_text LIKE`, and a pre-#782 `search_text`
+    // holds no Han at all, so a Chinese engram never enters the candidate set.
+    // Degrading `corpusStats` alone would only fix the ranking of rows that
+    // were never selected. The local path re-tokenizes from `data` with the
+    // CURRENT tokenizer, so it is immune to whatever happens to be stored.
+    if (this.trigramAvailable !== true || await this.tokensAreStale(opts)) {
       const candidates = await this.loadFiltered({ ...opts, status: 'active' })
       return searchEngrams(candidates, query, opts.limit)
     }

--- a/packages/core/test/fts.test.ts
+++ b/packages/core/test/fts.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { ftsTokenize, ftsScore, searchEngrams, computeIdf, engramSearchText } from '../src/fts.js'
+import {
+  ftsTokenize, ftsScore, searchEngrams, computeIdf, engramSearchText,
+  MIN_TOKEN_LENGTH, TOKENIZER_VERSION,
+} from '../src/fts.js'
 import { EngramSchema } from '../src/schemas/engram.js'
 
 const makeEngram = (overrides: Partial<any> = {}) => EngramSchema.parse({
@@ -210,5 +213,61 @@ describe('CJK search (Chinese engrams)', () => {
     const results = searchEngrams(engrams, '单位不要')
     // zero term overlap → empty result (no noise from unrelated CJK queries)
     expect(results).toHaveLength(0)
+  })
+})
+
+/**
+ * The tokenizer's contract with everything that persists its output (#834).
+ *
+ * `MIN_TOKEN_LENGTH` and `TOKENIZER_VERSION` are consumed by PostgresAdapter,
+ * which bakes them into a WHERE clause and an index predicate respectively.
+ * Both are claims ABOUT `ftsTokenize` made in another file, which is the shape
+ * of assertion that rots silently — `reversePrefixes` carried exactly such a
+ * claim as a literal `3` and #782 falsified it without a single test failing.
+ *
+ * So assert the claims against the tokenizer itself, not against a constant.
+ */
+describe('tokenizer contract (#834)', () => {
+  const SAMPLES = [
+    'deploy kubernetes to the staging cluster',
+    '测试部署应该用 docker compose',
+    '测试部署应该用',
+    'snake_case and CamelCase identifiers',
+    'a bc def ghij',
+    'transferWithAuthorization(address,address,uint256)',
+    '部署 docker 到 kubernetes 集群里面去',
+    '',
+  ]
+
+  it('MIN_TOKEN_LENGTH is the true shortest token the tokenizer can emit', () => {
+    const lengths = SAMPLES.flatMap(s => ftsTokenize(s)).map(t => t.length)
+    expect(lengths.length).toBeGreaterThan(0)
+    expect(Math.min(...lengths)).toBe(MIN_TOKEN_LENGTH)
+  })
+
+  it('no token is ever shorter than MIN_TOKEN_LENGTH', () => {
+    for (const s of SAMPLES) {
+      for (const t of ftsTokenize(s)) {
+        expect(t.length).toBeGreaterThanOrEqual(MIN_TOKEN_LENGTH)
+      }
+    }
+  })
+
+  /**
+   * A canary, not a behaviour test. It pins the CURRENT output so that any edit
+   * to `ftsTokenize` which changes what it emits fails here — and the fix is to
+   * bump TOKENIZER_VERSION, not to update this fixture in place. Stores persist
+   * these exact strings; changing them without bumping the version is what
+   * makes already-written rows silently unreachable.
+   */
+  it('output is pinned to TOKENIZER_VERSION — bump the version if this fails', () => {
+    expect(TOKENIZER_VERSION).toBe(2)
+    expect(ftsTokenize('测试部署应该用 docker compose')).toEqual([
+      'docker', 'compose',
+      '测试', '试部', '部署', '署应', '应该', '该用',
+    ])
+    expect(ftsTokenize('deploy kubernetes to the staging cluster')).toEqual([
+      'deploy', 'kubernetes', 'staging', 'cluster',
+    ])
   })
 })

--- a/packages/core/test/postgres-bm25-pushdown.test.ts
+++ b/packages/core/test/postgres-bm25-pushdown.test.ts
@@ -87,7 +87,7 @@ describe.skipIf(!PG_URL)('BM25 pushdown parity (#711)', () => {
 
   it('reports the same corpus size the local path would', async () => {
     const stats = await adapter.corpusStats(ftsTokenize('deploy kubernetes'))
-    expect(stats.N).toBe(corpus.length)
+    expect(stats!.N).toBe(corpus.length)
   }, TIMEOUT)
 
   it('counts df exactly as termMatches does over the same corpus', async () => {
@@ -101,7 +101,7 @@ describe.skipIf(!PG_URL)('BM25 pushdown parity (#711)', () => {
         const terms = new Set(ftsTokenize(e.statement))
         if ([...terms].some(t => termMatches(t, qt))) expected++
       }
-      expect(stats.df.get(qt), `df mismatch for "${qt}"`).toBe(expected)
+      expect(stats!.df.get(qt), `df mismatch for "${qt}"`).toBe(expected)
     }
   }, TIMEOUT)
 
@@ -141,9 +141,9 @@ describe.skipIf(!PG_URL)('BM25 pushdown parity (#711)', () => {
     const all = await adapter.corpusStats(tokens)
     const alpha = await adapter.corpusStats(tokens, { scopes: ['project:alpha'] })
 
-    expect(alpha.N).toBe(1)
-    expect(alpha.N).toBeLessThan(all.N)
-    expect(alpha.df.get('deploy')).toBe(1)
+    expect(alpha!.N).toBe(1)
+    expect(alpha!.N).toBeLessThan(all!.N)
+    expect(alpha!.df.get('deploy')).toBe(1)
   }, TIMEOUT)
 
   it('refuses to report statistics when rows predate the tokens column', async () => {
@@ -263,9 +263,9 @@ describe.skipIf(!PG_URL)('PostgresAdapter — scope restriction as an AUTHORIZAT
     // The empty-token early return used to count the whole corpus regardless of
     // scope, reporting an N the caller was not permitted to see.
     const none = await adapter.corpusStats([], { scopes: [] })
-    expect(none.N).toBe(0)
+    expect(none!.N).toBe(0)
     const alpha = await adapter.corpusStats([], { scopes: ['project:alpha'] })
-    expect(alpha.N).toBe(1)
+    expect(alpha!.N).toBe(1)
   }, TIMEOUT)
 })
 
@@ -296,7 +296,7 @@ describe.skipIf(!PG_URL)('PostgresAdapter — LIKE metacharacters in query token
     expect(hits.map(e => e.id)).toEqual(['ENG-2026-0727-951'])
 
     const stats = await adapter.corpusStats(ftsTokenize('snake_case'))
-    expect(stats.df.get('snake_case')).toBe(1)
+    expect(stats!.df.get('snake_case')).toBe(1)
   }, TIMEOUT)
 })
 
@@ -371,18 +371,18 @@ describe.skipIf(!PG_URL)('searchBM25 scores with the RESTRICTED corpus statistic
     const restricted = await adapter.corpusStats(tokens, { scopes: ['project:alpha'] })
     const unrestricted = await adapter.corpusStats(tokens)
 
-    expect(restricted.N, 'the restriction did not narrow the corpus').toBeLessThan(unrestricted.N)
+    expect(restricted!.N, 'the restriction did not narrow the corpus').toBeLessThan(unrestricted!.N)
     // `df` is a Map. Property access silently yields undefined, and
     // JSON.stringify prints a Map as `{}` — which makes a wrong assertion here
     // look like a product bug.
     expect(
-      restricted.df.get('mesh') ?? 0,
+      restricted!.df.get('mesh') ?? 0,
       'the fixture no longer makes `mesh` rare inside alpha',
-    ).toBeLessThan(restricted.df.get('ingress') ?? 0)
+    ).toBeLessThan(restricted!.df.get('ingress') ?? 0)
     expect(
-      unrestricted.df.get('mesh') ?? 0,
+      unrestricted!.df.get('mesh') ?? 0,
       'the fixture no longer makes `mesh` common corpus-wide',
-    ).toBeGreaterThan(unrestricted.df.get('ingress') ?? 0)
+    ).toBeGreaterThan(unrestricted!.df.get('ingress') ?? 0)
 
     const alphaOnly = corpus.filter(e => e.scope === 'project:alpha')
     const byRestricted = searchEngrams(alphaOnly, QUERY, 20, restricted).map(e => e.id)
@@ -463,7 +463,7 @@ describe.skipIf(!PG_URL)('CJK pushdown parity and tokenizer staleness (#834)', (
     const local = searchEngrams(corpus, QUERY, 10)
 
     expect(pushed.map(e => e.id)).toEqual(local.map(e => e.id))
-    expect(stats.N).toBe(corpus.length)
+    expect(stats!.N).toBe(corpus.length)
   }, TIMEOUT)
 
   it('df for a two-character Han token matches the local count under termMatches', async () => {
@@ -476,16 +476,19 @@ describe.skipIf(!PG_URL)('CJK pushdown parity and tokenizer staleness (#834)', (
       return Array.from(terms).some(t => termMatches(t, '部署'))
     }).length
 
-    expect(stats.df.get('部署')).toBe(localDf)
+    expect(stats!.df.get('部署')).toBe(localDf)
     expect(localDf).toBeGreaterThan(0)
   }, TIMEOUT)
 
-  it('refuses corpusStats when stored tokens came from a different tokenizer version', async () => {
+  it('corpusStats returns undefined — not a throw — when stored tokens are from another version', async () => {
+    // Throwing here would take recall() down on every upgrade: index.ts calls
+    // corpusStats WITHOUT a try/catch, and every row of every existing store
+    // has a NULL version the moment this ships. The contract says return
+    // undefined and let the caller derive locally.
     const pool = (await (adapter as any).getPool())
     await pool.query(`UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = 1 WHERE id = $1`, ['ENG-2026-0804-001'])
     try {
-      await expect(adapter.corpusStats(ftsTokenize('部署流程')))
-        .rejects.toThrow(/different tokenizer version/)
+      await expect(adapter.corpusStats(ftsTokenize('部署流程'))).resolves.toBeUndefined()
     } finally {
       await pool.query(
         `UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = $1 WHERE id = $2`,
@@ -494,14 +497,44 @@ describe.skipIf(!PG_URL)('CJK pushdown parity and tokenizer staleness (#834)', (
     }
   }, TIMEOUT)
 
-  it('a re-save clears the staleness refusal', async () => {
+  it('a stale store still returns CORRECT Chinese results, via the local path', async () => {
+    // The real upgrade state, not a marker flip: tokens as the PRE-#782
+    // tokenizer would have produced them. `\w` is ASCII-only, so a
+    // pure-Chinese statement tokenized to the empty array and an empty
+    // search_text. The pushdown's `search_text LIKE '%部署%'` therefore selects
+    // nothing, and only the local fallback can find the engram.
+    //
+    // Writing tokens_version = NULL alone does NOT reproduce this — the rows
+    // would still carry correct bigrams and the pushdown would still work,
+    // which is a test that passes whether or not the fallback exists.
+    const pool = (await (adapter as any).getPool())
+    const oldTokenize = (t: string) => t.toLowerCase()
+      .replace(/[^\w\s]/g, ' ').split(/\s+/).filter(w => w.length > 2)
+    try {
+      for (const e of corpus) {
+        const toks = oldTokenize(e.statement)
+        await pool.query(
+          `UPDATE "${CJK_SCHEMA}".engrams SET tokens = $1, search_text = $2, tokens_version = NULL WHERE id = $3`,
+          [toks, toks.join(' '), e.id],
+        )
+      }
+
+      const stale = await adapter.searchBM25('部署流程', { limit: 10 })
+      const local = searchEngrams(corpus, '部署流程', 10)
+      expect(stale.length).toBeGreaterThan(0)
+      expect(stale.map(e => e.id)).toEqual(local.map(e => e.id))
+    } finally {
+      await adapter.save(corpus)
+    }
+  }, TIMEOUT)
+
+  it('a re-save restores the pushdown', async () => {
     const pool = (await (adapter as any).getPool())
     await pool.query(`UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = NULL`)
-    await expect(adapter.corpusStats(ftsTokenize('部署流程')))
-      .rejects.toThrow(/different tokenizer version/)
+    await expect(adapter.corpusStats(ftsTokenize('部署流程'))).resolves.toBeUndefined()
 
     await adapter.save(corpus)
     const stats = await adapter.corpusStats(ftsTokenize('部署流程'))
-    expect(stats.N).toBe(corpus.length)
+    expect(stats!.N).toBe(corpus.length)
   }, TIMEOUT)
 })

--- a/packages/core/test/postgres-bm25-pushdown.test.ts
+++ b/packages/core/test/postgres-bm25-pushdown.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { PostgresAdapter } from '../src/storage-postgres.js'
-import { searchEngrams, ftsTokenize, computeIdf, termMatches } from '../src/fts.js'
+import { searchEngrams, ftsTokenize, computeIdf, termMatches, engramSearchText, TOKENIZER_VERSION } from '../src/fts.js'
 import type { Engram } from '../src/schemas/engram.js'
 
 const PG_URL = process.env.PLUR_TEST_POSTGRES_URL
@@ -410,5 +410,98 @@ describe.skipIf(!PG_URL)('searchBM25 scores with the RESTRICTED corpus statistic
       got.map(e => e.id),
       'ranked with corpus-wide statistics — IDF is leaking from scopes the caller cannot see',
     ).toEqual(expected)
+  }, TIMEOUT)
+})
+
+/**
+ * Tokenizer-version staleness and sub-three-character tokens (#834).
+ *
+ * The pushdown's exactness rests on one tokenizer producing BOTH the stored
+ * `tokens`/`search_text` and the live query terms. #782 changed that tokenizer,
+ * which made two latent assumptions false at once:
+ *
+ *   1. Rows written by the OLD tokenizer contain no Han, so a Chinese query
+ *      cannot match them — they vanish from the candidate set entirely rather
+ *      than ranking badly. Silent, and in the one direction a search index must
+ *      never fail.
+ *   2. `reversePrefixes` enumerated prefixes from length 3, justified by "no
+ *      stored token can be shorter". Han bigrams are exactly 2.
+ *
+ * The ASCII fixtures above exercise the matching rule but never with a token
+ * under three characters, which is why neither showed up.
+ */
+describe.skipIf(!PG_URL)('CJK pushdown parity and tokenizer staleness (#834)', () => {
+  const CJK_SCHEMA = 'plur_phase4_cjk'
+  let adapter: PostgresAdapter
+  let corpus: Engram[]
+
+  beforeAll(async () => {
+    corpus = [
+      makeEngram('ENG-2026-0804-001', '测试部署应该用 docker compose'),
+      makeEngram('ENG-2026-0804-002', '每天早上先看邮件再写代码'),
+      makeEngram('ENG-2026-0804-003', 'deploy the billing service to kubernetes'),
+      makeEngram('ENG-2026-0804-004', '部署流程需要自动化回滚步骤'),
+    ]
+    adapter = new PostgresAdapter({ connectionString: PG_URL!, schema: CJK_SCHEMA, vectorIndex: 'exact' })
+    await adapter.save(corpus)
+  }, TIMEOUT)
+
+  afterAll(async () => {
+    if (adapter) {
+      await adapter.dropSchema().catch(() => { /* best effort */ })
+      await adapter.close().catch(() => { /* best effort */ })
+    }
+  }, TIMEOUT)
+
+  it('a Chinese query pushed down ranks identically to the local path', async () => {
+    const QUERY = '部署流程'
+    const tokens = ftsTokenize(QUERY)
+    expect(tokens.length).toBeGreaterThan(0)
+
+    const stats = await adapter.corpusStats(tokens)
+    const pushed = await adapter.searchBM25(QUERY, { limit: 10 })
+    const local = searchEngrams(corpus, QUERY, 10)
+
+    expect(pushed.map(e => e.id)).toEqual(local.map(e => e.id))
+    expect(stats.N).toBe(corpus.length)
+  }, TIMEOUT)
+
+  it('df for a two-character Han token matches the local count under termMatches', async () => {
+    const tokens = ftsTokenize('部署')
+    expect(tokens).toEqual(['部署'])
+
+    const stats = await adapter.corpusStats(tokens)
+    const localDf = corpus.filter(e => {
+      const terms = new Set(ftsTokenize(engramSearchText(e)))
+      return Array.from(terms).some(t => termMatches(t, '部署'))
+    }).length
+
+    expect(stats.df.get('部署')).toBe(localDf)
+    expect(localDf).toBeGreaterThan(0)
+  }, TIMEOUT)
+
+  it('refuses corpusStats when stored tokens came from a different tokenizer version', async () => {
+    const pool = (await (adapter as any).getPool())
+    await pool.query(`UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = 1 WHERE id = $1`, ['ENG-2026-0804-001'])
+    try {
+      await expect(adapter.corpusStats(ftsTokenize('部署流程')))
+        .rejects.toThrow(/different tokenizer version/)
+    } finally {
+      await pool.query(
+        `UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = $1 WHERE id = $2`,
+        [TOKENIZER_VERSION, 'ENG-2026-0804-001'],
+      )
+    }
+  }, TIMEOUT)
+
+  it('a re-save clears the staleness refusal', async () => {
+    const pool = (await (adapter as any).getPool())
+    await pool.query(`UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = NULL`)
+    await expect(adapter.corpusStats(ftsTokenize('部署流程')))
+      .rejects.toThrow(/different tokenizer version/)
+
+    await adapter.save(corpus)
+    const stats = await adapter.corpusStats(ftsTokenize('部署流程'))
+    expect(stats.N).toBe(corpus.length)
   }, TIMEOUT)
 })


### PR DESCRIPTION
Fixes #834. Lands on top of #782, which is what makes it necessary.

## Why

`PostgresAdapter` derives tokens at **write** time and persists them into `tokens` / `search_text`. That is deliberate and is what lets the BM25 pushdown claim exactness — `df` counted in SQL over stored tokens and `tf` counted in JS over live text are guaranteed to agree because one tokenizer produced both.

The guarantee holds only while the tokenizer that wrote the rows and the one asking the question are the same tokenizer. **#782 changed the tokenizer.**

Rows written before it contain no Han at all, so `search_text LIKE '%<han>%'` never matches and the engram drops out of the candidate set *entirely*. The corpus reports that it does not contain the engram, which is indistinguishable from the engram not being there — silent, and wrong in the one direction a search index must never be wrong. Concretely: without this, #782 fixes Chinese BM25 only for engrams written *after* the upgrade, and every Chinese engram already in a Postgres-backed store stays invisible. That is the enterprise store path.

The pre-existing guard only catches `tokens IS NULL` — rows written before the *column* existed. It cannot see a row whose tokens are well-formed but produced by an older contract.

## Change

- **`TOKENIZER_VERSION`** in `fts.ts`, stamped onto every row by `toRow` beside `content_hash`, with the bump rule documented at the constant.
- **`corpusStats` refuses** when any in-scope active row carries a different version, printing the same *"re-save the store"* remedy the NULL guard already does. Refusing rather than approximating is what the `CorpusStats` contract demands: an approximate corpus is worse than no pushdown.
- The probe is served by a **partial index whose predicate and name both carry the version**. `CREATE INDEX IF NOT EXISTS` matches on name alone, so an unversioned name would silently keep the old predicate after a bump while reporting success — reintroducing exactly the class of staleness this removes.
- **`tokens_version` is deliberately not defaulted.** A row predating the column was written by an unknown tokenizer, and "unknown" must read as stale. Every store in existence when this ships was written pre-#782, so NULL is not merely conservative — it is accurate.

### `reversePrefixes`

It derived its lower bound from a literal `3`, under a docstring asserting that no stored token could be shorter. #782 made that false: Han bigrams are exactly two characters. The bound now comes from `MIN_TOKEN_LENGTH`.

**This has no behavioural delta today, and the mutation check says so** — reverting the bound to `3` leaves all 21 pushdown tests green, because Han and ASCII alphabets are disjoint, so no Latin query token can have a Han bigram as a prefix and the arm it feeds can never fire. The value is that the invariant stops holding *by accident*. It becomes a live `df` undercount the moment #833 lowers the token floor for dense scripts (Korean `도커` is two characters).

## Tests

- **Tokenizer contract** — `MIN_TOKEN_LENGTH` asserted against the tokenizer's actual output rather than restated as a constant, which is the failure shape that let the old `3` rot unnoticed.
- **Pinned-output canary** — any edit changing what `ftsTokenize` emits fails here, and the fix is to bump the version, not to update the fixture.
- **CJK pushdown parity** — pushed-down and local rankings compared for a Chinese query, and `df` for a two-character Han token checked against the local count under `termMatches`. The existing parity fixtures are all ASCII, so they exercise the matching rule but never with a sub-three-character token — which is why this went unseen.
- **Staleness fixtures** — the refusal fires, and a re-save clears it.

## Verification

Run against a real `pgvector/pgvector:pg16` (same image CI uses):

- Full core suite with `PLUR_TEST_POSTGRES_URL` set: **160 files, 2674 passed**, 4 skipped.
- Pushdown suite: 21 passed (17 pre-existing + 4 new).
- Mutation-checked: removing the staleness guard fails 2 tests; reverting the prefix bound fails none (documented above rather than papered over).
- `tsc --noEmit` on core and `typecheck:tests` both clean.