### PR TITLE
docs: interim git+https install for plur-ai and plur-langchain (#915)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ The plugin registers automatically via Hermes' plugin system. It injects relevan
 For Python environments that aren't Hermes:
 
 ```bash
-pip install plur-ai
+pip install "plur-ai @ git+https://github.com/plur-ai/plur.git#subdirectory=packages/python"
 npm install -g @plur-ai/cli   # bridge (required)
 ```
+
+> **Note:** `plur-ai` is not yet on PyPI — use the git install above until [#915](https://github.com/plur-ai/plur/issues/915) is resolved.
 
 ```python
 from plur_ai import Plur

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -5,8 +5,10 @@ LangChain memory adapter for [PLUR](https://plur.ai) — plug persistent, local-
 ## Install
 
 ```bash
-pip install plur-langchain
+pip install "plur-langchain @ git+https://github.com/plur-ai/plur.git#subdirectory=packages/langchain"
 ```
+
+> **Note:** `plur-langchain` is not yet on PyPI — use the git install above until [#915](https://github.com/plur-ai/plur/issues/915) is resolved.
 
 Requires Node.js (for the `@plur-ai/cli` runtime that PLUR shells out to) and `@plur-ai/mcp` installed.
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -8,8 +8,10 @@ stored as plain YAML on your disk with zero-cost local search. `plur-ai` is the
 Pythonic way to use it from any Python agent stack.
 
 ```bash
-pip install plur-ai
+pip install "plur-ai @ git+https://github.com/plur-ai/plur.git#subdirectory=packages/python"
 ```
+
+> **Note:** `plur-ai` is not yet on PyPI — use the git install above until [#915](https://github.com/plur-ai/plur/issues/915) is resolved.
 
 ## Quickstart
 


### PR DESCRIPTION
## What

`plur-ai` and `plur-langchain` are not on PyPI (the publish workflows have been failing since v0.11.0 for `plur-ai` and never landed for `plur-langchain`). The READMEs currently advertise `pip install plur-ai` / `pip install plur-langchain`, both of which produce an install error.

This PR replaces the broken PyPI paths with the git+https form verified to work in [#915](https://github.com/plur-ai/plur/issues/915), and adds a callout note linking to the tracking issue.

## Changes

- `README.md` — Python SDK section
- `packages/python/README.md` — install block
- `packages/langchain/README.md` — install block

All three use `pip install "<pkg> @ git+https://github.com/plur-ai/plur.git#subdirectory=packages/<dir>"`, which installs correctly from a clean venv (verified by the issue reporter on Python 3.12).

## Revert path

Once the PyPI trusted publishers are configured and both packages upload successfully (#915), revert the three install lines back to `pip install <pkg>` and drop the callout notes.

Closes #915 (docs half only — the PyPI publisher setup is the remaining human-gated step).