### PR TITLE
perf(core): let a pushdown adapter signal candidate-set exhaustion (#753)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3145,10 +3145,28 @@ export class Plur {
       let surviving: Engram[] = []
       let fetch = Math.max(limit * PUSHDOWN_OVERFETCH, limit)
       for (let round = 0; round < PUSHDOWN_MAX_ROUNDS; round++) {
-        narrowed = await adapter.searchBM25(query, { ...pushdownFilter, limit: fetch })
+        // #753: prefer the exhaustion-aware call when the adapter offers one.
+        //
+        // `narrowed.length < fetch` is the only exhaustion signal core can
+        // derive, and it is wrong for an adapter whose prefilter cannot rank:
+        // PostgresAdapter computes and scores the FULL candidate set and slices
+        // to `limit` here, so a full page means "your slice was full", not
+        // "there is more". The loop then re-ran an identical query up to three
+        // times to take a longer slice of an answer already computed — a 2-3x
+        // amplification, concentrated in the high-rejection case the widening
+        // exists to serve, at the scale that selects this tier.
+        let exhausted = false
+        if (adapter.searchBM25Exhaustive) {
+          const res = await adapter.searchBM25Exhaustive(query, { ...pushdownFilter, limit: fetch })
+          narrowed = res.rows
+          exhausted = res.exhausted
+        } else {
+          narrowed = await adapter.searchBM25(query, { ...pushdownFilter, limit: fetch })
+        }
         surviving = this._applyResidualFilters(narrowed, options)
-        // Enough survivors, or the store has nothing more to give.
-        if (surviving.length >= limit || narrowed.length < fetch) break
+        // Enough survivors, the adapter says there is no more, or the page came
+        // back short (the inferred signal, kept for adapters without the hook).
+        if (surviving.length >= limit || exhausted || narrowed.length < fetch) break
         fetch *= PUSHDOWN_OVERFETCH
       }
 

--- a/packages/core/src/storage-adapter.ts
+++ b/packages/core/src/storage-adapter.ts
@@ -343,6 +343,23 @@ export interface StorageAdapter {
    */
   searchBM25(query: string, opts: { limit: number } & StorageFilter): Promise<Engram[]>
   /**
+   * `searchBM25`, plus whether the candidate set was EXHAUSTED (#753). OPTIONAL
+   * and purely additive — an adapter that cannot know this leaves it undefined
+   * and core's widening loop behaves exactly as before.
+   *
+   * Core cannot derive the answer: `rows.length === limit` is
+   * indistinguishable from "more rows exist", so the widening loop re-queries
+   * on the assumption there might be. For an adapter whose prefilter cannot
+   * rank — `PostgresAdapter`, which computes and scores the FULL candidate set
+   * and slices in core — that assumption is wrong every time, and the re-query
+   * is a 2-3x cost amplification concentrated in exactly the high-rejection
+   * case the widening exists to serve.
+   */
+  searchBM25Exhaustive?(
+    query: string,
+    opts: { limit: number } & StorageFilter,
+  ): Promise<{ rows: Engram[]; exhausted: boolean }>
+  /**
    * Corpus-wide `N` and per-term `df` for BM25 scoring (convergence Phase 4,
    * #711). OPTIONAL — a store that cannot compute these exactly must leave it
    * undefined, and the caller falls back to deriving them from the candidate

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -1378,9 +1378,39 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    * and scoring locally when it is not, which is what this method did before
    * Phase 4.
    */
+  /**
+   * `searchBM25`, plus whether the candidate set was EXHAUSTED (#753).
+   *
+   * This adapter's trigram prefilter cannot rank, so both paths below compute
+   * and score the FULL candidate set and slice to `limit` in core. That makes
+   * the answer to "is there more?" free here — and core cannot derive it,
+   * because `rows.length === limit` is indistinguishable from "more rows
+   * exist". Without the signal, recall's widening loop re-ran this identical
+   * query up to three times purely to take a longer slice of an answer already
+   * computed, at the 50k+-engram scale that selects this tier.
+   */
   async searchBM25(query: string, opts: { limit: number } & StorageFilter): Promise<Engram[]> {
+    return (await this._searchBM25Full(query, opts)).rows
+  }
+
+  /**
+   * Exhaustion-aware variant (#753). Core prefers this when present and breaks
+   * out of its widening loop on `exhausted`, instead of re-querying an answer
+   * it already has.
+   */
+  async searchBM25Exhaustive(
+    query: string,
+    opts: { limit: number } & StorageFilter,
+  ): Promise<{ rows: Engram[]; exhausted: boolean }> {
+    return await this._searchBM25Full(query, opts)
+  }
+
+  private async _searchBM25Full(
+    query: string,
+    opts: { limit: number } & StorageFilter,
+  ): Promise<{ rows: Engram[]; exhausted: boolean }> {
     const queryTokens = ftsTokenize(query)
-    if (queryTokens.length === 0) return []
+    if (queryTokens.length === 0) return { rows: [], exhausted: true }
 
     // Resolve the pool FIRST. `trigramAvailable` is only assigned inside
     // `initSchema`, which `getPool` drives; reading it beforehand on a freshly
@@ -1398,7 +1428,10 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     // CURRENT tokenizer, so it is immune to whatever happens to be stored.
     if (this.trigramAvailable !== true || await this.tokensAreStale(opts)) {
       const candidates = await this.loadFiltered({ ...opts, status: 'active' })
-      return searchEngrams(candidates, query, opts.limit)
+      return {
+        rows: searchEngrams(candidates, query, opts.limit),
+        exhausted: candidates.length <= opts.limit,
+      }
     }
 
     // Reuse `buildFilterClause` for status/scope/domain/scopes rather than
@@ -1440,7 +1473,10 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     // already immune; only the BM25 pushdown was not.
     const candidates = rows.map((r: { data: Engram }) => parseRow(r as { data: any }))
     const stats = await this.corpusStats(queryTokens, opts)
-    return searchEngrams(candidates, query, opts.limit, stats)
+    return {
+      rows: searchEngrams(candidates, query, opts.limit, stats),
+      exhausted: candidates.length <= opts.limit,
+    }
   }
 
   /**

--- a/packages/core/test/pushdown-exhaustion.test.ts
+++ b/packages/core/test/pushdown-exhaustion.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #753 — the widening loop must stop when the adapter has nothing more.
+ *
+ * `recall()`'s adaptive over-fetch widens 3L → 9L → 27L when residual filters
+ * (expiry, `min_strength`) reject more than 2/3 of a page. Its early exit,
+ * `narrowed.length < fetch`, assumes an adapter that bounds its search by the
+ * requested limit.
+ *
+ * `PostgresAdapter.searchBM25` deliberately does the opposite: its trigram
+ * prefilter cannot rank, so it computes and scores the FULL candidate set and
+ * slices to `limit` in core. So a full page means "your slice was full", not
+ * "there is more" — and rounds 2 and 3 re-execute the identical query and
+ * re-rank identical rows purely to take a longer slice of an answer already
+ * computed. A 2–3x cost amplification, concentrated in exactly the
+ * high-rejection scenario the widening exists to serve, at the 50k+-engram
+ * scale that selects this tier.
+ *
+ * Correctness was never affected — this is a cost bug. So these tests count
+ * QUERIES, not results.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/**
+ * A primary query store that reports exhaustion, standing in for
+ * `PostgresAdapter` without booting one.
+ */
+function makeAdapter(opts: { corpus: Engram[]; exhaustive: boolean }) {
+  const calls = { bm25: 0, exhaustive: 0 }
+  const rank = (limit: number) => opts.corpus.slice(0, limit)
+
+  const base: Record<string, unknown> = {
+    kind: 'postgres',
+    location: 'postgres://stub',
+    role: 'primary',
+    load: async () => opts.corpus,
+    loadCached: async () => opts.corpus,
+    invalidate: () => {},
+    withExclusiveAccess: async <T>(fn: () => Promise<T>) => fn(),
+    save: async () => {},
+    loadByIds: async (ids: string[]) => opts.corpus.filter(e => ids.includes(e.id)),
+    updateMany: async () => {},
+    append: async () => {},
+    findActiveByContentHash: async () => null,
+    nextEngramId: async () => 'ENG-STUB-001',
+    searchVector: async () => [],
+    searchBM25: async (_q: string, o: { limit: number }) => { calls.bm25++; return rank(o.limit) },
+  }
+  if (opts.exhaustive) {
+    base.searchBM25Exhaustive = async (_q: string, o: { limit: number }) => {
+      calls.exhaustive++
+      // The PostgresAdapter property: the full candidate set is always known,
+      // so exhaustion is free.
+      return { rows: rank(o.limit), exhausted: opts.corpus.length <= o.limit }
+    }
+  }
+  return { store: base, calls }
+}
+
+/** An engram the residual filters will reject, so widening is triggered. */
+function expiredEngram(id: string): Engram {
+  return {
+    id, version: 2, status: 'active', consolidated: false,
+    type: 'behavioral', scope: 'global', visibility: 'private',
+    statement: `docker deployment note ${id}`,
+    activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-10' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+    abstract: null, derived_from: null, polarity: null, content_hash: `h-${id}`,
+    commitment: 'leaning', write_count: 1, injection_count: 0, sources: [], recurrence_count: 0,
+    summary: 's', engram_version: 1, episode_ids: [],
+    // Expired: `_applyResidualFilters` rejects it, which is what drives widening.
+    temporal: { learned_at: '2020-01-01', valid_until: '2020-01-02' },
+  } as unknown as Engram
+}
+
+describe('recall stops widening when the adapter says it is exhausted (#753)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-753-')) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('queries ONCE when a FULL page is nonetheless the whole candidate set', async () => {
+    // The discriminating case, and the only one that isolates this fix.
+    //
+    // limit 10 -> first fetch is 3L = 30. A corpus of exactly 30 fills that
+    // page, so `narrowed.length < fetch` is FALSE and the inferred signal
+    // cannot fire — yet the adapter knows those 30 rows are everything. This is
+    // precisely PostgresAdapter's situation: it computes and scores the full
+    // candidate set, so a full page means "your slice was full", not "there is
+    // more".
+    //
+    // (An earlier version of this test used a 5-row corpus and passed with the
+    // fix reverted, because the short page tripped the inferred signal. It
+    // proved nothing.)
+    const corpus = Array.from({ length: 30 }, (_, i) => expiredEngram(`ENG-EXP-${i}`))
+    const { store, calls } = makeAdapter({ corpus, exhaustive: true })
+    const plur = new Plur({ path: dir, store: store as never })
+
+    await plur.recall('docker', { limit: 10 })
+
+    expect(calls.exhaustive, 'rounds 2-3 re-rank rows the adapter already returned').toBe(1)
+    expect(calls.bm25, 'the exhaustion-aware path should be preferred').toBe(0)
+  })
+
+  it('still widens for an adapter WITHOUT the hook — purely additive', async () => {
+    const corpus = Array.from({ length: 5 }, (_, i) => expiredEngram(`ENG-EXP-${i}`))
+    const { store, calls } = makeAdapter({ corpus, exhaustive: false })
+    const plur = new Plur({ path: dir, store: store as never })
+
+    await plur.recall('docker', { limit: 10 })
+
+    // The inferred signal (`narrowed.length < fetch`) still applies, so this
+    // one short page also stops the loop — the point is that behaviour for
+    // adapters lacking the hook is unchanged.
+    expect(calls.bm25).toBeGreaterThanOrEqual(1)
+    expect(calls.exhaustive).toBe(0)
+  })
+
+  it('does not stop early when the adapter reports MORE is available', async () => {
+    // Corpus larger than the first fetch window, all rejected: exhausted is
+    // false, so the loop must still widen. Stopping here would be the opposite
+    // bug — a silent recall shortfall.
+    const corpus = Array.from({ length: 500 }, (_, i) => expiredEngram(`ENG-EXP-${i}`))
+    const { store, calls } = makeAdapter({ corpus, exhaustive: true })
+    const plur = new Plur({ path: dir, store: store as never })
+
+    await plur.recall('docker', { limit: 5 })
+
+    expect(calls.exhaustive, 'a non-exhausted adapter must still be widened against').toBeGreaterThan(1)
+  })
+})


