### PR TITLE
fix(core): rescope cancels the pending delivery to the store it moved away from (#848)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -515,6 +515,19 @@ export interface RescopeResult {
   kept_local?: boolean
   /** Echoed when options.dry_run was set — nothing was mutated. */
   dry_run?: boolean
+  /**
+   * Set when the source carried a PENDING outbox delivery that the rescope
+   * cancelled (#848).
+   *
+   * A failed remote write queues the engram with `structured_data._outbox`
+   * naming the target url + scope. Rescoping used to rewrite the scope and
+   * leave that entry untouched, so when the original store recovered the
+   * engram was delivered to the store the user explicitly moved it away from —
+   * silently undoing the rescope, arbitrarily later. Reported rather than done
+   * quietly, because the caller cannot otherwise tell a rescope that cancelled
+   * a queued delivery from one that did not.
+   */
+  cancelled_outbox?: { target_url: string; target_scope: string }
   error?: string
 }
 
@@ -5644,9 +5657,20 @@ export class Plur {
     }
 
     if (opts.dryRun) {
+      // #848: a dry run has to disclose the queued delivery too, or it does not
+      // describe what the real call would do.
+      const pendingOutbox = route === 'local'
+        ? ((source as any).structured_data?._outbox as { target_url?: string; target_scope?: string } | undefined)
+        : undefined
       return {
         id, status: 'rescoped', action, from_scope: source.scope, to_scope: target,
         ...(route === 'remote' ? { kept_local: opts.keepLocal } : { new_id: id }),
+        ...(pendingOutbox?.target_url
+          ? { cancelled_outbox: {
+              target_url: pendingOutbox.target_url,
+              target_scope: pendingOutbox.target_scope ?? source.scope,
+            } }
+          : {}),
         dry_run: true,
       }
     }
