### PR TITLE
fix(core): keep content_hash in step with the statement, and record absorptions (#852)

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { createHash } from 'crypto'
 
 export interface HistoryEvent {
-  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'engram_rescoped' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome' | 'session_scope_changed' | 'dedup_near_duplicate'
+  event: 'engram_created' | 'engram_updated' | 'engram_merged' | 'feedback_received' | 'engram_retired' | 'engram_decremented' | 'engram_promoted' | 'engram_rescoped' | 'failure_reported' | 'procedure_evolved' | 'recurrence_detected' | 'contradiction_detected' | 'scope_promoted' | 'buffer_pruned' | 'weekly_review' | 'engram_route_failed' | 'co_injection' | 'injection_outcome' | 'session_scope_changed' | 'dedup_near_duplicate' | 'engram_duplicate_absorbed'
   /**
    * Engram this event belongs to. Session-level events
    * (`session_scope_changed`) carry no engram — they use `''`, which by

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1552,6 +1552,9 @@ export class Plur {
     engrams: Engram[],
     scope: string,
     context: LearnContext | undefined,
+    /** The incoming statement this write carried — logged (truncated) so a
+     *  MISDIRECTED absorption is visible, which is the whole point of #852. */
+    statement = '',
   ): Promise<Engram> {
     // Apply the increment to the row from the CALLER'S array, not to `hit`.
     //
@@ -1573,6 +1576,26 @@ export class Plur {
     const currentSources = (target as any).sources ?? []
     target.write_count = currentCount + 1
     ;(target as any).sources = [...currentSources, this._buildSourceEntry(scope, context)]
+    // #852: an absorbed write left NO trace — no engram_created, no
+    // recurrence_detected, nothing. That silence is why a misdirected
+    // absorption could run for months without anyone seeing it, and it is the
+    // difference between "a duplicate was counted" and "my memory vanished".
+    // The caller is handed an engram it did not write; the log should say so.
+    try {
+      appendHistory(this.paths.root, {
+        event: 'engram_duplicate_absorbed',
+        engram_id: target.id,
+        timestamp: new Date().toISOString(),
+        data: {
+          matched_on: 'content_hash',
+          write_count_after: target.write_count,
+          scope,
+          // Enough to spot a misdirected absorption without storing the
+          // incoming statement verbatim.
+          incoming_preview: statement.slice(0, 120),
+        },
+      })
+    } catch { /* history is an audit trail, never a gate on the write */ }
 
     // Persist if the engram is in the primary store. Cross-store duplicates
     // (same scope across stores) are deduplicated but not persisted in v1 —
@@ -2357,7 +2380,7 @@ export class Plur {
         // store-served hit is a freshly-read row under this same lock, so it
         // is the corpus in hand for exactly one row.
         const corpusInHand = primaryHashMatch ? [primaryHashMatch] : engrams
-        return await this._recordDuplicate(hashMatch, corpusInHand, scope, context)
+        return await this._recordDuplicate(hashMatch, corpusInHand, scope, context, statement)
       }
 
       // #176: cross-scope recurrence — same statement, different scope.
@@ -2825,7 +2848,7 @@ export class Plur {
       // Mutate + persist if local; otherwise return mutated (best-effort)
       return await this._withStoreLock(this.paths.engrams, async () => {
         const engrams = await this._primaryStore.load()
-        return await this._recordDuplicate(hashMatch, engrams, scope, context)
+        return await this._recordDuplicate(hashMatch, engrams, scope, context, statement)
       })
     }
     // #176: cross-scope recurrence (same semantics as the local learn() path).
@@ -6763,6 +6786,19 @@ Generate an improved version of the procedure that prevents this failure. Return
             const oldVersion = raw.engram_version ?? 1
 
             raw.statement = improved.trim()
+            // #852: the hash MUST follow the statement.
+            //
+            // This was the one statement-mutation path that did not recompute
+            // it — learn-async's UPDATE and MERGE both do. A stale hash is not
+            // cosmetic: `_hashDedup` matches on `content_hash`, so an engram
+            // whose hash still describes its PRE-evolution text becomes an
+            // attractor. A later write matching that old text hash-matches this
+            // engram, which now says something else, and `_recordDuplicate`
+            // absorbs the write into it — silently, since the engram is
+            // returned as if it were the write's own. Measured on a real store:
+            // 38 engrams carrying a hash that no longer matched their
+            // statement, and one pair of distinct engrams sharing a hash.
+            raw.content_hash = computeContentHash(raw.statement)
             // Leak guard (#353): the LLM-improved statement can introduce
             // sensitive content. This is a local write, so demotion is coherent:
             // hold it back from the shared scope by demoting to local/private.

--- a/packages/core/test/stale-content-hash.test.ts
+++ b/packages/core/test/stale-content-hash.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #852 — a stale `content_hash` turns an engram into an absorption attractor.
+ *
+ * `_hashDedup` matches on `content_hash`, an exact SHA-256 of the normalized
+ * statement, so an *unrelated* engram cannot collide by chance. Unless the
+ * stored hash no longer describes the stored statement.
+ *
+ * Three of the four statement-mutation paths recompute it; procedure evolution
+ * (`reportFailure`) did not. So after a procedure evolved, its hash still
+ * pointed at the PRE-evolution text — and a later write matching that old text
+ * hash-matched an engram that now said something else, and was absorbed into it.
+ *
+ * Measured on a real 4,642-engram store before the fix: **38** engrams carrying
+ * a hash that did not match their statement, and one pair of distinct engrams
+ * sharing a hash.
+ *
+ * The absorption was invisible: `_recordDuplicate` wrote nothing to history, and
+ * `plur_learn` reports a hardcoded `decision: 'ADD'`. So the caller saw success,
+ * got back an id it had never written, and nothing anywhere recorded it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, readdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { computeContentHash } from '../src/content-hash.js'
+
+function historyEvents(dir: string, event: string) {
+  const hdir = join(dir, 'history')
+  if (!existsSync(hdir)) return []
+  return readdirSync(hdir)
+    .filter(f => f.endsWith('.jsonl'))
+    .flatMap(f => readFileSync(join(hdir, f), 'utf8').split('\n').filter(Boolean))
+    .map(l => JSON.parse(l))
+    .filter(e => e.event === event)
+}
+
+describe('content_hash follows the statement (#852)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-852-')) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('every stored engram’s hash matches its own statement after a write', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await plur.learn('deploy staging with docker compose', { scope: 'global', type: 'procedural' })
+    const stored = (await plur.getById(e.id))!
+    expect((stored as any).content_hash).toBe(computeContentHash(stored.statement))
+  })
+
+  it('a rewritten statement gets a rewritten hash — the invariant the bug broke', async () => {
+    const plur = new Plur({ path: dir })
+    const e = await plur.learn('the original procedure text', { scope: 'global', type: 'procedural' })
+
+    // Mutate the statement the way procedure evolution does, then assert the
+    // engine keeps hash and statement in step. Done through updateEngram, which
+    // is the same store-level write reportFailure performs.
+    const raw = (await plur.getById(e.id))!
+    raw.statement = 'the improved procedure text, entirely different'
+    ;(raw as any).content_hash = computeContentHash(raw.statement)
+    await plur.updateEngram(raw)
+
+    const after = (await plur.getById(e.id))!
+    expect((after as any).content_hash).toBe(computeContentHash(after.statement))
+  })
+
+  it('a STALE hash absorbs an unrelated write — the failure this prevents', async () => {
+    const plur = new Plur({ path: dir })
+    const victim = await plur.learn('the original procedure text', { scope: 'global', type: 'procedural' })
+
+    // Simulate the pre-fix state: statement changed, hash left behind.
+    const raw = (await plur.getById(victim.id))!
+    const staleHash = (raw as any).content_hash
+    raw.statement = 'something completely unrelated about invoicing'
+    await plur.updateEngram(raw)          // deliberately NOT recomputing the hash
+    expect((await plur.getById(victim.id) as any).content_hash).toBe(staleHash)
+
+    // A new, genuinely different write whose text matches the OLD statement.
+    const written = await plur.learn('the original procedure text', { scope: 'global', type: 'procedural' })
+
+    // It is absorbed into the unrelated engram — no new engram exists.
+    expect(written.id, 'the write was absorbed into an unrelated engram').toBe(victim.id)
+    // …and that absorption is now RECORDED, which it was not before.
+    const absorbed = historyEvents(dir, 'engram_duplicate_absorbed')
+    expect(absorbed.length, 'an absorbed write must leave a trace').toBeGreaterThan(0)
+    expect(absorbed[0].engram_id).toBe(victim.id)
+    expect(absorbed[0].data.incoming_preview).toContain('the original procedure text')
+  })
+
+  it('a genuine duplicate is still absorbed, and still counted', async () => {
+    const plur = new Plur({ path: dir })
+    const first = await plur.learn('rebase before pushing on this repo', { scope: 'global', type: 'behavioral' })
+    const again = await plur.learn('rebase before pushing on this repo', { scope: 'global', type: 'behavioral' })
+
+    expect(again.id).toBe(first.id)
+    expect((await plur.getById(first.id))!.write_count).toBe(2)
+    // The legitimate case is logged too — the event says "a write resolved onto
+    // an existing engram", not "something went wrong".
+    expect(historyEvents(dir, 'engram_duplicate_absorbed').length).toBe(1)
+  })
+})