### PR DESCRIPTION
Fixes #753.

`narrowed.length < fetch` is the only exhaustion signal core can derive, and it is **wrong for an adapter whose prefilter cannot rank**. `PostgresAdapter` computes and scores the *full* candidate set and slices to `limit` in core — so a full page means "your slice was full", not "there is more", and rounds 2–3 re-execute an identical query and re-rank identical rows to take a longer slice of an answer already computed.

## The change

Optional `searchBM25Exhaustive` on `StorageAdapter`, returning rows plus `exhausted`. **Purely additive** — an adapter without it takes exactly the path it takes today, pinned by a test.

`PostgresAdapter` gets it for free: both return paths already hold the full candidate set, so exhaustion is `candidates.length <= opts.limit` rather than new work. Both public methods delegate to one internal so they cannot drift apart.

## Tests count queries, not results

Correctness was never affected — this is a cost bug — so asserting on returned rows would prove nothing. One test asserts the **opposite** direction too: a non-exhausted adapter must *still* be widened against, or this fix quietly becomes a recall shortfall.

## How the test got written, because it nearly didn't work

The first version used a 5-row corpus and **passed with the fix reverted**. With `limit: 10` the first fetch is 30, so a short page trips the *inferred* signal and the new one is never consulted.

The discriminating case is a corpus of **exactly 3L** — a full page that is nonetheless the entire candidate set, which is precisely `PostgresAdapter`'s situation. Reverting then fails with `expected 2 to be 1`. The note is in the test so the next person does not reintroduce the weaker fixture.

## Verification

- 3 tests; `@plur-ai/core` **2777 passed, 0 failed**; `pnpm typecheck:tests` clean
- **Revert-checked** against the discriminating case