### PR TITLE
fix(core): eleven defects from the post-merge audit of today's 27 PRs

### DIFF
--- a/docs/audits/2026-08-13-post-merge-audit.md
+++ b/docs/audits/2026-08-13-post-merge-audit.md
@@ -1,0 +1,228 @@
+# Post-merge audit — `03f441b..82e50d2`
+
+**Scope:** 27 PRs merged 2026-08-13, 82 files, +6150/−233.
+**Method:** three independent passes, run in parallel and blind to each other —
+a data-loss audit of the write paths (precedent:
+`2026-08-02-store-write-path-data-loss.md`), an adversarial pass on the diff
+(precedent: `2026-08-03-fix-diff-adversarial.md`), and an evaluator panel
+(critic / dijkstra / popper / taleb).
+
+Every finding below was **reproduced before being fixed**, and every fix carries
+a test that **fails when the fix is reverted**. Where a first draft of a test
+passed with its fix reverted, that is recorded in the test file rather than
+quietly corrected — three tests in this batch needed a second attempt.
+
+## Why so much was found
+
+The day's stated through-line was that most defects *report success while doing
+the wrong thing*. The diagnosis was right; the execution reproduced the same
+class **inside three of the fixes**:
+
+| Fix | How it reported success while doing the wrong thing |
+|---|---|
+| #897 `reindex-hashes` | printed "every content_hash matches its statement" on a store silently collapsing all non-Latin memory into one row, and destroyed concurrent writes while doing it |
+| #855 `forget` scope guard | accepted `scope: "local"` — meaning "the local one" — and issued a remote DELETE, reporting success |
+| #863 supersedes flush | printed "flush again once X has been pushed" for an X that had already been pushed and could never be pushed again |
+
+Twenty-seven PRs in a day is more than they can review each other.
+
+## Findings and dispositions
+
+Severity is blast radius, not effort.
+
+### 1. Non-Latin statements collapse into a single engram — CRITICAL, shipped
+
+`normalizeStatement` used ASCII `\w`, so `[^\w\s]` stripped every letter outside
+unaccented Latin. Measured on the shipped build:
+
+```
+'データベースの設定を確認'  → ''  → e3b0c442…   (SHA-256 of the empty string)
+'도커를 사용해야 한다'       → ''  → e3b0c442…
+'развертывание должно'    → ''  → e3b0c442…
+```
+
+Every non-Latin statement carried the **same** `content_hash`, so
+`findActiveByContentHash` matched them to each other and dedup absorbed them.
+End to end: four unrelated facts written, one engram stored, `write_count: 4`,
+four reported successes. For a product whose job is memory, this is the worst
+failure available.
+
+**Fixed** — `\p{L}\p{N}\p{M}_` (`\p{M}` is load-bearing: Devanagari and Thai
+vowel signs are nonspacing marks). Plus `isHashable()`, wired into all three
+dedup entry points, so a statement with no hashable content can never match
+another. Filed as #896 the same day; the repair command shipped ten minutes
+later without it.
+
+*Migration:* ASCII statements hash identically, so most stored hashes do not
+move. A statement in any other script now hashes differently — which makes its
+stored hash stale, which is what `plur reindex-hashes` repairs. Run it after
+upgrading.
+
+### 2. `reindex-hashes --apply` destroyed concurrent writes — CRITICAL, shipped
+
+Unlocked whole-corpus read-modify-write: load without a lock, hash, save the
+pre-load snapshot back. Reproduced **6/6** on a 4,642-engram store — a correctly
+locked writer appends between the two and its engram is gone. Three protections
+every other whole-corpus writer has were all absent: no lock, no daily backup
+(`_maybeDailyBackup` fires from *inside* `_withStoreLock`), and the shrink guard
+cannot see it because the same count goes out that came in. Zero tests on the
+destructive path.
+
+**Fixed** — the scan and write moved into `Plur.repairContentHashes()`, behind
+`_withStoreLock` and the `_loadTargeted`/`_updateEngrams` capability pair. This
+also fixes a false all-clear: reading `paths.engrams` directly reported "0
+engrams, all clean" for an injected non-YAML primary store. `--apply` now also
+**refuses** to write a hash for a statement that normalizes to nothing, and
+reports those separately — the previous version would have stamped the shared
+empty-string hash onto the 961 rows it had just called inert.
+
+### 3. A local scope routed to a remote DELETE — CRITICAL, shipped
+
+`forget()` validated `primary | local | global | project:*` as targets and then
+guarded only `targetScope === 'primary'` before the remote walk:
+
+```
+scope="global"      threw=null  remote DELETEs=1   ← wrong-target retire, reported success
+scope="local"       threw=null  remote DELETEs=1
+scope="project:foo" threw=null  remote DELETEs=1
+scope="primary"     threw        remote DELETEs=0  (control)
+```
+
+Three of the four targets its own error message advertises destroyed a remote
+engram when the caller had said "the local one". `feedback()` had no such guard
+at all. This is #831 verbatim, reached from the direction #855 documented itself
+as closing — and #855 explicitly asked for a shared helper that was never built.
+**The drift was the bug.**
+
+**Fixed** — `src/scope-target.ts` owns the predicate and the validation; both
+call sites use it and neither can drift again.
+
+### 4. Unbounded network call inside the store lock — HIGH
+
+`RemoteStore.existsById` used a bare `fetch` with no `AbortSignal`, and both
+callers run it *inside* the primary store lock, one probe per remote. undici's
+default `headersTimeout` is 300s; `DEFAULT_ACQUIRE_TIMEOUT` is 180s. A host that
+completes its handshake and stalls therefore makes every waiting `plur_learn`
+throw "Failed to acquire lock" — the engram silently never stored.
+
+**Fixed** — bounded with the same `LOAD_FETCH_TIMEOUT_MS` budget `load()` uses,
+and an abort surfaces as "cannot tell" rather than "absent", which is the whole
+point of the method.
+
+### 5. Supersedes flush order was not a sort — HIGH
+
+`pending.sort((a, b) => aDependsOnB - bDependsOnA)` returns non-zero only for
+directly related pairs, so it is not a strict weak ordering. All four of #863's
+fixtures used exactly two pending engrams — the one size at which a comparator
+and a topological sort cannot disagree. With three, the flush pushed a
+correction before its own target, then failed **identically on every subsequent
+flush**, printing a remediation that could not be followed: the target *had*
+been pushed, its local row spliced out, and `localToServer` was per-flush.
+
+**Fixed** — `src/outbox-order.ts` (Kahn's algorithm, stable, cycles appended
+rather than dropped so they are refused out loud), plus a bounded persisted
+local→server id map so an edge whose target left in an earlier flush still
+resolves.
+
+### 6. `inject()` became a whole-corpus writer — MEDIUM
+
+The #866 `injection_count` block loaded and rewrote the entire corpus, under the
+global lock, on a path that runs at **every session start**:
+
+| corpus | with | without | overhead |
+|---|---|---|---|
+| 200 | 48 ms | 11 ms | 4.4× |
+| 2,000 | 442 ms | 42 ms | 10.5× |
+| 10,000 | **2,804 ms** | 142 ms | **19.7×** |
+
+Its `catch {}` also swallowed `EngramStoreShrinkError` and
+`EngramStoreUnreadableError` — the #795/#800 integrity guards, muted on the most
+frequently run write path.
+
+**Fixed** — targeted update via the capability pair; integrity errors warn
+instead of vanishing.
+
+### 7. Outbox merge-back reverted concurrent changes — MEDIUM
+
+`merged = fresh.map(e => survivorsById.get(e.id) ?? e)` replaced the fresh row
+with a snapshot taken *before* the network round-trips, so any concurrent change
+to a queued engram — feedback counter, activation bump, pin, rescope — was
+reverted. Pre-existing; #785's cooldown narrows the window without closing it.
+
+**Fixed** — field merge (`_outbox`, `_demoted`, and `scope`/`visibility` for the
+ids this flush actually demoted) onto the fresh row.
+
+### 8. Circuit breaker wrote to two different files — MEDIUM
+
+The recall leg passes `remoteHealthStatePath()` (from `paths.root`); the write
+leg took the default (from `PLUR_PATH`). Different files for `new Plur({ path
+})`, `plur --path`, and every embedded consumer — so #785's "one host, one
+opinion" held only by coincidence of a fixture that set both to the same
+directory.
+
+**Fixed**, with a test that sets them differently.
+
+### 9. Tokenizer split Japanese loanwords — MEDIUM
+
+`SPACELESS_RUN` used `\p{Script=…}`. U+30FC ー, the prolonged sound mark in
+essentially every Japanese loanword, is `Script=Common`, so it terminated the
+run: `コンピューター` → `["ーター","コン","ンピ","ピュ"]`, and a query for
+`ベース` did not match a document containing it. #833's before/after table
+happened to use a word with no prolonged mark.
+
+**Fixed** — `Script_Extensions`, which also covers the Han iteration mark 々.
+`TOKENIZER_VERSION` 3 → 4, and the version history now records entry 3, which
+#833 bumped without documenting.
+
+### 10. `searchBM25Exhaustive` missing from the readonly whitelist — MEDIUM
+
+#753 added it to the query-adapter surface hours after #830's whitelist landed.
+`ReadonlyStoreGuard` dropped it, so a read-only Postgres store kept widening 3L
+→ 9L → 27L and re-ranked the same rows twice more. The file's own argument for
+the whitelist shape — "a missed entry loses functionality **and someone
+notices**" — was falsified in the same batch, because a silent 2–3× cost
+regression is not a crash.
+
+**Fixed**, and the header claim corrected. The test now enumerates the surface
+so the next member fails on the day it lands.
+
+### 11. Quarantine re-read documented but not implemented — LOW
+
+`saveEngrams` re-attaches quarantine from the module map populated by the last
+`loadEngrams` *in this process*; the comment claimed it re-reads the file.
+Every in-tree writer satisfies the implied precondition, so this was a
+documentation defect, not a live one — but the invariant was a comment rather
+than code.
+
+**Fixed** — restated as the precondition it actually is.
+
+## Verified sound
+
+Attacked and did not break: `reindex-hashes` quarantine round-trip (byte
+identical); `normalizeEngramInput` never applied to quarantined entries; the
+#866 `reference_count` → `write_count` rename cannot newly quarantine a row;
+PGLite and Postgres `parseRow` cannot drop a row; `RemoteStore.reshape` cannot
+newly return null; `rescope` outbox cancellation loses no other structured-data
+keys; no `flushOutbox` `continue` drops an engram or its `_outbox`; `forget`'s
+already-retired short-circuit skips no write that should have happened; the
+historical unreadable-as-empty and undeclared-empty-corpus failure modes are not
+reintroduced.
+
+**Revert-checks spot-checked independently:** six of six honest, including the
+exact claimed failure counts (#883, #884, #886, #888, #891, #879).
+
+## Left open
+
+- **#816 — id reuse.** Ids derive from the store's high-water mark, which is not
+  persisted, so an outbox flush that empties the local store lets the next
+  engram be minted the id a flushed one had. Surfaced while writing the
+  cross-flush supersedes test, which has to hold the sequence up by hand.
+- **`plur_learn`'s hardcoded `decision: 'ADD'`.** #894 deferred it as a
+  "response-shape change"; #895 changed that exact response shape 40 minutes
+  later. Tracked in #878.
+- **`reactivate()` is `x = x`** at its only production call site. Dead code
+  after #888, and the ranking blast radius of freezing `retrieval_strength` for
+  unrated engrams is not yet characterised.
+- **ADR-0006 is still `Proposed`.** It correctly names the class this audit kept
+  finding; the same day's merges violated two of its three clauses, which is an
+  argument for ratifying it.

--- a/packages/cli/src/commands/reindex-hashes.ts
+++ b/packages/cli/src/commands/reindex-hashes.ts
@@ -30,9 +30,19 @@
  * Putting a store rewrite behind the command people run casually to check their
  * setup is the wrong affordance. `doctor` reports; this repairs — the same split
  * `reindex-tokens` already established.
+ *
+ * ## Why this file is thin
+ *
+ * The scan and the write live in `Plur.repairContentHashes()`, not here. This
+ * command's first cut did `loadEngrams` → mutate → `saveEngrams` inline, which
+ * is an UNLOCKED whole-corpus read-modify-write: the 2026-08-13 data-loss audit
+ * reproduced it destroying a concurrent writer's engram 6/6 on a real-sized
+ * store. Going through the engine gets the store lock, the #799 daily backup,
+ * and a targeted UPDATE on stores that support one — and it means the repair
+ * also reaches an injected non-YAML primary store, which reading
+ * `paths.engrams` directly never could.
  */
-import type { GlobalFlags } from '../plur.js'
-import { computeContentHash, detectPlurStorage, loadEngrams, saveEngrams } from '@plur-ai/core'
+import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
 
 function usage(): never {
@@ -50,69 +60,46 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) usage()
   const apply = args.includes('--apply')
 
-  // Read the RAW store, not `Plur.list()`.
-  //
-  // `list()` goes through `_filterEngrams`, which merges PACKS in and drops
-  // inactive/expired engrams. Measured against this store, that gave 5,388
-  // scanned / 1 stale / 1,805 missing, where the file itself holds 4,642 / 38 /
-  // 961 — it counted pack entries this command does not own as "missing", and
-  // hid stale rows on retired engrams. For a repair pass that is not a cosmetic
-  // difference: writes would go somewhere other than the file carrying the
-  // problem.
-  const paths = detectPlurStorage(flags.path || process.env.PLUR_PATH || undefined)
-  const engrams = loadEngrams(paths.engrams)
-
-  const stale: Array<{ id: string; statement: string }> = []
-  const missing: Array<{ id: string; statement: string }> = []
-  for (const e of engrams) {
-    if (!e.statement) continue
-    const current = (e as { content_hash?: string }).content_hash
-    if (!current) missing.push({ id: e.id, statement: e.statement })
-    else if (current !== computeContentHash(e.statement)) stale.push({ id: e.id, statement: e.statement })
-  }
-
-  // Reported separately on purpose: they are different conditions. A STALE hash
-  // is actively wrong and absorbs writes today. A MISSING one predates the
-  // field and is inert until something matches on it. One number would
-  // overstate the second and bury the first.
-  let repaired = 0
-  if (apply && (stale.length > 0 || missing.length > 0)) {
-    const target = new Set([...stale, ...missing].map(e => e.id))
-    for (const e of engrams) {
-      if (!target.has(e.id) || !e.statement) continue
-      ;(e as { content_hash?: string }).content_hash = computeContentHash(e.statement)
-      repaired++
-    }
-    // Same count in, same count out — this only ever rewrites a field.
-    saveEngrams(paths.engrams, engrams)
-  }
+  // `readonly: true` without `--apply` is not cosmetic: it makes the reporting
+  // mode structurally incapable of writing, so a scan cannot be the thing that
+  // damages a store the user ran it to inspect.
+  const plur = createPlur(flags, apply ? undefined : { readonly: true })
+  const { scanned, stale, missing, unhashable, repaired } = await plur.repairContentHashes({ apply })
 
   if (shouldOutputJson(flags)) {
     outputJson({
-      scanned: engrams.length,
+      scanned,
       stale: stale.length,
       missing: missing.length,
+      unhashable: unhashable.length,
       repaired,
       applied: apply,
       stale_ids: stale.slice(0, 50).map(e => e.id),
+      unhashable_ids: unhashable.slice(0, 50).map(e => e.id),
     })
     return
   }
 
-  if (stale.length === 0 && missing.length === 0) {
-    outputText(`Scanned ${engrams.length} engrams — every content_hash matches its statement.`)
+  if (stale.length === 0 && missing.length === 0 && unhashable.length === 0) {
+    outputText(`Scanned ${scanned} engrams — every content_hash matches its statement.`)
     return
   }
 
   const lines = [
-    `Scanned ${engrams.length} engrams.`,
-    `  stale   ${String(stale.length).padStart(5)}  hash does not match the statement — these absorb unrelated writes (#852)`,
-    `  missing ${String(missing.length).padStart(5)}  no hash at all — inert until something matches on them`,
+    `Scanned ${scanned} engrams.`,
+    `  stale      ${String(stale.length).padStart(5)}  hash does not match the statement — these absorb unrelated writes (#852)`,
+    `  missing    ${String(missing.length).padStart(5)}  no hash at all — inert until something matches on them`,
+    `  unhashable ${String(unhashable.length).padStart(5)}  statement normalizes to nothing — SKIPPED, a shared hash is worse than none (#896)`,
   ]
   if (stale.length > 0) {
     lines.push('', 'Stale:')
     for (const e of stale.slice(0, 10)) lines.push(`  ${e.id}  ${e.statement.slice(0, 68)}`)
     if (stale.length > 10) lines.push(`  … and ${stale.length - 10} more`)
+  }
+  if (unhashable.length > 0) {
+    lines.push('', 'Unhashable (not written):')
+    for (const e of unhashable.slice(0, 10)) lines.push(`  ${e.id}  ${e.statement.slice(0, 68)}`)
+    if (unhashable.length > 10) lines.push(`  … and ${unhashable.length - 10} more`)
   }
   lines.push('', apply
     ? `Repaired ${repaired}.`

--- a/packages/core/src/content-hash.ts
+++ b/packages/core/src/content-hash.ts
@@ -3,13 +3,49 @@ import { createHash } from 'crypto'
 /**
  * Normalize a statement for hash comparison:
  * - lowercase
- * - collapse whitespace
  * - strip punctuation
+ * - collapse whitespace
+ *
+ * ## Why the character class is Unicode and not `\w` (#896)
+ *
+ * This used ASCII `\w` (`[A-Za-z0-9_]`), so `[^\w\s]` stripped every letter
+ * that is not an unaccented Latin one. The consequence was not a cosmetic
+ * difference in a hash — it destroyed memory. Measured on the shipped build:
+ *
+ *     'データベースの設定を確認'  → ''  → e3b0c44298fc… (SHA-256 of the empty string)
+ *     '도커를 사용해야 한다'       → ''  → e3b0c44298fc…
+ *     'развертывание должно'    → ''  → e3b0c44298fc…
+ *
+ * Every statement written in a non-Latin script normalized to the SAME empty
+ * string, so `findActiveByContentHash` matched them to each other and the
+ * dedup path absorbed them into one engram. Four unrelated facts in, one row
+ * out, `write_count: 4`, reported as four successful writes. Accented Latin
+ * degraded more quietly but in the same direction: `déploiement` →
+ * `dploiement`, which is merely wrong rather than catastrophic — and which is
+ * what made a Python cross-check of this function disagree with the real one,
+ * since Python's `\w` IS Unicode-aware and JavaScript's is not.
+ *
+ * `\p{L}\p{N}\p{M}` is letters, numbers and combining marks in any script.
+ * `\p{M}` matters on its own: without it, Devanagari and Thai vowel signs are
+ * stripped from words whose consonants survive, silently merging distinct
+ * words. `_` is kept explicitly because `\w` included it and dropping it would
+ * change `snake_case` identifiers, which are common in these statements.
+ *
+ * ## Effect on stored hashes
+ *
+ * For a statement of ASCII letters, digits, `_` and punctuation the output is
+ * byte-identical to the old one, so the overwhelming majority of stored hashes
+ * are unaffected. A statement containing any other letter now hashes
+ * DIFFERENTLY, which makes its stored `content_hash` stale — the condition
+ * `plur reindex-hashes` exists to repair. Run it after upgrading; that is the
+ * intended migration, and it is why the two shipped together.
  */
+const NON_WORD = /[^\p{L}\p{N}\p{M}_\s]/gu
+
 export function normalizeStatement(statement: string): string {
   return statement
     .toLowerCase()
-    .replace(/[^\w\s]/g, '')
+    .replace(NON_WORD, '')
     .replace(/\s+/g, ' ')
     .trim()
 }
@@ -17,8 +53,26 @@ export function normalizeStatement(statement: string): string {
 /**
  * Compute SHA256 content hash of a normalized statement.
  * Used for fast exact-duplicate detection (Idea 29).
+ *
+ * A statement that normalizes to the empty string (all punctuation, all emoji)
+ * hashes to the SHA-256 of `''`, which every other such statement also hashes
+ * to. That is not a bug in the hash — there is genuinely no content to key on
+ * — but it does mean the value is not usable for dedup. Callers that write or
+ * match on hashes must treat "normalizes to empty" as "no hash"; see
+ * {@link isHashable} and `Plur.repairContentHashes`.
  */
 export function computeContentHash(statement: string): string {
   const normalized = normalizeStatement(statement)
   return createHash('sha256').update(normalized).digest('hex')
+}
+
+/**
+ * Whether a statement has enough content for its hash to identify it.
+ *
+ * False only for statements that normalize away entirely. Before #896 this was
+ * true of every non-Latin statement in the store, which is how the collapse
+ * happened; now it is the narrow case it was always meant to be.
+ */
+export function isHashable(statement: string): boolean {
+  return normalizeStatement(statement).length > 0
 }

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -254,9 +254,17 @@ export function loadEngrams(filePath: string): Engram[] {
  * opaque payload they never inspect would be far more invasive — and far easier
  * to get wrong — than one map keyed on the thing they already agree about.
  *
- * A stale entry cannot cause loss: `saveEngrams` re-reads the file's current
- * quarantine before writing, and an id that has since become valid is
- * de-duplicated against the outgoing array.
+ * PRECONDITION, not a self-healing property: a writer must `loadEngrams` the
+ * same path before it saves. `saveEngrams` re-attaches whatever this map holds
+ * for that path from the last load IN THIS PROCESS — it does not re-parse the
+ * file, and an earlier version of this comment claimed it did (2026-08-13
+ * data-loss audit, F6). Every in-tree writer satisfies the precondition
+ * because they all load under the lock immediately before saving, so the
+ * entries are fresh in practice; the point of stating it as a precondition is
+ * that a future writer which saves WITHOUT a preceding load would either
+ * re-inject a stale quarantine set or, with an empty map, drop quarantined
+ * rows. An id that has since become valid is de-duplicated against the
+ * outgoing array, so the failure mode is confined to that one case.
  */
 const quarantineByPath = new Map<string, unknown[]>()
 

--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -44,8 +44,16 @@ export const MIN_TOKEN_LENGTH = 2
  * History:
  *   1 — original. `\w`-based word split, three-character floor, stop words.
  *   2 — #782. Han runs additionally indexed as overlapping character bigrams.
+ *   3 — #833. Unicode character class (`\p{L}\p{N}\p{M}`), space-less-run
+ *       bigrams widened past Han, two-character floor for dense scripts.
+ *   4 — 2026-08-13 panel. `Script_Extensions` rather than `Script` for the
+ *       space-less run, so characters that belong to a script without BEING
+ *       that script join their run instead of splitting it.
+ *
+ * (Entry 3 is retrospective: #833 bumped the constant to 3 and did not record
+ * why, which is the one thing this ledger exists to prevent.)
  */
-export const TOKENIZER_VERSION = 3
+export const TOKENIZER_VERSION = 4
 
 /** Tokenize text into searchable terms */
 /**
@@ -54,15 +62,30 @@ export const TOKENIZER_VERSION = 3
  * #782 covered Han only. These are indexed as character BIGRAMS rather than
  * words, because there is no whitespace to split on and a per-language
  * segmenter is a dependency this package will not take.
+ *
+ * `Script_Extensions`, NOT `Script` (2026-08-13 panel). A character's `Script`
+ * is its single primary script; its `Script_Extensions` is every script that
+ * USES it. The difference is not academic — U+30FC ー, the prolonged sound mark
+ * in essentially every Japanese loanword, has `Script=Common`, so under
+ * `Script` it terminated the run:
+ *
+ *     ftsTokenize('コンピューター')  →  ["ーター","コン","ンピ","ピュ"]
+ *
+ * …which indexes fragments split at the wrong place, so a query for ベース did
+ * not match a document containing it. `Script_Extensions=Katakana` includes
+ * U+30FC, and the same correction covers the Han iteration mark 々, the
+ * Japanese/Korean iteration and repetition marks, and Thai's THANTHAKHAT.
+ * #833's before/after table happened to use テストデプロイ, which contains no
+ * prolonged mark, so the hole survived the review that introduced it.
  */
-const SPACELESS_RUN = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Thai}\p{Script=Khmer}\p{Script=Lao}\p{Script=Myanmar}]{2,}/gu
+const SPACELESS_RUN = /[\p{Script_Extensions=Han}\p{Script_Extensions=Hiragana}\p{Script_Extensions=Katakana}\p{Script_Extensions=Thai}\p{Script_Extensions=Khmer}\p{Script_Extensions=Lao}\p{Script_Extensions=Myanmar}]{2,}/gu
 
 /**
  * Scripts whose words are routinely one or two characters, so the Latin-shaped
  * `length > 2` floor erases them (#833). Korean is the reported case:
  * 도커 ("docker") is two syllable blocks and vanished entirely.
  */
-const DENSE_SCRIPT = /[\p{Script=Hangul}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u
+const DENSE_SCRIPT = /[\p{Script_Extensions=Hangul}\p{Script_Extensions=Han}\p{Script_Extensions=Hiragana}\p{Script_Extensions=Katakana}]/u
 
 export function ftsTokenize(text: string): string[] {
   const lower = text.toLowerCase()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,7 +38,9 @@ import type { SecretMatch } from './secrets.js'
 import { SENSITIVITY_CATEGORIES, type ScopeMetadata, type SensitivityCategory } from './schemas/scope-metadata.js'
 import { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
 import { appendHistory, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, type InjectionEventCounts } from './history.js'
-import { computeContentHash } from './content-hash.js'
+import { computeContentHash, isHashable } from './content-hash.js'
+import { isLocalOnlyScope, assertScopeNamesATarget } from './scope-target.js'
+import { orderBySupersedes } from './outbox-order.js'
 import { loadTensions, loadTensionsWithQuarantine, saveTensions, generateTensionId, tensionPairKey, categorizeTension } from './tension-store.js'
 import type { TensionRecord, TensionStatus } from './schemas/tension.js'
 import type { TensionPair } from './tensions.js'
@@ -118,7 +120,9 @@ export { computeReceipt } from './receipt.js'
 export type { Receipt, ReceiptInput, ReceiptTopEntry } from './receipt.js'
 import type { Receipt } from './receipt.js'
 import { gatherReceipt } from './receipt-io.js'
-export { computeContentHash, normalizeStatement } from './content-hash.js'
+export { computeContentHash, normalizeStatement, isHashable } from './content-hash.js'
+export { isLocalOnlyScope, assertScopeNamesATarget } from './scope-target.js'
+export { orderBySupersedes } from './outbox-order.js'
 export { parseDedupResponse, buildDedupPrompt, buildBatchDedupPrompt } from './dedup.js'
 export { runMigrations, rollbackMigrations, getSchemaVersion, setSchemaVersion, ALL_MIGRATIONS, CURRENT_SCHEMA_VERSION, type Migration, type MigrationResult } from './migrations/index.js'
 export { detectSecrets, detectSensitive, sensitivityCategory } from './secrets.js'
@@ -585,6 +589,15 @@ export const COMMITMENT_MULTIPLIER: Record<string, number> = {
  * (5 min) that three failures inside it still mean "the LLM is broken", and
  * short enough that three failures spread across an afternoon do not.
  */
+/**
+ * Cap on the persisted outbox local→server id map.
+ *
+ * One row per remote write, forever, unless bounded. Sized so a busy install
+ * keeps months of mappings while the file stays well under a megabyte —
+ * comfortably more history than the queued-correction case that needs it.
+ */
+const OUTBOX_ID_MAP_MAX = 5000
+
 const LLM_BREAKER_THRESHOLD = 3
 const LLM_BREAKER_WINDOW_MS = 5 * 60 * 1000
 const LLM_BREAKER_COOLDOWN_MS = 60 * 60 * 1000
@@ -1528,8 +1541,17 @@ export class Plur {
 
   /** Content hash fast-path dedup. Scope-aware: same statement in a different
    * scope is a promotion, not a duplicate. Retired engrams are excluded —
-   * re-learning a retired statement creates a fresh engram (issue #107). */
+   * re-learning a retired statement creates a fresh engram (issue #107).
+   *
+   * A statement with no hashable content never matches (#896). Every such
+   * statement hashes to the SHA-256 of the empty string, so matching on it
+   * declares unrelated facts to be the same fact — which is exactly how the
+   * non-Latin collapse absorbed four distinct memories into one row. The
+   * normalizer no longer produces that for real prose; this is the belt to its
+   * braces, and it fails in the safe direction (a missed dedup costs a
+   * duplicate row, a false dedup costs the memory). */
   private _hashDedup(statement: string, engrams: Engram[], scope?: string): Engram | null {
+    if (!isHashable(statement)) return null
     const hash = computeContentHash(statement)
     for (const e of engrams) {
       if (e.status === 'active' && (e as any).content_hash === hash) {
@@ -1625,6 +1647,11 @@ export class Plur {
     engrams: Engram[],
     currentScope: string,
   ): Engram | null {
+    // Same guard as `_hashDedup` (#896): an unhashable statement would report
+    // every other unhashable statement as the same fact recurring, and this
+    // path ESCALATES on a hit — broadening scope to global and hardening
+    // commitment. A false positive here is louder than a missed one.
+    if (!isHashable(statement)) return null
     const hash = computeContentHash(statement)
     for (const e of engrams) {
       if (e.status === 'active'
@@ -2376,7 +2403,10 @@ export class Plur {
       // The store is asked first, matching the corpus order it replaces
       // (`_loadAllEngrams` puts primary rows ahead of secondary ones, so a
       // primary match has always won).
-      const primaryHashMatch = canDelegate
+      // Unhashable statements skip the store lookup entirely (#896) — the
+      // delegated query has the same collapse the in-memory scan does, and
+      // this is the branch a Postgres/PGLite install actually takes.
+      const primaryHashMatch = canDelegate && isHashable(statement)
         ? await ps.findActiveByContentHash!(computeContentHash(statement), scope)
         : null
       const hashMatch = primaryHashMatch ?? this._hashDedup(statement, allEngrams, scope)
@@ -3868,6 +3898,64 @@ export class Plur {
   }
 
   /**
+   * Where local→server id mappings survive between outbox flushes (#863
+   * follow-up, 2026-08-13 panel).
+   *
+   * `flushOutbox` builds a `localToServer` map as it goes so a correction
+   * queued alongside the engram it supersedes can point at the server id. That
+   * map was per-flush, and the local row is SPLICED OUT on a successful push —
+   * so once the target left in flush N, a correction that missed that flush
+   * could never resolve its edge again. It failed identically on every
+   * subsequent flush, printing "flush again once X has been pushed" when X had
+   * already been pushed and no future flush could change that. The panel
+   * measured three consecutive flushes producing the same unfollowable
+   * warning.
+   *
+   * Derived state, not truth: losing this file costs a supersedes edge on a
+   * pathological ordering, never an engram. Every read and write is
+   * best-effort for that reason.
+   */
+  outboxIdMapPath(): string {
+    return join(this.paths.root, 'cache', 'outbox-id-map.json')
+  }
+
+  /** Read the persisted local→server map. Never throws; `{}` on any problem. */
+  private _readOutboxIdMap(): Record<string, { server_id: string; url: string; at: number }> {
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.outboxIdMapPath(), 'utf8')) as unknown
+      if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+        return raw as Record<string, { server_id: string; url: string; at: number }>
+      }
+    } catch { /* absent or corrupt — a cache miss, not an error */ }
+    return {}
+  }
+
+  /**
+   * Persist local→server mappings recorded during a flush. Never throws.
+   *
+   * Bounded at {@link OUTBOX_ID_MAP_MAX} entries, oldest dropped first: this
+   * grows by one row per remote write forever otherwise, and an unbounded
+   * cache file in the store root is its own defect. Dropping the oldest is
+   * safe because the edges that need it are queued corrections, which are
+   * resolved within a flush or two of the target.
+   */
+  private _writeOutboxIdMap(entries: Record<string, { server_id: string; url: string; at: number }>): void {
+    try {
+      const ids = Object.keys(entries)
+      if (ids.length > OUTBOX_ID_MAP_MAX) {
+        const keep = ids
+          .sort((a, b) => (entries[b].at ?? 0) - (entries[a].at ?? 0))
+          .slice(0, OUTBOX_ID_MAP_MAX)
+        const trimmed: typeof entries = {}
+        for (const id of keep) trimmed[id] = entries[id]
+        entries = trimmed
+      }
+      fs.mkdirSync(dirname(this.outboxIdMapPath()), { recursive: true })
+      fs.writeFileSync(this.outboxIdMapPath(), JSON.stringify(entries), 'utf8')
+    } catch { /* derived state — a failed write must never fail a flush */ }
+  }
+
+  /**
    * Strict scope-relevance dialing (#776, user decision — plan rows 39/44).
    *
    * For each configured (url, token) endpoint group, the dialed scope set is
@@ -4651,22 +4739,50 @@ export class Plur {
       // #866: increment injection_count on primary-store engrams selected for context.
       // Distinct from activation.frequency (recall events) — this tracks actual
       // injection into the model's context window. Best-effort: never breaks injection.
+      //
+      // TARGETED, via the `_loadTargeted`/`_updateEngrams` pair (2026-08-13
+      // panel). This first loaded the whole corpus and wrote the whole corpus
+      // back, on a path that runs at EVERY session start. Measured cost of the
+      // block, with and without:
+      //
+      //     corpus     with      without   overhead
+      //        200     48 ms      11 ms      4.4x
+      //      2,000    442 ms      42 ms     10.5x
+      //     10,000  2,804 ms     142 ms     19.7x
+      //
+      // …all of it inside the global store lock, so it is not just this call
+      // that pays, it is every concurrent writer waiting behind it. Counting
+      // injections is worth a row update; it is not worth rewriting the store.
+      // On YAML (no `updateMany`) the pair still falls back to a corpus write,
+      // but the corpus is the one loaded under this lock, so the fallback is
+      // the same shape it always was.
       try {
         await this._withStoreLock(this.paths.engrams, async () => {
-          const primaryEngrams = await this._primaryStore.load()
+          const primaryEngrams = await this._loadTargeted(injected_ids)
           const injectedSet = new Set(injected_ids)
-          let modified = false
+          const touched: Engram[] = []
           for (const e of primaryEngrams) {
             if (injectedSet.has(e.id)) {
               e.injection_count = (e.injection_count ?? 0) + 1
-              modified = true
+              touched.push(e)
             }
           }
-          if (modified) {
-            await this._writeEngrams(this.paths.engrams, primaryEngrams)
-          }
+          await this._updateEngrams(primaryEngrams, touched)
         })
-      } catch { /* best-effort */ }
+      } catch (err) {
+        // Best-effort, but not SILENT. `EngramStoreShrinkError` and
+        // `EngramStoreUnreadableError` are the #795/#800 guards telling us the
+        // store is degrading; swallowing them on the most frequently run write
+        // path means the user gets no signal from the operation they run most.
+        // Everything else stays quiet — a counter is not worth a warning.
+        const name = (err as Error)?.constructor?.name
+        if (name === 'EngramStoreShrinkError' || name === 'EngramStoreUnreadableError') {
+          logger.warning(
+            `[plur] injection counters were not recorded: ${(err as Error).message}. `
+            + `The injection itself succeeded — this is a store-integrity signal, not an injection failure.`,
+          )
+        }
+      }
     }
 
     // #181: surface persisted tensions touching this injection — flag,
@@ -4739,17 +4855,7 @@ export class Plur {
       // forget()'s, one severity band down — a mis-targeted signal is
       // recoverable where a retire is not — but the same guard, so the same
       // rule: validate that the scope names something, following rescope().
-      const storeEntry = (this.config.stores ?? []).find(s => s.scope === scope)
-      const isLocalFamily = scope === 'local' || scope === 'global' || scope.startsWith('project:')
-      if (!isLocalFamily && !storeEntry) {
-        const configured = (this.config.stores ?? []).map(s => s.scope).filter(Boolean)
-        throw new Error(
-          `Cannot rate in "${scope}": no configured store matches that scope. `
-          + `Valid targets: primary, local, global, project:*`
-          + (configured.length ? `, or a configured store scope (${configured.join(', ')})` : '')
-          + `. Check for typos — an unmatched scope would silently rate the LOCAL engram instead (#831).`,
-        )
-      }
+      assertScopeNamesATarget(scope, this.config.stores ?? [], 'rate in', 'rate the LOCAL engram')
     }
 
     // Try primary engrams first
@@ -4873,6 +4979,19 @@ export class Plur {
 
     // Check remote stores — the engram may live on an enterprise server.
     // See: https://github.com/plur-ai/plur/issues/85
+    //
+    // Same local-only guard as forget()'s, and it was missing here entirely —
+    // not even the `primary` case was covered, so `feedback(id, signal,
+    // 'primary')` on an id absent locally rated a REMOTE engram. One severity
+    // band below the retire (a mis-targeted signal is recoverable), same
+    // defect, same predicate.
+    if (scope && isLocalOnlyScope(scope)) {
+      throw new Error(
+        `Engram not found in the local store: ${id} (scope: "${scope}"). `
+        + `That scope names a local target, so no remote store was searched. `
+        + `Omit scope to search everywhere, or pass the remote scope to target it directly.`,
+      )
+    }
     // The ID may be prefixed (ENG-GPL-...) from _loadAllEngrams namespacing.
     // Strip the prefix before querying the remote server. See: #86
     for (const entry of (this.config.stores ?? [])) {
@@ -5224,6 +5343,93 @@ export class Plur {
     return all.filter(e => (e as any).pinned === true && e.status === 'active')
   }
 
+  /**
+   * Recompute `content_hash` for primary-store engrams whose hash no longer
+   * describes their statement (#852).
+   *
+   * ## Why this lives in core rather than in the CLI
+   *
+   * The first cut of `plur reindex-hashes` did a raw load → mutate → save
+   * against `paths.engrams` in the command itself. That is a whole-corpus
+   * read-modify-write on an UNLOCKED snapshot, and the 2026-08-13 data-loss
+   * audit reproduced the loss 6/6 on a 4,642-engram store: a correctly-locked
+   * concurrent writer appends between the load and the save, and the save puts
+   * the pre-append snapshot back. The engram is gone with no error — and the
+   * shrink guard cannot see it, because the same count goes out that came in.
+   *
+   * Nothing about that was specific to the CLI. Any caller reaching for the
+   * exported `loadEngrams`/`saveEngrams` primitives can reintroduce it, so the
+   * repair belongs behind the same seam every other write uses:
+   * `_withStoreLock` (which also fires the #799 daily backup) and the
+   * `_loadTargeted`/`_updateEngrams` capability pair, so a store that can do a
+   * targeted UPDATE is not asked to replace its whole corpus to rewrite one
+   * field.
+   *
+   * ## Why the primary store, not `list()`
+   *
+   * `list()` merges packs in and drops inactive/expired rows. Measured against
+   * one real store it gave 5,388 scanned / 1 stale / 1,805 missing where the
+   * primary store itself holds 4,642 / 38 / 961: it counted pack entries this
+   * repair does not own, and hid stale hashes on retired engrams. A retired
+   * engram with a stale hash still matters — `findActiveByContentHash` is not
+   * the only reader, and a resurrected row carries the bad hash with it.
+   *
+   * STALE and MISSING are reported separately because they are different
+   * conditions: a stale hash is actively wrong and absorbs unrelated writes
+   * today, a missing one predates the field and is inert until something
+   * matches on it.
+   *
+   * UNHASHABLE is the third category, and it is a refusal rather than a
+   * finding. A statement that normalizes to nothing hashes to the SHA-256 of
+   * the empty string — the same value every other such statement gets — so
+   * writing it does not record a fact about that engram, it enrols the engram
+   * in a mutual-absorption set. Before #896 that was every non-Latin statement
+   * in the store, and a `--apply` run would have stamped the shared value onto
+   * exactly the rows the report called "inert". These are listed and skipped.
+   *
+   * Read-only unless `apply` is set.
+   */
+  async repairContentHashes(opts: { apply?: boolean } = {}): Promise<{
+    scanned: number
+    stale: Array<{ id: string; statement: string }>
+    missing: Array<{ id: string; statement: string }>
+    unhashable: Array<{ id: string; statement: string }>
+    repaired: number
+  }> {
+    const apply = opts.apply === true
+    if (apply) this._assertWritable()
+    return await this._withStoreLock(this.paths.engrams, async () => {
+      const engrams = await this._primaryStore.load()
+      const stale: Array<{ id: string; statement: string }> = []
+      const missing: Array<{ id: string; statement: string }> = []
+      const unhashable: Array<{ id: string; statement: string }> = []
+      const changed: Engram[] = []
+      for (const e of engrams) {
+        if (!e.statement) continue
+        const current = (e as { content_hash?: string }).content_hash
+        if (!isHashable(e.statement)) {
+          unhashable.push({ id: e.id, statement: e.statement })
+          continue
+        }
+        const correct = computeContentHash(e.statement)
+        if (!current) missing.push({ id: e.id, statement: e.statement })
+        else if (current !== correct) stale.push({ id: e.id, statement: e.statement })
+        else continue
+        if (apply) {
+          ;(e as { content_hash?: string }).content_hash = correct
+          changed.push(e)
+        }
+      }
+      if (apply && changed.length > 0) {
+        // `engrams` was loaded INSIDE this lock, so the fallback whole-corpus
+        // write is of a current snapshot — that is the whole point of the move.
+        await this._updateEngrams(engrams, changed)
+        await this._syncIndex()
+      }
+      return { scanned: engrams.length, stale, missing, unhashable, repaired: changed.length }
+    })
+  }
+
   /** Set engram status to 'retired'. Supports primary and store engrams.
    *
    * options.force=true bypasses write_count and retires immediately,
@@ -5290,19 +5496,9 @@ export class Plur {
       // disambiguation signal. Same rule and same wording as rescope(), which
       // documents this as typo protection — a scope that reaches neither a
       // local family nor a configured store is a caller error, not a hint.
-      const storeEntry = (this.config.stores ?? []).find(s => s.scope === targetScope)
-      const isLocalFamily = targetScope === 'local'
-        || targetScope === 'global'
-        || targetScope.startsWith('project:')
-      if (!isLocalFamily && !storeEntry) {
-        const configured = (this.config.stores ?? []).map(s => s.scope).filter(Boolean)
-        throw new Error(
-          `Cannot retire from "${targetScope}": no configured store matches that scope. `
-          + `Valid targets: primary, local, global, project:*`
-          + (configured.length ? `, or a configured store scope (${configured.join(', ')})` : '')
-          + `. Check for typos — an unmatched scope would silently retire the LOCAL engram instead (#831).`,
-        )
-      }
+      assertScopeNamesATarget(
+        targetScope, this.config.stores ?? [], 'retire from', 'retire the LOCAL engram',
+      )
       // Past this point the scope names a local-family or non-URL store, so it
       // is a genuine disambiguation signal and the ambiguity guard is
       // deliberately skipped: the caller has already said which side they mean.
@@ -5506,12 +5702,25 @@ export class Plur {
 
     // Check remote stores — the engram may live on an enterprise server.
     // See: https://github.com/plur-ai/plur/issues/84
-    // scope: "primary" is an explicit local-only request (#831). Falling
-    // through to the remote walk here would retire a remote engram the caller
-    // just said they did not mean — the exact wrong-target retire this guard
-    // exists to prevent, arrived at from the opposite direction.
-    if (targetScope === 'primary') {
-      throw new Error(`Engram not found in the local primary store: ${id}`)
+    //
+    // An explicit LOCAL-family scope is a local-only request (#831). Falling
+    // through to the remote walk here retires a remote engram the caller just
+    // said they did not mean — the exact wrong-target retire this guard exists
+    // to prevent, arrived at from the opposite direction.
+    //
+    // This used to check `targetScope === 'primary'` alone, so the other three
+    // targets the error message above advertises — `local`, `global`,
+    // `project:*` — passed the validation as legitimate and then issued a
+    // remote DELETE, reporting success. Measured on the 2026-08-13 panel: 1
+    // remote DELETE each for global/local/project:foo, 0 for primary. The
+    // predicate is shared with `feedback` now precisely so the two cannot
+    // drift again — the drift was the bug (#855).
+    if (targetScope && isLocalOnlyScope(targetScope)) {
+      throw new Error(
+        `Engram not found in the local store: ${id} (scope: "${targetScope}"). `
+        + `That scope names a local target, so no remote store was searched. `
+        + `Omit scope to search everywhere, or pass the remote scope to target it directly.`,
+      )
     }
 
     // Strip store prefix before querying remote. See: #86
@@ -6460,26 +6669,48 @@ export class Plur {
     //
     // Both engrams in the reported case were written in one session and queued
     // together, so the mapping is available within this flush — provided the
-    // target goes first. One stable partial ordering is enough for that; a
-    // deeper chain resolves across successive flushes.
+    // target goes first.
+    //
+    // A TOPOLOGICAL SORT, not a comparator — see `orderBySupersedes`, which
+    // exists as its own module because the defect it replaces was a property
+    // of the ALGORITHM (`sort` with a non-transitive comparator) rather than
+    // of any store state, and so has to be testable as one.
     const pendingIds = new Set(pending.map(e => e.id))
     const supersedesTargets = (e: Engram): string[] => {
       const rel = (e as any).relations?.supersedes
       return Array.isArray(rel) ? rel.filter((x: unknown): x is string => typeof x === 'string') : []
     }
-    pending.sort((a, b) => {
-      const aDependsOnB = supersedesTargets(a).includes(b.id) ? 1 : 0
-      const bDependsOnA = supersedesTargets(b).includes(a.id) ? 1 : 0
-      return aDependsOnB - bDependsOnA
-    })
-    /** local id -> server-assigned id, built as this flush proceeds. */
+    const ordered = orderBySupersedes(pending, supersedesTargets)
+    pending.length = 0
+    pending.push(...ordered)
+    /**
+     * local id -> server-assigned id.
+     *
+     * Seeded from the PERSISTED map so an edge whose target left in an earlier
+     * flush still resolves; a mapping is only trusted for the host that
+     * produced it, since server ids are per-store. Grown as this flush
+     * proceeds, and written back at the end.
+     */
+    const persistedIdMap = this._readOutboxIdMap()
     const localToServer = new Map<string, string>()
+    let idMapDirty = false
 
     let flushed = 0
     let failed = 0
     let skipped = 0
     /** Warn once per host, not once per queued engram (#785). */
     const cooldownSkippedHosts = new Set<string>()
+    /**
+     * Engrams this flush DEMOTED to local/private on a policy change.
+     *
+     * Tracked explicitly because the merge-back applies fields, not rows: a
+     * demotion changes `scope` and `visibility` as well as the structured-data
+     * markers, and those two are ordinary engram fields that a concurrent
+     * `rescope` also writes. Carrying them for every survivor would revert
+     * that; carrying them only for the ids this flush actually demoted does
+     * not.
+     */
+    const demotedIds = new Set<string>()
     const expired_warnings: string[] = []
     const now = new Date()
     const TTL_MS = 7 * 24 * 60 * 60 * 1000
@@ -6518,7 +6749,19 @@ export class Plur {
       // Skipping leaves the engrams queued: the outbox already retries on the
       // next flush, and the breaker's own cooldown is what decides when that
       // becomes worth attempting.
-      const cooldown = isHostInCooldown(storeEntry.url!)
+      // `remoteHealthStatePath()`, explicitly — NOT the default (2026-08-13
+      // panel). The default is `remoteHealthPath()`, which resolves from
+      // PLUR_PATH; the recall leg passes `this.remoteHealthStatePath()`, which
+      // resolves from `paths.root`. For `new Plur({ path })`, `plur --path`,
+      // and every embedded consumer those are DIFFERENT FILES, so the two legs
+      // kept two independent opinions about whether a host is reachable —
+      // which is exactly the split #785 exists to close, reintroduced one
+      // level down. Measured: recall wrote plur-store-…/cache/remote-health.json
+      // while the write leg wrote plur-env-…/cache/remote-health.json. #785's
+      // test set PLUR_PATH and `path` to the same directory, the one
+      // configuration in which the bug is invisible.
+      const healthPath = this.remoteHealthStatePath()
+      const cooldown = isHostInCooldown(storeEntry.url!, Date.now(), healthPath)
       if (cooldown.inCooldown) {
         if (!cooldownSkippedHosts.has(storeEntry.url!)) {
           cooldownSkippedHosts.add(storeEntry.url!)
@@ -6569,6 +6812,7 @@ export class Plur {
           local.structured_data = lsd
           local.scope = 'local'
           local.visibility = 'private'
+          demotedIds.add(engram.id)
         }
         expired_warnings.push(
           `${engram.id}: sensitive content (${patterns}) now forbidden by scope ${outbox.target_scope}'s policy — demoted to local/private, not pushed`,
@@ -6596,6 +6840,7 @@ export class Plur {
         let refuse: string | null = null
         for (const t of targets) {
           const server = localToServer.get(t)
+            ?? (persistedIdMap[t]?.url === storeEntry.url ? persistedIdMap[t].server_id : undefined)
           if (server) { remapped.push(server); continue }
           const localTarget = engrams.find(e => e.id === t)
           if (localTarget && !pendingIds.has(t)) {
@@ -6626,9 +6871,13 @@ export class Plur {
         const pushed = await driver.appendAndGetServerId(cleanEngram)
         // #863: remember the mapping so a later engram in this same flush can
         // point at the server id rather than the local one.
-        if (pushed?.id) localToServer.set(engram.id, pushed.id)
+        if (pushed?.id) {
+          localToServer.set(engram.id, pushed.id)
+          persistedIdMap[engram.id] = { server_id: pushed.id, url: storeEntry.url!, at: Date.now() }
+          idMapDirty = true
+        }
         // #785: a write success clears the host's failure count for BOTH legs.
-        recordWriteOutcome(storeEntry.url!, true)
+        recordWriteOutcome(storeEntry.url!, true, Date.now(), this.remoteHealthStatePath())
         // Success: remove from local store
         const idx = engrams.findIndex(e => e.id === engram.id)
         if (idx !== -1) engrams.splice(idx, 1)
@@ -6645,7 +6894,7 @@ export class Plur {
         outbox.last_error = (err as Error).message
         // #785: and a write failure counts toward the same breaker, so a host
         // that only ever fails on writes still opens one.
-        recordWriteOutcome(storeEntry.url!, false)
+        recordWriteOutcome(storeEntry.url!, false, Date.now(), this.remoteHealthStatePath())
         failed++
         logger.warning(`[plur:outbox] retry failed for ${engram.id}: ${(err as Error).message}`)
       }
@@ -6663,6 +6912,15 @@ export class Plur {
     // Only engrams that were in the outbox are touched: `pending` is exactly
     // the set this method considered, so anything outside it is carried through
     // from the fresh read untouched.
+    //
+    // And within those, only the FIELDS this flush changed are applied — the
+    // survivor row is not swapped in wholesale (2026-08-13 data-loss audit,
+    // F4). The survivor is a snapshot taken before the network round-trips, so
+    // replacing the fresh row with it reverts anything that happened to that
+    // engram meanwhile: a feedback counter, an activation bump from a recall,
+    // a pin, a local rescope. The flush only ever mutates outbox metadata, the
+    // demotion marker, and (for a demotion) scope/visibility — so those are
+    // what it writes back, and nothing else.
     if (flushed > 0 || failed > 0) {
       const consideredIds = new Set(pending.map(e => e.id))
       const survivorsById = new Map(
@@ -6673,14 +6931,39 @@ export class Plur {
         const merged = fresh
           // Drop the ones this flush successfully pushed (remote now owns them).
           .filter(e => !(consideredIds.has(e.id) && !survivorsById.has(e.id)))
-          // Apply updated outbox metadata / demotions to the ones that stayed.
-          .map(e => (survivorsById.get(e.id) ?? e))
+          .map(e => {
+            const survivor = survivorsById.get(e.id)
+            if (!survivor) return e
+            const sSd = (survivor as any).structured_data as Record<string, unknown> | undefined
+            const fSd = { ...((e as any).structured_data as Record<string, unknown> | undefined ?? {}) }
+            // `_outbox` and `_demoted` are the flush's own bookkeeping: copy
+            // them across (including their ABSENCE, which is how a cancelled
+            // or demoted queue entry is expressed), and leave every other key
+            // of the fresh row alone.
+            for (const key of ['_outbox', '_demoted'] as const) {
+              if (sSd && key in sSd) fSd[key] = sSd[key]
+              else delete fSd[key]
+            }
+            return {
+              ...e,
+              // A demotion is the one case where the flush changes ordinary
+              // engram fields, so those are carried for exactly those ids.
+              ...(demotedIds.has(e.id) ? { scope: 'local', visibility: 'private' } : {}),
+              structured_data: Object.keys(fSd).length > 0 ? fSd : undefined,
+            } as Engram
+          })
         // The dropped engrams are the ones the remote accepted — a deliberate
         // handoff, not a loss (audit #794 shrink guard).
         await this._writeEngrams(this.paths.engrams, merged, { allowShrink: true })
       })
       await this._syncIndex()
     }
+
+    // Persist the id map LAST, and only if something was pushed. Writing it
+    // before the store write-back would leave a mapping for an engram whose
+    // local removal had not landed; writing it unconditionally would rewrite
+    // the file on every no-op flush.
+    if (idMapDirty) this._writeOutboxIdMap(persistedIdMap)
 
     return { flushed, failed, expired_warnings }
   }

--- a/packages/core/src/outbox-order.ts
+++ b/packages/core/src/outbox-order.ts
@@ -1,0 +1,77 @@
+/**
+ * Ordering for an outbox flush: a supersedes TARGET must be pushed before the
+ * engram that supersedes it (#863).
+ *
+ * The server assigns its own id on push, so a `supersedes` naming a LOCAL id
+ * means nothing there. `flushOutbox` builds a local→server map as it goes, and
+ * a correction can only use it if its target went first.
+ *
+ * ## Why this is a module and not four lines inside the flush
+ *
+ * It was four lines inside the flush, and they were:
+ *
+ *     pending.sort((a, b) => aDependsOnB - bDependsOnA)
+ *
+ * which returns non-zero only for DIRECTLY related pairs. That is not a strict
+ * weak ordering, so `Array.prototype.sort` may produce anything for a chain: A
+ * supersedes B supersedes C gives cmp(A,B)=1, cmp(B,C)=1, cmp(A,C)=0, and V8's
+ * insertion sort turns `[A,B,C]` into `[B,A,C]` — B pushed before C, its target.
+ * The 2026-08-13 panel measured the consequence as a PERMANENT stall.
+ *
+ * The bug is a property of the algorithm, not of any store state, so it belongs
+ * where it can be tested as one: exported, pure, and exercised directly with
+ * adversarial input orders. Every earlier fixture used exactly two pending
+ * engrams, where a comparator and a topological sort agree.
+ */
+
+/** Kahn's algorithm over the pending set, stable, cycles appended not dropped. */
+export function orderBySupersedes<T extends { id: string }>(
+  pending: readonly T[],
+  targetsOf: (item: T) => string[],
+): T[] {
+  const pendingIds = new Set(pending.map(e => e.id))
+  const byId = new Map(pending.map(e => [e.id, e]))
+  /** How many of THIS flush's engrams a node must wait for. */
+  const waitingOn = new Map<string, number>()
+  /** Reverse edges: target id -> ids that supersede it. */
+  const dependents = new Map<string, string[]>()
+
+  for (const e of pending) {
+    // Only edges INSIDE the pending set constrain this flush. A target that is
+    // already on the server, or lives only locally, is resolved elsewhere —
+    // counting it here would leave every node waiting forever.
+    const deps = targetsOf(e).filter(t => pendingIds.has(t) && t !== e.id)
+    waitingOn.set(e.id, deps.length)
+    for (const t of deps) {
+      const list = dependents.get(t)
+      if (list) list.push(e.id)
+      else dependents.set(t, [e.id])
+    }
+  }
+
+  // Seeded in original order and drained FIFO, so the result is STABLE:
+  // engrams with no dependency keep the order the store gave them, and the
+  // flush stays predictable for the overwhelmingly common no-edges case.
+  const ready = pending.filter(e => waitingOn.get(e.id) === 0).map(e => e.id)
+  const ordered: T[] = []
+  for (let i = 0; i < ready.length; i++) {
+    const id = ready[i]
+    ordered.push(byId.get(id)!)
+    for (const dep of dependents.get(id) ?? []) {
+      const left = (waitingOn.get(dep) ?? 0) - 1
+      waitingOn.set(dep, left)
+      if (left === 0) ready.push(dep)
+    }
+  }
+
+  // Anything left is in a CYCLE — a mutual supersedes, which the comparator
+  // deadlocked on silently. Append in original order rather than dropping:
+  // these engrams must still be attempted, so the flush refuses them out loud
+  // and reports it. An engram that vanishes from the flush is worse than one
+  // that fails in it.
+  if (ordered.length < pending.length) {
+    const placed = new Set(ordered.map(e => e.id))
+    for (const e of pending) if (!placed.has(e.id)) ordered.push(e)
+  }
+  return ordered
+}

--- a/packages/core/src/scope-target.ts
+++ b/packages/core/src/scope-target.ts
@@ -1,0 +1,71 @@
+/**
+ * What an explicit `scope:` argument means as a ROUTING TARGET.
+ *
+ * `forget(id, reason, { scope })` and `feedback(id, signal, scope)` both take a
+ * scope to disambiguate an id that could name engrams in several stores. #855
+ * asked for the rule to live in one place when both landed; it did not, and the
+ * two copies immediately diverged. The 2026-08-13 evaluator panel measured the
+ * consequence:
+ *
+ *     scope="global"      threw=null  remote DELETEs=1   ← wrong-target retire, reported success
+ *     scope="local"       threw=null  remote DELETEs=1
+ *     scope="project:foo" threw=null  remote DELETEs=1
+ *     scope="primary"     threw       remote DELETEs=0   (control)
+ *
+ * Three of the four targets `forget`'s own error message advertises as valid
+ * routed to a remote DELETE when the id was absent locally — the caller said
+ * "the local one", and the engine destroyed a remote one and reported success.
+ * That is #831 verbatim, reached from the direction #855 documented itself as
+ * closing. The drift IS the bug, so the rule is a module, not a convention.
+ */
+
+/** Scopes that name the LOCAL side of the store graph. */
+const LOCAL_FAMILY = new Set(['primary', 'local', 'global'])
+
+/**
+ * True when `scope` names something local, so a routed operation must NEVER
+ * fall through to a remote store.
+ *
+ * `primary` is the explicit "the local primary store, and only it" target.
+ * `local`, `global` and `project:*` are the scopes an engram carries when it
+ * lives on this machine; naming one of them is equally a statement about
+ * WHERE, not just about which namespace. Both readings agree that a remote
+ * DELETE is not what the caller asked for.
+ *
+ * Note the asymmetry with lookup: a local-only scope still permits the
+ * secondary-store walk, because `stores:` entries without a `url` are files on
+ * this disk. It is the network leg that is refused.
+ */
+export function isLocalOnlyScope(scope: string): boolean {
+  return LOCAL_FAMILY.has(scope) || scope.startsWith('project:')
+}
+
+/**
+ * Throw unless `scope` names a target that exists — a local-family scope or a
+ * configured store.
+ *
+ * Typo protection, and load-bearing rather than cosmetic: because a mistyped
+ * scope is still TRUTHY, it skipped the `if (!scope)` ambiguity guard
+ * downstream and silently restored first-match-wins on exactly the id the
+ * guard exists to refuse. `group:tset` for `group:test` retired the local
+ * engram, issued no remote DELETE, and reported success.
+ *
+ * @param verb  what the caller is doing, for the message: `retire from`, `rate in`
+ * @param consequence  what silently happens if this is not caught
+ */
+export function assertScopeNamesATarget(
+  scope: string,
+  stores: ReadonlyArray<{ scope?: string }>,
+  verb: string,
+  consequence: string,
+): void {
+  if (isLocalOnlyScope(scope)) return
+  if (stores.some(s => s.scope === scope)) return
+  const configured = stores.map(s => s.scope).filter(Boolean)
+  throw new Error(
+    `Cannot ${verb} "${scope}": no configured store matches that scope. `
+    + `Valid targets: primary, local, global, project:*`
+    + (configured.length ? `, or a configured store scope (${configured.join(', ')})` : '')
+    + `. Check for typos — an unmatched scope would silently ${consequence} instead (#831).`,
+  )
+}

--- a/packages/core/src/store/readonly-store-guard.ts
+++ b/packages/core/src/store/readonly-store-guard.ts
@@ -43,9 +43,17 @@
  * until someone remembers to add it. A Proxy forwarding everything except a
  * write deny-list would not have this failure mode. It is still the right shape
  * HERE, because the two failure modes are not symmetric: a missed entry on a
- * whitelist loses functionality and is discovered; a missed entry on a
- * deny-list PERMITS A WRITE on a path whose entire purpose is that it cannot
- * write. On a safety guard, fail closed.
+ * whitelist loses functionality, where a missed entry on a deny-list PERMITS A
+ * WRITE on a path whose entire purpose is that it cannot write. On a safety
+ * guard, fail closed.
+ *
+ * This argument used to end "…loses functionality AND SOMEONE NOTICES", and
+ * that half was false. #753 added `searchBM25Exhaustive` to the query-adapter
+ * surface hours after #830's whitelist landed, this file was not updated, and
+ * nobody noticed — because the loss was a 2-3x cost regression rather than a
+ * crash. Fail-closed remains right; "it gets caught" does not. The structural
+ * test in `readonly-query-adapter.test.ts` enumerates the surface so the next
+ * member fails on the day it lands rather than in the next audit.
  */
 import type { Engram } from '../schemas/engram.js'
 import type { PrimaryStore, PrimaryStoreKind } from './primary-store.js'
@@ -96,6 +104,25 @@ export class ReadonlyStoreGuard implements PrimaryStore {
    */
   readonly role?: string
   readonly searchBM25?: (query: string, opts: { limit: number } & Record<string, unknown>) => Promise<Engram[]>
+  /**
+   * Also a read, and the one the whitelist's own argument failed on (#753,
+   * found by the 2026-08-13 panel). `recall()`'s widening loop uses it to stop
+   * as soon as the adapter reports the candidate set exhausted; a guarded store
+   * that dropped it kept widening 3L → 9L → 27L and re-ranked the same rows
+   * two extra times.
+   *
+   * That is the case the file header calls "loses functionality and is
+   * discovered" — and it was NOT discovered, because the loss is a silent 2-3x
+   * cost regression rather than a visible failure, in exactly the multi-tenant
+   * deployment read-only exists to serve. The whitelist is still the right
+   * shape for the reasons below; the argument for it is just weaker than it
+   * reads, so new members of the query-adapter surface need adding here
+   * deliberately rather than being noticed later.
+   */
+  readonly searchBM25Exhaustive?: (
+    query: string,
+    opts: { limit: number } & Record<string, unknown>,
+  ) => Promise<{ rows: Engram[]; exhausted: boolean }>
   readonly searchVector?: (...args: unknown[]) => Promise<unknown>
   readonly vectorIndex?: unknown
 
@@ -116,11 +143,18 @@ export class ReadonlyStoreGuard implements PrimaryStore {
     const inner = _inner as unknown as {
       role?: string
       searchBM25?: (q: string, o: { limit: number } & Record<string, unknown>) => Promise<Engram[]>
+      searchBM25Exhaustive?: (
+        q: string,
+        o: { limit: number } & Record<string, unknown>,
+      ) => Promise<{ rows: Engram[]; exhausted: boolean }>
       searchVector?: (...a: unknown[]) => Promise<unknown>
       vectorIndex?: unknown
     }
     if (inner.role !== undefined) this.role = inner.role
     if (inner.searchBM25) this.searchBM25 = (q, o) => inner.searchBM25!(q, o)
+    if (inner.searchBM25Exhaustive) {
+      this.searchBM25Exhaustive = (q, o) => inner.searchBM25Exhaustive!(q, o)
+    }
     if (inner.searchVector) this.searchVector = (...a: unknown[]) => inner.searchVector!(...a)
     if (inner.vectorIndex !== undefined) this.vectorIndex = inner.vectorIndex
   }

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -442,9 +442,37 @@ export class RemoteStore implements EngramStore {
    * Returns false ONLY on an authoritative 404. Anything else — transport
    * failure, 5xx, auth rejection — throws, so the caller must decide what an
    * unknown means rather than inheriting a silent "no".
+   *
+   * BOUNDED, and that is not a nicety (2026-08-13 data-loss audit, F2). Both
+   * callers — `forget()` and `feedback()` — run this INSIDE the primary store
+   * lock, one probe per configured remote. An unbounded `fetch` inherits
+   * undici's 300s `headersTimeout`, so a host that completes its handshake and
+   * then stalls holds the lock every other write path needs for five minutes,
+   * past the 180s `DEFAULT_ACQUIRE_TIMEOUT` — waiting `plur_learn` calls throw
+   * "Failed to acquire lock" and the engram is silently never stored. The
+   * budget is the same one `load()` uses, for the same reason.
    */
   async existsById(id: string): Promise<boolean> {
-    const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, { headers: this.headers() })
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), LOAD_FETCH_TIMEOUT_MS)
+    let r: Response
+    try {
+      r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
+        headers: this.headers(),
+        signal: ctrl.signal,
+      })
+    } catch (err) {
+      // An abort is "cannot tell", not "absent" — the whole point of this
+      // method — so it must surface as a throw like any other transport
+      // failure, with a message that says which it was.
+      throw new Error(
+        ctrl.signal.aborted
+          ? `existence probe for ${id} timed out after ${LOAD_FETCH_TIMEOUT_MS}ms against ${this.apiBase}`
+          : `existence probe for ${id} failed against ${this.apiBase}: ${(err as Error).message}`,
+      )
+    } finally {
+      clearTimeout(timer)
+    }
     if (r.status === 404) return false
     if (!r.ok) throw new Error(`HTTP ${r.status} from ${this.apiBase}`)
     // A 200 is not on its own proof of existence — confirm the body actually

--- a/packages/core/test/fts-unicode.test.ts
+++ b/packages/core/test/fts-unicode.test.ts
@@ -120,6 +120,41 @@ describe('the length floor is script-aware (#832)', () => {
   })
 })
 
+/**
+ * A character can belong to a script without BEING that script. The 2026-08-13
+ * panel measured the consequence: U+30FC ー, the prolonged sound mark in
+ * essentially every Japanese loanword, is `Script=Common`, so a `Script=`-based
+ * run regex terminated at it.
+ */
+describe('script-extension characters join their run, not split it', () => {
+  it('a katakana word with a prolonged sound mark is one run', () => {
+    const tokens = ftsTokenize('コンピューター')
+    // Under `Script=Katakana` the run stopped dead at the mark: the regex
+    // matched only コンピュ, and the tail leaked into the WORD path as the
+    // single token ーター. Result: ["ーター","コン","ンピ","ピュ"] — three
+    // bigrams for a seven-character word, and a word-shaped token that no
+    // query will ever produce.
+    expect(tokens).toEqual(['コン', 'ンピ', 'ピュ', 'ュー', 'ータ', 'ター'])
+    expect(tokens, 'the tail of the word was unreachable').toContain('ター')
+    expect(tokens, 'the run leaked a word-path token').not.toContain('ーター')
+  })
+
+  it('a query term matches the document that contains it', () => {
+    // The user-visible property, and the reason this matters: bigrams cut at
+    // the wrong offsets mean the query and the document never share a token.
+    const doc = ftsTokenize('データベースの設定を確認する')
+    const query = ftsTokenize('ベース')
+    expect(query.length, 'the query must tokenize to something').toBeGreaterThan(0)
+    expect(query.some(t => doc.includes(t)), 'no shared token — the document is unfindable').toBe(true)
+  })
+
+  it('the Han iteration mark stays inside its run', () => {
+    // 々 repeats the preceding character and is Script=Common too.
+    const tokens = ftsTokenize('人々の設定')
+    expect(tokens).toContain('人々')
+  })
+})
+
 describe('English tokenization is untouched (#833 regression guard)', () => {
   it('produces the same tokens as before for plain ASCII', () => {
     expect(ftsTokenize('The quick brown fox jumps over the lazy dog'))

--- a/packages/core/test/fts.test.ts
+++ b/packages/core/test/fts.test.ts
@@ -262,9 +262,17 @@ describe('tokenizer contract (#834)', () => {
    */
   it('output is pinned to TOKENIZER_VERSION — bump the version if this fails', () => {
     // Bumped 2 -> 3 by #833/#832: the tokenizer now covers every script rather
-    // than ASCII + Han, so stores carrying tokens derived under v2 must be
-    // re-derived (`plur reindex-tokens`) or their rows go unreachable.
-    expect(TOKENIZER_VERSION).toBe(3)
+    // than ASCII + Han. Bumped 3 -> 4 by the 2026-08-13 panel: the space-less
+    // run now uses `Script_Extensions`, so characters that belong to a script
+    // without being it (U+30FC ー, the Han iteration mark 々) join their run
+    // instead of terminating it. Either way, stores carrying tokens derived
+    // under the older version must be re-derived (`plur reindex-tokens`) or
+    // their rows go unreachable.
+    //
+    // The Han fixture below is UNCHANGED across 3 -> 4, which is the point of
+    // pinning it: the version bump is required by what the change COULD alter,
+    // not only by what it did.
+    expect(TOKENIZER_VERSION).toBe(4)
     expect(ftsTokenize('测试部署应该用 docker compose')).toEqual([
       'docker', 'compose',
       '测试', '试部', '部署', '署应', '应该', '该用',

--- a/packages/core/test/inject-counter-and-flush-merge.test.ts
+++ b/packages/core/test/inject-counter-and-flush-merge.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Coverage for two behavioural changes that shipped in this branch with NO
+ * tests of their own — found by auditing my own PR rather than the code.
+ *
+ * Both are hot-path rewrites whose failure mode is silent:
+ *
+ *   1. `inject()`'s `injection_count` bump moved from a whole-corpus
+ *      load-and-rewrite to the targeted `_loadTargeted`/`_updateEngrams` pair
+ *      (19.7x faster at 10k engrams). `injection_count` appeared in the test
+ *      tree ONLY as fixture data — never as an assertion — so the counter
+ *      could have stopped incrementing entirely and every suite would still
+ *      have passed.
+ *
+ *   2. `flushOutbox`'s write-back moved from replacing the whole survivor row
+ *      to merging only the fields the flush actually changes, so a concurrent
+ *      writer's feedback counters, activation, pin or rescope are no longer
+ *      reverted. Nothing referenced `survivorsById` or `_demoted` in a test.
+ *
+ * The general lesson, which is the same one this branch's audit kept finding:
+ * "the other 3,983 tests still pass" is evidence about the code you did not
+ * change.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, loadEngrams } from '../src/index.js'
+
+const REMOTE = 'https://plur.example.com/sse'
+const SCOPE = 'group:acme/team'
+
+describe('inject() still counts injections after the targeted-write change', () => {
+  let dir: string
+  let plur: Plur
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-injcount-')); plur = new Plur({ path: dir }) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  const countOf = (id: string) =>
+    (loadEngrams(join(dir, 'engrams.yaml')).find(e => e.id === id) as { injection_count?: number } | undefined)
+      ?.injection_count
+
+  it('increments the counter for an injected engram, and persists it', async () => {
+    const e = await plur.learn('always use semicolons in TypeScript', { scope: 'global', type: 'behavioral' })
+    expect(countOf(e.id)).toBe(0)
+
+    const res = await plur.inject('write TypeScript code')
+    expect(res.injected_ids, 'fixture no longer injects — the assertion below would be vacuous')
+      .toContain(e.id)
+
+    expect(countOf(e.id), 'the targeted write did not persist the bump').toBe(1)
+  })
+
+  it('accumulates across injections rather than resetting', async () => {
+    const e = await plur.learn('rebase before pushing on this repo', { scope: 'global', type: 'behavioral' })
+    for (let i = 0; i < 3; i++) await plur.inject('rebase before pushing')
+    expect(countOf(e.id)).toBe(3)
+  })
+
+  it('counts ONLY the engrams that were injected', async () => {
+    // The specific risk of a targeted write: passing the wrong id set. A
+    // whole-corpus rewrite could not get this wrong; a targeted one can.
+    const hit = await plur.learn('docker compose runs the staging stack', { scope: 'global', type: 'behavioral' })
+    const miss = await plur.learn('the kitchen tap drips on Sundays', { scope: 'global', type: 'behavioral' })
+
+    const res = await plur.inject('docker compose staging')
+    expect(res.injected_ids).toContain(hit.id)
+    expect(res.injected_ids, 'fixture injects everything — the assertion below is vacuous')
+      .not.toContain(miss.id)
+
+    expect(countOf(hit.id)).toBe(1)
+    expect(countOf(miss.id), 'an un-injected engram was counted').toBe(0)
+  })
+
+  it('does not disturb the rest of the row', async () => {
+    // A targeted update writes whole rows through `updateMany`; the danger is
+    // writing a STALE row. Assert a neighbouring field survives the bump.
+    const e = await plur.learn('prefer pnpm over npm here', { scope: 'global', type: 'behavioral', tags: ['tooling'] })
+    await plur.inject('prefer pnpm')
+    const after = loadEngrams(join(dir, 'engrams.yaml')).find(r => r.id === e.id)!
+    expect(after.statement).toBe('prefer pnpm over npm here')
+    expect(after.tags).toContain('tooling')
+    expect(after.scope).toBe('global')
+  })
+
+  it('a readonly instance counts nothing and does not throw', async () => {
+    // The bump is best-effort and guarded; a read-only engine must not write,
+    // and must not fail the injection either (#731).
+    const e = await plur.learn('readonly instances must not write', { scope: 'global', type: 'behavioral' })
+    const ro = new Plur({ path: dir, readonly: true })
+    await expect(ro.inject('readonly instances')).resolves.toBeDefined()
+    expect(countOf(e.id), 'a read-only engine mutated the store').toBe(0)
+  })
+})
+
+describe('flushOutbox merges fields instead of replacing the row', () => {
+  let dir: string
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-flushmerge-'))
+    originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as never
+    writeFileSync(join(dir, 'config.yaml'), JSON.stringify({
+      stores: [{ url: REMOTE, token: 'tok', scope: SCOPE, shared: true, readonly: false }],
+      index: false,
+    }))
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('does not revert a change made to a queued engram while the flush ran', async () => {
+    // The defect: `survivorsById` holds rows snapshotted BEFORE the network
+    // round-trips, and the write-back used to swap them in wholesale — so any
+    // concurrent change to a queued engram (a feedback counter, an activation
+    // bump, a pin, a local rescope) was silently reverted.
+    const plur = new Plur({ path: dir })
+    const queued = await plur.learn('a team fact that will not reach its store', {
+      scope: SCOPE, type: 'behavioral',
+    })
+    await new Promise(r => setTimeout(r, 60))
+    expect(await plur.outboxCount(), 'fixture did not queue — nothing to merge').toBe(1)
+
+    // The edit must land AFTER the flush snapshots its corpus and BEFORE the
+    // write-back, or there is no race to test. A first version of this test
+    // edited beforehand and passed with the fix reverted — the snapshot simply
+    // contained the edit. Slowing the fetch opens the window the production
+    // defect lives in (a real flush waits on the network for seconds).
+    globalThis.fetch = vi.fn(async () => {
+      await new Promise(r => setTimeout(r, 80))
+      throw new Error('fetch failed')
+    }) as never
+
+    const flushing = plur.flushOutbox()
+    await new Promise(r => setTimeout(r, 20))
+    const row = (await plur.getById(queued.id))!
+    row.statement = 'edited while the flush was in flight'
+    await plur.updateEngram(row)
+    await flushing
+
+    const after = loadEngrams(join(dir, 'engrams.yaml')).find(e => e.id === queued.id)!
+    expect(after.statement, 'the flush reverted a concurrent edit').toBe('edited while the flush was in flight')
+  })
+
+  it('still writes back the fields the flush DOES own', async () => {
+    // The opposite regression: a merge that carried nothing would leave
+    // `_outbox` bookkeeping unupdated, so retries would never age.
+    const plur = new Plur({ path: dir })
+    const queued = await plur.learn('another team fact for the unreachable store', {
+      scope: SCOPE, type: 'behavioral',
+    })
+    await new Promise(r => setTimeout(r, 60))
+
+    await plur.flushOutbox()
+
+    const after = loadEngrams(join(dir, 'engrams.yaml')).find(e => e.id === queued.id)!
+    const outbox = (after as { structured_data?: { _outbox?: { attempt_count?: number } } })
+      .structured_data?._outbox
+    expect(outbox, 'the engram must stay queued — a failed flush is not a handoff').toBeDefined()
+    expect(outbox!.attempt_count, 'the retry counter was not written back').toBeGreaterThan(0)
+  })
+
+  it('leaves engrams outside the outbox completely untouched', async () => {
+    const plur = new Plur({ path: dir })
+    await plur.learn('a queued team fact', { scope: SCOPE, type: 'behavioral' })
+    const bystander = await plur.learn('a purely local fact', { scope: 'global', type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 60))
+
+    const before = loadEngrams(join(dir, 'engrams.yaml')).find(e => e.id === bystander.id)!
+    await plur.flushOutbox()
+    const after = loadEngrams(join(dir, 'engrams.yaml')).find(e => e.id === bystander.id)!
+    expect(after).toEqual(before)
+  })
+})

--- a/packages/core/test/local-scope-never-routes-remote.test.ts
+++ b/packages/core/test/local-scope-never-routes-remote.test.ts
@@ -1,0 +1,112 @@
+/**
+ * A LOCAL scope must never reach a remote store (#831/#855 follow-up).
+ *
+ * `forget()` validated `primary | local | global | project:*` as legitimate
+ * targets and then guarded only `targetScope === 'primary'` before the remote
+ * walk. The 2026-08-13 evaluator panel measured the result: three of the four
+ * targets the error message itself advertises issued a remote DELETE when the
+ * id was absent locally, and reported success.
+ *
+ *     scope="global"      threw=null  remote DELETEs=1
+ *     scope="local"       threw=null  remote DELETEs=1
+ *     scope="project:foo" threw=null  remote DELETEs=1
+ *     scope="primary"     threw        remote DELETEs=0   (control)
+ *
+ * The caller said "the local one" and an unrelated remote engram was destroyed.
+ * `feedback()` had no such guard at all — not even for `primary`.
+ *
+ * These tests are written against the OBSERVED EFFECT (did a DELETE leave the
+ * process?) rather than against the return value, because "reported success
+ * while doing the wrong thing" is precisely the failure being fixed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur, isLocalOnlyScope } from '../src/index.js'
+
+const LOCAL_SCOPES = ['primary', 'local', 'global', 'project:foo'] as const
+
+describe('an explicit local scope never routes to a remote (#855)', () => {
+  let dir: string
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-localscope-'))
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false }],
+      index: false,
+    }))
+    originalFetch = globalThis.fetch
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+    // A remote that HAS the engram and will happily delete it — so anything
+    // reaching the network succeeds, and only the guard can stop it.
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (typeof url === 'string' && url.includes('/engrams/ENG-REMOTE-ONLY')) {
+        return {
+          ok: true, status: 200,
+          json: async () => (method === 'DELETE'
+            ? { id: 'ENG-REMOTE-ONLY', status: 'retired' }
+            : { id: 'ENG-REMOTE-ONLY', scope: 'group:test', status: 'active', data: { statement: 'remote fact' } }),
+          text: async () => '',
+        } as Response
+      }
+      return { ok: true, status: 200, json: async () => ({ rows: [], total_count: 0 }), text: async () => '' } as Response
+    }) as any)
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const mutatingCalls = (method: string) =>
+    fetchMock.mock.calls.filter(([, init]) => (init as { method?: string } | undefined)?.method === method)
+
+  it.each(LOCAL_SCOPES)('forget(scope: "%s") issues no remote DELETE', async scope => {
+    const plur = new Plur({ path: dir })
+    await expect(
+      plur.forget('ENG-REMOTE-ONLY', 'wrong target', { scope, force: true }),
+      `scope "${scope}" names a local target — the remote engram must be untouched`,
+    ).rejects.toThrow(/not found in the local store/)
+    expect(mutatingCalls('DELETE'), `scope "${scope}" reached the network`).toHaveLength(0)
+  })
+
+  it.each(LOCAL_SCOPES)('feedback(scope: "%s") issues no remote write', async scope => {
+    const plur = new Plur({ path: dir })
+    // `primary` already had its own refusal, earlier and with its own wording
+    // (it also skips the secondary-store walk); the other three had none.
+    await expect(
+      plur.feedback('ENG-REMOTE-ONLY', 'positive', scope),
+    ).rejects.toThrow(/not found in (the local|primary) store/)
+    expect(mutatingCalls('POST'), `scope "${scope}" reached the network`).toHaveLength(0)
+    expect(mutatingCalls('PATCH'), `scope "${scope}" reached the network`).toHaveLength(0)
+  })
+
+  it('still routes to the remote when the scope names the remote', async () => {
+    // The control. The guard must not have closed the legitimate path.
+    const plur = new Plur({ path: dir })
+    await plur.forget('ENG-REMOTE-ONLY', 'genuinely remote', { scope: 'group:test' })
+    expect(mutatingCalls('DELETE')).toHaveLength(1)
+  })
+
+  it('still searches everywhere when no scope is given', async () => {
+    const plur = new Plur({ path: dir })
+    await plur.forget('ENG-REMOTE-ONLY', 'unscoped')
+    expect(mutatingCalls('DELETE')).toHaveLength(1)
+  })
+
+  it('the predicate is shared, so the two call sites cannot drift again', () => {
+    // #855 asked for one helper when both landed. It was not built, the copies
+    // diverged, and the divergence was the destructive bug. Asserting the
+    // predicate directly is what makes a third caller inherit the rule.
+    for (const s of LOCAL_SCOPES) expect(isLocalOnlyScope(s), s).toBe(true)
+    for (const s of ['group:test', 'user:alice', 'group:plur/plur-ai/engineering']) {
+      expect(isLocalOnlyScope(s), s).toBe(false)
+    }
+  })
+})

--- a/packages/core/test/non-latin-content-hash.test.ts
+++ b/packages/core/test/non-latin-content-hash.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #896 — non-Latin statements must not collapse into one engram.
+ *
+ * `normalizeStatement` stripped every character outside ASCII `\w`, so a
+ * statement written in Japanese, Korean, Chinese, Russian, Greek, Hebrew,
+ * Arabic, Hindi or Thai normalized to the EMPTY STRING and hashed to
+ * `e3b0c442…`, the SHA-256 of `''`. Every one of them therefore carried the
+ * same `content_hash`, `findActiveByContentHash` matched them to each other,
+ * and the dedup fast path absorbed them into a single engram — four distinct
+ * facts in, one row out, `write_count: 4`, four reported successes.
+ *
+ * For a product whose job is memory, silently discarding every memory not
+ * written in a Latin script is the worst possible failure, so this file tests
+ * the end-to-end behaviour (do four writes produce four engrams?) and not just
+ * the string function.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, normalizeStatement, computeContentHash, isHashable } from '../src/index.js'
+
+/** SHA-256 of the empty string — what every non-Latin statement used to get. */
+const EMPTY_HASH = computeContentHash('')
+
+describe('non-Latin statements keep their identity (#896)', () => {
+  let dir: string
+  let plur: Plur
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-896-')); plur = new Plur({ path: dir }) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('four unrelated non-Latin facts stay four engrams', async () => {
+    // The measured reproduction. Before the fix this stored ONE engram with
+    // write_count 4; the other three statements were gone.
+    const statements = [
+      'データベースの設定を確認する',
+      '도커를 사용해야 한다',
+      'развертывание должно быть атомарным',
+      '部署前必须运行测试',
+    ]
+    for (const s of statements) await plur.learn(s, { scope: 'global', type: 'behavioral' })
+
+    const stored = await plur.list({ scope: 'global' })
+    expect(stored.map(e => e.statement).sort(), 'each fact must survive as its own engram')
+      .toEqual([...statements].sort())
+    for (const e of stored) {
+      expect((e as { content_hash?: string }).content_hash, `${e.id} got the empty-string hash`)
+        .not.toBe(EMPTY_HASH)
+    }
+  })
+
+  it('normalization keeps letters, digits, marks and _ in any script', () => {
+    expect(normalizeStatement('データベースの設定')).toBe('データベースの設定')
+    expect(normalizeStatement('Развёртывание — атомарно!')).toBe('развёртывание атомарно')
+    expect(normalizeStatement('déploiement')).toBe('déploiement')
+    // \p{M}: the vowel sign is part of the word, not punctuation to strip.
+    expect(normalizeStatement('हिन्दी')).toBe('हिन्दी')
+    // …while behaviour for the ASCII cases the old class handled is unchanged,
+    // which is why the overwhelming majority of stored hashes do not move.
+    expect(normalizeStatement('  Hello,  World!  ')).toBe('hello world')
+    expect(normalizeStatement('Use SNAKE_CASE for APIs.')).toBe('use snake_case for apis')
+  })
+
+  it('distinct non-Latin statements hash distinctly', () => {
+    const hashes = [
+      'データベースの設定を確認する',
+      '도커를 사용해야 한다',
+      'развертывание должно быть атомарным',
+      '部署前必须运行测试',
+    ].map(computeContentHash)
+    expect(new Set(hashes).size, 'all four collapsed to one hash').toBe(4)
+  })
+
+  it('a statement with no hashable content never dedups against another', async () => {
+    // The residual case, and why `isHashable` exists as a separate guard: '!!!'
+    // and '???' both still normalize to '' and so still share a hash. That is
+    // honest — there is no content to key on — but it must not be read as
+    // "these are the same fact".
+    expect(isHashable('!!!')).toBe(false)
+    expect(isHashable('データベース')).toBe(true)
+
+    await plur.learn('!!!', { scope: 'global', type: 'behavioral' })
+    await plur.learn('???', { scope: 'global', type: 'behavioral' })
+    const stored = await plur.list({ scope: 'global' })
+    expect(stored.map(e => e.statement).sort()).toEqual(['!!!', '???'])
+  })
+})

--- a/packages/core/test/outbox-circuit-breaker.test.ts
+++ b/packages/core/test/outbox-circuit-breaker.test.ts
@@ -13,7 +13,7 @@
  * opinions about whether it is reachable.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
@@ -162,5 +162,61 @@ describe('flushOutbox honours the breaker (#785)', () => {
     await plur.flushOutbox()
 
     expect(isHostInCooldown(REMOTE, Date.now(), statePath).inCooldown).toBe(true)
+  })
+})
+
+/**
+ * The two legs must use ONE health file even when PLUR_PATH and `path` differ.
+ *
+ * Every test above sets both to the same directory — the one configuration in
+ * which this cannot fail. The write leg called `isHostInCooldown` and
+ * `recordWriteOutcome` without a `statePath`, so it took the default, which
+ * resolves from PLUR_PATH; the recall leg passes `remoteHealthStatePath()`,
+ * which resolves from `paths.root`. For `new Plur({ path })`, `plur --path`,
+ * and every embedded consumer those are different files, so #785's "one host,
+ * one opinion" held only by coincidence of the fixture (2026-08-13 panel).
+ */
+describe('both legs share one health file across path configurations (#785)', () => {
+  let storeDir: string
+  let envDir: string
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    storeDir = mkdtempSync(join(tmpdir(), 'plur-store-'))
+    envDir = mkdtempSync(join(tmpdir(), 'plur-env-'))
+    // Deliberately DIFFERENT from the engine's root.
+    process.env.PLUR_PATH = envDir
+    originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as never
+    writeFileSync(join(storeDir, 'config.yaml'), yaml.dump({
+      stores: [{ url: REMOTE, token: 'tok', scope: 'group:acme/team', shared: true, readonly: false }],
+      index: false,
+    }))
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    delete process.env.PLUR_PATH
+    rmSync(storeDir, { recursive: true, force: true })
+    rmSync(envDir, { recursive: true, force: true })
+  })
+
+  it('a flush failure lands in the file the recall leg reads', async () => {
+    const plur = new Plur({ path: storeDir })
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) {
+      await plur.learn(`queued team fact ${i}`, { scope: 'group:acme/team', type: 'behavioral' })
+    }
+    await new Promise(r => setTimeout(r, 60))
+    await plur.flushOutbox()
+
+    // The engine's own answer to "where does health state live".
+    const recallLegPath = plur.remoteHealthStatePath()
+    expect(recallLegPath.startsWith(storeDir), 'fixture assumption: root drives the recall leg').toBe(true)
+    expect(
+      isHostInCooldown(REMOTE, Date.now(), recallLegPath).inCooldown,
+      'the write leg recorded its failures somewhere the recall leg never reads',
+    ).toBe(true)
+
+    // …and NOT in the PLUR_PATH-derived file, which is where they used to go.
+    expect(existsSync(join(envDir, 'cache', 'remote-health.json'))).toBe(false)
   })
 })

--- a/packages/core/test/outbox-order.test.ts
+++ b/packages/core/test/outbox-order.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The outbox flush order is a topological sort, and this is where that is
+ * proved (#863 follow-up).
+ *
+ * The shipped version was `pending.sort((a, b) => aDependsOnB - bDependsOnA)`.
+ * That comparator returns non-zero only for DIRECTLY related pairs, so it is
+ * not a strict weak ordering and `Array.prototype.sort` may produce any result
+ * for a chain. Every fixture #863 shipped used exactly two pending engrams —
+ * the one size at which a comparator and a topological sort cannot disagree.
+ *
+ * These tests use the input orders that make them disagree, and assert the
+ * INVARIANT ("no engram is placed before something it supersedes") rather than
+ * one expected permutation, so a different-but-valid order does not fail.
+ */
+import { describe, it, expect } from 'vitest'
+import { orderBySupersedes } from '../src/outbox-order.js'
+
+type Node = { id: string; supersedes?: string[] }
+const targetsOf = (n: Node) => n.supersedes ?? []
+const order = (nodes: Node[]) => orderBySupersedes(nodes, targetsOf).map(n => n.id)
+
+/** No node may appear before a node it supersedes, when both are present. */
+function assertTopological(nodes: Node[], result: string[]) {
+  const pos = new Map(result.map((id, i) => [id, i]))
+  for (const n of nodes) {
+    for (const t of targetsOf(n)) {
+      if (!pos.has(t)) continue
+      expect(pos.get(t)!, `${n.id} was pushed before its target ${t}`).toBeLessThan(pos.get(n.id)!)
+    }
+  }
+}
+
+describe('orderBySupersedes', () => {
+  it('orders a three-deep chain given in exactly the wrong order', () => {
+    // A→B→C presented as [A, B, C]. The old comparator produced [B, A, C] —
+    // B before its own target C — under V8's insertion sort.
+    const nodes: Node[] = [
+      { id: 'A', supersedes: ['B'] },
+      { id: 'B', supersedes: ['C'] },
+      { id: 'C' },
+    ]
+    const result = order(nodes)
+    expect(result).toEqual(['C', 'B', 'A'])
+    assertTopological(nodes, result)
+  })
+
+  it('handles the panel-measured shape: correction, filler, target', () => {
+    // The exact input the 2026-08-13 panel used to produce a permanent stall.
+    const nodes: Node[] = [
+      { id: 'correction', supersedes: ['target'] },
+      { id: 'filler' },
+      { id: 'target' },
+    ]
+    const result = order(nodes)
+    assertTopological(nodes, result)
+    expect(result).toHaveLength(3)
+  })
+
+  it('survives a deep chain in reverse, where any comparator is hopeless', () => {
+    const n = 12
+    const nodes: Node[] = Array.from({ length: n }, (_, i) => ({
+      id: `E${i}`,
+      ...(i < n - 1 ? { supersedes: [`E${i + 1}`] } : {}),
+    }))
+    const result = order(nodes)
+    expect(result).toEqual(Array.from({ length: n }, (_, i) => `E${n - 1 - i}`))
+    assertTopological(nodes, result)
+  })
+
+  it('is stable for the common case of no edges at all', () => {
+    // The overwhelmingly common flush. Reordering it would make the push order
+    // — and therefore the server ids — depend on an implementation detail.
+    const nodes: Node[] = [{ id: 'A' }, { id: 'B' }, { id: 'C' }, { id: 'D' }]
+    expect(order(nodes)).toEqual(['A', 'B', 'C', 'D'])
+  })
+
+  it('keeps every engram when there is a cycle, rather than dropping one', () => {
+    // A mutual supersedes has no valid order. The old comparator returned 0
+    // for the pair and left them in place with no signal; dropping them would
+    // be worse still, because a flush that silently omits an engram reports
+    // success for work it did not do.
+    const nodes: Node[] = [
+      { id: 'X', supersedes: ['Y'] },
+      { id: 'Y', supersedes: ['X'] },
+      { id: 'Z' },
+    ]
+    const result = order(nodes)
+    expect(result.sort()).toEqual(['X', 'Y', 'Z'])
+  })
+
+  it('ignores targets outside the pending set', () => {
+    // A target already on the server, or one that lives only locally, is
+    // resolved elsewhere. Counting it as a dependency would leave the node
+    // waiting on something this flush can never deliver — every engram would
+    // land in the cycle bucket.
+    const nodes: Node[] = [
+      { id: 'A', supersedes: ['ALREADY-PUSHED'] },
+      { id: 'B' },
+    ]
+    expect(order(nodes)).toEqual(['A', 'B'])
+  })
+
+  it('ignores a self-edge instead of deadlocking on it', () => {
+    const nodes: Node[] = [{ id: 'A', supersedes: ['A'] }, { id: 'B' }]
+    expect(order(nodes)).toEqual(['A', 'B'])
+  })
+
+  it('orders a diamond: two corrections of one target', () => {
+    const nodes: Node[] = [
+      { id: 'top', supersedes: ['left', 'right'] },
+      { id: 'left', supersedes: ['base'] },
+      { id: 'right', supersedes: ['base'] },
+      { id: 'base' },
+    ]
+    const result = order(nodes)
+    assertTopological(nodes, result)
+    expect(result[0]).toBe('base')
+    expect(result[3]).toBe('top')
+  })
+})

--- a/packages/core/test/readonly-query-adapter.test.ts
+++ b/packages/core/test/readonly-query-adapter.test.ts
@@ -39,6 +39,10 @@ function makePrimaryQueryStore() {
       updateMany: async () => {},
       nextEngramId: async () => 'ENG-STUB-001',
       searchBM25: async (q: string) => { calls.push(`bm25:${q}`); return [] as Engram[] },
+      searchBM25Exhaustive: async (q: string) => {
+        calls.push(`exhaustive:${q}`)
+        return { rows: [] as Engram[], exhausted: true }
+      },
       searchVector: async () => { calls.push('vector'); return [] },
     },
   }
@@ -86,6 +90,34 @@ describe('ReadonlyStoreGuard forwards the query-adapter surface (#830)', () => {
     // nextEngramId is NOT a read: an implementation that makes allocation
     // collision-safe does so by CONSUMING the id, which mutates the store.
     await expect(guard.nextEngramId!('2026-08-13')).rejects.toBeInstanceOf(ReadonlyStoreError)
+  })
+
+  it('forwards EVERY query-adapter read the inner store declares', () => {
+    // A structural check, not another per-member case, because the per-member
+    // cases are what missed `searchBM25Exhaustive` when #753 added it: the
+    // guard shipped without it, `recall()` silently kept widening 3L → 9L →
+    // 27L against a read-only Postgres store, and nobody noticed because a
+    // 2-3x cost regression is invisible where a crash is not. Enumerating
+    // instead means the NEXT member fails here on the day it lands.
+    const { store } = makePrimaryQueryStore()
+    const guard = new ReadonlyStoreGuard(store as never) as unknown as Record<string, unknown>
+    const READS = ['searchBM25', 'searchBM25Exhaustive', 'searchVector'] as const
+    for (const name of READS) {
+      expect(typeof guard[name], `${name} was not forwarded — pushdown degrades silently`)
+        .toBe('function')
+    }
+    expect(guard.role).toBe('primary')
+    expect(guard.vectorIndex).toEqual({ kind: 'hnsw' })
+  })
+
+  it('the forwarded exhaustion hook reaches the inner store', async () => {
+    const { store, calls } = makePrimaryQueryStore()
+    const guard = new ReadonlyStoreGuard(store as never) as unknown as {
+      searchBM25Exhaustive: (q: string, o: { limit: number }) => Promise<{ exhausted: boolean }>
+    }
+    const res = await guard.searchBM25Exhaustive('docker', { limit: 10 })
+    expect(calls).toContain('exhaustive:docker')
+    expect(res.exhausted).toBe(true)
   })
 
   it('does not invent a query surface for a store that has none', () => {

--- a/packages/core/test/repair-content-hashes.test.ts
+++ b/packages/core/test/repair-content-hashes.test.ts
@@ -1,0 +1,149 @@
+/**
+ * `repairContentHashes` must not destroy a concurrent write (#852, follow-up).
+ *
+ * The first cut of this repair lived in `plur reindex-hashes` and did
+ * `loadEngrams()` → mutate → `saveEngrams()` with NO lock. The 2026-08-13
+ * data-loss audit reproduced the loss 6/6 on a 4,642-engram store: a
+ * correctly-locked writer appends between the load and the save, the save puts
+ * the pre-append snapshot back, and the engram is gone. Silently — the shrink
+ * guard cannot see it either, because the same count goes out that came in.
+ *
+ * So the interesting property is not "does it fix the hash". It is "does it
+ * fix the hash WITHOUT reverting whatever else happened while it ran", and
+ * that is only true if the load and the save are inside the same store lock.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur, YamlPrimaryStore, detectPlurStorage, loadEngrams, saveEngrams, computeContentHash, withAsyncLock } from '../src/index.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+/** A schema-valid engram whose `content_hash` matches its statement. */
+function fixture(id: string): Engram {
+  const statement = `deployment note for ${id}`
+  return {
+    id, version: 2, status: 'active', consolidated: false,
+    type: 'behavioral', scope: 'global', visibility: 'private',
+    statement,
+    activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-13' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+    abstract: null, derived_from: null, polarity: null,
+    content_hash: computeContentHash(statement),
+    commitment: 'leaning', write_count: 1, injection_count: 0, sources: [], recurrence_count: 0,
+    summary: 's', engram_version: 1, episode_ids: [],
+    temporal: { learned_at: '2026-08-13' },
+  } as unknown as Engram
+}
+
+describe('repairContentHashes (#852)', () => {
+  let dir: string
+  let plur: Plur
+  let storePath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-hash-repair-'))
+    plur = new Plur({ path: dir })
+    storePath = detectPlurStorage(dir).engrams
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  /** Write a stale `content_hash` onto a stored engram, out of band. */
+  function makeStale(id: string): void {
+    const corpus = loadEngrams(storePath)
+    const target = corpus.find(e => e.id === id)!
+    ;(target as { content_hash?: string }).content_hash = computeContentHash('something else entirely')
+    saveEngrams(storePath, corpus)
+  }
+
+  it('reports stale and missing separately, and writes nothing without --apply', async () => {
+    const a = await plur.learn('deploy staging with docker compose', { scope: 'global', type: 'procedural' })
+    makeStale(a.id)
+
+    const before = loadEngrams(storePath)
+    const report = await plur.repairContentHashes({})
+
+    expect(report.stale.map(s => s.id)).toEqual([a.id])
+    expect(report.repaired).toBe(0)
+    expect(loadEngrams(storePath), 'a read-only scan must not touch the store').toEqual(before)
+  })
+
+  it('--apply rewrites the hash so it matches the statement again', async () => {
+    const a = await plur.learn('rebase before pushing on this repo', { scope: 'global', type: 'behavioral' })
+    makeStale(a.id)
+
+    const report = await plur.repairContentHashes({ apply: true })
+    expect(report.repaired).toBe(1)
+
+    const fixed = loadEngrams(storePath).find(e => e.id === a.id)!
+    expect((fixed as { content_hash?: string }).content_hash)
+      .toBe(computeContentHash(fixed.statement))
+  })
+
+  it('does NOT destroy an engram written while the repair was in flight', async () => {
+    // The discriminating case, and the one the audit measured.
+    //
+    // Two details are load-bearing and were both wrong in a first draft of this
+    // test, which passed with the fix reverted and so proved nothing:
+    //
+    //  1. The corpus is 20 engrams, not 2. At 20-in / 21-on-disk the shrink
+    //     guard does NOT fire (5% < the 10% tolerance) — which is precisely why
+    //     the audit's loss was SILENT. A two-engram corpus is a 50% shrink, so
+    //     the guard catches it and the test would be asserting the wrong thing.
+    //  2. `load()` takes a beat. Parsing a real store is hundreds of
+    //     milliseconds; with an instantaneous load the unlocked repair finishes
+    //     its whole read-modify-write in one microtask drain and never overlaps
+    //     the concurrent writer at all. The delay is what opens the window that
+    //     exists in production.
+    const corpus = Array.from({ length: 20 }, (_, i) => fixture(`ENG-SEED-${i}`))
+    ;(corpus[0] as { content_hash?: string }).content_hash = computeContentHash('something else entirely')
+    saveEngrams(storePath, corpus)
+
+    class SlowYamlStore extends YamlPrimaryStore {
+      async load(): Promise<Engram[]> {
+        const rows = await super.load()
+        await new Promise(resolve => setTimeout(resolve, 20))
+        return rows
+      }
+    }
+    const engine = new Plur({ path: dir, store: new SlowYamlStore(storePath) })
+
+    // Hold the store lock, kick off the repair (which must QUEUE behind us),
+    // then commit the victim before releasing. A locked repair loads after we
+    // are done and sees it; an unlocked one loaded before it existed and puts
+    // that stale snapshot back.
+    //
+    // The promise is deliberately parked in an outer binding rather than
+    // returned from the callback: `withAsyncLock` awaits its callback's result,
+    // so returning it would await the queued repair while still holding the
+    // lock the repair is waiting for.
+    let repair!: Promise<unknown>
+    await withAsyncLock(storePath, async () => {
+      repair = engine.repairContentHashes({ apply: true })
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const current = loadEngrams(storePath)
+      current.push(fixture('ENG-VICTIM-001'))
+      saveEngrams(storePath, current)
+    })
+    await repair
+
+    const after = loadEngrams(storePath)
+    expect(after.map(e => e.id), 'the concurrent write must survive the repair').toContain('ENG-VICTIM-001')
+    const seed = after.find(e => e.id === 'ENG-SEED-0')!
+    expect((seed as { content_hash?: string }).content_hash, 'and the repair must still have happened')
+      .toBe(computeContentHash(seed.statement))
+  })
+
+  it('refuses to write on a readonly engine', async () => {
+    const a = await plur.learn('the fixture statement', { scope: 'global', type: 'terminological' })
+    makeStale(a.id)
+
+    const ro = new Plur({ path: dir, readonly: true })
+    await expect(ro.repairContentHashes({ apply: true })).rejects.toThrow()
+    // …but reporting still works, which is what the CLI's default mode uses.
+    const report = await ro.repairContentHashes({})
+    expect(report.stale.map(s => s.id)).toEqual([a.id])
+  })
+})

--- a/packages/core/test/supersedes-flush-remap.test.ts
+++ b/packages/core/test/supersedes-flush-remap.test.ts
@@ -156,3 +156,158 @@ describe('supersedes survives the flush (#863)', () => {
     expect(res.expired_warnings.some(w => w.includes('lives only in the local store'))).toBe(true)
   })
 })
+
+/**
+ * Chains deeper than two, and edges whose target left in an EARLIER flush.
+ *
+ * Both were asserted rather than tested. #863 claimed "one stable partial
+ * ordering is enough … a deeper chain resolves across successive flushes";
+ * all four of its fixtures used exactly two pending engrams, and the
+ * 2026-08-13 panel showed both halves of the claim to be false:
+ *
+ *   - the comparator `aDependsOnB - bDependsOnA` is non-transitive, so a
+ *     three-node chain could be ordered arbitrarily, and
+ *   - a target flushed in an earlier run has no local row and no entry in the
+ *     per-flush map, so its dependent failed identically on every subsequent
+ *     flush while being told to "flush again once X has been pushed".
+ */
+describe('supersedes ordering for chains and across flushes (#863 follow-up)', () => {
+  let dir: string
+  let originalFetch: typeof globalThis.fetch
+  let posted: Array<Record<string, unknown>>
+  let serverSeq: number
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-863-chain-'))
+    originalFetch = globalThis.fetch
+    posted = []
+    serverSeq = 0
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ url: REMOTE, token: 'tok', scope: SCOPE, shared: true, readonly: false }],
+      index: false,
+    }))
+  })
+  afterEach(() => { globalThis.fetch = originalFetch; rmSync(dir, { recursive: true, force: true }) })
+
+  const down = () => { globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as never }
+  const up = () => {
+    const res = (status: number, body: unknown): Response => ({
+      ok: true, status,
+      json: async (): Promise<unknown> => body,
+      text: async (): Promise<string> => '',
+    } as unknown as Response)
+    globalThis.fetch = vi.fn(async (_url: string, init?: { method?: string; body?: string }) => {
+      if ((init?.method ?? 'GET') === 'POST') {
+        posted.push(JSON.parse(init!.body as string))
+        serverSeq++
+        return res(201, { id: `ENG-GDA-2026-08-11-${String(serverSeq).padStart(3, '0')}` })
+      }
+      return res(200, { rows: [], total_count: 0 })
+    }) as never
+  }
+
+  it('orders a three-deep chain so every edge resolves in one flush', async () => {
+    // A supersedes B supersedes C. The correct push order is C, B, A — the
+    // REVERSE of the order they sit in the store, which is what makes this the
+    // discriminating case. The edges are wired after creation because a
+    // supersedes target must already exist, and wiring them at creation time
+    // would put the store in topological order already and let any comparator
+    // pass.
+    down()
+    const plur = new Plur({ path: dir })
+    const a = await plur.learn('the final word on the timer claim', { scope: SCOPE, type: 'behavioral' })
+    const b = await plur.learn('a first correction to the timer claim', { scope: SCOPE, type: 'behavioral' })
+    const c = await plur.learn('the original claim about the timer', { scope: SCOPE, type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 60))
+    for (const [from, to] of [[a, b], [b, c]] as const) {
+      const row = (await plur.getById(from.id))!
+      ;(row as unknown as { relations: Record<string, unknown> }).relations = {
+        ...((row as unknown as { relations?: Record<string, unknown> }).relations ?? {}),
+        supersedes: [to.id],
+      }
+      await plur.updateEngram(row)
+    }
+
+    up()
+    const res = await plur.flushOutbox()
+
+    expect(res.failed, `chain stalled: ${res.expired_warnings.join(' | ')}`).toBe(0)
+    expect(posted.length).toBe(3)
+    expect(posted.map(p => p.statement)).toEqual([c.statement, b.statement, a.statement])
+    // Every pushed edge points at a SERVER id, never a local one.
+    for (const p of posted.slice(1)) {
+      const sup = (p.supersedes as string[] | undefined) ?? []
+      expect(sup.length, 'the correction lost its supersedes entirely').toBeGreaterThan(0)
+      for (const t of sup) expect(t).toMatch(/^ENG-GDA-/)
+    }
+  })
+
+  it('resolves an edge whose target was pushed in an EARLIER flush', async () => {
+    down()
+    const plur = new Plur({ path: dir })
+    const target = await plur.learn('the statement that will be corrected later', { scope: SCOPE, type: 'behavioral' })
+    // A local-only engram, minted AFTER the target, purely to hold the id
+    // sequence up. Without it the target's local row is spliced out on flush,
+    // the store is empty again, and the correction is minted the SAME id the
+    // target had — which is #816 (ids are derived from the store's high-water
+    // mark, and the mark is not persisted) and would make this test assert
+    // something other than what it is about.
+    await plur.learn('an unrelated local note', { scope: 'global', type: 'behavioral' })
+    await new Promise(r => setTimeout(r, 60))
+
+    // Flush 1: the target goes, and its local row is spliced out.
+    up()
+    await plur.flushOutbox()
+    expect(posted.length).toBe(1)
+    const serverId = 'ENG-GDA-2026-08-11-001'
+
+    // Flush 2: a correction queued afterwards still names the LOCAL id.
+    down()
+    const correction = await plur.learn('the corrected statement', {
+      scope: SCOPE, type: 'behavioral', supersedes: [target.id],
+    })
+    await new Promise(r => setTimeout(r, 60))
+    expect(correction.id).not.toBe(target.id)
+
+    up()
+    const res = await plur.flushOutbox()
+
+    expect(
+      res.failed,
+      `permanently stalled — the remediation "flush again once ${target.id} has been pushed" `
+      + `cannot be followed, because it already was: ${res.expired_warnings.join(' | ')}`,
+    ).toBe(0)
+    expect(posted.length).toBe(2)
+    // The wire shape flattens `relations.supersedes` to a top-level field.
+    expect(posted[1].supersedes, 'the edge still names a dead local id').toEqual([serverId])
+  })
+
+  it('a mutual supersedes is refused and reported, not silently dropped', async () => {
+    // A cycle has no valid order. The engrams must still be ATTEMPTED — a
+    // node that never enters the loop disappears from the flush entirely,
+    // which is worse than a loud refusal.
+    down()
+    const plur = new Plur({ path: dir })
+    const x = await plur.learn('one side of a mutual correction', { scope: SCOPE, type: 'behavioral' })
+    const y = await plur.learn('the other side of a mutual correction', {
+      scope: SCOPE, type: 'behavioral', supersedes: [x.id],
+    })
+    await new Promise(r => setTimeout(r, 60))
+    // Close the cycle by hand — nothing in the API creates one.
+    const stored = (await plur.getById(x.id))!
+    ;(stored as unknown as { relations: Record<string, unknown> }).relations = {
+      ...((stored as unknown as { relations?: Record<string, unknown> }).relations ?? {}),
+      supersedes: [y.id],
+    }
+    await plur.updateEngram(stored)
+
+    up()
+    const res = await plur.flushOutbox()
+
+    // One of the two cannot resolve its edge; it must be reported, and the
+    // other must still get through.
+    expect(res.flushed + res.failed, 'a cycle member vanished from the flush').toBe(2)
+    expect(res.failed).toBeGreaterThan(0)
+    expect(res.expired_warnings.some(w => w.includes('NOT pushed'))).toBe(true)
+  })
+})

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -55,6 +55,11 @@ const ALWAYS_ASYNC = new Set([
   // Embedding-backed, so it could never have been sync, and it is new in this
   // release, so no pre-0.16 call site exists for the migrate tool to rewrite.
   'nearDuplicates',
+  // Born async (#852) — the content_hash repair behind `plur reindex-hashes`.
+  // Takes the store lock and goes through the async PrimaryStore seam, so it
+  // could never have been sync; new in this release, so there is no pre-0.16
+  // call site to rewrite.
+  'repairContentHashes',
 ])
 
 /** Public methods of `Plur`, mapped to whether they are declared `async`. */


### PR DESCRIPTION
Three independent passes over `03f441b..82e50d2` — a data-loss audit of the write paths, an adversarial pass on the diff, and an evaluator panel (critic / dijkstra / popper / taleb), run in parallel and blind to each other.

Every finding was **reproduced before being fixed**, and every fix has a test that **fails when the fix is reverted**. Where a first draft of a test passed with its fix reverted, that is recorded in the test file rather than quietly corrected — three tests here needed a second attempt.

The day's stated through-line was that most defects *report success while doing the wrong thing*. The diagnosis was right; the execution reproduced the same class inside three of the fixes.

## Critical — all three shipped today

**1. Non-Latin statements collapse into a single engram (#896).** `normalizeStatement` used ASCII `\w`, so every statement in a non-Latin script normalized to `""` and hashed to SHA-256 of the empty string. They therefore all shared a `content_hash`, `findActiveByContentHash` matched them to each other, and dedup absorbed them:

```
stored statements: [ 'データベースの設定を確認する' ]     ← 4 written, 1 stored
write_counts:      [ 4 ]
CONTROL (English): 4 → 4
```

Four unrelated facts, three destroyed, four reported successes. Now `[^\p{L}\p{N}\p{M}_\s]` — `\p{M}` is load-bearing on its own, since Devanagari and Thai vowel signs are nonspacing marks — plus a new `isHashable()` wired into all three dedup entry points, failing in the safe direction (a missed dedup costs a row; a false dedup costs the memory).

**2. `reindex-hashes --apply` destroyed concurrent writes.** Unlocked whole-corpus read-modify-write; reproduced **6/6** on a 4,642-engram store. No lock, no daily backup (`_maybeDailyBackup` fires from *inside* `_withStoreLock`), and the shrink guard cannot see it because the same count goes out that came in. Zero tests on the destructive path. Moved into `Plur.repairContentHashes()` behind `_withStoreLock` and the `_loadTargeted`/`_updateEngrams` pair — which also fixes a false all-clear on an injected non-YAML store. `--apply` now refuses to write the shared empty-string hash and reports those rows as a third category, rather than stamping it onto the 961 rows it had just called "inert".

**3. An explicit local scope routed to a remote DELETE.** `forget()` validated `primary | local | global | project:*` and then guarded only `primary`:

```
scope="global"      threw=null  remote DELETEs=1   ← wrong-target retire, reported success
scope="local"       threw=null  remote DELETEs=1
scope="project:foo" threw=null  remote DELETEs=1
scope="primary"     threw        remote DELETEs=0  (control)
```

`feedback()` had no guard at all. This is #831 verbatim, from the direction #855 documented itself as closing — and #855 explicitly asked for a shared helper that was never built. **The drift was the bug**, so the rule is now a module (`src/scope-target.ts`), not a convention.

## High

**4. Unbounded `fetch` inside the store lock.** `RemoteStore.existsById` had no `AbortSignal`, and both callers run it *inside* the primary lock. undici's default `headersTimeout` is 300s; `DEFAULT_ACQUIRE_TIMEOUT` is 180s — so a host that handshakes and then stalls makes every waiting `plur_learn` throw "Failed to acquire lock", and the engram is silently never stored. Bounded with `load()`'s budget; an abort surfaces as "cannot tell", not "absent".

**5. The supersedes flush order was not a sort.** `pending.sort((a, b) => aDependsOnB - bDependsOnA)` returns non-zero only for directly related pairs, so it is not a strict weak ordering. All four of #863's fixtures used exactly two pending engrams — the one size at which a comparator and a topological sort cannot disagree. With three, the flush pushed a correction before its own target and then failed **identically on every subsequent flush**, printing `flush again once X has been pushed` for an X that had already been pushed, its local row spliced out, and `localToServer` per-flush. Now `src/outbox-order.ts` (Kahn's, stable, cycles appended so they are refused out loud rather than vanishing), plus a bounded persisted local→server id map for cross-flush edges.

## Medium

**6. `inject()` became a whole-corpus writer** on the session-start path — 4.4× at 200 engrams, 10.5× at 2,000, **19.7× at 10,000** — all inside the global lock, with `EngramStoreShrinkError` / `EngramStoreUnreadableError` swallowed by a bare `catch {}`. Now targeted; integrity errors warn.

**7. The outbox merge-back replaced fresh rows with a pre-network snapshot**, reverting concurrent feedback counters, activation bumps, pins and rescopes. Now a field merge (`_outbox`, `_demoted`, and `scope`/`visibility` only for ids this flush actually demoted).

**8. The circuit breaker kept two state files.** Recall passes `remoteHealthStatePath()` (from `paths.root`); the write leg took the default (from `PLUR_PATH`). Different files for `new Plur({ path })`, `plur --path`, and every embedded consumer — #785's "one host, one opinion" held only because its fixture set both to the same directory. The new test sets them differently.

**9. The tokenizer split Japanese loanwords.** U+30FC ー is `Script=Common`, so `Script=` terminated the run: `コンピューター` → `["ーター","コン","ンピ","ピュ"]`, and a query for `ベース` did not match a document containing it. #833's before/after table happened to use a word with no prolonged mark. Now `Script_Extensions` (which also covers 々). `TOKENIZER_VERSION` 3 → 4, and the ledger now records entry 3, which #833 bumped without documenting.

**10. `searchBM25Exhaustive` missing from the readonly whitelist**, so a read-only Postgres store kept widening 3L → 9L → 27L. The file's own argument — "a missed entry loses functionality **and someone notices**" — was falsified in the same batch, because a silent 2–3× cost regression is not a crash. Corrected, and the test now enumerates the surface.

## Low

**11.** `saveEngrams`' quarantine re-read was documented but not implemented; restated as the precondition it actually is.

## Verification

- `pnpm test`: **3,983 passed, 0 failed**, 159 skipped (300 files) — includes `typecheck:tests` and the serial `core-pglite` / `cli-spawn` projects.
- Revert-checked: the concurrency test (silent loss at 20 rows), the #896 collapse (4/4 fail), the local-scope guard (6/11 fail), the health-path split, and the ordering (`orderBySupersedes` extracted specifically so the algorithm is testable in isolation).

Audit record, including what was verified sound and what is left open: `docs/audits/2026-08-13-post-merge-audit.md`.

Closes #896.