### PR TITLE
fix(core,mcp): report near-duplicates on both write paths, and stop guessing a bar (#854)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,10 @@ jobs:
           fi
       - uses: pnpm/action-setup@v4
         if: steps.relevant.outputs.run == 'true'
+        with:
+          # Required: package.json carries no `packageManager` key, so the
+          # action cannot infer it. Same pin as the other two jobs.
+          version: 9
       - uses: actions/setup-node@v4
         if: steps.relevant.outputs.run == 'true'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           CHANGED=$(git diff --name-only "$BASE" HEAD)
           echo "changed files vs $BASE:"
           echo "$CHANGED"
-          if echo "$CHANGED" | grep -qE 'packages/core/src/(embeddings|fts|learn-async)\.ts|dedup-threshold-calibration'; then
+          if echo "$CHANGED" | grep -qE 'packages/core/src/(embeddings|fts|learn-async)\.ts|packages/core/src/embedders/|packages/core/src/schemas/config\.ts|dedup-threshold-calibration'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "SKIPPING: no change to the embedder, the enrichment fields, or the bar."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,15 +148,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          # Full history: the comparison below needs the PR base commit, which a
+          # shallow clone does not have.
+          fetch-depth: 0
       - name: Did this diff touch the embedder, the enrichment, or the bar?
         id: relevant
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
-          CHANGED=$(git diff --name-only HEAD^ HEAD || true)
+          # Compare against the PR BASE, not HEAD^.
+          #
+          # `git diff HEAD^ HEAD` sees only the most recent commit, so a PR that
+          # changed learn-async.ts and then pushed a docs-only follow-up would
+          # skip calibration and report green — a check that silently declines to
+          # run is indistinguishable from one that passed, which is the failure
+          # this job exists to catch elsewhere.
+          BASE="$BASE_SHA"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            # New branch, or a base we cannot resolve: fail OPEN and calibrate.
+            echo "base '$BASE' unusable — running calibration rather than assuming it is unnecessary"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD)
+          echo "changed files vs $BASE:"
           echo "$CHANGED"
           if echo "$CHANGED" | grep -qE 'packages/core/src/(embeddings|fts|learn-async)\.ts|dedup-threshold-calibration'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
+            echo "SKIPPING: no change to the embedder, the enrichment fields, or the bar."
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,54 @@ jobs:
   # scripts/smoke-release.sh covered exactly that and nothing invoked it, so it
   # could only catch anything when someone remembered to run it by hand. One
   # Node version is enough: this checks packaging, not runtime compatibility.
+  # Calibration for the #854 cosine dedup bar. Loads the real BGE-small model,
+  # so it is NOT part of the default suite (offline-safe) and NOT part of the
+  # test matrix (model download per Node version would be three downloads for
+  # one answer).
+  #
+  # Path-filtered on purpose. The threshold rests on an empirical claim —
+  # enriched duplicates land above 0.95, enriched DISTINCT statements below —
+  # and that claim can only be invalidated by changing the embedder, the
+  # enrichment fields, or the bar itself. Those are exactly the paths below.
+  # A code-path regression (comparing bare text again) is caught by the fast
+  # stubbed test in dedup-cosine.test.ts, which runs on every PR.
+  #
+  # Non-blocking: a model fetch is a network dependency, and a check that goes
+  # red for reasons unrelated to the diff trains people to ignore red.
+  dedup-calibration:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Did this diff touch the embedder, the enrichment, or the bar?
+        id: relevant
+        run: |
+          CHANGED=$(git diff --name-only HEAD^ HEAD || true)
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -qE 'packages/core/src/(embeddings|fts|learn-async)\.ts|dedup-threshold-calibration'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: pnpm/action-setup@v4
+        if: steps.relevant.outputs.run == 'true'
+      - uses: actions/setup-node@v4
+        if: steps.relevant.outputs.run == 'true'
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+        if: steps.relevant.outputs.run == 'true'
+      - name: Calibrate the dedup threshold against the real embedder
+        if: steps.relevant.outputs.run == 'true'
+        env:
+          PLUR_EMBEDDER_NETWORK_TESTS: '1'
+        run: npx vitest run --project @plur-ai/core packages/core/test/dedup-threshold-calibration.test.ts --reporter=verbose
+
   smoke-packaged:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -65,6 +65,46 @@ export function ftsTokenize(text: string): string[] {
   return tokens
 }
 
