### PR TITLE
fix(mcp): report learn ids in the namespaced form recall returns

### DIFF
--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -608,6 +608,21 @@ export function loadAllPacks(packsDir: string): LoadedPack[] {
   return packs
 }
 
+/**
+ * Namespace a store-local id the way the read paths hand it back.
+ *
+ * A store's ids are prefixed with `ENG-{storePrefix(scope)}-` on load so ids
+ * from different stores cannot collide locally. The write path has to return
+ * the same shape, or a caller that records what it just wrote is holding an id
+ * no read path ever produced (#914). Idempotent: an already-namespaced id is
+ * returned unchanged, so the two call sites can't double-prefix each other.
+ */
+export function namespaceEngramId(id: string, scope: string): string {
+  const prefix = storePrefix(scope)
+  if (new RegExp(`^(ENG|ABS|META)-${prefix}-`).test(id)) return id
+  return id.replace(/^(ENG|ABS|META)-/, `$1-${prefix}-`)
+}
+
 /** Derive a 3-char prefix from a store scope (e.g. 'datafund' → 'DFU', 'project:myapp' → 'PMY') */
 export function storePrefix(scope: string): string {
   const parts = scope.split(/[:\-_./]/).filter(Boolean)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ import { detectPlurStorage, type PlurPaths } from './storage.js'
 import { IndexedStorage } from './storage-indexed.js'
 import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
-import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, initFilesystemStore } from './engrams.js'
+import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, namespaceEngramId, initFilesystemStore } from './engrams.js'
 import { maybeDailyBackup } from './backup.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats, searchTextFrom } from './fts.js'
@@ -100,6 +100,10 @@ export { EngramStoreUnreadableError, EngramStoreShrinkError } from './engrams.js
 // entries it does not own. Exposing the existing loader rather than letting a
 // caller write a fourth one is the whole point of #877.
 export { loadEngrams, saveEngrams } from './engrams.js'
+// The id-namespacing pair (#914). `readIdFor` is the API a surface should use;
+// these are exported so a caller (and the tests) can reason about the shape
+// without re-deriving the prefix rule a fourth time.
+export { storePrefix, namespaceEngramId } from './engrams.js'
 export {
   maybeDailyBackup,
   listBackups,
@@ -2976,6 +2980,28 @@ export class Plur {
       )
     }
     return serverEngram
