### PR TITLE
fix(core): three defects — CJK bigram cap, pack double-injection, engram id reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,17 @@ name: CI
 on:
   push:
     branches: [main]
+  # EVERY pull request, not only those targeting main.
+  #
+  # This was `branches: [main]`, so a STACKED pr — one based on another
+  # in-review branch — ran no CI at all. It did not fail; it showed a green
+  # `issue-guard` and read as verified, which is worse than a red check.
+  # Discovered on #903 (based on #900), where three core fixes sat with no
+  # matrix run behind them and nothing said so.
+  #
+  # Stacking is the normal way to keep a review chain moving when one PR
+  # depends on another, so the trigger has to cover it.
   pull_request:
-    branches: [main]
 
 # Principle of least privilege: workflow only needs to checkout and run tests.
 permissions:

--- a/.github/workflows/hermes.yml
+++ b/.github/workflows/hermes.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [main]
     paths: ['packages/hermes/**', '.github/workflows/hermes.yml']
+  # Every pull request, not only those targeting main — a stacked PR (one based
+  # on another in-review branch) otherwise runs no CI and reads as verified.
+  # See the note in ci.yml.
   pull_request:
-    branches: [main]
     paths: ['packages/hermes/**', '.github/workflows/hermes.yml']
 
   # manual matrix runs (crtahlin review, #541)

--- a/.github/workflows/langchain.yml
+++ b/.github/workflows/langchain.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [main]
     paths: ['packages/langchain/**', 'packages/python/**', '.github/workflows/langchain.yml']
+  # Every pull request, not only those targeting main — a stacked PR (one based
+  # on another in-review branch) otherwise runs no CI and reads as verified.
+  # See the note in ci.yml.
   pull_request:
-    branches: [main]
     paths: ['packages/langchain/**', 'packages/python/**', '.github/workflows/langchain.yml']
 
 permissions:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [main]
     paths: ['packages/python/**', 'packages/langchain/**', '.github/workflows/python.yml']
+  # Every pull request, not only those targeting main — a stacked PR (one based
+  # on another in-review branch) otherwise runs no CI and reads as verified.
+  # See the note in ci.yml.
   pull_request:
-    branches: [main]
     paths: ['packages/python/**', 'packages/langchain/**', 'packages/cli/**', 'packages/core/**', '.github/workflows/python.yml']
 
 permissions:

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -664,15 +664,38 @@ export function engramIdDatePrefix(now: Date = new Date()): string {
   return `ENG-${now.toISOString().slice(0, 10)}-`
 }
 
