### PR TITLE
fix(core): one place for engram field-compat rules, applied at every loader (#877)

### DIFF
--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -5,6 +5,7 @@ import { EngramSchemaPassthrough, type Engram } from './schemas/engram.js'
 import { PackManifestSchema, type PackManifest } from './schemas/pack.js'
 import { logger } from './logger.js'
 import { atomicWrite } from './sync.js'
+import { normalizeEngramInput } from './normalize-engram.js'
 
 /**
  * Error thrown when the engram file exists but cannot be read as engrams.
@@ -140,23 +141,9 @@ export function parseEngramFile(
   const valid: Engram[] = []
   const quarantined: unknown[] = []
   for (const entry of raw.engrams) {
-    // Backward compat (#866): migrate the pre-866 field name `reference_count`
-    // to `write_count` on first parse, and strip the old key so passthrough
-    // does not re-serialise it and the YAML stays clean after the next write.
-    // Only applied when `write_count` is absent, so a store already migrated
-    // (or written by a newer PLUR) is untouched.
-    let normalized = entry
-    if (
-      entry &&
-      typeof entry === 'object' &&
-      !Array.isArray(entry) &&
-      !('write_count' in entry) &&
-      'reference_count' in entry
-    ) {
-      const { reference_count, ...rest } = entry as Record<string, unknown>
-      normalized = { ...rest, write_count: reference_count }
-    }
-    const result = EngramSchemaPassthrough.safeParse(normalized)
+    // Field-compat rules live in ONE place (#877) — normalise before parse, so
+    // "absent" is still distinguishable from "Zod filled the default".
+    const result = EngramSchemaPassthrough.safeParse(normalizeEngramInput(entry))
     if (result.success) valid.push(result.data)
     // Quarantine the ORIGINAL entry, not the normalised one: quarantined
     // entries are written back verbatim, and a rejected engram must not be

--- a/packages/core/src/normalize-engram.ts
+++ b/packages/core/src/normalize-engram.ts
@@ -1,0 +1,73 @@
+/**
+ * The ONE place field-compatibility rules live (#877).
+ *
+ * Three code paths turn stored data into an `Engram` — the YAML primary store
+ * (`parseEngramFile`), Postgres/PGLite rows (`parseRow`), and rows reshaped
+ * from an enterprise server (`RemoteStore.reshape`) — and each used to
+ * normalise independently. Any per-field rule therefore had to be written three
+ * times, with nothing enforcing that it was, and a miss is SILENT: Zod fills the
+ * schema default and the result is indistinguishable from a real value.
+ *
+ * That is not hypothetical. `parseRow`'s own history records a row lacking
+ * `associations` crashing `recall()`, and #875's `reference_count` → `write_count`
+ * rename landed the backfill in the YAML loader only — so on the Postgres tier a
+ * legacy row loaded as `write_count: 1` while `reference_count: 5` sat unread
+ * under passthrough. `write_count` gates retirement, so a single `forget()`
+ * would have retired an engram with five corroborating writes.
+ *
+ * ## Invariants
+ *
+ * 1. **Normalise BEFORE parse, never after.** Once Zod has filled a default,
+ *    "absent" is unrecoverable — that is exactly the trap above.
+ * 2. **Idempotent.** A store already migrated, or written by a newer PLUR, must
+ *    be untouched. Every rule guards on the new key being absent.
+ * 3. **Never applied to quarantined entries.** A rejected engram is written back
+ *    verbatim and must not be silently rewritten on its way to being preserved.
+ * 4. **Non-destructive on anything unrecognised.** A non-object is returned as
+ *    given; the caller's own guards still apply.
+ *
+ * To add a migration: append a rule to `RULES`. `normalize-engram.test.ts` runs
+ * every rule against every loader, so a fourth backend cannot quietly skip the
+ * set.
+ */
+
+/** One field-compatibility rule. `apply` receives and returns a plain object. */
+export interface NormalizeRule {
+  /** Issue that introduced the rule — shows up in test names and failures. */
+  readonly id: string
+  /** What it does, in one line. */
+  readonly description: string
+  /** True when the rule still needs to run for this record. */
+  applies: (raw: Record<string, unknown>) => boolean
+  /** Return a NEW object; never mutate the input. */
+  apply: (raw: Record<string, unknown>) => Record<string, unknown>
+}
+
+export const RULES: readonly NormalizeRule[] = [
+  {
+    id: '#866',
+    description: 'reference_count → write_count (renamed in #866)',
+    // Guarded on write_count being ABSENT, so a record already carrying the new
+    // name keeps its value even if a stale reference_count rides alongside it.
+    applies: raw => !('write_count' in raw) && 'reference_count' in raw,
+    apply: ({ reference_count, ...rest }) => ({ ...rest, write_count: reference_count }),
+  },
+]
+
+/**
+ * Apply every field-compatibility rule to one stored record.
+ *
+ * Returns the input unchanged (same reference) when nothing applies, so the
+ * common path — a current-format store — allocates nothing.
+ */
+export function normalizeEngramInput(raw: unknown): unknown {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return raw
+  let out = raw as Record<string, unknown>
+  let touched = false
+  for (const rule of RULES) {
+    if (!rule.applies(out)) continue
+    out = rule.apply(out)
+    touched = true
+  }
+  return touched ? out : raw
+}

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -26,6 +26,8 @@
  */
 import { existsSync } from 'fs'
 import type { Engram } from './schemas/engram.js'
+import { EngramSchemaPassthrough } from './schemas/engram.js'
+import { normalizeEngramInput } from './normalize-engram.js'
 import { loadEngrams } from './engrams.js'
 import { searchEngrams } from './fts.js'
 import { logger } from './logger.js'
@@ -447,9 +449,26 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
     return { where, params, nextIndex: i }
   }
 
