### PR TITLE
fix(core): ReadonlyStoreGuard forwards the query-adapter surface (#830)

### DIFF
--- a/packages/core/src/store/readonly-store-guard.ts
+++ b/packages/core/src/store/readonly-store-guard.ts
@@ -26,6 +26,26 @@
  *   callback still rejects at the store method itself.
  * - **All writes reject with the same typed error**, so callers can
  *   distinguish "this instance is read-only" from a real store failure.
+ * - **The query-adapter surface delegates unchanged** (`role`, `searchBM25`,
+ *   `searchVector`, `vectorIndex`). These are reads, so they need no guarding —
+ *   exactly like `loadByIds`. Omitting them was #830: `_primaryQueryAdapter()`
+ *   keys on `role === 'primary' && typeof searchBM25 === 'function'`, so a
+ *   guarded store failed that check, `recall()` fell back to `_filterEngrams()`,
+ *   and for a store that answers queries ITSELF — which therefore has no
+ *   `indexedStorage`, since `indexTier` resolves to 'none' when a primary query
+ *   store is present — that path had nothing to read and threw. Readonly is the
+ *   documented way to say "this recall must not write", and it was unusable
+ *   exactly where it is most wanted: shared multi-tenant storage, where core's
+ *   per-read activation write is a real cost.
+ *
+ * A note on the shape, since it looks like the wrong one: this is a WHITELIST,
+ * and a whitelist is why #830 happened — a new read member is silently dropped
+ * until someone remembers to add it. A Proxy forwarding everything except a
+ * write deny-list would not have this failure mode. It is still the right shape
+ * HERE, because the two failure modes are not symmetric: a missed entry on a
+ * whitelist loses functionality and is discovered; a missed entry on a
+ * deny-list PERMITS A WRITE on a path whose entire purpose is that it cannot
+ * write. On a safety guard, fail closed.
  */
 import type { Engram } from '../schemas/engram.js'
 import type { PrimaryStore, PrimaryStoreKind } from './primary-store.js'
@@ -67,6 +87,18 @@ export class ReadonlyStoreGuard implements PrimaryStore {
    */
   readonly nextEngramId?: (datePrefix: string) => Promise<string>
 
+  /**
+   * Query-adapter surface (#830). All READS, all delegating unchanged.
+   *
+   * `role` is what `_primaryQueryAdapter()` keys on, so dropping it silently
+   * disabled search pushdown for every read-only instance over a primary query
+   * store — and then crashed, because the fallback path has no index to read.
+   */
+  readonly role?: string
+  readonly searchBM25?: (query: string, opts: { limit: number } & Record<string, unknown>) => Promise<Engram[]>
+  readonly searchVector?: (...args: unknown[]) => Promise<unknown>
+  readonly vectorIndex?: unknown
+
   constructor(private readonly _inner: PrimaryStore) {
     this.kind = _inner.kind
     this.location = _inner.location
@@ -79,6 +111,18 @@ export class ReadonlyStoreGuard implements PrimaryStore {
       this.findActiveByContentHash = (hash, scope) => _inner.findActiveByContentHash!(hash, scope)
     }
     if (_inner.nextEngramId) this.nextEngramId = () => Promise.reject(new ReadonlyStoreError())
+
+    // Query-adapter surface (#830) — reads, forwarded verbatim like loadByIds.
+    const inner = _inner as unknown as {
+      role?: string
+      searchBM25?: (q: string, o: { limit: number } & Record<string, unknown>) => Promise<Engram[]>
+      searchVector?: (...a: unknown[]) => Promise<unknown>
+      vectorIndex?: unknown
+    }
+    if (inner.role !== undefined) this.role = inner.role
+    if (inner.searchBM25) this.searchBM25 = (q, o) => inner.searchBM25!(q, o)
+    if (inner.searchVector) this.searchVector = (...a: unknown[]) => inner.searchVector!(...a)
+    if (inner.vectorIndex !== undefined) this.vectorIndex = inner.vectorIndex
   }
 
   load(): Promise<Engram[]> { return this._inner.load() }

--- a/packages/core/test/readonly-query-adapter.test.ts
+++ b/packages/core/test/readonly-query-adapter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #830 — a read-only Plur over a PRIMARY QUERY STORE must keep pushdown.
+ *
+ * `ReadonlyStoreGuard` forwarded a whitelist and omitted `role`, `searchBM25`,
+ * `searchVector` and `vectorIndex`. `_primaryQueryAdapter()` keys on
+ * `role === 'primary' && typeof searchBM25 === 'function'`, so a guarded store
+ * failed that check, `recall()` fell back to `_filterEngrams()` — and for a
+ * store that answers queries itself (which therefore has no `indexedStorage`,
+ * because `indexTier` resolves to 'none' when a primary query store is present)
+ * that path had nothing to read and threw
+ * `Cannot read properties of undefined (reading 'length')`.
+ *
+ * Which made `readonly: true` unusable exactly where it is most wanted: shared
+ * multi-tenant storage, where core's per-read activation write — `recall()`
+ * updates `retrieval_strength`, `last_accessed` and `frequency` on every hit —
+ * is a real cost rather than a harmless single-user convenience.
+ */
+import { describe, it, expect } from 'vitest'
+import { ReadonlyStoreGuard, ReadonlyStoreError } from '../src/store/readonly-store-guard.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/** Minimal stand-in for a Postgres-backed primary query store. */
+function makePrimaryQueryStore() {
+  const calls: string[] = []
+  return {
+    calls,
+    store: {
+      kind: 'postgres' as never,
+      location: 'postgres://stub',
+      role: 'primary',
+      vectorIndex: { kind: 'hnsw' },
+      load: async () => [] as Engram[],
+      loadCached: async () => [] as Engram[],
+      invalidate: () => {},
+      withExclusiveAccess: async <T>(fn: () => Promise<T>) => fn(),
+      save: async () => {},
+      loadByIds: async () => [] as Engram[],
+      append: async () => {},
+      updateMany: async () => {},
+      nextEngramId: async () => 'ENG-STUB-001',
+      searchBM25: async (q: string) => { calls.push(`bm25:${q}`); return [] as Engram[] },
+      searchVector: async () => { calls.push('vector'); return [] },
+    },
+  }
+}
+
+describe('ReadonlyStoreGuard forwards the query-adapter surface (#830)', () => {
+  it('forwards role — the field _primaryQueryAdapter actually keys on', () => {
+    const { store } = makePrimaryQueryStore()
+    const guard = new ReadonlyStoreGuard(store as never)
+    // Without this the adapter resolver returns null and recall silently loses
+    // pushdown before it crashes.
+    expect((guard as unknown as { role?: string }).role).toBe('primary')
+  })
+
+  it('satisfies the exact predicate _primaryQueryAdapter uses', () => {
+    const { store } = makePrimaryQueryStore()
+    const g = new ReadonlyStoreGuard(store as never) as unknown as
+      { role?: string; searchBM25?: unknown }
+    expect(g.role === 'primary' && typeof g.searchBM25 === 'function').toBe(true)
+  })
+
+  it('delegates searchBM25 to the inner store', async () => {
+    const { store, calls } = makePrimaryQueryStore()
+    const guard = new ReadonlyStoreGuard(store as never) as unknown as
+      { searchBM25: (q: string, o: { limit: number }) => Promise<Engram[]> }
+    await guard.searchBM25('rebase policy', { limit: 5 })
+    expect(calls).toContain('bm25:rebase policy')
+  })
+
+  it('delegates searchVector and forwards vectorIndex', async () => {
+    const { store, calls } = makePrimaryQueryStore()
+    const guard = new ReadonlyStoreGuard(store as never) as unknown as
+      { searchVector: (...a: unknown[]) => Promise<unknown>; vectorIndex?: { kind: string } }
+    await guard.searchVector()
+    expect(calls).toContain('vector')
+    expect(guard.vectorIndex).toEqual({ kind: 'hnsw' })
+  })
+
+  it('still refuses every write — forwarding reads must not open a write path', async () => {
+    const { store } = makePrimaryQueryStore()
+    const guard = new ReadonlyStoreGuard(store as never)
+    await expect(guard.save([])).rejects.toBeInstanceOf(ReadonlyStoreError)
+    await expect(guard.append!({} as Engram)).rejects.toBeInstanceOf(ReadonlyStoreError)
+    await expect(guard.updateMany!([])).rejects.toBeInstanceOf(ReadonlyStoreError)
+    // nextEngramId is NOT a read: an implementation that makes allocation
+    // collision-safe does so by CONSUMING the id, which mutates the store.
+    await expect(guard.nextEngramId!('2026-08-13')).rejects.toBeInstanceOf(ReadonlyStoreError)
+  })
+
+  it('does not invent a query surface for a store that has none', () => {
+    // A plain YAML store declares none of these. The guard must mirror that
+    // absence rather than fabricate it, or capability probes see a store that
+    // can answer queries when it cannot.
+    const plain = {
+      kind: 'yaml' as never, location: '/tmp/e.yaml',
+      load: async () => [] as Engram[], loadCached: async () => [] as Engram[],
+      invalidate: () => {}, withExclusiveAccess: async <T>(fn: () => Promise<T>) => fn(),
+      save: async () => {},
+    }
+    const g = new ReadonlyStoreGuard(plain as never) as unknown as
+      { role?: string; searchBM25?: unknown; vectorIndex?: unknown }
+    expect(g.role).toBeUndefined()
+    expect(g.searchBM25).toBeUndefined()
+    expect(g.vectorIndex).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #830.

The guard omitted `role`, `searchBM25`, `searchVector` and `vectorIndex`. `_primaryQueryAdapter()` keys on `role === 'primary' && typeof searchBM25 === 'function'`, so a guarded store failed that check, `recall()` fell back to `_filterEngrams()`, and for a store that answers queries itself — which has no `indexedStorage`, since `indexTier` resolves to `'none'` when a primary query store is present — that path had nothing to read and threw.

Net effect: `readonly: true` was unusable exactly where it is most wanted. Shared multi-tenant storage is the case where core's per-read activation write (`retrieval_strength`, `last_accessed`, `frequency`, on every hit) stops being a harmless single-user convenience and becomes a real cost.

## On keeping the whitelist

This looks like the wrong shape, so the reasoning is in the file rather than only here. A whitelist is *what caused this* — a new read member is silently dropped until someone remembers to add it — and a Proxy forwarding everything except a write deny-list would not have that failure mode. It is still right here, because the failure modes are not symmetric:

| shape | a missed entry means |
|---|---|
| whitelist | functionality is lost, and someone notices |
| deny-list | **a write is permitted** on a path whose entire purpose is that it cannot write |

On a safety guard, fail closed. The whitelist grows by four.

## Verification

- 6 tests, including that every write still rejects (`save`, `append`, `updateMany`, and `nextEngramId` — which is *not* a read, since collision-safe allocation consumes the id) and that a plain YAML store does not gain a fabricated query surface
- `@plur-ai/core` **2746 passed, 0 failed**; `pnpm typecheck:tests` clean
- **Revert-checked**: dropping the `role` forward fails 2 tests, including the one asserting the exact predicate `_primaryQueryAdapter` uses