### PR TITLE
fix(core): let the caller place the transformers.js model cache (#845)

### DIFF
--- a/packages/core/src/embedders/transformers-base.ts
+++ b/packages/core/src/embedders/transformers-base.ts
@@ -38,8 +38,37 @@ async function loadPipeline(modelId: string, dtype: TransformersAdapterConfig['d
       // producing corrupt models ("Protobuf parsing failed") that silently
       // degrade recall to fallback. Never use Xet. (#340)
       process.env.HF_HUB_DISABLE_XET ??= '1'
-      const { pipeline } = await import('@huggingface/transformers')
-      return pipeline('feature-extraction', modelId, dtype ? { dtype } : undefined)
+      const transformers = await import('@huggingface/transformers')
+
+      // Let the caller place the model cache (#845).
+      //
+      // transformers.js v3 derives its cache directory from the PACKAGE
+      // LOCATION (`<package>/.cache`) and reads no environment variable —
+      // HF_HOME and TRANSFORMERS_CACHE are both ignored (see its src/env.js).
+      // The only lever is `env.cacheDir`, set before the first pipeline() call,
+      // and that call site is HERE, in core. So for any consumer installing
+      // from npm the model lives inside node_modules, and every `npm ci`
+      // destroys it: a server running from a git checkout re-downloaded ~128MB
+      // per deploy, and an air-gapped host could not work at all.
+      //
+      // That failure is quiet, which is what made it expensive. embed()
+      // returning null is a DELIBERATE degradation — hybrid recall drops to
+      // BM25-only and new records are written without vectors, with nothing
+      // raised. enterprise#662 reached production that way: every "hybrid"
+      // recall on a containerised deployment had been BM25-only since the
+      // feature shipped, and not one engram had ever been embedded.
+      //
+      // Precedence: explicit PLUR var, then the HF convention (honoured here
+      // even though the library ignores it, because operators reasonably expect
+      // it to work), then the library default.
+      const cacheDir = process.env.PLUR_MODEL_CACHE_DIR || process.env.HF_HOME
+      if (cacheDir) {
+        // Assigned before pipeline() — after the first load the value is
+        // already baked into the resolved paths and changing it does nothing.
+        ;(transformers as { env?: { cacheDir?: string } }).env!.cacheDir = cacheDir
+      }
+
+      return transformers.pipeline('feature-extraction', modelId, dtype ? { dtype } : undefined)
     })()
     pipelineCache.set(key, pending)
   }

