### PR TITLE
fix(core): outbox flush consults the per-host circuit breaker (#785)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,8 +49,7 @@ import { RemoteStore, normalizeEndpointUrl } from './store/remote-store.js'
 import {
   remoteRecall, isRemoteRecallDisabled, resolveRemoteRecallTimeoutMs, scopeOrg,
   REMOTE_STATUS_TTL_MS, PROBE_CLEARABLE_STATES,
-  type RemoteRecallHost, type RemoteRecallResult, type HostRecallOutcome, type RemoteStoreStatusEntry,
-} from './remote-recall.js'
+  type RemoteRecallHost, type RemoteRecallResult, type HostRecallOutcome, type RemoteStoreStatusEntry, isHostInCooldown, recordWriteOutcome} from './remote-recall.js'
 import { YamlPrimaryStore } from './store/yaml-primary-store.js'
 import { ReadonlyStoreGuard, ReadonlyStoreError } from './store/readonly-store-guard.js'
 import { withAsyncLock } from './store/async-lock.js'
@@ -6395,6 +6394,9 @@ export class Plur {
 
     let flushed = 0
     let failed = 0
+    let skipped = 0
+    /** Warn once per host, not once per queued engram (#785). */
+    const cooldownSkippedHosts = new Set<string>()
     const expired_warnings: string[] = []
     const now = new Date()
     const TTL_MS = 7 * 24 * 60 * 60 * 1000
@@ -6422,6 +6424,31 @@ export class Plur {
         failed++
         continue
       }
+      // #785: consult the per-host breaker the RECALL leg maintains before
+      // spending a full fetch timeout on a host already known to be down.
+      //
+      // Without this, N queued engrams for an unreachable host cost N
+      // sequential timeouts on EVERY session start — and those failures never
+      // fed back, so the recall leg learned nothing from them either. Two legs,
+      // one host, two independent opinions about whether it is reachable.
+      //
+      // Skipping leaves the engrams queued: the outbox already retries on the
+      // next flush, and the breaker's own cooldown is what decides when that
+      // becomes worth attempting.
+      const cooldown = isHostInCooldown(storeEntry.url!)
+      if (cooldown.inCooldown) {
+        if (!cooldownSkippedHosts.has(storeEntry.url!)) {
+          cooldownSkippedHosts.add(storeEntry.url!)
+          const secs = Math.max(1, Math.ceil(((cooldown.until ?? 0) - Date.now()) / 1000))
+          expired_warnings.push(
+            `${storeEntry.url}: skipped — ${cooldown.reason === 'rate_limit' ? 'rate-limited' : 'circuit breaker open'}, `
+            + `retrying in ~${secs}s. Queued engrams stay queued.`,
+          )
+        }
+        skipped++
+        continue
+      }
+
       const driver = this._getRemoteDriver({ url: storeEntry.url!, token: storeEntry.token, scope: storeEntry.scope })
 
       // Build clean copy without outbox metadata for the remote
@@ -6472,6 +6499,8 @@ export class Plur {
 
       try {
         await driver.appendAndGetServerId(cleanEngram)
+        // #785: a write success clears the host's failure count for BOTH legs.
+        recordWriteOutcome(storeEntry.url!, true)
         // Success: remove from local store
         const idx = engrams.findIndex(e => e.id === engram.id)
         if (idx !== -1) engrams.splice(idx, 1)
@@ -6486,6 +6515,9 @@ export class Plur {
         outbox.last_attempt = now.toISOString()
         outbox.attempt_count += 1
         outbox.last_error = (err as Error).message
+        // #785: and a write failure counts toward the same breaker, so a host
+        // that only ever fails on writes still opens one.
+        recordWriteOutcome(storeEntry.url!, false)
         failed++
         logger.warning(`[plur:outbox] retry failed for ${engram.id}: ${(err as Error).message}`)
       }

--- a/packages/core/src/remote-recall.ts
+++ b/packages/core/src/remote-recall.ts
@@ -419,6 +419,77 @@ function mergeWriteRemoteHealth(statePath: string, touched: Record<string, HostH
   withRemoteHealthLock(statePath, readMergeWrite, readMergeWrite)
 }
 
+/**
+ * Is this host's breaker open right now? (#785)
+ *
+ * The recall leg has always consulted this state; the WRITE leg never did, so
+ * `flushOutbox()` sent one full-timeout attempt per queued engram to a host the
+ * read leg already knew was down — on every session start, and with the failures
+ * not feeding back, so the read leg learned nothing from them either. Two legs,
+ * one host, two independent opinions about whether it is reachable.
+ *
+ * Exported rather than duplicated: the breaker, its persistence, the
+ * classification table and the file-lock helper all already exist here and are
+ * already correct. The write path only has to ask.
+ */
+export function isHostInCooldown(
+  url: string,
+  now: number = Date.now(),
+  statePath: string = remoteHealthPath(),
+): { inCooldown: boolean; until?: number; reason?: 'breaker' | 'rate_limit' } {
+  try {
+    const health = readRemoteHealth(statePath)
+    const h = health.hosts[normalizeEndpointUrl(url)]
+    if (!h?.cooldown_until || h.cooldown_until <= now) return { inCooldown: false }
+    // `cooldown_until` is set by both the failure breaker and a 429
+    // Retry-After. `last_state` distinguishes them for the operator-facing
+    // message; the skip decision is the same either way.
+    return {
+      inCooldown: true,
+      until: h.cooldown_until,
+      reason: h.last_state === 'rate_limited' ? 'rate_limit' : 'breaker',
+    }
+  } catch {
+    // Health state is an optimisation. If it cannot be read, do NOT block the
+    // write — a corrupt cache file must not become an outage.
+    return { inCooldown: false }
+  }
+}
+
+/**
+ * Record a WRITE-leg failure into the same per-host state the recall leg uses,
+ * so a host that only ever fails on writes still opens its breaker (#785).
+ *
+ * Mirrors the recall leg's accounting: count consecutive network-class
+ * failures, open for {@link BREAKER_COOLDOWN_MS} at
+ * {@link BREAKER_FAILURE_THRESHOLD}. A success clears the counter.
+ */
+export function recordWriteOutcome(
+  url: string,
+  ok: boolean,
+  now: number = Date.now(),
+  statePath: string = remoteHealthPath(),
+): void {
+  try {
+    const key = normalizeEndpointUrl(url)
+    const health = readRemoteHealth(statePath)
+    const h: HostHealth = { ...(health.hosts[key] ?? {}) }
+    if (ok) {
+      h.failures = 0
+      delete h.cooldown_until
+      h.last_state = 'ok'
+    } else {
+      h.failures = (h.failures ?? 0) + 1
+      h.last_state = 'unreachable'
+      if (h.failures >= BREAKER_FAILURE_THRESHOLD) h.cooldown_until = now + BREAKER_COOLDOWN_MS
+    }
+    h.updated_at = now
+    mergeWriteRemoteHealth(statePath, { [key]: h })
+  } catch {
+    // Same reasoning as above: never let health bookkeeping fail a write.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Org extraction for the dialing rule
 // ---------------------------------------------------------------------------

--- a/packages/core/test/outbox-circuit-breaker.test.ts
+++ b/packages/core/test/outbox-circuit-breaker.test.ts
@@ -1,0 +1,166 @@
+/**
+ * #785 — the write leg must consult the breaker the read leg maintains.
+ *
+ * The recall leg has a per-host circuit breaker: three consecutive
+ * network-class failures open a five-minute cooldown, 429s honour
+ * Retry-After, and the whole thing is persisted cross-process in
+ * `<root>/cache/remote-health.json`.
+ *
+ * `flushOutbox()` consulted none of it. So a host the read leg already knew was
+ * down still received one full-timeout write attempt PER QUEUED ENGRAM, on
+ * every session start — and those failures never fed back, so the read leg
+ * learned nothing from them either. Two legs, one host, two independent
+ * opinions about whether it is reachable.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import {
+  isHostInCooldown, recordWriteOutcome, remoteHealthPath,
+  BREAKER_FAILURE_THRESHOLD, BREAKER_COOLDOWN_MS,
+} from '../src/remote-recall.js'
+
+const REMOTE = 'https://plur.example.com/sse'
+
+describe('breaker helpers are shared, not duplicated (#785)', () => {
+  let dir: string
+  let statePath: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-breaker-'))
+    mkdirSync(join(dir, 'cache'), { recursive: true })
+    statePath = join(dir, 'cache', 'remote-health.json')
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('reports no cooldown for an unknown host', () => {
+    expect(isHostInCooldown(REMOTE, Date.now(), statePath).inCooldown).toBe(false)
+  })
+
+  it('opens the breaker after the threshold of write failures', () => {
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) recordWriteOutcome(REMOTE, false, Date.now(), statePath)
+    const r = isHostInCooldown(REMOTE, Date.now(), statePath)
+    expect(r.inCooldown).toBe(true)
+    expect(r.reason).toBe('breaker')
+  })
+
+  it('does not open it before the threshold', () => {
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD - 1; i++) recordWriteOutcome(REMOTE, false, Date.now(), statePath)
+    expect(isHostInCooldown(REMOTE, Date.now(), statePath).inCooldown).toBe(false)
+  })
+
+  it('a write SUCCESS clears the count, so both legs see a recovered host', () => {
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) recordWriteOutcome(REMOTE, false, Date.now(), statePath)
+    recordWriteOutcome(REMOTE, true, Date.now(), statePath)
+    expect(isHostInCooldown(REMOTE, Date.now(), statePath).inCooldown).toBe(false)
+  })
+
+  it('the cooldown expires rather than parking the host forever', () => {
+    const t0 = Date.now()
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) recordWriteOutcome(REMOTE, false, t0, statePath)
+    expect(isHostInCooldown(REMOTE, t0 + BREAKER_COOLDOWN_MS + 1, statePath).inCooldown).toBe(false)
+  })
+
+  it('writes into the same file the recall leg reads', () => {
+    recordWriteOutcome(REMOTE, false, Date.now(), statePath)
+    const f = JSON.parse(readFileSync(statePath, 'utf8'))
+    // Keyed by the normalised endpoint, exactly as the recall leg keys it —
+    // otherwise the two legs would maintain parallel entries for one host.
+    expect(Object.keys(f.hosts)).toContain('https://plur.example.com')
+  })
+
+  it('never throws on unreadable health state — it is an optimisation, not a gate', () => {
+    writeFileSync(statePath, 'not json at all')
+    expect(() => isHostInCooldown(REMOTE, Date.now(), statePath)).not.toThrow()
+    expect(isHostInCooldown(REMOTE, Date.now(), statePath).inCooldown).toBe(false)
+    expect(() => recordWriteOutcome(REMOTE, false, Date.now(), statePath)).not.toThrow()
+  })
+})
+
+describe('flushOutbox honours the breaker (#785)', () => {
+  let dir: string
+  let originalFetch: typeof globalThis.fetch
+  let attempts: number
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-outbox-breaker-'))
+    process.env.PLUR_PATH = dir
+    originalFetch = globalThis.fetch
+    attempts = 0
+    globalThis.fetch = vi.fn(async () => { attempts++; throw new Error('fetch failed') }) as never
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ url: REMOTE, token: 'tok', scope: 'group:acme/team', shared: true, readonly: false }],
+      index: false,
+    }))
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    delete process.env.PLUR_PATH
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** Queue several engrams against the unreachable remote. */
+  async function queue(plur: Plur, n: number) {
+    for (let i = 0; i < n; i++) {
+      await plur.learn(`queued team fact number ${i}`, { scope: 'group:acme/team', type: 'behavioral' })
+    }
+    await new Promise(r => setTimeout(r, 60))
+  }
+
+  it('stops attempting once the breaker is open, instead of one timeout per engram', async () => {
+    const plur = new Plur({ path: dir })
+    await queue(plur, 4)
+
+    // Force the breaker open, as the recall leg would have.
+    const statePath = remoteHealthPath({ PLUR_PATH: dir } as never)
+    mkdirSync(join(dir, 'cache'), { recursive: true })
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) recordWriteOutcome(REMOTE, false, Date.now(), statePath)
+
+    attempts = 0
+    const res = await plur.flushOutbox()
+
+    expect(attempts, 'a host in cooldown must not be dialled at all').toBe(0)
+    expect(res.flushed).toBe(0)
+    expect(res.expired_warnings.some(w => w.includes('circuit breaker open'))).toBe(true)
+  })
+
+  it('warns once per host, not once per queued engram', async () => {
+    const plur = new Plur({ path: dir })
+    await queue(plur, 4)
+    const statePath = remoteHealthPath({ PLUR_PATH: dir } as never)
+    mkdirSync(join(dir, 'cache'), { recursive: true })
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) recordWriteOutcome(REMOTE, false, Date.now(), statePath)
+
+    const res = await plur.flushOutbox()
+    const breakerWarnings = res.expired_warnings.filter(w => w.includes('circuit breaker open'))
+    expect(breakerWarnings).toHaveLength(1)
+  })
+
+  it('leaves the engrams queued — skipping is not discarding', async () => {
+    const plur = new Plur({ path: dir })
+    await queue(plur, 3)
+    const statePath = remoteHealthPath({ PLUR_PATH: dir } as never)
+    mkdirSync(join(dir, 'cache'), { recursive: true })
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) recordWriteOutcome(REMOTE, false, Date.now(), statePath)
+
+    await plur.flushOutbox()
+
+    const doc = yaml.load(readFileSync(join(dir, 'engrams.yaml'), 'utf8')) as
+      { engrams: Array<{ structured_data?: { _outbox?: unknown } }> }
+    const stillQueued = doc.engrams.filter(e => e.structured_data?._outbox)
+    expect(stillQueued.length).toBe(3)
+  })
+
+  it('write failures feed the shared breaker, so the read leg learns from them', async () => {
+    const plur = new Plur({ path: dir })
+    await queue(plur, BREAKER_FAILURE_THRESHOLD)
+
+    // No pre-existing cooldown: the flush itself should open the breaker.
+    const statePath = remoteHealthPath({ PLUR_PATH: dir } as never)
+    await plur.flushOutbox()
+
+    expect(isHostInCooldown(REMOTE, Date.now(), statePath).inCooldown).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #785.

## The asymmetry

The recall leg has a per-host breaker — 3 consecutive network-class failures open a 5-minute cooldown, 429s honour `Retry-After`, all persisted cross-process in `cache/remote-health.json`. `flushOutbox()` consulted **none** of it.

So a host the read leg already knew was down still received one **full-timeout** write attempt *per queued engram*, on every session start. With N queued engrams for a down host, every session start burned N sequential timeouts against an endpoint the client had already given up on — and the failures never fed back, so the read leg learned nothing from them either.

## Reused, not reimplemented

`isHostInCooldown()` and `recordWriteOutcome()` are now exported from `remote-recall.ts`. The breaker, its persistence, the classification table and the file-lock helper were all already there and already correct; the write path only had to ask.

Keyed on `normalizeEndpointUrl` — the same key the recall leg uses. A different key would have given one host two parallel entries, which is the bug one level up.

## Three decisions worth naming

- **Skipping is not discarding.** Queued engrams stay queued; the outbox already retries on the next flush, and the breaker's cooldown is what decides when that becomes worth attempting. Pinned by a test.
- **Warn once per host, not per engram.** A host with 40 pending writes would otherwise produce 40 identical lines — which is how a useful warning becomes noise people filter out.
- **Both helpers swallow their own errors.** Health state is an optimisation; a corrupt cache file must never become an outage. Pinned by a test that feeds them invalid JSON.

## Verification

- 11 tests, covering the helpers directly (threshold, expiry, success-clears, shared file key, corrupt state) and `flushOutbox` end-to-end
- `@plur-ai/core` **2767 passed, 0 failed**; `pnpm typecheck:tests` clean
- **Revert-checked**: without the cooldown consult, the host is dialled once per engram and the once-per-host warning collapses