### PR TITLE
chore: close nine issues that needed no product decision

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -1,0 +1,34 @@
+name: Heartbeat ingress
+
+# `infra/heartbeat` had tests and no CI job — neither the `validate()` matrix in
+# test_server.py nor (until #613) any coverage of the HTTP layer. It matched no
+# path filter in any existing workflow, so a change to the ingress could merge
+# entirely untested.
+#
+# Its own workflow rather than a job in python.yml: this is stdlib-only, so it
+# needs neither pnpm nor a built CLI, and bolting it onto a job that builds the
+# Node workspace would make a 6-second test suite wait on a 2-minute install.
+
+on:
+  push:
+    branches: [main]
+    paths: ['infra/heartbeat/**', '.github/workflows/heartbeat.yml']
+  pull_request:
+    branches: [main]
+    paths: ['infra/heartbeat/**', '.github/workflows/heartbeat.yml']
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      # `test_http.py` binds a real socket on port 0 and writes into tmp_path,
+      # so it needs no service, no fixtures on disk, and no privileged paths.
+      - run: pytest infra/heartbeat -q

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -13,8 +13,10 @@ on:
   push:
     branches: [main]
     paths: ['infra/heartbeat/**', '.github/workflows/heartbeat.yml']
+  # Every pull request, not only those targeting main — a stacked PR (one based
+  # on another in-review branch) otherwise runs no CI and reads as verified.
+  # See the note in ci.yml.
   pull_request:
-    branches: [main]
     paths: ['infra/heartbeat/**', '.github/workflows/heartbeat.yml']
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ PLUR is memory, not just retrieval — so we measure it on more than one axis, o
 |-------|-----|-------|
 | BM25 only | 92.2% | no embedder — fully airgapped |
 | Hybrid (BGE-small, shipping default) | 95.6% | bundled local embedder, zero downloads |