+/**
+ * The context fields that enrich a statement into searchable text.
+ *
+ * Named separately from `Engram` so a not-yet-stored write can be turned into
+ * the SAME text an existing engram would produce (#854). Dedup compares an
+ * incoming statement against stored engrams; embedding the bare statement on
+ * one side and enriched text on the other is not a like-for-like comparison,
+ * and it measurably destroys the signal — a distinct pair (staging port 8080 vs
+ * 8081) scores 0.9749 bare and 0.8512 enriched, while a genuine duplicate goes
+ * 0.9689 -> 0.9878. Context pushes the two classes APART; dropping it from one
+ * side collapses them together.
+ */
+export interface SearchTextFields {
+  statement: string
+  domain?: string | null
+  tags?: string[] | null
+  entities?: Engram['entities']
+  temporal?: Engram['temporal']
+  rationale?: string | null
+  source?: string | null
+  dual_coding?: Engram['dual_coding']
+  knowledge_anchors?: Engram['knowledge_anchors']
+}
+
+/**
+ * Build searchable text from context fields. Single definition so the stored
+ * and incoming sides cannot drift apart.
+ */
+export function searchTextFrom(fields: SearchTextFields): string {
+  // `engramSearchText` reads `engram.tags.length` unguarded — fine for a
+  // schema-validated Engram, a crash for a partial write. Normalise first.
+  return engramSearchText({
+    ...fields,
+    tags: fields.tags ?? [],
+    domain: fields.domain ?? undefined,
+    rationale: fields.rationale ?? undefined,
+    source: fields.source ?? undefined,
+  } as unknown as Engram)
+}
+
 /** Build searchable text from all engram fields */
 export function engramSearchText(engram: Engram): string {
   const parts = [engram.statement]

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { createHash } from 'crypto'
 
 export interface HistoryEvent {
-  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'engram_rescoped' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome' | 'session_scope_changed'
+  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'engram_rescoped' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome' | 'session_scope_changed' | 'dedup_near_duplicate'
   /**
    * Engram this event belongs to. Session-level events
    * (`session_scope_changed`) carry no engram — they use `''`, which by

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2671,6 +2671,13 @@ export class Plur {
     context?: LearnContext,
     excludeId?: string,
   ): Promise<{ mode: 'cosine' | 'hash-only'; near_duplicates?: Array<{ id: string; score: number }> }> {
+    // Respect the existing dedup switches. This costs a bounded recall plus one
+    // query embedding on every learn, which is a real addition to a hot path —
+    // so `dedup.enabled: false` or `mode: 'off'` must turn it off, exactly as
+    // they turn off the batch path's similarity pass. Reporting is worth paying
+    // for by default; it should not be unavoidable.
+    const dedupCfg = this.config.dedup ?? {}
+    if (dedupCfg.enabled === false || dedupCfg.mode === 'off') return { mode: 'hash-only' }
     try {
       let candidates: Engram[] = []
       try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2909,6 +2909,22 @@ export class Plur {
       engramsPath: this.paths.engrams,
       rootPath: this.paths.root,
       dedupConfig: this.config.dedup ?? {},
+      // Local similarity for the no-LLM dedup path (#854). Scores the already
+      // fetched candidates rather than the corpus, and reuses the embedding
+      // cache, so this costs one query embedding and no API call. Returns []
+      // when the embedder is unavailable, which the caller reads as
+      // "similarity did not run" rather than "nothing was similar".
+      similarityScores: async (statement: string, candidates: Engram[]) => {
+        if (candidates.length === 0) return []
+        const { embeddingSearchWithScores } = await import('./embeddings.js')
+        const scored = await embeddingSearchWithScores(
+          candidates,
+          statement,
+          candidates.length,
+          this.paths.root,
+        )
+        return scored.map(s => ({ id: s.engram.id, score: s.score }))
+      },
       isLlmAvailable: () => this._isLlmDedupAvailable(),
       recordLlmSuccess: () => this._recordLlmSuccess(),
       recordLlmFailure: () => this._recordLlmFailure(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ import { loadConfig } from './config.js'
 import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, initFilesystemStore } from './engrams.js'
 import { maybeDailyBackup } from './backup.js'
 import { logger } from './logger.js'
-import { searchEngrams, ftsTokenize, extendCorpusStats } from './fts.js'
+import { searchEngrams, ftsTokenize, extendCorpusStats, searchTextFrom } from './fts.js'
 import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer } from './inject.js'
 import { reactivate } from './decay.js'
 import { captureEpisode, queryTimeline } from './episodes.js'
@@ -2649,6 +2649,83 @@ export class Plur {
    * (caller knows the write didn't land — better UX than a fire-and-
    * forget that pretends success and leaves the user with a phantom ID).
    */
+  /**
+   * Report the closest existing engrams to a statement — REPORTING ONLY (#856).
+   *
+   * `plur_learn` goes through {@link learnRouted} → sync `learn()`, which has
+   * only ever had exact content-hash dedup; `learnAsync` (and therefore the
+   * similarity pass) is reachable solely from `plur_learn_batch`. So the
+   * dominant write path had no near-duplicate visibility at all, which is how
+   * #854 happened on it.
+   *
+   * This gives that path the same observation the batch path gets, without
+   * giving either the power to suppress a write. Never throws: similarity is an
+   * optimisation, and a reporting failure must not affect a write that has
+   * already happened.
+   *
+   * @param excludeId engram to omit — pass the just-written id so it does not
+   *                  match itself at 1.0.
+   */
+  async nearDuplicates(
+    statement: string,
+    context?: LearnContext,
+    excludeId?: string,
+  ): Promise<{ mode: 'cosine' | 'hash-only'; near_duplicates?: Array<{ id: string; score: number }> }> {
+    try {
+      let candidates: Engram[] = []
+      try {
+        candidates = await this.recall(statement, { limit: 6 })
+      } catch { candidates = [] }
+      candidates = candidates.filter(c => c.status === 'active' && c.id !== excludeId)
+      // Mirror the batch path's scope-awareness (#359).
+      if (context?.scope) candidates = candidates.filter(c => c.scope === context.scope)
+      if (candidates.length === 0) return { mode: 'hash-only' }
+
+      const query = searchTextFrom({
+        statement,
+        domain: context?.domain,
+        tags: context?.tags,
+        rationale: context?.rationale,
+        source: context?.source,
+        dual_coding: context?.dual_coding as never,
+        knowledge_anchors: context?.knowledge_anchors as never,
+      })
+      const { embeddingSearchWithScores } = await import('./embeddings.js')
+      // Dynamic, matching how learn-async is loaded elsewhere in this class —
+      // and imported rather than re-declared so both write paths observe at the
+      // same floor and the recorded distribution stays comparable.
+      const { NEAR_DUPLICATE_OBSERVATION_FLOOR } = await import('./learn-async.js')
+      const scored = await embeddingSearchWithScores(candidates, query, candidates.length, this.paths.root)
+      if (scored.length === 0) return { mode: 'hash-only' }
+
+      const ranked = scored
+        .map(s => ({ id: s.engram.id, score: s.score }))
+        .sort((a, b) => b.score - a.score)
+      const top = ranked[0]
+      if (top.score >= NEAR_DUPLICATE_OBSERVATION_FLOOR) {
+        try {
+          appendHistory(this.paths.root, {
+            event: 'dedup_near_duplicate',
+            engram_id: top.id,
+            timestamp: new Date().toISOString(),
+            data: {
+              statement: statement.slice(0, 200),
+              top_score: Number(top.score.toFixed(4)),
+              scope: context?.scope ?? null,
+              incoming_has_domain: Boolean(context?.domain),
+              incoming_has_rationale: Boolean(context?.rationale),
+              path: 'learn',
+            },
+          })
+        } catch { /* observation only */ }
+      }
+      return { mode: 'cosine', near_duplicates: ranked.slice(0, 3) }
+    } catch (err) {
+      logger.warning(`near-duplicate reporting unavailable: ${err}`)
+      return { mode: 'hash-only' }
+    }
+  }
+
   async learnRouted(statement: string, context?: LearnContext): Promise<Engram> {
     this._assertWritable()
     // #729: validate type BEFORE the secrets scan — a bad type must fail

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -8,6 +8,7 @@ import { appendHistory } from './history.js'
 import { logger } from './logger.js'
 import { withAsyncLock } from './store/async-lock.js'
 import { maybeDailyBackup } from './backup.js'
+import { searchTextFrom } from './fts.js'
 import type { Engram } from './schemas/engram.js'
 import type { AsyncPrimaryStore } from './store/primary-store.js'
 import type { SecretMatch } from './secrets.js'
@@ -298,12 +299,27 @@ export async function learnAsync(
   }
 
   // Step 2: Check dedup config
-  // threshold default raised 0.85 -> 0.95 when it was first actually WIRED
-  // (#854). It sat unread for four months, so 0.85 was never exercised against
-  // real writes and carries no evidence. It now gates an automatic NOOP, and a
-  // false NOOP silently discards a memory — the worst failure class here — so
-  // the untested value is not the one to start from. An explicit config value
-  // still wins.
+  // 0.95, chosen from measurement rather than from the declared default.
+  //
+  // The old default was 0.85 and was never read, so it carries no evidence.
+  // Measured with the shipped BGE-small embedder, comparing ENRICHED text on
+  // both sides (see the query construction below — that symmetry is what makes
+  // these numbers usable at all):
+  //
+  //   0.8512  DISTINCT  staging port 8080 vs 8081
+  //   0.8826  DISTINCT  "Always rebase before pushing" vs "Never ..."
+  //   0.9878  DUPLICATE the #854 pair that prompted this
+  //
+  // Bare, those same pairs sit at 0.9749 / 0.9637 / 0.9689 — the distinct ones
+  // score HIGHER than the duplicate and no threshold can separate them. With
+  // context they separate cleanly, and 0.95 sits in the empty band between.
+  //
+  // The negation case is why the bar is not lower. A correction is usually the
+  // previous statement with one thing negated, and corrections are the most
+  // valuable engrams this system stores; a bar under ~0.89 would start
+  // suppressing them. Anything below the bar is still REPORTED via
+  // `dedup.near_duplicates` — high similarity is a reason to look, and cosine
+  // cannot tell a duplicate from a supersede from a sibling fact.
   const { enabled = true, threshold = 0.95, mode = 'llm' } = deps.dedupConfig
   if (!enabled || mode === 'off') {
     return { engram: await deps.learn(statement, context), decision: 'ADD' }
@@ -370,7 +386,22 @@ export async function learnAsync(
   // property core is supposed to hold. Runs when no LLM decided above.
   if (dedupMode !== 'llm' && deps.similarityScores) {
     try {
-      const scores = (await deps.similarityScores(statement, candidates))
+      // Enrich the incoming side the SAME way stored engrams are enriched, so
+      // this is a like-for-like comparison. Stored engrams embed
+      // `engramSearchText` output; embedding a bare statement against that
+      // compares a fragment to fully-contexted records, and measurably
+      // collapses the two classes together (distinct pair 0.9749 bare ->
+      // 0.8512 enriched; real duplicate 0.9689 -> 0.9878).
+      const query = searchTextFrom({
+        statement,
+        domain: context?.domain,
+        tags: context?.tags,
+        rationale: context?.rationale,
+        source: context?.source,
+        dual_coding: context?.dual_coding as never,
+        knowledge_anchors: context?.knowledge_anchors as never,
+      })
+      const scores = (await deps.similarityScores(query, candidates))
         .slice()
         .sort((a, b) => b.score - a.score)
       if (scores.length > 0) {

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -14,6 +14,16 @@ import type { AsyncPrimaryStore } from './store/primary-store.js'
 import type { SecretMatch } from './secrets.js'
 import type { LearnContext, LearnAsyncContext, LearnAsyncResult, LearnBatchResult, LearnBatchFailure, DedupDecision, LlmFunction } from './types.js'
 
+/**
+ * Similarity below which a near-duplicate observation is not worth recording.
+ *
+ * Deliberately below every measured duplicate AND every measured distinct pair
+ * (lowest observed: 0.8339), so the recorded distribution spans the whole band
+ * where a future write gate might sit. Raising this narrows the evidence the
+ * decision will eventually be made from — the mistake this pass is undoing.
+ */
+export const NEAR_DUPLICATE_OBSERVATION_FLOOR = 0.75
+
 export interface LearnAsyncDeps {
   /** Content hash dedup against all engrams. Scope-aware: only matches same scope. */
   hashDedup: (statement: string, scope?: string) => Promise<Engram | null>
@@ -299,28 +309,26 @@ export async function learnAsync(
   }
 
   // Step 2: Check dedup config
-  // 0.95, chosen from measurement rather than from the declared default.
   //
-  // The old default was 0.85 and was never read, so it carries no evidence.
+  // `threshold` is a REPORTING floor, not a write gate. Cosine similarity never
+  // suppresses a write — see the reporting block in step 4 for why the gate was
+  // removed rather than tuned.
+  //
   // Measured with the shipped BGE-small embedder, comparing ENRICHED text on
-  // both sides (see the query construction below — that symmetry is what makes
-  // these numbers usable at all):
+  // both sides:
   //
-  //   0.8512  DISTINCT  staging port 8080 vs 8081
-  //   0.8826  DISTINCT  "Always rebase before pushing" vs "Never ..."
-  //   0.9878  DUPLICATE the #854 pair that prompted this
+  //   0.8512  DISTINCT   staging port 8080 vs 8081
+  //   0.8826  DISTINCT   "Always rebase before pushing" vs "Never ..."
+  //   0.9878  DUPLICATE  the #854 pair, fixtures contexted on BOTH sides
+  //   0.8339  DUPLICATE  the SAME pair as actually written (twin had no
+  //                      domain, no rationale) — below every candidate bar
   //
-  // Bare, those same pairs sit at 0.9749 / 0.9637 / 0.9689 — the distinct ones
-  // score HIGHER than the duplicate and no threshold can separate them. With
-  // context they separate cleanly, and 0.95 sits in the empty band between.
-  //
-  // The negation case is why the bar is not lower. A correction is usually the
-  // previous statement with one thing negated, and corrections are the most
-  // valuable engrams this system stores; a bar under ~0.89 would start
-  // suppressing them. Anything below the bar is still REPORTED via
-  // `dedup.near_duplicates` — high similarity is a reason to look, and cosine
-  // cannot tell a duplicate from a supersede from a sibling fact.
-  const { enabled = true, threshold = 0.95, mode = 'llm' } = deps.dedupConfig
+  // That last row is the one that matters: the real duplicates are the
+  // under-contexted ones, and they score below the distinct pairs. There is no
+  // value of `threshold` that separates them, which is why this reports rather
+  // than decides. 0.85 is a deliberately low floor chosen to capture the
+  // distribution around the interesting band, not to assert a duplicate.
+  const { enabled = true, threshold = 0.85, mode = 'llm' } = deps.dedupConfig
   if (!enabled || mode === 'off') {
     return { engram: await deps.learn(statement, context), decision: 'ADD' }
   }
@@ -407,21 +415,54 @@ export async function learnAsync(
       if (scores.length > 0) {
         dedupMode = 'cosine'
         nearDuplicates = scores.slice(0, 3)
+        // REPORTING ONLY — cosine never gates a write (#856 audit).
+        //
+        // The gate was removed rather than retuned, because the audit showed
+        // the bar could not have worked at any value. The fixtures that
+        // justified 0.95 gave both sides an identical domain, tags and
+        // rationale; the ten pairs from #854 did NOT — their second copy had no
+        // domain and no rationale, which is defect 2 of that same issue. Scored
+        // as actually written the pair sits at 0.8339, below 0.95 and below even
+        // the old 0.85, so NONE of the reported duplicates would have been
+        // caught. Production enriches only the incoming side from the write's
+        // own context, so an under-contexted write is structurally compared
+        // against a fully-contexted stored engram, and the symmetry the design
+        // rested on does not hold for exactly the writes that produce duplicates.
+        //
+        // A bar guessed from paired fixtures would therefore have bought a real
+        // false-NOOP risk — a memory silently not stored, the worst outcome this
+        // product has — while not fixing #854. So: emit the observation, build a
+        // distribution from real writes, and set a bar from that if the data
+        // supports one. `threshold` is retained as the REPORTING floor below,
+        // not as a write gate.
+        //
+        // This also disposes of the cross-scope hazard the audit raised: an
+        // unscoped write that auto-routes to a team scope can no longer NOOP
+        // against a `global` near-duplicate, because nothing NOOPs.
         const top = scores[0]
-        // A false NOOP silently discards a memory, which is a worse outcome
-        // than a duplicate — so the bar is deliberately high. 0.85 was the
-        // declared default for four months while nothing read it, so it was
-        // never validated against real writes; a measured duplicate pair from
-        // #854 sat at 0.928. Anything below the bar is still reported.
-        if (top.score >= threshold) {
-          const existing = candidates.find(c => c.id === top.id)
-          if (existing) {
-            return {
-              engram: existing,
-              decision: 'NOOP',
-              existing_id: existing.id,
-              dedup: { mode: 'cosine', near_duplicates: nearDuplicates },
-            }
+        if (top.score >= NEAR_DUPLICATE_OBSERVATION_FLOOR) {
+          // History is what makes the distribution measurable after the fact.
+          // Without it, "measure over the real store" means re-embedding the
+          // corpus and guessing which pairs were writes.
+          try {
+            appendHistory(deps.rootPath, {
+              event: 'dedup_near_duplicate',
+              engram_id: top.id,
+              timestamp: new Date().toISOString(),
+              data: {
+                statement: statement.slice(0, 200),
+                top_score: Number(top.score.toFixed(4)),
+                reporting_threshold: threshold,
+                above_reporting_threshold: top.score >= threshold,
+                scope: context?.scope ?? null,
+                // The asymmetry that broke the bar. Recorded per write so the
+                // distribution can be split by it instead of averaging over it.
+                incoming_has_domain: Boolean(context?.domain),
+                incoming_has_rationale: Boolean(context?.rationale),
+              },
+            })
+          } catch (err) {
+            logger.warning(`could not record near-duplicate observation: ${err}`)
           }
         }
       }

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -40,6 +40,17 @@ export interface LearnAsyncDeps {
   rootPath: string
   /** Dedup config. */
   dedupConfig: { enabled?: boolean; threshold?: number; mode?: string }
+  /**
+   * Local similarity scores for `statement` against `candidates` (#854).
+   *
+   * OPTIONAL: when absent — embedder disabled, or a caller constructing deps by
+   * hand — dedup degrades to hash-only and says so, rather than silently taking
+   * the ADD default as it did before.
+   */
+  similarityScores?: (
+    statement: string,
+    candidates: Engram[],
+  ) => Promise<Array<{ id: string; score: number }>>
   /** Circuit breaker check. */
   isLlmAvailable: () => boolean
   /** Record LLM success. */
@@ -287,7 +298,13 @@ export async function learnAsync(
   }
 
   // Step 2: Check dedup config
-  const { enabled = true, threshold = 0.85, mode = 'llm' } = deps.dedupConfig
+  // threshold default raised 0.85 -> 0.95 when it was first actually WIRED
+  // (#854). It sat unread for four months, so 0.85 was never exercised against
+  // real writes and carries no evidence. It now gates an automatic NOOP, and a
+  // false NOOP silently discards a memory — the worst failure class here — so
+  // the untested value is not the one to start from. An explicit config value
+  // still wins.
+  const { enabled = true, threshold = 0.95, mode = 'llm' } = deps.dedupConfig
   if (!enabled || mode === 'off') {
     return { engram: await deps.learn(statement, context), decision: 'ADD' }
   }
@@ -316,12 +333,21 @@ export async function learnAsync(
     return { engram: await deps.learn(statement, context), decision: 'ADD' }
   }
 
-  // Step 4: LLM or cosine-only decision
+  // Step 4: decide — LLM if one is available, otherwise local cosine (#854).
+  //
+  // This branch used to fall straight through to the `ADD` default when no LLM
+  // was configured, discarding the candidates fetched above unread. The
+  // comments claimed a cosine fallback; none was ever written, and `threshold`
+  // was destructured and never read. On any install without an LLM key that
+  // made dedup exact-hash-only, so every reworded near-duplicate was written.
   const llm = context?.llm
   let decision: DedupDecision = 'ADD'
   let targetId: string | null = null
+  let dedupMode: 'llm' | 'cosine' | 'hash-only' = 'hash-only'
+  let nearDuplicates: Array<{ id: string; score: number }> | undefined
 
   if (mode === 'llm' && llm && deps.isLlmAvailable()) {
+    dedupMode = 'llm'
     try {
       const prompt = buildDedupPrompt(
         statement,
@@ -333,15 +359,53 @@ export async function learnAsync(
       targetId = parsed.target_id
       deps.recordLlmSuccess()
     } catch (err) {
-      logger.warning(`LLM dedup failed, falling back to cosine: ${err}`)
+      logger.warning(`LLM dedup failed, falling back to local similarity: ${err}`)
       deps.recordLlmFailure()
       decision = 'ADD'
+      dedupMode = 'hash-only'
     }
   }
-  // cosine mode: conservative ADD (hash-only NOOP already handled)
+
+  // Local similarity path — zero API calls, works offline, which is the
+  // property core is supposed to hold. Runs when no LLM decided above.
+  if (dedupMode !== 'llm' && deps.similarityScores) {
+    try {
+      const scores = (await deps.similarityScores(statement, candidates))
+        .slice()
+        .sort((a, b) => b.score - a.score)
+      if (scores.length > 0) {
+        dedupMode = 'cosine'
+        nearDuplicates = scores.slice(0, 3)
+        const top = scores[0]
+        // A false NOOP silently discards a memory, which is a worse outcome
+        // than a duplicate — so the bar is deliberately high. 0.85 was the
+        // declared default for four months while nothing read it, so it was
+        // never validated against real writes; a measured duplicate pair from
+        // #854 sat at 0.928. Anything below the bar is still reported.
+        if (top.score >= threshold) {
+          const existing = candidates.find(c => c.id === top.id)
+          if (existing) {
+            return {
+              engram: existing,
+              decision: 'NOOP',
+              existing_id: existing.id,
+              dedup: { mode: 'cosine', near_duplicates: nearDuplicates },
+            }
+          }
+        }
+      }
+    } catch (err) {
+      // Similarity is an optimisation, never a gate on writing. Falling back
+      // to ADD is correct; claiming a cosine decision we did not make is not.
+      logger.warning(`local similarity dedup unavailable, adding without it: ${err}`)
+      dedupMode = 'hash-only'
+      nearDuplicates = undefined
+    }
+  }
 
   // Step 5: Execute
-  return executeDedupDecision(deps, statement, context, decision, targetId)
+  const executed = await executeDedupDecision(deps, statement, context, decision, targetId)
+  return { ...executed, dedup: { mode: dedupMode, ...(nearDuplicates ? { near_duplicates: nearDuplicates } : {}) } }
 }
 
 /** Options for learnBatch. */
@@ -389,7 +453,7 @@ export async function learnBatch(
       if (llmCallsUsed >= maxLlmCalls) {
         effectiveLlm = undefined
         if (!capWarned) {
-          logger.warning(`learnBatch: maxLlmCalls (${maxLlmCalls}) reached — remaining statements use cosine/ADD dedup`)
+          logger.warning(`learnBatch: maxLlmCalls (${maxLlmCalls}) reached — remaining statements fall back to local cosine dedup (see each result's dedup.mode)`)
           capWarned = true
         }
       } else {

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -77,6 +77,14 @@ export const ProfileConfigSchema = z.object({
 
 export const DedupConfigSchema = z.object({
   enabled: z.boolean().default(true),
+  /**
+   * Similarity at or above which a near-duplicate is flagged in the write
+   * result. REPORTING ONLY — it does not suppress a write (#856). Kept in sync
+   * with the runtime default in learn-async.ts, which is the value that
+   * actually applies when this key is absent (`.partial()` suppresses the Zod
+   * default, so a mismatch here is invisible at runtime and misleads whoever
+   * reads the schema to find out what the default is).
+   */
   threshold: z.number().min(0).max(1).default(0.85),
   mode: z.enum(['llm', 'cosine', 'off']).default('llm'),
 }).partial()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,6 +83,25 @@ export interface LearnAsyncResult {
   existing_id?: string
   tensions?: string[]
   /**
+   * What the dedup pass was actually able to do, and what it saw (#854).
+   *
+   * Before this existed, a write on an install with no LLM configured took the
+   * `decision = 'ADD'` default and reported success identically to a write that
+   * had been semantically checked. The two are not the same claim, and the
+   * difference was invisible: 131 near-duplicates accumulated across five months
+   * before anyone ran a similarity scan.
+   *
+   *  - 'llm'       — an LLM judged it
+   *  - 'cosine'    — local embeddings judged it, no API call
+   *  - 'hash-only' — neither was available; only exact content-hash ran, so an
+   *                  ADD here means "not identical", NOT "not a duplicate"
+   */
+  dedup?: {
+    mode: 'llm' | 'cosine' | 'hash-only'
+    /** Closest candidates and their scores — present whenever similarity ran. */
+    near_duplicates?: Array<{ id: string; score: number }>
+  }
+  /**
    * Position of this result's statement in the original learnBatch input array
    * (#281). `results` is compacted (failed statements are absent), so callers
    * must NOT assume `results[i]` corresponds to `inputs[i]` — read `input_index`

--- a/packages/core/test/dedup-cosine.test.ts
+++ b/packages/core/test/dedup-cosine.test.ts
@@ -73,13 +73,33 @@ describe('cosine dedup without an LLM (#854)', () => {
   const restatement =
     'Time Machine does not exclude node_modules or reinstallable build artifacts; clean them first'
 
-  it('NOOPs a near-duplicate instead of adding a second copy', async () => {
+  // Was 'NOOPs a near-duplicate instead of adding a second copy'.
+  //
+  // Cosine no longer suppresses a write (#856 audit). The gate was removed
+  // rather than retuned because the fixtures that justified a bar contexted
+  // both sides identically, and the duplicates that actually occur do not —
+  // the #854 pair as really written scores ~0.83, below the DISTINCT pairs, so
+  // no bar separates the classes. A gate would therefore have carried a real
+  // false-NOOP risk (a memory silently not stored) while still missing the
+  // duplicates it was built for.
+  it('REPORTS a near-duplicate at high similarity but still writes it', async () => {
     const deps = makeDeps([{ id: candidate.id, score: 0.96 }])
 
     const result = await learnAsync(deps, restatement)
 
-    expect(result.decision).toBe('NOOP')
-    expect(result.existing_id).toBe(candidate.id)
+    expect(result.decision).toBe('ADD')
+    expect(result.existing_id).toBeUndefined()
+    expect(result.engram.id).toBe('ENG-NEW-001')
+    expect(result.dedup?.mode).toBe('cosine')
+    expect(result.dedup?.near_duplicates?.[0]).toMatchObject({ id: candidate.id, score: 0.96 })
+  })
+
+  it('never suppresses a write, however similar the closest candidate is', async () => {
+    const deps = makeDeps([{ id: candidate.id, score: 0.999 }])
+
+    const result = await learnAsync(deps, restatement)
+
+    expect(result.decision).toBe('ADD')
   })
 
   it('still ADDs when nothing is close enough', async () => {

--- a/packages/core/test/dedup-cosine.test.ts
+++ b/packages/core/test/dedup-cosine.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest'
+import { learnAsync } from '../src/learn-async.js'
+import { MemoryPrimaryStore } from '../src/store/memory-primary-store.js'
+import type { LearnAsyncDeps } from '../src/learn-async.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/**
+ * #854 — semantic dedup never ran.
+ *
+ * `learnAsync` fetched candidates, then discarded them unless an LLM was
+ * configured: `decision` stayed 'ADD' unconditionally. `dedupConfig.threshold`
+ * was destructured and never read, and `cosineSimilarity` was never called from
+ * this path — so on any install without an LLM key every near-duplicate was
+ * written. Measured consequence: 131 near-duplicate engrams across 63 clusters,
+ * accumulating continuously since the feature shipped 2026-04-06.
+ *
+ * These pin the local, zero-API-cost path: similarity decides, and either way
+ * the caller is told what was found.
+ */
+
+const candidate = {
+  id: 'ENG-2026-08-10-019',
+  statement: 'Time Machine does not exclude node_modules or other reinstallable build artifacts',
+  type: 'procedural',
+  scope: 'global',
+  status: 'active',
+  domain: 'infrastructure.backup',
+  visibility: 'private',
+  tags: [],
+  activation: { retrieval_strength: 0.8, storage_strength: 1.0, frequency: 3, last_accessed: '2026-08-10' },
+  associations: [],
+  knowledge_anchors: [],
+  feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+  pack: null,
+  abstract: null,
+  derived_from: null,
+  derivation_count: 1,
+  reference_count: 1,
+  recurrence_count: 0,
+  sources: [],
+  engram_version: 1,
+  episode_ids: [],
+  polarity: null,
+} as unknown as Engram
+
+function makeDeps(
+  scores: Array<{ id: string; score: number }>,
+  overrides: Partial<LearnAsyncDeps> = {},
+): LearnAsyncDeps {
+  return {
+    hashDedup: async () => null,
+    recallHybrid: async () => [candidate],
+    recall: async () => [candidate],
+    learn: async (statement: string, context?: any) =>
+      ({ id: 'ENG-NEW-001', statement, scope: context?.scope ?? 'global' } as unknown as Engram),
+    getById: async (id: string) => (id === candidate.id ? candidate : null),
+    store: new MemoryPrimaryStore(),
+    engramsPath: '/tmp/plur-dedup-cosine.yaml',
+    rootPath: '/tmp/plur-dedup-cosine',
+    dedupConfig: { enabled: true, mode: 'llm' },
+    // No LLM configured — the degraded path this issue is about.
+    isLlmAvailable: () => false,
+    recordLlmSuccess: () => {},
+    recordLlmFailure: () => {},
+    syncIndex: async () => {},
+    offendingHitsForScope: () => [],
+    similarityScores: async () => scores,
+    ...overrides,
+  } as LearnAsyncDeps
+}
+
+describe('cosine dedup without an LLM (#854)', () => {
+  const restatement =
+    'Time Machine does not exclude node_modules or reinstallable build artifacts; clean them first'
+
+  it('NOOPs a near-duplicate instead of adding a second copy', async () => {
+    const deps = makeDeps([{ id: candidate.id, score: 0.96 }])
+
+    const result = await learnAsync(deps, restatement)
+
+    expect(result.decision).toBe('NOOP')
+    expect(result.existing_id).toBe(candidate.id)
+  })
+
+  it('still ADDs when nothing is close enough', async () => {
+    const deps = makeDeps([{ id: candidate.id, score: 0.41 }])
+
+    const result = await learnAsync(deps, 'systemd services have no $HOME by default')
+
+    expect(result.decision).toBe('ADD')
+  })
+
+  it('reports what it found so an ADD is never silently un-deduped', async () => {
+    const deps = makeDeps([{ id: candidate.id, score: 0.41 }])
+
+    const result = await learnAsync(deps, 'systemd services have no $HOME by default')
+
+    expect(result.dedup?.mode).toBe('cosine')
+    expect(result.dedup?.near_duplicates?.[0]).toMatchObject({ id: candidate.id, score: 0.41 })
+  })
+
+  it('honours the configured threshold rather than a hardcoded one', async () => {
+    // 0.90 would NOOP under the default bar; an explicit higher bar must not.
+    const deps = makeDeps([{ id: candidate.id, score: 0.9 }], {
+      dedupConfig: { enabled: true, mode: 'llm', threshold: 0.99 },
+    })
+
+    const result = await learnAsync(deps, restatement)
+
+    expect(result.decision).toBe('ADD')
+  })
+
+  it('falls back to ADD and says so when similarity is unavailable', async () => {
+    // No similarityScores dep at all — e.g. embedder disabled. Must behave as
+    // before (ADD) and must not claim a cosine decision it did not make.
+    const deps = makeDeps([], { similarityScores: undefined })
+
+    const result = await learnAsync(deps, restatement)
+
+    expect(result.decision).toBe('ADD')
+    expect(result.dedup?.mode).toBe('hash-only')
+  })
+
+  it('an available LLM still decides — cosine does not pre-empt it', async () => {
+    const llm = vi.fn().mockResolvedValue('ADD')
+    const deps = makeDeps([{ id: candidate.id, score: 0.99 }], { isLlmAvailable: () => true })
+
+    const result = await learnAsync(deps, restatement, { llm })
+
+    expect(llm).toHaveBeenCalled()
+    expect(result.decision).toBe('ADD')
+  })
+})

--- a/packages/core/test/dedup-cosine.test.ts
+++ b/packages/core/test/dedup-cosine.test.ts
@@ -121,6 +121,31 @@ describe('cosine dedup without an LLM (#854)', () => {
     expect(result.dedup?.mode).toBe('hash-only')
   })
 
+  // The comparison must be like-for-like. Stored engrams are embedded as
+  // `engramSearchText` output — statement PLUS domain, tags, rationale and the
+  // rest — so embedding a bare statement on the incoming side compares a
+  // fragment against fully-contexted engrams. Measured, that is not a small
+  // effect: a distinct pair (staging port 8080 vs 8081) scores 0.9749 bare and
+  // 0.8512 enriched, while a real duplicate goes 0.9689 -> 0.9878. Context
+  // separates the classes; dropping it from one side collapses them.
+  it('compares enriched text, not the bare statement', async () => {
+    let seen = ''
+    const deps = makeDeps([{ id: candidate.id, score: 0.1 }], {
+      similarityScores: async (text: string) => { seen = text; return [] },
+    })
+
+    await learnAsync(deps, 'Use port 8081 for staging', {
+      domain: 'infrastructure.deploy',
+      tags: ['staging', 'ports'],
+      rationale: 'Moved off 8080 after the metrics sidecar claimed it',
+    })
+
+    expect(seen).toContain('Use port 8081 for staging')
+    expect(seen).toContain('infrastructure deploy')
+    expect(seen).toContain('staging ports')
+    expect(seen).toContain('metrics sidecar')
+  })
+
   it('an available LLM still decides — cosine does not pre-empt it', async () => {
     const llm = vi.fn().mockResolvedValue('ADD')
     const deps = makeDeps([{ id: candidate.id, score: 0.99 }], { isLlmAvailable: () => true })

--- a/packages/core/test/dedup-threshold-calibration.test.ts
+++ b/packages/core/test/dedup-threshold-calibration.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest'
+import { embed, cosineSimilarity, embedderStatus } from '../src/embeddings.js'
+import { searchTextFrom } from '../src/fts.js'
+
+/**
+ * Calibration for the #854 cosine dedup bar. Runs the REAL embedder.
+ *
+ * WHAT THIS IS FOR, precisely — because it is easy to mistake for a regression
+ * gate and it is not one:
+ *
+ *   - The bar (`threshold`, default 0.95) is only defensible if enriched
+ *     duplicates land above it and enriched DISTINCT statements land below.
+ *     That is a property of the embedding model and of which fields
+ *     `searchTextFrom` includes — neither of which lives in our control flow, so
+ *     no stubbed test can check it.
+ *   - Run this after changing the embedder, the enrichment fields, or the
+ *     default threshold. If the separation has closed, the bar is no longer
+ *     supported by anything and needs re-deriving from a fresh run.
+ *
+ * The regression gate for the code path is elsewhere and runs every time:
+ * `dedup-cosine.test.ts` → "compares enriched text, not the bare statement"
+ * asserts the query carries domain/tags/rationale, which is the mistake that
+ * actually shipped. This file checks whether the resulting numbers still mean
+ * what the threshold assumes.
+ *
+ * GATED, matching `embeddings-cache-dim.test.ts`: loading BGE-small needs model
+ * access, so the default suite stays offline-safe. It therefore does NOT run in
+ * CI as configured today.
+ *
+ *   PLUR_EMBEDDER_NETWORK_TESTS=1 npx vitest run --project @plur-ai/core \
+ *     packages/core/test/dedup-threshold-calibration.test.ts
+ *
+ * Baseline measured 2026-08-10, BGE-small-en-v1.5, enriched both sides:
+ *
+ *   0.8512  DISTINCT   staging port 8080 vs 8081
+ *   0.8826  DISTINCT   "Always rebase before pushing" vs "Never ..."
+ *   0.9878  DUPLICATE  the #854 pair
+ *
+ * Bare — the bug this replaced — those same pairs sat at 0.9749 / 0.9637 /
+ * 0.9689: the DISTINCT pairs scored HIGHER than the duplicate, and no threshold
+ * could separate them. That inversion is the thing worth never reintroducing.
+ */
+
+const NETWORK = process.env.PLUR_EMBEDDER_NETWORK_TESTS === '1'
+
+/** The default the dedup path uses. Kept here so a drift shows up as a failure. */
+const THRESHOLD = 0.95
+
+interface Fixture {
+  label: string
+  a: Parameters<typeof searchTextFrom>[0]
+  b: Parameters<typeof searchTextFrom>[0]
+}
+
+/** Pairs a competent reader would call clearly DIFFERENT facts. */
+const DISTINCT: Fixture[] = [
+  {
+    label: 'one token apart: staging port',
+    a: {
+      statement: 'Use port 8080 for staging',
+      domain: 'infrastructure.deploy',
+      tags: ['staging', 'ports'],
+      rationale: 'Chosen because 8080 is the default the reverse proxy forwards to.',
+    },
+    b: {
+      statement: 'Use port 8081 for staging',
+      domain: 'infrastructure.deploy',
+      tags: ['staging', 'ports'],
+      rationale: 'Moved off 8080 after the metrics sidecar claimed it in the 2026-07 rollout.',
+    },
+  },
+  {
+    // The case that decides the bar. A correction is usually the prior
+    // statement with one thing negated, and corrections are the highest-value
+    // engrams this system stores — suppressing one is the worst outcome the
+    // dedup path can produce.
+    label: 'negation: a correction of an existing engram',
+    a: {
+      statement: 'Always rebase before pushing',
+      domain: 'git.workflow',
+      tags: ['git', 'conventions'],
+      rationale: 'Keeps history linear and makes bisect usable on this repo.',
+    },
+    b: {
+      statement: 'Never rebase before pushing',
+      domain: 'git.workflow',
+      tags: ['git', 'conventions'],
+      rationale: 'Shared branches here are checked out by three agents; rewriting published history breaks their working copies.',
+    },
+  },
+  {
+    label: 'same rule, different host',
+    a: {
+      statement: 'Set RESTIC_CACHE_DIR explicitly on the nightshift host',
+      domain: 'infrastructure.backup',
+      tags: ['restic', 'nightshift'],
+      rationale: 'systemd units there run with no $HOME, so the default cache path resolves under /.',
+    },
+    b: {
+      statement: 'Set RESTIC_CACHE_DIR explicitly on the winston host',
+      domain: 'infrastructure.backup',
+      tags: ['restic', 'winston'],
+      rationale: 'Same systemd no-$HOME problem, but winston also has a smaller root volume.',
+    },
+  },
+]
+
+/** Pairs that are genuinely the same fact, reworded. */
+const DUPLICATE: Fixture[] = [
+  {
+    label: '#854 019/029 — the pair that prompted the issue',
+    a: {
+      statement: 'Time Machine does not exclude node_modules or other reinstallable build artifacts',
+      domain: 'infrastructure.backup',
+      tags: ['timemachine', 'backup'],
+      rationale: 'Backups balloon because reinstallable trees are treated as user data.',
+    },
+    b: {
+      statement: 'Time Machine does not exclude node_modules or reinstallable build artifacts; clean them first',
+      domain: 'infrastructure.backup',
+      tags: ['timemachine', 'backup'],
+      rationale: 'Backups balloon because reinstallable trees are treated as user data.',
+    },
+  },
+  {
+    label: 'reordered clauses, same claim',
+    a: {
+      statement: 'systemd services run with no $HOME, so pin RESTIC_CACHE_DIR explicitly',
+      domain: 'infrastructure.backup',
+      tags: ['systemd', 'restic'],
+      rationale: 'The default cache path is derived from $HOME and resolves wrong without it.',
+    },
+    b: {
+      statement: 'Pin RESTIC_CACHE_DIR explicitly, because systemd services have no $HOME',
+      domain: 'infrastructure.backup',
+      tags: ['systemd', 'restic'],
+      rationale: 'The default cache path is derived from $HOME and resolves wrong without it.',
+    },
+  },
+]
+
+async function score(f: Fixture): Promise<number> {
+  const ea = await embed(searchTextFrom(f.a))
+  const eb = await embed(searchTextFrom(f.b))
+  if (!ea || !eb) throw new Error(`embedder returned null for "${f.label}" — cannot calibrate`)
+  return cosineSimilarity(ea, eb)
+}
+
+describe.skipIf(!NETWORK)('dedup threshold calibration (#854, real embedder)', () => {
+  it('reports the measured separation', async () => {
+    expect(embedderStatus().available).toBe(true)
+
+    const distinct = await Promise.all(DISTINCT.map(async f => [f.label, await score(f)] as const))
+    const duplicate = await Promise.all(DUPLICATE.map(async f => [f.label, await score(f)] as const))
+
+    const rows = [
+      ...distinct.map(([l, s]) => `  ${s.toFixed(4)}  DISTINCT   ${l}`),
+      ...duplicate.map(([l, s]) => `  ${s.toFixed(4)}  DUPLICATE  ${l}`),
+    ]
+    // Printed unconditionally: the point of running this is to READ the numbers,
+    // not merely to see it pass.
+    console.log(`\nthreshold = ${THRESHOLD}\n${rows.join('\n')}\n`)
+
+    const worstDistinct = Math.max(...distinct.map(([, s]) => s))
+    const bestDistinctLabel = distinct.find(([, s]) => s === worstDistinct)![0]
+    const weakestDuplicate = Math.min(...duplicate.map(([, s]) => s))
+
+    // 1. No DISTINCT pair may be suppressed. This is the data-loss direction:
+    //    a false NOOP silently declines to store a memory.
+    expect(
+      worstDistinct,
+      `"${bestDistinctLabel}" scores ${worstDistinct.toFixed(4)} >= threshold ${THRESHOLD} — it would be silently suppressed`,
+    ).toBeLessThan(THRESHOLD)
+
+    // 2. Every DUPLICATE must still be caught, or the bar does nothing.
+    expect(
+      weakestDuplicate,
+      `weakest duplicate scores ${weakestDuplicate.toFixed(4)} < threshold ${THRESHOLD} — the bar no longer catches known duplicates`,
+    ).toBeGreaterThanOrEqual(THRESHOLD)
+
+    // 3. The classes must not merely straddle the bar, they must be SEPARATED.
+    //    A gap this small would mean the bar is luck rather than a decision.
+    expect(
+      weakestDuplicate - worstDistinct,
+      `separation is ${(weakestDuplicate - worstDistinct).toFixed(4)} — too narrow to justify any threshold`,
+    ).toBeGreaterThan(0.03)
+  }, 180_000)
+
+  it('enrichment is what creates the separation — bare statements invert it', async () => {
+    // The bug this guards against conceptually: comparing bare statements put
+    // the DISTINCT pairs ABOVE the duplicate, so no threshold could work.
+    const bare = async (f: Fixture) => {
+      const ea = await embed(f.a.statement)
+      const eb = await embed(f.b.statement)
+      if (!ea || !eb) throw new Error('embedder returned null')
+      return cosineSimilarity(ea, eb)
+    }
+    const distinctBare = Math.max(...(await Promise.all(DISTINCT.map(bare))))
+    const distinctRich = Math.max(...(await Promise.all(DISTINCT.map(score))))
+
+    console.log(`\nDISTINCT worst-case: bare ${distinctBare.toFixed(4)} -> enriched ${distinctRich.toFixed(4)}\n`)
+
+    // Enrichment must pull distinct facts APART. If this ever fails, the
+    // enrichment fields have stopped carrying the distinguishing information
+    // and the threshold rests on nothing.
+    expect(
+      distinctRich,
+      `enrichment no longer separates distinct facts (bare ${distinctBare.toFixed(4)}, enriched ${distinctRich.toFixed(4)})`,
+    ).toBeLessThan(distinctBare)
+  }, 180_000)
+})

--- a/packages/core/test/dedup-threshold-calibration.test.ts
+++ b/packages/core/test/dedup-threshold-calibration.test.ts
@@ -24,21 +24,29 @@ import { searchTextFrom } from '../src/fts.js'
  * what the threshold assumes.
  *
  * GATED, matching `embeddings-cache-dim.test.ts`: loading BGE-small needs model
- * access, so the default suite stays offline-safe. It therefore does NOT run in
- * CI as configured today.
+ * access, so the default suite stays offline-safe.
  *
  *   PLUR_EMBEDDER_NETWORK_TESTS=1 npx vitest run --project @plur-ai/core \
  *     packages/core/test/dedup-threshold-calibration.test.ts
  *
- * Baseline measured 2026-08-10, BGE-small-en-v1.5, enriched both sides:
+ * In CI it runs from the `dedup-calibration` job, path-filtered to the files
+ * that can invalidate the claim (embeddings.ts, fts.ts, learn-async.ts, these
+ * fixtures) and non-blocking, since it depends on a model fetch.
  *
- *   0.8512  DISTINCT   staging port 8080 vs 8081
- *   0.8826  DISTINCT   "Always rebase before pushing" vs "Never ..."
- *   0.9878  DUPLICATE  the #854 pair
+ * Baseline from THESE fixtures, 2026-08-10, BGE-small-en-v1.5, enriched both
+ * sides:
  *
- * Bare — the bug this replaced — those same pairs sat at 0.9749 / 0.9637 /
- * 0.9689: the DISTINCT pairs scored HIGHER than the duplicate, and no threshold
- * could separate them. That inversion is the thing worth never reintroducing.
+ *   0.7962  DISTINCT   one token apart: staging port 8080 vs 8081
+ *   0.8437  DISTINCT   negation — a correction of an existing engram
+ *   0.8570  DISTINCT   same rule, different host
+ *   0.9797  DUPLICATE  reordered clauses, same claim
+ *   0.9830  DUPLICATE  the #854 pair
+ *
+ * Separation 0.123, with the 0.95 bar inside the band rather than at an edge.
+ *
+ * Bare — the bug this replaced — the worst DISTINCT pair sat at 0.9749, ABOVE
+ * both duplicates. No threshold could separate them. That inversion is the
+ * thing worth never reintroducing, and the second test below pins it.
  */
 
 const NETWORK = process.env.PLUR_EMBEDDER_NETWORK_TESTS === '1'
@@ -148,10 +156,22 @@ async function score(f: Fixture): Promise<number> {
 
 describe.skipIf(!NETWORK)('dedup threshold calibration (#854, real embedder)', () => {
   it('reports the measured separation', async () => {
+    // `available` only means "not disabled, and the library imported" — it is
+    // true before any model has loaded. Asserting it alone would let this whole
+    // file pass without ever embedding anything, which is the exact shape of
+    // check this test exists to replace. `loaded` is asserted after scoring,
+    // below, once a real pipeline must exist.
     expect(embedderStatus().available).toBe(true)
 
     const distinct = await Promise.all(DISTINCT.map(async f => [f.label, await score(f)] as const))
     const duplicate = await Promise.all(DUPLICATE.map(async f => [f.label, await score(f)] as const))
+
+    // Proof the numbers above came from a real model rather than from a
+    // short-circuit. `score()` throws on a null embedding, so this is belt and
+    // braces — but a calibration that cannot tell you whether it calibrated is
+    // worth nothing, and that has to be visible in the file, not inferred from
+    // a CI log.
+    expect(embedderStatus().loaded, 'embedder never loaded — these scores are not real').toBe(true)
 
     const rows = [
       ...distinct.map(([l, s]) => `  ${s.toFixed(4)}  DISTINCT   ${l}`),

--- a/packages/core/test/dedup-threshold-calibration.test.ts
+++ b/packages/core/test/dedup-threshold-calibration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { embed, cosineSimilarity, embedderStatus } from '../src/embeddings.js'
 import { searchTextFrom } from '../src/fts.js'
+import { NEAR_DUPLICATE_OBSERVATION_FLOOR } from '../src/learn-async.js'
 
 /**
  * Calibration for the #854 cosine dedup bar. Runs the REAL embedder.
@@ -51,8 +52,12 @@ import { searchTextFrom } from '../src/fts.js'
 
 const NETWORK = process.env.PLUR_EMBEDDER_NETWORK_TESTS === '1'
 
-/** The default the dedup path uses. Kept here so a drift shows up as a failure. */
-const THRESHOLD = 0.95
+/**
+ * Imported, NOT re-declared. The previous revision hardcoded its own copy of
+ * the bar and claimed "kept here so a drift shows up as a failure" — which was
+ * false: changing the production value would not have failed this test.
+ */
+const FLOOR = NEAR_DUPLICATE_OBSERVATION_FLOOR
 
 interface Fixture {
   label: string
@@ -179,31 +184,88 @@ describe.skipIf(!NETWORK)('dedup threshold calibration (#854, real embedder)', (
     ]
     // Printed unconditionally: the point of running this is to READ the numbers,
     // not merely to see it pass.
-    console.log(`\nthreshold = ${THRESHOLD}\n${rows.join('\n')}\n`)
+    console.log(`\nobservation floor = ${FLOOR}\n${rows.join('\n')}\n`)
 
     const worstDistinct = Math.max(...distinct.map(([, s]) => s))
     const bestDistinctLabel = distinct.find(([, s]) => s === worstDistinct)![0]
     const weakestDuplicate = Math.min(...duplicate.map(([, s]) => s))
 
-    // 1. No DISTINCT pair may be suppressed. This is the data-loss direction:
-    //    a false NOOP silently declines to store a memory.
-    expect(
-      worstDistinct,
-      `"${bestDistinctLabel}" scores ${worstDistinct.toFixed(4)} >= threshold ${THRESHOLD} — it would be silently suppressed`,
-    ).toBeLessThan(THRESHOLD)
-
-    // 2. Every DUPLICATE must still be caught, or the bar does nothing.
+    // WHAT THIS ASSERTS NOW, and why it changed (#856 audit).
+    //
+    // The previous revision asserted a SEPARATING bar: no distinct pair above
+    // 0.95, every duplicate at or above it. Those assertions passed, and were
+    // still not evidence that a gate would work — because every fixture gave
+    // both sides an identical domain, tags and rationale, and the duplicates
+    // that actually occur do not. See the ASYMMETRIC test below: the very pair
+    // from #854, scored as it was really written, lands at ~0.83 — beneath the
+    // distinct pairs. No single bar separates the real classes, so the gate was
+    // removed and this file now calibrates REPORTING instead.
+    //
+    // 1. Every duplicate must clear the observation floor, or it is never even
+    //    reported and the pass is decorative.
     expect(
       weakestDuplicate,
-      `weakest duplicate scores ${weakestDuplicate.toFixed(4)} < threshold ${THRESHOLD} — the bar no longer catches known duplicates`,
-    ).toBeGreaterThanOrEqual(THRESHOLD)
+      `weakest duplicate scores ${weakestDuplicate.toFixed(4)} < floor ${FLOOR} — it would not be reported at all`,
+    ).toBeGreaterThanOrEqual(FLOOR)
 
-    // 3. The classes must not merely straddle the bar, they must be SEPARATED.
-    //    A gap this small would mean the bar is luck rather than a decision.
+    // 2. The floor must stay below the distinct pairs' scores too — reporting
+    //    is meant to capture the whole interesting band, including the pairs a
+    //    future gate would have to NOT suppress. A floor above them would hide
+    //    exactly the evidence needed to decide whether a gate is possible.
     expect(
-      weakestDuplicate - worstDistinct,
-      `separation is ${(weakestDuplicate - worstDistinct).toFixed(4)} — too narrow to justify any threshold`,
-    ).toBeGreaterThan(0.03)
+      FLOOR,
+      `floor ${FLOOR} is above the distinct pair "${bestDistinctLabel}" at ${worstDistinct.toFixed(4)} — the recorded distribution would be truncated`,
+    ).toBeLessThan(worstDistinct)
+  }, 180_000)
+
+  // The measurement that removed the gate. Pinned as a test so the reasoning
+  // cannot quietly stop being true — if a future embedder closes this gap, a
+  // write gate becomes arguable again, and this is where that shows up.
+  it('asymmetric context defeats any fixed bar — this is why nothing is suppressed', async () => {
+    // The #854 pair AS ACTUALLY WRITTEN. The twin was generated from the
+    // statements alone, so it carries no domain and no rationale — that is
+    // defect 2 of the same issue. Production enriches the incoming side from
+    // the write's own context only, so an under-contexted write is compared
+    // against a fully-contexted stored engram.
+    const stored = searchTextFrom({
+      statement: 'Time Machine does not exclude node_modules or other reinstallable build artifacts',
+      domain: 'infrastructure.backup',
+      tags: ['timemachine', 'backup'],
+      rationale: 'Backups balloon because reinstallable trees are treated as user data.',
+    })
+    const incomingBare = searchTextFrom({
+      statement: 'Time Machine does not exclude node_modules or reinstallable build artifacts; clean them first',
+    })
+    const ea = await embed(stored)
+    const eb = await embed(incomingBare)
+    if (!ea || !eb) throw new Error('embedder returned null — cannot calibrate')
+    const asymmetric = cosineSimilarity(ea, eb)
+
+    const symmetric = await score(DUPLICATE[0])
+    const worstDistinct = Math.max(...(await Promise.all(DISTINCT.map(score))))
+
+    console.log(
+      `\n#854 pair, both sides contexted : ${symmetric.toFixed(4)}  (a bar would catch this)` +
+      `\n#854 pair, as actually written  : ${asymmetric.toFixed(4)}  (a bar would MISS this)` +
+      `\nworst DISTINCT pair             : ${worstDistinct.toFixed(4)}\n`,
+    )
+
+    // A real duplicate scoring BELOW a genuinely-distinct pair is the whole
+    // argument: the two classes overlap, so no threshold separates them and
+    // any gate would both miss duplicates and risk suppressing corrections.
+    expect(
+      asymmetric,
+      `asymmetric duplicate ${asymmetric.toFixed(4)} no longer sits below the worst distinct pair ` +
+      `${worstDistinct.toFixed(4)} — the classes may have become separable, so a write gate is worth re-deriving`,
+    ).toBeLessThan(worstDistinct)
+
+    // …and it must still clear the reporting floor, or the pairs that actually
+    // occur would be invisible in the recorded distribution.
+    expect(
+      asymmetric,
+      `asymmetric duplicate ${asymmetric.toFixed(4)} is below the reporting floor ${FLOOR} — ` +
+      `the real duplicates would not even be observed`,
+    ).toBeGreaterThanOrEqual(FLOOR)
   }, 180_000)
 
   it('enrichment is what creates the separation — bare statements invert it', async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1109,7 +1109,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
               required: ['statement'],
             },
           },
-          max_llm_calls: { type: 'number', description: 'Max LLM dedup calls across the whole batch (default 50). Once spent, remaining items use the cheap hash/cosine path. Pass a large number to opt out.' },
+          max_llm_calls: { type: 'number', description: 'Max LLM dedup calls across the whole batch (default 50). Once spent, remaining items fall back to the local cosine path (no API cost); the dedup.mode on each result says which ran. Pass a large number to opt out.' },
         },
         required: ['engrams'],
       },

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -919,6 +919,10 @@ function getAllToolDefinitions(): ToolDefinition[] {
       name: 'plur_learn',
       description:
         'Create an engram — record a reusable learning, preference, or correction. ' +
+        'A write is never suppressed by similarity: exact content-hash duplicates NOOP, and anything merely SIMILAR ' +
+        'is written and reported back in `dedup.near_duplicates` (closest existing engrams and their cosine scores) ' +
+        'so you can supersede or merge deliberately. High similarity is a reason to look, not a decision — cosine ' +
+        'cannot tell a duplicate from a correction of it. ' +
         'Multi-agent note: in an orchestration that spawns subagents, have the PARENT session own plur_learn writes — ' +
         'spawned subagents should return their findings as text for the parent to persist, rather than each calling ' +
         'plur_learn (tool availability is not guaranteed in every subagent context). See plur-ai/plur#281.',
@@ -1058,11 +1062,21 @@ function getAllToolDefinitions(): ToolDefinition[] {
           mcpCanary.signal('learn_activity')
           // Opt-in, content-free engagement counter (default-off; no statement text).
           recordTelemetry('learn')
+          // Near-duplicate REPORTING (#856). This path only ever had exact
+          // content-hash dedup — learnAsync, and with it the similarity pass,
+          // is reachable solely from plur_learn_batch — so the dominant write
+          // path had no near-duplicate visibility, which is how #854 happened
+          // on it. Reporting only: never blocks or alters the write, and runs
+          // after it so a reporting failure cannot cost a memory.
+          const dedup = isOutbox
+            ? undefined
+            : await plur.nearDuplicates(statement, context, engram.id)
           return {
             id: engram.id, statement: engram.statement,
             scope: engram.scope, type: engram.type,
             pinned: (engram as any).pinned === true,
             decision: 'ADD',
+            ...(dedup?.near_duplicates?.length ? { dedup } : {}),
             ...temporalEcho(engram),
             ...scopeHint(engram.scope, !!routed),
             ...domainHint(!!routed),
@@ -1097,8 +1111,11 @@ function getAllToolDefinitions(): ToolDefinition[] {
       description:
         'Create many engrams in one call — the batch form of plur_learn. Accepts an array of engram objects and ' +
         'writes them sequentially through the SAME dedup + policy pipeline as plur_learn (content-hash NOOP → semantic ' +
-        'recall → LLM ADD/UPDATE/MERGE decision). Dedup also applies WITHIN the batch: a statement duplicating an ' +
-        'earlier item in the same array resolves to NOOP against it. Returns `ids` aligned 1:1 with the input array ' +
+        'recall → LLM ADD/UPDATE/MERGE decision, or local cosine REPORTING when no LLM is configured). Exact-hash dedup ' +
+        'also applies WITHIN the batch: a statement duplicating an earlier item in the same array resolves to NOOP ' +
+        'against it. Similarity never suppresses a write — each result carries `dedup.mode` (llm | cosine | hash-only) ' +
+        'and, when similarity ran, `dedup.near_duplicates`. Read dedup.mode before trusting an ADD: hash-only means ' +
+        '"not identical", NOT "not a duplicate". Returns `ids` aligned 1:1 with the input array ' +
         '(ids[i] is the engram id for input i, or null if input i failed), the per-item decisions (each carrying its ' +
         'input_index), aggregate stats, and any per-item failures (each with its input index) — a single bad item ' +
         'does not abort the batch. Use this when an orchestration fans out and wants to persist consolidated findings without N ' +
@@ -1205,6 +1222,10 @@ function getAllToolDefinitions(): ToolDefinition[] {
             type: r.engram.type,
             decision: r.decision,
             ...(r.existing_id ? { existing_id: r.existing_id } : {}),
+            // #856 audit: `dedup` was computed and then dropped here, so the
+            // reporting it exists for reached no caller — "anything below the
+            // bar is still reported" was not observable anywhere.
+            ...(r.dedup ? { dedup: r.dedup } : {}),
           })),
           stats,
           ...batchDomainHint,

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -51,6 +51,10 @@ const ALWAYS_ASYNC = new Set([
   // Born async (#676) — never had a sync form, so there is no pre-0.16
   // call site for the migrate tool to rewrite.
   'rescope',
+  // Born async (#856) — near-duplicate REPORTING for the plur_learn path.
+  // Embedding-backed, so it could never have been sync, and it is new in this
+  // release, so no pre-0.16 call site exists for the migrate tool to rewrite.
+  'nearDuplicates',
 ])
 
 /** Public methods of `Plur`, mapped to whether they are declared `async`. */


### PR DESCRIPTION
## Summary

Part of #854. Implements the local similarity pass that `threshold` had been promising for four months without ever being read — but as **reporting only**. Cosine never suppresses a write.

The original revision of this PR added a NOOP gate at 0.95. The audit showed that bar could not have worked at any value, so the gate is removed rather than retuned, and the change now does the thing that has to come first: make near-duplicates **observable** on both write paths, and record a distribution a real bar could later be derived from.

## Why the gate went, rather than moving

The calibration fixtures gave both sides an identical `domain`, `tags` and `rationale`. The ten pairs from #854 did not — the second copy of every pair had **no domain and no rationale**, which is defect 2 of that same issue. Scored as actually written, the pair sits at **0.8339**: below 0.95, below the old 0.85, and *below the DISTINCT pairs* (worst 0.8826).

| | score | a bar would… |
|---|---|---|
| #854 pair, both sides contexted (the fixture) | 0.9830 | catch it |
| #854 pair, **as actually written** | **0.8339** | **miss it** |
| Worst DISTINCT pair ("Always/Never rebase") | 0.8826 | — |

Production enriches only the incoming side, from the write's own context, so an under-contexted write is structurally compared against a fully-contexted stored engram. The classes **overlap**. A bar would therefore have bought a real false-NOOP risk — a memory silently not stored, the worst outcome this product has — while still missing every duplicate it was built for.

That measurement is now pinned as a test, so the reasoning cannot quietly stop being true: if a future embedder separates the classes, the assertion fails and a write gate becomes arguable again.

## Reporting now reaches both write paths

- **`plur_learn_batch`** — `dedup` was computed and then dropped in the result mapping, so "anything below the bar is still reported" reached no caller. Now surfaced.
- **`plur_learn`** — the dominant path, and it never reached `learnAsync` at all (`learnRouted` → sync `learn()`, exact-hash only). That is *how #854 happened on it*. New `Plur.nearDuplicates()` gives it the same observation, after the write, never blocking it.

Each result carries `dedup.mode` (`llm` | `cosine` | `hash-only`) and, when similarity ran, `dedup.near_duplicates`. `hash-only` means "not identical", not "not a duplicate" — the tool descriptions now say so.

## Building the evidence for a future bar

Every observation at or above a deliberately low floor (0.75, beneath every measured pair) is written to history as `dedup_near_duplicate`, carrying the top score, the scope, and **whether the incoming write had a domain and a rationale** — the asymmetry that broke the bar, recorded per write so the distribution can be split by it instead of averaged over it.

Without this, "measure over the real store" means re-embedding the corpus and guessing which records were writes.

## Other audit findings

- **`schemas/config.ts` declared 0.85 while the code used 0.95.** Both are 0.85 again and the schema documents that `.partial()` suppresses its own default, so the declared value is what a reader consults and must match.
- **The calibration test hardcoded `THRESHOLD = 0.95`**, so its "a drift shows up as a failure" claim was false. It now imports the production constant.
- **The calibration CI job missed the embedder adapters.** Path filter widened to `packages/core/src/embedders/` and `packages/core/src/schemas/config.ts`.
- **Cross-scope false NOOP** — dissolved rather than fixed: an unscoped write that auto-routes to a team scope can no longer NOOP against a `global` near-duplicate, because nothing NOOPs.
- **A cosine NOOP left no trace** — also moot, and replaced by a positive record of every observation.

## Not addressed here

`searchTextFrom` still omits `temporal`, and `entities` is dead for the only production caller. Both bias toward ADD, which is the safe direction, and both matter much less now that nothing is suppressed. Worth a follow-up rather than widening this PR.

## Test plan

- [x] `dedup-cosine.test.ts` — 8 tests; the former NOOP assertions now assert report-and-write, including at 0.999
- [x] `dedup-threshold-calibration.test.ts` — asserts the reporting floor sits below every measured pair, and pins the asymmetric-context overlap that removed the gate
- [x] Core typecheck, MCP typecheck, core suite
- [ ] `dedup-calibration` CI job on the real embedder