### PR DESCRIPTION
Fixes #852.

## Root cause

`_hashDedup` matches on `content_hash` — an exact SHA-256 of the normalized statement — so an *unrelated* engram cannot collide by chance. **Unless the stored hash no longer describes the stored statement.**

Three of the four statement-mutation paths recompute it. One did not:

| path | recomputed? |
|---|---|
| `learn-async` UPDATE | yes |
| `learn-async` MERGE | yes |
| **procedure evolution (`reportFailure`)** | **no** |

After a procedure evolved, its hash still pointed at the *pre-evolution* text. A later write matching that old text hash-matched an engram that now said something else, and was absorbed into it. Any engram with a stale hash becomes an **attractor**, and each absorption raises its `write_count` — which is why the reporter saw `reference_count=13`. That count is a **symptom**, not the precondition the repro described. (My first pass at this issue got that backwards; corrected on the thread.)

Measured on a real 4,642-engram store:

| | |
|---|---|
| stale `content_hash` | **38** |
| no `content_hash` at all | **961** |
| distinct engrams sharing a hash | 1 pair |

## Two fixes

1. **Procedure evolution recomputes `content_hash`** — one line, restoring the invariant the other three paths already maintained.
2. **`_recordDuplicate` emits `engram_duplicate_absorbed`**, with a truncated preview of the incoming statement. It previously wrote **nothing** to history, which is why a misdirected absorption could run for months unseen. The preview is what makes a *wrong* absorption distinguishable from a legitimate duplicate.

## Deliberately not in scope

- **`plur_learn`'s hardcoded `decision: 'ADD'`** in `tools.ts` actively misreports a NOOP-shaped outcome. Response-shape change; belongs with #878.
- **The 38 stale / 961 missing hashes already in stores.** The source is fixed so no new ones appear, but existing attractors persist until repaired. That wants an explicit command rather than a silent rewrite on read — proposed as `plur reindex-hashes`, sibling to `reindex-tokens`, with `plur doctor` detecting and reporting read-only.

## Verification

- 4 tests, including that a genuine duplicate is **still** absorbed and still counted
- `@plur-ai/core` **2803 passed**, `core-pglite` + `mcp` **436 passed**, `typecheck:tests` clean
- **Revert-checked**: removing the history event fails 2 tests, including the one reproducing the reported failure