### PR TITLE
fix(release): gate smoke on core propagation, and stop advising a version burn for lag

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,6 +1,6 @@
 # PLUR monorepo
 
-*Last updated: 2026-08-03*
+*Last updated: 2026-08-04*
 
 ## Purpose
 
@@ -17,6 +17,7 @@ pnpm monorepo, seven packages (four npm, three PyPI) — see `CLAUDE.md` for the
 | `PrimaryStore` split from `StorageAdapter` (ADR-0003) | A row-backed store needs its own persistence contract distinct from the query index — the split lets core stop hard-coding "the source of truth is a YAML file at this path." |
 | Optional store capabilities gated as *sets*, not individual methods | A store either implements a whole fallback-sharing group or none of it. Partial implementation of a shared-state group silently turns a targeted optimization into a full-corpus write — see Pitfalls. |
 | Cross-scope recurrence intentionally skipped when dedup is delegated to a store | `findActiveByContentHash` is scope-bound by contract; answering the cross-scope check (#176) would disclose another tenant's engram. Deliberate trade-off, documented in ADR-0003's 2026-08-03 amendment and the 0.17.1 CHANGELOG entry. |
+| Rejected Intl.Segmenter for Chinese tokenization in the Postgres store (#833) despite better output quality | Segmenter output tracks the host Node/ICU version; `PostgresAdapter` persists tokens at write time and recomputes at read time, so a version-skewed deployment would silently corrupt search results. A directly-worse-but-stable bigram tokenizer fails predictably; a better-but-drifting one fails invisibly. |
 
 ## Pitfalls
 
@@ -24,7 +25,7 @@ pnpm monorepo, seven packages (four npm, three PyPI) — see `CLAUDE.md` for the
 - **A scope-bound lookup silently disables the feature built on the wider query**: `findActiveByContentHash(hash, scope)` cannot answer the cross-scope recurrence check (#176) by design — it would disclose another tenant's engram if it did. Any store implementing the dedup seam loses that feature's primary-store half without an error; it's a deliberate trade-off, not a bug, but it has to be documented at every layer (JSDoc, call site, ADR, CHANGELOG) or it gets "discovered" later as a regression.
 - **A latency assertion is not a structural assertion**: "zero full-corpus loads" is the right acceptance test; a timing threshold for the same claim will flake. If you build a counting spy store, don't layer it on an existing store whose "targeted" methods call `load()` internally — the counter will report a full load per query and prove nothing.
 - **A benchmark nobody runs rots silently**: `benchmark/micro.ts` was broken on main since #794 hardened the YAML loader (it seeds `engrams.yaml` with a bare `[]`, which the loader now refuses). Nothing failed CI because nothing runs it in CI — always baseline on main before attributing a benchmark break to your own change.
-- **`release.sh` step 5b can false-positive on npm propagation lag**: `npx` returning `ETARGET` after all 6 retries doesn't always mean the publish failed — `npm view` may already show the version live under the `@next` dist-tag. Verify by hand before burning a version number on a "fix." Recovery documented in `RELEASING.md`; this has now happened twice (0.14.0, 0.17.1) — treat a third occurrence as a signal to fix the retry logic itself.
+- **`release.sh` step 5b can false-positive on npm propagation lag**: `npx` returning `ETARGET` after all 6 retries doesn't always mean the publish failed — `npm view` may already show the version live under the `@next` dist-tag. Verify by hand before burning a version number on a "fix." Recovery documented in `RELEASING.md`. This happened a third time on 0.17.2 (2026-08-04) — PR #842 adds Step 5a.5, which waits for `@plur-ai/core@VERSION` via `npm view` before any smoke check runs (the cli package smokes first and pins core exactly, so it absorbs the whole propagation wait) and sharpens the abort message to distinguish lag from a real defect. **Unproven**: no real publish has exercised this fix yet — watch the next release closely before considering it resolved.
 
 ## Getting Started
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,15 +69,28 @@ packages**, not just `cli`:
   import-time crash class that bricked `cli@0.9.2` (`Dynamic require of "os" is not supported`,
   #64) — the audited fixes live in `core`, so promoting it unchecked was a real gap (#584).
 
-Each smoke check **retries on npm-propagation lag** (up to 6 attempts, 8s apart): a package
+Each smoke check **retries on npm-propagation lag** (up to 6 attempts, 20s apart): a package
 published to `@next` seconds earlier may not be visible to `npx` yet, returning `ETARGET`
 ("no matching version") — which is not a real failure. Only that signature is retried; any
 other failure (crash, wrong version) fails fast. Without this, a propagation race aborts the
 whole release after `@next` is published — 0.14.0 hit exactly that and needed a manual
 promote → PyPI → GH release → website → tweet recovery.
 
+Before any smoke check runs, Step 5a.5 waits (up to 5 minutes) for `@plur-ai/core@<version>` to
+become resolvable via `npm view`. `cli` and `mcp` pin `core` at the exact version, so they cannot
+resolve until it is visible — without that gate the FIRST package smoked absorbs the whole set's
+propagation wait and its private retry budget decides the fate of the release. v0.17.2 died exactly
+there: `cli` exhausted its retries while `mcp`, checked seconds later against a now-propagated
+`core`, passed on its first retry. The packages were fine; the ordering was the bug.
+
 If a smoke check still fails after retries, `@next` is published but `@latest` is untouched;
-the script prints the `npm dist-tag rm … next` revert commands and aborts before promotion.
+the script prints the revert commands and aborts before promotion.
+
+**The abort message now distinguishes lag from a defect**, because the correct recovery is opposite
+in each case. If every failure matched the propagation signature (`ETARGET` / no matching version)
+and nothing crashed or reported a wrong version, the artefacts are good and the release should be
+**resumed from the promote step** — not reissued. Printing "ship the next patch" for a propagation
+timeout would burn a version number for no reason, which is what the v0.17.2 message did.
 
 **Website version pre-flight (Step 3.8).** Step 8 only *deploys* the website (rsync); it does
 not update content. The content bump (`softwareVersion` + `@plur-ai/cli@<version>` install

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -713,11 +713,20 @@ done
 # Plur class is actually exported at the promoted version, before @latest moves.
 echo -n "  @plur-ai/core@$VERSION install + import → "
 core_exit=0
+# Whether the INSTALL itself ever resolved, tracked separately because
+# `core_exit` is reused by the import check below and so cannot answer that
+# question afterwards. It is the whole distinction the classifier rests on:
+# "core never installed" is propagation lag, "core installed and is broken" is
+# a defect. Losing it is what let a broken core be advised for promotion.
+core_installed=false
 # Same propagation-retry as the --version checks above: the install can ETARGET
 # while @next is still propagating.
 for attempt in 1 2 3 4 5 6; do
   core_install_out=$(npm install --no-save --no-audit --no-fund "@plur-ai/core@$VERSION" 2>&1) && core_exit=0 || core_exit=$?
-  [ "$core_exit" -eq 0 ] && break
+  if [ "$core_exit" -eq 0 ]; then
+    core_installed=true
+    break
+  fi
   if echo "$core_install_out" | grep -qiE 'ETARGET|No matching version|notarget'; then
     [ "$attempt" -lt 6 ] && { echo -n "(propagating, retry $attempt) "; sleep 20; }
     continue
@@ -734,9 +743,18 @@ if [ "$core_exit" -eq 0 ] && [ "$core_inst" = "$VERSION" ]; then
 else
   echo "✗"
   echo "      Expected core@$VERSION to import with a Plur export (exit=$core_exit, installed=$core_inst): ${core_out:-}"
-  # Install resolved but import/version still failed → a real defect, not lag.
-  # (Pure install-ETARGET exhaustion leaves core_inst="?" — that stays as lag.)
-  [ "$core_inst" = "$VERSION" ] && SMOKE_ONLY_PROPAGATION=false
+  # The install resolved and core STILL failed — it either crashed on import or
+  # is present at the wrong version. Both are genuine defects, and both are the
+  # exact class this check exists to catch (#584, #64). Clearing the flag stops
+  # the abort from advising "resume → promote core@latest" over a broken core.
+  #
+  # Guarding on `core_installed` rather than on `core_inst = $VERSION` matters:
+  # a version MISMATCH is itself one of the two defects, so keying on the
+  # version would misfile it as lag — the same hole one level down.
+  # A pure ETARGET exhaustion never sets `core_installed`, so it stays lag.
+  if [ "$core_installed" = true ]; then
+    SMOKE_ONLY_PROPAGATION=false
+  fi
   SMOKE_OK=false
 fi
 popd > /dev/null

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -629,10 +629,47 @@ echo ""
 # the broken-publish case 0.9.2 hit (esbuild regression — the package
 # installed but `--version` would crash). If smoke fails, abort BEFORE
 # promoting to @latest so @latest stays on the prior good release.
+# --- 5a.5. Wait for the shared dependency to become resolvable ---
+# `cli` and `mcp` pin `core` at this exact version, so `npx @plur-ai/cli@X`
+# cannot resolve until `core@X` is visible to the registry's resolver. Without
+# this gate the FIRST package smoked absorbs the entire propagation wait for
+# the whole set, and its private retry budget decides the fate of the release.
+# v0.17.2 died exactly there: cli exhausted its retries, and mcp — smoked
+# seconds later against a now-propagated core — passed on its first retry. The
+# packages were fine; the ordering was the bug.
+#
+# Waiting on `npm view` here is much cheaper than an `npx` install per attempt,
+# so a generous budget costs seconds rather than minutes.
+echo "--- Step 5a.5: Wait for @plur-ai/core@$VERSION to propagate ---"
+echo -n "  "
+core_visible=false
+for _attempt in $(seq 1 30); do
+  if npm view "@plur-ai/core@$VERSION" version > /dev/null 2>&1; then
+    core_visible=true
+    break
+  fi
+  echo -n "."
+  sleep 10
+done
+if [ "$core_visible" = true ]; then
+  echo " ✓ resolvable"
+else
+  # Not fatal on its own — the smoke checks below still decide. This only means
+  # they start without the head start this gate exists to give them.
+  echo " ⚠ still not visible after 5 minutes; smoke checks may time out below"
+fi
+echo ""
+
 echo "--- Step 5b: Smoke test from @next ---"
 SMOKE_DIR=$(mktemp -d)
 pushd "$SMOKE_DIR" > /dev/null
 SMOKE_OK=true
+# Did every failure we saw look like propagation lag, rather than a defect?
+# The distinction changes the RECOVERY ADVICE completely: a crash means burn the
+# version and ship a patch; lag means the artefacts are good and the release
+# should be resumed from the promote step. v0.17.2 printed the former for the
+# latter, which would have burned a version for no reason.
+SMOKE_ONLY_PROPAGATION=true
 # CLI-shaped packages ship a `--version` bin (cli → `plur`, mcp → `plur-mcp`).
 # Both are promoted to @latest, so both are smoke-tested — #584: previously only
 # cli was checked, yet the audited fixes live in core (pulled in transitively).
@@ -659,6 +696,7 @@ for pkg_check in "cli:$VERSION" "mcp:$VERSION"; do
       [ "$attempt" -lt 6 ] && { echo -n "(propagating, retry $attempt) "; sleep 20; }
       continue
     fi
+    SMOKE_ONLY_PROPAGATION=false
     break
   done
   if [ "$smoke_ok_pkg" = true ]; then
@@ -684,6 +722,7 @@ for attempt in 1 2 3 4 5 6; do
     [ "$attempt" -lt 6 ] && { echo -n "(propagating, retry $attempt) "; sleep 20; }
     continue
   fi
+  SMOKE_ONLY_PROPAGATION=false
   break
 done
 if [ "$core_exit" -eq 0 ]; then
@@ -702,14 +741,38 @@ rm -rf "$SMOKE_DIR"
 if [ "$SMOKE_OK" != true ]; then
   echo ""
   echo "✗ Smoke test FAILED. @next is published but @latest is unchanged."
-  echo "  To revert @next:"
+  if [ "$SMOKE_ONLY_PROPAGATION" = true ]; then
+    # Every failure matched the propagation signature and none was a crash or a
+    # wrong version. The published artefacts are almost certainly fine and the
+    # registry was simply still catching up — do NOT burn the version.
+    echo ""
+    echo "  Every failure was npm-propagation lag (ETARGET / no matching version),"
+    echo "  never a crash or a version mismatch. The published artefacts are most"
+    echo "  likely GOOD and the registry was still catching up."
+    echo ""
+    echo "  DO NOT ship a new patch version for this. Verify, then RESUME:"
+    echo "    1. npx -y @plur-ai/cli@$VERSION --version    # expect $VERSION"
+    echo "    2. npx -y @plur-ai/mcp@$VERSION --version    # expect $VERSION"
+    echo "    3. If both report $VERSION, promote and continue the release:"
+    echo "         for p in core cli mcp migrate; do npm dist-tag add @plur-ai/\$p@$VERSION latest; done"
+    echo "       then finish PyPI (Step 6), GitHub release (7), website (8), tweet (9)."
+    echo "    4. Only if a check CRASHES or reports the wrong version is this a real"
+    echo "       defect — then revert @next and ship the next patch (see below)."
+    echo ""
+    echo "  Revert @next only if step 1 or 2 shows a genuine defect:"
+  else
+    echo "  A check crashed or reported the wrong version — this is a real defect."
+    echo "  To revert @next:"
+  fi
   echo "    npm dist-tag rm @plur-ai/core next"
   echo "    npm dist-tag rm @plur-ai/mcp next"
   echo "    npm dist-tag rm @plur-ai/cli next"
   if [ -n "$CLAW_VERSION" ]; then
     echo "    npm dist-tag rm @plur-ai/claw next"
   fi
-  echo "  Then ship a fix as the next patch (e.g. $VERSION → next-patch) and re-run."
+  if [ "$SMOKE_ONLY_PROPAGATION" != true ]; then
+    echo "  Then ship a fix as the next patch (e.g. $VERSION → next-patch) and re-run."
+  fi
   exit 1
 fi
 echo "✓ Smoke test passed."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -734,6 +734,9 @@ if [ "$core_exit" -eq 0 ] && [ "$core_inst" = "$VERSION" ]; then
 else
   echo "✗"
   echo "      Expected core@$VERSION to import with a Plur export (exit=$core_exit, installed=$core_inst): ${core_out:-}"
+  # Install resolved but import/version still failed → a real defect, not lag.
+  # (Pure install-ETARGET exhaustion leaves core_inst="?" — that stays as lag.)
+  [ "$core_inst" = "$VERSION" ] && SMOKE_ONLY_PROPAGATION=false
   SMOKE_OK=false
 fi
 popd > /dev/null


### PR DESCRIPTION
Fixes the failure that aborted the v0.17.2 release mid-flight.

## What happened

The release published all four packages to `@next`, then aborted at the smoke test. **Nothing was wrong with the artefacts** — I verified each by hand immediately afterwards and every one reported `0.17.2`.

`cli` and `mcp` pin `core` at the exact version, so `npx @plur-ai/cli@X` cannot resolve until `core@X` is visible to the registry's resolver. `cli` is smoked **first**, so it absorbed the entire propagation wait for the whole set, and its private six-attempt budget decided the fate of the release:

```
npx -y @plur-ai/cli@0.17.2 --version → (propagating, retry 1) … (retry 5) ✗
    npm error notarget No matching version found for @plur-ai/core@0.17.2
npx -y @plur-ai/mcp@0.17.2 --version → (propagating, retry 1) ✓
@plur-ai/core@0.17.2 install + import → ✓
```

`mcp`, checked seconds later against a now-propagated `core`, passed on its **first** retry. The packages were fine; the ordering was the bug. RELEASING.md already records v0.14.0 dying the same way — the retry loop added afterwards narrowed the window without closing it.

## The worse half: the advice was wrong

On abort the script printed:

> Then ship a fix as the next patch (e.g. 0.17.2 → next-patch) and re-run.

Following that would have **burned 0.17.2 and republished a byte-identical artefact as 0.17.3**. The correct recovery — resume from the promote step — is the opposite action, and the script gave no way to tell which situation you were in.

## Changes

**1. Gate on the shared dependency (Step 5a.5).** Wait up to 5 minutes for `@plur-ai/core@$VERSION` to become resolvable via `npm view` before any smoke check runs, so no single package's retry budget stands in for the whole set's propagation. `npm view` is far cheaper than an `npx` install per attempt, so a generous budget costs seconds. Non-fatal on its own — the smoke checks still decide.

**2. Distinguish lag from a defect.** Track whether *every* failure matched the propagation signature. If nothing crashed and no wrong version was ever seen, say so and give the resume path:

```
Every failure was npm-propagation lag (ETARGET / no matching version),
never a crash or a version mismatch. …
DO NOT ship a new patch version for this. Verify, then RESUME:
  1. npx -y @plur-ai/cli@X --version    # expect X
  …
  3. for p in core cli mcp migrate; do npm dist-tag add @plur-ai/$p@X latest; done
```

A genuine crash or version mismatch still gets the revert-and-patch advice, unchanged.

**3. Docs.** RELEASING.md documents the gate and corrects a stale claim that retries are "8s apart" — the code has used 20s.

## Verification

- Both message branches render correctly (lag → resume; crash → revert+patch).
- The gate resolves a genuinely published version, and correctly never resolves an absent one.
- `bash -n` clean; `--preview-tweet` still works and still reports 262/270 for 0.17.2.

Not claiming an end-to-end rehearsal: the only faithful test is a real publish, and that is not something to rehearse against the registry.