### PR TITLE
fix(ci): detect addAssignees silent-drop for new contributors

### DIFF
--- a/.github/workflows/pr-issue-guard.yml
+++ b/.github/workflows/pr-issue-guard.yml
@@ -50,6 +50,44 @@ jobs:
 
             if (seen.size === 0) return;
 
+            // IDEMPOTENCY (#862 review).
+            //
+            // The trigger includes `edited`, so this runs again on every PR
+            // description change. Both comment paths below are unconditional,
+            // so without a guard the same notice accumulates once per edit —
+            // and for the fallback path the person affected is a first-time
+            // contributor editing their PR description, which is exactly what
+            // first-time contributors do. #835 exists to keep that person from
+            // getting a red X on their first contribution; an unbounded stack
+            // of identical "you cannot be assigned" comments is no better.
+            //
+            // Dedup on a marker rather than gating on `context.payload.action`,
+            // so that an edit which FIRST introduces `Fixes #123` still
+            // comments. Markers are per-issue, so a run handling two issues
+            // posts for each without either suppressing the other.
+            let existingComments = [];
+            try {
+              existingComments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: prNumber, per_page: 100,
+              });
+            } catch (e) {
+              // Fail open: a missed dedup is a duplicate comment, whereas
+              // skipping the notice entirely loses the signal it carries.
+              core.warning(`Could not list PR comments for dedup: ${e.message}. Posting without it.`);
+            }
+
+            const postOnce = (marker, body) => {
+              if (existingComments.some(c => c.body?.includes(marker))) {
+                core.info(`Notice already present on #${prNumber} (${marker}) — not reposting`);
+                return Promise.resolve();
+              }
+              return github.rest.issues.createComment({
+                owner, repo,
+                issue_number: prNumber,
+                body: `${marker}\n${body}`,
+              });
+            };
+
             for (const issueNumber of seen) {
               let issue;
               try {
@@ -99,21 +137,19 @@ jobs:
                   );
                 }
                 if (needsFallback) {
-                  await github.rest.issues.createComment({
-                    owner, repo,
-                    issue_number: prNumber,
-                    body: `ℹ️ Could not auto-assign #${issueNumber} to @${prAuthor} — `
+                  await postOnce(
+                    `<!-- pr-issue-guard:fallback:${issueNumber} -->`,
+                    `ℹ️ Could not auto-assign #${issueNumber} to @${prAuthor} — `
                       + `GitHub only allows assigning users with repo access or prior interaction on the issue. `
                       + `Maintainer: please assign it manually so the claim is recorded. This is not a problem with the PR.`,
-                  }).catch(err => core.warning(`Fallback comment failed: ${err.message}`));
+                  ).catch(err => core.warning(`Fallback comment failed: ${err.message}`));
                 }
               } else if (!assignees.includes(prAuthor)) {
                 const list = assignees.map(a => `@${a}`).join(', ');
-                await github.rest.issues.createComment({
-                  owner, repo,
-                  issue_number: prNumber,
-                  body: `⚠️ This PR addresses #${issueNumber}, which is assigned to ${list} — possible duplicate effort. Confirm coordination before merging.`,
-                });
+                await postOnce(
+                  `<!-- pr-issue-guard:conflict:${issueNumber} -->`,
+                  `⚠️ This PR addresses #${issueNumber}, which is assigned to ${list} — possible duplicate effort. Confirm coordination before merging.`,
+                );
                 core.warning(`Conflict: #${issueNumber} is assigned to ${list}; PR opened by @${prAuthor}`);
               }
             }

--- a/.github/workflows/pr-issue-guard.yml
+++ b/.github/workflows/pr-issue-guard.yml
@@ -68,18 +68,37 @@ jobs:
                 // issue — a brand-new contributor may simply not be assignable.
                 // That is a fact about the account, not a fault in the PR, and
                 // it must not put a red X on someone's first contribution.
+                //
+                // addAssignees returns HTTP 201 and silently drops non-permitted
+                // logins — no exception is raised (#861). Verify via the response.
+                let needsFallback = false;
                 try {
-                  await github.rest.issues.addAssignees({
+                  const { data: updated } = await github.rest.issues.addAssignees({
                     owner, repo,
                     issue_number: issueNumber,
                     assignees: [prAuthor],
                   });
-                  core.info(`Auto-assigned #${issueNumber} to @${prAuthor}`);
+                  const assigned = (updated.assignees || []).some(
+                    a => a.login.toLowerCase() === prAuthor.toLowerCase()
+                  );
+                  if (assigned) {
+                    core.info(`Auto-assigned #${issueNumber} to @${prAuthor}`);
+                  } else {
+                    needsFallback = true;
+                    core.warning(
+                      `Could not auto-assign #${issueNumber} to @${prAuthor}: `
+                      + `assignee silently dropped (no repo access or prior issue interaction). `
+                      + `A maintainer should assign it manually so the claim is recorded.`,
+                    );
+                  }
                 } catch (e) {
+                  needsFallback = true;
                   core.warning(
                     `Could not auto-assign #${issueNumber} to @${prAuthor}: ${e.message}. `
                     + `A maintainer should assign it manually so the claim is recorded.`,
                   );
+                }
+                if (needsFallback) {
                   await github.rest.issues.createComment({
                     owner, repo,
                     issue_number: prNumber,


### PR DESCRIPTION
Fixes #861.

## What

`addAssignees` returns HTTP 201 and **silently drops** logins that lack
repo access or prior issue interaction — no exception is raised. The
existing `try/catch` in `pr-issue-guard.yml` therefore never fired for
the case it was written to handle (#835): a brand-new contributor whose
first PR triggers the auto-assign path.

## Fix

Capture the `addAssignees` response and verify the login appears in the
returned `assignees` list. Introduce a `needsFallback` flag so the PR
comment (telling a maintainer to assign manually) posts for **both**:

- the silent-drop case (assignee not in response — was the unreachable path)
- genuine transport / auth errors (existing `catch` branch)

No extra API call: `addAssignees` already returns the updated issue object.

## Test plan

- [ ] Open a PR from an account with no repo access — fallback comment
  should now appear on the PR (previously never fired for this case)
- [ ] Open a PR from an org member — `core.info("Auto-assigned…")` emits
  and no fallback comment is posted
- [ ] Simulate a 404 / auth error — `catch` branch still fires and posts
  the fallback comment