@@ -5704,6 +5728,7 @@ export class Plur {
     // Local route: rewrite scope IN PLACE under the store lock — the same
     // incremental update path as updateEngram's local branch. Id, activation,
     // feedback, relations and history all stay attached to the same row.
+    let cancelledOutbox: { target_url: string; target_scope: string } | undefined
     const rewritten = await this._withStoreLock(this.paths.engrams, async () => {
       // Targeted read (#827): resolving one engram by id.
       const fresh = await this._loadTargeted([id])
@@ -5712,10 +5737,31 @@ export class Plur {
       const from = t.scope
       t.scope = target
       const tsd = (t as any).structured_data
-      ;(t as any).structured_data = {
+      const nextSd: Record<string, unknown> = {
         ...(tsd && typeof tsd === 'object' && !Array.isArray(tsd) ? tsd : {}),
         _rescoped: { from_scope: from, at: now },
       }
+      // #848: CANCEL any pending delivery to the store we are moving away from.
+      //
+      // A failed remote write leaves `_outbox` naming the original url + scope.
+      // Rewriting the scope and leaving that entry queued meant the engram was
+      // delivered to the old store whenever it came back — silently reverting
+      // the rescope, arbitrarily later, with hand-editing engrams.yaml as the
+      // only reliable fix. The window is unbounded, because the queue only
+      // flushes when the store recovers.
+      //
+      // Dropping is correct on THIS branch specifically: `route === 'local'`
+      // means the target matched no URL-backed store, so the user has said the
+      // engram does not belong in a shared store at all. (A target that maps to
+      // a different remote takes the `remote` branch, which builds a fresh copy
+      // with the bookkeeping keys stripped and retires the source — and
+      // flushOutbox already skips retired rows, so that path is not exposed.)
+      const ob = nextSd._outbox as { target_url?: string; target_scope?: string } | undefined
+      if (ob?.target_url) {
+        cancelledOutbox = { target_url: ob.target_url, target_scope: ob.target_scope ?? from }
+        delete nextSd._outbox
+      }
+      ;(t as any).structured_data = nextSd
       // Incremental write (#740): only the rescoped row changed.
       await this._updateEngrams(fresh, [t])
       await this._syncIndex()
@@ -5731,9 +5777,22 @@ export class Plur {
       event: 'engram_rescoped',
       engram_id: id,
       timestamp: now,
-      data: { from_scope: source.scope, to_scope: target, new_id: id, routed_to: 'local' },
+      data: {
+        from_scope: source.scope, to_scope: target, new_id: id, routed_to: 'local',
+        ...(cancelledOutbox ? { cancelled_outbox: cancelledOutbox } : {}),
+      },
     })
-    return { id, status: 'rescoped', action, from_scope: source.scope, to_scope: target, new_id: id }
+    if (cancelledOutbox) {
+      logger.warning(
+        `[plur] rescope of ${id} cancelled a pending delivery to ${cancelledOutbox.target_url} ` +
+        `(scope "${cancelledOutbox.target_scope}"). That queued write would have re-delivered the engram to the ` +
+        `store it was moved away from once the host recovered (#848).`,
+      )
+    }
+    return {
+      id, status: 'rescoped', action, from_scope: source.scope, to_scope: target, new_id: id,
+      ...(cancelledOutbox ? { cancelled_outbox: cancelledOutbox } : {}),
+    }
   }
 
   /**

--- a/packages/core/test/rescope-outbox-cancel.test.ts
+++ b/packages/core/test/rescope-outbox-cancel.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #848 — a rescope must cancel the pending delivery to the store it moved away from.
+ *
+ * A failed remote write queues the engram with `structured_data._outbox` naming
+ * the target url + scope. `rescope` rewrote the local scope and left that entry
+ * untouched, so when the original store recovered the engram was delivered to
+ * the store the user had explicitly moved it away from — silently undoing the
+ * rescope, arbitrarily later.
+ *
+ * The window is unbounded: the queue only flushes when the store comes back. And
+ * it bites in exactly the situation the outbox exists for — the store being
+ * unreachable is what makes the misroute recoverable, and also what leaves the
+ * stale entry sitting there.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+
+const REMOTE = 'https://plur.example.com/sse'
+
+describe('rescope cancels a stale outbox entry (#848)', () => {
+  let dir: string
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-rescope-outbox-'))
+    originalFetch = globalThis.fetch
+    // Store is unreachable: every write fails, so learn() queues to the outbox.
+    globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as any
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ url: REMOTE, token: 'tok', scope: 'group:acme/team', shared: true, readonly: false }],
+      index: false,
+    }))
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** Write an engram destined for the unreachable remote, so it lands queued. */
+  async function queuedEngram(plur: Plur) {
+    const e = await plur.learn('a team fact written while the store was down', {
+      scope: 'group:acme/team', type: 'behavioral',
+    })
+    await new Promise(r => setTimeout(r, 50))   // let the fire-and-forget push settle
+    return e
+  }
+
+  function outboxOf(id: string): { target_url?: string; target_scope?: string } | undefined {
+    const doc = yaml.load(readFileSync(join(dir, 'engrams.yaml'), 'utf8')) as
+      { engrams: Array<{ id: string; scope: string; structured_data?: { _outbox?: any } }> }
+    return doc.engrams.find(e => e.id === id)?.structured_data?._outbox
+  }
+
+  it('drops the queued delivery when the engram is moved to a local scope', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await queuedEngram(plur)
+    expect(outboxOf(e.id), 'precondition: the write should have queued').toBeDefined()
+
+    const { results } = await plur.rescope(e.id, 'global')
+
+    expect(results[0].status).toBe('rescoped')
+    expect(results[0].action).toBe('local_rewrite')
+    // The whole point: no queued delivery survives to re-route it later.
+    expect(outboxOf(e.id), 'a pending delivery to the old store survived the rescope').toBeUndefined()
+  })
+
+  it('reports the cancellation rather than doing it quietly', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await queuedEngram(plur)
+
+    const { results } = await plur.rescope(e.id, 'global')
+
+    // A caller cannot otherwise distinguish a rescope that cancelled a queued
+    // delivery from one that did not.
+    expect(results[0].cancelled_outbox).toEqual({
+      target_url: REMOTE,
+      target_scope: 'group:acme/team',
+    })
+  })
+
+  it('records the cancellation in history', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await queuedEngram(plur)
+    await plur.rescope(e.id, 'global')
+
+    const { readdirSync } = await import('fs')
+    const hist = readdirSync(join(dir, 'history'))
+      .filter(f => f.endsWith('.jsonl'))
+      .flatMap(f => readFileSync(join(dir, 'history', f), 'utf8').split('\n').filter(Boolean))
+      .map(l => JSON.parse(l))
+      .filter(ev => ev.engram_id === e.id && ev.event === 'engram_rescoped')
+
+    expect(hist).toHaveLength(1)
+    expect(hist[0].data.cancelled_outbox?.target_url).toBe(REMOTE)
+  })
+
+  it('dry_run discloses the queued delivery without mutating anything', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await queuedEngram(plur)
+
+    const { results } = await plur.rescope(e.id, 'global', { dry_run: true })
+
+    expect(results[0].dry_run).toBe(true)
+    expect(results[0].cancelled_outbox?.target_url).toBe(REMOTE)
+    // Nothing actually changed.
+    expect(outboxOf(e.id), 'dry_run must not cancel the delivery').toBeDefined()
+  })
+
+  it('leaves an engram with no queued delivery untouched', async () => {
+    const plur = new Plur({ path: dir })
+    // Purely local write — never had an outbox entry.
+    const e = await plur.learn('a purely local fact', { scope: 'global', type: 'behavioral' })
+
+    const { results } = await plur.rescope(e.id, 'project:demo')
+
+    expect(results[0].status).toBe('rescoped')
+    expect(results[0].cancelled_outbox, 'nothing was queued, so nothing to report').toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #848.

## The fix

`rescope`'s local-rewrite branch now **cancels** any pending `_outbox` delivery, and says so.

```
rescope ENG-… → global
  ↳ cancelled_outbox: { target_url: "https://…/sse", target_scope: "group:acme/team" }
```

It lands in three places, because a silent cancellation is only marginally better than a silent revert: the `RescopeResult`, the `engram_rescoped` history event, and a `logger.warning`. `dry_run` discloses it too — without mutating — since otherwise a dry run does not describe what the real call would do.

## Only one of the three proposed options is reachable

The issue offers drop → retarget → at-minimum-report, in preference order. Reading the routing, **retarget cannot happen on this path**: the local branch runs precisely when the target matched no URL-backed store, so there is never a remote to retarget *to*. A target that maps to a different remote takes the `remote` branch, which builds a fresh copy with the PLUR-internal bookkeeping keys stripped and retires the source.

So this implements **drop + report**, and option 2 is unreachable by construction rather than deferred.

## The sibling case the issue asks about

> Same class of problem as `forget` — worth checking whether retiring an engram also leaves its outbox entry live.

Checked. Two retirement paths, different answers:

| Path | Strips `_outbox`? | |
|---|---|---|
| `forget()` | yes, explicitly (#766) | safe at the write |
| `_retireRescopedSource` | **no** — bypasses `forget()`, preserves `structured_data` wholesale | safe only because `flushOutbox` filters `status !== 'retired'` |

So the second one is not a live bug, but it is defended one layer down rather than at the write. That is now noted in the code, because removing the flush filter would silently re-expose it and nothing would say so.

## Verification

- 5 new tests: drop, report, history, `dry_run` discloses-without-mutating, and the no-outbox case stays untouched
- Tests nearest the change (rescope, outbox, remote-routing, learn-async-scope): **77 passed**
- `@plur-ai/core`: **2722 passed, 0 failed**; `pnpm typecheck:tests` clean
- **Revert-checked**: removing the `delete nextSd._outbox` fails with *"a pending delivery to the old store survived the rescope"*

Note on scope of verification: the full-workspace run was killed twice by the environment, so the above is the core project plus the targeted set rather than all 284 files. The change is confined to `packages/core/src/index.ts`, so core is the meaningful surface — but CI is the authority here, not my local run.

## Related

- #877 / #879, #843 / #880 — same cluster: the remote-store sync path, where the failure mode is consistently "reports success, does the wrong thing later"
