### PR TITLE
docs(spec): add measured_under to ENGRAM-STANDARD-v1.md, guard markdown drift (#924)

### DIFF
--- a/packages/core/test/spec-schema-drift.test.ts
+++ b/packages/core/test/spec-schema-drift.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
+import path from 'path'
 import {
   buildEngramSchema,
   buildPackManifestSchema,
@@ -52,5 +53,24 @@ describe('spec JSON Schema drift (#315)', () => {
     expect(engram.properties.insight).toBeDefined()
     // Draft 2020-12 identity.
     expect(engram.$schema).toBe('https://json-schema.org/draft/2020-12/schema')
+  })
+
+  it('ENGRAM-STANDARD-v1.md documents every top-level EngramSchema field (#924)', () => {
+    const schema = buildEngramSchema() as { properties: Record<string, unknown> }
+    const standardPath = path.join(path.dirname(ENGRAM_SCHEMA_PATH), 'ENGRAM-STANDARD-v1.md')
+    const standardText = readFileSync(standardPath, 'utf8')
+
+    // Fields whose documentation pattern does not use the bare `fieldname`
+    // backtick form and are therefore excluded from the field-presence check:
+    //   exchange — §4.11 documents sub-fields as `exchange.foo`; the parent
+    //              object is implied by the section heading.
+    //   insight  — complex metacognition sub-object; warrants a dedicated
+    //              section, tracked in plur-ai/plur#924 follow-up.
+    const EXCLUDED = new Set(['exchange', 'insight'])
+
+    const missing = Object.keys(schema.properties).filter(
+      field => !EXCLUDED.has(field) && !standardText.includes(`\`${field}\``),
+    )
+    expect(missing).toEqual([])
   })
 })

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -417,6 +417,7 @@ ignore the values.
 | `episode_ids` | string[] | default `[]` | Source episode IDs. |
 | `summary` | string | ≤80 chars | Injection-friendly short form. |
 | `pinned` | boolean | | Always-load flag; bypasses keyword gating. Use sparingly. |
+| `measured_under` | object | `model?`, `source_type?`, `hardware?`, `dataset?`, `date?` (ISO date) | Measurement conditions for numeric/benchmark engrams — which model, environment type, hardware tier, dataset, and date the value was recorded under. Allows tension-aware retrieval to treat differently-measured values as refinements rather than contradictions (#869). |
 
 ### 4.13 Required-field summary
 


### PR DESCRIPTION
Closes #924.

## Problem

`ENGRAM-STANDARD-v1.md` is the published interoperability standard — it is what a third-party implementer reads to know what fields to accept. `measured_under` was added to `EngramSchema` by #919 but the standard's field table was not updated. A consumer reading the standard today concludes the field is not part of v1, while the reference implementation accepts and writes it.

The pattern is structural: the JSON Schema is drift-guarded by CI (`gen:schemas` + `spec-schema-drift.test.ts`), but the markdown has no equivalent check.

## Changes

**`spec/ENGRAM-STANDARD-v1.md`** — adds `measured_under` row to §4.12:
- Inline object (`model?`, `source_type?`, `hardware?`, `dataset?`, `date?`)
- Semantics: measurement conditions for numeric/benchmark engrams; allows tension-aware retrieval to treat differently-measured values as refinements rather than contradictions

**`packages/core/test/spec-schema-drift.test.ts`** — adds field-presence guard:
- Extracts every top-level property from `buildEngramSchema()`
- Asserts each appears as `` `fieldname` `` in the markdown
- Documents two exclusions with rationale:
  - `exchange`: §4.11 documents sub-fields (`exchange.foo`); parent object implied by section heading
  - `insight`: complex metacognition sub-object; warrants a dedicated section (follow-up)

After this PR, adding a field to `EngramSchema` without updating the standard produces a CI failure.

## The `commitment: 'draft'` gap from #924

PR #908 (widening commitment to include `draft`) is still open. Once that merges, the test will catch the standard being out of date and the table row in §4.12 will need updating then. That is the guard working as intended.