+  }
+
+  /**
+   * The id shape the READ paths hand back for an engram (#914).
+   *
+   * A store's engrams are namespaced with `ENG-{storePrefix(scope)}-` on load,
+   * so `recall` returns `ENG-GPL-2026-08-13-025` where the write path returned
+   * the server's own `ENG-2026-08-13-025`. Core keeps returning the server id
+   * from `learnRouted` — that is the id the remote actually holds, and callers
+   * that talk to the store need it — but a surface that reports an id back to a
+   * caller alongside `recall` results should report the form `recall` uses, or
+   * a caller recording what it just wrote ends up holding a shape no read path
+   * produced.
+   *
+   * Returns the id unchanged when the scope is not backed by a REMOTE store:
+   * a locally-written engram keeps a local id, and the read paths hand that one
+   * back as it is. This mirrors `_isRemoteBackedScope`'s exact-scope rule, so
+   * the two agree on which writes leave the machine.
+   */
+  readIdFor(engram: { id: string; scope: string }): string {
+    if (!this._isRemoteBackedScope(engram.scope)) return engram.id
+    return namespaceEngramId(engram.id, engram.scope)
   }
 
   /**

--- a/packages/core/src/remote-recall.ts
+++ b/packages/core/src/remote-recall.ts
@@ -55,7 +55,7 @@ import { z } from 'zod'
 import type { Engram } from './schemas/engram.js'
 import { RemoteRowSchema, normalizeEndpointUrl } from './store/remote-store.js'
 import { isScopeWithin, isSharedScope } from './scope-util.js'
-import { storePrefix } from './engrams.js'
+import { namespaceEngramId } from './engrams.js'
 import { logger } from './logger.js'
 import { withLock } from './sync.js'
 
@@ -591,7 +591,7 @@ function processHostRows(
     const cloned = { ...e } as any
     if (cloned.scope === 'global') cloned.scope = entry.scope
     const originalId = cloned.id
-    cloned.id = cloned.id.replace(/^(ENG|ABS|META)-/, `$1-${storePrefix(entry.scope)}-`)
+    cloned.id = namespaceEngramId(cloned.id, entry.scope)
     cloned._originalId = originalId
     cloned._storeScope = entry.scope
     // The injection scorer iterates `tags` unguarded — a row without them

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -31,6 +31,7 @@ import { tmpdir } from 'os'
 import yaml from 'js-yaml'
 import { RemoteStore } from '../src/store/remote-store.js'
 import { Plur } from '../src/index.js'
+import { storePrefix } from '../src/engrams.js'
 import { StubServer } from './helpers/stub-server.js'
 
 const TOKEN = 'integration-test-token'
@@ -458,6 +459,37 @@ describe('Plur integration with stub server', () => {
       const local = yaml.load(readFileSync(localYaml, 'utf-8')) as { engrams?: any[] } | null
       return (local?.engrams ?? []).find((e: any) => e.statement === 'integration test engram')
     }, { timeout: 10_000, interval: 25 }).toBeUndefined()
+  })
+
+  it('#914 readIdFor reports a remote write in the shape recall hands back', async () => {
+    // The read paths namespace a store's ids with `ENG-{storePrefix(scope)}-`
+    // (remote-recall.ts), so a surface reporting an id next to recall results
+    // has to use that form. learnRouted keeps returning the server's own id:
+    // that is what the remote holds, and callers talking to it need it.
+    const plur = new Plur({ path: primaryDir })
+    const engram = await plur.learnRouted('round-trip id shape', {
+      scope: 'group:test',
+      type: 'behavioral',
+    })
+
+    await expect.poll(() => server.engramCount, { timeout: 10_000, interval: 25 }).toBe(1)
+
+    const prefix = storePrefix('group:test')
+    expect(engram.id).toBe('ENG-SRV-001')
+    expect(plur.readIdFor(engram)).toBe(`ENG-${prefix}-SRV-001`)
+  })
+
+  it('#914 readIdFor leaves an id alone when the scope has no remote store', async () => {
+    const plur = new Plur({ path: primaryDir })
+    // 'local' is not among the configured stores, so nothing namespaces it.
+    expect(plur.readIdFor({ id: 'ENG-2026-08-14-001', scope: 'local' })).toBe('ENG-2026-08-14-001')
+  })
+
+  it('#914 readIdFor is idempotent, so an already-namespaced id is not doubled', async () => {
+    const plur = new Plur({ path: primaryDir })
+    const prefix = storePrefix('group:test')
+    const already = `ENG-${prefix}-SRV-009`
+    expect(plur.readIdFor({ id: already, scope: 'group:test' })).toBe(already)
   })
 
   it('#768 learn with valid_until + supersedes transmits them flat on the wire (real routed path)', async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1109,7 +1109,13 @@ function getAllToolDefinitions(): ToolDefinition[] {
             ? undefined
             : await plur.nearDuplicates(statement, context, engram.id)
           return {
-            id: engram.id, statement: engram.statement,
+            // #914: report the id in the form plur_recall hands back, so a
+            // caller that records what it just learned and passes it to
+            // plur_feedback / plur_forget is holding an id shape the read side
+            // actually produces. An outbox engram is excluded: it is sitting in
+            // the LOCAL store under a local id until the retry lands, and that
+            // is the id recall returns for it.
+            id: isOutbox ? engram.id : plur.readIdFor(engram), statement: engram.statement,
             scope: engram.scope, type: engram.type,
             pinned: (engram as any).pinned === true,
             // See the note on recall results: same fact, not same record.

--- a/packages/mcp/test/e2e-remote.test.ts
+++ b/packages/mcp/test/e2e-remote.test.ts
@@ -19,7 +19,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { Client } from '@modelcontextprotocol/client'
 import { InMemoryTransport } from '@modelcontextprotocol/server'
-import { Plur } from '@plur-ai/core'
+import { Plur, storePrefix } from '@plur-ai/core'
 import { createServer } from '../src/server.js'
 import { StubServer } from '../../core/test/helpers/stub-server.js'
 
@@ -113,7 +113,7 @@ describe('MCP plur_learn routing', () => {
     expect(stub.engramCount).toBe(1)
   })
 
-  it('returned ID matches server-assigned ID', async () => {
+  it('returned ID is the server-assigned ID in the namespaced form recall uses (#914)', async () => {
     const { client } = await makeClient(dir)
 
     const raw = await client.callTool({
@@ -122,10 +122,16 @@ describe('MCP plur_learn routing', () => {
     })
     const result = callResult(raw) as any
 
-    expect(result.id).toMatch(/^ENG-SRV-/)
-    const serverEngram = stub.getEngram(result.id)
+    // plur_recall namespaces a store's ids with `ENG-{storePrefix(scope)}-`, so
+    // plur_learn reports the same form (#914). The server's own row keeps the
+    // id it assigned: the namespace is a local view of the same engram, and
+    // stripping the prefix has to land exactly on the row the write created.
+    const prefix = storePrefix(REMOTE_SCOPE)
+    expect(result.id).toMatch(new RegExp(`^ENG-${prefix}-SRV-`))
+    const serverId = result.id.replace(`ENG-${prefix}-`, 'ENG-')
+    const serverEngram = stub.getEngram(serverId)
     expect(serverEngram).toBeDefined()
-    expect(serverEngram!.id).toBe(result.id)
+    expect(serverEngram!.id).toBe(serverId)
   })
 
   it('local engrams.yaml does NOT contain the remote-scoped engram', async () => {
@@ -167,14 +173,17 @@ describe('MCP plur_forget routing', () => {
       arguments: { statement: 'Squash commits before merging feature branches', scope: REMOTE_SCOPE, type: 'procedural' },
     })
     const learned = callResult(learnRaw) as any
-    const serverId = learned.id
+    // The id plur_learn reports is namespaced (#914); the server row keeps the
+    // id it assigned. Forgetting by the reported id still has to reach it.
+    const reportedId = learned.id
+    const serverId = reportedId.replace(`ENG-${storePrefix(REMOTE_SCOPE)}-`, 'ENG-')
 
     expect(stub.getEngram(serverId)?.status).toBe('active')
 
-    // Forget by server ID
+    // Forget by the id the caller was handed
     const forgetRaw = await client.callTool({
       name: 'plur_forget',
-      arguments: { id: serverId },
+      arguments: { id: reportedId },
     })
     const forgotten = callResult(forgetRaw) as any
 
@@ -196,11 +205,14 @@ describe('MCP plur_feedback routing', () => {
       arguments: { statement: 'Write tests before submitting a PR', scope: REMOTE_SCOPE, type: 'procedural' },
     })
     const learned = callResult(learnRaw) as any
-    const serverId = learned.id
+    // Same as forget: feedback by the reported (namespaced) id has to land on
+    // the server row that carries the id the server assigned (#914).
+    const reportedId = learned.id
+    const serverId = reportedId.replace(`ENG-${storePrefix(REMOTE_SCOPE)}-`, 'ENG-')
 
     const fbRaw = await client.callTool({
       name: 'plur_feedback',
-      arguments: { id: serverId, signal: 'positive' },
+      arguments: { id: reportedId, signal: 'positive' },
     })
     const fb = callResult(fbRaw) as any
 

--- a/packages/mcp/test/session-scope-tool.test.ts
+++ b/packages/mcp/test/session-scope-tool.test.ts
@@ -20,7 +20,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { Plur, readHistory } from '@plur-ai/core'
+import { Plur, readHistory, storePrefix } from '@plur-ai/core'
 import { getToolDefinitions, _resetSessionTelemetry } from '../src/tools.js'
 
 describe('plur_session_scope (#243)', () => {
@@ -245,7 +245,9 @@ describe('plur_session_scope — remote routing and dialing (#243 × #778)', () 
 
     const engram = await callTool('plur_learn', { statement: 'routed to the enterprise store via the adjusted scope' })
     expect(engram.scope).toBe('group:plur/eng')
-    expect(engram.id).toBe('ENG-REMOTE-001')
+    // The server assigned ENG-REMOTE-001; plur_learn reports it in the same
+    // namespaced form plur_recall uses for that store (#914).
+    expect(engram.id).toBe(`ENG-${storePrefix('group:plur/eng')}-REMOTE-001`)
     const engramPosts = fetchMock.mock.calls.filter(([u, i]) =>
       (i as any)?.method === 'POST' && String(u).includes('/api/v1/engrams'))
     expect(engramPosts.length).toBe(1)


### PR DESCRIPTION
Closes #914. Claimed on the issue first, per CONTRIBUTING step 2, since I have no write access to self-assign.

**Where the normalisation happens, and why not in core.** My first attempt namespaced `learnRouted`'s return value. Two existing tests pin the opposite (`session-scope.test.ts` asserts `engram.id === 'ENG-REMOTE-001'`), and they are right to: the server id is what the remote holds, and a core caller talking to the store needs it. So core keeps returning it, and the reporting surface gets a separate answer:

```ts
/** The id shape the READ paths hand back for an engram (#914). */
readIdFor(engram: { id: string; scope: string }): string
```

`plur_learn` reports `plur.readIdFor(engram)`. An outbox engram is excluded, because it sits in the local store under a local id until the retry lands, and that is the id `recall` returns for it. `readIdFor` returns the id unchanged when the scope is not backed by a remote store, mirroring `_isRemoteBackedScope`'s exact-scope rule so the two agree on which writes leave the machine.

The namespacing rule itself moves into `namespaceEngramId()` next to `storePrefix`, and `remote-recall.ts` now calls it instead of repeating the regex, so the write report and the read path cannot drift. It is idempotent, so an already-namespaced id is never doubled.

**The acceptance test from the issue, run for real.** Before touching the assertions in `e2e-remote.test.ts` I wanted to know whether the round trip actually works with the namespaced form, rather than assume it from #907. A throwaway probe drove `plur_learn` then `plur_forget` through the real MCP server against the stub:

```json
{"returnedId":"ENG-TE2-SRV-001","serverId":"ENG-SRV-001","forgetSuccess":true,"serverStatusAfter":"retired"}
```

So forgetting by the reported id retires the right server row. The probe is not in the diff; it existed to justify the assertion changes below.

**Four existing assertions changed, all the same shape.** They took the reported id and used it as a direct server-side lookup key (`stub.getEngram(result.id)`). That is exactly the coupling this issue is about, so each now derives the server id by stripping the prefix and keeps asserting against the server row, while asserting the reported id is the namespaced form. The `plur_forget` and `plur_feedback` tests additionally now pass the *reported* id into the tool, which is the round trip the issue asks for and which the probe above confirms end to end. Nothing was weakened: every one of them still asserts server-side state.

**What I ran**, Windows, Node 22.20.0, pnpm 10.34.1:

| suite | with the change | on unmodified `7c3aadb` |
| --- | --- | --- |
| `packages/core` | 2791 passed, 8 files failing | 2789 passed, the same 8 files |
| `packages/mcp` | 389 passed, 1 failing | 1 failing, the same one |

The three tests added here account for the core delta. The failures are mine, not the branch's:

- the eight core files are all SQLite ones (`store-contract`, `storage-indexed`, `scope-pushdown`, `read-side-scope-visibility`, …). I installed with `--ignore-scripts`, so `better-sqlite3` never built. Identical set before and after.
- `session.test.ts > cross-session: project A scope does not leak into project B` fails on unmodified `main` here too; it is a `process.chdir` + tmpdir case that does not hold on Windows.
- `concurrency-write-path.test.ts` appeared once in each direction under the full parallel run and passes 3 of 3 in isolation, so it is a flake rather than a signal.

`pnpm --filter @plur-ai/core build` was run before the MCP suites, per CONTRIBUTING.

One note for review: `storePrefix` and `namespaceEngramId` are now exported from `@plur-ai/core`. `readIdFor` is the API a surface should use; the two are exported so the tests (and any caller reasoning about the shape) do not re-derive the prefix rule a fourth time. Happy to keep them internal and have the tests import from `../src/engrams.js` instead if you would rather not widen the public surface.
