### PR TITLE
fix(test): count both adapter entry points in the pushdown routing spy

### DIFF
--- a/packages/core/test/postgres-recall-pushdown.test.ts
+++ b/packages/core/test/postgres-recall-pushdown.test.ts
@@ -60,17 +60,30 @@ describe.skipIf(!PG_URL)('Plur.recall() through an injected Postgres adapter (#7
   it('actually routes through the adapter, not the in-memory path', async () => {
     // Without this the rest of the file would pass on the old code path and
     // prove nothing about the wiring. Counts a real query against the store.
+    //
+    // Spies on BOTH entry points (#753): core prefers `searchBM25Exhaustive`
+    // when the adapter offers it, so watching only `searchBM25` counted zero
+    // and reported "did not go through the adapter" for a recall that did.
+    // What this test means is "exactly one real query hit the store", which is
+    // independent of which method core picked.
     let calls = 0
-    const real = adapter.searchBM25.bind(adapter)
-    ;(adapter as unknown as { searchBM25: typeof adapter.searchBM25 }).searchBM25 = async (q, o) => {
-      calls++
-      return await real(q, o)
+    type A = typeof adapter
+    const realBM25 = adapter.searchBM25.bind(adapter)
+    const realExhaustive = adapter.searchBM25Exhaustive?.bind(adapter)
+    const patch = adapter as unknown as {
+      searchBM25: A['searchBM25']
+      searchBM25Exhaustive?: NonNullable<A['searchBM25Exhaustive']>
+    }
+    patch.searchBM25 = async (q, o) => { calls++; return await realBM25(q, o) }
+    if (realExhaustive) {
+      patch.searchBM25Exhaustive = async (q, o) => { calls++; return await realExhaustive(q, o) }
     }
     try {
       await plur.recall('deploy kubernetes')
       expect(calls, 'recall() did not go through the adapter').toBe(1)
     } finally {
-      ;(adapter as unknown as { searchBM25: typeof adapter.searchBM25 }).searchBM25 = real
+      patch.searchBM25 = realBM25
+      if (realExhaustive) patch.searchBM25Exhaustive = realExhaustive
     }
   }, TIMEOUT)
 


### PR DESCRIPTION
Follow-up to #891 (#753). **Main is currently red on `test (22)`, `test (24)` and `test (26)`** — this fixes it.

## What broke

#753 made core prefer `searchBM25Exhaustive` when an adapter offers one. `postgres-recall-pushdown.test.ts` spies on `searchBM25` to assert that recall routes through the adapter rather than the in-memory path — so it counted zero and reported *"recall() did not go through the adapter"* for a recall that did.

The test's **meaning** is "exactly one real query hit the store", which is independent of which method core picked. It now spies on both entry points and asserts the total.

## Why it was not caught before merge

Two compounding reasons, and only the second is a real process failure:

1. `postgres-*.test.ts` **skips entirely** unless `PLUR_TEST_POSTGRES_URL` is set, and lives in the `core-pglite` project that `--project @plur-ai/core` excludes. Verified locally: that project runs 7 passed / 10 skipped. CI, with its real Postgres service, is the **only** place this file executes.
2. I merged #891 while its checks were still pending. That is the actual error — when a change touches the adapter surface, CI is the sole verifier and there is no substitute for waiting.

## Verification

- `pnpm typecheck:tests` clean; `core-pglite` project passes locally (with the Postgres suites skipping, as expected)
- **CI is the real check here** — this PR must go green on the full matrix before merging, and I am not merging it early.