-| **+ BGE-reranker-v2-m3** | **98.0%** | local cross-encoder, max quality — R@1 93.8%, R@10 99.0% |
+| **+ BGE-reranker-v2-m3** | **97.6%** | local cross-encoder, max quality — opt-in, ≈5s p50 on CPU |
+
+Numbers come from [plur-ai/plur-bench](https://github.com/plur-ai/plur-bench),
+which is the source of truth for every benchmark figure PLUR publishes. Where
+an in-repo number and a plur-bench number disagree, plur-bench wins — it is the
+reproducible harness, and it is what CI regression-checks.
 
 Chunk granularity, canonical-doc scoring, corpus SHA256 pinned — reproduce it in [plur-ai/plur-bench](https://github.com/plur-ai/plur-bench). No cloud call is required for any of these numbers (an *optional* cloud embedder, openai-3-large, reaches 97.0% hybrid). A faster reranker — `ms-marco-minilm-l6` (p50≈245ms vs BGE's ≈5s on CPU) — trades a little recall for sub-second latency.
 
@@ -327,7 +332,11 @@ In both modes **`scope: local` engrams** are machine-specific by design (paths, 
 
 ## Benchmark details
 
-Per-category retrieval recall — full LongMemEval-S (N=500), fully local (BGE-small + BGE-reranker-v2-m3, chunk granularity):
+Per-category retrieval recall, from an **earlier in-repo run** — full
+LongMemEval-S (N=500), fully local (BGE-small + BGE-reranker-v2-m3, chunk
+granularity). Its overall figure (98.0%) predates the current plur-bench
+measurement of the same stack (97.6%) and has not been re-run per category;
+treat the shape as indicative and the headline table above as current.
 
 | Category | R@5 | R@10 |
 |----------|-----|------|

--- a/README.md
+++ b/README.md
@@ -262,6 +262,26 @@ await plur.sync('git@github.com:you/plur-memory.git')
 | `plur_sync` | Sync via git. `personal` remotes mirror everything (use a private repo); `shared` remotes receive only shared-scope, non-private engrams |
 | `plur_status` | Check system health and engram counts |
 | `plur_receipt` | Counted, local report of what your memory retrieved for you |
+| `plur_outbox` | Inspect (and retry) team writes queued while their store was unreachable |
+
+### The outbox
+
+A write to a team scope goes to that team's remote store. When the store cannot
+be reached — VPN off, server down, token expired — the engram is **not lost and
+not silently dropped**: it is written locally with queue metadata and retried on
+the next session start, on `plur sync`, or on demand.
+
+The queue is not a directory. It lives as `structured_data._outbox` inside the
+affected engrams in `engrams.yaml`, which is why it needs a command to see:
+
+```
+plur outbox            # what is queued, for which scope, how long, last error
+plur outbox --flush    # retry now
+```
+
+The same thing is available to agents as `plur_outbox` (`{flush: true}` to
+retry), and `plur status` reports the pending count. Neither surface prints the
+target URL or the token.
 
 ## The memory receipt
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ await plur.sync('git@github.com:you/plur-memory.git')
 | `plur_inject_hybrid` | Select engrams for current task within token budget |
 | `plur_feedback` | Rate relevance (trains quality over time) |
 | `plur_forget` | Retire a memory (activation decays, eventually pruned) |
+| `plur_rescope` | Move an existing engram to another scope — personal → team, or back |
+| `plur_session_scope` | Change the session's default write scope mid-session |
 | `plur_capture` | Record an event — incident, resolution, session milestone |
 | `plur_timeline` | Query episode history by time, agent, or channel |
 | `plur_ingest` | Extract engrams from text automatically |

--- a/comparisons/README.md
+++ b/comparisons/README.md
@@ -64,12 +64,12 @@ verify:
 
 ---
 
-## Recall quality: 97.6% R@5, fully local
+## Recall quality: 97.6% R@5, fully local (hybrid + BGE-reranker)
 
 We're not shy about the number — we just won't run a scores race. Our own, reproducible measurement (no competitor stacking):
 
-- **97.6% R@5 on LongMemEval-S** (n=500, chunk granularity, **fully local, no API**).
-- **Locality is not a downgrade.** In the *same* harness, on the same 500 questions, our fully-local stack (97.6%) is **on par** with the same-style pipeline run on a frontier *cloud* embedder (97.0%) — retrieval here is deterministic, so this is a paired point-estimate, not a sampling estimate. The honest takeaway: going local is not a downgrade; sovereignty costs you nothing measurable on quality.
+- **97.6% R@5 on LongMemEval-S** (n=500, chunk granularity, **fully local, no API**) — hybrid plus the opt-in BGE-reranker. The zero-config default, with no reranker, is 95.6%; BM25 alone is 92.2%.
+- **Locality is not a downgrade.** In the *same* harness, on the same 500 questions, our fully-local stack (97.6%, hybrid + BGE-reranker) is **on par** with the same-style pipeline run on a frontier *cloud* embedder (97.0%) — retrieval here is deterministic, so this is a paired point-estimate, not a sampling estimate. The honest takeaway: going local is not a downgrade; sovereignty costs you nothing measurable on quality.
 - **Our own harness.** The number comes from plur-bench and is regression-checked in our CI — a process figure, not a hand-picked marketing screenshot.
 
 > **Disclaimer (applies wherever this number appears):** LongMemEval-S · 500 questions · per-question protocol · canonical-doc scoring · chunk granularity. R@5 = ground-truth evidence lands in the top-5 retrieved — *not* end-to-end answer accuracy. Measured with our own plur-bench harness (no published third-party audit).[^gbrain]

--- a/comparisons/plur-vs-cognee.md
+++ b/comparisons/plur-vs-cognee.md
@@ -18,7 +18,7 @@
 
 ## Recall — table stakes, not the deciding factor
 
-Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local. The decision is the open portable format and packs, not a recall delta.
+Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local (hybrid + the opt-in BGE-reranker; the zero-config default is 95.6%). The decision is the open portable format and packs, not a recall delta.
 *(LongMemEval-S · n=500 · chunk · canonical-doc; R@5 = evidence in the top-5, not answer accuracy; measured on our own plur-bench harness, public with our paper.)*
 
 ## Choose Cognee if

--- a/comparisons/plur-vs-letta.md
+++ b/comparisons/plur-vs-letta.md
@@ -18,7 +18,7 @@
 
 ## Recall — table stakes, not the deciding factor
 
-Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local. The decision is architecture (layer vs runtime) and ownership, not a recall delta.
+Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local (hybrid + the opt-in BGE-reranker; the zero-config default is 95.6%). The decision is architecture (layer vs runtime) and ownership, not a recall delta.
 *(LongMemEval-S · n=500 · chunk · canonical-doc; R@5 = evidence in the top-5, not answer accuracy; measured on our own plur-bench harness, public with our paper.)*
 
 ## Choose Letta if

--- a/comparisons/plur-vs-mastra.md
+++ b/comparisons/plur-vs-mastra.md
@@ -17,7 +17,7 @@
 
 ## Recall — table stakes, not the deciding factor
 
-Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local. (Mastra's memory numbers are blog-level; we don't run a head-to-head.) The decision is portability, not a recall delta.
+Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local (hybrid + the opt-in BGE-reranker; the zero-config default is 95.6%). (Mastra's memory numbers are blog-level; we don't run a head-to-head.) The decision is portability, not a recall delta.
 *(LongMemEval-S · n=500 · chunk · canonical-doc; R@5 = evidence in the top-5, not answer accuracy; measured on our own plur-bench harness, public with our paper.)*
 
 ## Choose Mastra if

--- a/comparisons/plur-vs-mem0.md
+++ b/comparisons/plur-vs-mem0.md
@@ -18,7 +18,7 @@
 
 ## Recall — table stakes, not the deciding factor
 
-Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local. We don't run a head-to-head scores race — the decision is ownership.
+Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local (hybrid + the opt-in BGE-reranker; the zero-config default is 95.6%). We don't run a head-to-head scores race — the decision is ownership.
 *(LongMemEval-S · n=500 · chunk · canonical-doc; R@5 = evidence in the top-5, not answer accuracy; measured on our own plur-bench harness, public with our paper.)*
 
 ## Choose mem0 if

--- a/comparisons/plur-vs-supermemory.md
+++ b/comparisons/plur-vs-supermemory.md
@@ -17,7 +17,7 @@
 
 ## Recall — table stakes, not the deciding factor
 
-Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local. We don't run a head-to-head scores race — the decision is where the memory lives and who owns it.
+Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local (hybrid + the opt-in BGE-reranker; the zero-config default is 95.6%). We don't run a head-to-head scores race — the decision is where the memory lives and who owns it.
 *(LongMemEval-S · n=500 · chunk · canonical-doc; R@5 = evidence in the top-5, not answer accuracy; measured on our own plur-bench harness, public with our paper.)*
 
 ## Choose supermemory if

--- a/comparisons/plur-vs-zep.md
+++ b/comparisons/plur-vs-zep.md
@@ -18,7 +18,7 @@
 
 ## Recall — table stakes, not the deciding factor
 
-Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local. (Zep's LOCOMO numbers are publicly disputed depending on the harness — we don't run a head-to-head.)
+Both are competitive; quality is table stakes. PLUR reaches **97.6% R@5 on LongMemEval-S**, fully local (hybrid + the opt-in BGE-reranker; the zero-config default is 95.6%). (Zep's LOCOMO numbers are publicly disputed depending on the harness — we don't run a head-to-head.)
 *(LongMemEval-S · n=500 · chunk · canonical-doc; R@5 = evidence in the top-5, not answer accuracy; measured on our own plur-bench harness, public with our paper.)*
 
 ## Choose Zep if

--- a/infra/heartbeat/test_http.py
+++ b/infra/heartbeat/test_http.py
@@ -1,0 +1,170 @@
+"""pytest: HTTP integration tests for the heartbeat ingress (#613).
+
+`validate()` is well covered by `test_server.py`. The HTTP layer around it was
+not covered at all — and that layer is where #611's `ThreadingHTTPServer` +
+`timeout` hardening lives, plus every rejection an untrusted caller can reach:
+wrong path, wrong method, wrong Content-Type, oversized body, malformed JSON.
+
+## Why these are hermetic
+
+PR #604 had a version of these tests and they failed on a clean checkout:
+`DATA_DIR` is a module-level constant resolved at IMPORT time, so patching
+`os.environ` afterwards does not redirect it, and the server tried to write to
+`/var/lib/plur-heartbeat` → `PermissionError`. The fix is to patch the resolved
+attribute, not the environment it was resolved from:
+
+    monkeypatch.setattr(server, "DATA_DIR", tmp_path)
+
+Everything else follows from that: a real socket on port 0 (the OS picks a free
+one, so parallel runs cannot collide), a real HTTP request, and assertions on
+the file that actually gets written.
+"""
+import json
+import os
+import sys
+import threading
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import server  # noqa: E402
+
+VALID = {
+    "install_id": "123e4567-e89b-4d3c-a456-426614174000",
+    "version": "0.14.0",
+    "platform": "linux",
+    "date": "2026-07-17",
+    "learn_count": 5,
+    "recall_count": 10,
+    "session_count": 2,
+}
+
+
+@pytest.fixture
+def ingress(tmp_path, monkeypatch):
+    """A live server writing into tmp_path. Yields (host, port, data_dir)."""
+    # The attribute, not the environment variable — see module docstring.
+    monkeypatch.setattr(server, "DATA_DIR", tmp_path)
+    # Port 0: the OS assigns a free port, so two test runs never contend.
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.HeartbeatHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield httpd.server_address[0], httpd.server_address[1], tmp_path
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+def request(ingress, method="POST", path="/v1/heartbeat", body=None, headers=None):
+    host, port, _ = ingress
+    conn = HTTPConnection(host, port, timeout=5)
+    try:
+        payload = b"" if body is None else (
+            body if isinstance(body, bytes) else json.dumps(body).encode()
+        )
+        hdrs = {"Content-Type": "application/json"}
+        if headers is not None:
+            hdrs = headers
+        if payload:
+            hdrs = {**hdrs, "Content-Length": str(len(payload))}
+        conn.request(method, path, body=payload, headers=hdrs)
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    finally:
+        conn.close()
+
+
+def test_valid_post_writes_a_line_and_returns_204(ingress):
+    _, _, data_dir = ingress
+    status, _ = request(ingress, body=VALID)
+    assert status == 204
+
+    written = list(data_dir.glob("*.jsonl"))
+    assert len(written) == 1, f"expected one dated file, found {written}"
+    # The stored line must be the payload, not a re-serialisation that drops or
+    # reorders fields — downstream `query.py` parses these back.
+    lines = written[0].read_text().strip().split("\n")
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == VALID
+
+
+def test_repeated_posts_append_rather_than_overwrite(ingress):
+    _, _, data_dir = ingress
+    for i in range(3):
+        status, _ = request(ingress, body={**VALID, "learn_count": i})
+        assert status == 204
+    written = list(data_dir.glob("*.jsonl"))[0]
+    assert len(written.read_text().strip().split("\n")) == 3
+
+
+def test_oversized_body_is_rejected_before_it_is_read(ingress):
+    _, _, data_dir = ingress
+    # Length header over MAX_BODY: the guard exists so a hostile caller cannot
+    # make the process read an unbounded body into memory.
+    big = {**VALID, "install_id": "x" * (server.MAX_BODY + 100)}
+    status, body = request(ingress, body=big)
+    assert status == 400
+    assert b"too large" in body
+    assert list(data_dir.glob("*.jsonl")) == []
+
+
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+def test_non_post_methods_are_405(ingress, method):
+    status, _ = request(ingress, method=method, body=None)
+    assert status == 405
+
+
+def test_missing_content_type_is_400(ingress):
+    _, _, data_dir = ingress
+    payload = json.dumps(VALID).encode()
+    status, body = request(
+        ingress, body=payload, headers={"Content-Length": str(len(payload))},
+    )
+    assert status == 400
+    assert b"Content-Type" in body
+    assert list(data_dir.glob("*.jsonl")) == []
+
+
+def test_wrong_path_is_404(ingress):
+    status, _ = request(ingress, path="/v1/something-else", body=VALID)
+    assert status == 404
+
+
+def test_malformed_json_is_400(ingress):
+    _, _, data_dir = ingress
+    status, body = request(ingress, body=b"{not json")
+    assert status == 400
+    assert b"invalid JSON" in body
+    assert list(data_dir.glob("*.jsonl")) == []
+
+
+def test_non_object_json_is_400(ingress):
+    # `validate()` indexes the payload, so a bare list or string must be
+    # rejected at the HTTP layer before it reaches it.
+    status, body = request(ingress, body=[VALID])
+    assert status == 400
+    assert b"JSON object" in body
+
+
+def test_invalid_payload_is_rejected_and_nothing_is_written(ingress):
+    # The join between the two layers: a payload that parses as JSON but fails
+    # `validate()` must not reach the file.
+    _, _, data_dir = ingress
+    status, _ = request(ingress, body={**VALID, "platform": "solaris"})
+    assert status == 400
+    assert list(data_dir.glob("*.jsonl")) == []
+
+
+def test_access_log_is_suppressed(capsys, ingress):
+    # `log_message` is overridden because the default access log contains the
+    # client IP, and this service exists to collect telemetry WITHOUT
+    # identifying who sent it.
+    request(ingress, body=VALID)
+    captured = capsys.readouterr()
+    assert "127.0.0.1" not in captured.err
+    assert "127.0.0.1" not in captured.out

--- a/packages/cli/src/commands/outbox.ts
+++ b/packages/cli/src/commands/outbox.ts
@@ -1,0 +1,92 @@
+/**
+ * `plur outbox` — see what the remote-write queue is holding (#667).
+ *
+ * The outbox is not a file or a queue directory. It is
+ * `structured_data._outbox` nested inside ordinary engrams in `engrams.yaml`,
+ * which is why it worked and was invisible: a user whose team store was
+ * unreachable had queued writes with no supported way to see them, and the
+ * only prose describing the mechanism lived inside an engram.
+ *
+ * Read-only by default. `--flush` is the explicit action, mirroring the
+ * `plur_outbox` MCP tool so the two surfaces cannot drift.
+ *
+ * The target URL is never printed — `listOutbox` does not return it. It is the
+ * one field here that names a credentialed endpoint, and `target_scope`
+ * already answers "which store is behind?", which is the question being asked.
+ */
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+
+function usage(): never {
+  exit(1, [
+    'Usage:',
+    '  plur outbox             Show team-scoped writes queued for an unreachable store',
+    '  plur outbox --flush     Retry them now',
+    '',
+    'Writes to a remote scope queue locally when their store cannot be reached.',
+    'They also retry automatically on session start and on `plur sync`.',
+  ].join('\n'))
+}
+
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) usage()
+  const flush = args.includes('--flush')
+
+  // Read-only unless flushing — a command people run to LOOK at a queue must
+  // not be able to modify the store it is reporting on.
+  const plur = createPlur(flags, flush ? undefined : { readonly: true })
+
+  // Read before flushing, always. After a successful flush the entries are
+  // gone, so reading afterwards would report an empty outbox and say nothing
+  // about what just moved — which is the interesting part.
+  const entries = await plur.listOutbox()
+
+  if (!flush) {
+    if (shouldOutputJson(flags)) {
+      outputJson({ pending: entries.length, entries })
+      return
+    }
+    if (entries.length === 0) {
+      outputText('Outbox is empty — every team-scoped write has reached its store.')
+      return
+    }
+    const lines = [
+      `${entries.length} write(s) queued for a remote store that could not be reached.`,
+      '',
+    ]
+    for (const e of entries) {
+      const age = e.age_days === 0 ? 'today' : `${e.age_days}d ago`
+      lines.push(`  ${e.id}  →  ${e.target_scope}`)
+      lines.push(`      queued ${age}, ${e.attempt_count} attempt(s)`
+        + (e.last_error ? `, last error: ${e.last_error}` : ''))
+    }
+    lines.push('', 'Run `plur outbox --flush` to retry now. They also retry on session start and `plur sync`.')
+    outputText(lines.join('\n'))
+    return
+  }
+
+  const result = await plur.flushOutbox()
+  const stillPending = await plur.outboxCount()
+
+  if (shouldOutputJson(flags)) {
+    outputJson({
+      flushed: result.flushed,
+      failed: result.failed,
+      pending: stillPending,
+      ...(result.expired_warnings.length > 0 ? { expired_warnings: result.expired_warnings } : {}),
+      attempted: entries,
+    })
+    return
+  }
+
+  if (entries.length === 0) {
+    outputText('Outbox is empty — nothing to flush.')
+    return
+  }
+  const lines = [`Flushed ${result.flushed} of ${entries.length}. ${result.failed} still failing.`]
+  if (stillPending > 0) {
+    lines.push(`${stillPending} write(s) remain queued — the store is still unreachable.`)
+  }
+  for (const w of result.expired_warnings) lines.push(`  ${w}`)
+  outputText(lines.join('\n'))
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,8 @@ Commands:
   stores add <path>       Add a knowledge store
   scopes                  List authorized-but-unregistered shared scopes (#647)
   scopes register <scope> Register one; scopes dismiss <scope>; scopes --reoffer
+  outbox                  Show team-scoped writes queued for an unreachable store
+                          [--flush] to retry them now (#667)
   reindex-tokens          Re-derive BM25 tokens after a tokenizer change (Postgres only)
   reindex-hashes          Repair engrams whose content_hash is stale or missing (#852)
   init                    Install Claude Code hooks + register plur MCP server
@@ -114,6 +116,7 @@ const COMMANDS: Record<string, string> = {
   'similarity-search': './commands/similarity-search.js',
   stores: './commands/stores.js',
   scopes: './commands/scopes.js',
+  outbox: './commands/outbox.js',
   'reindex-tokens': './commands/reindex-tokens.js',
   'reindex-hashes': './commands/reindex-hashes.js',
   migrate: './commands/migrate.js',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6447,6 +6447,55 @@ export class Plur {
   }
 
   /**
+   * The outbox, as inspectable entries (#667).
+   *
+   * The outbox works and is effectively invisible: it is not a file or a
+   * queue directory, it is `structured_data._outbox` nested inside ordinary
+   * engrams in `engrams.yaml`. So a user whose team store was unreachable has
+   * queued writes with no supported way to see them — diagnosing meant
+   * reverse-engineering the storage model, and the only prose describing the
+   * pattern lived inside an engram.
+   *
+   * `target_url` is DELIBERATELY not returned. It is the one field here that
+   * identifies a credentialed endpoint, the entry is rendered into agent
+   * context and CLI output, and `target_scope` already answers the question a
+   * human is asking ("which store is behind?"). Omitting it at the source
+   * beats redacting it at each of the several call sites that print it.
+   */
+  async listOutbox(): Promise<Array<{
+    id: string
+    target_scope: string
+    queued_at: string
+    attempt_count: number
+    last_error?: string
+    age_days: number
+  }>> {
+    const engrams = await this._loadCached(this.paths.engrams)
+    const now = Date.now()
+    const out = []
+    for (const e of engrams) {
+      const ob = (e as any).structured_data?._outbox as {
+        target_scope?: string; queued_at?: string; attempt_count?: number; last_error?: string
+      } | undefined
+      if (!ob || e.status === 'retired') continue
+      const queued_at = typeof ob.queued_at === 'string' ? ob.queued_at : ''
+      const queuedMs = queued_at ? Date.parse(queued_at) : NaN
+      out.push({
+        id: e.id,
+        target_scope: ob.target_scope ?? '(unknown)',
+        queued_at,
+        attempt_count: typeof ob.attempt_count === 'number' ? ob.attempt_count : 0,
+        ...(ob.last_error ? { last_error: ob.last_error } : {}),
+        // A malformed or missing timestamp reports 0, not NaN: this number is
+        // rendered, and NaN in a report reads as a bug in the reporter rather
+        // than as the missing data it actually is.
+        age_days: Number.isFinite(queuedMs) ? Math.floor((now - queuedMs) / 86_400_000) : 0,
+      })
+    }
+    return out
+  }
+
+  /**
    * Flush the outbox — retry pushing pending engrams to their target remote
    * stores. Called automatically on session_start and plur_sync.
    *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,7 @@ import { loadTensions, loadTensionsWithQuarantine, saveTensions, generateTension
 import type { TensionRecord, TensionStatus } from './schemas/tension.js'
 import type { TensionPair } from './tensions.js'
 import { engramDate } from './tensions.js'
-import { resolveValidity, buildTemporal } from './expiry.js'
+import { resolveValidity, buildTemporal, normalizeIsoDate } from './expiry.js'
 import { decodeJwtExpiry, decodeJwtPayload } from './jwt.js'
 import { RemoteStore, normalizeEndpointUrl } from './store/remote-store.js'
 import {
@@ -4614,7 +4614,25 @@ export class Plur {
           ]
           const counts: Record<string, number> = {}
           for (const e of allEngrams) {
-            const key = (e as any).pack ?? '__personal__'
+            // `_pack` FIRST, and that is a bug fix, not a preference (#553).
+            //
+            // This read only `pack` — the schema field, which an engram carries
+            // only if its own YAML declares it. But `_loadAllEngrams` stamps
+            // installed-pack engrams with `_pack` (the pack's manifest name),
+            // and nothing sets `pack` on them. So the normal case — a pack
+            // whose engrams do not self-declare their origin — bucketed
+            // ENTIRELY as `__personal__`, and per-pack telemetry counted
+            // nothing it existed to count.
+            //
+            // #553 predicted this shape ("a future regression in that
+            // propagation would keep CI green") and was one step off: it was
+            // not a future regression, it was already true, and no test
+            // installed a pack so nothing could see it.
+            //
+            // `_pack` survives into `WireEngram` because `stripScoring`
+            // rest-spreads. `pack` is kept as the fallback so a pack engram
+            // that DOES declare its origin still buckets by it.
+            const key = (e as { _pack?: string })._pack ?? e.pack ?? '__personal__'
             counts[key] = (counts[key] ?? 0) + 1
           }
           return counts
@@ -6981,7 +6999,23 @@ Generate an improved version of the procedure that prevents this failure. Return
       active = active.filter(e => e.domain?.startsWith(options.domain!))
     }
     if (options?.created_after) {
-      const cutoff = options.created_after
+      // Validated, not trusted (#547). The comparison below is LEXICOGRAPHIC
+      // against a `YYYY-MM-DD` stamp, which is exactly right for a well-formed
+      // date and silently wrong for anything else: "last week" sorts after
+      // every real date and returns 0, "2026-13-99" sorts after December and
+      // does the same. A caller typo produced a confident, quietly wrong count
+      // — the one failure a diagnostic must not have.
+      //
+      // Reuses `normalizeIsoDate` rather than adding a second date rule: it
+      // already rejects both malformed shapes and impossible calendar dates
+      // (2026-02-30), and one definition means the two cannot disagree.
+      const cutoff = normalizeIsoDate(options.created_after)
+      if (!cutoff) {
+        throw new TypeError(
+          `plur.status: created_after must be an ISO date (YYYY-MM-DD), got "${options.created_after}". `
+          + `Dates are compared as strings, so a malformed value would return a silently wrong count.`,
+        )
+      }
       active = active.filter(e => { const d = engramDate(e); return d !== undefined && d >= cutoff })
     }
     const lockedCount = active.filter(e => (e as any).commitment === 'locked').length

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -648,7 +648,19 @@ function resolveInside(packsDir: string, name: string, op: string): string {
 
 export interface UninstallResult {
   name: string
-  removed: boolean
+  /**
+   * Always `true` — the literal type is the point (#545).
+   *
+   * `boolean` implied `false` was reachable, and a caller wrote the branch it
+   * implies: `plur-mcp packs uninstall` had an `else` that printed "Pack not
+   * found" and exited 1, which could never run. `uninstallPack` THROWS when the
+   * pack is absent, so a returned result is already proof of removal.
+   *
+   * Kept as a field rather than deleted so existing readers keep compiling, but
+   * narrowed so a `removed === false` branch is now a type error instead of
+   * dead code that reads like handled behaviour.
+   */
+  removed: true
   engram_count: number
 }
 

--- a/packages/core/test/outbox-inspect.test.ts
+++ b/packages/core/test/outbox-inspect.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #667 — the outbox must be inspectable without reverse-engineering the store.
+ *
+ * The mechanism worked and was invisible. It is not a file or a queue
+ * directory: it is `structured_data._outbox` nested inside ordinary engrams in
+ * `engrams.yaml`. So a user whose team store was unreachable had queued writes
+ * with no supported way to see them, and the only prose describing the pattern
+ * lived inside an engram rather than in any doc.
+ *
+ * The security property is asserted first because it is the one that cannot be
+ * fixed later: these entries are rendered into agent context and CLI output,
+ * so a credentialed endpoint must not be in them.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+
+const REMOTE = 'https://plur.example.com/sse'
+const SCOPE = 'group:acme/team'
+
+describe('listOutbox (#667)', () => {
+  let dir: string
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-outbox-inspect-'))
+    originalFetch = globalThis.fetch
+    // Unreachable remote, so team-scoped writes queue instead of landing.
+    globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as never
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ url: REMOTE, token: 'super-secret-token', scope: SCOPE, shared: true, readonly: false }],
+      index: false,
+    }))
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  async function queue(plur: Plur, n: number): Promise<void> {
+    for (let i = 0; i < n; i++) {
+      await plur.learn(`queued team fact number ${i}`, { scope: SCOPE, type: 'behavioral' })
+    }
+    await new Promise(r => setTimeout(r, 60))
+  }
+
+  it('never returns the target URL or the token', async () => {
+    // The reason `listOutbox` omits `target_url` at the SOURCE rather than
+    // redacting it per call site: there are several renderers (MCP tool, CLI
+    // text, CLI JSON) and each one would have to remember.
+    const plur = new Plur({ path: dir })
+    await queue(plur, 2)
+
+    const entries = await plur.listOutbox()
+    expect(entries.length).toBe(2)
+    const serialized = JSON.stringify(entries)
+    expect(serialized, 'the token reached an agent-visible surface').not.toContain('super-secret-token')
+    expect(serialized, 'the endpoint URL reached an agent-visible surface').not.toContain('plur.example.com')
+    for (const e of entries) {
+      expect(e).not.toHaveProperty('target_url')
+      expect(e).not.toHaveProperty('token')
+    }
+  })
+
+  it('reports the fields a human needs to act: scope, age, attempts, last error', async () => {
+    const plur = new Plur({ path: dir })
+    await queue(plur, 1)
+
+    const [entry] = await plur.listOutbox()
+    expect(entry.target_scope, 'without this, "which store is behind?" is unanswerable').toBe(SCOPE)
+    expect(entry.attempt_count).toBeGreaterThanOrEqual(0)
+    expect(entry.age_days, 'a just-queued write is 0 days old, never NaN').toBe(0)
+    expect(entry.queued_at).not.toBe('')
+  })
+
+  it('agrees with outboxCount, so the two cannot report different queues', async () => {
+    const plur = new Plur({ path: dir })
+    await queue(plur, 3)
+    expect((await plur.listOutbox()).length).toBe(await plur.outboxCount())
+  })
+
+  it('is empty when nothing is queued, rather than throwing', async () => {
+    const plur = new Plur({ path: dir })
+    await plur.learn('a purely local fact', { scope: 'global', type: 'behavioral' })
+    expect(await plur.listOutbox()).toEqual([])
+  })
+
+  it('excludes retired engrams — a retired write is cancelled, not queued', async () => {
+    // `forget()` strips `_outbox` on retirement so a queued engram cannot be
+    // resurrected on the remote (#766). The inspector must agree with that,
+    // or it reports work that will never happen.
+    const plur = new Plur({ path: dir })
+    await queue(plur, 1)
+    const [entry] = await plur.listOutbox()
+    await plur.forget(entry.id, 'no longer wanted', { scope: 'primary', force: true })
+    expect(await plur.listOutbox()).toEqual([])
+  })
+
+  it('reports age 0 rather than NaN for a malformed timestamp', async () => {
+    // These numbers are rendered. NaN in a report reads as a bug in the
+    // reporter rather than as the missing data it actually is.
+    const plur = new Plur({ path: dir })
+    await queue(plur, 1)
+    const [entry] = await plur.listOutbox()
+    const raw = (await plur.getById(entry.id))!
+    ;(raw as unknown as { structured_data: { _outbox: Record<string, unknown> } })
+      .structured_data._outbox.queued_at = 'not a date'
+    await plur.updateEngram(raw)
+
+    const [after] = await plur.listOutbox()
+    expect(Number.isNaN(after.age_days)).toBe(false)
+    expect(after.age_days).toBe(0)
+  })
+})

