### PR TITLE
ci: add Node 26 to the test matrix (#876)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,20 @@ jobs:
     permissions:
       contents: read
     strategy:
-      # Don't let one node's failure cancel the other — we want the full signal
-      # from both Node versions, not a fail-fast cancellation (#311).
+      # Don't let one node's failure cancel the others — we want the full signal
+      # from every Node version, not a fail-fast cancellation (#311).
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        # 26 is here because its ABSENCE cost a day (#876). The matrix topped out
+        # at 24, so #874 — better-sqlite3@11 has no ABI-147 prebuild and its
+        # source uses V8 APIs removed in Node 26 — shipped fully green and then
+        # failed ENTIRELY on the workstation it was written on: 55 tests across 8
+        # files, all module-load errors. A native-ABI break is invisible to a
+        # matrix that does not run the version people develop on, and "green CI,
+        # broken locally" is the worst possible signal because the suite stops
+        # being trusted. Track the current Node release here, not just the LTS
+        # line, and expect this list to keep moving.
+        node-version: [20, 22, 24, 26]
     # Real Postgres + pgvector for the PostgresAdapter suite (ADR-0005). The
     # suite skips when PLUR_TEST_POSTGRES_URL is unset, so without this service
     # it would be permanently skipped and permanently unproven — which is worse


### PR DESCRIPTION
Fixes #876.

```diff
-        node-version: [20, 22, 24]
+        node-version: [20, 22, 24, 26]
```

The matrix topped out at 24, so a native-ABI break was structurally invisible to it. #874 shipped **fully green** and then failed *entirely* on the workstation it was written on — 55 tests across 8 files, all module-load errors, because `better-sqlite3@11` has no ABI-147 prebuild and its source uses V8 APIs removed in Node 26.

"Green CI, broken locally" is the worst available signal: it is the one that makes people stop trusting the suite. Earlier today that cost real time — 55 local failures looked like they might have been caused by the change under test, and ruling that out took a rebuild and a bisect of the environment rather than the code.

Safe to add now: #875 bumped `better-sqlite3` to `^12` and declared `engines.node >= 20`, so 26 is expected to pass. **The CI run on this PR is the verification** — that is the point of the change, and if it goes red then Node 26 support is not actually there and #874 was closed too early.