-export function generateEngramId(existing: Engram[]): string {
+export function generateEngramId(existing: Engram[], alsoAllocated: Iterable<string> = []): string {
   const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
   const prefix = `ENG-${day}-`
   // Legacy compact form minted by earlier releases: ENG-YYYYMMDD → ENG-YYYY-MMDD-
   const legacyPrefix = `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`
-  const existingNums = existing
-    .filter(e => e.id.startsWith(prefix) || e.id.startsWith(legacyPrefix))
-    .map(e => parseInt(e.id.slice(e.id.startsWith(prefix) ? prefix.length : legacyPrefix.length), 10))
-    .filter(n => !isNaN(n))
-  const next = existingNums.length > 0 ? Math.max(...existingNums) + 1 : 1
-  return `${prefix}${String(next).padStart(3, '0')}`
+  const suffixOf = (id: string): number | null => {
+    const p = id.startsWith(prefix) ? prefix : id.startsWith(legacyPrefix) ? legacyPrefix : null
+    if (p === null) return null
+    const n = parseInt(id.slice(p.length), 10)
+    return isNaN(n) ? null : n
+  }
+  let max = 0
+  for (const e of existing) {
+    const n = suffixOf(e.id)
+    if (n !== null && n > max) max = n
+  }
+  // Ids that were minted and are no longer in the corpus (#816).
+  //
+  // The corpus is not a record of what has been ALLOCATED, only of what
+  // currently exists — `compact()` removes rows and frees their ids, so the
+  // next `learn()` mints an id a different engram already had. Everything
+  // keyed by id that outlives the corpus entry then merges two lives into one:
+  // history narrates a single story out of two, a restore diff reads a
+  // substitution as an edit, and a `supersedes` edge silently re-targets.
+  //
+  // Callers pass the ids this store has minted (from the append-only history
+  // log, which never forgets). Purely additive: this can only raise `max`, so
+  // an incomplete list degrades to the previous behaviour and can never cause
+  // a collision that the previous behaviour would have avoided.
+  for (const id of alsoAllocated) {
+    const n = suffixOf(id)
+    if (n !== null && n > max) max = n
+  }
+  return `${prefix}${String(max + 1).padStart(3, '0')}`
 }

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -36,11 +36,27 @@ export const NEGATIVE_STRENGTH_DELTA = 0.1
  * leaving it unset would let an older engram accrue unlimited positive signal
  * while still reading as though nobody had an opinion about it.
  *
- * Anything unrecognised is returned untouched. That is load-bearing rather than
- * defensive: a deployment may extend the enum — `commitment: 'draft'` stages an
- * engram in a review queue (see the extension note in `schemas/engram.ts`) — and
- * silently promoting a draft out of review on a thumbs-up would publish
- * unreviewed content. Unknown means "not mine to advance".
+ * Anything unrecognised is returned untouched — defence in depth, not support
+ * for an extension mechanism (#905).
+ *
+ * This previously read "a deployment may extend the enum — `commitment:
+ * 'draft'` stages an engram in a review queue (see the extension note in
+ * `schemas/engram.ts`)". There is no such extension note, and no such
+ * extension: `EngramSchema.commitment` is a closed
+ * `z.enum(['exploring','leaning','decided','locked'])`, so an engram carrying
+ * `'draft'` fails validation and is QUARANTINED at load rather than reaching
+ * this function. The docstring described a feature that was never built, and
+ * the schema and the prose contradicted each other for anyone reading either
+ * one on its own.
+ *
+ * The branch itself stays, and is still worth having: a value can arrive here
+ * from a store written by a newer version, a hand-edited YAML file, or a code
+ * path that constructs an engram without parsing it. Advancing a commitment
+ * this function does not understand would be a silent semantic change to
+ * somebody else's state — so unknown means "not mine to advance".
+ *
+ * If a review-queue state is ever actually wanted, it needs a schema change
+ * and a migration, not a docstring.
  */
 export function nextCommitment(current: string | undefined): string | undefined {
   switch (current) {

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -36,27 +36,11 @@ export const NEGATIVE_STRENGTH_DELTA = 0.1
  * leaving it unset would let an older engram accrue unlimited positive signal
  * while still reading as though nobody had an opinion about it.
  *
- * Anything unrecognised is returned untouched — defence in depth, not support
- * for an extension mechanism (#905).
- *
- * This previously read "a deployment may extend the enum — `commitment:
- * 'draft'` stages an engram in a review queue (see the extension note in
- * `schemas/engram.ts`)". There is no such extension note, and no such
- * extension: `EngramSchema.commitment` is a closed
- * `z.enum(['exploring','leaning','decided','locked'])`, so an engram carrying
- * `'draft'` fails validation and is QUARANTINED at load rather than reaching
- * this function. The docstring described a feature that was never built, and
- * the schema and the prose contradicted each other for anyone reading either
- * one on its own.
- *
- * The branch itself stays, and is still worth having: a value can arrive here
- * from a store written by a newer version, a hand-edited YAML file, or a code
- * path that constructs an engram without parsing it. Advancing a commitment
- * this function does not understand would be a silent semantic change to
- * somebody else's state — so unknown means "not mine to advance".
- *
- * If a review-queue state is ever actually wanted, it needs a schema change
- * and a migration, not a docstring.
+ * Anything unrecognised is returned untouched. That is load-bearing rather than
+ * defensive: a deployment may extend the enum — `commitment: 'draft'` stages an
+ * engram in a review queue (see the extension note in `schemas/engram.ts`) — and
+ * silently promoting a draft out of review on a thumbs-up would publish
+ * unreviewed content. Unknown means "not mine to advance".
  */
 export function nextCommitment(current: string | undefined): string | undefined {
   switch (current) {

--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -48,7 +48,8 @@ export const MIN_TOKEN_LENGTH = 2
  *       bigrams widened past Han, two-character floor for dense scripts.
  *   4 — 2026-08-13 panel. `Script_Extensions` rather than `Script` for the
  *       space-less run, so characters that belong to a script without BEING
- *       that script join their run instead of splitting it.
+ *       that script join their run instead of splitting it. Also caps
+ *       bigram emission per run at {@link MAX_SPACELESS_RUN_CHARS} (#899).
  *
  * (Entry 3 is retrospective: #833 bumped the constant to 3 and did not record
  * why, which is the one thing this ledger exists to prevent.)
@@ -85,6 +86,21 @@ const SPACELESS_RUN = /[\p{Script_Extensions=Han}\p{Script_Extensions=Hiragana}\
  * `length > 2` floor erases them (#833). Korean is the reported case:
  * 도커 ("docker") is two syllable blocks and vanished entirely.
  */
+/**
+ * Longest space-less run that gets fully bigram-indexed (#899).
+ *
+ * 512 characters is far above any real statement in a space-less script — a
+ * Japanese or Chinese engram statement runs to tens of characters, not
+ * hundreds — and far below the scale at which a single pasted document starts
+ * to dominate a shared GIN index. Chosen to be a no-op for every engram the
+ * store is meant to hold, and a bound for the ones it is not.
+ *
+ * Changing this alters the token list for long runs, so it is covered by
+ * {@link TOKENIZER_VERSION}: bump the version and reindex, or stored tokens
+ * and query tokens stop agreeing.
+ */
+export const MAX_SPACELESS_RUN_CHARS = 512
+
 const DENSE_SCRIPT = /[\p{Script_Extensions=Hangul}\p{Script_Extensions=Han}\p{Script_Extensions=Hiragana}\p{Script_Extensions=Katakana}]/u
 
 export function ftsTokenize(text: string): string[] {
@@ -133,7 +149,19 @@ export function ftsTokenize(text: string): string[] {
   // Space-less scripts, indexed as character bigrams (#782, widened in #833).
   // Read from `lower`, not from wordSource — the runs were stripped there.
   for (const run of lower.match(SPACELESS_RUN) ?? []) {
-    for (let i = 0; i < run.length - 1; i++) tokens.push(run.slice(i, i + 2))
+    // Capped (#899). A run of length n emits n-1 bigrams, and every one becomes
+    // a row in Postgres's GIN index — so a 5,000-character CJK engram writes
+    // ~5,000 index entries where English prose of the same length writes a few
+    // hundred. Uncapped, one pasted document can dominate the index for the
+    // whole store.
+    //
+    // The cap is per RUN, not per engram, so ordinary statements — which are
+    // assertions, not documents — are untouched: nothing here changes for a run
+    // under the limit, which is essentially all of them. A run over it is
+    // TRUNCATED rather than dropped: its opening is the part a query is most
+    // likely to share, and indexing a prefix beats indexing nothing.
+    const span = Math.min(run.length, MAX_SPACELESS_RUN_CHARS)
+    for (let i = 0; i < span - 1; i++) tokens.push(run.slice(i, i + 2))
   }
   return tokens
 }

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import { logger } from './logger.js'
 import { join } from 'path'
 import { createHash } from 'crypto'
 
@@ -38,14 +39,44 @@ export function appendHistory(root: string, event: HistoryEvent): void {
   // Best-effort on the fsync itself: the append already succeeded, and failing
   // the caller's mutation because a diagnostic log could not be flushed would
   // trade a small durability gap for a large availability one.
-  const fd = fs.openSync(filePath, 'a')
+  // Best-effort on the WHOLE append, not just the fsync.
+  //
+  // The reasoning above — that failing a caller's mutation because a
+  // diagnostic log could not be written trades a small durability gap for a
+  // large availability one — was applied only to `fsyncSync`. `openSync` and
+  // `writeSync` were unguarded, so an unwritable history directory (disk full,
+  // permissions, a path that is not a file) propagated out and failed the
+  // learn/forget/feedback that called it. Found by a test that made the month
+  // file unreadable to check id allocation degraded safely: it did not
+  // degrade, it threw EISDIR out of `plur.learn()`.
+  //
+  // Warned rather than silently swallowed: history is load-bearing for `plur
+  // restore` (it NAMES the engrams a restore cannot recover) and, since #816,
+  // for id allocation. A store writing no history is degraded and the operator
+  // needs to know — but the write itself must still land.
   try {
-    fs.writeSync(fd, line)
-    try { fs.fsyncSync(fd) } catch { /* append landed; durability is best-effort */ }
-  } finally {
-    fs.closeSync(fd)
+    const fd = fs.openSync(filePath, 'a')
+    try {
+      fs.writeSync(fd, line)
+      try { fs.fsyncSync(fd) } catch { /* append landed; durability is best-effort */ }
+    } finally {
+      fs.closeSync(fd)
+    }
+  } catch (err) {
+    if (!warnedHistoryPaths.has(filePath)) {
+      warnedHistoryPaths.add(filePath)
+      logger.warning(
+        `[plur] history could not be written to ${filePath}: ${(err as Error).message}. ` +
+        `The operation itself succeeded. While this persists, \`plur restore\` cannot name ` +
+        `unrecoverable engrams and engram-id allocation loses its cross-compaction guarantee (#816).`,
+      )
+    }
   }
 }
+
+/** Warn once per path — this is on the hot write path; a broken log must not
+ *  also become a log flood. */
+const warnedHistoryPaths = new Set<string>()
 
 /**
  * Read history events from a specific month's JSONL file.

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -69,6 +69,48 @@ export function readHistory(root: string, yearMonth: string): HistoryEvent[] {
 }
 
 /**
+ * Ids this store has ever MINTED whose prefix matches one of `prefixes` (#816).
+ *
+ * `generateEngramId` allocates by scanning the corpus for the highest same-day
+ * suffix, so the corpus is the only record of what has been handed out — and
+ * `compact()` removes rows, which frees their ids for reuse. Two different
+ * engrams then share an id, and everything keyed by id that outlives the corpus
+ * entry (history itself, backups and restore diffs, `supersedes` edges, outbox
+ * rows, remote store rows) silently merges two lives into one.
+ *
+ * The repair needs a record of allocation that survives removal. That record
+ * already exists: this log is append-only, keyed by engram id, and written on
+ * every create — nothing is ever deleted from it, which is exactly the property
+ * the corpus lacks. No new state, no store-format change, no migration.
+ *
+ * ## Why this is safe even though history writes are best-effort
+ *
+ * Several call sites wrap `appendHistory` in try/catch, deliberately: a failed
+ * history write must not fail the write it describes. So this can UNDER-report.
+ * That is tolerable because the failure is one-directional — a missed record
+ * leaves allocation exactly where it is today, while every record found can
+ * only push the next suffix higher. Reading more allocation history can never
+ * create a collision, only avoid one.
+ *
+ * Reads a single month (allocation is per-day, so only the current month can
+ * hold same-day ids) and never throws: an unreadable log degrades to today's
+ * corpus-only behaviour rather than blocking a write.
+ */
+export function mintedIdsWithPrefix(root: string, yearMonth: string, prefixes: string[]): string[] {
+  try {
+    const out: string[] = []
+    for (const ev of readHistory(root, yearMonth)) {
+      if (ev.event !== 'engram_created') continue
+      const id = ev.engram_id
+      if (typeof id === 'string' && prefixes.some(p => id.startsWith(p))) out.push(id)
+    }
+    return out
+  } catch {
+    return []
+  }
+}
+
+/**
  * List all available history months (YYYY-MM format).
  */
 export function listHistoryMonths(root: string): string[] {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3468,7 +3468,8 @@ export class Plur {
     // #776: remote leg starts BEFORE the local pipeline (added latency =
     // max(0, remote − local)); merged below via RRF.
     const remotePromise = this._startRemoteRecall(query, options)
-    const filtered = await this._filterEngrams(options)
+    // #906: narrowed by the store when provably equivalent, else the full read.
+    const filtered = await this._hybridCandidates(query, options)
     const limit = options?.limit ?? 20
     const rerank = await this._resolveRerankOptions(options?.rerank)
     const intent = this._resolveIntentProfile(query, options?.intentOverride)
@@ -4369,6 +4370,57 @@ export class Plur {
       filtered = filtered.filter(e => visible(e.scope))
     }
     return filtered
+  }
+
+  /**
+   * Candidates for the hybrid path — narrowed by the store when that is
+   * PROVABLY equivalent, otherwise the full filtered corpus (#906).
+   *
+   * `recallHybridWithMeta` called `_filterEngrams()` unconditionally, and for a
+   * Postgres primary query store that is a full scan on every call: `indexTier`
+   * resolves to 'none' when a primary query store is present (ADR-0005 — such
+   * an adapter IS both the source of truth and the query engine), so it takes
+   * `_filterEngrams`'s else branch and loads everything. `plur_recall` defaults
+   * to hybrid, so that is one whole-corpus read per query, on exactly the
+   * deployment where a scan is expensive.
+   *
+   * Narrowing before RRF would normally be a RECALL-QUALITY change — the vector
+   * leg can only rank what it is given — and would need a plur-bench number
+   * before shipping. This does not, because it narrows only when the adapter
+   * reports `exhausted`: the returned rows are then not a sample but everything
+   * the store holds for that filter, so ranking over them is identical to
+   * ranking over the full corpus BY CONSTRUCTION. Not exhausted, and it falls
+   * back to the previous behaviour untouched.
+   *
+   * The filters are passed through in full. `searchBM25Exhaustive` takes
+   * `{ limit } & StorageFilter`, and StorageFilter carries every field
+   * `_filterEngrams` applies — status, scope, scopes, visibilityGrants,
+   * domain — so this cannot silently drop an authorization filter. That parity
+   * is the precondition for the whole approach; if it ever stops holding, this
+   * must revert to `_filterEngrams` rather than narrow.
+   */
+  private async _hybridCandidates(
+    query: string,
+    options?: RecallOptions & { include_expired?: boolean },
+  ): Promise<Engram[]> {
+    const adapter = this._primaryQueryAdapter()
+    if (adapter?.searchBM25Exhaustive) {
+      try {
+        const narrowed = await adapter.searchBM25Exhaustive(query, {
+          limit: (options?.limit ?? 20) * PUSHDOWN_OVERFETCH,
+          status: 'active',
+          ...(options?.scope !== undefined ? { scope: options.scope } : {}),
+          ...(options?.scopes !== undefined ? { scopes: options.scopes } : {}),
+          ...(options?.domain !== undefined ? { domain: options.domain } : {}),
+          visibilityGrants: this._grantedScopes(),
+        })
+        if (narrowed.exhausted) return narrowed.rows
+      } catch {
+        // A pushdown failure must never fail a recall — fall back to the read
+        // that has always worked.
+      }
+    }
+    return await this._filterEngrams(options)
   }
 
   private async _filterEngrams(options?: RecallOptions & { include_expired?: boolean }): Promise<Engram[]> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4678,7 +4678,23 @@ export class Plur {
     // allow-list. A caller that wants pack content in scope names it.
     const permitted = options?.scopes
     const inScope = (e: Engram): boolean => permitted === undefined || permitted.includes(e.scope)
-    const engrams = permitted === undefined ? allEngrams : allEngrams.filter(inScope)
+    // Pack engrams are carried by `packs`, NOT by this array (#901).
+    //
+    // `_loadAllEngrams` merges installed-pack engrams into the corpus and
+    // stamps `_pack` — deliberately, and for RECALL: its own comment says
+    // "include pack engrams so they're searchable via recall". Injection does
+    // not need that merge, because it receives `packs` separately.
+    //
+    // Leaving them in meant `selectAndSpread` scored every pack engram TWICE:
+    // once in its personal-engram loop and once in its pack loop. Not merely a
+    // double count — the two loops apply different rules (the pack loop uses
+    // `packMatchTerms` and is capped by MAX_PER_PACK, the personal loop is
+    // neither), so the stray copy was scored under rules never meant for it,
+    // competed for the same token budget, and could displace a genuinely
+    // distinct engram. It also inflated `total_injections`, which feeds the
+    // H003 activation-rate assumption in hypotheses.yaml.
+    const withoutPacks = allEngrams.filter(e => (e as { _pack?: string })._pack === undefined)
+    const engrams = permitted === undefined ? withoutPacks : withoutPacks.filter(inScope)
     const packs = permitted === undefined
       ? allPacks
       : allPacks

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5139,6 +5139,8 @@ export class Plur {
     }
     // The ID may be prefixed (ENG-GPL-...) from _loadAllEngrams namespacing.
     // Strip the prefix before querying the remote server. See: #86
+    /** Stores this walk could not reach — so "not found" can say so (#907). */
+    const unverifiedStores: string[] = []
     for (const entry of (this.config.stores ?? [])) {
       if (!entry.url) continue
       const serverId = this._stripRemotePrefix(id, entry.scope)
@@ -5149,6 +5151,32 @@ export class Plur {
         continue
       }
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
+      // OWNERSHIP is decided by `existsById`, not `getById` (#907).
+      //
+      // `getById` catches everything and returns null, so a timeout, a 5xx or
+      // an auth rejection was indistinguishable from a genuine 404 — the walk
+      // read silence as "this store does not have it", moved on, and reported
+      // "Engram not found" for an engram the store demonstrably held. That is
+      // the exact collapse `existsById` exists to prevent, quoting its own
+      // docstring: safe for reads that only want the engram, unsafe for
+      // anything deciding whether it is free to act. Deciding which store owns
+      // an id IS deciding whether to act.
+      let owns: boolean
+      try {
+        owns = await driver.existsById(serverId)
+      } catch (err) {
+        // Could not tell. Feedback's established policy is to proceed rather
+        // than refuse — a mis-targeted rating is recoverable and rating is a
+        // hot path — but the store is COUNTED, so the message below cannot
+        // claim knowledge this walk does not have.
+        unverifiedStores.push(entry.scope ?? entry.url!)
+        logger.warning(
+          `[plur] could not reach "${entry.scope ?? entry.url}" while looking for ${id} `
+          + `(${(err as Error).message}) — it may hold this engram.`,
+        )
+        continue
+      }
+      if (!owns) continue
       const found = await driver.getById(serverId)
       if (found) {
         await driver.feedback(serverId, signal)
@@ -5172,7 +5200,7 @@ export class Plur {
     }
 
     // Search pack engrams by scanning pack directories
-    await this._feedbackPack(id, signal)
+    await this._feedbackPack(id, signal, unverifiedStores)
     this._logInjectionOutcome(id, signal)
   }
 
@@ -6586,7 +6614,16 @@ export class Plur {
   }
 
   /** Search packs for an engram by ID and apply feedback, writing back to the pack's engrams.yaml. */
-  private async _feedbackPack(id: string, signal: 'positive' | 'negative' | 'neutral'): Promise<void> {
+  /**
+   * @param unreachedStores stores the caller's remote walk could not probe, so
+   *   the terminal "not found" can say so rather than claiming a search that
+   *   did not run (#907).
+   */
+  private async _feedbackPack(
+    id: string,
+    signal: 'positive' | 'negative' | 'neutral',
+    unreachedStores: string[] = [],
+  ): Promise<void> {
     if (!fs.existsSync(this.paths.packs)) throw new Error(`Engram not found: ${id}`)
 
     for (const entry of fs.readdirSync(this.paths.packs)) {
@@ -6619,7 +6656,16 @@ export class Plur {
       if (handled) return
     }
 
-    throw new Error(`Engram not found: ${id}`)
+    // "Not found" must not mean "did not look" (#907). If a store could not be
+    // reached, say which — the caller can retry or pass an explicit scope, and
+    // neither is actionable if the message claims a search that did not run.
+    throw new Error(
+      unreachedStores.length > 0
+        ? `Engram not found: ${id} — but ${unreachedStores.length} store(s) could not be reached `
+          + `(${unreachedStores.join(', ')}). This is "not found where I could look", not "does not exist". `
+          + `Retry, or pass scope explicitly to target a store directly.`
+        : `Engram not found: ${id}`,
+    )
   }
 
   /** Capture an episodic memory. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5912,6 +5912,11 @@ export class Plur {
 
     // Strip store prefix before querying remote. See: #86
     let refusedBy: string | null = null
+    /** Stores this walk could not reach — so "not found" cannot claim absence
+     *  it never verified (#907). Recorded, NOT thrown on: the existing
+     *  contract (`forget handles remote server error gracefully`, #84) is that
+     *  a degraded fleet must not stop a retire, and that is worth keeping. */
+    const unreachedStores: string[] = []
     for (const entry of (this.config.stores ?? [])) {
       if (!entry.url) continue
       const serverId = this._stripRemotePrefix(id, entry.scope)
@@ -5924,6 +5929,33 @@ export class Plur {
         continue
       }
       const driver = this._getRemoteDriver({ url: entry.url, token: entry.token, scope: entry.scope })
+      // Tri-state (#907). `getById` alone cannot distinguish "this store does
+      // not have it" from "this store did not answer", so an unreachable
+      // remote was walked past and the engram reported as simply not found —
+      // absence the walk never verified, which is #831's harm by another route.
+      //
+      // The walk CONTINUES on `unknown` rather than refusing: `forget handles
+      // remote server error gracefully` (#84) asserts a degraded fleet does
+      // not stop a retire, and that availability is worth keeping. What
+      // changes is only that the store is recorded, so the terminal message
+      // below stops claiming knowledge it does not have. Same resolution
+      // `feedback` already uses.
+      // Optional capability: a driver without `probeById` (an injected stub, a
+      // third-party implementation) keeps the previous two-state behaviour
+      // rather than crashing. Absence of the capability is not a reason to
+      // fail a retire.
+      const ownership: 'owned' | 'absent' | 'unknown' = driver.probeById
+        ? await driver.probeById(serverId)
+        : ((await driver.getById(serverId)) ? 'owned' : 'absent')
+      if (ownership === 'unknown') {
+        unreachedStores.push(entry.scope ?? entry.url!)
+        logger.warning(
+          `[plur] could not reach "${entry.scope ?? entry.url}" while looking for ${id} — `
+          + `it may hold this engram.`,
+        )
+        continue
+      }
+      if (ownership === 'absent') continue
       const found = await driver.getById(serverId)
       if (found) {
         const removed = await driver.remove(serverId)
@@ -5952,7 +5984,16 @@ export class Plur {
         + `Check that the token has delete rights for that scope.`,
       )
     }
-    throw new Error(`Engram not found: ${id}`)
+    // Still "Engram not found" — the existing contract and its test both
+    // depend on that phrase — but never a bare claim of absence when a store
+    // could not be reached (#907).
+    throw new Error(
+      unreachedStores.length > 0
+        ? `Engram not found: ${id} — but ${unreachedStores.length} store(s) could not be reached `
+          + `(${unreachedStores.join(', ')}). This is "not found where I could look", not `
+          + `"does not exist". Retry, or pass scope explicitly to target a store directly.`
+        : `Engram not found: ${id}`,
+    )
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,7 @@ import { detectSecrets, detectSensitive, sensitivityCategory, SCAN_TRUNCATED } f
 import type { SecretMatch } from './secrets.js'
 import { SENSITIVITY_CATEGORIES, type ScopeMetadata, type SensitivityCategory } from './schemas/scope-metadata.js'
 import { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
-import { appendHistory, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, type InjectionEventCounts } from './history.js'
+import { mintedIdsWithPrefix, appendHistory, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, type InjectionEventCounts } from './history.js'
 import { computeContentHash, isHashable } from './content-hash.js'
 import { isLocalOnlyScope, assertScopeNamesATarget } from './scope-target.js'
 import { orderBySupersedes } from './outbox-order.js'
@@ -1417,6 +1417,20 @@ export class Plur {
     }
   }
 
+  /**
+   * Ids this store has minted today that are no longer in the corpus (#816).
+   *
+   * Read from the append-only history log, which — unlike the corpus — never
+   * forgets. See `mintedIdsWithPrefix` for why an incomplete answer is safe.
+   */
+  private _mintedTodayIds(): string[] {
+    const day = new Date().toISOString().slice(0, 10)
+    return mintedIdsWithPrefix(this.paths.root, day.slice(0, 7), [
+      `ENG-${day}-`,
+      `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`,
+    ])
+  }
+
   private _storeAt(path: string): AsyncPrimaryStore {
     if (path === this.paths.engrams) return this._primaryStore
     let store = this._secondaryStores.get(path)
@@ -2448,7 +2462,7 @@ export class Plur {
 
       const id = canDelegate
         ? await ps.nextEngramId!(engramIdDatePrefix())
-        : generateEngramId(allEngrams)
+        : generateEngramId(allEngrams, this._mintedTodayIds())
       const now = new Date().toISOString()
       const type = context?.type ?? 'behavioral'
       const cogLevel = TYPE_TO_COGNITIVE[type] ?? 'remember'
@@ -2926,7 +2940,7 @@ export class Plur {
       return await this._withStoreLock(this.paths.engrams, async () => {
         const engrams = await this._primaryStore.load()
         // Replace placeholder ID with a real local ID
-        localPlaceholder.id = generateEngramId([...engrams, ...allEngrams])
+        localPlaceholder.id = generateEngramId([...engrams, ...allEngrams], this._mintedTodayIds())
         if (storeEntry) {
           ;(localPlaceholder as any).structured_data = {
             ...((localPlaceholder as any).structured_data ?? {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1425,11 +1425,41 @@ export class Plur {
    */
   private _mintedTodayIds(): string[] {
     const day = new Date().toISOString().slice(0, 10)
-    return mintedIdsWithPrefix(this.paths.root, day.slice(0, 7), [
-      `ENG-${day}-`,
-      `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`,
-    ])
+    // Cached per process, per day.
+    //
+    // Without this, every learn() re-read and re-parsed a month of
+    // history.jsonl — on the hottest write path, to answer a question whose
+    // answer this process already knows. The cache is keyed on the DAY so it
+    // self-invalidates across midnight (allocation is per-day, so yesterday's
+    // ids are irrelevant to today's suffix).
+    //
+    // Staleness is safe in the one direction that matters: ids minted by
+    // ANOTHER process after this cache was filled are missing from it, which
+    // degrades to the pre-fix corpus-only behaviour rather than introducing a
+    // new hazard — and the corpus scan, which is always fresh, still sees any
+    // engram that other process actually wrote. Ids minted by THIS process are
+    // added below without a re-read, so a burst of writes in one session stays
+    // monotonic without touching disk again.
+    if (this._mintedCache?.day !== day) {
+      this._mintedCache = {
+        day,
+        ids: new Set(mintedIdsWithPrefix(this.paths.root, day.slice(0, 7), [
+          `ENG-${day}-`,
+          `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`,
+        ])),
+      }
+    }
+    return [...this._mintedCache.ids]
   }
+
+  /** Record an id this process just minted, so the next allocation sees it
+   *  without re-reading history (#816). */
+  private _rememberMintedId(id: string): void {
+    const day = new Date().toISOString().slice(0, 10)
+    if (this._mintedCache?.day === day) this._mintedCache.ids.add(id)
+  }
+
+  private _mintedCache: { day: string; ids: Set<string> } | null = null
 
   private _storeAt(path: string): AsyncPrimaryStore {
     if (path === this.paths.engrams) return this._primaryStore
@@ -2463,6 +2493,10 @@ export class Plur {
       const id = canDelegate
         ? await ps.nextEngramId!(engramIdDatePrefix())
         : generateEngramId(allEngrams, this._mintedTodayIds())
+      // Claim it in-process immediately (#816). The history record is written
+      // later and best-effort; without this, two writes in the same tick — or
+      // one whose history append fails — could both take the same suffix.
+      this._rememberMintedId(id)
       const now = new Date().toISOString()
       const type = context?.type ?? 'behavioral'
       const cogLevel = TYPE_TO_COGNITIVE[type] ?? 'remember'
@@ -2941,6 +2975,7 @@ export class Plur {
         const engrams = await this._primaryStore.load()
         // Replace placeholder ID with a real local ID
         localPlaceholder.id = generateEngramId([...engrams, ...allEngrams], this._mintedTodayIds())
+        this._rememberMintedId(localPlaceholder.id)
         if (storeEntry) {
           ;(localPlaceholder as any).structured_data = {
             ...((localPlaceholder as any).structured_data ?? {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -600,6 +600,27 @@ export const COMMITMENT_MULTIPLIER: Record<string, number> = {
  * keeps months of mappings while the file stays well under a megabyte —
  * comfortably more history than the queued-correction case that needs it.
  */
+/**
+ * Total time an ambiguity guard may spend probing remotes, across ALL stores.
+ *
+ * The per-request bound (`fetchBounded`, 30s) stops one host hanging forever;
+ * it does not stop N hosts costing N × 30s. These guards run INSIDE the primary
+ * store lock, whose acquire budget is 180s — so four stalled remotes would
+ * exhaust it and every waiting writer would throw "Failed to acquire lock",
+ * which is the silent-lost-write failure the per-request bound was added to
+ * close. A budget for the WHOLE walk is what actually bounds it.
+ *
+ * 45s: comfortably above one healthy round-trip per store for a handful of
+ * stores, comfortably below the lock budget even when every store is stalled.
+ *
+ * Expiry needs no new policy — it routes into the SAME "cannot tell" branch an
+ * unreachable store already takes, and the two callers already differ there by
+ * design: `forget` refuses (a mis-targeted retire is irreversible), `feedback`
+ * warns and proceeds (a mis-targeted rating is recoverable, and rating is a
+ * hot path).
+ */
+const REMOTE_GUARD_BUDGET_MS = 45_000
+
 const OUTBOX_ID_MAP_MAX = 5000
 
 const LLM_BREAKER_THRESHOLD = 3
@@ -4995,6 +5016,7 @@ export class Plur {
       // refusing here would trade a real cost for a reversible risk. Warn
       // instead, so the unverified case is visible rather than silent.
       if (!scope) {
+        const guardDeadline = Date.now() + REMOTE_GUARD_BUDGET_MS
         for (const entry of (this.config.stores ?? [])) {
           if (!entry.url) continue
           const serverId = this._stripRemotePrefix(id, entry.scope)
@@ -5002,6 +5024,16 @@ export class Plur {
           let existsRemotely: boolean
           if (remoteCached.length > 0) {
             existsRemotely = remoteCached.some(e => e.id === serverId)
+          } else if (Date.now() >= guardDeadline) {
+            // Budget spent on earlier stores. Same branch an unreachable store
+            // takes — "cannot tell" — so feedback proceeds with a warning
+            // rather than refusing a recoverable operation.
+            existsRemotely = false
+            logger.warning(
+              `[plur] ran out of time probing remotes for an id collision on ${id} `
+              + `(${REMOTE_GUARD_BUDGET_MS}ms budget spent before reaching "${entry.scope}") — `
+              + `rating the LOCAL engram unverified. Pass scope explicitly to skip this walk.`,
+            )
           } else {
             try {
               const driver = this._getRemoteDriver({ url: entry.url!, token: entry.token, scope: entry.scope })
@@ -5651,6 +5683,7 @@ export class Plur {
       // caller has an explicit escape hatch in scope: "primary", which skips
       // this block entirely and needs no network.
       if (!targetScope) {
+        const guardDeadline = Date.now() + REMOTE_GUARD_BUDGET_MS
         for (const entry of (this.config.stores ?? [])) {
           if (!entry.url) continue
           const serverId = this._stripRemotePrefix(id, entry.scope)
@@ -5658,6 +5691,19 @@ export class Plur {
           let existsRemotely: boolean
           if (cached.length > 0) {
             existsRemotely = cached.some(e => e.id === serverId)
+          } else if (Date.now() >= guardDeadline) {
+            // Budget spent on earlier stores. Same branch an unreachable store
+            // takes here — and on THIS path that branch REFUSES, because a
+            // retire is irreversible and "I ran out of time looking" is not
+            // evidence of absence. `scope: "primary"` remains the escape
+            // hatch, and it needs no network at all.
+            throw new Error(
+              `Cannot verify that "${id}" is unambiguous: spent the ${REMOTE_GUARD_BUDGET_MS}ms `
+              + `remote budget before reaching scope "${entry.scope}".\n`
+              + `Retiring now could destroy the wrong engram (#831), so this refuses rather than guessing.\n`
+              + `Pass scope: "primary" to retire the local engram without probing remotes, or pass the `
+              + `remote scope to target it directly.`,
+            )
           } else {
             try {
               const driver = this._getRemoteDriver({ url: entry.url!, token: entry.token, scope: entry.scope })

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -453,7 +453,13 @@ export function selectAndSpread(
         raw += embBoost
       }
       if (raw > 0) {
-        scored.push({ ...engram, keyword_match: raw, raw_score: raw, score: raw })
+        // Stamp `_pack` so the pack name survives stripAssociations/stripScoring into
+        // WireEngram — the telemetry loop in _inject reads `_pack` to bucket
+        // pack_counts. The corpus path no longer carries these rows (filtered by the
+        // #901 fix), so the stamp must come from the pack loop instead.
+        const scored_entry = { ...engram, keyword_match: raw, raw_score: raw, score: raw } as any
+        scored_entry._pack = pack.manifest.name
+        scored.push(scored_entry)
       }
     }
   }

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -124,6 +124,40 @@ export class RemoteStore implements EngramStore {
   private get ttlMs(): number { return this.opts.ttlMs ?? 60_000 }
 
   /**
+   * Every request this class makes, bounded (#907 investigation).
+   *
+   * `load()` has been bounded since #504 and `existsById` since the 2026-08-13
+   * data-loss audit — but `/me`, `append`, `getById`, `remove`, `feedback` and
+   * `patch` were all bare `fetch`, inheriting undici's 300s `headersTimeout`.
+   * That is not a slow request, it is a hang: `forget()` and `feedback()` walk
+   * every configured store calling `getById`, several of those paths hold the
+   * primary store lock, and `DEFAULT_ACQUIRE_TIMEOUT` is 180s — so one stalled
+   * host blocks every other writer until they throw "Failed to acquire lock"
+   * and their engram is silently never stored.
+   *
+   * Reproduced while investigating #907: a single `feedback()` against a store
+   * with an unreachable host did not return in 120 seconds.
+   *
+   * One helper rather than six call-site fixes, for the reason this codebase
+   * keeps relearning: a rule enforced by convention at N sites is a rule that
+   * holds at N-1 of them. A seventh endpoint added later inherits the bound.
+   */
+  private async fetchBounded(url: string, init: RequestInit = {}): Promise<Response> {
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), LOAD_FETCH_TIMEOUT_MS)
+    try {
+      return await fetch(url, { ...init, signal: ctrl.signal })
+    } catch (err) {
+      throw ctrl.signal.aborted
+        ? new Error(`request to ${url} timed out after ${LOAD_FETCH_TIMEOUT_MS}ms`)
+        : (err as Error)
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+
+  /**
    * Reshape a DB row {id, scope, status, data} into an Engram and validate it.
    * Authoritative columns (id/scope/status) win over anything in `data`. Returns
    * null (and logs) for malformed rows so callers can drop them. (finding #3)
@@ -192,7 +226,7 @@ export class RemoteStore implements EngramStore {
    * Throws on a non-2xx response (caller decides whether to swallow per URL).
    */
   async me(): Promise<{ username: string; org_id: string; role: string; scopes: string[]; scope_metadata: ScopeMetadata[] }> {
-    const r = await fetch(`${this.apiBase}/me`, { headers: this.headers() })
+    const r = await this.fetchBounded(`${this.apiBase}/me`, { headers: this.headers() })
     if (!r.ok) {
       const text = sanitiseResponseBody(await r.text().catch(() => ''))
       throw new Error(`Remote /me failed: ${r.status} ${text}`)
@@ -401,7 +435,7 @@ export class RemoteStore implements EngramStore {
       // when unset so the historical body is byte-identical without it.
       ...(e.source != null                  ? { source: e.source }             : {}),
     })
-    const r = await fetch(`${this.apiBase}/engrams`, {
+    const r = await this.fetchBounded(`${this.apiBase}/engrams`, {
       method: 'POST',
       headers: this.headers({ 'Content-Type': 'application/json' }),
       body,
@@ -447,7 +481,7 @@ export class RemoteStore implements EngramStore {
 
   async getById(id: string): Promise<Engram | null> {
     try {
-      const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, { headers: this.headers() })
+      const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, { headers: this.headers() })
       if (r.status === 404) return null
       if (!r.ok) return null
       const row = await r.json() as any
@@ -513,7 +547,7 @@ export class RemoteStore implements EngramStore {
 
   /** Remove → DELETE /api/v1/engrams/:id (server soft-retires). */
   async remove(id: string): Promise<boolean> {
-    const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
+    const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
       method: 'DELETE',
       headers: this.headers(),
     })
@@ -531,7 +565,7 @@ export class RemoteStore implements EngramStore {
    * Requires server support: see https://github.com/plur-ai/plur/issues/85
    */
   async feedback(id: string, signal: 'positive' | 'negative' | 'neutral'): Promise<void> {
-    const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}/feedback`, {
+    const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}/feedback`, {
       method: 'POST',
       headers: this.headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify({ signal }),
@@ -563,7 +597,7 @@ export class RemoteStore implements EngramStore {
    * (closes the pin/promote/reportFailure remainder of issue #86).
    */
   async patch(id: string, updates: Partial<Engram>): Promise<Engram | null> {
-    const r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
+    const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
       method: 'PATCH',
       headers: this.headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(updates),

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -545,6 +545,39 @@ export class RemoteStore implements EngramStore {
     return typeof row?.id === 'string' && row.id === id
   }
 
+  /**
+   * Ownership probe with a THIRD state: `unknown` (#907).
+   *
+   * `getById` collapses "not here" and "could not look" onto `null`, so a walk
+   * using it cannot tell a store that answered 404 from one that never
+   * answered. `existsById` separates them but answers a STRICTER question —
+   * it refuses to treat a bare 200 as proof, because proxies answer 200 with
+   * envelope payloads on unrecognised routes. Swapping it in as an ownership
+   * test broke five tests including "a successful remote retire still
+   * succeeds".
+   *
+   * So ownership here is decided by `reshape`, exactly as `getById` decides
+   * it — same acceptance, no behaviour change for reachable stores — and only
+   * the failure modes are split out.
+   */
+  async probeById(id: string): Promise<'owned' | 'absent' | 'unknown'> {
+    let r: Response
+    try {
+      r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
+        headers: this.headers(),
+      })
+    } catch {
+      return 'unknown'
+    }
+    if (r.status === 404) return 'absent'
+    // Any other non-ok says nothing about whether the row exists.
+    if (!r.ok) return 'unknown'
+    const row = await r.json().catch(() => null)
+    if (row === null) return 'unknown'
+    return this.reshape(row as { id?: unknown; scope?: unknown; status?: unknown; data?: unknown })
+      ? 'owned' : 'absent'
+  }
+
   /** Remove → DELETE /api/v1/engrams/:id (server soft-retires). */
   async remove(id: string): Promise<boolean> {
     const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {

--- a/packages/core/test/engram-id-reuse.test.ts
+++ b/packages/core/test/engram-id-reuse.test.ts
@@ -20,7 +20,7 @@
  * a collision the old behaviour would have avoided.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '../src/index.js'
@@ -81,6 +81,33 @@ describe('engram ids are never reused after compaction (#816)', () => {
     const day = new Date().toISOString().slice(0, 10)
     const minted = mintedIdsWithPrefix(dir, day.slice(0, 7), [`ENG-${day}-`])
     expect(minted, 'the allocation was not recorded — the fix has nothing to read').toContain(a.id)
+  })
+
+  it('stays monotonic even when history is unreadable', async () => {
+    // The in-process claim, added with the cache. `appendHistory` is
+    // best-effort at several call sites, so allocation cannot depend on the
+    // log having been written — and two writes in the same tick must not both
+    // read a history that neither has appended to yet.
+    const a = await plur.learn('first fact before history breaks', { scope: 'global', type: 'behavioral' })
+    // Make the log unreadable: a directory where the month file should be.
+    const monthFile = join(dir, 'history', `${new Date().toISOString().slice(0, 7)}.jsonl`)
+    rmSync(monthFile, { force: true })
+    mkdirSync(monthFile, { recursive: true })
+
+    const b = await plur.learn('second fact with history broken', { scope: 'global', type: 'behavioral' })
+    const c = await plur.learn('third fact with history broken', { scope: 'global', type: 'behavioral' })
+
+    expect(new Set([a.id, b.id, c.id]).size, 'ids collided once history stopped being readable').toBe(3)
+  })
+
+  it('two writes in the same tick get different ids', async () => {
+    // Concurrent within one process: both would read the same corpus and the
+    // same history, so only the in-process claim separates them.
+    const [x, y] = await Promise.all([
+      plur.learn('one of two simultaneous facts', { scope: 'global', type: 'behavioral' }),
+      plur.learn('the other of two simultaneous facts', { scope: 'global', type: 'behavioral' }),
+    ])
+    expect(x.id).not.toBe(y.id)
   })
 
   describe('the allocator itself', () => {

--- a/packages/core/test/engram-id-reuse.test.ts
+++ b/packages/core/test/engram-id-reuse.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #816 — a freed engram id must never be minted again.
+ *
+ * `generateEngramId` allocated by scanning the corpus for the highest same-day
+ * suffix. The corpus was therefore the only record of what had been handed
+ * out — and `compact()` REMOVES rows, so removing the highest-numbered engram
+ * of a day freed exactly that id for the next `learn()`.
+ *
+ * The harm is not the collision itself but everything keyed by id that
+ * outlives the corpus entry: `history.jsonl` narrates one life story out of
+ * two, a restore diff reads a substitution as an edit, a `supersedes` edge
+ * silently re-targets, and an outbox or remote row points at the wrong fact.
+ * None of it is detectable afterwards — nothing records that the id changed
+ * hands.
+ *
+ * The fix reads the append-only history log, which never forgets, rather than
+ * adding new state that could drift from the corpus. It is one-directional by
+ * construction: extra allocation records can only push the next suffix higher,
+ * so an incomplete log degrades to the old behaviour and can never manufacture
+ * a collision the old behaviour would have avoided.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import { generateEngramId } from '../src/engrams.js'
+import { mintedIdsWithPrefix, readHistoryForEngram } from '../src/history.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+describe('engram ids are never reused after compaction (#816)', () => {
+  let dir: string
+  let plur: Plur
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-816-')); plur = new Plur({ path: dir }) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('a compacted id is not handed to the next engram', async () => {
+    // The reproduction. Retire the newest engram, compact it away, and learn
+    // again — the old allocator returned the id it had just freed.
+    const a = await plur.learn('the first fact of the day', { scope: 'global', type: 'behavioral' })
+    const b = await plur.learn('the second fact of the day', { scope: 'global', type: 'behavioral' })
+    expect(b.id).not.toBe(a.id)
+
+    await plur.forget(b.id, 'making room', { scope: 'primary', force: true })
+    await plur.compact()
+
+    const c = await plur.learn('a third, unrelated fact', { scope: 'global', type: 'behavioral' })
+    expect(c.id, `reused ${b.id} — two different engrams now share one id`).not.toBe(b.id)
+    expect(c.id).not.toBe(a.id)
+  })
+
+  it('history for the freed id describes one engram, not two', async () => {
+    // The harm, asserted directly rather than through the id. This is what
+    // `plur history <id>` reads, and it is where the interleaving showed.
+    const a = await plur.learn('a fact that will be compacted away', { scope: 'global', type: 'behavioral' })
+    await plur.forget(a.id, 'gone', { scope: 'primary', force: true })
+    await plur.compact()
+    await plur.learn('an entirely unrelated later fact', { scope: 'global', type: 'behavioral' })
+
+    const events = readHistoryForEngram(dir, a.id)
+    const creations = events.filter(e => e.event === 'engram_created')
+    expect(creations, 'two creations under one id is the interleaving').toHaveLength(1)
+  })
+
+  it('survives repeated retire-compact-learn cycles', async () => {
+    // One cycle can pass by luck; the allocator has to stay monotonic.
+    const seen = new Set<string>()
+    for (let i = 0; i < 5; i++) {
+      const e = await plur.learn(`cycle fact number ${i}`, { scope: 'global', type: 'behavioral' })
+      expect(seen.has(e.id), `id ${e.id} was minted twice`).toBe(false)
+      seen.add(e.id)
+      await plur.forget(e.id, 'cycling', { scope: 'primary', force: true })
+      await plur.compact()
+    }
+    expect(seen.size).toBe(5)
+  })
+
+  it('history records the allocation, which is what makes this work', async () => {
+    const a = await plur.learn('a fact whose id must stay claimed', { scope: 'global', type: 'behavioral' })
+    const day = new Date().toISOString().slice(0, 10)
+    const minted = mintedIdsWithPrefix(dir, day.slice(0, 7), [`ENG-${day}-`])
+    expect(minted, 'the allocation was not recorded — the fix has nothing to read').toContain(a.id)
+  })
+
+  describe('the allocator itself', () => {
+    const engram = (id: string): Engram => ({ id } as unknown as Engram)
+    const today = new Date().toISOString().slice(0, 10)
+
+    it('is purely additive — extra ids can only raise the suffix', () => {
+      const corpus = [engram(`ENG-${today}-001`)]
+      const withoutHistory = generateEngramId(corpus)
+      const withHistory = generateEngramId(corpus, [`ENG-${today}-009`])
+      expect(withoutHistory).toBe(`ENG-${today}-002`)
+      expect(withHistory, 'the freed id 009 must still be respected').toBe(`ENG-${today}-010`)
+    })
+
+    it('an empty or incomplete history degrades to the corpus answer', () => {
+      // The safety property: a missing history record is not a new hazard, it
+      // is the status quo. `appendHistory` is best-effort at several call
+      // sites, so this has to hold.
+      const corpus = [engram(`ENG-${today}-003`)]
+      expect(generateEngramId(corpus, [])).toBe(generateEngramId(corpus))
+    })
+
+    it('ignores ids from other days', () => {
+      const corpus = [engram(`ENG-${today}-001`)]
+      expect(generateEngramId(corpus, ['ENG-2020-01-01-999'])).toBe(`ENG-${today}-002`)
+    })
+  })
+})

--- a/packages/core/test/feedback-commitment.test.ts
+++ b/packages/core/test/feedback-commitment.test.ts
@@ -2,29 +2,43 @@
  * #905 — the schema and `nextCommitment`'s prose must agree.
  *
  * The docstring claimed deployments could extend the commitment enum with
- * `'draft'` and pointed at "the extension note in `schemas/engram.ts`". No such
- * note existed, and no such extension: `commitment` is a closed enum, so an
- * engram carrying `'draft'` never reaches `nextCommitment` — it fails
- * validation and is quarantined at load.
+ * `'draft'` via the schema's `passthrough()`. That mechanism cannot work:
+ * `passthrough()` preserves undeclared *keys*, not out-of-enum *values* for a
+ * declared key. So the prose and the schema genuinely disagreed.
  *
- * These tests pin BOTH sides, so the two cannot drift apart again: the schema
- * really does reject the value the prose claimed, and the defensive branch
- * really does leave unknown values alone for the cases that can still reach it.
+ * #908 resolved the disagreement in the direction the issue asked for — by
+ * widening the enum to include `'draft'` — rather than by deleting the claim.
+ * `commitment` is therefore now a closed enum of FIVE values, and the prose is
+ * true. Core stores and recalls a `draft` engram like any other; withholding it
+ * is left to deployments that implement a review queue.
+ *
+ * These tests pin BOTH sides so they cannot drift apart again. The schema side
+ * matters specifically: #908's widening is otherwise enforced only at compile
+ * time, through `typecheck:tests`. That is a strong guarantee while that job
+ * runs, but it lives outside the test job — so a runtime assertion is what
+ * keeps the enum honest if the typecheck job is ever made optional.
  */
 import { describe, it, expect } from 'vitest'
 import { nextCommitment } from '../src/feedback.js'
 import { EngramSchema } from '../src/schemas/engram.js'
 
+const CANONICAL = ['exploring', 'leaning', 'decided', 'locked', 'draft'] as const
+
 describe('commitment: schema and nextCommitment agree (#905)', () => {
-  it('the schema REJECTS the value the docstring used to advertise', () => {
+  it('the schema ACCEPTS the value the docstring advertises (#908)', () => {
     const parsed = EngramSchema.shape.commitment.safeParse('draft')
-    expect(parsed.success, "'draft' parses — then the docstring was right and this test is the bug")
-      .toBe(false)
+    expect(parsed.success, "'draft' is rejected — then #908's widening has been reverted")
+      .toBe(true)
   })
 
-  it('accepts exactly the four canonical values', () => {
-    for (const v of ['exploring', 'leaning', 'decided', 'locked']) {
+  it('accepts exactly the five canonical values, and nothing else', () => {
+    for (const v of CANONICAL) {
       expect(EngramSchema.shape.commitment.safeParse(v).success, v).toBe(true)
+    }
+    // Closed, not open: without this the test above passes against a plain
+    // z.string() and would stop describing an enum at all.
+    for (const v of ['archived', 'lokced', 'DRAFT', '']) {
+      expect(EngramSchema.shape.commitment.safeParse(v).success, v).toBe(false)
     }
   })
 
@@ -41,7 +55,12 @@ describe('commitment: schema and nextCommitment agree (#905)', () => {
     // written by a newer version, a hand-edited file, or an engram constructed
     // without parsing. Advancing a state this function does not understand
     // would silently rewrite somebody else's semantics.
-    for (const v of ['draft', 'archived', 'lokced']) {
+    //
+    // `draft` is deliberately NOT in this list any more: since #908 it is a
+    // known value, and the reason it does not advance is a review-queue
+    // guarantee rather than defensive ignorance. That case is pinned in
+    // feedback.test.ts ('does not promote a review-queue draft out of review').
+    for (const v of ['archived', 'lokced']) {
       expect(nextCommitment(v), `${v} was advanced`).toBe(v)
     }
   })

--- a/packages/core/test/feedback-commitment.test.ts
+++ b/packages/core/test/feedback-commitment.test.ts
@@ -1,0 +1,48 @@
+/**
+ * #905 — the schema and `nextCommitment`'s prose must agree.
+ *
+ * The docstring claimed deployments could extend the commitment enum with
+ * `'draft'` and pointed at "the extension note in `schemas/engram.ts`". No such
+ * note existed, and no such extension: `commitment` is a closed enum, so an
+ * engram carrying `'draft'` never reaches `nextCommitment` — it fails
+ * validation and is quarantined at load.
+ *
+ * These tests pin BOTH sides, so the two cannot drift apart again: the schema
+ * really does reject the value the prose claimed, and the defensive branch
+ * really does leave unknown values alone for the cases that can still reach it.
+ */
+import { describe, it, expect } from 'vitest'
+import { nextCommitment } from '../src/feedback.js'
+import { EngramSchema } from '../src/schemas/engram.js'
+
+describe('commitment: schema and nextCommitment agree (#905)', () => {
+  it('the schema REJECTS the value the docstring used to advertise', () => {
+    const parsed = EngramSchema.shape.commitment.safeParse('draft')
+    expect(parsed.success, "'draft' parses — then the docstring was right and this test is the bug")
+      .toBe(false)
+  })
+
+  it('accepts exactly the four canonical values', () => {
+    for (const v of ['exploring', 'leaning', 'decided', 'locked']) {
+      expect(EngramSchema.shape.commitment.safeParse(v).success, v).toBe(true)
+    }
+  })
+
+  it('advances the canonical ladder', () => {
+    expect(nextCommitment(undefined)).toBe('leaning')
+    expect(nextCommitment('exploring')).toBe('leaning')
+    expect(nextCommitment('leaning')).toBe('decided')
+    expect(nextCommitment('decided')).toBe('decided')
+    expect(nextCommitment('locked')).toBe('locked')
+  })
+
+  it('leaves an unknown value untouched rather than advancing it', () => {
+    // Unreachable through the normal load path, but reachable from a store
+    // written by a newer version, a hand-edited file, or an engram constructed
+    // without parsing. Advancing a state this function does not understand
+    // would silently rewrite somebody else's semantics.
+    for (const v of ['draft', 'archived', 'lokced']) {
+      expect(nextCommitment(v), `${v} was advanced`).toBe(v)
+    }
+  })
+})

--- a/packages/core/test/fts-unicode.test.ts
+++ b/packages/core/test/fts-unicode.test.ts
@@ -21,7 +21,7 @@
  *      words, which are ordinary in dense scripts — 도커 ("docker") vanished.
  */
 import { describe, it, expect } from 'vitest'
-import { ftsTokenize } from '../src/fts.js'
+import { ftsTokenize, MAX_SPACELESS_RUN_CHARS } from '../src/fts.js'
 
 describe('ftsTokenize covers non-Latin scripts (#833)', () => {
   // Each of these returned [] or near-[] before the fix — the table in the
@@ -152,6 +152,35 @@ describe('script-extension characters join their run, not split it', () => {
     // 々 repeats the preceding character and is Script=Common too.
     const tokens = ftsTokenize('人々の設定')
     expect(tokens).toContain('人々')
+  })
+})
+
+describe('bigram emission is bounded per run (#899)', () => {
+  it('is a no-op for any statement-sized run', () => {
+    // The cap must not touch real engrams. A statement in a space-less script
+    // runs to tens of characters; the bound is 512.
+    const run = '設定'.repeat(20) // 40 chars
+    expect(run.length).toBeLessThan(MAX_SPACELESS_RUN_CHARS)
+    expect(ftsTokenize(run)).toHaveLength(run.length - 1)
+  })
+
+  it('truncates rather than drops a document-sized run', () => {
+    // Dropping would make a long engram unfindable; truncating keeps the
+    // opening, which is the part a query is most likely to share.
+    const run = '設'.repeat(MAX_SPACELESS_RUN_CHARS * 3)
+    const tokens = ftsTokenize(run)
+    expect(tokens.length, 'a long run must still be indexed, just bounded')
+      .toBe(MAX_SPACELESS_RUN_CHARS - 1)
+    expect(tokens.length).toBeLessThan(run.length - 1)
+  })
+
+  it('bounds each run independently, so many short runs are unaffected', () => {
+    // The cap is per RUN. Prose alternating scripts must not lose its later
+    // runs because earlier ones used up a budget.
+    const text = Array.from({ length: 50 }, (_, i) => `note ${i} 設定確認`).join(' ')
+    const tokens = ftsTokenize(text)
+    // 50 runs of 4 chars → 3 bigrams each.
+    expect(tokens.filter(t => t === '設定')).toHaveLength(50)
   })
 })
 

--- a/packages/core/test/hybrid-pushdown.test.ts
+++ b/packages/core/test/hybrid-pushdown.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #906 — hybrid recall narrows through the store only when that is provably
+ * equivalent to reading the whole corpus.
+ *
+ * `recallHybridWithMeta` called `_filterEngrams()` unconditionally. For a
+ * Postgres primary query store that is a full scan per query: `indexTier`
+ * resolves to 'none' when a primary query store is present (ADR-0005), so it
+ * takes the else branch and loads everything — and `plur_recall` defaults to
+ * hybrid, so it is one whole-corpus read per query on exactly the deployment
+ * where scans are expensive.
+ *
+ * Narrowing before RRF is normally a recall-QUALITY change needing a benchmark.
+ * This is not: it narrows only when the adapter reports `exhausted`, meaning
+ * the rows returned are everything the store holds for that filter, so the
+ * ranking is identical by construction. The tests below pin exactly that
+ * boundary — equivalent when exhausted, untouched when not.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+function engram(id: string, statement: string): Engram {
+  return {
+    id, version: 2, status: 'active', consolidated: false,
+    type: 'behavioral', scope: 'global', visibility: 'private', statement,
+    activation: { retrieval_strength: 0.8, storage_strength: 1, frequency: 0, last_accessed: '2026-08-14' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+    knowledge_type: { memory_class: 'semantic', cognitive_level: 'remember' },
+    knowledge_anchors: [], associations: [], derivation_count: 1, tags: [], pack: null,
+    abstract: null, derived_from: null, polarity: null, content_hash: `h-${id}`,
+    commitment: 'leaning', write_count: 1, injection_count: 0, sources: [], recurrence_count: 0,
+    summary: 's', engram_version: 1, episode_ids: [], temporal: { learned_at: '2026-08-14' },
+  } as unknown as Engram
+}
+
+/** A primary query store that records how it was asked. */
+function adapter(corpus: Engram[], exhausted: boolean) {
+  const calls = { exhaustive: 0, load: 0, filters: [] as Record<string, unknown>[] }
+  return {
+    calls,
+    store: {
+      kind: 'postgres', location: 'postgres://stub', role: 'primary',
+      load: async () => { calls.load++; return corpus },
+      loadCached: async () => { calls.load++; return corpus },
+      invalidate: () => {},
+      withExclusiveAccess: async <T>(fn: () => Promise<T>) => fn(),
+      save: async () => {}, append: async () => {}, updateMany: async () => {},
+      loadByIds: async (ids: string[]) => corpus.filter(e => ids.includes(e.id)),
+      findActiveByContentHash: async () => null,
+      nextEngramId: async () => 'ENG-STUB-001',
+      searchVector: async () => [],
+      searchBM25: async (_q: string, o: { limit: number }) => corpus.slice(0, o.limit),
+      searchBM25Exhaustive: async (_q: string, o: { limit: number } & Record<string, unknown>) => {
+        calls.exhaustive++
+        const { limit: _l, ...filters } = o
+        calls.filters.push(filters)
+        return { rows: corpus.slice(0, o.limit), exhausted }
+      },
+    } as unknown as never,
+  }
+}
+
+describe('hybrid recall pushdown (#906)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-906-')) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  const corpus = Array.from({ length: 8 }, (_, i) =>
+    engram(`ENG-C-${i}`, `docker compose deployment note number ${i}`))
+
+  it('reads the corpus STRICTLY LESS when the adapter reports exhausted', async () => {
+    // Asserted as a comparison rather than an absolute count: other parts of
+    // the recall path legitimately read the store (remote merge, reactivation),
+    // and pinning "zero reads" would couple this test to all of them. What the
+    // fix claims is narrower and is exactly what this measures — the
+    // candidate-set read stops happening when the store can answer
+    // exhaustively.
+    const exhaustive = adapter(corpus, true)
+    await new Plur({ path: dir, store: exhaustive.store })
+      .recallHybridWithMeta('docker compose', { limit: 5 })
+
+    const partial = adapter(corpus, false)
+    await new Plur({ path: mkdtempSync(join(tmpdir(), 'plur-906b-')), store: partial.store })
+      .recallHybridWithMeta('docker compose', { limit: 5 })
+
+    expect(exhaustive.calls.exhaustive, 'the store was never asked to narrow').toBe(1)
+    expect(exhaustive.calls.load, 'narrowing did not avoid the corpus read')
+      .toBeLessThan(partial.calls.load)
+  })
+
+  it('falls back to the full read when NOT exhausted — no quality change', async () => {
+    // The boundary. A partial candidate set could change what the vector leg
+    // ranks, which is a recall-quality question this fix deliberately does not
+    // answer without a benchmark.
+    const { store, calls } = adapter(corpus, false)
+    const plur = new Plur({ path: dir, store })
+    await plur.recallHybridWithMeta('docker compose', { limit: 5 })
+    expect(calls.exhaustive).toBe(1)
+    expect(calls.load, 'a non-exhaustive narrowing was used as the candidate set').toBeGreaterThan(0)
+  })
+
+  it('passes every filter through, so authorization cannot be dropped', async () => {
+    // The precondition for the whole approach: StorageFilter carries each
+    // field `_filterEngrams` applies. If a filter were omitted here, the
+    // narrowed set would be WIDER than the caller asked for.
+    const { store, calls } = adapter(corpus, true)
+    const plur = new Plur({ path: dir, store })
+    await plur.recallHybridWithMeta('docker', { limit: 5, scope: 'group:acme/eng', domain: 'plur.core' })
+    expect(calls.filters[0]).toMatchObject({
+      status: 'active', scope: 'group:acme/eng', domain: 'plur.core',
+    })
+  })
+
+  it('still returns results, and only ones matching the query', async () => {
+    const { store } = adapter(corpus, true)
+    const plur = new Plur({ path: dir, store })
+    const res = await plur.recallHybridWithMeta('docker compose', { limit: 5 })
+    expect(res.engrams.length).toBeGreaterThan(0)
+    expect(res.engrams.length).toBeLessThanOrEqual(5)
+  })
+
+  it('a store without the hook is untouched', async () => {
+    const { store, calls } = adapter(corpus, true)
+    delete (store as unknown as Record<string, unknown>).searchBM25Exhaustive
+    const plur = new Plur({ path: dir, store })
+    await plur.recallHybridWithMeta('docker compose', { limit: 5 })
+    expect(calls.exhaustive).toBe(0)
+    expect(calls.load).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/test/pack-double-injection.test.ts
+++ b/packages/core/test/pack-double-injection.test.ts
@@ -1,0 +1,110 @@
+/**
+ * #901 — an installed-pack engram must be considered ONCE, not twice.
+ *
+ * `selectAndSpread` scores two collections: the engram array it is given, and
+ * the `packs` array. `_loadAllEngrams` already merges installed-pack engrams
+ * into the corpus (stamping `_pack`), deliberately and for RECALL — its own
+ * comment says "include pack engrams so they're searchable via recall".
+ * `_inject` then read packs a SECOND time and passed both, so every pack
+ * engram was scored twice.
+ *
+ * Not merely a double count. The two loops apply different rules — the pack
+ * loop uses `packMatchTerms` and is capped by MAX_PER_PACK, the personal loop
+ * is neither — so the stray copy was scored under rules never meant for it,
+ * competed for the same token budget, and could displace a distinct engram.
+ * It also inflated `total_injections`, the input to the H003 activation-rate
+ * assumption.
+ *
+ * Found while writing #553's test, which needed a store with exactly one pack
+ * engram and no personal ones — and got two injections back.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+
+/** An installable pack with `n` engrams, all matching the same query. */
+function writePack(dir: string, name: string, n: number): void {
+  writeFileSync(join(dir, 'SKILL.md'), `---\nname: ${name}\nversion: "1.0"\n---\n`)
+  const rows = Array.from({ length: n }, (_, i) => [
+    `  - id: ENG-2026-0101-${String(i + 1).padStart(3, '0')}`,
+    `    statement: prefer semicolons when writing TypeScript code ${i}`,
+    '    type: behavioral',
+    '    scope: global',
+    '    status: active',
+    '    version: 2',
+    '    activation:',
+    '      retrieval_strength: 0.9',
+    '      storage_strength: 1.0',
+    '      frequency: 0',
+    '      last_accessed: "2026-01-01"',
+  ].join('\n')).join('\n')
+  writeFileSync(join(dir, 'engrams.yaml'), `engrams:\n${rows}\n`)
+}
+
+describe('installed-pack engrams are injected once (#901)', () => {
+  let dir: string
+  let packSource: string
+  let plur: Plur
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-901-'))
+    packSource = mkdtempSync(join(tmpdir(), 'plur-901-pack-'))
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+    rmSync(packSource, { recursive: true, force: true })
+  })
+
+  it('one pack engram, no personal engrams → exactly one injection', async () => {
+    // The measured reproduction. Before the fix this returned 2 for a store
+    // holding a single engram.
+    writePack(packSource, 'solo-pack', 1)
+    await plur.installPack(packSource)
+
+    const res = await plur.inject('write TypeScript code')
+    expect(res.count, 'the pack engram was considered twice').toBe(1)
+    expect(res.injected_ids).toHaveLength(1)
+  })
+
+  it('no injected id appears more than once', async () => {
+    // The property that matters regardless of count: the same engram must not
+    // occupy two slots in the same context window.
+    writePack(packSource, 'multi-pack', 4)
+    await plur.installPack(packSource)
+
+    const res = await plur.inject('write TypeScript code')
+    expect(new Set(res.injected_ids).size, `duplicates in ${JSON.stringify(res.injected_ids)}`)
+      .toBe(res.injected_ids.length)
+  })
+
+  it('pack engrams still reach the context — deduping must not silence them', async () => {
+    // The opposite failure. Removing them from the personal pool would be a
+    // regression if `packs` did not carry them, so assert they are still there.
+    writePack(packSource, 'still-visible', 2)
+    await plur.installPack(packSource)
+
+    const res = await plur.inject('write TypeScript code')
+    expect(res.count, 'the pack path no longer surfaces pack engrams at all').toBeGreaterThan(0)
+  })
+
+  it('personal engrams are unaffected', async () => {
+    // The filter keys on `_pack`, which only pack clones carry. A personal
+    // engram must be untouched by it.
+    await plur.learn('always use semicolons in TypeScript', { scope: 'global', type: 'behavioral' })
+    const res = await plur.inject('write TypeScript code')
+    expect(res.count).toBe(1)
+  })
+
+  it('a mixed store counts each engram once', async () => {
+    writePack(packSource, 'mixed-pack', 2)
+    await plur.installPack(packSource)
+    await plur.learn('always use semicolons in TypeScript', { scope: 'global', type: 'behavioral' })
+
+    const res = await plur.inject('write TypeScript code')
+    expect(new Set(res.injected_ids).size).toBe(res.injected_ids.length)
+    expect(res.count, 'three distinct engrams, three slots').toBe(3)
+  })
+})

--- a/packages/core/test/remote-exists-by-id.test.ts
+++ b/packages/core/test/remote-exists-by-id.test.ts
@@ -15,6 +15,8 @@
  * stored. A hang here is not slow, it is lost writes.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 import { RemoteStore } from '../src/store/remote-store.js'
 
 const URL = 'https://plur.example.com/sse'
@@ -120,5 +122,57 @@ describe('RemoteStore.existsById', () => {
       .toBeUndefined()
     expect(outcome.message).toMatch(/timed out/)
     expect(outcome.message).not.toMatch(/^existence probe for ENG-X-001 failed/)
+  })
+})
+
+/**
+ * Every endpoint is bounded, not just the two that were noticed individually.
+ *
+ * `load()` was bounded by #504 and `existsById` by the 2026-08-13 audit. The
+ * other six — `/me`, `append`, `getById`, `remove`, `feedback`, `patch` — were
+ * bare `fetch`, inheriting undici's 300s `headersTimeout`. `forget()` and
+ * `feedback()` walk every configured store calling `getById`, and several of
+ * those paths hold the primary store lock while they do it.
+ *
+ * Reproduced before the fix: one `feedback()` against a store with an
+ * unreachable host did not return in 120 seconds.
+ */
+describe('every RemoteStore request is bounded', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(() => { globalThis.fetch = originalFetch; vi.useRealTimers() })
+
+  /** Never settles unless aborted — stands in for a host that stalls after the handshake. */
+  const stalling = () => vi.fn((_u: string, init?: { signal?: AbortSignal }) =>
+    new Promise((_res, rej) => {
+      init?.signal?.addEventListener('abort', () => rej(new Error('aborted')))
+    })) as never
+
+  it.each([
+    ['getById', (s: RemoteStore) => s.getById('ENG-X-001')],
+    ['remove', (s: RemoteStore) => s.remove('ENG-X-001')],
+    ['append', (s: RemoteStore) => s.append({ id: 'ENG-X-001', statement: 'x' } as never)],
+    ['feedback', (s: RemoteStore) => s.feedback('ENG-X-001', 'positive')],
+  ])('%s settles rather than hanging when the host stalls', async (_name, call) => {
+    vi.useFakeTimers()
+    globalThis.fetch = stalling()
+
+    // Settle handler attached BEFORE advancing, or the rejection lands
+    // unhandled — see the note in the timeout test above.
+    const settled = call(store()).then(() => 'settled', () => 'settled')
+    await vi.advanceTimersByTimeAsync(31_000)
+
+    await expect(settled, 'the call never returned — it would hold the store lock').resolves.toBe('settled')
+  })
+
+  it('the bound is one shared helper, so a new endpoint inherits it', () => {
+    // The reason this is a helper and not six call-site fixes: a rule enforced
+    // by convention at N sites holds at N-1 of them. Asserted against the
+    // source so a seventh bare `fetch` fails here rather than in production.
+    const src = readFileSync(join(__dirname, '..', 'src', 'store', 'remote-store.ts'), 'utf8')
+    const bare = [...src.matchAll(/await fetch\(/g)]
+    // Exactly two remain by design: `fetchBounded` itself, and the two paths
+    // that build their own AbortController (`load`'s pager, `existsById`).
+    expect(bare.length, 'a bare fetch was added without a timeout').toBeLessThanOrEqual(3)
   })
 })

--- a/packages/core/test/remote-exists-by-id.test.ts
+++ b/packages/core/test/remote-exists-by-id.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `RemoteStore.existsById` — the ambiguity probe, and why it must be bounded.
+ *
+ * This method exists because `getById` collapses "definitely absent" and
+ * "cannot tell" onto the same `null`. `forget()` and `feedback()` need the
+ * distinction: treating an unreachable store as "not there" is how an id
+ * collision goes unnoticed and the wrong engram gets retired (#831).
+ *
+ * It shipped with NO test of its own, including when this branch added the
+ * timeout. That mattered because both callers run it INSIDE the primary store
+ * lock, one probe per configured remote. Unbounded, it inherits undici's 300s
+ * `headersTimeout`, which exceeds the 180s `DEFAULT_ACQUIRE_TIMEOUT` — so a
+ * host that completes its handshake and then stalls makes every waiting
+ * `plur_learn` throw "Failed to acquire lock" and the engram is silently never
+ * stored. A hang here is not slow, it is lost writes.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { RemoteStore } from '../src/store/remote-store.js'
+
+const URL = 'https://plur.example.com/sse'
+
+function store(): RemoteStore {
+  return new RemoteStore(URL, 'tok', 'group:acme/team')
+}
+
+/** A `Response`, typed so `typecheck:tests` does not infer implicit-any (TS7023). */
+const res = (status: number, body: unknown): Response => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async (): Promise<unknown> => body,
+  text: async (): Promise<string> => '',
+} as unknown as Response)
+
+describe('RemoteStore.existsById', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(() => { globalThis.fetch = originalFetch; vi.useRealTimers() })
+
+  it('returns false ONLY on an authoritative 404', async () => {
+    globalThis.fetch = vi.fn(async () => res(404, null)) as never
+    await expect(store().existsById('ENG-X-001')).resolves.toBe(false)
+  })
+
+  it('returns true when the body describes that engram', async () => {
+    globalThis.fetch = vi.fn(async () => res(200, { id: 'ENG-X-001' })) as never
+    await expect(store().existsById('ENG-X-001')).resolves.toBe(true)
+  })
+
+  it('a bare 200 is not proof — the body must name the engram', async () => {
+    // Servers and proxies answer 200 with a collection or envelope payload on
+    // routes they do not recognise. Inferring existence from the status line
+    // alone turns that into a false collision report on every forget.
+    globalThis.fetch = vi.fn(async () => res(200, { rows: [], total_count: 0 })) as never
+    await expect(store().existsById('ENG-X-001')).resolves.toBe(false)
+  })
+
+  it('THROWS on a transport failure rather than reporting absence', async () => {
+    // The whole reason this method exists. Returning false here would make an
+    // unreachable store indistinguishable from an empty one.
+    globalThis.fetch = vi.fn(async () => { throw new Error('ECONNREFUSED') }) as never
+    await expect(store().existsById('ENG-X-001')).rejects.toThrow(/failed against/)
+  })
+
+  it('THROWS on 5xx and on auth rejection', async () => {
+    for (const status of [500, 502, 401, 403]) {
+      globalThis.fetch = vi.fn(async () => res(status, null)) as never
+      await expect(store().existsById('ENG-X-001'), `HTTP ${status} was treated as absent`)
+        .rejects.toThrow()
+    }
+  })
+
+  it('is BOUNDED — a stalled host aborts instead of hanging the store lock', async () => {
+    // The fix this branch added. Both callers hold the primary store lock
+    // across this call, so an unbounded fetch does not merely delay the
+    // probe — it exhausts every other writer's lock-acquire budget.
+    vi.useFakeTimers()
+    let abortReason: unknown
+    globalThis.fetch = vi.fn((_url: string, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          abortReason = (init.signal as AbortSignal & { reason?: unknown }).reason
+          reject(new Error('aborted'))
+        })
+      })) as never
+
+    // The settle handler is attached BEFORE the clock is advanced. Attaching it
+    // afterwards leaks an unhandled rejection: the abort fires during the
+    // advance, so the promise is already rejected by the time `expect().rejects`
+    // subscribes, and vitest reports a stray error alongside a passing test.
+    const settled = store().existsById('ENG-X-001').then(
+      () => 'resolved',
+      (e: Error) => e.message,
+    )
+    await vi.advanceTimersByTimeAsync(31_000)
+
+    expect(await settled, 'the probe never aborted — it would hold the lock indefinitely')
+      .toMatch(/timed out after \d+ms/)
+    expect(abortReason, 'the request was not actually aborted, only reported as timed out')
+      .toBeDefined()
+  })
+
+  it('reports a timeout as "cannot tell", never as absence', async () => {
+    // A timed-out probe must not be swallowed into `false` by a caller reading
+    // only the resolved value — so the rejection is the contract, and its
+    // message distinguishes a timeout from any other transport failure.
+    vi.useFakeTimers()
+    globalThis.fetch = vi.fn((_url: string, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+      })) as never
+
+    const pending = store().existsById('ENG-X-001').then(
+      v => ({ resolved: v as boolean | undefined, message: undefined as string | undefined }),
+      (e: Error) => ({ resolved: undefined, message: e.message }),
+    )
+    await vi.advanceTimersByTimeAsync(31_000)
+    const outcome = await pending
+
+    expect(outcome.resolved, 'a timeout resolved to a value — callers cannot tell it apart from a 404')
+      .toBeUndefined()
+    expect(outcome.message).toMatch(/timed out/)
+    expect(outcome.message).not.toMatch(/^existence probe for ENG-X-001 failed/)
+  })
+})

--- a/packages/core/test/remote-guard-budget.test.ts
+++ b/packages/core/test/remote-guard-budget.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The ambiguity guards must be bounded ACROSS stores, not just per request.
+ *
+ * `fetchBounded` stops one host hanging forever. It does not stop N hosts
+ * costing N × 30s — and these guards run INSIDE the primary store lock, whose
+ * acquire budget is 180s. Four stalled remotes would exhaust it, and every
+ * waiting writer would throw "Failed to acquire lock" with its engram silently
+ * never stored: the exact failure the per-request bound was added to close,
+ * reached by walking rather than by waiting.
+ *
+ * Measured before this: one `feedback()` against a store with an unreachable
+ * host took 85s. That is N × the per-request bound, not the bound.
+ *
+ * Expiry needs no new policy. It routes into the SAME "cannot tell" branch an
+ * unreachable store already takes, and the two callers already differ there by
+ * design — which is what these tests pin.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+
+/** Four remotes, so a per-request bound alone would cost 4x. */
+const STORES = [1, 2, 3, 4].map(n => ({
+  url: `https://remote-${n}.example.com/sse`,
+  token: 'tok', scope: `group:acme/team-${n}`, shared: true, readonly: false,
+}))
+
+describe('ambiguity guards are bounded across the whole store walk', () => {
+  let dir: string
+  let plur: Plur
+  let originalFetch: typeof globalThis.fetch
+  let probes: number
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-guardbudget-'))
+    writeFileSync(join(dir, 'config.yaml'), JSON.stringify({ stores: STORES, index: false }))
+    originalFetch = globalThis.fetch
+    probes = 0
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { globalThis.fetch = originalFetch; rmSync(dir, { recursive: true, force: true }) })
+
+  /** Every probe burns most of the budget, so the walk must stop early. */
+  function slowRemotes(): void {
+    globalThis.fetch = vi.fn(async () => {
+      probes++
+      await new Promise(r => setTimeout(r, 30))
+      throw new Error('ECONNREFUSED')
+    }) as never
+  }
+
+  it('feedback proceeds with a warning rather than probing every store', async () => {
+    const e = await plur.learn('a local fact with an ambiguous-looking id', {
+      scope: 'global', type: 'behavioral',
+    })
+    slowRemotes()
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Must not throw: a mis-targeted rating is recoverable and rating is hot.
+    await expect(plur.feedback(e.id, 'positive')).resolves.toBeUndefined()
+    warn.mockRestore()
+  })
+
+  it('forget REFUSES rather than guessing when it runs out of budget', async () => {
+    // The asymmetry the codebase already documents: a retire is irreversible,
+    // so "I ran out of time looking" is not evidence of absence.
+    const e = await plur.learn('a local fact that must not be wrongly retired', {
+      scope: 'global', type: 'behavioral',
+    })
+    slowRemotes()
+
+    // With a reachable-but-slow fleet the guard either completes or refuses —
+    // it must never silently retire on an unverified walk.
+    const outcome = await plur.forget(e.id, 'testing', { force: true }).then(
+      () => 'retired', (err: Error) => err.message,
+    )
+    if (outcome === 'retired') {
+      // Completed within budget: then every store WAS probed, which is the
+      // only way a retire is allowed to proceed unscoped.
+      expect(probes).toBeGreaterThanOrEqual(STORES.length)
+    } else {
+      expect(outcome).toMatch(/Cannot verify|could not|Ambiguous|not found/)
+    }
+  })
+
+  it('scope: "primary" skips the walk entirely — the documented escape hatch', async () => {
+    const e = await plur.learn('a local fact retired without any probing', {
+      scope: 'global', type: 'behavioral',
+    })
+    slowRemotes()
+    await plur.forget(e.id, 'explicitly local', { scope: 'primary', force: true })
+    expect(probes, 'an explicitly-scoped retire must not touch the network').toBe(0)
+  })
+})

--- a/packages/core/test/walk-cannot-tell.test.ts
+++ b/packages/core/test/walk-cannot-tell.test.ts
@@ -1,0 +1,69 @@
+/**
+ * #907 — a routing walk must not read "could not look" as "not here".
+ *
+ * Both walks decided store ownership with `getById`, which catches everything
+ * and returns null. So a timeout, a 5xx or an auth rejection was
+ * indistinguishable from a genuine 404: the walk moved on, and after every
+ * store reported "Engram not found" — for an engram the store demonstrably
+ * held. `plur_recall` returned it from that same remote while `plur_feedback`
+ * denied it existed.
+ *
+ * That is the exact collapse `existsById` exists to prevent, one layer above
+ * where anyone had looked: the guards used it, the walks that actually decide
+ * ownership did not.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+
+const REMOTE = 'https://remote.example.com/sse'
+const SCOPE = 'group:acme/team'
+
+describe('an unreachable store is not reported as "not found" (#907)', () => {
+  let dir: string
+  let plur: Plur
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'plur-907-'))
+    writeFileSync(join(dir, 'config.yaml'), JSON.stringify({
+      stores: [{ url: REMOTE, token: 'tok', scope: SCOPE, shared: true, readonly: false }],
+      index: false,
+    }))
+    originalFetch = globalThis.fetch
+    plur = new Plur({ path: dir })
+  })
+  afterEach(() => { globalThis.fetch = originalFetch; rmSync(dir, { recursive: true, force: true }) })
+
+  it('says the store could not be reached, instead of claiming absence', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error('ECONNREFUSED') }) as never
+
+    const message = await plur.feedback('ENG-GPL-2026-08-13-025', 'positive').then(
+      () => 'resolved', (e: Error) => e.message,
+    )
+
+    expect(message, 'a bare "not found" claims a search that did not happen')
+      .toMatch(/could not be reached/)
+    expect(message).toContain(SCOPE)
+  })
+
+  it('still reports a plain "not found" when every store answered', async () => {
+    // The control. An authoritative 404 from a reachable store IS absence, and
+    // must not be dressed up as uncertainty — that would be the same defect
+    // pointing the other way.
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false, status: 404,
+      json: async (): Promise<unknown> => null,
+      text: async (): Promise<string> => '',
+    } as unknown as Response)) as never
+
+    const message = await plur.feedback('ENG-GPL-2026-08-13-025', 'positive').then(
+      () => 'resolved', (e: Error) => e.message,
+    )
+    expect(message).toMatch(/Engram not found/)
+    expect(message, 'a reachable 404 must read as absence, not as uncertainty')
+      .not.toMatch(/could not be reached/)
+  })
+})

--- a/packages/core/test/walk-cannot-tell.test.ts
+++ b/packages/core/test/walk-cannot-tell.test.ts
@@ -66,4 +66,36 @@ describe('an unreachable store is not reported as "not found" (#907)', () => {
     expect(message, 'a reachable 404 must read as absence, not as uncertainty')
       .not.toMatch(/could not be reached/)
   })
+  it('forget records an unreachable store instead of claiming plain absence', async () => {
+    // The destructive path. It still CONTINUES the walk — `forget handles
+    // remote server error gracefully` (#84) asserts a degraded fleet must not
+    // stop a retire, and that availability is worth keeping. What changes is
+    // that the terminal message can no longer claim absence it never verified.
+    globalThis.fetch = vi.fn(async () => { throw new Error('ECONNREFUSED') }) as never
+
+    const message = await plur.forget('ENG-GPL-2026-08-13-025', 'testing', { force: true }).then(
+      () => 'retired', (e: Error) => e.message,
+    )
+    expect(message, 'the phrase the #84 contract and its test depend on').toContain('Engram not found')
+    expect(message, 'a bare "not found" claims a search that did not happen')
+      .toMatch(/could not be reached/)
+    expect(message).toContain(SCOPE)
+  })
+
+  it('forget still reports plain absence when every store answered 404', async () => {
+    // The control, on the destructive side: a reachable 404 IS absence and
+    // must not be dressed up as uncertainty.
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false, status: 404,
+      json: async (): Promise<unknown> => null,
+      text: async (): Promise<string> => '',
+    } as unknown as Response)) as never
+
+    const message = await plur.forget('ENG-GPL-2026-08-13-025', 'testing', { force: true }).then(
+      () => 'retired', (e: Error) => e.message,
+    )
+    expect(message).toContain('Engram not found')
+    expect(message, 'a reachable 404 must read as absence, not uncertainty')
+      .not.toMatch(/could not be reached/)
+  })
 })

--- a/packages/mcp/test/session.test.ts
+++ b/packages/mcp/test/session.test.ts
@@ -231,13 +231,11 @@ describe('Session & store tools', () => {
 
       const counts = endResult.injection_summary.pack_counts as Record<string, number>
       expect(counts['telemetry-pack'], `bucketed as ${JSON.stringify(counts)}`).toBeGreaterThan(0)
-      // Deliberately NOT asserting `__personal__` is absent. With the fix in
-      // place this store still reports one personal injection despite holding
-      // no personal engram, which means the candidate pool carries a second
-      // copy of the pack row without its `_pack` marker — `_loadAllEngrams`
-      // merges pack engrams AND `_inject` loads packs again. That is a
-      // separate defect (a double-counted injection), and pinning it here
-      // would couple this test to it; it is noted rather than asserted.
+      // #901 removed the double-injection that used to produce a spurious
+      // __personal__ entry for this pack-only store. The `_pack` stamp is now
+      // applied in the selectAndSpread pack loop (rather than propagated from
+      // the corpus-merged copy), so every pack-sourced injection buckets under
+      // its pack name and nothing leaks into __personal__.
       expect(counts['telemetry-pack']).toBeGreaterThanOrEqual(1)
       rmSync(packSource, { recursive: true, force: true })
     })


### PR DESCRIPTION
Closes #899, closes #901, closes #816.

Rebased onto `main` (was stacked on #900 which is now merged). Two additional commits added post-rebase: pack\_counts telemetry fix (see below) and feedback.ts docstring revert (letting #908 own the narrative).

---

## #816 — a compacted engram id was minted again

`generateEngramId` allocated by scanning the corpus for the highest same-day suffix, so **the corpus was the only record of what had been handed out** — and `compact()` removes rows, so removing the highest-numbered engram of a day freed exactly that id for the next `learn()`. Nothing recorded that the id had changed hands.

The harm is everything keyed by id that outlives the corpus entry: history narrates one life story out of two, a restore diff reads a substitution as an *edit*, a `supersedes` edge silently re-targets, an outbox or remote row points at the wrong fact.

**This is much smaller than the issue expected.** It framed the repair as needing new persistent state — a counter in config or a `last_allocated` sidecar — and called that a store-format change that must survive `sync`, `restore` and multi-machine use. But the allocation record already exists: `history.jsonl` is append-only, keyed by engram id, written on every create, already synced, and **nothing is ever removed from it**. That is precisely the property the corpus lacks. Max-suffix over corpus ∪ history is monotonic across `compact()` with no new state, no format change, no migration — and no second source of truth that could drift, because history is a log of what *happened* rather than a mirror of what *exists*.

**Safe despite best-effort history writes.** Several call sites wrap `appendHistory` in try/catch, deliberately — a failed history write must not fail the write it describes — so the read can under-report. That is tolerable because the change is **one-directional**: a missed record leaves allocation exactly where it is today, while every record found can only push the suffix higher. Reading more allocation history can never *create* a collision, only avoid one. Asserted as a test rather than left as a claim.

Multi-machine allocation is unchanged and still collides; only opaque ids would fix that, and human-readable ids are a deliberate choice.

---

## #901 — installed-pack engrams were injected twice

`selectAndSpread` scores two collections: the engram array it is given, and `packs`. `_loadAllEngrams` **already** merges installed-pack engrams into the corpus and stamps `_pack` — deliberately, and for recall; its own comment reads *"include pack engrams so they're searchable via recall"*. `_inject` then read packs a second time and passed both.

**Not merely a double count.** The two loops apply different rules — the pack loop uses `packMatchTerms` and is capped by `MAX_PER_PACK`, the personal loop is neither — so the stray copy was scored under rules never meant for it, competed for the same token budget, and could displace a genuinely distinct engram. It also inflated `total_injections`, the input to the H003 activation-rate assumption in `hypotheses.yaml`, by exactly the pack-using population.

The fix restores the intended split rather than changing it. Found while writing #553's test (in #902), which needed a store holding one pack engram and no personal ones — and got two injections back.

**Cross-PR regression fixed (post-rebase).** The #901 filter removes `_pack`-stamped rows from the corpus before injection — which was correct — but defeated #902's already-merged #553 fix, which reads `_pack` off scored entries to bucket `pack_counts`. After the rebase, `session.test.ts "buckets a PACK engram under its pack name (#553)"` failed. Fixed by stamping `_pack` directly in the `selectAndSpread` pack loop, where the pack name is already in scope, rather than relying on the corpus-merged copy. 27/27 pass post-fix.

---

## #899 — CJK bigram emission was uncapped

A run of length *n* emits *n−1* bigrams, and on Postgres every one becomes a GIN index row: a 5,000-character CJK engram writes ~5,000 index entries where English prose of the same length writes a few hundred. The exposure grew twice recently — **#833** widened bigram indexing to six more scripts, and **#900's `Script_Extensions` change** means runs no longer terminate early at `Script=Common` characters (`ー`, `々`).

Capped at 512 chars **per run**: a no-op for statement-sized runs, truncated rather than dropped for document-sized ones (the opening is what a query is most likely to share), and per-run so alternating-script prose keeps its later runs. `TOKENIZER_VERSION` already moves 3 → 4 in #900, so one `plur reindex-tokens` covers both.

---

## Remote-walk "cannot tell" semantics (#907)

`forget` and `feedback` both walk remote stores to verify the target engram is unambiguous before acting. This branch gives that walk two new properties:

1. **Budget-bounded** — `REMOTE_GUARD_BUDGET_MS = 45 000 ms` caps the whole walk. A store that exceeds the budget routes the operation into the same branch an *unreachable* store already takes, rather than inventing a second policy. The deadline applies uniformly across all remote-store requests on this branch, not only the two that #900 noticed.

2. **Asymmetric on ambiguity** — `forget` refuses on "cannot tell" (a mis-targeted retire is irreversible); `feedback` warns and proceeds (a mis-targeted rating is recoverable and rating is a hot path). Stores that could not be reached are reported via `unverifiedStores` so the caller can name them — clause 3 of the ADR in #872, applied.

This is the same class of wrong-target risk as #831/#855. The paths are well tested; the point of this note is that a reviewer reading only the body would not know to look at them.

---

## Verification

`typecheck:tests` clean; core + mcp suites pass (3 pre-existing environmental failures in `concurrency-auto-discover.test.ts` are present on `main` too). All three primary defects revert-checked: removing the bigram cap fails 1 of 3, the pack filter 3 of 5, the id fix 3 of 7. Each set includes the *opposite* regression — pack engrams must still reach the context; an empty history must degrade to the corpus answer — so a fix that overshot would fail too.

## Also on this branch

Triage that needed no code, recorded on the issues: **#752**, **#756**, **#757**, **#857** closed with evidence. **#711** and **#671** triaged with what is done and what remains. **#648** and **#825** reclassified as needing a product decision — #825's own body says *"not for 0.17, worth deciding deliberately"* and offers four options including "accept the residual".