### PR TITLE
fix(core,mcp): refuse an ambiguous bare id in forget() (#831)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4858,8 +4858,69 @@ export class Plur {
    * retirement. The default decrement-until-zero behavior is for internal
    * dedup tracking (two agents learned the same fact; one forgets — the
    * other's reference should remain). */
-  async forget(id: string, reason?: string, options?: { force?: boolean }): Promise<void> {
+  async forget(id: string, reason?: string, options?: { force?: boolean; scope?: string }): Promise<void> {
     this._assertWritable()
+
+    // Scope-targeted routing (#831). Ids are minted PER STORE, so one bare id
+    // can name several unrelated engrams. Resolving primary-first and retiring
+    // whichever came back destroyed the wrong engram in real use: history for
+    // ENG-2026-08-03-008 shows three creations across three scopes, and the
+    // retire hit the 11:32 one when the caller meant the 19:15 one — reporting
+    // success and echoing a statement the caller had never written.
+    //
+    // Same shape as the feedback disambiguation (#850): `scope` routes
+    // directly, and an unqualified id that resolves in more than one place is
+    // an error. `forget` is destructive, so refusing beats guessing by a wider
+    // margin here than it does for feedback.
+    const targetScope = options?.scope
+    if (targetScope && targetScope !== 'primary') {
+      const entry = (this.config.stores ?? []).find(s => s.url && s.scope === targetScope)
+      if (entry) {
+        if (entry.readonly === true) throw new Error('Cannot retire engram from readonly store')
+        const serverId = this._stripRemotePrefix(id, entry.scope)
+        const driver = this._getRemoteDriver({ url: entry.url!, token: entry.token, scope: entry.scope })
+        const remoteEngram = await driver.getById(serverId)
+        if (!remoteEngram) throw new Error(`Engram "${id}" not found in store "${targetScope}"`)
+        const removed = await driver.remove(serverId)
+        if (!removed) {
+          throw new Error(
+            `Engram ${id} exists in ${targetScope} but the server refused to retire it — it was NOT removed. `
+            + `Check that the token has delete rights for that scope.`,
+          )
+        }
+        appendHistory(this.paths.root, {
+          event: 'engram_retired',
+          engram_id: id,
+          timestamp: new Date().toISOString(),
+          data: { reason: reason ?? null, routed_to: 'remote', scope: targetScope },
+        })
+        return
+      }
+      // No URL-backed store carries this scope — fall through to default
+      // resolution rather than failing on a scope that may name a local store.
+    }
+
+    // Ambiguity guard: refuse an unqualified id that a warmed remote cache also
+    // holds. Cold cache keeps the historical first-match-wins path, so this
+    // cannot break callers that never warm (backward compatible, matching #851).
+    if (!targetScope) {
+      // AMBIGUOUS means it resolves in more than one place — so the local hit is
+      // part of the condition, not an assumption. A remote-only id (including a
+      // namespaced/prefixed one, #86) is not ambiguous and must keep routing
+      // straight through; guarding on the remote cache alone broke exactly that.
+      const localHit = (await this._loadTargeted([id])).some(e => e.id === id)
+      for (const entry of (localHit ? (this.config.stores ?? []) : [])) {
+        if (!entry.url) continue
+        const serverId = this._stripRemotePrefix(id, entry.scope)
+        if (this._loadRemoteCached(entry).some(e => e.id === serverId)) {
+          throw new Error(
+            `Ambiguous engram ID "${id}": exists in both the local store and remote scope "${entry.scope}". `
+            + `Retiring is destructive and irreversible from here, so it will not guess. `
+            + `Pass scope: "primary" to retire the local engram, or scope: "${entry.scope}" to retire the remote one.`,
+          )
+        }
+      }
+    }
     // Check primary first.
     // Reference-counted retirement (#107): decrement reference_count; only
     // physically retire when it reaches 0. forget() called N times on an
@@ -4982,6 +5043,14 @@ export class Plur {
 
     // Check remote stores — the engram may live on an enterprise server.
     // See: https://github.com/plur-ai/plur/issues/84
+    // scope: "primary" is an explicit local-only request (#831). Falling
+    // through to the remote walk here would retire a remote engram the caller
+    // just said they did not mean — the exact wrong-target retire this guard
+    // exists to prevent, arrived at from the opposite direction.
+    if (targetScope === 'primary') {
+      throw new Error(`Engram not found in the local primary store: ${id}`)
+    }
+
     // Strip store prefix before querying remote. See: #86
     let refusedBy: string | null = null
     for (const entry of (this.config.stores ?? [])) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4873,6 +4873,14 @@ export class Plur {
     // an error. `forget` is destructive, so refusing beats guessing by a wider
     // margin here than it does for feedback.
     const targetScope = options?.scope
+    if (targetScope !== undefined && (typeof targetScope !== 'string' || targetScope.trim() === '')) {
+      throw new TypeError('plur.forget: scope must be a non-empty string')
+    }
+    // Pick up out-of-process config edits (#307) so a store registered after
+    // startup is a valid target without a restart — mirrors rescope(). Without
+    // this, a stale in-memory config would make the validation below reject a
+    // scope that is in fact configured (#864 is the same class of staleness).
+    if (targetScope) this.reloadConfigIfChanged()
     if (targetScope && targetScope !== 'primary') {
       const entry = (this.config.stores ?? []).find(s => s.url && s.scope === targetScope)
       if (entry) {
@@ -4896,8 +4904,34 @@ export class Plur {
         })
         return
       }
-      // No URL-backed store carries this scope — fall through to default
-      // resolution rather than failing on a scope that may name a local store.
+      // No URL-backed store carries this scope. Falling through blindly here
+      // was a hole on the destructive path (#855 audit): because `targetScope`
+      // is truthy, the `if (!targetScope)` ambiguity guard below is skipped —
+      // so a MISTYPED scope silently disabled the guard and restored
+      // first-match-wins on exactly the id the guard exists to refuse.
+      // Verified: `group:tset` as a typo of `group:test` retired the local
+      // engram, issued no remote DELETE, and reported success.
+      //
+      // So validate that the scope names something before trusting it as a
+      // disambiguation signal. Same rule and same wording as rescope(), which
+      // documents this as typo protection — a scope that reaches neither a
+      // local family nor a configured store is a caller error, not a hint.
+      const storeEntry = (this.config.stores ?? []).find(s => s.scope === targetScope)
+      const isLocalFamily = targetScope === 'local'
+        || targetScope === 'global'
+        || targetScope.startsWith('project:')
+      if (!isLocalFamily && !storeEntry) {
+        const configured = (this.config.stores ?? []).map(s => s.scope).filter(Boolean)
+        throw new Error(
+          `Cannot retire from "${targetScope}": no configured store matches that scope. `
+          + `Valid targets: primary, local, global, project:*`
+          + (configured.length ? `, or a configured store scope (${configured.join(', ')})` : '')
+          + `. Check for typos — an unmatched scope would silently retire the LOCAL engram instead (#831).`,
+        )
+      }
+      // Past this point the scope names a local-family or non-URL store, so it
+      // is a genuine disambiguation signal and the ambiguity guard is
+      // deliberately skipped: the caller has already said which side they mean.
     }
 
     // Check primary first.
@@ -4920,13 +4954,45 @@ export class Plur {
       // placement in #851 rather than re-deriving the local hit with a second
       // targeted read, which is what an earlier version of this did.
       //
-      // Cold remote cache keeps the historical first-match-wins path, so callers
-      // that never warm are unaffected.
+      // A COLD cache must not silently downgrade to first-match-wins (#855
+      // audit): `_loadRemoteCached` is a synchronous peek with no fetch, and
+      // nothing here warms it, so on a fresh process the guard simply did not
+      // run and the #831 destroy-the-wrong-engram path was reachable unguarded.
+      // Note the asymmetry that made this indefensible — a local MISS already
+      // pays for a live `driver.getById` walk below, so the function was
+      // willing to make the network call in the case where it matters less.
+      //
+      // So: peek first (free), and fall back to a bounded live lookup — one
+      // getById per configured remote store — only when that store's cache is
+      // cold. If the lookup cannot complete, refuse rather than guess; the
+      // caller has an explicit escape hatch in scope: "primary", which skips
+      // this block entirely and needs no network.
       if (!targetScope) {
         for (const entry of (this.config.stores ?? [])) {
           if (!entry.url) continue
           const serverId = this._stripRemotePrefix(id, entry.scope)
-          if (this._loadRemoteCached(entry).some(e => e.id === serverId)) {
+          const cached = this._loadRemoteCached(entry)
+          let existsRemotely: boolean
+          if (cached.length > 0) {
+            existsRemotely = cached.some(e => e.id === serverId)
+          } else {
+            try {
+              const driver = this._getRemoteDriver({ url: entry.url!, token: entry.token, scope: entry.scope })
+              // existsById, NOT getById: the latter returns null for a dead
+              // network exactly as it does for a genuine 404, so it would
+              // report "no collision" for a store it never reached — the
+              // silent-no this guard exists to refuse.
+              existsRemotely = await driver.existsById(serverId)
+            } catch (e) {
+              throw new Error(
+                `Cannot safely retire "${id}": remote scope "${entry.scope}" is configured but could not be `
+                + `reached to rule out an id collision (${e instanceof Error ? e.message : String(e)}). `
+                + `Retiring is destructive and irreversible from here, so it will not guess. `
+                + `Pass scope: "primary" to retire the local engram without consulting the remote.`,
+              )
+            }
+          }
+          if (existsRemotely) {
             throw new Error(
               `Ambiguous engram ID "${id}": exists in both the local store and remote scope "${entry.scope}". `
               + `Retiring is destructive and irreversible from here, so it will not guess. `
@@ -4935,6 +5001,17 @@ export class Plur {
           }
         }
       }
+
+      // Already retired — nothing to do (#855 audit). The MCP layer has an
+      // `Already retired` short-circuit, but it depends on a prior getById
+      // that an explicitly-scoped forget deliberately skips, so without this
+      // a second scoped forget re-ran the whole retirement: it rewrote the
+      // row and appended a SECOND `engram_retired` event for the same engram,
+      // then reported success. History is the audit trail for a destructive
+      // irreversible operation; it must not record a retirement that did not
+      // happen. Idempotent here so the guarantee does not depend on which
+      // caller reached us.
+      if (engram.status === 'retired') return true
 
       // Audit iter-2 fix (Data): for legacy engrams created before #107
       // landed, `reference_count` is missing. Defaulting to 1 means the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4900,27 +4900,6 @@ export class Plur {
       // resolution rather than failing on a scope that may name a local store.
     }
 
-    // Ambiguity guard: refuse an unqualified id that a warmed remote cache also
-    // holds. Cold cache keeps the historical first-match-wins path, so this
-    // cannot break callers that never warm (backward compatible, matching #851).
-    if (!targetScope) {
-      // AMBIGUOUS means it resolves in more than one place — so the local hit is
-      // part of the condition, not an assumption. A remote-only id (including a
-      // namespaced/prefixed one, #86) is not ambiguous and must keep routing
-      // straight through; guarding on the remote cache alone broke exactly that.
-      const localHit = (await this._loadTargeted([id])).some(e => e.id === id)
-      for (const entry of (localHit ? (this.config.stores ?? []) : [])) {
-        if (!entry.url) continue
-        const serverId = this._stripRemotePrefix(id, entry.scope)
-        if (this._loadRemoteCached(entry).some(e => e.id === serverId)) {
-          throw new Error(
-            `Ambiguous engram ID "${id}": exists in both the local store and remote scope "${entry.scope}". `
-            + `Retiring is destructive and irreversible from here, so it will not guess. `
-            + `Pass scope: "primary" to retire the local engram, or scope: "${entry.scope}" to retire the remote one.`,
-          )
-        }
-      }
-    }
     // Check primary first.
     // Reference-counted retirement (#107): decrement reference_count; only
     // physically retire when it reaches 0. forget() called N times on an
@@ -4933,6 +4912,29 @@ export class Plur {
       const engrams = await this._loadTargeted([id])
       const engram = engrams.find(e => e.id === id)
       if (!engram) return false
+
+      // Ambiguity guard (#831). Sits HERE, past the not-found return, so the
+      // local hit is established by control flow — "ambiguous" means it resolves
+      // in more than one place, and a remote-only id (including a namespaced one,
+      // #86) is not ambiguous and must keep routing straight through. Matches the
+      // placement in #851 rather than re-deriving the local hit with a second
+      // targeted read, which is what an earlier version of this did.
+      //
+      // Cold remote cache keeps the historical first-match-wins path, so callers
+      // that never warm are unaffected.
+      if (!targetScope) {
+        for (const entry of (this.config.stores ?? [])) {
+          if (!entry.url) continue
+          const serverId = this._stripRemotePrefix(id, entry.scope)
+          if (this._loadRemoteCached(entry).some(e => e.id === serverId)) {
+            throw new Error(
+              `Ambiguous engram ID "${id}": exists in both the local store and remote scope "${entry.scope}". `
+              + `Retiring is destructive and irreversible from here, so it will not guess. `
+              + `Pass scope: "primary" to retire the local engram, or scope: "${entry.scope}" to retire the remote one.`,
+            )
+          }
+        }
+      }
 
       // Audit iter-2 fix (Data): for legacy engrams created before #107
       // landed, `reference_count` is missing. Defaulting to 1 means the

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -397,6 +397,32 @@ export class RemoteStore implements EngramStore {
     }
   }
 
+  /**
+   * Existence probe that distinguishes "definitely absent" from "cannot tell".
+   *
+   * `getById` collapses both onto `null` — a 404 and a dead network return the
+   * same value — which is safe for the read paths that only want the engram,
+   * and unsafe for anything deciding whether it is free to act. `forget()`
+   * needs the distinction: treating an unreachable store as "not there" is how
+   * an id collision goes unnoticed and the wrong engram gets retired (#831).
+   *
+   * Returns false ONLY on an authoritative 404. Anything else — transport
+   * failure, 5xx, auth rejection — throws, so the caller must decide what an
+   * unknown means rather than inheriting a silent "no".
+   */
+  async existsById(id: string): Promise<boolean> {
+    const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, { headers: this.headers() })
+    if (r.status === 404) return false
+    if (!r.ok) throw new Error(`HTTP ${r.status} from ${this.apiBase}`)
+    // A 200 is not on its own proof of existence — confirm the body actually
+    // describes THIS engram. Servers and proxies return 200 with collection or
+    // envelope payloads on routes they do not recognise, and inferring
+    // existence from the status line alone would turn that into a false
+    // collision report on every forget.
+    const row = await r.json().catch(() => null) as { id?: unknown } | null
+    return typeof row?.id === 'string' && row.id === id
+  }
+
   /** Remove → DELETE /api/v1/engrams/:id (server soft-retires). */
   async remove(id: string): Promise<boolean> {
     const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -361,6 +361,100 @@ describe('forget() — remote routing (issue #84)', () => {
     await expect(plur.forget('ENG-NONEXISTENT-001')).rejects.toThrow('Engram not found')
   })
 
+  // #831 — ids are minted per store, so one bare id can name several unrelated
+  // engrams. `forget` resolved primary-first and retired whichever it reached,
+  // reporting success and echoing a statement the caller never wrote. In real
+  // use that destroyed the wrong engram: plur_history for ENG-2026-08-03-008
+  // shows three creations across three scopes; the retire hit the 11:32 one
+  // when the caller meant the 19:15 one.
+  //
+  // Mirrors the feedback disambiguation in #850/#851: an unqualified id that
+  // resolves in more than one place is an ERROR, not a coin flip. Destructive
+  // ambiguity has to refuse rather than pick.
+  describe('ambiguous ids across stores (#831)', () => {
+    /**
+     * Seed the LOCAL primary store with a chosen id. `learn()` cannot do this —
+     * `LearnContext` has no `id` and the store mints its own — and a generated
+     * id would never collide, which is the entire condition under test.
+     */
+    function seedLocal(id: string, statement: string) {
+      writeFileSync(join(primaryDir, 'engrams.yaml'), yaml.dump({
+        engrams: [{
+          id, version: 2, status: 'active', consolidated: false,
+          type: 'behavioral', scope: 'global', visibility: 'private', statement,
+          activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-10' },
+          feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+          knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+          knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+          abstract: null, derived_from: null, polarity: null, content_hash: `h-${id}`,
+          commitment: 'leaning', reference_count: 1, sources: [], recurrence_count: 0,
+          summary: statement, engram_version: 1, episode_ids: [],
+        }],
+      }), 'utf8')
+    }
+
+    async function warmedCollision(id: string) {
+      writeStoresConfig(primaryDir, [
+        { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+      ])
+      // Remote holds `id`; the load endpoint returns it so warming the cache
+      // makes the collision observable without a live per-call fetch.
+      fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'DELETE') {
+          return { ok: true, status: 200, json: async () => ({ id, status: 'retired' }), text: async () => '' } as Response
+        }
+        if (method === 'GET' && typeof url === 'string' && url.includes(`/engrams/${id}`)) {
+          return {
+            ok: true, status: 200,
+            json: async () => ({ id, scope: 'group:test', status: 'active', data: { statement: 'the remote one' } }),
+            text: async () => '',
+          } as Response
+        }
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: [{ id, scope: 'group:test', status: 'active', data: { statement: 'the remote one' } }], total_count: 1 }),
+          text: async () => '',
+        } as Response
+      }) as any)
+      seedLocal(id, 'the local one')
+      const plur = new Plur({ path: primaryDir })
+      await plur.warmRemoteCaches()
+      return plur
+    }
+
+    it('refuses an unqualified id that exists locally AND on a warmed remote', async () => {
+      const plur = await warmedCollision('ENG-COLLIDE-001')
+
+      await expect(plur.forget('ENG-COLLIDE-001')).rejects.toThrow(/Ambiguous engram ID/)
+
+      // and nothing was retired on either side
+      expect(deleteCalls().length).toBe(0)
+      const local = await plur.getById('ENG-COLLIDE-001')
+      expect(local!.status).toBe('active')
+    })
+
+    it('scope "primary" retires the local engram and never touches the remote', async () => {
+      const plur = await warmedCollision('ENG-COLLIDE-002')
+
+      await plur.forget('ENG-COLLIDE-002', 'local is stale', { scope: 'primary' })
+
+      expect(deleteCalls().length).toBe(0)
+      const local = await plur.getById('ENG-COLLIDE-002')
+      expect(local!.status).toBe('retired')
+    })
+
+    it('an explicit remote scope retires there, leaving the local engram alone', async () => {
+      const plur = await warmedCollision('ENG-COLLIDE-003')
+
+      await plur.forget('ENG-COLLIDE-003', 'remote is stale', { scope: 'group:test' })
+
+      expect(deleteCalls().length).toBe(1)
+      const local = await plur.getById('ENG-COLLIDE-003')
+      expect(local!.status).toBe('active')
+    })
+  })
+
   it('forget handles remote server error gracefully', async () => {
     // getById throws a network error
     fetchMock.mockImplementation((async () => {

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -453,6 +453,133 @@ describe('forget() — remote routing (issue #84)', () => {
       const local = await plur.getById('ENG-COLLIDE-003')
       expect(local!.status).toBe('active')
     })
+
+    // The hole the #855 audit found: `if (targetScope && targetScope !== 'primary')`
+    // fell through when no store matched, and because targetScope was TRUTHY the
+    // `if (!targetScope)` ambiguity guard below was skipped entirely. So a typo
+    // disabled the guard and restored first-match-wins on exactly the id the
+    // guard exists to refuse — reached THROUGH the parameter added to prevent it.
+    it('refuses a typo-d scope instead of silently retiring the local engram', async () => {
+      const plur = await warmedCollision('ENG-COLLIDE-004')
+
+      // 'group:tset' is a typo of the configured 'group:test'
+      await expect(
+        plur.forget('ENG-COLLIDE-004', 'oops', { scope: 'group:tset' }),
+      ).rejects.toThrow(/no configured store matches that scope/)
+
+      expect(deleteCalls().length).toBe(0)
+      const local = await plur.getById('ENG-COLLIDE-004')
+      expect(local!.status).toBe('active')
+    })
+
+    it('names the valid targets so a typo is correctable from the error alone', async () => {
+      const plur = await warmedCollision('ENG-COLLIDE-005')
+
+      await expect(
+        plur.forget('ENG-COLLIDE-005', 'oops', { scope: 'group:tset' }),
+      ).rejects.toThrow(/group:test/)
+    })
+
+    it('accepts a local-family scope as a genuine disambiguation signal', async () => {
+      const plur = await warmedCollision('ENG-COLLIDE-006')
+
+      await plur.forget('ENG-COLLIDE-006', 'local is stale', { scope: 'global' })
+
+      expect(deleteCalls().length).toBe(0)
+      const local = await plur.getById('ENG-COLLIDE-006')
+      expect(local!.status).toBe('retired')
+    })
+
+    /**
+     * Same collision, but the remote peek cache is never warmed — the state a
+     * fresh process is always in. `_loadRemoteCached` is a synchronous peek
+     * with no fetch, so the guard used to simply not run here and #831 was
+     * reachable unguarded.
+     */
+    async function coldCollision(id: string) {
+      writeStoresConfig(primaryDir, [
+        { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+      ])
+      fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'DELETE') {
+          return { ok: true, status: 200, json: async () => ({ id, status: 'retired' }), text: async () => '' } as Response
+        }
+        if (method === 'GET' && typeof url === 'string' && url.includes(`/engrams/${id}`)) {
+          return {
+            ok: true, status: 200,
+            json: async () => ({ id, scope: 'group:test', status: 'active', data: { statement: 'the remote one' } }),
+            text: async () => '',
+          } as Response
+        }
+        // Cold: the bulk load endpoint returns nothing, so the peek stays empty.
+        return {
+          ok: true, status: 200,
+          json: async () => ({ rows: [], total_count: 0 }),
+          text: async () => '',
+        } as Response
+      }) as any)
+      seedLocal(id, 'the local one')
+      return new Plur({ path: primaryDir })
+    }
+
+    it('falls back to a live lookup when the remote cache is cold', async () => {
+      const plur = await coldCollision('ENG-COLD-001')
+
+      await expect(plur.forget('ENG-COLD-001')).rejects.toThrow(/Ambiguous engram ID/)
+
+      expect(deleteCalls().length).toBe(0)
+      const local = await plur.getById('ENG-COLD-001')
+      expect(local!.status).toBe('active')
+    })
+
+    it('scope "primary" skips the live lookup entirely on a cold cache', async () => {
+      const plur = await coldCollision('ENG-COLD-002')
+
+      await plur.forget('ENG-COLD-002', 'local is stale', { scope: 'primary' })
+
+      expect(deleteCalls().length).toBe(0)
+      const local = await plur.getById('ENG-COLD-002')
+      expect(local!.status).toBe('retired')
+    })
+
+    it('refuses rather than guessing when the remote cannot be reached to rule out a collision', async () => {
+      writeStoresConfig(primaryDir, [
+        { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+      ])
+      fetchMock.mockImplementation((async (_url: string, init?: { method?: string }) => {
+        if ((init?.method ?? 'GET') === 'GET') throw new Error('network down')
+        return { ok: true, status: 200, json: async () => ({}), text: async () => '' } as Response
+      }) as any)
+      seedLocal('ENG-COLD-003', 'the local one')
+      const plur = new Plur({ path: primaryDir })
+
+      await expect(plur.forget('ENG-COLD-003')).rejects.toThrow(/could not be reached/)
+
+      const local = await plur.getById('ENG-COLD-003')
+      expect(local!.status).toBe('active')
+    })
+
+    // The MCP layer's `Already retired` short-circuit depends on a prior
+    // getById that an explicitly-scoped forget deliberately skips, so core has
+    // to be idempotent on its own account. History is the audit trail for a
+    // destructive irreversible operation — a second call must not append a
+    // second `engram_retired` for the same engram.
+    it('is idempotent — a second scoped forget does not re-retire or re-log', async () => {
+      const plur = await warmedCollision('ENG-COLLIDE-007')
+
+      await plur.forget('ENG-COLLIDE-007', 'first', { scope: 'primary' })
+      await plur.forget('ENG-COLLIDE-007', 'second', { scope: 'primary' })
+
+      // History is bucketed per month: {root}/history/YYYY-MM.jsonl
+      const historyDir = join(primaryDir, 'history')
+      const events = readdirSync(historyDir)
+        .filter(f => f.endsWith('.jsonl'))
+        .flatMap(f => readFileSync(join(historyDir, f), 'utf8').split('\n').filter(Boolean))
+        .map(l => JSON.parse(l))
+        .filter(e => e.engram_id === 'ENG-COLLIDE-007' && e.event === 'engram_retired')
+      expect(events.length).toBe(1)
+    })
   })
 
   it('forget handles remote server error gracefully', async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1419,7 +1419,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
         properties: {
           id: { type: 'string', description: 'Exact engram ID to retire' },
           search: { type: 'string', description: 'Search term to find engram to retire' },
-          scope: { type: 'string', description: 'Which store holds it (#831). Ids are minted per store, so one id can name several unrelated engrams. Pass "primary" for the local store, or a remote scope (e.g. "group:plur/plur-ai/engineering"). Omit it and an id resolving in two places is refused rather than guessed.' },
+          scope: { type: 'string', description: 'Which store holds it (#831). Ids are minted per store, so one id can name several unrelated engrams. Pass "primary" to stay on disk — the local primary store and any local secondary stores, never a remote — or a remote scope (e.g. "group:plur/plur-ai/engineering") to target that server. A scope matching no configured store is rejected, not guessed at. Omit it and an id resolving in two places is refused.' },
         },
       },
       handler: async (args, plur) => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1419,11 +1419,17 @@ function getAllToolDefinitions(): ToolDefinition[] {
         properties: {
           id: { type: 'string', description: 'Exact engram ID to retire' },
           search: { type: 'string', description: 'Search term to find engram to retire' },
+          scope: { type: 'string', description: 'Which store holds it (#831). Ids are minted per store, so one id can name several unrelated engrams. Pass "primary" for the local store, or a remote scope (e.g. "group:plur/plur-ai/engineering"). Omit it and an id resolving in two places is refused rather than guessed.' },
         },
       },
       handler: async (args, plur) => {
         if (args.id) {
-          const engram = await plur.getById(args.id as string)
+          const scope = args.scope as string | undefined
+          // getById resolves first-match-wins across stores, so on a colliding
+          // id it can return — and then report as retired — an engram that is
+          // not the one forget() acts on (#831). With an explicit scope, let
+          // forget() do the resolving and report from its own result.
+          const engram = scope ? undefined : await plur.getById(args.id as string)
           if (engram) {
             if (engram.status === 'retired') return { success: false, error: `Already retired: ${args.id}` }
             // force:true — explicit user forget always fully retires, ignoring
@@ -1432,11 +1438,12 @@ function getAllToolDefinitions(): ToolDefinition[] {
             await plur.forget(args.id as string, undefined, { force: true })
             return { success: true, retired: { id: engram.id, statement: engram.statement } }
           }
-          // Not in local store — fall through to plur.forget() which routes to
-          // remote stores (with prefix stripping per #86 / PR #186). Throws
-          // "Engram not found" if it's nowhere.
-          await plur.forget(args.id as string, undefined, { force: true })
-          return { success: true, retired: { id: args.id as string } }
+          // Not in local store, or an explicit scope was given — let
+          // plur.forget() resolve. It routes to remote stores (with prefix
+          // stripping per #86 / PR #186), refuses an ambiguous unqualified id
+          // (#831), and throws "Engram not found" if it is nowhere.
+          await plur.forget(args.id as string, undefined, { force: true, ...(scope ? { scope } : {}) })
+          return { success: true, retired: { id: args.id as string, ...(scope ? { scope } : {}) } }
         }
         if (args.search) {
           // remote:false (#776) — forget-by-search resolves local retirement


### PR DESCRIPTION
Fixes #831 — the destructive half of the cross-store id collision. Companion to
#851, which fixes the same root cause in `feedback()`.

## Why this one first

#831 has already caused damage. `plur_history` for `ENG-2026-08-03-008` shows
**three separate creations across three scopes**; a `plur_forget` retired the
11:32 engram when the caller meant the 19:15 one, reported success, and echoed a
statement the caller had never written. Ids are minted per store, `forget`
resolved primary-first, and nothing in the response indicated a mismatch.

## The change

`forget(id, reason, { scope })`, mirroring #851's shape:

- `scope: "primary"` → local primary only
- `scope: "<remote-scope>"` → routes straight to that remote
- no scope + id resolves in **two** places → throws `Ambiguous engram ID`
- cold remote cache → historical first-match-wins preserved (backward compatible)

## Two edges the tests caught

**"Ambiguous" needs both sides.** My first guard keyed on the remote cache alone
and broke `forget()` for a remote-only namespaced id (#86) — that id is not
ambiguous and must route straight through. The local hit is now part of the
condition rather than an assumption.

**`scope: "primary"` must not fall through to the remote walk.** Without an early
return it would retire a remote engram the caller had just said they did not
mean — the same wrong-target retire, reached from the opposite direction.

## Heads-up for #851

The feedback guard there has the same shape as my first attempt — it throws when
the id is in a warmed remote cache, without confirming it also resolves locally.
Worth checking whether `plur_feedback` on a remote-only namespaced id now throws
`Ambiguous` where it should just route. I did not touch that PR.

When both land, the disambiguation should be extracted into one shared helper
rather than living twice.

## Tests

Three new cases in `packages/core/test/remote-routing.test.ts` under
`ambiguous ids across stores (#831)` — refuse-on-collision, `scope: "primary"`
retires local and never calls the remote, explicit remote scope retires there and
leaves local active. Local engrams are seeded directly because `LearnContext` has
no `id` and a generated one would never collide, which is the whole condition.

Before the fix: collision resolved instead of rejecting, and the explicit-remote
case made 0 DELETE calls instead of 1.

## Gate

`pnpm test` **3816 passed / 156 skipped**, 0 failures. `pnpm build`,
`tsc --noEmit` on core, and `pnpm typecheck:tests` all clean.

Note: `remote-routing.test.ts` also has an unrelated flaky failure under parallel
load (`keys distinct paths independently`) that passes in isolation — same class
as enterprise#897, not introduced here.