--- a/packages/core/test/model-cache-dir.test.ts
+++ b/packages/core/test/model-cache-dir.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #845 — the embedding model cache directory must be placeable by the caller.
+ *
+ * transformers.js v3 derives its cache directory from the PACKAGE LOCATION
+ * (`<package>/.cache`) and reads no environment variable — `HF_HOME` and
+ * `TRANSFORMERS_CACHE` are both ignored (its `src/env.js`). The only lever is
+ * `env.cacheDir`, assigned before the first `pipeline()` call, and that call
+ * site is in core.
+ *
+ * So for any consumer installing from npm the model sits inside `node_modules`,
+ * and every `npm ci` destroys it: ~128MB re-downloaded per deploy, and an
+ * air-gapped host cannot work at all.
+ *
+ * The reason it stayed unnoticed is that the failure is silent by design —
+ * `embed()` returning null is a DELIBERATE degradation, so hybrid recall drops
+ * to BM25-only and new records are written without vectors, with nothing
+ * raised. enterprise#662 reached production that way: every "hybrid" recall on
+ * a containerised deployment had been BM25-only since the feature shipped, and
+ * not one engram had ever been embedded.
+ *
+ * These tests exercise the wiring without downloading a model: the
+ * `@huggingface/transformers` import is mocked, so what is asserted is that
+ * core assigns `env.cacheDir` BEFORE calling `pipeline()`, and with the right
+ * precedence.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/** Captures what the adapter did to the module before pipeline() was called. */
+const seen: { cacheDirAtPipelineTime?: string; pipelineCalls: number } = { pipelineCalls: 0 }
+const fakeEnv: { cacheDir?: string } = {}
+
+vi.mock('@huggingface/transformers', () => ({
+  env: fakeEnv,
+  pipeline: async () => {
+    // Record the value AS IT STOOD when pipeline ran — assigning after this
+    // point would be useless, since the resolved paths are already baked.
+    seen.cacheDirAtPipelineTime = fakeEnv.cacheDir
+    seen.pipelineCalls++
+    return async () => ({ data: new Float32Array(384) })
+  },
+}))
+
+const ORIGINAL = { plur: process.env.PLUR_MODEL_CACHE_DIR, hf: process.env.HF_HOME }
+
+async function loadOnce() {
+  const mod = await import('../src/embedders/transformers-base.js')
+  mod._resetTransformersPipelineCache()
+  const adapter = mod.makeTransformersAdapter({
+    name: 'stub', modelId: 'stub/model', dim: 384, pooling: 'mean',
+  } as never)
+  await adapter.embed('anything')
+}
+
+describe('model cache directory is configurable (#845)', () => {
+  beforeEach(() => {
+    seen.cacheDirAtPipelineTime = undefined
+    seen.pipelineCalls = 0
+    delete fakeEnv.cacheDir
+    delete process.env.PLUR_MODEL_CACHE_DIR
+    delete process.env.HF_HOME
+  })
+  afterEach(() => {
+    if (ORIGINAL.plur === undefined) delete process.env.PLUR_MODEL_CACHE_DIR
+    else process.env.PLUR_MODEL_CACHE_DIR = ORIGINAL.plur
+    if (ORIGINAL.hf === undefined) delete process.env.HF_HOME
+    else process.env.HF_HOME = ORIGINAL.hf
+    vi.resetModules()
+  })
+
+  it('honours PLUR_MODEL_CACHE_DIR', async () => {
+    process.env.PLUR_MODEL_CACHE_DIR = '/var/lib/plur/models'
+    await loadOnce()
+    expect(seen.cacheDirAtPipelineTime).toBe('/var/lib/plur/models')
+  })
+
+  it('sets it BEFORE pipeline() runs, which is the only moment it matters', async () => {
+    process.env.PLUR_MODEL_CACHE_DIR = '/var/lib/plur/models'
+    await loadOnce()
+    // Not merely "the value ended up set" — it was set at the point of use.
+    expect(seen.pipelineCalls).toBe(1)
+    expect(seen.cacheDirAtPipelineTime).toBeDefined()
+  })
+
+  it('falls back to HF_HOME, which operators reasonably expect to work', async () => {
+    process.env.HF_HOME = '/opt/hf'
+    await loadOnce()
+    expect(seen.cacheDirAtPipelineTime).toBe('/opt/hf')
+  })
+
+  it('prefers the explicit PLUR var over HF_HOME', async () => {
+    process.env.PLUR_MODEL_CACHE_DIR = '/var/lib/plur/models'
+    process.env.HF_HOME = '/opt/hf'
+    await loadOnce()
+    expect(seen.cacheDirAtPipelineTime).toBe('/var/lib/plur/models')
+  })
+
+  it('leaves the library default alone when neither is set', async () => {
+    await loadOnce()
+    // Unset, not empty-string: assigning '' would be a path, and a wrong one.
+    expect(seen.cacheDirAtPipelineTime).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #845.

```bash
PLUR_MODEL_CACHE_DIR=/var/lib/plur/models   # explicit
HF_HOME=/opt/hf                             # honoured as a fallback
# neither set → library default, unchanged
```

## Why core has to do it

transformers.js v3 derives its cache directory from the **package location** (`<package>/.cache`) and reads no environment variable — `HF_HOME` and `TRANSFORMERS_CACHE` are both ignored (its `src/env.js`). The only lever is `env.cacheDir`, assigned **before the first `pipeline()` call** — and that call site is `loadPipeline` in core. A consumer cannot reach it.

Consequence for anyone installing from npm: the model sits inside `node_modules`, so every `npm ci` destroys it. ~128MB re-downloaded per deploy, and an air-gapped host cannot work at all.

## Why it went unnoticed for so long

The failure is silent **by design**. `embed()` returning null is a *deliberate* degradation: hybrid recall drops to BM25-only and new records are written without vectors, with nothing raised. That is how enterprise#662 reached production — every "hybrid" recall on a containerised deployment had been BM25-only since the feature shipped, and not one engram had ever been embedded.

Worth pairing with a loud warning on that degradation as a follow-up; the silence is the expensive part, not the path.

## Precedence, and one small decision

`PLUR_MODEL_CACHE_DIR` → `HF_HOME` → library default. `HF_HOME` is honoured even though the library ignores it, because an operator reasonably expects it to work and being surprised there is exactly how you end up with a 128MB re-download you did not plan for.

Unset stays **unset** rather than becoming `''` — an empty string is a path, and a wrong one.

## Verification

- 5 tests, mocking `@huggingface/transformers` so they assert the **wiring** without downloading a model. The load-bearing one checks `cacheDir` is set *before* `pipeline()` runs — assigning afterwards is useless, since the resolved paths are already baked.
- `@plur-ai/core` **2745 passed, 0 failed**; `pnpm typecheck:tests` clean
- **Revert-checked**: 4 of 5 fail without the fix