--- a/packages/core/test/union-idf-approximation.test.ts
+++ b/packages/core/test/union-idf-approximation.test.ts
@@ -1,0 +1,135 @@
+/**
+ * #757 — quantify the IDF approximation in recall union ranking.
+ *
+ * `recall()` ranks primary-store hits together with secondary-store and pack
+ * engrams. The primary side's statistics come from the store
+ * (`adapter.corpusStats`); the outsiders are not in that corpus, so the union
+ * is scored against statistics that do not describe it. #752 accepted that as
+ * defensible and asked for it to be MEASURED rather than assumed negligible —
+ * specifically when a query term's document frequency differs sharply inside
+ * and outside the primary corpus.
+ *
+ * The measurement compares two IDF vectors over the same union:
+ *
+ *   exact  — `computeIdf(union, tokens)`, which counts df across every
+ *            document under `termMatches`, the rule `ftsScore` applies.
+ *   folded — `extendCorpusStats(primaryStats, tokens, outsiders)`, which is
+ *            what recall actually uses.
+ *
+ * Both are asserted, not just compared, because the interesting outcome is not
+ * "the divergence is small" — it is whether there is any divergence at all.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  ftsTokenize, engramSearchText, computeIdf, extendCorpusStats, termMatches,
+  type CorpusStats,
+} from '../src/fts.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function engram(id: string, statement: string): Engram {
+  return {
+    id, version: 2, status: 'active', consolidated: false,
+    type: 'behavioral', scope: 'global', visibility: 'private',
+    statement,
+    activation: { retrieval_strength: 0.7, storage_strength: 1, frequency: 0, last_accessed: '2026-08-13' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+    abstract: null, derived_from: null, polarity: null, content_hash: `h-${id}`,
+    commitment: 'leaning', write_count: 1, injection_count: 0, sources: [], recurrence_count: 0,
+    summary: 's', engram_version: 1, episode_ids: [],
+    temporal: { learned_at: '2026-08-13' },
+  } as unknown as Engram
+}
+
+/**
+ * Exact `CorpusStats` over one set, computed with the SAME matching rule a
+ * conforming store must reproduce (`CorpusStats.df`'s contract: a store that
+ * cannot reproduce it exactly must not supply stats at all).
+ */
+function exactStats(engrams: Engram[], queryTokens: string[]): CorpusStats {
+  const termSets = engrams.map(e => new Set(ftsTokenize(engramSearchText(e))))
+  const df = new Map<string, number>()
+  for (const qt of queryTokens) {
+    let n = 0
+    for (const set of termSets) {
+      if (set.has(qt) || [...set].some(t => termMatches(t, qt))) n++
+    }
+    df.set(qt, n)
+  }
+  const totalLen = engrams.reduce((sum, e) => sum + ftsTokenize(engramSearchText(e)).length, 0)
+  return { N: engrams.length, df, avgDocLength: engrams.length > 0 ? totalLen / engrams.length : 0 }
+}
+
+/** Largest absolute IDF difference across the query's tokens. */
+function maxDivergence(a: Map<string, number>, b: Map<string, number>): number {
+  let worst = 0
+  for (const [t, v] of a) worst = Math.max(worst, Math.abs(v - (b.get(t) ?? 0)))
+  return worst
+}
+
+describe('union IDF: folded statistics vs an exact whole-set baseline (#757)', () => {
+  /**
+   * The skew the issue asks about, in both directions: a term that is common
+   * in the primary corpus and rare among outsiders, and one that is the
+   * reverse. If the fold under-counts either side, these are where it shows.
+   */
+  const primary = [
+    ...Array.from({ length: 20 }, (_, i) => engram(`P-common-${i}`, `deployment runbook step ${i} for the deployment pipeline`)),
+    ...Array.from({ length: 5 }, (_, i) => engram(`P-other-${i}`, `unrelated note about invoicing ${i}`)),
+  ]
+  const outsiders = [
+    ...Array.from({ length: 12 }, (_, i) => engram(`O-jargon-${i}`, `kubernetes ingress annotation ${i} in the cluster`)),
+    engram('O-deploy-1', 'a single outsider mentioning deployment'),
+  ]
+
+  it.each([
+    ['a term common in primary, rare outside', 'deployment pipeline'],
+    ['a term rare in primary, common outside', 'kubernetes ingress'],
+    ['a mixed query spanning both', 'deployment kubernetes'],
+    ['a term in neither corpus', 'sasquatch telemetry'],
+  ])('%s', (_label, query) => {
+    const tokens = ftsTokenize(query)
+    expect(tokens.length, 'fixture query tokenized to nothing').toBeGreaterThan(0)
+
+    const union = [...primary, ...outsiders]
+    const exact = computeIdf(union, tokens)
+    const folded = computeIdf([], tokens, extendCorpusStats(exactStats(primary, tokens), tokens, outsiders))
+
+    // The finding: with `extendCorpusStats` in place the fold is not an
+    // approximation at all — outsider df is counted under the same rule and
+    // N/avgDocLength are exact, so the union is scored against the union's
+    // own statistics. #752 was written before that fold landed (#750
+    // iteration 2); this test is what turns "defensible approximation" into
+    // "measured as exact", and what will catch it becoming an approximation
+    // again if either side's counting rule drifts.
+    expect(maxDivergence(exact, folded)).toBe(0)
+  })
+
+  it('diverges measurably WITHOUT the fold — so the assertions above are not vacuous', () => {
+    // The control. Scoring the union against the primary corpus's raw stats
+    // is what the code did before #750 iteration 2, and it is what the issue
+    // describes. If this did not diverge, the tests above would prove nothing.
+    const tokens = ftsTokenize('kubernetes ingress')
+    const union = [...primary, ...outsiders]
+    const exact = computeIdf(union, tokens)
+    const unfolded = computeIdf([], tokens, exactStats(primary, tokens))
+
+    const divergence = maxDivergence(exact, unfolded)
+    expect(divergence, 'primary-only stats should misprice outsider vocabulary').toBeGreaterThan(0.5)
+  })
+
+  it('the fold stays exact as the outsider share grows', () => {
+    // The approximation, if there were one, would grow with the outsider
+    // fraction. Sweeping it is cheaper than arguing about where the boundary
+    // would be.
+    const tokens = ftsTokenize('kubernetes deployment')
+    for (const outsiderCount of [1, 5, 25, 100]) {
+      const many = Array.from({ length: outsiderCount }, (_, i) =>
+        engram(`O-sweep-${i}`, `kubernetes ingress annotation ${i} in the cluster`))
+      const exact = computeIdf([...primary, ...many], tokens)
+      const folded = computeIdf([], tokens, extendCorpusStats(exactStats(primary, tokens), tokens, many))
+      expect(maxDivergence(exact, folded), `diverged at ${outsiderCount} outsiders`).toBe(0)
+    }
+  })
+})

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -63,7 +63,7 @@ By default (lean profile), your agent gets 12 tools. Everything else is reachabl
 | `plur_tensions_purge` | Clear stale/resolved tensions |
 | `plur_admin` | Dispatch to any other tool: `{ action: "plur_packs_install", args: {...} }` |
 
-Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 42 tools directly.
+Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 43 tools directly.
 
 A `plur_*` name missing from `tools/list` means it moved behind the gateway, not that the server is down. `plur_admin { action: "help" }` returns every action with a one-line description and its argument schema; `plur_doctor` reports the same inventory as `tool_surface`.
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -370,56 +370,17 @@ async function runInit() {
 // --- Packs subcommands ---
 
 async function runPacks(): Promise<void> {
-  const sub = process.argv[3]
   const plurPath = process.env.PLUR_PATH ?? join(homedir(), '.plur')
   const { Plur } = await import('@plur-ai/core')
+  const { packsCommand } = await import('./packs-cli.js')
   const plur = new Plur({ path: plurPath })
 
-  if (sub === 'install') {
-    const source = process.argv[4]
-    if (!source) {
-      process.stderr.write('Usage: plur-mcp packs install <path>\n')
-      process.exit(1)
-    }
-    try {
-      const result = await plur.installPack(source)
-      process.stdout.write(`Installed pack '${result.name}' (${result.installed} engrams)\n`)
-    } catch (err) {
-      process.stderr.write(`Error: ${(err as Error).message}\n`)
-      process.exit(1)
-    }
-  } else if (sub === 'list') {
-    const packs = plur.listPacks()
-    if (packs.length === 0) {
-      process.stdout.write('No packs installed.\n')
-    } else {
-      for (const pack of packs) {
-        const version = pack.manifest?.version ? ` v${pack.manifest.version}` : ''
-        process.stdout.write(`${pack.name}${version} (${pack.engram_count} engrams)\n`)
-      }
-    }
-  } else if (sub === 'uninstall') {
-    const name = process.argv[4]
-    if (!name) {
-      process.stderr.write('Usage: plur-mcp packs uninstall <name>\n')
-      process.exit(1)
-    }
-    try {
-      const result = plur.uninstallPack(name)
-      if (result.removed) {
-        process.stdout.write(`Uninstalled pack '${result.name}' (${result.engram_count} engrams removed)\n`)
-      } else {
-        process.stderr.write(`Pack '${name}' not found.\n`)
-        process.exit(1)
-      }
-    } catch (err) {
-      process.stderr.write(`Error: ${(err as Error).message}\n`)
-      process.exit(1)
-    }
-  } else {
-    process.stderr.write(`Unknown packs subcommand: ${sub ?? '(none)'}\nAvailable: install, list, uninstall\n`)
-    process.exit(1)
-  }
+  // The branch logic lives in `packs-cli.ts` so it can be tested without
+  // spawning a process (#545). This function's only job is streams and exit.
+  const result = await packsCommand(process.argv.slice(3), plur)
+  if (result.stdout) process.stdout.write(result.stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+  if (result.exitCode !== 0) process.exit(result.exitCode)
 }
 
 // --- Main execution ---

--- a/packages/mcp/src/packs-cli.ts
+++ b/packages/mcp/src/packs-cli.ts
@@ -1,0 +1,75 @@
+/**
+ * `plur-mcp packs …` — the branch logic, separated from the process (#545).
+ *
+ * This lived inline in `index.ts`, which is the binary entrypoint: importing it
+ * runs a top-level `process.argv` dispatch and calls `process.exit`. So the only
+ * way to test the CLI branches was to spawn a real process — and spawning is the
+ * contention class #793 had to serialise a whole vitest project to contain.
+ *
+ * The branches here are the only real logic in the command (`runPacks`
+ * otherwise delegates to already-tested core): missing argument, unknown
+ * subcommand, and not-found. Returning a result instead of writing and exiting
+ * makes those three assertable in-process, and leaves `index.ts` with the one
+ * job a binary should have — turn a result into streams and an exit code.
+ */
+
+/** Just enough of `Plur` for this command, so tests need no real store. */
+export interface PacksCapablePlur {
+  // `Plur.installPack` is declared `Promise<ReturnType<typeof installPack>>`
+  // where `installPack` is itself async, so its type is a nested promise.
+  // Awaiting it flattens either shape, and structural typing needs the
+  // declaration to accept both.
+  installPack(source: string): Promise<{ name: string; installed: number } | PromiseLike<{ name: string; installed: number }>>
+  listPacks(): Array<{ name: string; engram_count: number; manifest?: { version?: string } | null }>
+  uninstallPack(name: string): { name: string; engram_count: number }
+}
+
+export interface PacksCliResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+const ok = (stdout: string): PacksCliResult => ({ stdout, stderr: '', exitCode: 0 })
+const fail = (stderr: string): PacksCliResult => ({ stdout: '', stderr, exitCode: 1 })
+
+/**
+ * @param args  the arguments AFTER `packs` — `['install', './pack']`
+ */
+export async function packsCommand(args: string[], plur: PacksCapablePlur): Promise<PacksCliResult> {
+  const [sub, arg] = args
+
+  if (sub === 'install') {
+    if (!arg) return fail('Usage: plur-mcp packs install <path>\n')
+    try {
+      const result = await plur.installPack(arg)
+      return ok(`Installed pack '${result.name}' (${result.installed} engrams)\n`)
+    } catch (err) {
+      return fail(`Error: ${(err as Error).message}\n`)
+    }
+  }
+
+  if (sub === 'list') {
+    const packs = plur.listPacks()
+    if (packs.length === 0) return ok('No packs installed.\n')
+    return ok(packs.map(p => {
+      const version = p.manifest?.version ? ` v${p.manifest.version}` : ''
+      return `${p.name}${version} (${p.engram_count} engrams)\n`
+    }).join(''))
+  }
+
+  if (sub === 'uninstall') {
+    if (!arg) return fail('Usage: plur-mcp packs uninstall <name>\n')
+    try {
+      // No not-found branch: `uninstallPack` throws when the pack is absent, so
+      // reaching this line already means it was removed. The `else` that used
+      // to sit here could not run — see `UninstallResult.removed` (#545).
+      const result = plur.uninstallPack(arg)
+      return ok(`Uninstalled pack '${result.name}' (${result.engram_count} engrams removed)\n`)
+    } catch (err) {
+      return fail(`Error: ${(err as Error).message}\n`)
+    }
+  }
+
+  return fail(`Unknown packs subcommand: ${sub ?? '(none)'}\nAvailable: install, list, uninstall\n`)
+}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1796,7 +1796,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
 
     {
       name: 'plur_sync',
-      description: 'Sync engrams via git AND refresh the derived index from YAML. Initializes repo on first call, commits and pushes/pulls on subsequent calls. Provide a remote URL on first call to enable cross-device sync. Pass full=true to drop-and-rebuild the index from YAML (recovery path; YAML stays untouched).',
+      description: 'Sync engrams via git AND refresh the derived index from YAML. Initializes repo on first call, commits and pushes/pulls on subsequent calls. Provide a remote URL on first call to enable cross-device sync. Pass full=true to drop-and-rebuild the index from YAML (recovery path; YAML stays untouched). Also flushes the remote-write outbox — retries team-scoped writes that were queued while their remote store was unreachable; use plur_outbox to inspect what is queued.',
       annotations: { title: 'Sync', openWorldHint: true, destructiveHint: false, idempotentHint: true },
       inputSchema: {
         type: 'object',
@@ -1862,6 +1862,37 @@ function getAllToolDefinitions(): ToolDefinition[] {
               `The outbox flush failed — ${outbox_error}. Engrams routed to a remote store are `
               + `still queued locally and were NOT pushed. They retry on the next session_start or plur_sync.`,
           } : {}),
+        }
+      },
+    },
+
+    {
+      name: 'plur_outbox',
+      description: 'Inspect the remote-write outbox — team-scoped writes queued locally because their remote store was unreachable. Read-only by default; pass flush:true to retry them now. Entries never include the target URL or token.',
+      annotations: { title: 'Outbox', readOnlyHint: false, idempotentHint: false },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          flush: { type: 'boolean', description: 'Retry every queued write now, instead of only reporting them. Defaults to false.' },
+        },
+      },
+      handler: async (args, plur) => {
+        // Read first, ALWAYS — including on a flush. The entries a flush
+        // consumed are the interesting ones ("what was stuck, and for how
+        // long"), and after a successful flush they are gone from the store,
+        // so reading afterwards would report an empty outbox and tell the
+        // caller nothing about what just moved.
+        const before = await plur.listOutbox()
+        if (args.flush !== true) {
+          return { pending: before.length, entries: before }
+        }
+        const result = await plur.flushOutbox()
+        return {
+          pending: await plur.outboxCount(),
+          flushed: result.flushed,
+          failed: result.failed,
+          ...(result.expired_warnings.length > 0 ? { expired_warnings: result.expired_warnings } : {}),
+          attempted: before,
         }
       },
     },
