### PR TITLE
feat(cli): plur reindex-hashes — repair engrams whose content_hash is stale

### DIFF
--- a/packages/cli/src/commands/reindex-hashes.ts
+++ b/packages/cli/src/commands/reindex-hashes.ts
@@ -1,0 +1,121 @@
+/**
+ * `plur reindex-hashes` — repair engrams whose `content_hash` no longer
+ * describes their statement (#852).
+ *
+ * ## Why this needs a command rather than a background fix
+ *
+ * `content_hash` is what `_hashDedup` matches on. An engram whose hash points at
+ * text it no longer contains becomes an ATTRACTOR: a later write matching that
+ * old text hash-matches it and is absorbed into an engram that now says
+ * something else. Each absorption raises its `write_count`, making it a stronger
+ * attractor still.
+ *
+ * The source of the drift is fixed — procedure evolution now recomputes the
+ * hash, as the UPDATE and MERGE paths always did — so no NEW stale hashes
+ * appear. But the ones already on disk stay until something rewrites them, and
+ * they keep absorbing writes in the meantime.
+ *
+ * ## Why not silently, on read
+ *
+ * Recomputing during `loadEngrams` would fix it invisibly and is exactly the
+ * wrong shape: it mutates the YAML source of truth as a side effect of reading,
+ * which is the class of behaviour #766 and #794 exist because of. It would also
+ * hide the count, and the count is the interesting part — 38 stale hashes in one
+ * store is a finding, not a chore.
+ *
+ * ## Why not under `plur doctor`
+ *
+ * `doctor` diagnoses INTEGRATION (Claude Code / Desktop wiring, MCP entries,
+ * embedder health) and has no repair mode at all. This rewrites stored engrams.
+ * Putting a store rewrite behind the command people run casually to check their
+ * setup is the wrong affordance. `doctor` reports; this repairs — the same split
+ * `reindex-tokens` already established.
+ */
+import type { GlobalFlags } from '../plur.js'
+import { computeContentHash, detectPlurStorage, loadEngrams, saveEngrams } from '@plur-ai/core'
+import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+
+function usage(): never {
+  exit(1, [
+    'Usage:',
+    '  plur reindex-hashes            Report engrams whose content_hash is stale or missing',
+    '  plur reindex-hashes --apply    Rewrite them',
+    '',
+    'A stale content_hash makes an engram absorb unrelated writes (#852).',
+    'Runs read-only by default: nothing is written without --apply.',
+  ].join('\n'))
+}
+
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) usage()
+  const apply = args.includes('--apply')
+
+  // Read the RAW store, not `Plur.list()`.
+  //
+  // `list()` goes through `_filterEngrams`, which merges PACKS in and drops
+  // inactive/expired engrams. Measured against this store, that gave 5,388
+  // scanned / 1 stale / 1,805 missing, where the file itself holds 4,642 / 38 /
+  // 961 — it counted pack entries this command does not own as "missing", and
+  // hid stale rows on retired engrams. For a repair pass that is not a cosmetic
+  // difference: writes would go somewhere other than the file carrying the
+  // problem.
+  const paths = detectPlurStorage(flags.path || process.env.PLUR_PATH || undefined)
+  const engrams = loadEngrams(paths.engrams)
+
+  const stale: Array<{ id: string; statement: string }> = []
+  const missing: Array<{ id: string; statement: string }> = []
+  for (const e of engrams) {
+    if (!e.statement) continue
+    const current = (e as { content_hash?: string }).content_hash
+    if (!current) missing.push({ id: e.id, statement: e.statement })
+    else if (current !== computeContentHash(e.statement)) stale.push({ id: e.id, statement: e.statement })
+  }
+
+  // Reported separately on purpose: they are different conditions. A STALE hash
+  // is actively wrong and absorbs writes today. A MISSING one predates the
+  // field and is inert until something matches on it. One number would
+  // overstate the second and bury the first.
+  let repaired = 0
+  if (apply && (stale.length > 0 || missing.length > 0)) {
+    const target = new Set([...stale, ...missing].map(e => e.id))
+    for (const e of engrams) {
+      if (!target.has(e.id) || !e.statement) continue
+      ;(e as { content_hash?: string }).content_hash = computeContentHash(e.statement)
+      repaired++
+    }
+    // Same count in, same count out — this only ever rewrites a field.
+    saveEngrams(paths.engrams, engrams)
+  }
+
+  if (shouldOutputJson(flags)) {
+    outputJson({
+      scanned: engrams.length,
+      stale: stale.length,
+      missing: missing.length,
+      repaired,
+      applied: apply,
+      stale_ids: stale.slice(0, 50).map(e => e.id),
+    })
+    return
+  }
+
+  if (stale.length === 0 && missing.length === 0) {
+    outputText(`Scanned ${engrams.length} engrams — every content_hash matches its statement.`)
+    return
+  }
+
+  const lines = [
+    `Scanned ${engrams.length} engrams.`,
+    `  stale   ${String(stale.length).padStart(5)}  hash does not match the statement — these absorb unrelated writes (#852)`,
+    `  missing ${String(missing.length).padStart(5)}  no hash at all — inert until something matches on them`,
+  ]
+  if (stale.length > 0) {
+    lines.push('', 'Stale:')
+    for (const e of stale.slice(0, 10)) lines.push(`  ${e.id}  ${e.statement.slice(0, 68)}`)
+    if (stale.length > 10) lines.push(`  … and ${stale.length - 10} more`)
+  }
+  lines.push('', apply
+    ? `Repaired ${repaired}.`
+    : 'Run with --apply to rewrite them. Nothing has been written.')
+  outputText(lines.join('\n'))
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,7 @@ Commands:
   scopes                  List authorized-but-unregistered shared scopes (#647)
   scopes register <scope> Register one; scopes dismiss <scope>; scopes --reoffer
   reindex-tokens          Re-derive BM25 tokens after a tokenizer change (Postgres only)
+  reindex-hashes          Repair engrams whose content_hash is stale or missing (#852)
   init                    Install Claude Code hooks + register plur MCP server
   init-remote             Opt this project into recall from a PLUR Enterprise server
   login --status          Enterprise token validity per host (probe + expiry) (#587)
@@ -114,6 +115,7 @@ const COMMANDS: Record<string, string> = {
   stores: './commands/stores.js',
   scopes: './commands/scopes.js',
   'reindex-tokens': './commands/reindex-tokens.js',
+  'reindex-hashes': './commands/reindex-hashes.js',
   migrate: './commands/migrate.js',
   init: './commands/init.js',
   'init-remote': './commands/init-remote.js',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,13 @@ export type { MetaField, StructuralTemplate, EvidenceEntry, MetaConfidence, Doma
 export { MetaFieldSchema, StructuralTemplateSchema, EvidenceEntrySchema, MetaConfidenceSchema, DomainCoverageSchema, HierarchyPositionSchema, FalsificationSchema } from './schemas/meta-engram.js'
 export { engramSearchText, termMatches, computeIdf, type CorpusStats } from './fts.js'
 export { EngramStoreUnreadableError, EngramStoreShrinkError } from './engrams.js'
+// Exported for store-repair tooling (#852's `plur reindex-hashes`), which must
+// read the RAW store rows. `Plur.list()` goes through `_filterEngrams`, which
+// merges packs in and drops inactive/expired engrams — fine for recall, wrong
+// for a repair pass, which would then miss stale rows and try to "fix" pack
+// entries it does not own. Exposing the existing loader rather than letting a
+// caller write a fourth one is the whole point of #877.
+export { loadEngrams, saveEngrams } from './engrams.js'
 export {
   maybeDailyBackup,
   listBackups,


### PR DESCRIPTION
Follow-up to #852, which fixed the *source* of hash drift. This repairs rows already on disk.

```
$ plur reindex-hashes
{"scanned":4642,"stale":1,"missing":961,"repaired":0,"applied":false,"stale_ids":["ENG-2026-0524-007"]}
```

Read-only by default; `--apply` rewrites.

## It reads the raw store, and that took two attempts

The first version used `Plur.list()`. That goes through `_filterEngrams`, which merges **packs** in and drops **inactive/expired** rows. Measured against a real store:

| | `Plur.list()` | the file |
|---|---|---|
| scanned | 5,388 | 4,642 |
| missing | 1,805 | 961 |

It counted pack entries this command does not own, and hid rows on retired engrams. For a *reporting* command that is a wrong number; for a **repair** command it is worse — writes would land somewhere other than the file carrying the problem. It now uses `loadEngrams`, and the counts match the file exactly.

`loadEngrams` / `saveEngrams` are exported from core for this. Exposing the existing loader rather than letting the CLI write a fourth one is the point of #877.

## Stale and missing are reported separately

Different conditions, and collapsing them would mislead in both directions. A **stale** hash is actively wrong and absorbs writes today. A **missing** one predates the field and is inert until something matches on it. 961 missing is not 961 problems.

## Not under `plur doctor`

`doctor` diagnoses *integration* — Claude Code / Desktop wiring, MCP entries, embedder health — and has no repair mode at all. This rewrites stored engrams. Putting a store rewrite behind the command people run casually to check their setup is the wrong affordance. Same diagnose/repair split `reindex-tokens` already established.

(A grouped `Diagnose` / `Repair` / `Sync` help layout is proposed separately — headings rather than a rename, so `reindex-tokens` keeps working.)

## Note on the numbers

An earlier comment on #852 said 38 stale. That was a **measurement error**, corrected on the issue: my scan used Python's Unicode-aware `\w` where JavaScript's is ASCII-only. The true figure is 1 — and the discrepancy turned out to be a real defect in its own right, now #896.

## Verification

- **3,246 passed**, `typecheck:tests` clean
- Run read-only against a real 4,642-engram store; counts match a direct file scan exactly