### PR TITLE
fix(core): auto-backfill stale tokens, and add plur reindex-tokens (#839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Chinese search works — found and fixed by skyeryg.
 - Chinese text is searchable
 - BM25 saw no Han at all
 - Postgres guards stale tokens
-- Stale stores degrade safely
+- Stale stores self-heal
 
 ### Fixed
 
@@ -22,6 +22,14 @@ Chinese search works — found and fixed by skyeryg.
   [@skyeryg](https://github.com/skyeryg), who hit it integrating PLUR into a Chinese-language
   workflow. Chinese only — Japanese kana, Korean, Cyrillic, Arabic, Indic scripts and accented
   Latin are still dropped or mangled, tracked in #833.
+- **Stale tokens re-derive themselves, and `plur reindex-tokens` forces it** (#840, #839): the
+  detection above named a remedy — re-save the store — that nothing in ordinary use performs.
+  `PostgresAdapter` implements the targeted `append` / `updateMany` seams, so `learn()` and
+  `feedback()` each touch one row and leave every other row's version untouched; an upgraded store
+  would sit on the correct-but-slower fallback indefinitely, having permanently lost the pushdown,
+  visible only as a log line. Stale rows are now re-derived in the background the first time they
+  are noticed, and `plur reindex-tokens` forces the same pass synchronously with a count for
+  operators who want the pushdown back before the first user query rather than after it.
 - **Postgres stores detect tokens written by an older tokenizer** (#834, #837): `PostgresAdapter`
   derives tokens at write time and persists them, which is what lets the BM25 pushdown claim
   exactness — `df` counted in SQL and `tf` counted in JS agree because one tokenizer produced both.

--- a/packages/cli/src/commands/reindex-tokens.ts
+++ b/packages/cli/src/commands/reindex-tokens.ts
@@ -1,0 +1,66 @@
+/**
+ * `plur reindex-tokens` — re-derive BM25 tokens on a Postgres-backed store
+ * after a tokenizer change (#839).
+ *
+ * The adapter kicks this in the background the first time it notices stale
+ * rows, so most deployments never need to run it. It exists for the cases
+ * where "eventually, in the background" is not good enough:
+ *
+ *   - an operator upgrading deliberately, who wants the pushdown back before
+ *     the first user query rather than after it,
+ *   - a store that is read rarely, where "on the next recall" could be days,
+ *   - anyone who wants a count rather than a log line.
+ *
+ * Only Postgres persists tokens. Every other tier re-derives them per query,
+ * so there is nothing to reindex and this reports that rather than pretending
+ * to work.
+ */
+import type { GlobalFlags } from '../plur.js'
+import { PostgresAdapter } from '@plur-ai/core'
+import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+
+function usage(): never {
+  exit(1, [
+    'Usage:',
+    '  plur reindex-tokens          Re-derive BM25 tokens for rows written by an older tokenizer',
+    '',
+    'Only applies to Postgres-backed stores (postgres.url / PLUR_POSTGRES_URL).',
+    'Other tiers derive tokens per query and need no reindex.',
+  ].join('\n'))
+}
+
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) usage()
+
+  const url = process.env.PLUR_POSTGRES_URL
+  if (!url) {
+    // Not an error: it is the correct and common state. Saying so plainly
+    // beats a stack trace for someone following an upgrade note.
+    const msg = 'No Postgres store configured (postgres.url / PLUR_POSTGRES_URL). '
+      + 'Other tiers derive tokens per query — nothing to reindex.'
+    if (shouldOutputJson(flags)) {
+      outputJson({ reindexed: 0, applicable: false, reason: 'no-postgres-store' })
+    } else {
+      outputText(msg)
+    }
+    return
+  }
+
+  const adapter = new PostgresAdapter({ connectionString: url })
+  try {
+    const started = Date.now()
+    const count = await adapter.backfillTokens()
+    const ms = Date.now() - started
+
+    if (shouldOutputJson(flags)) {
+      outputJson({ reindexed: count, applicable: true, durationMs: ms })
+      return
+    }
+    outputText(count === 0
+      ? 'Tokens are already current — nothing to reindex.'
+      : `Re-derived tokens for ${count} engram(s) in ${ms}ms. BM25 pushdown is active again.`)
+  } finally {
+    // The adapter owns a connection pool; leaving it open hangs the process.
+    await adapter.close().catch(() => { /* best effort */ })
+  }
+}

--- a/packages/cli/src/commands/reindex-tokens.ts
+++ b/packages/cli/src/commands/reindex-tokens.ts
@@ -16,7 +16,7 @@
  * to work.
  */
 import type { GlobalFlags } from '../plur.js'
-import { PostgresAdapter } from '@plur-ai/core'
+import { PostgresAdapter, detectPlurStorage, loadConfig } from '@plur-ai/core'
 import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
 
 function usage(): never {
@@ -32,7 +32,13 @@ function usage(): never {
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) usage()
 
-  const url = process.env.PLUR_POSTGRES_URL
+  // Resolve EXACTLY as the engine does (index.ts `_postgresUrl`): environment
+  // first, then config.yaml. Reading only the env var made this command report
+  // "no Postgres store configured" for a deployment that had one — a false
+  // negative on the very question it exists to answer.
+  const paths = detectPlurStorage(flags.path || process.env.PLUR_PATH || undefined)
+  const config = loadConfig(paths.config) as { postgres?: { url?: string, schema?: string } }
+  const url = process.env.PLUR_POSTGRES_URL || config.postgres?.url
   if (!url) {
     // Not an error: it is the correct and common state. Saying so plainly
     // beats a stack trace for someone following an upgrade note.
@@ -46,7 +52,15 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
 
-  const adapter = new PostgresAdapter({ connectionString: url })
+  // The schema MUST come from config too. Omitting it does not fail loudly —
+  // `initSchema` runs CREATE SCHEMA IF NOT EXISTS, so a store on a custom
+  // schema would get a spurious empty default schema created, find zero stale
+  // rows in it, and print "Tokens are already current". A false all-clear is
+  // worse than no command at all.
+  const adapter = new PostgresAdapter({
+    connectionString: url,
+    ...(config.postgres?.schema ? { schema: config.postgres.schema } : {}),
+  })
   try {
     const started = Date.now()
     const count = await adapter.backfillTokens()

--- a/packages/cli/src/commands/reindex-tokens.ts
+++ b/packages/cli/src/commands/reindex-tokens.ts
@@ -1,6 +1,6 @@
 /**
  * `plur reindex-tokens` — re-derive BM25 tokens on a Postgres-backed store
- * after a tokenizer change (#839).
+ * after a tokenizer change (#840).
  *
  * The adapter kicks this in the background the first time it notices stale
  * rows, so most deployments never need to run it. It exists for the cases

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,7 @@ Commands:
   stores add <path>       Add a knowledge store
   scopes                  List authorized-but-unregistered shared scopes (#647)
   scopes register <scope> Register one; scopes dismiss <scope>; scopes --reoffer
+  reindex-tokens          Re-derive BM25 tokens after a tokenizer change (Postgres only)
   init                    Install Claude Code hooks + register plur MCP server
   init-remote             Opt this project into recall from a PLUR Enterprise server
   login --status          Enterprise token validity per host (probe + expiry) (#587)
@@ -112,6 +113,7 @@ const COMMANDS: Record<string, string> = {
   'similarity-search': './commands/similarity-search.js',
   stores: './commands/stores.js',
   scopes: './commands/scopes.js',
+  'reindex-tokens': './commands/reindex-tokens.js',
   migrate: './commands/migrate.js',
   init: './commands/init.js',
   'init-remote': './commands/init-remote.js',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,6 +125,11 @@ export { rankScopes, SCOPE_MATCH_THRESHOLD, WEIGHT_TAG, SUGGEST_DISPLAY_MIN_CONF
 // (`isSharedScope`, `isPersonalScope`, `SHARED_SCOPE_PREFIXES`) is unchanged.
 export { isSharedScope, isPersonalScope, SHARED_SCOPE_PREFIXES, scopeAllowFilter, makeVisibilityPredicate } from './scope-util.js'
 export { detectPlurStorage, type PlurPaths } from './storage.js'
+// Exported so the CLI resolves the Postgres DSN and schema exactly as the
+// engine does (#840). A second, divergent resolution in the CLI is how
+// `plur reindex-tokens` came to report a false all-clear on a store whose
+// connection lived in config.yaml rather than the environment.
+export { loadConfig } from './config.js'
 export { IndexedStorage } from './storage-indexed.js'
 export { PGLiteAdapter, type PGLiteAdapterOptions, type VectorPrecision } from './storage-pglite.js'
 export type {

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -300,7 +300,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
   /** One-shot latch for the stale-tokenizer warning (#834). */
   private staleTokensWarned = false
 
-  /** In-flight token backfill, so concurrent queries kick at most one (#839). */
+  /** In-flight token backfill, so concurrent queries kick at most one (#840). */
   private tokenBackfill: Promise<void> | null = null
   /** Actual dim of the embedding column after init; writes are checked against reality. */
   private activeVecDim: number | null = null
@@ -1132,7 +1132,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    */
   /**
    * Re-derive `tokens` / `search_text` for rows written by an older tokenizer
-   * (#839).
+   * (#840).
    *
    * Needed because nothing else does it. `save()` re-derives the whole corpus,
    * but a row store does not take that path in ordinary use: `learn()` prefers

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -1159,7 +1159,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       )
       if (rows.length === 0) break
       const engrams = rows.map(parseRow)
-      await pool.query(
+      const updated = await pool.query(
         `UPDATE "${this.schema}".engrams AS e
          SET tokens = t.tokens, search_text = t.search_text, tokens_version = t.tokens_version
          FROM jsonb_to_recordset($1::jsonb)
@@ -1170,10 +1170,21 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
           return { id: r.id, tokens: r.tokens, search_text: r.search_text, tokens_version: r.tokens_version }
         }))],
       )
-      total += rows.length
-      // A batch that cannot shrink the remaining set would loop forever. This
-      // cannot happen while the UPDATE stamps the current version, but the
-      // cost of being wrong here is an infinite loop holding a pool client.
+      // Progress, not attempts, is the loop condition. The UPDATE joins on
+      // `e.id = t.id` where `t.id` comes from the engram's OWN data, so a row
+      // whose `id` column disagrees with `data->>'id'` matches nothing, keeps
+      // its stale version, and is selected again by the identical next query —
+      // a tight infinite loop holding a pool connection. Bounding on the
+      // SELECT alone would not catch it, because that batch stays full.
+      if (updated.rowCount === 0) {
+        logger.warning(
+          `[postgres] token backfill stalled: ${rows.length} row(s) reported stale but none could be `
+          + `updated, which means their id column disagrees with data->>'id'. Skipping the backfill; `
+          + `the local-scoring fallback keeps results correct.`,
+        )
+        break
+      }
+      total += updated.rowCount ?? 0
       if (rows.length < batchSize) break
     }
     if (total > 0) {

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -299,6 +299,9 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
 
   /** One-shot latch for the stale-tokenizer warning (#834). */
   private staleTokensWarned = false
+
+  /** In-flight token backfill, so concurrent queries kick at most one (#839). */
+  private tokenBackfill: Promise<void> | null = null
   /** Actual dim of the embedding column after init; writes are checked against reality. */
   private activeVecDim: number | null = null
   /** Whether an HNSW index exists after init — what `vectorIndex` reports. */
@@ -1128,6 +1131,76 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * it, so the next change to the token floor cannot silently under-count `df`.
    */
   /**
+   * Re-derive `tokens` / `search_text` for rows written by an older tokenizer
+   * (#839).
+   *
+   * Needed because nothing else does it. `save()` re-derives the whole corpus,
+   * but a row store does not take that path in ordinary use: `learn()` prefers
+   * the `append` seam and `feedback()` prefers `updateMany`, each touching one
+   * row and leaving every other row's version untouched. So a store upgraded
+   * across a tokenizer change would sit on the local-scoring fallback
+   * indefinitely — correct, but having permanently lost the pushdown, and
+   * visible only as a log line. That is the whole reason the marker could not
+   * simply be a warning.
+   *
+   * Set-based per batch, and `toRow` is the single derivation used by every
+   * write path, so a backfilled row is byte-identical to a freshly saved one.
+   *
+   * Returns the number of rows re-derived, so a caller (the CLI) can report it.
+   */
+  async backfillTokens(batchSize = 500): Promise<number> {
+    const pool = await this.getPool()
+    let total = 0
+    for (;;) {
+      const { rows } = await pool.query(
+        `SELECT data FROM "${this.schema}".engrams
+         WHERE tokens_version IS DISTINCT FROM $1 LIMIT $2`,
+        [TOKENIZER_VERSION, batchSize],
+      )
+      if (rows.length === 0) break
+      const engrams = rows.map(parseRow)
+      await pool.query(
+        `UPDATE "${this.schema}".engrams AS e
+         SET tokens = t.tokens, search_text = t.search_text, tokens_version = t.tokens_version
+         FROM jsonb_to_recordset($1::jsonb)
+           AS t(id text, tokens text[], search_text text, tokens_version int)
+         WHERE e.id = t.id`,
+        [JSON.stringify(engrams.map((e: Engram) => {
+          const r = toRow(e)
+          return { id: r.id, tokens: r.tokens, search_text: r.search_text, tokens_version: r.tokens_version }
+        }))],
+      )
+      total += rows.length
+      // A batch that cannot shrink the remaining set would loop forever. This
+      // cannot happen while the UPDATE stamps the current version, but the
+      // cost of being wrong here is an infinite loop holding a pool client.
+      if (rows.length < batchSize) break
+    }
+    if (total > 0) {
+      logger.info(`[postgres] re-derived tokens for ${total} engram(s) after a tokenizer change`)
+    }
+    return total
+  }
+
+  /**
+   * Start a backfill without blocking the query that noticed the staleness.
+   *
+   * Fire-and-forget, mirroring the embedding backfill: the caller has already
+   * been routed to a correct-but-slower path, so waiting would trade a wrong
+   * answer for a slow one twice over. At most one runs per adapter; failures
+   * are logged and the latch clears so a later query can retry.
+   */
+  private kickTokenBackfill(): void {
+    if (this.tokenBackfill) return
+    this.tokenBackfill = this.backfillTokens()
+      .then(() => { /* logged inside */ })
+      .catch(err => {
+        logger.warning(`[postgres] token backfill failed: ${(err as Error).message}`)
+      })
+      .finally(() => { this.tokenBackfill = null })
+  }
+
+  /**
    * Whether any in-scope active row was tokenized by a different tokenizer than
    * the one now in force (#834).
    *
@@ -1163,10 +1236,11 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       logger.warning(
         `[postgres] some active engrams were tokenized by an older tokenizer than the current one `
         + `(v${TOKENIZER_VERSION}); their stored tokens no longer match how query terms are tokenized. `
-        + `BM25 is falling back to loading candidates and scoring in core — correct, but slower, and it `
-        + `forfeits the pushdown. Re-save the store (PostgresAdapter.save) to re-derive tokens.`,
+        + `BM25 is falling back to loading candidates and scoring in core — correct, but slower. `
+        + `Re-deriving them in the background; \`plur reindex-tokens\` forces it synchronously.`,
       )
     }
+    this.kickTokenBackfill()
     return true
   }
 

--- a/packages/core/test/postgres-bm25-pushdown.test.ts
+++ b/packages/core/test/postgres-bm25-pushdown.test.ts
@@ -528,6 +528,54 @@ describe.skipIf(!PG_URL)('CJK pushdown parity and tokenizer staleness (#834)', (
     }
   }, TIMEOUT)
 
+  it('auto-backfill restores the pushdown without an operator step (#839)', async () => {
+    // The gap this closes: `learn()` uses the `append` seam and `feedback()`
+    // uses `updateMany`, each touching ONE row. Neither re-derives the rest of
+    // the corpus, so ordinary use never clears staleness and the store would
+    // sit on the local-scoring fallback indefinitely.
+    const pool = (await (adapter as any).getPool())
+    const oldTokenize = (t: string) => t.toLowerCase()
+      .replace(/[^\w\s]/g, ' ').split(/\s+/).filter(w => w.length > 2)
+    for (const e of corpus) {
+      const toks = oldTokenize(e.statement)
+      await pool.query(
+        `UPDATE "${CJK_SCHEMA}".engrams SET tokens = $1, search_text = $2, tokens_version = NULL WHERE id = $3`,
+        [toks, toks.join(' '), e.id],
+      )
+    }
+
+    // The query that notices staleness answers from the fallback AND kicks the
+    // backfill; it must not block on it.
+    const during = await adapter.searchBM25('部署流程', { limit: 10 })
+    expect(during.length).toBeGreaterThan(0)
+
+    // Deterministic wait — the kick is fire-and-forget, so poll the marker
+    // rather than sleeping on a guess.
+    for (let i = 0; i < 100; i++) {
+      const { rows } = await pool.query(
+        `SELECT 1 FROM "${CJK_SCHEMA}".engrams WHERE tokens_version IS DISTINCT FROM $1 LIMIT 1`,
+        [TOKENIZER_VERSION],
+      )
+      if (rows.length === 0) break
+      await new Promise(r => setTimeout(r, 50))
+    }
+
+    // Pushdown is live again: corpusStats answers instead of declining.
+    const stats = await adapter.corpusStats(ftsTokenize('部署流程'))
+    expect(stats).toBeDefined()
+    expect(stats!.N).toBe(corpus.length)
+
+    // And the rows carry real bigrams now, not the pre-#782 empty tokenization.
+    const { rows: tok } = await pool.query(
+      `SELECT search_text FROM "${CJK_SCHEMA}".engrams WHERE id = $1`, ['ENG-2026-0804-004'])
+    expect(tok[0].search_text).toContain('部署')
+  }, TIMEOUT)
+
+  it('backfillTokens is idempotent and reports zero on a current store', async () => {
+    await adapter.save(corpus)
+    expect(await adapter.backfillTokens()).toBe(0)
+  }, TIMEOUT)
+
   it('a re-save restores the pushdown', async () => {
     const pool = (await (adapter as any).getPool())
     await pool.query(`UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = NULL`)

--- a/packages/core/test/postgres-bm25-pushdown.test.ts
+++ b/packages/core/test/postgres-bm25-pushdown.test.ts
@@ -571,6 +571,25 @@ describe.skipIf(!PG_URL)('CJK pushdown parity and tokenizer staleness (#834)', (
     expect(tok[0].search_text).toContain('部署')
   }, TIMEOUT)
 
+  it('backfill stops instead of looping when a row cannot be updated (#840)', async () => {
+    // The UPDATE joins on `e.id = t.id` where `t.id` comes from the engram's
+    // own data. Desynchronise the two and the row stays stale forever while
+    // being re-selected by an identical query — an infinite loop holding a
+    // pool connection. Bounding on the SELECT alone would not catch it.
+    const pool = (await (adapter as any).getPool())
+    await pool.query(
+      `UPDATE "${CJK_SCHEMA}".engrams SET tokens_version = NULL, data = jsonb_set(data, '{id}', '"ENG-9999-9999-999"') WHERE id = $1`,
+      ['ENG-2026-0804-002'],
+    )
+    try {
+      // The assertion that matters is that this RETURNS at all.
+      const n = await adapter.backfillTokens()
+      expect(n).toBe(0)
+    } finally {
+      await adapter.save(corpus)
+    }
+  }, TIMEOUT)
+
   it('backfillTokens is idempotent and reports zero on a current store', async () => {
     await adapter.save(corpus)
     expect(await adapter.backfillTokens()).toBe(0)


### PR DESCRIPTION
Closes #840. Follow-up to #837, found by asking a question that PR did not answer: **who actually runs `save()`?**

## The gap

#837 made stale tokens detectable and degraded safely to local scoring. Its stated remedy was "re-save the store". Nobody does that:

```ts
// index.ts:1216 — row stores take the seam, not the whole-corpus write
await this._primaryStore.append(engram)
...
await this._writeEngrams(this.paths.engrams, corpus)   // only the fallback
```

`PostgresAdapter` implements `append` and `updateMany`, so `learn()` and `feedback()` each touch **one** row. Every other row keeps its stale marker, the guard asks whether *any* row is stale, and the answer stays yes forever.

The irony is that 0.17.1's targeted-write work is exactly what removed the incidental whole-corpus rewrite that used to clear this. So an upgraded store would sit on the correct-but-slower fallback **indefinitely** — having permanently lost the pushdown that exists to stop `recall` loading and scoring the whole active set — and the only symptom would be a log line.

Correctness was never at risk. The performance regression was, silently, and on exactly the deployments that need the pushdown most.

## Two remedies, because they serve different moments

**`backfillTokens()`** — re-derives in batches, set-based per batch, reusing `toRow` so a backfilled row is byte-identical to a freshly saved one. Kicked fire-and-forget by the staleness detector, mirroring the embedding backfill (#812): the caller has already been routed to a correct path, so blocking it would trade a wrong answer for a slow one twice over. At most one runs per adapter; a failure logs and clears the latch so a later query retries.

**`plur reindex-tokens`** — forces it synchronously and reports a count. For the operator upgrading deliberately who wants the pushdown back *before* the first user query rather than after it, and for rarely-read stores where "on the next recall" could be days. On non-Postgres tiers it says so plainly and exits zero, rather than pretending to work — only Postgres persists tokens; every other tier re-derives them per query.

## Tests

- Auto-backfill restores the pushdown with no operator step, polling the version marker rather than sleeping on a guess.
- The fallback still answers *while* the backfill is in flight — the kick must not block the query that noticed.
- Rows carry real bigrams afterwards, not the pre-#782 empty tokenization.
- `backfillTokens` is idempotent and reports 0 on a current store.

Mutation-checked: removing the kick fails the first test.

## Verification

Full monorepo suite against real `pgvector/pgvector:pg16`: **277 files, 3932 passed**, 4 skipped. `tsc --noEmit` clean on core and cli; `typecheck:tests` clean.

## Release note

This should ship **with** 0.17.2, not after. Without it, 0.17.2 turns the pushdown off on every existing Postgres store and offers no way back that anyone would find.