### PR TITLE
fix(core): separate deliberate feedback from mere use (#846)

### DIFF
--- a/packages/core/src/decay.ts
+++ b/packages/core/src/decay.ts
@@ -39,9 +39,50 @@ export function shouldInject(
   return effective >= threshold
 }
 
-/** Bump retrieval strength when accessed (reactivation) */
+/**
+ * How much a passive retrieval used to add to `retrieval_strength`.
+ *
+ * Exported as a named constant because it was never one, and that was half the
+ * problem (#846): `POSITIVE_STRENGTH_DELTA` and `NEGATIVE_STRENGTH_DELTA` are
+ * public values precisely so consumers do not re-type them, while the one
+ * constant a downstream consumer needed in order to reason about what a
+ * feedback delta is WORTH was an unnamed literal inside this function. PLUR
+ * Enterprise hand-copied it and guarded the copy by measuring core empirically.
+ *
+ * @deprecated Retrieval no longer moves `retrieval_strength` — see
+ * {@link reactivate}. Kept exported so a consumer that hand-copied the old
+ * value can find this note.
+ */
+export const LEGACY_REACTIVATION_STRENGTH_DELTA = 0.1
+
+/**
+ * Reactivation on access.
+ *
+ * Returns the strength UNCHANGED (#846). Retrieval used to add +0.10 here while
+ * a deliberate ★ added +0.05 and a ✗ subtracted 0.10 — so a rating was worth
+ * half of being incidentally fetched, and a "this is wrong" was EXACTLY
+ * cancelled by the next recall that happened to return the engram.
+ *
+ * That mattered because `retrieval_strength` reads as "how well-regarded is
+ * this": it is what `min_strength` filters on, what `scoreEngram` multiplies
+ * into injection ranking, and what admin surfaces present. It actually encoded
+ * "how often has this been fetched" — a self-reinforcing loop in which the
+ * quality term was structurally unable to outvote the traffic term, and which
+ * saturated at 1.0 after three recalls, after which no feedback in either
+ * direction was visible in the value at all.
+ *
+ * The fix is separation, not a new ratio: traffic already has a home in
+ * `activation.frequency`, which counts retrieval events, works, and shows 62
+ * distinct values across a real store. `retrieval_strength` now moves ONLY on
+ * deliberate feedback, so the two signals stop fighting over one field and a
+ * ranker can weigh them explicitly.
+ *
+ * Recency is unaffected: `_reactivateResults` still refreshes `last_accessed`
+ * on every recall, and decay is driven by that — so a frequently-recalled
+ * engram still resists decay without its strength being inflated.
+ */
 export function reactivate(currentStrength: number): number {
-  return Math.min(1.0, currentStrength + 0.1)
+  return currentStrength
 }
 
 /** Co-access decay for associations (spreading activation) */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4259,7 +4259,15 @@ export class Plur {
       // supports targeted updates write only those.
       const touched = new Map<string, Engram>()
 
-      // Reactivate accessed engrams
+      // Reactivate accessed engrams.
+      //
+      // TRAFFIC and QUALITY are separate signals here (#846). `frequency`
+      // counts retrievals and `last_accessed` carries recency — which is what
+      // decay actually keys on, so a frequently-recalled engram still resists
+      // decay. `retrieval_strength` is deliberately NOT touched: it moves only
+      // on deliberate feedback now, because when retrieval moved it too the
+      // traffic term structurally outvoted the quality term (+0.10 per fetch
+      // against +0.05 per ★) and saturated at 1.0 within three recalls.
       for (const e of allEngrams) {
         if (resultIds.has(e.id)) {
           e.activation.retrieval_strength = reactivate(e.activation.retrieval_strength)

--- a/packages/core/test/decay.test.ts
+++ b/packages/core/test/decay.test.ts
@@ -37,8 +37,15 @@ describe('decay as deprioritization', () => {
     expect(result).toBe(false)
   })
 
-  it('reactivate bumps strength', () => {
-    expect(reactivate(0.3)).toBe(0.4)
-    expect(reactivate(0.95)).toBe(1.0)
+  // Was 'reactivate bumps strength'. That bump is the defect (#846): passive
+  // retrieval added +0.10 while a deliberate ★ added +0.05 and a ✗ subtracted
+  // 0.10 — so a rating was worth half of being incidentally fetched, and a
+  // "this is wrong" was exactly cancelled by the next recall that returned the
+  // engram. Traffic and quality now live in different fields.
+  it('reactivate leaves strength untouched — retrieval is not a quality signal', () => {
+    expect(reactivate(0.3)).toBe(0.3)
+    expect(reactivate(0.95)).toBe(0.95)
+    expect(reactivate(1.0)).toBe(1.0)
+    expect(reactivate(0)).toBe(0)
   })
 })

--- a/packages/core/test/feedback-vs-traffic.test.ts
+++ b/packages/core/test/feedback-vs-traffic.test.ts
@@ -1,0 +1,112 @@
+/**
+ * #846 — deliberate feedback must not be outvoted by mere use.
+ *
+ * Three constants moved `activation.retrieval_strength`, set in two files that
+ * did not reference each other:
+ *
+ *   passive retrieval  decay.ts    reactivate()               +0.10
+ *   positive (★)       feedback.ts POSITIVE_STRENGTH_DELTA    +0.05
+ *   negative (✗)       feedback.ts NEGATIVE_STRENGTH_DELTA    −0.10
+ *
+ * So a ★ was worth HALF of being incidentally fetched, and a ✗ was EXACTLY
+ * cancelled by the next recall that returned the engram — a considered "this is
+ * wrong" survived until the engram was next looked at, then did not exist.
+ *
+ * That mattered because the field reads as "how well-regarded is this": it is
+ * what `min_strength` filters on, what `scoreEngram` multiplies into injection
+ * ranking, and what admin surfaces present. It actually encoded "how often has
+ * this been fetched" — self-reinforcing, and saturating at 1.0 after three
+ * recalls, after which no feedback in either direction was visible at all.
+ *
+ * Fixed by separation rather than a new ratio: traffic already has a home in
+ * `activation.frequency`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { reactivate, LEGACY_REACTIVATION_STRENGTH_DELTA } from '../src/decay.js'
+import { POSITIVE_STRENGTH_DELTA, NEGATIVE_STRENGTH_DELTA } from '../src/feedback.js'
+
+describe('retrieval no longer moves retrieval_strength (#846)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-846-')) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('recall leaves strength unchanged but still counts the retrieval', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await plur.learn('rebase before pushing on this repo', { scope: 'global', type: 'behavioral' })
+    const before = (await plur.getById(e.id))!.activation.retrieval_strength
+
+    await plur.recall('rebase')
+    await plur.recall('rebase')
+    await plur.recall('rebase')
+
+    const after = (await plur.getById(e.id))!
+    expect(after.activation.retrieval_strength, 'traffic must not inflate a quality field').toBe(before)
+    // …but the retrieval itself is still recorded, in the field that means it.
+    expect(after.activation.frequency).toBeGreaterThan(0)
+  })
+
+  it('recall still refreshes recency, so decay behaviour is unaffected', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await plur.learn('pin RESTIC_CACHE_DIR for systemd units', { scope: 'global', type: 'procedural' })
+    // Backdate, then recall: decay keys on last_accessed, not on strength, so
+    // this is what actually protects a frequently-used engram.
+    const stale = await plur.getById(e.id)
+    stale!.activation.last_accessed = '2020-01-01'
+    await plur.updateEngram(stale!)
+
+    await plur.recall('RESTIC_CACHE_DIR')
+
+    const after = (await plur.getById(e.id))!
+    expect(after.activation.last_accessed).not.toBe('2020-01-01')
+  })
+
+  it('a negative rating is no longer erased by the next recall', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await plur.learn('always squash merge on this repo', { scope: 'global', type: 'behavioral' })
+    const before = (await plur.getById(e.id))!.activation.retrieval_strength
+
+    await plur.feedback(e.id, 'negative', 'primary')
+    const rated = (await plur.getById(e.id))!.activation.retrieval_strength
+    expect(rated).toBeLessThan(before)
+
+    // The whole bug: one incidental fetch used to cancel this exactly.
+    await plur.recall('squash merge')
+    expect((await plur.getById(e.id))!.activation.retrieval_strength).toBe(rated)
+  })
+
+  it('a positive rating still moves it', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await plur.learn('prefer flock over lockfiles where available', { scope: 'global', type: 'architectural' })
+    const before = (await plur.getById(e.id))!.activation.retrieval_strength
+
+    await plur.feedback(e.id, 'positive', 'primary')
+
+    expect((await plur.getById(e.id))!.activation.retrieval_strength).toBeGreaterThan(before)
+  })
+})
+
+describe('the constants tell a coherent story now (#846)', () => {
+  it('reactivate is a no-op', () => {
+    for (const v of [0, 0.3, 0.7, 0.95, 1]) expect(reactivate(v)).toBe(v)
+  })
+
+  it('the old reactivation delta is exported and named, not an anonymous literal', () => {
+    // It was the one constant a downstream consumer had to know in order to
+    // reason about what a feedback delta is WORTH, and it was the only one not
+    // exported — so enterprise hand-copied it and guarded the copy by measuring
+    // core's behaviour empirically.
+    expect(LEGACY_REACTIVATION_STRENGTH_DELTA).toBe(0.1)
+  })
+
+  it('deliberate feedback is no longer outvoted by traffic', () => {
+    // The property that failed before: a ★ has to be worth at least as much as
+    // a retrieval. Retrieval is now worth zero, so any positive delta wins.
+    expect(POSITIVE_STRENGTH_DELTA).toBeGreaterThan(0)
+    expect(NEGATIVE_STRENGTH_DELTA).toBeGreaterThan(0)
+    expect(POSITIVE_STRENGTH_DELTA).toBeGreaterThanOrEqual(reactivate(0.5) - 0.5)
+  })
+})


### PR DESCRIPTION
Fixes #846.

| signal | where | before | after |
|---|---|---|---|
| passive retrieval | `decay.ts` → `reactivate()` | **+0.10** | **0** |
| positive (★) | `feedback.ts` | +0.05 | +0.05 |
| negative (✗) | `feedback.ts` | −0.10 | −0.10 |

A ★ was worth **half** of being incidentally fetched, and a ✗ was **exactly cancelled** by the next recall that returned the engram.

## Why separation rather than a new ratio

Rebalancing the three constants is a guess — any ratio is — and it leaves saturation intact: from the 0.7 default the field hits 1.0 in three recalls, after which no feedback in either direction is visible in the value at all.

The actual defect is that `retrieval_strength` duplicates a counter that already exists and works. `activation.frequency` counts retrieval events and shows 62 distinct values across a real store (0–594 observed). So traffic keeps its home, and `retrieval_strength` becomes what its name and all three of its consumers — `min_strength`, `scoreEngram`, the admin surfaces — already assume it is.

## Decay is unaffected — checked, not assumed

The obvious risk is that removing the bump lets engrams decay out of injection. It doesn't: `shouldInject` computes `decayedStrength(retrieval_strength, daysSince(last_accessed))`, and `_reactivateResults` still refreshes `last_accessed` on every recall. Decay keys on **recency**, which is untouched — a frequently-recalled engram still resists decay without its quality field being inflated. Pinned by a test.

## The constant stays exported

`reactivate()` remains an exported no-op, and the old `0.1` is now `LEGACY_REACTIVATION_STRENGTH_DELTA`. The issue's specific complaint was that this was *the one constant a downstream consumer needed in order to reason about what a feedback delta is worth, and the only one not exported* — enterprise hand-copied it and guarded the copy by measuring core empirically. Deleting it silently would leave that copy pointing at nothing.

## Verification

- 7 new tests; `decay.test.ts`'s `reactivate bumps strength` updated, since it asserted the defect
- `@plur-ai/core` **2763 passed, 0 failed**; `pnpm typecheck:tests` clean
- **Revert-checked**: 4 fail without the fix, including *"a negative rating is no longer erased by the next recall"*