-  /** Parse a `data` row back to an Engram. PGLite returns JSONB as parsed JSON. */
+  /**
+   * Parse a `data` row back to an Engram. PGLite returns JSONB as parsed JSON.
+   *
+   * Normalise + validate, matching `storage-postgres.ts`'s `parseRow` (#877).
+   * This returned `row.data` VERBATIM, which is the same defect that adapter's
+   * own doc comment records having already been fixed there — two loaders
+   * disagreeing about what a valid engram looks like, so a row whose JSONB
+   * lacked `associations` crashed `recall()`. It also meant a pre-#866 row kept
+   * `reference_count` and never gained `write_count`, and `write_count` gates
+   * retirement: one `forget()` would retire an engram with five corroborating
+   * writes.
+   *
+   * A row that cannot be parsed is returned as-is rather than dropped — losing
+   * an engram silently is worse than passing along one that is odd, and the
+   * caller's own guards still apply.
+   */
   private parseRow(row: { data: any }): Engram {
-    return typeof row.data === 'string' ? JSON.parse(row.data) : row.data
+    const raw = typeof row.data === 'string' ? JSON.parse(row.data) : row.data
+    const parsed = EngramSchemaPassthrough.safeParse(normalizeEngramInput(raw))
+    return parsed.success ? (parsed.data as Engram) : (raw as Engram)
   }
 
   async loadFiltered(filter: StorageFilter): Promise<Engram[]> {

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -73,6 +73,7 @@
  */
 import type { Engram } from './schemas/engram.js'
 import { EngramSchemaPassthrough } from './schemas/engram.js'
+import { normalizeEngramInput } from './normalize-engram.js'
 import {
   searchEngrams, ftsTokenize, engramSearchText, embeddingContentHash,
   MIN_TOKEN_LENGTH, TOKENIZER_VERSION, type CorpusStats,
@@ -1779,7 +1780,10 @@ export function buildFilterClause(filter: StorageFilter): { where: string; param
  */
 function parseRow(row: { data: any }): Engram {
   const raw = typeof row.data === 'string' ? JSON.parse(row.data) : row.data
-  const parsed = EngramSchemaPassthrough.safeParse(raw)
+  // Same field-compat rules as every other loader (#877). This site had NONE,
+  // so #875's reference_count -> write_count rename silently reset the count on
+  // the Postgres tier — and write_count gates retirement.
+  const parsed = EngramSchemaPassthrough.safeParse(normalizeEngramInput(raw))
   return parsed.success ? (parsed.data as Engram) : (raw as Engram)
 }
 

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import type { Engram } from '../schemas/engram.js'
 import type { EngramStore } from './types.js'
 import { logger } from '../logger.js'
+import { normalizeEngramInput } from '../normalize-engram.js'
 import { ScopeMetadataSchema, type ScopeMetadata } from '../schemas/scope-metadata.js'
 
 /**
@@ -102,7 +103,11 @@ export class RemoteStore implements EngramStore {
    */
   private reshape(raw: { id?: unknown; scope?: unknown; status?: unknown; data?: unknown; created_at?: unknown }): Engram | null {
     const d = raw.data && typeof raw.data === 'object' ? raw.data as Record<string, unknown> : {}
-    const candidate = { ...d, id: raw.id, scope: raw.scope, status: raw.status }
+    // Same field-compat rules as the YAML and Postgres loaders (#877). Without
+    // this, a server row still carrying a pre-#866 `reference_count` arrived
+    // with the old key and no `write_count`, and every read site had to know to
+    // fall back — which two of the three did not.
+    const candidate = normalizeEngramInput({ ...d, id: raw.id, scope: raw.scope, status: raw.status })
     const parsed = RemoteRowSchema.safeParse(candidate)
     if (!parsed.success) {
       // #408: do NOT echo server-controlled VALUES into the log. Zod messages can

--- a/packages/core/test/normalize-engram.test.ts
+++ b/packages/core/test/normalize-engram.test.ts
@@ -1,0 +1,159 @@
+/**
+ * #877 — field-compatibility rules must hold at EVERY loader.
+ *
+ * Three code paths turn stored data into an `Engram`, and each used to
+ * normalise independently. A miss is silent: Zod fills the schema default and
+ * the result is indistinguishable from a real value. #875's
+ * `reference_count` → `write_count` rename recurred exactly this way — the
+ * backfill landed in the YAML loader only, so on the Postgres tier a legacy row
+ * loaded as `write_count: 1` while `reference_count: 5` sat unread under
+ * passthrough. `write_count` gates retirement, so one `forget()` would have
+ * retired an engram with five corroborating writes.
+ *
+ * So the rules are tested twice over: once as pure functions, and once THROUGH
+ * each loader. The second half is the part that matters — it is what fails when
+ * a fourth backend skips the set.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { normalizeEngramInput, RULES } from '../src/normalize-engram.js'
+import { parseEngramFile } from '../src/engrams.js'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import { RemoteStore } from '../src/store/remote-store.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/** A complete, schema-valid engram carrying the PRE-#866 field name. */
+function legacyEngram(id: string): Record<string, unknown> {
+  return {
+    id, version: 2, status: 'active', consolidated: false,
+    type: 'behavioral', scope: 'global', visibility: 'private',
+    statement: 'a legacy engram with five corroborating writes',
+    activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-10' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+    abstract: null, derived_from: null, polarity: null, content_hash: `h-${id}`,
+    commitment: 'leaning', recurrence_count: 0, summary: 's', engram_version: 1,
+    episode_ids: [], sources: [],
+    // The whole point: the OLD name, with a value a default would mask.
+    reference_count: 5,
+  }
+}
+
+describe('normalizeEngramInput — rule semantics (#877)', () => {
+  it('migrates reference_count to write_count and strips the old key', () => {
+    const out = normalizeEngramInput({ id: 'ENG-1', reference_count: 5 }) as Record<string, unknown>
+    expect(out.write_count).toBe(5)
+    expect('reference_count' in out).toBe(false)
+  })
+
+  it('is idempotent — a migrated record is untouched, by reference', () => {
+    const already = { id: 'ENG-1', write_count: 5 }
+    expect(normalizeEngramInput(already)).toBe(already)
+  })
+
+  it('does not clobber a new-format value when a stale old key rides alongside', () => {
+    // Order matters here: if the rule keyed on the OLD name being present it
+    // would overwrite a correct value with a stale one.
+    const out = normalizeEngramInput({ id: 'ENG-1', write_count: 9, reference_count: 5 }) as Record<string, unknown>
+    expect(out.write_count).toBe(9)
+  })
+
+  it('never mutates its input', () => {
+    const input = { id: 'ENG-1', reference_count: 5 }
+    normalizeEngramInput(input)
+    expect(input).toEqual({ id: 'ENG-1', reference_count: 5 })
+  })
+
+  it('passes non-objects through untouched', () => {
+    for (const v of [null, undefined, 42, 'str', ['a']]) expect(normalizeEngramInput(v)).toBe(v)
+  })
+
+  it('has at least one rule, and every rule is self-describing', () => {
+    // An emptied RULES array would make every loader test below vacuous.
+    expect(RULES.length).toBeGreaterThan(0)
+    for (const r of RULES) {
+      expect(r.id, 'each rule names the issue that introduced it').toMatch(/^#\d+$/)
+      expect(r.description.length).toBeGreaterThan(10)
+    }
+  })
+})
+
+/**
+ * The anti-regression half. Each loader gets the SAME legacy record and must
+ * produce the same normalised result — so adding a backend that forgets to call
+ * `normalizeEngramInput` fails here rather than silently losing data in
+ * production.
+ */
+describe('every loader applies the rules (#877)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-norm-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('YAML loader (parseEngramFile)', () => {
+    const content = yaml.dump({ engrams: [legacyEngram('ENG-YAML-1')] })
+    const { valid, quarantined } = parseEngramFile(join(dir, 'engrams.yaml'), content, content.length)
+    expect(quarantined).toHaveLength(0)
+    expect(valid).toHaveLength(1)
+    expect((valid[0] as any).write_count).toBe(5)
+    expect('reference_count' in (valid[0] as any)).toBe(false)
+  })
+
+  it('Postgres/PGLite loader (parseRow)', async () => {
+    // The row has to be written with the LEGACY key still in its JSONB, which
+    // means bypassing syncFromYaml — that path reads through the YAML loader,
+    // which normalises, so a row seeded that way can never exercise parseRow's
+    // own normalisation. (An earlier version of this test did exactly that and
+    // passed with the fix reverted: it proved nothing.)
+    const yamlPath = join(dir, 'engrams.yaml')
+    writeFileSync(yamlPath, yaml.dump({ engrams: [] }))
+    const adapter = new PGLiteAdapter(yamlPath, join(dir, 'idx'))
+    await adapter.syncFromYaml()   // initialises the schema
+
+    const legacy = legacyEngram('ENG-PG-1')
+    // Deliberate reach into the private handle: there is no public write path
+    // that preserves an un-normalised row, and the WIRING is what this asserts.
+    const db = (adapter as unknown as { db: { query: (sql: string, params?: unknown[]) => Promise<unknown> } }).db
+    await db.query(
+      `INSERT INTO engrams (id, status, scope, domain, last_accessed, data, source)
+       VALUES ($1, $2, $3, $4, $5, $6, 'primary')`,
+      ['ENG-PG-1', 'active', 'global', null, '2026-08-10', JSON.stringify(legacy)],
+    )
+
+    const loaded = await adapter.loadFiltered({})
+    const found = loaded.find(e => e.id === 'ENG-PG-1')
+    expect(found, 'row did not come back from the index').toBeDefined()
+    // Without normalisation in parseRow this is 1 (the Zod default) while
+    // reference_count: 5 sits unread under passthrough — and write_count gates
+    // retirement, so one forget() would retire a five-write engram.
+    expect((found as any).write_count).toBe(5)
+    expect('reference_count' in (found as any)).toBe(false)
+  }, 120_000)
+
+  it('remote-row loader (RemoteStore.reshape, via load)', async () => {
+    const original = globalThis.fetch
+    globalThis.fetch = (async () => ({
+      ok: true, status: 200,
+      json: async () => ({
+        rows: [{
+          id: 'ENG-REMOTE-1', scope: 'group:test', status: 'active',
+          data: legacyEngram('ENG-REMOTE-1'),
+        }],
+        total_count: 1,
+      }),
+      text: async () => '',
+    })) as any
+    try {
+      const store = new RemoteStore('https://example.test/sse', 'tok', 'group:test', { ttlMs: 0 })
+      const engrams = await store.load()
+      expect(engrams).toHaveLength(1)
+      expect((engrams[0] as any).write_count).toBe(5)
+      expect('reference_count' in (engrams[0] as any)).toBe(false)
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+})


### PR DESCRIPTION
Fixes #877.

## There are four loaders, not three

The issue counts three. `PGLiteAdapter` has its **own** `parseRow` in `storage-pglite.ts`, separate from `storage-postgres.ts`'s, and it returned `row.data` **verbatim** — no normalisation *and* no schema validation:

```ts
private parseRow(row: { data: any }): Engram {
  return typeof row.data === 'string' ? JSON.parse(row.data) : row.data
}
```

That is the same defect `storage-postgres.ts`'s own doc comment records having already been fixed *there*:

> This returned `r.data` verbatim, so the two loaders disagreed about what a valid engram looks like: a row whose JSONB lacked `associations` crashed `recall()` outright.

Still live in the adapter most personal installs actually run. So the `write_count` reset this issue predicted for the Postgres tier is real, just in a different file than it pointed at — a pre-#866 row loaded from PGLite keeps `reference_count` and gains no `write_count`, and `write_count` gates retirement, so one `forget()` retires an engram with five corroborating writes.

## The change

`normalizeEngramInput()` (`normalize-engram.ts`) holds every field-compat rule in one ordered `RULES` list, applied immediately before `safeParse` in all four loaders:

| Loader | Before | After |
|---|---|---|
| `parseEngramFile` (YAML) | inline `reference_count` migration | shared call |
| `storage-postgres` `parseRow` | none | shared call |
| `storage-pglite` `parseRow` | **verbatim `data`** | shared call **+ the validation the Postgres one already had** |
| `RemoteStore.reshape` | ad-hoc `??` at read sites | shared call |

Properties from the issue, kept:

- **Normalise before parse.** Once Zod fills a default, "absent" is unrecoverable — that is the trap.
- **Idempotent**, guarded on the *new* key being absent, so a stale `reference_count` riding alongside a correct `write_count` cannot clobber it.
- **Never applied to quarantined entries** — a rejected engram is written back verbatim and must not be rewritten on its way to being preserved.
- Returns the input **by reference** when nothing applies, so a current-format store allocates nothing on the hot path.

## On the tests, because this nearly went wrong

Every rule is exercised twice: as a pure function, and **through each loader** — the second half being what fails when a fifth backend skips the set.

The first version of the Postgres/PGLite loader test **passed with the fix reverted.** It seeded via `syncFromYaml`, which reads through the YAML loader and normalises on the way in, so `parseRow` never saw a legacy key. It proved nothing.

It now inserts legacy JSONB directly (reaching into the private `db` handle, deliberately — there is no public write path that preserves an un-normalised row, and the *wiring* is what needs asserting) and fails with `expected 1 to be 5` without the fix. Verified by reverting and re-running. That note is in the test, since a test that cannot fail is the same class of false-green this issue is about.

## Verification

- Full workspace: **3866 passed, 0 failed**
- `pnpm typecheck:tests`: clean
- Revert check: removing the call from `storage-pglite.ts` fails the loader test with `expected 1 to be 5`

## Follow-up worth considering

`storage-pglite`'s `parseRow` now validates per row on `loadFiltered`, matching `storage-postgres`. That is a correctness win but a per-row cost on the hot read path; if it shows up in `pnpm bench:micro`, the fix is to hoist validation to write time rather than to drop it.