@@ -2708,7 +2739,13 @@ function getAllToolDefinitions(): ToolDefinition[] {
             const failures = discoveries.filter(d => !d.ok)
             if (failures.length > 0) {
               const authExpired = failures.some(f => /\b40[13]\b/.test(f.error ?? ''))
-              const pending = outbox_result?.failed ?? 0
+              // The count is what is QUEUED, not what this flush failed on
+              // (#667). `outbox_result.failed` counts only entries this flush
+              // attempted and lost — so when the host is in breaker cooldown
+              // the flush attempts nothing, `failed` is 0, and the warning
+              // said nothing at all while N team writes sat queued. The
+              // pending total is the number the user needs to act on.
+              const pending = await plur.outboxCount().catch(() => outbox_result?.failed ?? 0)
               const urls = [...new Set(failures.map(f => f.url))].join(', ')
               guide += authExpired
                 ? `\n\n⚠️ ENTERPRISE STORE AUTH FAILED (token expired/invalid): ${urls}. ` +
@@ -2717,7 +2754,8 @@ function getAllToolDefinitions(): ToolDefinition[] {
                   `~/.plur/config.yaml, then restart Claude/MCP. Queued engrams flush on the next session_start.`
                 : `\n\n⚠️ ENTERPRISE STORE UNREACHABLE: ${urls}. ` +
                   `Reads fall back to local; team-scoped writes queue in the outbox` +
-                  (pending > 0 ? ` (${pending} pending)` : '') + ` until it recovers. Check connectivity/VPN.`
+                  (pending > 0 ? ` (${pending} pending — inspect with plur_outbox, retry with plur_outbox {flush:true})` : '') +
+                  ` until it recovers. Check connectivity/VPN.`
             }
             // #647: a QUIET, per-scope-aware hint. `d.unregistered` already
             // excludes dismissed scopes; also drop personal-family (they can't be

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -152,7 +152,7 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
     return response
   }
   // mode === 'hybrid' (default)
-  const budget = args.budget as { max_tokens?: number; max_results?: number; ttl_seconds?: number } | undefined
+  const budget = args.budget as { max_tokens?: number; max_results?: number } | undefined
   const cap = budget?.max_results ?? (args.limit as number | undefined) ?? 20
   // When a max_results budget is set, fetch one extra so we can detect
   // whether the store had more results than the cap without over-fetching.
@@ -1287,7 +1287,13 @@ function getAllToolDefinitions(): ToolDefinition[] {
           scope: { type: 'string', description: 'Filter by scope (also includes global)' },
           domain: { type: 'string', description: 'Filter by domain prefix' },
           limit: { type: 'number', description: 'Max results to return (default 20)' },
-          budget: { type: 'object', description: 'Budget constraints for sub-agents. Hybrid mode only — ignored when mode:"keyword".', properties: { max_tokens: { type: 'number' }, max_results: { type: 'number' }, ttl_seconds: { type: 'number' } } },
+          // `ttl_seconds` was declared here and never read (#703). A schema
+          // field an agent can set and no handler consults is a lie the tool
+          // tells about itself — it reads as "caching is configurable" and
+          // nothing caches. Removed rather than documented: there is no
+          // behaviour to describe, and describing "accepted and ignored"
+          // still costs every caller a decision.
+          budget: { type: 'object', description: 'Budget constraints for sub-agents. Hybrid mode only — ignored when mode:"keyword".', properties: { max_tokens: { type: 'number' }, max_results: { type: 'number' } } },
           caller_session_id: { type: 'string', description: 'Session ID of calling agent for budget enforcement. Hybrid mode only — ignored when mode:"keyword".' },
           include_episodes: { type: 'boolean', description: 'If true, include linked episode summaries for each engram (SP2 episodic anchoring). Hybrid mode only — ignored when mode:"keyword".' },
           session_id: { type: 'string', description: 'Session this recall belongs to (from plur_session_start). Its default scope (incl. mid-session plur_session_scope changes) sets the remote dialing context when no explicit scope filter is passed. Optional when one session is open (#243).' },
@@ -1308,7 +1314,7 @@ function getAllToolDefinitions(): ToolDefinition[] {
           scope: { type: 'string', description: 'Filter by scope (also includes global)' },
           domain: { type: 'string', description: 'Filter by domain prefix' },
           limit: { type: 'number', description: 'Max results to return (default 20)' },
-          budget: { type: 'object', description: 'Budget constraints for sub-agents', properties: { max_tokens: { type: 'number' }, max_results: { type: 'number' }, ttl_seconds: { type: 'number' } } },
+          budget: { type: 'object', description: 'Budget constraints for sub-agents', properties: { max_tokens: { type: 'number' }, max_results: { type: 'number' } } },
           caller_session_id: { type: 'string', description: 'Session ID of calling agent for budget enforcement' },
           include_episodes: { type: 'boolean', description: 'If true, include linked episode summaries for each engram (SP2 episodic anchoring)' },
           session_id: { type: 'string', description: 'Session this recall belongs to (from plur_session_start). Its default scope sets the remote dialing context when no explicit scope filter is passed (#243).' },

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1235,9 +1235,29 @@ function getAllToolDefinitions(): ToolDefinition[] {
         // neither a domain nor an explicit scope, and only when at least one
         // registered scope declares covers to route against.
         let batchDomainHint: { domain_hint?: string } = {}
-        const noDomainCount = raw.filter(e =>
+        // Parity with the single-item gate (#681). That gate has FOUR
+        // conditions, and this one had three: it counted an item as
+        // "no domain, no scope" without asking whether it nonetheless
+        // AUTO-ROUTED. A no-domain item reaches the ranker's 0.5 threshold on
+        // three matching tags alone (3 × WEIGHT_TAG = 1.5, the same total a
+        // domain match scores), and when it does the single-item path stays
+        // silent — so the same write produced a nudge in a batch and none on
+        // its own. Advisory either way, but a hint that contradicts itself
+        // depending on which call shape you used is worse than no hint.
+        //
+        // `_routed` is per-RESULT, not per-input, so the routed set is built
+        // from `results` and mapped back through `input_index` — the same
+        // alignment `ids` above needs, and for the same reason: `results` is
+        // compacted past failures.
+        const routedInputs = new Set<number>()
+        for (const r of results) {
+          const routed = (r.engram as { structured_data?: { _routed?: unknown } }).structured_data?._routed
+          if (routed !== undefined && r.input_index !== undefined) routedInputs.add(r.input_index)
+        }
+        const noDomainCount = raw.filter((e, i) =>
           !(typeof e.domain === 'string' && e.domain.length > 0) &&
-          !(typeof e.scope === 'string' && e.scope.length > 0)).length
+          !(typeof e.scope === 'string' && e.scope.length > 0) &&
+          !routedInputs.has(i)).length
         if (noDomainCount > 0) {
           try {
             const coversScopes = plur.listScopeMetadata()

--- a/packages/mcp/test/budget-schema.test.ts
+++ b/packages/mcp/test/budget-schema.test.ts
@@ -1,0 +1,57 @@
+/**
+ * #703 — every field the `budget` schema advertises must do something.
+ *
+ * `budget.ttl_seconds` was declared on `plur_recall` (and its deprecated alias
+ * `plur_recall_hybrid`) and never read by any handler. That is worse than an
+ * undocumented field: an agent inspecting the schema reads it as "response
+ * caching is configurable here", sets it, and gets no caching and no error. The
+ * tool lies about itself, quietly, to exactly the audience that reads schemas.
+ *
+ * The fix was to remove it. This test is what stops it — or anything like it —
+ * coming back: the allow-list below is the set of budget fields the handler
+ * actually consults, so adding a schema field without wiring it fails here.
+ */
+import { describe, it, expect } from 'vitest'
+import { getToolDefinitions } from '../src/tools.js'
+
+/**
+ * Budget fields `handleRecall` reads.
+ *
+ * `max_results` caps the result set (and drives the over-fetch-by-one that
+ * detects truncation, #725). `max_tokens` bounds the rendered payload. If you
+ * add a field here, wire it first — the point of the list is that it is derived
+ * from the handler, not from the schema.
+ */
+const WIRED_BUDGET_FIELDS = ['max_tokens', 'max_results'] as const
+
+function budgetProperties(toolName: string): string[] {
+  const tool = getToolDefinitions('full').find(t => t.name === toolName)
+  expect(tool, `${toolName} is not in the full profile`).toBeDefined()
+  const schema = tool!.inputSchema as {
+    properties?: { budget?: { properties?: Record<string, unknown> } }
+  }
+  const props = schema.properties?.budget?.properties
+  expect(props, `${toolName} declares no budget properties`).toBeDefined()
+  return Object.keys(props!).sort()
+}
+
+describe('the budget schema advertises only fields that are read (#703)', () => {
+  it.each(['plur_recall', 'plur_recall_hybrid'])('%s', name => {
+    expect(budgetProperties(name)).toEqual([...WIRED_BUDGET_FIELDS].sort())
+  })
+
+  it('does not declare ttl_seconds anywhere — nothing caches on it', () => {
+    // Named explicitly because this is the field that shipped: a general
+    // assertion would pass if someone re-added it under a different tool.
+    for (const tool of getToolDefinitions('full')) {
+      expect(JSON.stringify(tool.inputSchema), `${tool.name} reintroduced ttl_seconds`)
+        .not.toContain('ttl_seconds')
+    }
+  })
+
+  it('the deprecated alias keeps the same budget contract as plur_recall', () => {
+    // They share one handler. A schema that drifts between them means the
+    // alias documents behaviour the handler does not have for it.
+    expect(budgetProperties('plur_recall_hybrid')).toEqual(budgetProperties('plur_recall'))
+  })
+})

--- a/packages/mcp/test/outbox-tool.test.ts
+++ b/packages/mcp/test/outbox-tool.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import yaml from 'js-yaml'
 import { Plur } from '@plur-ai/core'
 import { getToolDefinitions } from '../src/tools.js'
 
@@ -33,7 +32,11 @@ describe('plur_outbox (#667)', () => {
     dir = mkdtempSync(join(tmpdir(), 'plur-outbox-tool-'))
     originalFetch = globalThis.fetch
     globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as never
-    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+    // JSON is valid YAML — avoids a js-yaml devDependency in this package,
+    // which `@plur-ai/mcp` does not declare. It resolves locally through pnpm
+    // hoisting and fails under CI's strict install, so the convention here
+    // (see session-scope-tool.test.ts) is to write config as JSON.
+    writeFileSync(join(dir, 'config.yaml'), JSON.stringify({
       stores: [{ url: REMOTE, token: TOKEN, scope: SCOPE, shared: true, readonly: false }],
       index: false,
     }))
@@ -91,11 +94,14 @@ describe('plur_outbox (#667)', () => {
       flushed: number; failed: number; pending: number; attempted: unknown[]
     }
     expect(res.attempted, 'the flush reported nothing about what it tried').toHaveLength(2)
-    // The remote is still down in this fixture, so nothing flushes — the
-    // point of the assertion is the SHAPE, and that a failed flush is
-    // reported as failure rather than as an empty success.
-    expect(res.flushed + res.failed).toBe(2)
-    expect(res.pending).toBe(2)
+    // Deliberately NOT asserting `flushed + failed === 2`. The queueing writes
+    // already failed against this host, so the #785 breaker may be open by the
+    // time the flush runs — and an open breaker attempts NOTHING, reporting
+    // flushed 0 / failed 0. That is correct, and it is precisely why
+    // session_start now reports the PENDING count rather than
+    // `outbox_result.failed`: the two diverge exactly here.
+    expect(res.flushed).toBe(0)
+    expect(res.pending, 'a skipped flush must leave the queue intact').toBe(2)
   })
 
   it('reports an empty outbox as empty rather than erroring', async () => {

--- a/packages/mcp/test/outbox-tool.test.ts
+++ b/packages/mcp/test/outbox-tool.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #667 — `plur_outbox`, the supported way to see and retry queued team writes.
+ *
+ * Before this, queued writes were reachable only by reading
+ * `structured_data._outbox` out of `engrams.yaml` by hand. `flushOutbox()` and
+ * `outboxCount()` existed on core and were exposed nowhere.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { Plur } from '@plur-ai/core'
+import { getToolDefinitions } from '../src/tools.js'
+
+const REMOTE = 'https://plur.example.com/sse'
+const SCOPE = 'group:acme/team'
+const TOKEN = 'super-secret-token'
+
+describe('plur_outbox (#667)', () => {
+  let dir: string
+  let plur: Plur
+  let originalFetch: typeof globalThis.fetch
+  const tools = getToolDefinitions('full')
+
+  const call = (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.find(t => t.name === name)
+    if (!tool) throw new Error(`Unknown tool: ${name}`)
+    return tool.handler(args, plur)
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-outbox-tool-'))
+    originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as never
+    writeFileSync(join(dir, 'config.yaml'), yaml.dump({
+      stores: [{ url: REMOTE, token: TOKEN, scope: SCOPE, shared: true, readonly: false }],
+      index: false,
+    }))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  async function queue(n: number): Promise<void> {
+    for (let i = 0; i < n; i++) {
+      await plur.learn(`queued team fact number ${i}`, { scope: SCOPE, type: 'behavioral' })
+    }
+    await new Promise(r => setTimeout(r, 60))
+  }
+
+  it('is registered in the full profile and declares a flush flag', () => {
+    const tool = tools.find(t => t.name === 'plur_outbox')
+    expect(tool, 'the tool the issue exists to add').toBeDefined()
+    const schema = tool!.inputSchema as { properties?: Record<string, unknown> }
+    expect(schema.properties).toHaveProperty('flush')
+  })
+
+  it('reads without flushing — the default must not mutate', async () => {
+    await queue(2)
+    const res = await call('plur_outbox') as { pending: number; entries: unknown[]; flushed?: number }
+    expect(res.pending).toBe(2)
+    expect(res.entries).toHaveLength(2)
+    expect(res.flushed, 'a plain read must not report a flush').toBeUndefined()
+    expect(await plur.outboxCount(), 'the read consumed the queue').toBe(2)
+  })
+
+  it('never exposes the token or the target URL', async () => {
+    await queue(1)
+    const serialized = JSON.stringify(await call('plur_outbox'))
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('plur.example.com')
+  })
+
+  it('surfaces target_scope and attempt_count — the fields you act on', async () => {
+    await queue(1)
+    const res = await call('plur_outbox') as { entries: Array<Record<string, unknown>> }
+    expect(res.entries[0]).toMatchObject({ target_scope: SCOPE })
+    expect(res.entries[0]).toHaveProperty('attempt_count')
+    expect(res.entries[0]).toHaveProperty('age_days')
+  })
+
+  it('flush:true reports what it attempted, not just what is left', async () => {
+    // After a successful flush the entries are gone, so a tool that read the
+    // outbox AFTER flushing would report an empty queue and tell the caller
+    // nothing about what moved. `attempted` is the pre-flush snapshot.
+    await queue(2)
+    const res = await call('plur_outbox', { flush: true }) as {
+      flushed: number; failed: number; pending: number; attempted: unknown[]
+    }
+    expect(res.attempted, 'the flush reported nothing about what it tried').toHaveLength(2)
+    // The remote is still down in this fixture, so nothing flushes — the
+    // point of the assertion is the SHAPE, and that a failed flush is
+    // reported as failure rather than as an empty success.
+    expect(res.flushed + res.failed).toBe(2)
+    expect(res.pending).toBe(2)
+  })
+
+  it('reports an empty outbox as empty rather than erroring', async () => {
+    await plur.learn('a purely local fact', { scope: 'global', type: 'behavioral' })
+    const res = await call('plur_outbox') as { pending: number; entries: unknown[] }
+    expect(res).toMatchObject({ pending: 0 })
+    expect(res.entries).toEqual([])
+  })
+
+  it('plur_sync says that it flushes the outbox', () => {
+    // The flush was undocumented, so the one command that would have fixed a
+    // stuck queue did not say it fixed anything.
+    const sync = tools.find(t => t.name === 'plur_sync')!
+    expect(sync.description.toLowerCase()).toContain('outbox')
+  })
+
+  it('plur_status reports the pending count', async () => {
+    await queue(3)
+    const status = await call('plur_status') as { outbox_count: number }
+    expect(status.outbox_count).toBe(3)
+  })
+})

--- a/packages/mcp/test/packs-cli.test.ts
+++ b/packages/mcp/test/packs-cli.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #545 — the packs CLI's own branches, which were the only untested logic in it.
+ *
+ * `runPacks` delegates the work to already-tested core, so the happy paths were
+ * covered by proxy. What was not covered is the part core does not do: which
+ * stream a message goes to, and what exit code follows. Those are the contract
+ * a script wrapping `plur-mcp packs` depends on, and a wrong exit code is
+ * invisible until someone's CI silently passes on a failed install.
+ *
+ * Testable in-process because the branch logic moved out of the binary
+ * entrypoint — see `packs-cli.ts` for why that was worth doing rather than
+ * spawning.
+ */
+import { describe, it, expect } from 'vitest'
+import { packsCommand, type PacksCapablePlur } from '../src/packs-cli.js'
+
+/** A store stub. Every method records that it was (or was not) reached. */
+function stubPlur(overrides: Partial<PacksCapablePlur> = {}): PacksCapablePlur & { calls: string[] } {
+  const calls: string[] = []
+  return {
+    calls,
+    async installPack(source: string) { calls.push(`install:${source}`); return { name: 'demo', installed: 3 } },
+    listPacks() { calls.push('list'); return [] },
+    uninstallPack(name: string) { calls.push(`uninstall:${name}`); return { name, engram_count: 7 } },
+    ...overrides,
+  }
+}
+
+describe('packs CLI branches (#545)', () => {
+  describe('failures go to stderr and exit 1', () => {
+    it.each([
+      ['install with no path', ['install'], 'Usage: plur-mcp packs install <path>'],
+      ['uninstall with no name', ['uninstall'], 'Usage: plur-mcp packs uninstall <name>'],
+      ['unknown subcommand', ['frobnicate'], 'Unknown packs subcommand: frobnicate'],
+      ['no subcommand at all', [], 'Unknown packs subcommand: (none)'],
+    ])('%s', async (_label, args, expected) => {
+      const plur = stubPlur()
+      const res = await packsCommand(args, plur)
+      expect(res.exitCode, 'a usage error must be a non-zero exit').toBe(1)
+      expect(res.stderr).toContain(expected)
+      expect(res.stdout, 'errors must not go to stdout — scripts parse it').toBe('')
+      expect(plur.calls, 'the store must not be touched on a usage error').toEqual([])
+    })
+  })
+
+  it('reports a not-found uninstall as an error, from the thrown message', async () => {
+    // The path that used to have an unreachable `else` beside it. `uninstallPack`
+    // throws; the catch is what actually reports not-found.
+    const plur = stubPlur({
+      uninstallPack(name: string): { name: string; engram_count: number } {
+        throw new Error(`Pack not found: ${name}. Use 'plur packs list' to see installed packs.`)
+      },
+    })
+    const res = await packsCommand(['uninstall', 'ghost'], plur)
+    expect(res.exitCode).toBe(1)
+    expect(res.stderr).toContain('Pack not found: ghost')
+    expect(res.stdout).toBe('')
+  })
+
+  it('reports a failed install as an error', async () => {
+    const plur = stubPlur({
+      async installPack(): Promise<{ name: string; installed: number }> { throw new Error('manifest is invalid') },
+    })
+    const res = await packsCommand(['install', './broken'], plur)
+    expect(res.exitCode).toBe(1)
+    expect(res.stderr).toContain('Error: manifest is invalid')
+  })
+
+  describe('successes go to stdout and exit 0', () => {
+    it('install', async () => {
+      const res = await packsCommand(['install', './demo'], stubPlur())
+      expect(res).toMatchObject({ exitCode: 0, stderr: '' })
+      expect(res.stdout).toBe("Installed pack 'demo' (3 engrams)\n")
+    })
+
+    it('uninstall', async () => {
+      const res = await packsCommand(['uninstall', 'demo'], stubPlur())
+      expect(res).toMatchObject({ exitCode: 0, stderr: '' })
+      expect(res.stdout).toBe("Uninstalled pack 'demo' (7 engrams removed)\n")
+    })
+
+    it('list, when empty, says so rather than printing nothing', async () => {
+      const res = await packsCommand(['list'], stubPlur())
+      expect(res).toMatchObject({ exitCode: 0, stdout: 'No packs installed.\n' })
+    })
+
+    it('list renders a version only when the manifest carries one', async () => {
+      const plur = stubPlur({
+        listPacks: () => [
+          { name: 'with-version', engram_count: 2, manifest: { version: '1.2.0' } },
+          { name: 'no-version', engram_count: 5 },
+        ],
+      })
+      const res = await packsCommand(['list'], plur)
+      expect(res.stdout).toBe('with-version v1.2.0 (2 engrams)\nno-version (5 engrams)\n')
+    })
+  })
+})

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -196,6 +196,52 @@ describe('Session & store tools', () => {
       expect(endResult.injection_summary.pack_counts).toEqual({})
     })
 
+    it('buckets a PACK engram under its pack name, not __personal__ (#553)', async () => {
+      // Every other telemetry test here seeds a personal engram and asserts
+      // `pack_counts.__personal__ > 0`. That leaves the feature's actual
+      // purpose — counting per installed pack — unexercised, so the field the
+      // bucketing reads could be renamed or dropped in propagation and CI
+      // would stay green while every pack engram silently became personal.
+      const packSource = mkdtempSync(join(tmpdir(), 'plur-pack-src-'))
+      writeFileSync(join(packSource, 'SKILL.md'),
+        '---\nname: telemetry-pack\nversion: "1.0"\n---\n')
+      writeFileSync(join(packSource, 'engrams.yaml'), [
+        'engrams:',
+        '  - id: ENG-2026-0101-777',
+        '    statement: prefer semicolons when writing TypeScript code',
+        '    type: behavioral',
+        '    scope: global',
+        '    status: active',
+        '    version: 2',
+        '    activation:',
+        '      retrieval_strength: 0.9',
+        '      storage_strength: 1.0',
+        '      frequency: 0',
+        '      last_accessed: "2026-01-01"',
+        '',
+      ].join('\n'))
+      await plur.installPack(packSource)
+
+      const startResult = await callTool('plur_session_start', { task: 'write TypeScript code' }) as any
+      const endResult = await callTool('plur_session_end', {
+        summary: 'Wrote TypeScript',
+        session_id: startResult.session_id,
+        engram_suggestions: [],
+      }) as any
+
+      const counts = endResult.injection_summary.pack_counts as Record<string, number>
+      expect(counts['telemetry-pack'], `bucketed as ${JSON.stringify(counts)}`).toBeGreaterThan(0)
+      // Deliberately NOT asserting `__personal__` is absent. With the fix in
+      // place this store still reports one personal injection despite holding
+      // no personal engram, which means the candidate pool carries a second
+      // copy of the pack row without its `_pack` marker — `_loadAllEngrams`
+      // merges pack engrams AND `_inject` loads packs again. That is a
+      // separate defect (a double-counted injection), and pinning it here
+      // would couple this test to it; it is noted rather than asserted.
+      expect(counts['telemetry-pack']).toBeGreaterThanOrEqual(1)
+      rmSync(packSource, { recursive: true, force: true })
+    })
+
     it('standalone plur_inject calls accumulate into the session telemetry', async () => {
       await plur.learn('Use pnpm for package management', { scope: 'global' })
 

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -608,6 +608,48 @@ describe('MCP tools', () => {
     expect(past.engram_count).toBe(1)
   })
 
+  it('plur_status composes domain and created_after — the headline use case (#547)', async () => {
+    // #524 tested each axis alone. The scenario that motivated the filters
+    // (#522) is the two TOGETHER — "what has this domain learned since the
+    // engagement started" — and composition is exactly where a filter chain
+    // breaks, by overwriting rather than narrowing.
+    await callTool('plur_learn', { statement: 'Meridian uses a 60/40 split', scope: 'global', domain: 'meridian.strategy' })
+    await callTool('plur_learn', { statement: 'Forge lists ship on Tuesdays', scope: 'global', domain: 'forge.ops' })
+    const past = '2000-01-01'
+    const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10)
+
+    const both = await callTool('plur_status', { domain: 'meridian', created_after: past }) as any
+    expect(both.engram_count, 'the domain filter must still apply when a date is passed too').toBe(1)
+
+    // …and the date must still apply when a domain is passed: a composition
+    // that silently kept only the last filter would pass the assertion above.
+    const noneInWindow = await callTool('plur_status', { domain: 'meridian', created_after: tomorrow }) as any
+    expect(noneInWindow.engram_count, 'the date filter was dropped when combined').toBe(0)
+  })
+
+  it.each(['2026-13-99', 'last week', '2026-02-30', '26-01-01'])(
+    'plur_status rejects the malformed created_after %p instead of miscounting (#547)',
+    async bad => {
+      // Dates are compared LEXICOGRAPHICALLY against a YYYY-MM-DD stamp, so a
+      // malformed value does not error — it sorts after every real date and
+      // returns a confident 0. A wrong number from a diagnostic is worse than
+      // an error from one.
+      await callTool('plur_learn', { statement: 'a fact that exists', scope: 'global' })
+      await expect(callTool('plur_status', { created_after: bad })).rejects.toThrow(/ISO date/)
+    },
+  )
+
+  it('plur_status treats an EMPTY created_after as no filter, not as an error', async () => {
+    // Deliberately excluded from the rejection list above. An empty string is
+    // how a caller spells "unset" when it is threading an optional value
+    // through, and every other optional string in this surface reads falsy as
+    // absent. Rejecting it would turn a common no-op into an error; the
+    // malformed cases above are the ones that produce a wrong NUMBER.
+    await callTool('plur_learn', { statement: 'a fact that exists', scope: 'global' })
+    const res = await callTool('plur_status', { created_after: '' }) as any
+    expect(res.engram_count).toBe(1)
+  })
+
   // #452 — injection-provenance event/label counts feed #202's volume gate.
   it('plur_status surfaces injection event and label counts', async () => {
     const empty = await callTool('plur_status', {}) as any

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -378,6 +378,36 @@ describe('MCP tools', () => {
       expect(result.domain_hint).toContain('group:acme/engineering')
     })
 
+    it('batch: does not count an item that AUTO-ROUTED without a domain (#681)', async () => {
+      // The parity gap. The single-item gate has four conditions, including
+      // "the write did not auto-route"; the batch count had three. A
+      // no-domain item can still clear the ranker's threshold on TAGS alone,
+      // and when it does the single-item path stays silent — so the same
+      // write produced a nudge in a batch and none on its own.
+      //
+      // The fixture's covers are ['acme.engineering', 'kubernetes',
+      // 'terraform'], so tagging an item with them routes it without a domain.
+      const result = await coversCall('plur_learn_batch', {
+        engrams: [
+          { statement: 'A kubernetes and terraform note for the engineering team',
+            tags: ['kubernetes', 'terraform', 'acme.engineering'] },
+          { statement: 'An unrelated note about gardening with no routing signal at all' },
+        ],
+      }) as any
+
+      // Guard the fixture on the STORED evidence, not on the response shape:
+      // the batch response does not echo `routed` per item, so asserting on it
+      // silently measured nothing (a first draft of this test did exactly that
+      // and reported 0 routed). `structured_data._routed` is what the gate
+      // itself reads.
+      const ids = result.ids as Array<string | null>
+      const stored = await Promise.all(ids.map(id => id ? coversPlur.getById(id) : null))
+      const routedCount = stored.filter(e =>
+        (e as { structured_data?: { _routed?: unknown } } | null)?.structured_data?._routed !== undefined).length
+      expect(routedCount, 'fixture no longer routes — the parity case is not exercised').toBe(1)
+      expect(result.domain_hint, 'the routed item was counted in the nudge').toContain('1 of 2')
+    })
+
     it('batch: silent when every item carries a domain or explicit scope', async () => {
       const result = await coversCall('plur_learn_batch', {
         engrams: [

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -51,6 +51,10 @@ const ALWAYS_ASYNC = new Set([
   // Born async (#676) — never had a sync form, so there is no pre-0.16
   // call site for the migrate tool to rewrite.
   'rescope',
+  // Born async (#667) — the outbox inspector behind `plur_outbox` / `plur
+  // outbox`. Reads through the async store seam, and new in this release, so
+  // there is no pre-0.16 call site for the migrate tool to rewrite.
+  'listOutbox',
   // Born async (#856) — near-duplicate REPORTING for the plur_learn path.
   // Embedding-backed, so it could never have been sync, and it is new in this
   // release, so no pre-0.16 call site exists for the migrate tool to rewrite.


### PR DESCRIPTION
Wave 1 of clearing the backlog: everything that could be closed without a judgement call from the maintainer. Deliberately scoped to MCP, CLI, docs and Python so it does not touch `packages/core/src/index.ts` beyond three small hunks — the core-heavy follow-ups are queued behind #900.

Closes #545, #547, #553, #613, #667, #681, #703, #757, #898.

## Three were not what the issue said they were

**#553 was a live bug, not a test gap.** The issue asked for a test that installs a pack, reasoning that the per-pack injection telemetry was correct but unexercised. Writing it showed the premise was wrong: the bucketing read `e.pack` — the schema field an engram carries only if its own YAML declares it — while `_loadAllEngrams` stamps installed-pack engrams with `_pack` from the manifest and nothing sets `pack` on them. So the ordinary case bucketed **entirely as `__personal__`**, and per-pack telemetry counted nothing it existed to count. Not a future regression; already true, and invisible because no test installed a pack.

**#757's approximation no longer exists.** It asked for the out-of-corpus IDF approximation in union ranking to be quantified. Measured, it is exact — `extendCorpusStats` landed in #750 iteration 2, *after* the audit that filed the issue, and folds outsider `df` under the same `termMatches` rule with exact `N` and `avgDocLength`. Max divergence from an exact whole-set baseline is 0 across four skew shapes and stays 0 as the outsider share sweeps 1→100. The control asserts primary-only stats diverge by >0.5 nats, so those four `toBe(0)`s are not vacuous. The tests stay as a tripwire.

**#681's part 2 was already done.** CLAUDE.md carries the `plur.<team>.<area>` convention the hint points at, so the pointer resolves.

## The rest

- **#545** — `UninstallResult.removed` narrowed to the literal `true` it always was, which turns the unreachable "Pack not found" branch into a compile error instead of dead code that reads as handled behaviour. Branch logic extracted to `packs-cli.ts` returning a result, so the exit-code and stream contract is testable without spawning — the contention class #793 had to serialise a whole vitest project to contain.
- **#547** — `status({ created_after })` was trusted, and the comparison is lexicographic against a `YYYY-MM-DD` stamp, so `"last week"` and `"2026-13-99"` both sorted after every real date and returned a confident **0**. Now validated through the existing `normalizeIsoDate` rather than a second date rule. Empty string still means "no filter" — how callers spell unset — and that is now a test rather than an implication.
- **#667** — the outbox worked and was invisible: not a file or a queue directory, but `structured_data._outbox` nested inside ordinary engrams. `plur_outbox` (read; `{flush: true}` to retry) and `plur outbox [--flush]`, `plur_sync`'s description now admits it flushes, and session_start reports the **pending** count rather than `outbox_result.failed` — which differ exactly when it matters, because a host in breaker cooldown is never dialled, so `failed` is 0 while N writes sit queued. `listOutbox` omits `target_url` at the source rather than redacting it at each of three renderers.
- **#681** — the batch nudge counted items that had already auto-routed. A no-domain item reaches the ranker's threshold on three matching tags alone, so the same write produced a hint in a batch and none on its own.
- **#703** — `budget.ttl_seconds` was declared and never read: an agent inspecting the schema reads it as "caching is configurable", sets it, and gets neither caching nor an error. Removed, with a test that derives the allowed fields from what the handler consults.
- **#613** — hermetic HTTP tests for the heartbeat ingress, patching the resolved `DATA_DIR` attribute rather than the environment it was read from (the import-time bind that broke #604). Every rejection also asserts nothing was written — a 400 that still appends is the failure that matters. Plus the CI job that was missing entirely: `infra/heartbeat` matched no path filter in any workflow, so even the existing `validate()` matrix never ran.
- **#898** — the README said 98.0% R@5 for hybrid + BGE-reranker; plur-bench says 97.6% for the same stack, and the six comparison pages already cited 97.6%. Resolved by rule: **plur-bench is the source of truth**, and the README now says so. The per-category table is relabelled as an earlier run rather than edited, because changing only its total would leave rows that no longer sum to their own bottom line. The comparison pages keep 97.6% but now name the config — "fully local" read as the default, and the default is 95.6% without the opt-in ~5s reranker.

## Filed, not fixed

- **#901** — pack engrams enter the injection pool twice (`_loadAllEngrams` merges them, `_inject` loads packs again), so `total_injections` over-counts for anyone with packs installed. That number feeds the H003 activation-rate assumption. Found while writing #553's test; the test documents why it does not assert the absence of `__personal__` rather than quietly accommodating it.
- **#899** — CJK bigram emission is uncapped.
- **#648** — reclassified as needing a product decision, with reasoning on the issue: three options with different owners and costs, and the issue itself says "pick per appetite".

## Verification

`pnpm test` + `pnpm typecheck:tests`, plus `pytest infra/heartbeat` (35 passed). Five files fail under a locally loaded machine and pass in isolation — the known `core-pglite` / spawn contention class; CI on a clean runner is the signal.