### PR TITLE
fix(core): tolerate server nulls in scope metadata, and never drop an entry silently (#843)

### DIFF
--- a/packages/core/src/schemas/scope-metadata.ts
+++ b/packages/core/src/schemas/scope-metadata.ts
@@ -127,15 +127,36 @@ const NO_CONTROL_MSG = 'must not contain control characters or newlines (directi
 export const ScopeMetadataSchema = z.object({
   scope: z.string()
     .describe('The scope this metadata describes (e.g. "group:plur/engineering", "project:plur").'),
-  description: z.string().max(MAX_DESCRIPTION_LEN).regex(NO_CONTROL_CHARS, NO_CONTROL_MSG)
-    .describe('Human-readable explanation of what this scope is for. Surfaced VERBATIM in scope/store discovery — bounded in length and free of control chars/newlines so a hostile remote cannot inject instructions (#345).'),
+  // null-tolerant (#843). A server serialising an unset nullable column as JSON
+  // `null` used to fail this field outright, and because RemoteStore.me() drops
+  // failures inside a flatMap, EVERY ordinary scope row vanished — silently
+  // disabling covers-based auto-routing on a live deployment. Coerced to '' so
+  // the OUTPUT type stays `string` and no consumer has to learn about null.
+  // `=== null` deliberately, NOT `== null`: an explicit null is a server
+  // serialising an unset column, but an ABSENT description is a malformed row
+  // and must still be rejected. Coercing undefined too would quietly turn a
+  // required field optional.
+  description: z.preprocess(
+    v => (v === null ? '' : v),
+    z.string().max(MAX_DESCRIPTION_LEN).regex(NO_CONTROL_CHARS, NO_CONTROL_MSG),
+  )
+    .describe('Human-readable explanation of what this scope is for. Surfaced VERBATIM in scope/store discovery — bounded in length and free of control chars/newlines so a hostile remote cannot inject instructions (#345). An explicit null reads as empty, so a server serialising an unset column does not fail the row; the key itself is still required (#843).'),
   covers: z.array(z.string().max(MAX_COVER_LEN).regex(NO_CONTROL_CHARS, NO_CONTROL_MSG)).max(MAX_COVERS).default([])
     .describe('Topics, domains, or areas this scope is the home for. Advisory; helps an agent pick the right scope and is surfaced in discovery. Each entry is length-bounded and control-char-free, and the list is capped, for the same directive-surface reason as `description` (#345).'),
-  sensitivity: ScopeSensitivitySchema.optional()
+  // null -> undefined at the trust boundary (#843): Zod's .optional()
+  // REJECTS null, and an unset nullable column is exactly what a server
+  // sends as null.
+  sensitivity: z.preprocess(v => (v === null ? undefined : v), ScopeSensitivitySchema.optional())
     .describe('Per-scope sensitivity policy. When present, the leak guard uses it; when absent, the guard falls back to the default shared-scope behavior.'),
-  injection_policy: z.enum(['on_match', 'on_request', 'always']).optional()
+  // null -> undefined at the trust boundary (#843): Zod's .optional()
+  // REJECTS null, and an unset nullable column is exactly what a server
+  // sends as null.
+  injection_policy: z.preprocess(v => (v === null ? undefined : v), z.enum(['on_match', 'on_request', 'always']).optional())
     .describe("When the loader may inject this scope's engrams. Mirrors pack injection_policy semantics."),
-  owner: z.string().optional()
+  // null -> undefined at the trust boundary (#843): Zod's .optional()
+  // REJECTS null, and an unset nullable column is exactly what a server
+  // sends as null.
+  owner: z.preprocess(v => (v === null ? undefined : v), z.string().optional())
     .describe('Owner of the scope (person or team). Advisory.'),
 }).describe('Self-describing metadata for an engram scope (Open Engram Standard, scope layer).')
 

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -187,10 +187,38 @@ export class RemoteStore implements EngramStore {
       // drop entries that don't parse (and any whose `scope` isn't in the
       // authorized set, so a remote can't smuggle metadata for an unrelated
       // scope into discovery). Absent/empty → [] (older servers).
+      // #843: a dropped entry must SAY SO. A server/client shape mismatch here
+      // disabled covers-based auto-routing on a live deployment and produced no
+      // signal anywhere — no warning, no log line, no degraded-mode flag. It was
+      // found only by diffing plur_scopes_discover against the admin UI, because
+      // `rankScopes` skips entries with empty covers, so an empty metadata list
+      // means zero candidates and every unscoped write falls to the personal
+      // `unscoped_default`. Team knowledge silently stopped reaching team scopes
+      // while the admin dashboard rendered all five scopes as fine.
+      //
+      // One warning on the first connection would have caught it. The authorized-
+      // set drop stays quiet: that one is a deliberate refusal (a remote must not
+      // smuggle metadata for a scope it did not grant), not an unexpected shape.
       scope_metadata: Array.isArray(body.scope_metadata)
         ? body.scope_metadata.flatMap((m) => {
             const parsed = ScopeMetadataSchema.safeParse(m)
-            if (!parsed.success) return []
+            if (!parsed.success) {
+              // Log PATHS and CODES only, never server-controlled values (#408):
+              // a Zod message can embed the received value, and a crafted one
+              // could carry control chars to forge log lines.
+              const why = parsed.error.issues
+                .map(i => `${i.path.join('.') || '(root)'}: ${i.code}`)
+                .join('; ')
+              const safeScope = String((m as { scope?: unknown } | null)?.scope ?? '<unknown>')
+                .replace(/[^\w:./-]/g, '?')
+                .slice(0, 64)
+              logger.warning(
+                `[plur:remote-store] ${this.url} sent scope metadata for "${safeScope}" that does not conform ` +
+                `(${why}) — DROPPED. That scope cannot participate in covers-based auto-routing until the ` +
+                `server sends a conforming shape, so unscoped writes may fall back to the personal default (#843).`,
+              )
+              return []
+            }
             if (!scopes.includes(parsed.data.scope)) return []
             return [parsed.data]
           })

--- a/packages/core/test/scope-metadata-null-tolerance.test.ts
+++ b/packages/core/test/scope-metadata-null-tolerance.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #843 — a server/client shape mismatch on scope metadata must not be silent.
+ *
+ * `ScopeMetadataSchema` declared `description` as a required string and
+ * `sensitivity` / `injection_policy` / `owner` as `.optional()`. Zod's
+ * `.optional()` REJECTS null, and an unset nullable column is exactly what a
+ * server serialises as null — so every ordinary row (one saved without a
+ * sensitivity override or an injection policy) failed `safeParse`.
+ *
+ * `RemoteStore.me()` drops failures inside a `flatMap`, so all of them vanished.
+ * `rankScopes` skips entries with empty covers, so an empty metadata list means
+ * ZERO candidates and `_resolveUnscopedScope` falls through to the personal
+ * `unscoped_default` — team knowledge silently stopped reaching team scopes,
+ * while the admin dashboard rendered every scope as correctly configured.
+ *
+ * Two independent guards, because either alone leaves the failure silent:
+ * tolerate the null shape, AND warn when something is dropped anyway.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { ScopeMetadataSchema } from '../src/schemas/scope-metadata.js'
+import { RemoteStore } from '../src/store/remote-store.js'
+import { logger } from '../src/logger.js'
+
+/** The shape a server sends for a scope with no overrides set. */
+const rowWithNulls = {
+  scope: 'group:acme/engineering',
+  description: 'Engineering — all software work',
+  covers: ['software', 'testing'],
+  sensitivity: null,
+  injection_policy: null,
+  owner: null,
+}
+
+describe('ScopeMetadataSchema tolerates server nulls (#843)', () => {
+  it('parses a row whose unset optional columns are null', () => {
+    const parsed = ScopeMetadataSchema.safeParse(rowWithNulls)
+    expect(parsed.success, 'the ordinary server row must parse').toBe(true)
+  })
+
+  it('normalises null optionals to undefined, so no consumer learns about null', () => {
+    const md = ScopeMetadataSchema.parse(rowWithNulls)
+    expect(md.sensitivity).toBeUndefined()
+    expect(md.injection_policy).toBeUndefined()
+    expect(md.owner).toBeUndefined()
+  })
+
+  it('keeps covers, which is what auto-routing actually ranks on', () => {
+    expect(ScopeMetadataSchema.parse(rowWithNulls).covers).toEqual(['software', 'testing'])
+  })
+
+  it('reads a null description as empty rather than failing the whole row', () => {
+    const md = ScopeMetadataSchema.parse({ ...rowWithNulls, description: null })
+    expect(md.description).toBe('')
+    expect(md.covers).toEqual(['software', 'testing'])
+  })
+
+  it('still rejects a genuinely malformed row', () => {
+    // Null-tolerance must not become "accept anything" — control chars in the
+    // description are a prompt-injection channel and stay refused.
+    expect(ScopeMetadataSchema.safeParse({ ...rowWithNulls, description: 'a\nb' }).success).toBe(false)
+    expect(ScopeMetadataSchema.safeParse({ ...rowWithNulls, scope: 123 }).success).toBe(false)
+  })
+})
+
+describe('RemoteStore.me() reports a dropped entry (#843)', () => {
+  const original = globalThis.fetch
+  afterEach(() => { globalThis.fetch = original; vi.restoreAllMocks() })
+
+  function mockMe(scope_metadata: unknown[]) {
+    globalThis.fetch = (async () => ({
+      ok: true, status: 200,
+      json: async () => ({
+        username: 'u', org_id: 'o', role: 'member',
+        scopes: ['group:acme/engineering'],
+        scope_metadata,
+      }),
+      text: async () => '',
+    })) as any
+    return new RemoteStore('https://example.test/sse', 'tok', 'group:acme/engineering', { ttlMs: 0 })
+  }
+
+  it('surfaces the server row with nulls instead of dropping it', async () => {
+    const md = (await mockMe([rowWithNulls]).me()).scope_metadata
+    expect(md).toHaveLength(1)
+    expect(md[0].covers).toEqual(['software', 'testing'])
+  })
+
+  it('WARNS when an entry is dropped — the silence was the bug', async () => {
+    const warn = vi.spyOn(logger, 'warning').mockImplementation(() => {})
+    const md = (await mockMe([{ scope: 'group:acme/engineering', description: 'x\ny' }]).me()).scope_metadata
+
+    expect(md).toHaveLength(0)
+    expect(warn, 'a dropped scope must not be silent').toHaveBeenCalledTimes(1)
+    const msg = warn.mock.calls[0][0] as string
+    expect(msg).toContain('group:acme/engineering')
+    expect(msg).toContain('DROPPED')
+  })
+
+  it('does not echo server-controlled values into the log (#408)', async () => {
+    const warn = vi.spyOn(logger, 'warning').mockImplementation(() => {})
+    await mockMe([{ scope: 'group:acme/engineering\n[plur] FORGED LINE', description: 'x' }]).me()
+    // The scope is sanitised before it reaches the log, so a crafted name
+    // cannot forge a log line or smuggle instructions.
+    if (warn.mock.calls.length > 0) {
+      expect(warn.mock.calls[0][0] as string).not.toContain('FORGED LINE')
+    }
+  })
+
+  it('stays quiet for the authorized-set drop, which is a deliberate refusal', async () => {
+    const warn = vi.spyOn(logger, 'warning').mockImplementation(() => {})
+    // Well-formed, but for a scope the token was not granted — a remote must not
+    // smuggle metadata for an unrelated scope. Expected, so not a warning.
+    const md = (await mockMe([{ ...rowWithNulls, scope: 'group:other/team' }]).me()).scope_metadata
+    expect(md).toHaveLength(0)
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/spec/scope-metadata.schema.json
+++ b/spec/scope-metadata.schema.json
@@ -13,7 +13,7 @@
       "type": "string",
       "maxLength": 500,
       "pattern": "^[^\\u0000-\\u001F\\u007F-\\u009F\\u2028\\u2029]*$",
-      "description": "Human-readable explanation of what this scope is for. Surfaced VERBATIM in scope/store discovery — bounded in length and free of control chars/newlines so a hostile remote cannot inject instructions (#345)."
+      "description": "Human-readable explanation of what this scope is for. Surfaced VERBATIM in scope/store discovery — bounded in length and free of control chars/newlines so a hostile remote cannot inject instructions (#345). An explicit null reads as empty, so a server serialising an unset column does not fail the row; the key itself is still required (#843)."
     },
     "covers": {
       "type": "array",


### PR DESCRIPTION
Fixes #843.

## Why the whole metadata list vanished

`ScopeMetadataSchema` declared `description` as a required string and `sensitivity` / `injection_policy` / `owner` as `.optional()`. Zod's `.optional()` means "may be **undefined**" and **rejects null** — and an unset nullable column is exactly what a server serialises as `null`. So every *ordinary* row failed `safeParse`, and `me()` drops failures inside a `flatMap`.

The consequence is not cosmetic. `rankScopes` skips entries with empty `covers`, so an empty metadata list means **zero candidates**, and `_resolveUnscopedScope` falls through to the personal `unscoped_default` for every unscoped write. Team knowledge silently stopped reaching team scopes — while the admin dashboard rendered all five scopes as correctly configured, because the admin UI never crosses the schema boundary.

## Two guards, because either alone stays silent

**1 — tolerate the shape.** `sensitivity` / `injection_policy` / `owner` normalise `null → undefined` at the boundary, so the *output* type is unchanged and no consumer has to learn about null. `description` coerces an explicit `null` to `''`.

That second one is `=== null`, **not** `== null`, and the distinction matters: my first version used `== null`, which swallows `undefined` too and quietly turned a required field optional. The repo's own `rejects missing required fields` test caught it. An explicit null is a server serialising an unset column; an **absent** description is a malformed row and is still rejected.

**2 — say something when an entry is dropped anyway.** This is the actual ask in the issue, and it is the half that would have caught the original incident on the first connection instead of letting it survive from #345 D2 into production.

```
[plur:remote-store] <host> sent scope metadata for "group:acme/engineering" that does not
conform (sensitivity: invalid_type) — DROPPED. That scope cannot participate in
covers-based auto-routing until the server sends a conforming shape, so unscoped writes
may fall back to the personal default (#843).
```

Paths and codes only, never server-controlled values (#408) — a Zod message can embed the received value, and a crafted scope name carrying control chars would otherwise forge a log line. The scope is sanitised and bounded before it reaches the log.

The **authorized-set** drop stays quiet on purpose: a remote must not smuggle metadata for a scope it did not grant, so that path is a deliberate refusal rather than an unexpected shape, and warning on it would train the operator to ignore the warning that matters.

## Not a loosening

Null-tolerance is not "accept anything". Control chars in a `description` remain a prompt-injection channel into the agent's directive surface and are still refused, as is a non-string `scope`. Both are pinned by tests.

`spec/scope-metadata.schema.json` is regenerated, and worth noting what changed: **only the description text**. The published contract is still `type: "string"`, required. PLUR now reads leniently where a server writes `null` without loosening what the spec promises — the right asymmetry for an interop layer.

## Verification

- 9 new tests; full workspace **3866 passed, 0 failed**; `pnpm typecheck:tests` clean
- **Revert-checked**: reverting the schema fix fails 5 of them. (Doing this by default now — an earlier test today passed with its fix reverted and proved nothing.)

## Related

- #877 / #879 — the same class one layer down: field-compat rules that had to be written at every loader and silently lost data when one was missed
