### PR TITLE
docs: declare 0.17.2 in CHANGELOG (#782, #837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.17.2 (2026-08-04)
 
-Chinese search works — found and fixed by skyeryg.
+🇨🇳 Chinese search works — found and fixed by skyeryg.
 
 - Chinese text is searchable
 - BM25 saw no Han at all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 0.17.2 (2026-08-04)
 
-Chinese search works — found and fixed by a contributor.
+Chinese search works — found and fixed by skyeryg.
 
 - Chinese text is searchable
-- BM25 indexed no Han before
-- Fixed by @skyeryg
+- BM25 saw no Han at all
 - Postgres guards stale tokens
+- Stale stores degrade safely
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.17.2 (2026-08-04)
+
+Chinese search works — found and fixed by a contributor.
+
+- Chinese text is searchable
+- BM25 indexed no Han before
+- Fixed by @skyeryg
+- Postgres guards stale tokens
+
+### Fixed
+
+- **Chinese text is now indexed for BM25** (#780, #782): `ftsTokenize` discarded every Han
+  character, because JavaScript's `\w` is ASCII-only (`[A-Za-z0-9_]`). Pure-Chinese queries
+  tokenized to zero terms, so BM25 contributed nothing for non-English stores — hybrid recall
+  silently degenerated to embedding-only, and under `bm25-only` degradation a Chinese query
+  returned nothing at all. Han runs are now indexed as overlapping character bigrams: the standard
+  approach for scripts without word boundaries, no new dependency, and deterministic across
+  runtimes in a way a locale-dependent segmenter is not. ASCII behaviour is unchanged, at a
+  measured 4.50µs → 4.78µs per tokenization. Reported and fixed by
+  [@skyeryg](https://github.com/skyeryg), who hit it integrating PLUR into a Chinese-language
+  workflow. Chinese only — Japanese kana, Korean, Cyrillic, Arabic, Indic scripts and accented
+  Latin are still dropped or mangled, tracked in #833.
+- **Postgres stores detect tokens written by an older tokenizer** (#834, #837): `PostgresAdapter`
+  derives tokens at write time and persists them, which is what lets the BM25 pushdown claim
+  exactness — `df` counted in SQL and `tf` counted in JS agree because one tokenizer produced both.
+  Changing the tokenizer breaks that for rows already written, and breaks it silently: pre-#782
+  rows contain no Han, so a Chinese query never matches them and the corpus reports it does not
+  hold an engram it does hold. Rows now carry the tokenizer version that produced them, and
+  `corpusStats` refuses rather than answering from a corpus it cannot vouch for, naming the
+  re-save that fixes it. Without this, the fix above would have reached only engrams written
+  *after* the upgrade.
+
 ## 0.17.1 (2026-08-03)
 
 Learning something no longer reads your whole memory first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.17.2 (2026-08-04)
 
-🇨🇳 Chinese search works — found and fixed by skyeryg.
+Chinese search works — found and fixed by skyeryg.
 
 - Chinese text is searchable
 - BM25 saw no Han at all


### PR DESCRIPTION
Release-prep for **0.17.2**, which ships the first community bug fix.

Declares the two user-facing PRs shipping since `v0.17.1`, as the manifest gate (#544) requires:

- **#782** — Chinese text is now indexed for BM25. Reported *and* fixed by [@skyeryg](https://github.com/skyeryg).
- **#837** — Postgres stores detect tokens written by an older tokenizer, without which #782 would only have reached engrams written *after* the upgrade.

#836 is `ci:` and is curated out of the gate by convention.

## Tweet

The release tweet is generated from this section — the lede and first four bullets *are* the copy. Verified with `--preview-tweet`:

```
🚀 New release: PLUR 0.17.2

Chinese search works — found and fixed by a contributor.

✅ Chinese text is searchable
✅ BM25 indexed no Han before
✅ Fixed by @skyeryg
✅ Postgres guards stale tokens

Tell your agent to update.
github.com/plur-ai/plur/releases/tag/v0.17.2
```

**267 / 270 chars.** Three characters of headroom, so any edit to the lede or the top four bullets needs a re-preview before release.

## Note on scope honesty

The entry says "Chinese", not "CJK", and names what is still broken (Japanese kana, Korean, Cyrillic, Arabic, Indic, accented Latin — #833). The original PR title said CJK; someone reading this in six months would otherwise conclude Korean worked.