### PR TITLE
fix(core): sanitise only control characters, not all non-ASCII (#923)

### DIFF
--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -40,8 +40,28 @@ export const RemoteRowSchema = z.object({
 // #912: Truncate and strip control chars from server error bodies before
 // persisting them (append → _outbox.last_error) or surfacing in thrown errors.
 // Mirrors the treatment applied to server-assigned ids in append().
+//
+// CONTROL CHARACTERS ONLY (#923). The first cut used `[^\x20-\x7E]`, which is
+// every code point outside printable ASCII — so a server returning a localised
+// error produced a row of question marks in `plur outbox`, the one surface that
+// exists to answer "why is this write stuck?":
+//
+//   'エラー: 認証に失敗しました'  -> '???: ?????????'
+//   'Ошибка: неверный токен'   -> '??????: ???????? ?????'
+//   'Échec de authentification' -> '?chec de authentification'
+//
+// Both classes neutralise the escape-injection vector identically — that is
+// what \x00-\x1F and \x7F cover — so the wider class bought nothing and cost
+// the diagnostic. It was also the same ASCII-only assumption #896 had just
+// been fixed for one layer down, in `normalizeStatement`.
+//
+// Truncation is by CODE POINT, not UTF-16 unit. `String.prototype.slice` cuts
+// mid-surrogate, and a lone surrogate in this value is persisted to YAML —
+// so the bound has to respect character boundaries, and it has to run AFTER
+// the substitution so the replacement characters are counted too.
 function sanitiseResponseBody(raw: string): string {
-  return raw.slice(0, 200).replace(/[^\x20-\x7E]/g, '?')
+  const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, '?')
+  return Array.from(cleaned).slice(0, 200).join('')
 }
 
 /**

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -252,6 +252,50 @@ describe('RemoteStore against stub server', () => {
     server.appendErrorResponse = null
   })
 
+  // The two assertions above pass under EITHER character class, which is how
+  // #923 shipped: the first cut stripped everything outside printable ASCII, so
+  // a localised server error arrived as '??????: ????????' in `plur outbox` —
+  // the one surface that exists to explain a stuck write. This pins the
+  // distinction the other tests cannot see.
+  it('#923 a non-ASCII error body survives sanitisation', async () => {
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test')
+    const bodies = [
+      'エラー: 認証に失敗しました',
+      'Ошибка: неверный токен',
+      "Échec de l'authentification",
+    ]
+    for (const body of bodies) {
+      server.appendErrorResponse = { status: 500, body }
+      const err = await store.append({ id: 'x', scope: 'group:test', status: 'active', statement: 'y' } as any)
+        .then(() => null).catch((e: Error) => e)
+      expect(err).not.toBeNull()
+      expect(err!.message, `body was mangled: ${err!.message}`).toContain(body)
+    }
+    server.appendErrorResponse = null
+  })
+
+  // Truncation must not split a surrogate pair: a lone surrogate in this value
+  // is persisted to YAML (append → _outbox.last_error).
+  //
+  // The single leading 'x' is load-bearing. Emoji are 2 UTF-16 units, so a bare
+  // run of them puts every pair on an even offset and a UTF-16 `slice(0, 200)`
+  // lands exactly on a boundary — the test would pass against the very bug it
+  // is meant to catch. One ASCII character shifts the pairs onto odd offsets so
+  // the 200th unit is a high surrogate.
+  it('#923 truncation respects character boundaries', async () => {
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test')
+    server.appendErrorResponse = { status: 500, body: 'x' + '🔥'.repeat(300) }
+    const err = await store.append({ id: 'x', scope: 'group:test', status: 'active', statement: 'y' } as any)
+      .then(() => null).catch((e: Error) => e)
+    expect(err).not.toBeNull()
+    // No unpaired surrogate survived the cut.
+    expect(err!.message).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/)
+    // Bounded at 200 CODE POINTS, which is more than 200 UTF-16 units here.
+    const bodyPart = err!.message.replace('Remote store append failed: 500 ', '')
+    expect(Array.from(bodyPart).length).toBeLessThanOrEqual(200)
+    server.appendErrorResponse = null
+  })
+
   it('scope filtering returns only matching engrams', async () => {
     const store = new RemoteStore(baseUrl, TOKEN, 'group:alpha', { ttlMs: 0 })
     await store.append({ id: 'tmp', scope: 'group:alpha', status: 'active', statement: 'alpha-1' } as any)


### PR DESCRIPTION
Closes #923. Follow-up to [#919](https://github.com/plur-ai/plur/pull/919), which introduced `sanitiseResponseBody` for [#912](https://github.com/plur-ai/plur/issues/912).

## Problem

The character class was `[^\x20-\x7E]` — every code point outside printable ASCII, not the control characters [#919](https://github.com/plur-ai/plur/pull/919)'s description named. So a server returning a localised error produced a row of question marks in `plur outbox`, the one surface that exists to answer "why is this write stuck?":

| Server error body | Before | After |
|---|---|---|
| `エラー: 認証に失敗しました` | `???: ?????????` | `エラー: 認証に失敗しました` |
| `Ошибка: неверный токен` | `??????: ???????? ?????` | `Ошибка: неверный токен` |
| `Échec de l'authentification` | `?chec de l'authentification` | `Échec de l'authentification` |
| `error:\x00\x1b[31mred\x07` | `error:??[31mred?` | `error:??[31mred?` |

Both classes neutralise the escape-injection vector identically — `\x00-\x1F` and `\x7F` are what cover it — so the wider class bought nothing and cost the diagnostic.

## Changes

**Narrowed to control characters**, matching the stated intent.

**Truncation now counts code points and runs after the substitution.** `String.prototype.slice` cuts mid-surrogate, and a lone surrogate in this value is persisted to YAML through `_outbox.last_error`. Running after the substitution also means the `?` replacements count toward the bound.

```js
function sanitiseResponseBody(raw: string): string {
  const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, '?')
  return Array.from(cleaned).slice(0, 200).join('')
}
```

## Tests

The two existing [#912](https://github.com/plur-ai/plur/issues/912) tests pass under **either** character class — they assert truncation length and the absence of control characters, neither of which distinguishes the two. That is how this shipped. Two tests added, each pinning one half:

- a non-ASCII body survives sanitisation
- truncation respects character boundaries

One detail in the second is load-bearing and easy to lose: the fixture is `'x' + '🔥'.repeat(300)`, not a bare emoji run. Emoji are 2 UTF-16 units, so without the leading ASCII character every pair sits on an even offset and a UTF-16 `slice(0, 200)` lands exactly on a boundary — the test would pass against the very bug it exists to catch. The `'x'` shifts the pairs onto odd offsets. Noted in a comment on the test.

## Verification

```
pnpm build                                    clean
pnpm typecheck:tests                          clean
core + mcp suites          3265 passed, 38 skipped, 3 failed
                           (sync-push-failure — git-in-worktree, environmental)
remote-integration.test.ts 49/49
```

Revert-checked both halves independently:

| Reverted to | Result |
|---|---|
| `[^\x20-\x7E]` (old class) | fails `a non-ASCII error body survives` — 1 of 49 |
| narrowed class, UTF-16 `slice(0, 200)` | fails `truncation respects character boundaries` — 1 of 49 |

So neither new test is vacuous, and neither passes without its half of the fix.

## Note

This is the same ASCII-only assumption [#896](https://github.com/plur-ai/plur/issues/896) was fixed for one layer down, in `normalizeStatement`, and it reappeared in code written to improve diagnostics. Worth watching for in any future `[^\x20-\x7E]` or `\w` on text that can carry user or server content.
