### PR TITLE
test(cli): run spawn-heavy suites serially instead of raising their timeouts (#793)

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vitest/config'
+
+// The spawn-heavy suites are EXCLUDED here and run as a separate serial project
+// (see the root vitest.config.ts). They are not excluded from the test run —
+// only from the fully-parallel pool. Same shape, and the same reasoning, as
+// core's PGLITE_SUITES.
+//
+// Why: each of these files spawns real CLI processes and waits on their exit,
+// against fixed 5s/30s timeouts. Vitest runs files in parallel across every
+// core, so under a full-workspace run — or alongside a concurrent vitest — the
+// spawns contend for CPU and blow their budget while doing nothing wrong.
+// Measured: hook-learn-check completes in ~2.6s in isolation against a 5s
+// timeout, and fails under load. Four separate work sessions hit it on the same
+// day (#786, #788, #790, #791, #792 all disclosed it).
+//
+// Raising the timeouts was rejected deliberately. It is the same goalpost-move
+// that #311 already made once for the embedder (5s → 30s) and that regressed
+// anyway, and it has a specific cost: a genuinely hung spawn takes longer to
+// report, so the suite gets slower at exactly the moment it should be fastest.
+// Serialising removes the contention instead of budgeting for it.
+//
+// The cost is bounded — these four files run one at a time while the rest of
+// the CLI suite stays fully parallel — and the benefit is that a red suite
+// means something again. A known-flaky baseline is worse than a slow one:
+// today a real 55-test breakage was nearly attributed to the change under test
+// because the suite's noise floor was not zero.
+export const SPAWN_SUITES = [
+  'test/hook-learn-check.test.ts',
+  'test/hook-session-guard.test.ts',
+  'test/list.test.ts',
+  'test/tensions-lifecycle.test.ts',
+]
+
+export default defineConfig({
+  test: {
+    globals: true,
+    exclude: ['**/node_modules/**', '**/dist/**', ...SPAWN_SUITES],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,40 @@ export default defineConfig({
       'packages/migrate',
       {
         test: {
+          // Same shape as core-pglite, same reason: contention, not defects.
+          // These four spawn real CLI processes and wait on their exit against
+          // fixed 5s/30s budgets. In the fully-parallel pool the spawns starve
+          // each other and blow those budgets while doing nothing wrong —
+          // hook-learn-check runs in ~2.6s alone against a 5s timeout, and four
+          // separate work sessions hit it on one day (#793).
+          //
+          // Serialised rather than given bigger timeouts: raising the budget is
+          // the move #311 already made once for the embedder and that regressed
+          // anyway, and it makes a genuinely hung spawn slower to report. A
+          // suite with a known-flaky baseline stops being a signal, which is how
+          // a real 55-test breakage nearly got blamed on the change under test.
+          name: 'cli-spawn',
+          root: 'packages/cli',
+          globals: true,
+          // Keep in sync with SPAWN_SUITES in packages/cli/vitest.config.ts.
+          include: [
+            'test/hook-learn-check.test.ts',
+            'test/hook-session-guard.test.ts',
+            'test/list.test.ts',
+            'test/tensions-lifecycle.test.ts',
+          ],
+          // The whole point: one file at a time, so no two batches of CLI
+          // processes are spawning concurrently.
+          fileParallelism: false,
+          // Generous, because serial execution means a slow run costs
+          // wall-clock rather than correctness. A timeout here should mean a
+          // real hang, not a busy machine.
+          testTimeout: 60000,
+          hookTimeout: 60000,
+        },
+      },
+      {
+        test: {
           name: 'core-pglite',
           root: 'packages/core',
           globals: true,


### PR DESCRIPTION
Fixes #793.

Adds a `cli-spawn` project, mirroring the existing `core-pglite` one — same shape, same reasoning, and a pattern this repo already established for exactly this class rather than a new invention.

## Why serialise rather than raise the budget

`hook-learn-check` completes in **~2.6s in isolation against a 5s timeout**, and fails under load. That is contention, not slowness — four separate work sessions hit it on the same day (#786, #788, #790, #791, #792 all disclosed it).

Raising the timeouts is the move #311 already made once for the embedder (5s → 30s), and it regressed anyway. It also has a specific cost: a genuinely hung spawn takes **longer to report**, so the suite gets slower at exactly the moment it should be fastest.

## The files moved — checked, not assumed

This repo has been bitten by the opposite failure: the root config header records a period when `vitest.workspace.ts` was silently ignored and every file ran **twice**, including stateful ones sharing tmpdir state. So the arithmetic is the verification:

| | files | tests |
|---|---|---|
| before — `@plur-ai/cli` | 54 | 467 |
| after — `@plur-ai/cli` | 50 | 447 |
| after — `cli-spawn` | 4 | 20 |
| **total** | **54** ✓ | **467** ✓ |

Nothing dropped, nothing double-run.

## Why it is worth doing now rather than eventually

A suite with a known-flaky baseline stops being a signal. Earlier today a **real** 55-test breakage was nearly attributed to the change under test, because the noise floor was not zero and "some of these always fail" is an easy thing to believe.

## Verification

- `cli-spawn` 4 files / 20 tests pass serially; `@plur-ai/cli` 50 / 447 pass in parallel
- mcp + claw + migrate: 597 passed
- `pnpm typecheck:tests` clean
- The full-workspace local run kept being killed by the environment, so **CI's four-Node matrix is the authority here** — which is the right check for a config-only change anyway.