### PR TITLE
fix(mcp): record scalar-only payload drops so the log can falsify #297

### DIFF
--- a/packages/mcp/src/drop-log.ts
+++ b/packages/mcp/src/drop-log.ts
@@ -23,8 +23,15 @@ import { atomicWrite, withLock } from '@plur-ai/core'
  *    diagnosing — every failure path is swallowed.
  */
 
-/** Newest-N cap applied on every write. */
-export const PAYLOAD_DROP_LOG_MAX_ENTRIES = 100
+/**
+ * Newest-N cap applied on every write.
+ *
+ * Raised from 100 when scalar-only partial drops started being recorded: that
+ * population is dominated by ordinary caller errors and is far more frequent
+ * than a genuine client drop, so the old cap would evict the rare events the
+ * log exists to preserve. A record is a few hundred bytes of field names.
+ */
+export const PAYLOAD_DROP_LOG_MAX_ENTRIES = 500
 
 export interface PayloadDropRecord {
   /** ISO-8601 timestamp of the drop. */
@@ -46,6 +53,16 @@ export interface PayloadDropRecord {
   received_fields: string[]
   /** Schema-required field NAMES that were missing. */
   missing_fields: string[]
+  /**
+   * The subset of {@link missing_fields} that is array-typed.
+   *
+   * This is the discriminator that makes the log falsifiable. A partial drop
+   * missing an array is the #297 shape; one missing only scalars is usually an
+   * ordinary caller error. Both are recorded — recording only the former made
+   * "every partial drop involves an array" true by construction and so unable
+   * to test the hypothesis it appeared to confirm. Empty array = scalar-only.
+   */
+  missing_array_params: string[]
   /** JSON-RPC request id, when the SDK exposes it. */
   request_id?: string | number
   /** @plur-ai/mcp version that recorded the drop. */

--- a/packages/mcp/src/drop-log.ts
+++ b/packages/mcp/src/drop-log.ts
@@ -61,8 +61,14 @@ export interface PayloadDropRecord {
    * ordinary caller error. Both are recorded — recording only the former made
    * "every partial drop involves an array" true by construction and so unable
    * to test the hypothesis it appeared to confirm. Empty array = scalar-only.
+   *
+   * OPTIONAL because records predating the discriminator do not carry it, and
+   * `readPayloadDropLog` returns those too. `undefined` is not `[]`: it means
+   * "unknown, and array-shaped by construction" — the old gate could not record
+   * anything else — whereas `[]` is a measured scalar-only drop. Anything
+   * computing the ratio must exclude `undefined` rather than count it as zero.
    */
-  missing_array_params: string[]
+  missing_array_params?: string[]
   /** JSON-RPC request id, when the SDK exposes it. */
   request_id?: string | number
   /** @plur-ai/mcp version that recorded the drop. */

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -278,6 +278,7 @@ export async function createServer(plur?: Plur, options?: { profile?: ToolProfil
             params_keys: Object.keys((request.params ?? {}) as Record<string, unknown>),
             received_fields: validated.errorPayload.received_fields,
             missing_fields: validated.errorPayload.missing_fields,
+            missing_array_params: validated.missingArrayParams,
             request_id: (request as { id?: string | number }).id,
             server_version: VERSION,
           })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -281,6 +281,12 @@ export function validateToolArgs(
   rawArgs: Record<string, unknown>,
 ): { ok: true; data: Record<string, unknown> } | {
   ok: false
+  /**
+   * Missing field NAMES that are array-typed. Sits OUTSIDE `errorPayload` so
+   * the forensic log can separate the #297 array shape from a scalar-only miss
+   * without adding a field to the client-visible error response.
+   */
+  missingArrayParams: string[]
   errorPayload: {
     error: string
     success: false
@@ -330,7 +336,22 @@ export function validateToolArgs(
       .filter((k: string) => (schema.properties as any)?.[k]?.type === 'array')
 
     const wholePayloadDrop = receivedFields.length === 0
-    const partialDrop = !wholePayloadDrop && missingArrayParams.length > 0
+    // Any partial arrival is recorded, not only one missing an array param.
+    //
+    // Gating on `missingArrayParams.length > 0` meant every partial drop in the
+    // log involved an array BY CONSTRUCTION, so the log agreed with #297's
+    // array hypothesis no matter what was true and could never test it — and
+    // testing it is what #772 asks for. A scalar-only miss is usually an
+    // ordinary caller error rather than a client drop, so the two populations
+    // are separated by `missingArrayParams` on the record instead of by
+    // excluding one of them from the evidence.
+    const partialDrop = !wholePayloadDrop && missingFields.length > 0
+    // What gets RECORDED and what gets EXPLAINED are now different questions.
+    // The #297 hint tells a caller to reshape array params, which is wrong (and
+    // misleading) advice for a scalar-only miss — that caller simply omitted a
+    // field. So the hint stays keyed on an array actually being missing, while
+    // the log records both populations.
+    const arrayShapedDrop = partialDrop && missingArrayParams.length > 0
 
     let dropHint = ''
     if (wholePayloadDrop) {
@@ -345,7 +366,7 @@ export function validateToolArgs(
             '(e.g. tags: "[\\"a\\",\\"b\\"]") or a comma-separated string (tags: "a, b") — the server ' +
             'coerces both back into arrays.'
           : '')
-    } else if (partialDrop) {
+    } else if (arrayShapedDrop) {
       dropHint = ' Known client-side bug (plur-ai/plur#297): some MCP clients drop ' +
         `array-typed parameters from a large arguments payload while keeping the earlier fields ` +
         `(here: ${missingArrayParams.join(', ')}). This is size-sensitive — the same call often ` +
@@ -367,6 +388,7 @@ export function validateToolArgs(
         'Fix the field(s) named above and retry; do not abandon the call.'
     return {
       ok: false,
+      missingArrayParams,
       errorPayload: {
         error: `Invalid arguments: ${details}. ${receivedNote} ${disposition}${dropHint}`,
         success: false,

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -325,15 +325,39 @@ describe('MCP server (wire protocol)', () => {
       expect(readPayloadDropLog(dir)).toEqual([])
     })
 
-    it('an ordinary caller error (fields present, non-array missing) is NOT logged as a drop', async () => {
+    // Contract change (#772): this case used to be excluded from the log on the
+    // reasoning that a non-array miss is an ordinary caller error, not a client
+    // drop. True — but the exclusion made the log unfalsifiable. Recording a
+    // partial drop ONLY when a missing field is array-typed guarantees that
+    // 100% of recorded partial drops involve an array, whatever the truth is,
+    // so the log could never test #297's array hypothesis — the one question
+    // #772 exists to answer. Both populations are now recorded and separated by
+    // `missing_array_params`, which is what makes the ratio measurable.
+    it('a scalar-only partial drop is recorded, so the array correlation can be falsified (#772)', async () => {
       const result = await client.callTool({
         name: 'plur_learn',
         arguments: { scope: 'global', type: 'behavioral' },
       })
       expect(result.isError).toBe(true)
       const parsed = JSON.parse((result.content as any)[0].text)
-      expect(parsed.drop).toBeUndefined()
-      expect(readPayloadDropLog(dir)).toEqual([])
+      expect(parsed.drop).toBe('partial')
+      const records = readPayloadDropLog(dir)
+      expect(records.length).toBe(1)
+      expect(records[0].arguments_wire).toBe('partial')
+      expect(records[0].missing_fields).toContain('statement')
+      // No array among the missing fields — this is the population the old gate
+      // could not see.
+      expect(records[0].missing_array_params).toEqual([])
+    })
+
+    it('missing_array_params separates the #297 shape from a scalar-only miss', async () => {
+      await client.callTool({ name: 'plur_learn', arguments: { scope: 'global' } })
+      await client.callTool({ name: 'plur_session_end', arguments: { summary: 'x' } })
+
+      const records = readPayloadDropLog(dir)
+      expect(records.length).toBe(2)
+      expect(records[0].missing_array_params).toEqual([])
+      expect(records[1].missing_array_params).toEqual(['engram_suggestions'])
     })
 
     // Server-side exoneration pin: #772's strongest observed correlation is


### PR DESCRIPTION
Progresses #772.

## The problem

`drop-log.ts` records a partial drop only when a missing field is array-typed:

```ts
const partialDrop = !wholePayloadDrop && missingArrayParams.length > 0
```

So 100% of recorded partial drops involve an array **by construction**. The log
agrees with #297's array hypothesis whatever the truth is, and cannot test it —
which is exactly what #772's "suggested follow-up" asks the log to do. A partial
drop losing only scalar fields is structurally invisible.

## Evidence this is not hypothetical

Seven days of the shipped log (v0.17.0 landed 2026-08-03, `166c3c4` / #779):

| | |
|---|---|
| `plur_session_end`, `partial`, missing `engram_suggestions` | **5** |
| whole-payload drops (the #772 signature) | **0** |

Read naively that is a perfect array correlation. It is the gate reporting its
own shape. Worth stating plainly: **the #772 whole-payload signature has not
recurred once in seven days** — that gate is unconditional
(`receivedFields.length === 0`), so an occurrence would have been recorded, and
the log sat at 5/100 entries so nothing was evicted.

## The change

- Record any partial arrival, not only array-shaped ones.
- Add `missing_array_params` to the record, separating the #297 shape from a
  scalar-only miss so the ratio is **measured** rather than assumed.
- Cap 100 → 500. A scalar-only miss is usually an ordinary caller error and far
  more frequent than a real drop; at the old cap it would evict the rare events
  the log exists to preserve.
- Keep the #297 hint keyed on an array actually being missing. "Reshape your
  array params" is misleading advice for a caller who simply omitted a scalar,
  and recording is a separate question from explaining.

## Compatibility

Records written before this change carry no `missing_array_params` key — and all
of them are array-shaped by construction. `readPayloadDropLog` parses them
unchanged.

## Tests

Replaces the test that pinned the old exclusion (`an ordinary caller error … is
NOT logged as a drop`) — that assertion *was* the bias — with two that pin the
new contract: a scalar-only partial drop is recorded, and `missing_array_params`
separates the populations.

`pnpm test`: **3814 passed / 156 skipped**, 0 failures. `pnpm build` clean,
`tsc --noEmit` clean.