### PR TITLE
fix(core,mcp): stop reporting a cached remote failure as the live state (#864)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ import { decodeJwtExpiry, decodeJwtPayload } from './jwt.js'
 import { RemoteStore, normalizeEndpointUrl } from './store/remote-store.js'
 import {
   remoteRecall, isRemoteRecallDisabled, resolveRemoteRecallTimeoutMs, scopeOrg,
+  REMOTE_STATUS_TTL_MS, PROBE_CLEARABLE_STATES,
   type RemoteRecallHost, type RemoteRecallResult, type HostRecallOutcome, type RemoteStoreStatusEntry,
 } from './remote-recall.js'
 import { YamlPrimaryStore } from './store/yaml-primary-store.js'
@@ -294,6 +295,8 @@ export {
   claimHookDegradationLines,
   MAX_REMOTE_QUERY_CHARS, MAX_REMOTE_RESPONSE_BYTES, DEFAULT_REMOTE_RECALL_TIMEOUT_MS,
   BREAKER_FAILURE_THRESHOLD, BREAKER_COOLDOWN_MS, UNSUPPORTED_TTL_MS, HOOK_HEADER_REPEAT_MS,
+  REMOTE_STATUS_TTL_MS, PROBE_CLEARABLE_STATES,
+  startBudgetTimer, BUDGET_TICK_MS, MAX_STARVATION_CREDIT_MS,
   type RemoteRecallHost, type RemoteRecallResult, type HostRecallOutcome,
   type RemoteHostState, type RemoteStoreStatusEntry, type RemoteRecallOptions,
 } from './remote-recall.js'
@@ -3675,8 +3678,11 @@ export class Plur {
   // -------------------------------------------------------------------------
 
   /** Last per-host recall outcomes (in-process), keyed by normalized URL —
-   *  feeds `remoteStoreStatus()` (plan A4′). */
-  private _lastRemoteOutcomes = new Map<string, HostRecallOutcome>()
+   *  feeds `remoteStoreStatus()` (plan A4′). Each entry carries the time it
+   *  was observed: the map is written ONLY by hosts a recall actually dialed,
+   *  so without an age the newest entry is indistinguishable from one made
+   *  days ago by a process that has since been idle (#864). */
+  private _lastRemoteOutcomes = new Map<string, { outcome: HostRecallOutcome; observed_at: number }>()
 
   /** Where breaker/cooldown/unsupported state persists across processes.
    *  Inside the store root so tests and PLUR_PATH overrides isolate it. */
@@ -3714,6 +3720,12 @@ export class Plur {
    * feeds the doctor warning for that misconfiguration.
    */
   private _remoteRecallHosts(options?: { scope?: string; session?: string; remote_project?: RemoteProjectConfig }): RemoteRecallHost[] {
+    // Pick up out-of-process config edits (#307) before reading tokens: a
+    // rotated credential must reach the very next dial, not the next restart.
+    // The constructor's only re-read compares `stores.length`, so a rotation
+    // that leaves the store count unchanged was previously invisible for the
+    // life of the process (#864).
+    this.reloadConfigIfChanged()
     const stores = (this.config.stores ?? []).filter(s => s.url)
     const rp = options?.remote_project
     const rpKey = rp ? normalizeEndpointUrl(rp.url) : null
@@ -3800,7 +3812,10 @@ export class Plur {
       limit: options?.limit,
       statePath: this.remoteHealthStatePath(),
     }).then(result => {
-      for (const o of result.outcomes) this._lastRemoteOutcomes.set(normalizeEndpointUrl(o.url), o)
+      const observed_at = Date.now()
+      for (const o of result.outcomes) {
+        this._lastRemoteOutcomes.set(normalizeEndpointUrl(o.url), { outcome: o, observed_at })
+      }
       return result
     }).catch((): RemoteRecallResult => ({ engrams: [], scores: new Map(), outcomes: [] }))
   }
@@ -3890,15 +3905,53 @@ export class Plur {
    * outcomes this process observed — NOT by driver caches or fresh probes.
    * MCP surfaces attach a `remote_stores` block from this when any host is
    * non-ok (or silently scope-narrowed); plur_doctor renders remediation.
+   *
+   * Every entry carries `observed_at` and `age_ms` (#864). An observation is
+   * evidence about the moment it was taken, and this map is only written by
+   * hosts a recall actually DIALED — a recall that dials nothing leaves the
+   * previous entry untouched. Callers that speak in the present tense
+   * ("serving local only") must pass `freshOnly` so a stale failure stops
+   * being reported as the live state; callers that are explicitly historical
+   * (doctor's "last live recall") should read everything and render the age.
    */
-  remoteStoreStatus(): RemoteStoreStatusEntry[] {
-    return [...this._lastRemoteOutcomes.values()].map(o => ({
-      host: normalizeEndpointUrl(o.url),
-      status: o.state,
-      ...(o.dropped_scopes && o.dropped_scopes.length > 0 ? { dropped_scopes: o.dropped_scopes } : {}),
-      ms: o.ms,
-      count: o.count,
-    }))
+  remoteStoreStatus(opts?: { freshOnly?: boolean; now?: number }): RemoteStoreStatusEntry[] {
+    const now = opts?.now ?? Date.now()
+    const out: RemoteStoreStatusEntry[] = []
+    for (const { outcome: o, observed_at } of this._lastRemoteOutcomes.values()) {
+      const age_ms = Math.max(0, now - observed_at)
+      if (opts?.freshOnly && age_ms > REMOTE_STATUS_TTL_MS) continue
+      out.push({
+        host: normalizeEndpointUrl(o.url),
+        status: o.state,
+        ...(o.dropped_scopes && o.dropped_scopes.length > 0 ? { dropped_scopes: o.dropped_scopes } : {}),
+        ms: o.ms,
+        count: o.count,
+        observed_at,
+        age_ms,
+      })
+    }
+    return out
+  }
+
+  /**
+   * Record that a non-recall interaction with `url` just SUCCEEDED, clearing a
+   * cached network-class failure for that host (#864).
+   *
+   * Without this, `plur_doctor` contradicts itself inside one report: the
+   * `/me` probe says "Reachable, auth valid" and the line directly beneath it
+   * says the host timed out, because the second line is a cached recall
+   * outcome that nothing ever invalidates. A store that just answered a
+   * request is not unreachable, and the fresher observation wins.
+   *
+   * Only {@link PROBE_CLEARABLE_STATES} are cleared — see that constant for
+   * why an authorization or endpoint-support failure must survive a probe.
+   */
+  noteRemoteHostReachable(url: string): void {
+    const key = normalizeEndpointUrl(url)
+    const entry = this._lastRemoteOutcomes.get(key)
+    if (entry && PROBE_CLEARABLE_STATES.has(entry.outcome.state)) {
+      this._lastRemoteOutcomes.delete(key)
+    }
   }
 
   /**
@@ -7482,6 +7535,10 @@ Generate an improved version of the procedure that prevents this failure. Return
    */
   async checkRemoteHealth(opts?: { timeoutMs?: number }): Promise<RemoteHealth[]> {
     const timeoutMs = opts?.timeoutMs ?? 5000
+    // Decode the token that is on DISK now, not the one read at construction
+    // (#307/#864). Reporting "expires in 4d" from a 13-day-old in-memory copy
+    // of a credential the user rotated hours ago sends them to fix the server.
+    this.reloadConfigIfChanged()
     const groups = this.remoteEndpointTokenGroups()
     return Promise.all(groups.map(async ({ url, token, scopes }) => {
       const exp = decodeJwtExpiry(token)
@@ -7509,6 +7566,9 @@ Generate an improved version of the procedure that prevents this failure. Return
             timeoutHandle = setTimeout(() => reject(new Error(`/me timeout (${timeoutMs}ms)`)), timeoutMs)
           }),
         ])
+        // A host that just answered /me is not unreachable — retire any cached
+        // network-class recall failure for it rather than reporting both (#864).
+        this.noteRemoteHostReachable(url)
         return { url, scopes, status: 'ok' as const, ok: true,
           ...(me.username ? { username: me.username } : {}),
           ...(me.org_id ? { orgId: me.org_id } : {}),

--- a/packages/core/src/remote-recall.ts
+++ b/packages/core/src/remote-recall.ts
@@ -99,6 +99,123 @@ export const RATE_LIMIT_MAX_COOLDOWN_MS = 60 * 60 * 1000
  *  pair prints again at most once per this window (plan A4′, default 4h). */
 export const HOOK_HEADER_REPEAT_MS = 4 * 60 * 60 * 1000
 
+/** How often {@link startBudgetTimer} samples the event loop to tell elapsed
+ *  time apart from time this process spent unable to service I/O. */
+export const BUDGET_TICK_MS = 50
+
+/**
+ * Ceiling on the extra wall time a request may earn back from event-loop
+ * starvation (see {@link startBudgetTimer}).
+ *
+ * Absolute rather than a multiple of the budget: the hook path runs inside a
+ * user's prompt with a 1500 ms budget, and a multiplier would let a starved
+ * process stretch that into something a human notices. Credit is only ever
+ * earned while the loop is genuinely blocked — during which the caller is
+ * already waiting on that local work — so the practical worst case is bounded
+ * by the local work, not by this constant.
+ */
+export const MAX_STARVATION_CREDIT_MS = 5000
+
+/**
+ * A timeout that measures the time the request was actually SERVICED, not raw
+ * wall time.
+ *
+ * The remote leg is deliberately started before the local pipeline so its
+ * latency overlaps. But local work — above all the first-call BGE embedder
+ * initialisation — blocks Node's single event loop, and a plain `setTimeout`
+ * keeps counting through the block. The response cannot be read, the timer
+ * fires the moment the loop frees up, and the request is recorded as a host
+ * timeout that the host had no part in: measured cold, the connect phase
+ * aborted at ~1335 ms against a server answering in ~600 ms, while the very
+ * next call on the same process and host succeeded in ~1.1 s.
+ *
+ * That misattribution is not cosmetic. Hooks are one-shot processes at ~86% of
+ * recall volume, so for most of the fleet EVERY call is a cold call, and the
+ * breaker then counts these as host failures and parks a healthy host.
+ *
+ * So: sample the loop every {@link BUDGET_TICK_MS}. A tick that arrives late
+ * proves the loop was blocked, and the overshoot is credited back rather than
+ * charged to the network. A host that is simply slow or dead accrues no credit
+ * — the loop is responsive, ticks land on time, and the original budget is
+ * enforced exactly. Credit is capped by {@link MAX_STARVATION_CREDIT_MS} so a
+ * pathologically busy process still terminates the request.
+ *
+ * Returns a cancel function.
+ */
+export function startBudgetTimer(
+  budgetMs: number,
+  onExpire: () => void,
+  opts: { tickMs?: number; maxCreditMs?: number; now?: () => number } = {},
+): () => void {
+  const now = opts.now ?? Date.now
+  const tickMs = Math.max(1, opts.tickMs ?? BUDGET_TICK_MS)
+  const maxCredit = Math.max(0, opts.maxCreditMs ?? MAX_STARVATION_CREDIT_MS)
+  const started = now()
+  let last = started
+  let credit = 0
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let done = false
+
+  const schedule = (): void => {
+    if (done) return
+    const serviced = (now() - started) - credit
+    const remaining = Math.max(1, Math.min(tickMs, budgetMs - serviced))
+    timer = setTimeout(tick, remaining)
+    // Never hold the process open on account of a timeout sampler.
+    ;(timer as { unref?: () => void }).unref?.()
+  }
+
+  const tick = (): void => {
+    if (done) return
+    const t = now()
+    // Anything beyond the interval we asked for is time the loop was busy
+    // elsewhere — the request was not being serviced, so it is not charged.
+    credit = Math.min(maxCredit, credit + Math.max(0, (t - last) - tickMs))
+    last = t
+    const wall = t - started
+    if ((wall - credit) >= budgetMs || wall >= budgetMs + maxCredit) {
+      done = true
+      onExpire()
+      return
+    }
+    schedule()
+  }
+
+  schedule()
+  return () => { done = true; if (timer) clearTimeout(timer) }
+}
+
+/**
+ * How long a recorded per-host recall outcome may still be presented as the
+ * host's CURRENT state (#864).
+ *
+ * The outcome map is fed only by hosts a recall actually dialed. A recall that
+ * dials nothing — `remote: false`, the kill-switch, an empty query, or no host
+ * implicated by the current project/work — leaves the previous entry in place,
+ * so without an age bound a single early failure is re-reported as live
+ * degradation for the entire life of the process. On a workstation that is
+ * days, and it accuses the server of a fault that is entirely client-side.
+ *
+ * Aligned with {@link BREAKER_COOLDOWN_MS}: once the breaker would have
+ * re-dialed the host anyway, a stale failure has outlived its evidence.
+ */
+export const REMOTE_STATUS_TTL_MS = BREAKER_COOLDOWN_MS
+
+/**
+ * States a successful non-recall interaction with the host (e.g. the
+ * `/me` probe behind `checkRemoteHealth`) genuinely CONTRADICTS, and may
+ * therefore clear (#864).
+ *
+ * Deliberately network-class only. `unsupported` (404 on the recall route)
+ * and `rate_limited` (429 against a separate budget) say nothing about `/me`
+ * and vice versa, and `auth_expired`/`forbidden` are authorization facts that
+ * a probe on a different route with different scope requirements must not be
+ * allowed to mask. Clearing those would trade a false alarm for a silent
+ * failure, which is the worse of the two.
+ */
+export const PROBE_CLEARABLE_STATES: ReadonlySet<RemoteHostState> =
+  new Set<RemoteHostState>(['timeout', 'unreachable', 'skipped_cooldown'])
+
 // ---------------------------------------------------------------------------
 // Env knobs
 // ---------------------------------------------------------------------------
@@ -547,9 +664,12 @@ export async function remoteRecall(
     if ((h.unsupported_until ?? 0) > t0) return finish('unsupported', { detail: 'unsupported_ttl' })
 
     const ctrl = new AbortController()
-    const overallTimer = setTimeout(() => ctrl.abort(), timeoutMs)
-    let connectTimer: ReturnType<typeof setTimeout> | undefined =
-      setTimeout(() => ctrl.abort(), Math.min(connectMs, timeoutMs))
+    // Starvation-aware (#864 follow-up): a cold process spends its first
+    // seconds initialising the embedder, and a wall-clock timer would abort a
+    // request the loop never got round to servicing.
+    const cancelOverall = startBudgetTimer(timeoutMs, () => ctrl.abort())
+    let cancelConnect: (() => void) | undefined =
+      startBudgetTimer(Math.min(connectMs, timeoutMs), () => ctrl.abort())
     try {
       const res = await fetchImpl(`${key}/api/v1/recall`, {
         method: 'POST',
@@ -574,8 +694,8 @@ export async function remoteRecall(
       })
       // Headers arrived — connect phase over; the overall timer still bounds
       // the body read.
-      clearTimeout(connectTimer)
-      connectTimer = undefined
+      cancelConnect?.()
+      cancelConnect = undefined
 
       if (res.status === 401) {
         h.failures = 0
@@ -635,8 +755,8 @@ export async function remoteRecall(
       return networkFailure(isAbort ? 'timeout' : 'unreachable',
         isAbort ? undefined : (err instanceof Error ? err.message.slice(0, 120) : undefined))
     } finally {
-      if (connectTimer) clearTimeout(connectTimer)
-      clearTimeout(overallTimer)
+      cancelConnect?.()
+      cancelOverall()
     }
   }
 
@@ -688,6 +808,11 @@ export interface RemoteStoreStatusEntry {
   dropped_scopes?: string[]
   ms?: number
   count?: number
+  /** When this outcome was observed (epoch ms) — #864. */
+  observed_at?: number
+  /** Age of the observation at the time the status was read (ms) — #864.
+   *  Renderers MUST NOT present a non-zero age as the host's state "now". */
+  age_ms?: number
 }
 
 /**

--- a/packages/core/test/remote-recall.test.ts
+++ b/packages/core/test/remote-recall.test.ts
@@ -21,14 +21,14 @@
  *     skipped_cooldown/unsupported never print)
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, utimesSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '../src/index.js'
 import {
   remoteRecall, claimHookDegradationLines, readRemoteHealth,
-  BREAKER_FAILURE_THRESHOLD, HOOK_HEADER_REPEAT_MS, UNSUPPORTED_TTL_MS,
-  scopeOrg,
+  BREAKER_FAILURE_THRESHOLD, HOOK_HEADER_REPEAT_MS, UNSUPPORTED_TTL_MS, REMOTE_STATUS_TTL_MS,
+  scopeOrg, startBudgetTimer,
   type RemoteRecallHost, type HostRecallOutcome,
 } from '../src/remote-recall.js'
 import { StubServer } from './helpers/stub-server.js'
@@ -794,5 +794,267 @@ describe('claimHookDegradationLines — suppression policy', () => {
     expect(lines).toHaveLength(1)
     // And the rewrite produced a valid file.
     expect(() => JSON.parse(readFileSync(sp, 'utf8'))).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #864 — a cached outcome is evidence about WHEN it was taken
+//
+// `_lastRemoteOutcomes` is written only by hosts a recall actually dialed. A
+// recall that dials nothing (no org context, `remote: false`, kill-switch,
+// empty query) leaves the previous entry untouched, so before this fix one
+// early failure was re-reported as the live state for the whole life of the
+// process — on a workstation, days — and accused the server of a client-side
+// fault inside the operator's own diagnostics.
+// ---------------------------------------------------------------------------
+
+describe('#864 remote status freshness', () => {
+  function plurWithDeadHost(): { plur: Plur; dir: string } {
+    const dir = tmp('plur-864-dead-')
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "http://127.0.0.1:1"\n    token: "t"\n    scope: "${TEAM_SCOPE}"\n`,
+    )
+    return { plur: new Plur({ path: dir }), dir }
+  }
+
+  async function recordFailure(plur: Plur): Promise<void> {
+    await plur.recall('anything', { scope: 'project:plur/anything', remote_timeout_ms: 300 })
+  }
+
+  it('stamps observed_at and age_ms on every entry', async () => {
+    const { plur } = plurWithDeadHost()
+    const before = Date.now()
+    await recordFailure(plur)
+    const [s] = plur.remoteStoreStatus()
+    expect(s).toBeDefined()
+    expect(s.observed_at).toBeGreaterThanOrEqual(before)
+    expect(s.age_ms).toBeGreaterThanOrEqual(0)
+    expect(s.age_ms).toBeLessThan(60_000)
+  })
+
+  it('freshOnly hides an observation older than the TTL; the historical read keeps it', async () => {
+    const { plur } = plurWithDeadHost()
+    await recordFailure(plur)
+    expect(plur.remoteStoreStatus({ freshOnly: true })).toHaveLength(1)
+
+    const later = Date.now() + REMOTE_STATUS_TTL_MS + 1
+    // Present-tense surfaces must fall silent...
+    expect(plur.remoteStoreStatus({ freshOnly: true, now: later })).toHaveLength(0)
+    // ...while doctor can still report it as history, with its age.
+    const historical = plur.remoteStoreStatus({ now: later })
+    expect(historical).toHaveLength(1)
+    expect(historical[0].age_ms).toBeGreaterThan(REMOTE_STATUS_TTL_MS)
+  })
+
+  it('a later recall that dials NOTHING does not refresh the stale entry', async () => {
+    const { plur } = plurWithDeadHost()
+    await recordFailure(plur)
+    const first = plur.remoteStoreStatus()[0].observed_at
+
+    // No project/org context → zero remote calls (the strict dialing rule).
+    await plur.recall('anything at all')
+    const second = plur.remoteStoreStatus()[0].observed_at
+    expect(second).toBe(first) // untouched — nothing re-observed it
+
+    // Which is exactly why the present-tense surface must age it out.
+    const later = Date.now() + REMOTE_STATUS_TTL_MS + 1
+    expect(plur.remoteStoreStatus({ freshOnly: true, now: later })).toHaveLength(0)
+  })
+
+  it('a successful /me probe clears a cached network-class failure', async () => {
+    const dir = tmp('plur-864-probe-')
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "${baseUrl}"\n    token: "${TOKEN}"\n    scope: "${TEAM_SCOPE}"\n`,
+    )
+    const plur = new Plur({ path: dir })
+
+    server.recallStatus = 500 // network-class → 'unreachable'
+    await plur.recall('anything', { scope: 'project:plur/anything' })
+    server.recallStatus = null
+    expect(plur.remoteStoreStatus()[0].status).toBe('unreachable')
+
+    // The host answers /me — it is demonstrably not unreachable.
+    const health = await plur.checkRemoteHealth({ timeoutMs: 5000 })
+    expect(health[0].status).toBe('ok')
+    expect(plur.remoteStoreStatus()).toHaveLength(0)
+  })
+
+  it('a successful probe does NOT clear an endpoint-support failure', async () => {
+    const dir = tmp('plur-864-unsupported-')
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "${baseUrl}"\n    token: "${TOKEN}"\n    scope: "${TEAM_SCOPE}"\n`,
+    )
+    const plur = new Plur({ path: dir })
+
+    server.recallStatus = 404 // the recall route is absent; /me says nothing about that
+    await plur.recall('anything', { scope: 'project:plur/anything' })
+    server.recallStatus = null
+    expect(plur.remoteStoreStatus()[0].status).toBe('unsupported')
+
+    await plur.checkRemoteHealth({ timeoutMs: 5000 })
+    // Still reported — masking this would trade a false alarm for a silent failure.
+    expect(plur.remoteStoreStatus()[0].status).toBe('unsupported')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #864 — a rotated credential must reach the next dial, not the next restart
+//
+// The constructor's only re-read compares `stores.length`, so rotating a token
+// in place (same store count) left the process dialing with the credential it
+// read at spawn. On a 13-day-old MCP server that is a 13-day-old token.
+// ---------------------------------------------------------------------------
+
+describe('#864 config staleness on the dial path', () => {
+  function writeConfig(dir: string, token: string): void {
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "${baseUrl}"\n    token: "${token}"\n    scope: "${TEAM_SCOPE}"\n`,
+    )
+    // Guarantee a visible mtime change even if both writes land in the same
+    // millisecond — the reload trigger is mtime, and the test must not race it.
+    const t = new Date(Date.now() + 2000)
+    utimesSync(join(dir, 'config.yaml'), t, t)
+  }
+
+  it('picks up a rotated token without reconstructing Plur', async () => {
+    const dir = tmp('plur-864-rotate-')
+    writeConfig(dir, 'stale-token')
+    const plur = new Plur({ path: dir })
+
+    server.recallRows = [serverRow('ENG-2026-0812-101')]
+    await plur.recall('remote statement', { scope: 'project:plur/anything' })
+    // The stub rejects the wrong bearer outright.
+    expect(plur.remoteStoreStatus()[0].status).toBe('auth_expired')
+
+    // Operator rotates the credential on disk. Same store count as before.
+    writeConfig(dir, TOKEN)
+
+    server.recallRows = [serverRow('ENG-2026-0812-102')]
+    const results = await plur.recall('remote statement', { scope: 'project:plur/anything' })
+    expect(plur.remoteStoreStatus()[0].status).toBe('ok')
+    expect(results.some(e => (e as any)._originalId === 'ENG-2026-0812-102')).toBe(true)
+  })
+
+  it('checkRemoteHealth decodes the token on disk, not the one read at construction', async () => {
+    const dir = tmp('plur-864-rotate-health-')
+    writeConfig(dir, 'stale-token')
+    const plur = new Plur({ path: dir })
+    expect((await plur.checkRemoteHealth({ timeoutMs: 5000 }))[0].status).toBe('auth_expired')
+
+    writeConfig(dir, TOKEN)
+    expect((await plur.checkRemoteHealth({ timeoutMs: 5000 }))[0].status).toBe('ok')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #864 — a response may not contradict itself
+//
+// The report that opened the issue returned remote-only records while calling
+// the remote unreachable. Self-contradiction is the cheapest possible signal
+// that a cache is stale, so the invariant is asserted rather than assumed: a
+// host that contributed rows to THIS recall reports ok, and nothing degraded
+// is attached alongside those rows.
+// ---------------------------------------------------------------------------
+
+describe('#864 status/result self-consistency', () => {
+  it('a host that served rows is never reported degraded in the same breath', async () => {
+    const dir = tmp('plur-864-consistency-')
+    writeFileSync(
+      join(dir, 'config.yaml'),
+      `embeddings:\n  enabled: false\nstores:\n  - url: "${baseUrl}"\n    token: "${TOKEN}"\n    scope: "${TEAM_SCOPE}"\n`,
+    )
+    const plur = new Plur({ path: dir })
+
+    server.recallRows = [serverRow('ENG-2026-0812-201', { score: 1 })]
+    const results = await plur.recall('remote statement', { scope: 'project:plur/anything' })
+    const servedRemote = results.some(e => (e as any)._originalId === 'ENG-2026-0812-201')
+    expect(servedRemote).toBe(true)
+
+    for (const s of plur.remoteStoreStatus()) {
+      if ((s.count ?? 0) > 0) expect(s.status).toBe('ok')
+    }
+    // Nothing for a present-tense surface to warn about.
+    const degraded = plur.remoteStoreStatus({ freshOnly: true })
+      .filter(s => s.status !== 'ok' || (s.dropped_scopes?.length ?? 0) > 0)
+    expect(degraded).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #864 follow-up — the cold-start race
+//
+// The remote leg starts before the local pipeline so its latency overlaps.
+// The first recall in a process then loads the BGE embedder, which blocks the
+// single event loop; a wall-clock timer keeps counting through the block and
+// aborts a request the loop never serviced. Measured against production: cold
+// call aborted at ~1335ms (the connect budget) against a server answering in
+// ~600ms, while the next call on the same process succeeded in ~1.1s. Hooks
+// are one-shot processes at ~86% of recall volume, so for most of the fleet
+// EVERY call is a cold call.
+// ---------------------------------------------------------------------------
+
+/** Block the event loop for `ms`, the way a synchronous model load does. */
+function starveLoop(ms: number): void {
+  const until = Date.now() + ms
+  while (Date.now() < until) { /* deliberate busy-wait */ }
+}
+
+describe('#864 starvation-aware budget', () => {
+  it('does not expire when the loop was blocked for longer than the budget', async () => {
+    let expired = false
+    const cancel = startBudgetTimer(150, () => { expired = true })
+    starveLoop(400) // 400ms of wall time in which nothing could be serviced
+    await new Promise(r => setTimeout(r, 60))
+    expect(expired).toBe(false) // the time was credited, not charged
+    cancel()
+  })
+
+  it('still expires on time when the loop is healthy (a slow host must fail)', async () => {
+    let expired = false
+    const cancel = startBudgetTimer(120, () => { expired = true })
+    await new Promise(r => setTimeout(r, 400)) // loop free the whole time
+    expect(expired).toBe(true)
+    cancel()
+  })
+
+  it('honors the absolute credit ceiling — a starved process still terminates', async () => {
+    let expired = false
+    const cancel = startBudgetTimer(100, () => { expired = true }, { maxCreditMs: 150 })
+    starveLoop(500) // far beyond budget + credit
+    await new Promise(r => setTimeout(r, 60))
+    expect(expired).toBe(true)
+    cancel()
+  })
+
+  it('cancel() stops the sampler', async () => {
+    let expired = false
+    startBudgetTimer(50, () => { expired = true })()
+    await new Promise(r => setTimeout(r, 200))
+    expect(expired).toBe(false)
+  })
+
+  it('a live host survives a cold-start block that would have aborted it', async () => {
+    server.recallRows = [serverRow('ENG-2026-0812-301')]
+    const p = remoteRecall([host()], 'cold start', {
+      statePath: statePath(),
+      timeoutMs: 300, // connect budget 200ms — far less than the block below
+    })
+    starveLoop(700) // the embedder-load equivalent, while the request is in flight
+    const result = await p
+    expect(result.outcomes[0].state).toBe('ok')
+    expect(result.outcomes[0].count).toBe(1)
+  })
+
+  it('a dead host still fails at its budget, starvation or not', async () => {
+    const p = remoteRecall([host({ url: 'http://127.0.0.1:1' })], 'dead host', {
+      statePath: statePath(),
+      timeoutMs: 300,
+    })
+    const result = await p
+    expect(['unreachable', 'timeout']).toContain(result.outcomes[0].state)
   })
 })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,7 +1,7 @@
 import { existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName, SUGGEST_DISPLAY_MIN_CONFIDENCE, mcpRemoteWarningLine, doctorRemoteRemediation } from '@plur-ai/core'
+import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName, SUGGEST_DISPLAY_MIN_CONFIDENCE, mcpRemoteWarningLine, doctorRemoteRemediation, normalizeEndpointUrl, REMOTE_STATUS_TTL_MS, PROBE_CLEARABLE_STATES } from '@plur-ai/core'
 import type { LlmFunction, MetaField, TensionStatus, RerankerEvalResult, HistoryEvent, Receipt, RemoteStoreStatusEntry } from '@plur-ai/core'
 import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
@@ -47,6 +47,26 @@ export interface ToolDefinition {
 }
 
 /**
+ * Render an observation age as a short human suffix (#864).
+ *
+ * Doctor lines that report a cached outcome must say WHEN it was observed.
+ * "Last live recall: timeout" reads as a present-tense fact about the server;
+ * "Last live recall: timeout 3h ago" reads as what it is — a record of a past
+ * call, which the operator can weigh against the live probe beside it.
+ */
+function formatAge(ageMs: number | undefined): string {
+  if (typeof ageMs !== 'number' || !Number.isFinite(ageMs)) return '(age unknown)'
+  const s = Math.floor(ageMs / 1000)
+  if (s < 10) return 'just now'
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.floor(h / 24)}d ago`
+}
+
+/**
  * A4′ (#776): attach per-host remote degradation to a tool response — ONLY
  * when a host is non-ok or was silently scope-narrowed (`dropped_scopes`).
  * Structured block + ONE prose `warning` line (agent-directed strings from
@@ -56,7 +76,13 @@ export interface ToolDefinition {
 function attachRemoteStoreDegradation(response: Record<string, unknown>, plur: Plur): void {
   let status: RemoteStoreStatusEntry[]
   try {
-    status = plur.remoteStoreStatus()
+    // `freshOnly` (#864): this block speaks in the present tense ("serving
+    // local only"), so it may only report observations recent enough to still
+    // describe now. The outcome map is written only by hosts a recall dialed,
+    // and most tools that reach here dial nothing — without the age bound, one
+    // early failure stamps a degradation warning onto every later response for
+    // the life of the process, long after the host recovered.
+    status = plur.remoteStoreStatus({ freshOnly: true })
   } catch {
     return // surfacing must never break the tool response
   }
@@ -2223,9 +2249,13 @@ function getAllToolDefinitions(): ToolDefinition[] {
         // Remote store auth/reachability (#295) — without this, doctor reports
         // "healthy" while the enterprise token is expired and writes silently
         // queue. Probe /me per configured remote and decode token expiry.
+        // Hosts a FRESH /me probe just reached, so the recall-status block
+        // below can defer to live evidence instead of contradicting it (#864).
+        const probedOkHosts = new Set<string>()
         try {
           const remotes = await plur.checkRemoteHealth({ timeoutMs: 5000 })
           for (const h of remotes) {
+            if (h.status === 'ok') probedOkHosts.add(normalizeEndpointUrl(h.url))
             const expiresNote = typeof h.tokenExpiresInDays === 'number'
               ? ` — token ${h.tokenExpiresInDays < 0 ? `expired ${-h.tokenExpiresInDays}d ago` : `expires in ${h.tokenExpiresInDays}d`}`
               : ''
@@ -2255,15 +2285,40 @@ function getAllToolDefinitions(): ToolDefinition[] {
         // narrowing via dropped_scopes).
         try {
           for (const s of plur.remoteStoreStatus()) {
-            const fix = doctorRemoteRemediation(s)
-            const degraded = s.status !== 'ok' || (s.dropped_scopes?.length ?? 0) > 0
+            const dropped = s.dropped_scopes?.length ? ` (dropped scopes: ${s.dropped_scopes.join(', ')})` : ''
+            const failed = s.status !== 'ok' || (s.dropped_scopes?.length ?? 0) > 0
+            // An observation describes the moment it was taken. Past the TTL,
+            // or once a fresh /me probe has reached the host, it is history —
+            // report it as history rather than as a live fault, and do not
+            // hand the operator remediation for a problem that may be over
+            // (#864). Both facts are stated so nothing is silently dropped.
+            const stale = (s.age_ms ?? 0) > REMOTE_STATUS_TTL_MS
+            // Same rule the invalidation path uses: a successful /me probe
+            // contradicts a network-class failure only. An authorization or
+            // endpoint-support failure is not disproved by a different route
+            // succeeding, and downgrading it here would hide a live problem
+            // behind a green check.
+            const contradicted = probedOkHosts.has(s.host) && PROBE_CLEARABLE_STATES.has(s.status)
+            const historical = failed && (stale || contradicted)
+            if (historical) {
+              const why = contradicted
+                ? 'the /me probe above just reached this host, so this is not the current state'
+                : 'older than the status TTL, so this is not the current state'
+              checks.push({
+                check: `remote recall: ${s.host}`,
+                ok: true,
+                detail: `Last live recall: ${s.status}${dropped} ${formatAge(s.age_ms)} — ${why}. Recalls at that time served local results only.`,
+              })
+              continue
+            }
             checks.push({
               check: `remote recall: ${s.host}`,
-              ok: !degraded,
-              detail: degraded
-                ? `Last live recall: ${s.status}${s.dropped_scopes?.length ? ` (dropped scopes: ${s.dropped_scopes.join(', ')})` : ''} — recent recalls served local results only.`
-                : `Last live recall ok (${s.count} row(s) in ${s.ms}ms)`,
+              ok: !failed,
+              detail: failed
+                ? `Last live recall: ${s.status}${dropped} ${formatAge(s.age_ms)} — recent recalls served local results only.`
+                : `Last live recall ok (${s.count} row(s) in ${s.ms}ms) ${formatAge(s.age_ms)}`,
             })
+            const fix = doctorRemoteRemediation(s)
             if (fix) remediation.push(fix)
           }
           // (url, token) fan-out sanity: differing tokens per endpoint mean


### PR DESCRIPTION
Closes #864.

## What was happening

A long-lived MCP process reported one early recall failure as the host's current state for the rest of its life, and pointed the operator at a server that was healthy throughout. The issue reports diagnosis taking about an hour and ending in `git log` over the local engram store.

While reproducing it I hit the same wall from the other side: two thorough searches confidently reported that an engram did not exist. It did — created that day, in a team scope, on a host answering in ~600ms. Recall had been serving local-only results while reporting the remote unreachable.

## Root cause is two bugs compounding

**The cold-start race** produces the failure. The remote leg deliberately starts before the local pipeline so its latency overlaps. But the first recall in a process initialises the BGE embedder, which blocks Node's single event loop, and a plain `setTimeout` keeps counting through the block — so the abort fires on a request the loop never got round to servicing.

Measured against production:

| | result |
|---|---|
| Server, 1 scope, hybrid | 0.52–0.85s |
| Server, 12 scopes, hybrid | 0.63–0.85s |
| Client **cold** call (first in process) | **timeout**, host_ms 1335–1621 |
| Client **warm** call, same process | **ok**, ~1.1s, 10 rows |

The cold abort lands at ~1333ms — exactly the connect budget, 2/3 of the 2000ms default. The server is never given a chance.

This is worse than it first looks: `remote-recall.ts` notes hooks are one-shot processes at **~86% of recall volume**. For those, *every* call is a cold call — and the breaker counts these as host failures and parks healthy hosts.

**#864** then makes it permanent: the genuine timeout is cached and re-reported indefinitely, including inside `plur_doctor` directly beneath a fresh probe saying the host is fine.

## Changes

**1. Status carries its age.** `_lastRemoteOutcomes` is written only by hosts a recall actually dialed; a recall that dials nothing leaves the previous entry untouched. Outcomes now carry `observed_at`/`age_ms`. `remoteStoreStatus({ freshOnly: true })` is used by present-tense surfaces (the `remote_stores` block says "serving local only") and falls silent past the TTL; doctor reads everything and renders the age, so a cached outcome reads as history rather than as a live fault.

**2. A successful interaction invalidates a cached failure.** `checkRemoteHealth` retires a network-class failure for a host whose `/me` probe just succeeded. Deliberately network-class only (`PROBE_CLEARABLE_STATES`) — `unsupported`, `rate_limited`, `auth_expired` and `forbidden` are not disproved by a different route succeeding, and clearing them would trade a false alarm for a silent failure. The doctor rendering uses the same rule; an existing test in `remote-recall-surfacing.test.ts` caught an earlier version of this patch that applied the downgrade too broadly.

**3. Config is re-read where tokens are read.** The constructor's only re-read compares `stores.length`, so rotating a token in place was invisible until restart. `_remoteRecallHosts` and `checkRemoteHealth` now call `reloadConfigIfChanged()` (#307).

**4. `startBudgetTimer` measures serviced time, not wall time.** It samples the loop every 50ms; a late tick proves the loop was blocked and the overshoot is credited back rather than charged to the network. A host that is merely slow or dead accrues no credit and still fails at exactly its budget — that safety property is covered by a test. Credit is capped by an absolute `MAX_STARVATION_CREDIT_MS` rather than a multiple of the budget, so the 1500ms hook path cannot be stretched into something a human notices.

## Verification

Live, against the production store — cold process, first call, **stock 2000ms budget**:

```
before:  remote=timeout  host_ms=1335  rows=0
after:   remote=ok       host_ms=1583  rows=10
```

16 tests added. Verified failing against the unfixed source (6 of the 7 status/config tests; the 7th asserts unchanged behaviour as a guard against over-clearing, and the cold-start test was confirmed failing by reverting just the timer wiring to `setTimeout`).

`remote-recall.test.ts` 66/66, `remote-recall-surfacing.test.ts` 10/10.

Full suite is 55 failed / 3762 passed — **all 55 pre-existing and unrelated**: `better-sqlite3@11.10.0` cannot load or compile against Node 26 (its C++ uses V8 APIs removed in 26: `GetPrototype`, `Context::GetIsolate`, `PropertyCallbackInfo::This`). Identical failures reproduce on unmodified `main`; every one is a module-load error, with zero assertion failures. Worth its own issue — this branch does not touch it.

## Not addressed

Rows can still reach a response via the `RemoteStore` peek cache while the live leg failed, which is its own reported self-contradiction — that belongs to #844/enterprise#428 and is left alone here. The "stdio servers should exit with their parent session" suggestion from the issue is also out of scope; the eight accumulated processes that motivated it deserve a separate change.
