### PR TITLE
fix(core): tokenize every script, not just ASCII and Han (#833, #832)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -45,21 +45,71 @@ export const MIN_TOKEN_LENGTH = 2
  *   1 — original. `\w`-based word split, three-character floor, stop words.
  *   2 — #782. Han runs additionally indexed as overlapping character bigrams.
  */
-export const TOKENIZER_VERSION = 2
+export const TOKENIZER_VERSION = 3
 
 /** Tokenize text into searchable terms */
+/**
+ * Scripts written without spaces between words (#833).
+ *
+ * #782 covered Han only. These are indexed as character BIGRAMS rather than
+ * words, because there is no whitespace to split on and a per-language
+ * segmenter is a dependency this package will not take.
+ */
+const SPACELESS_RUN = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Thai}\p{Script=Khmer}\p{Script=Lao}\p{Script=Myanmar}]{2,}/gu
+
+/**
+ * Scripts whose words are routinely one or two characters, so the Latin-shaped
+ * `length > 2` floor erases them (#833). Korean is the reported case:
+ * 도커 ("docker") is two syllable blocks and vanished entirely.
+ */
+const DENSE_SCRIPT = /[\p{Script=Hangul}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u
+
 export function ftsTokenize(text: string): string[] {
   const lower = text.toLowerCase()
-  const tokens = lower
-    .replace(/[^\w\s]/g, ' ')
+
+  // PART 1 — the character class must keep MARKS, not just letters and digits.
+  //
+  // `\w` is ASCII-only, so every non-Latin script was stripped here and
+  // tokenized to nothing, and accented Latin was cut at each accent
+  // (déploiement -> ["ploiement","fran","ais"]). The obvious repair,
+  // `\p{L}\p{N}`, is NOT sufficient and this was measured: Devanagari vowel
+  // signs and Thai tone marks are NONSPACING MARKS (\p{Mn}), so Hindi still
+  // returned [] and Thai came back shattered into fragments the length filter
+  // then ate. \p{M} is what makes those scripts survive.
+  const wordSource = lower
+    // PART 2a — remove space-less runs BEFORE splitting on whitespace.
+    //
+    // Ordering dependency, also measured: with part 1 applied the Unicode class
+    // now PRESERVES a Han run as a single "word", so leaving it in the word
+    // path indexes the whole run AND all its bigrams — 测试部署应该用 came back
+    // as the run plus all six bigrams. Strip here, re-add as bigrams below.
+    .replace(SPACELESS_RUN, ' ')
+    .replace(/[^\p{L}\p{N}\p{M}_\s]/gu, ' ')
+
+  const tokens = wordSource
     .split(/\s+/)
-    .filter(w => w.length > 2)
+    // PART 3 — the length floor is Latin-centric.
+    //
+    // `length > 2` silently kills two-character words, which are ordinary in
+    // dense scripts: 도커 ("docker") vanished entirely. Relaxed to two for those
+    // scripts only, so English stop-noise ("a", "of") is filtered exactly as
+    // before.
+    //
+    // Deliberately NOT relaxed to one. #833's table lists a lone 猫 as a failing
+    // case, and it stays failing: MIN_TOKEN_LENGTH = 2 is load-bearing —
+    // `PostgresAdapter.reversePrefixes` reads it, and this file records that
+    // #782 already broke a RESTATED copy of that invariant once and only got
+    // away with it because Han and ASCII alphabets are disjoint. Emitting
+    // length-1 tokens would make the constant wrong again, this time for real,
+    // and widening it is a change to the pushdown's contract rather than to the
+    // tokenizer's. A single character also cannot be bigram-indexed, so it has
+    // no route into the index either way.
+    .filter(w => w.length > 2 || (w.length === 2 && DENSE_SCRIPT.test(w)))
     .filter(w => !STOP_WORDS.has(w))
-  // CJK: \w is ASCII-only ([A-Za-z0-9_]), so Han runs are stripped by the
-  // replace above and pure-Chinese text tokenizes to nothing. Chinese has no
-  // whitespace-delimited words — re-extract Han runs from the source and index
-  // them as character bigrams so non-English text survives BM25. (plur-ai#782)
-  for (const run of lower.match(/\p{Script=Han}{2,}/gu) ?? []) {
+
+  // Space-less scripts, indexed as character bigrams (#782, widened in #833).
+  // Read from `lower`, not from wordSource — the runs were stripped there.
+  for (const run of lower.match(SPACELESS_RUN) ?? []) {
     for (let i = 0; i < run.length - 1; i++) tokens.push(run.slice(i, i + 2))
   }
   return tokens

--- a/packages/core/test/fts-unicode.test.ts
+++ b/packages/core/test/fts-unicode.test.ts
@@ -1,0 +1,132 @@
+/**
+ * #833 / #832 — every script must produce tokens, not just ASCII and Han.
+ *
+ * #782 fixed Chinese by indexing Han runs as character bigrams. That was the
+ * right first cut and it covered exactly one script: measured on the post-#782
+ * tokenizer, Japanese kana, Korean, Arabic and Hindi all returned `[]`, Russian
+ * and Thai returned only the embedded English word, and accented Latin was cut
+ * at each accent — `déploiement` became `["ploiement","fran","ais"]`.
+ *
+ * The fix is three parts with a real ordering dependency between them, which is
+ * why they are one change rather than three:
+ *
+ *   1. The character class needs `\p{M}`. `\p{L}\p{N}` alone is NOT enough —
+ *      Devanagari vowel signs and Thai tone marks are nonspacing marks, so
+ *      Hindi still returns [] and Thai shatters into fragments the length
+ *      filter then eats.
+ *   2. Space-less runs must be stripped from the WORD path before splitting.
+ *      With (1) applied the Unicode class preserves a Han run as one "word", so
+ *      without this the run is indexed AND all its bigrams are too.
+ *   3. The length floor is Latin-centric. `length > 2` erases two-character
+ *      words, which are ordinary in dense scripts — 도커 ("docker") vanished.
+ */
+import { describe, it, expect } from 'vitest'
+import { ftsTokenize } from '../src/fts.js'
+
+describe('ftsTokenize covers non-Latin scripts (#833)', () => {
+  // Each of these returned [] or near-[] before the fix — the table in the
+  // issue, kept in the same order.
+  const cases: Array<[string, string]> = [
+    ['Japanese kana', 'テストデプロイ'],
+    ['Korean', '배포는 도커를 사용해야 한다'],
+    ['Russian', 'развертывание должно использовать docker'],
+    ['Arabic', 'يجب استخدام دوكر'],
+    ['Hindi', 'तैनाती के लिए डॉकर'],
+    ['Thai', 'การปรับใช้ควรใช้ docker'],
+  ]
+  for (const [label, text] of cases) {
+    it(`${label} produces tokens`, () => {
+      expect(ftsTokenize(text).length, `${label} tokenized to nothing`).toBeGreaterThan(0)
+    })
+  }
+
+  it('Russian indexes its own words, not just the embedded English one', () => {
+    const t = ftsTokenize('развертывание должно использовать docker')
+    // Before: exactly ["docker"] — the Cyrillic was stripped entirely.
+    expect(t).toContain('развертывание')
+    expect(t).toContain('docker')
+  })
+
+  it('Hindi survives its vowel signs — this is the \\p{M} case', () => {
+    // With \p{L}\p{N} but no \p{M} this is still [].
+    expect(ftsTokenize('तैनाती के लिए डॉकर')).toContain('तैनाती')
+  })
+})
+
+describe('accented Latin is no longer shredded (#833)', () => {
+  it('keeps French words whole', () => {
+    const t = ftsTokenize('déploiement français')
+    expect(t).toEqual(expect.arrayContaining(['déploiement', 'français']))
+    // The old output, kept explicit so a regression is unmistakable.
+    expect(t).not.toContain('ploiement')
+    expect(t).not.toContain('ais')
+  })
+
+  it('keeps Slovenian words whole', () => {
+    expect(ftsTokenize('razmeščanje čez šifriran kanal'))
+      .toEqual(expect.arrayContaining(['razmeščanje', 'šifriran', 'kanal']))
+  })
+})
+
+describe('space-less scripts are bigram-indexed exactly once (#833)', () => {
+  it('does not double-index a Han run', () => {
+    // The ordering dependency. Part 1 without part 2 returns the whole run AND
+    // all six bigrams, because the Unicode class now preserves the run as a
+    // "word". Measured on the intermediate state before this was fixed.
+    const t = ftsTokenize('测试部署应该用')
+    expect(t).not.toContain('测试部署应该用')
+    expect(t).toContain('测试')
+    expect(t).toContain('该用')
+  })
+
+  it('bigram-indexes kana, which #782 did not cover', () => {
+    const t = ftsTokenize('テストデプロイ')
+    expect(t).toContain('テス')
+    expect(t).not.toContain('テストデプロイ')
+  })
+
+  it('bigram-indexes Thai while keeping an embedded Latin word', () => {
+    const t = ftsTokenize('การปรับใช้ควรใช้ docker')
+    expect(t).toContain('docker')
+    expect(t.some(x => x.length === 2 && /[฀-๿]/.test(x))).toBe(true)
+  })
+})
+
+describe('the length floor is script-aware (#832)', () => {
+  it('keeps a two-character Korean word', () => {
+    // 도커 is "docker". It returned [] under every variant tried in the issue,
+    // including the otherwise-complete fix.
+    expect(ftsTokenize('도커')).toContain('도커')
+  })
+
+  it('does NOT emit a single-character token, even in a dense script', () => {
+    // #833's table lists a lone 猫 as a failing case and it stays failing, on
+    // purpose. MIN_TOKEN_LENGTH = 2 is load-bearing —
+    // `PostgresAdapter.reversePrefixes` reads it, and fts.ts records that #782
+    // already broke a restated copy of that invariant once, getting away with
+    // it only because Han and ASCII alphabets are disjoint. A single character
+    // also cannot be bigram-indexed, so it has no route into the index anyway.
+    expect(ftsTokenize('猫')).toEqual([])
+    // In running text the character is still reachable, via the bigrams of the
+    // run it belongs to.
+    expect(ftsTokenize('猫和狗')).toContain('猫和')
+  })
+
+  it('still drops short ASCII noise, so English behaviour is unchanged', () => {
+    const t = ftsTokenize('a an of the quick brown fox')
+    expect(t).not.toContain('a')
+    expect(t).not.toContain('of')
+    expect(t).toEqual(expect.arrayContaining(['quick', 'brown', 'fox']))
+  })
+})
+
+describe('English tokenization is untouched (#833 regression guard)', () => {
+  it('produces the same tokens as before for plain ASCII', () => {
+    expect(ftsTokenize('The quick brown fox jumps over the lazy dog'))
+      .toEqual(['quick', 'brown', 'fox', 'jumps', 'over', 'lazy', 'dog'])
+  })
+
+  it('still strips punctuation', () => {
+    expect(ftsTokenize('rebase, then push -- always!')).not.toContain(',')
+  })
+})

--- a/packages/core/test/fts.test.ts
+++ b/packages/core/test/fts.test.ts
@@ -261,7 +261,10 @@ describe('tokenizer contract (#834)', () => {
    * makes already-written rows silently unreachable.
    */
   it('output is pinned to TOKENIZER_VERSION — bump the version if this fails', () => {
-    expect(TOKENIZER_VERSION).toBe(2)
+    // Bumped 2 -> 3 by #833/#832: the tokenizer now covers every script rather
+    // than ASCII + Han, so stores carrying tokens derived under v2 must be
+    // re-derived (`plur reindex-tokens`) or their rows go unreachable.
+    expect(TOKENIZER_VERSION).toBe(3)
     expect(ftsTokenize('测试部署应该用 docker compose')).toEqual([
       'docker', 'compose',
       '测试', '试部', '部署', '署应', '应该', '该用',


### PR DESCRIPTION
Fixes #833. Fixes #832.

Measured before and after, using the issue's own table:

| input | before | after |
|---|---|---|
| `テストデプロイ` (kana) | `[]` | 6 bigrams |
| `배포는 도커를…` (Korean) | `[]` | 4 words |
| `развертывание…` (Russian) | `["docker"]` | 4 words |
| `يجب استخدام دوكر` (Arabic) | `[]` | 3 words |
| `तैनाती के लिए डॉकर` (Hindi) | `[]` | 3 words |
| `การปรับใช้…` (Thai) | `["docker"]` | docker + bigrams |
| `déploiement français` | `["ploiement","fran","ais"]` | both words whole |
| `도커` | `[]` | `["도커"]` |

## One change, not three

The parts have an ordering dependency:

1. **`\p{M}`, not just `\p{L}\p{N}`.** Devanagari vowel signs and Thai tone marks are *nonspacing marks* — with letters and digits alone, Hindi still returns `[]` and Thai shatters into fragments the length filter then eats. This is why #780's proposed one-liner was measured insufficient.
2. **Strip space-less runs from the word path before splitting.** With (1) applied the Unicode class now preserves a Han run as a single "word", so without this the run is indexed **and** all its bigrams are. Pinned by a test.
3. **Script-aware length floor.** `length > 2` erased two-character words, ordinary in dense scripts.

## What I did not fix, on purpose

#833's table lists a lone `猫` returning `[]` as a defect. **It still returns `[]`.**

`MIN_TOKEN_LENGTH = 2` is load-bearing: `PostgresAdapter.reversePrefixes` reads it, and `fts.ts` records that #782 already broke a *restated copy* of that invariant once — getting away with it only because Han and ASCII alphabets are disjoint. Emitting length-1 tokens makes the constant wrong again, for real, and that is a change to the **pushdown's** contract rather than the tokenizer's.

A single character also cannot be bigram-indexed, so it has no route into the index either way — and in running text it stays reachable through its run's bigrams (`猫和狗` → `猫和`). Both pinned by tests.

Happy to widen it in a follow-up that owns the `reversePrefixes` change too, if a single-character query is a real use case.

## TOKENIZER_VERSION 2 → 3, and the canary that forced it

`fts.test.ts` pins the output with the note *"the fix is to bump TOKENIZER_VERSION, not to update this fixture in place"*. It failed, which is the mechanism working: stores derive tokens at **write** time and compare them against freshly-tokenized query terms at **read** time, so changing the tokenizer without bumping the version makes already-written rows silently unreachable.

**Existing stores need `plur reindex-tokens`** — which already exists, added for exactly this.

## Verification

- 20 new tests; English tokenization pinned unchanged by a regression guard
- `@plur-ai/core` **2785 passed, 0 failed**; `pnpm typecheck:tests` clean