### PR TITLE
fix(core): migration recomputes stale content hashes on upgrade (#911)

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -770,7 +770,8 @@ export function printText(report: DoctorReport, flags?: GlobalFlags): void {
     outputText('   — any statement containing non-ASCII letters hashes differently under the new')
     outputText('   normalizer. Stale hashes act as dedup attractors: re-learns that hash-match the')
     outputText('   old value are absorbed into the wrong engram. Pure-ASCII stores are unaffected.')
-    outputText('   Fix: run `plur reindex-hashes --apply` to recompute and repair.')
+    outputText('   Fix: run `plur migrate` (migration 006 recomputes them, with backup and rollback)')
+    outputText('   or `plur reindex-hashes --apply` for the repair alone.')
   }
 
   outputText('')

--- a/packages/core/src/content-hash.ts
+++ b/packages/core/src/content-hash.ts
@@ -40,6 +40,21 @@ import { createHash } from 'crypto'
  * `plur reindex-hashes` exists to repair. Run it after upgrading; that is the
  * intended migration, and it is why the two shipped together.
  */
+/**
+ * Version of the `normalizeStatement` output contract.
+ *
+ * v1 — ASCII `\w`; stripped diacritics and every non-Latin script before
+ *      hashing (the collapse documented above).
+ * v2 — `\p{L}\p{N}\p{M}_`; preserves them.
+ *
+ * Bump this on any change that alters normalized output for a statement that
+ * previously normalized to something non-empty, and add a migration alongside
+ * it: every stored `content_hash` written under the old contract becomes stale
+ * at that moment, and nothing else in the store records which contract it was
+ * written under. Migration `20260813-006` is the one that carries v1 → v2.
+ */
+export const HASH_NORMALIZER_VERSION = 2
+
 const NON_WORD = /[^\p{L}\p{N}\p{M}_\s]/gu
 
 export function normalizeStatement(statement: string): string {

--- a/packages/core/src/migrations/20260813-006-recompute-content-hashes.ts
+++ b/packages/core/src/migrations/20260813-006-recompute-content-hashes.ts
@@ -12,9 +12,16 @@ import { computeContentHash, isHashable } from '../content-hash.js'
  * written under v1 and are stale for any statement containing a character the
  * old ASCII `\w` stripped. `Plur.repairContentHashes` (the CLI's
  * `plur reindex-hashes`) repairs them, but only when a user knows to run it.
- * Nothing prompts them to, so an upgraded store does not self-heal and keeps
- * matching on hashes that no longer describe their statements. That gap is
- * #911; this closes it by making the repair part of the upgrade.
+ *
+ * #911 tracked the discoverability gap and is closed: the 0.18.0 changelog
+ * names the affected population and the command (its option A), and `plur
+ * doctor` counts stale hashes and prints the remedy (#919, its option B).
+ * What #911's options did not include is folding the repair into `plur
+ * migrate` — the step an upgrading user runs anyway — which is what this
+ * migration adds. Note this is NOT #911's rejected option C (rewrite on
+ * first load): `plur migrate` is an explicit write command that runs under
+ * the corpus lock with a backup and rollback, not a write smuggled into a
+ * read path.
  *
  * ## It must agree with `repairContentHashes`, not merely resemble it
  *
@@ -53,7 +60,7 @@ import { computeContentHash, isHashable } from '../content-hash.js'
  */
 export const migration: Migration = {
   id: '20260813-006-recompute-content-hashes',
-  description: 'Recompute content_hash with the Unicode-aware normalizer (#896, closes #911)',
+  description: 'Recompute content_hash with the Unicode-aware normalizer (#896, #911)',
   up(engrams: Engram[]): Engram[] {
     return engrams.map(e => {
       if (!e.statement || !isHashable(e.statement)) return e

--- a/packages/core/src/migrations/20260813-006-recompute-content-hashes.ts
+++ b/packages/core/src/migrations/20260813-006-recompute-content-hashes.ts
@@ -1,0 +1,68 @@
+import type { Migration } from './types.js'
+import type { Engram } from '../schemas/engram.js'
+import { computeContentHash, isHashable } from '../content-hash.js'
+
+/**
+ * Recompute `content_hash` under the Unicode-aware normalizer (v2, #896).
+ *
+ * ## Why a migration when `plur reindex-hashes` already exists
+ *
+ * #896 was fixed forward — `normalizeStatement` now preserves non-Latin
+ * letters, so newly written hashes are correct. Hashes already ON DISK were
+ * written under v1 and are stale for any statement containing a character the
+ * old ASCII `\w` stripped. `Plur.repairContentHashes` (the CLI's
+ * `plur reindex-hashes`) repairs them, but only when a user knows to run it.
+ * Nothing prompts them to, so an upgraded store does not self-heal and keeps
+ * matching on hashes that no longer describe their statements. That gap is
+ * #911; this closes it by making the repair part of the upgrade.
+ *
+ * ## It must agree with `repairContentHashes`, not merely resemble it
+ *
+ * The two now run over the same corpus from different entry points, so any
+ * divergence means the store's hashes depend on which one the user happened to
+ * trigger — worse than having only one of them. The three rules below are
+ * lifted from that method deliberately; change them together or not at all.
+ *
+ * 1. **Skip statement-less rows.** Nothing to hash.
+ *
+ * 2. **Skip unhashable statements** — those that normalize away entirely
+ *    (all punctuation, all emoji). Hashing them stamps SHA-256 of the empty
+ *    string onto every one, which is precisely the #896 collapse mechanism:
+ *    they share a hash and dedup absorbs them into a single engram. #900 added
+ *    this guard to the repair path after measuring 961 such rows. A migration
+ *    that skipped it would re-inflict the bug it exists to repair, on the rows
+ *    least able to survive it.
+ *
+ *    Any SHA-256("") value migration 002 already stamped on such a row is left
+ *    in place rather than cleared — matching `repairContentHashes`, and inert
+ *    because every matcher (`_hashDedup`, the cross-scope recurrence path,
+ *    `learn`'s primary-delegate check) refuses to match an unhashable
+ *    statement before it ever compares hashes.
+ *
+ * 3. **Only rewrite when the value actually changes.** An ASCII statement's v2
+ *    hash is byte-identical to its v1 hash, which is the overwhelming majority
+ *    of any real store. Rewriting them all would touch every row to change
+ *    nothing.
+ *
+ * ## down()
+ *
+ * A no-op, deliberately. The v1 hashes were wrong; restoring them would
+ * reintroduce #896. There is also no way back — v1's output is not recoverable
+ * from v2's, so "restore" could only mean "recompute under the buggy
+ * normalizer", which is the bug rather than a rollback.
+ */
+export const migration: Migration = {
+  id: '20260813-006-recompute-content-hashes',
+  description: 'Recompute content_hash with the Unicode-aware normalizer (#896, closes #911)',
+  up(engrams: Engram[]): Engram[] {
+    return engrams.map(e => {
+      if (!e.statement || !isHashable(e.statement)) return e
+      const correct = computeContentHash(e.statement)
+      if ((e as { content_hash?: string }).content_hash === correct) return e
+      return { ...e, content_hash: correct } as Engram
+    })
+  },
+  down(engrams: Engram[]): Engram[] {
+    return engrams
+  },
+}

--- a/packages/core/src/migrations/runner.ts
+++ b/packages/core/src/migrations/runner.ts
@@ -13,9 +13,10 @@ import { migration as m002 } from './20260406-002-add-content-hash.js'
 import { migration as m003 } from './20260406-003-populate-memory-class.js'
 import { migration as m004 } from './20260406-004-populate-cognitive-level.js'
 import { migration as m005 } from './20260406-005-add-version-field.js'
+import { migration as m006 } from './20260813-006-recompute-content-hashes.js'
 
 /** All registered migrations, ordered by ID. */
-export const ALL_MIGRATIONS: Migration[] = [m001, m002, m003, m004, m005]
+export const ALL_MIGRATIONS: Migration[] = [m001, m002, m003, m004, m005, m006]
 
 /** Current schema version after all migrations have run. */
 export const CURRENT_SCHEMA_VERSION = ALL_MIGRATIONS.length

--- a/packages/core/test/migration-006-recompute-hashes.test.ts
+++ b/packages/core/test/migration-006-recompute-hashes.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Migration 006 — recompute content_hash under the v2 normalizer (#896, #911).
+ *
+ * The migration and `Plur.repairContentHashes` repair the same corpus from two
+ * entry points, so these tests pin the three rules they must share. If they
+ * ever diverge, a store's hashes depend on which one the user happened to
+ * trigger — the failure this suite exists to prevent.
+ */
+import { describe, it, expect } from 'vitest'
+import { migration } from '../src/migrations/20260813-006-recompute-content-hashes.js'
+import { ALL_MIGRATIONS, CURRENT_SCHEMA_VERSION } from '../src/migrations/index.js'
+import { computeContentHash, isHashable, HASH_NORMALIZER_VERSION } from '../src/content-hash.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+const EMPTY_SHA = computeContentHash('')
+
+function mk(id: string, statement: string, content_hash?: string): Engram {
+  return {
+    id,
+    version: 2,
+    status: 'active',
+    type: 'behavioral',
+    scope: 'global',
+    statement,
+    ...(content_hash !== undefined ? { content_hash } : {}),
+    activation: {
+      retrieval_strength: 0.7,
+      storage_strength: 1.0,
+      frequency: 0,
+      last_accessed: '2026-08-13',
+    },
+    tags: [],
+  } as unknown as Engram
+}
+
+const hashOf = (e: Engram) => (e as { content_hash?: string }).content_hash
+
+describe('migration 006: recompute content hashes (#896)', () => {
+  it('is registered and is the newest migration', () => {
+    expect(ALL_MIGRATIONS.map(m => m.id)).toContain(migration.id)
+    expect(ALL_MIGRATIONS[ALL_MIGRATIONS.length - 1]!.id).toBe(migration.id)
+    expect(CURRENT_SCHEMA_VERSION).toBe(ALL_MIGRATIONS.length)
+  })
+
+  it('repairs a stale non-Latin hash — the #896 case', () => {
+    // What v1 actually stored: every non-Latin statement normalized to '' and
+    // therefore shared the SHA-256 of the empty string. That collision is the
+    // bug; these two must come out with DIFFERENT hashes.
+    const cyrillic = mk('ENG-1', 'развертывание должно', EMPTY_SHA)
+    const japanese = mk('ENG-2', 'データベースの設定を確認', EMPTY_SHA)
+
+    const [a, b] = migration.up([cyrillic, japanese])
+
+    expect(hashOf(a!)).toBe(computeContentHash('развертывание должно'))
+    expect(hashOf(b!)).toBe(computeContentHash('データベースの設定を確認'))
+    expect(hashOf(a!)).not.toBe(hashOf(b!))
+    expect(hashOf(a!)).not.toBe(EMPTY_SHA)
+  })
+
+  it('SKIPS an unhashable statement rather than stamping SHA-256("") on it', () => {
+    // The rule lifted from repairContentHashes. Hashing these would give every
+    // one of them the same value and let dedup absorb them into one engram —
+    // re-inflicting #896 from inside the migration meant to repair it.
+    const punctuation = mk('ENG-3', '!!! ???', 'whatever-was-there')
+    const emoji = mk('ENG-4', '🔥🔥🔥')
+
+    expect(isHashable('!!! ???')).toBe(false)
+    const [a, b] = migration.up([punctuation, emoji])
+
+    expect(hashOf(a!)).toBe('whatever-was-there') // untouched, not overwritten
+    expect(hashOf(b!)).toBeUndefined() // and not invented
+  })
+
+  it('leaves an ASCII statement byte-identical — v1 and v2 agree there', () => {
+    // Including the underscore case: `_` is inside the v2 character class, so
+    // snake_case identifiers hash the same under both contracts. A migration
+    // that changed these would mean the normalizer had regressed.
+    for (const s of ['plain ascii statement', 'use snake_case identifiers', 'set RESTIC_CACHE_DIR explicitly']) {
+      const before = computeContentHash(s)
+      const [out] = migration.up([mk('ENG-5', s, before)])
+      expect(hashOf(out!), s).toBe(before)
+    }
+  })
+
+  it('does not rewrite a row whose hash is already correct', () => {
+    // Identity, not just equality: an unchanged row must be the SAME object, so
+    // a large already-migrated store is not rewritten wholesale to change
+    // nothing.
+    const correct = mk('ENG-6', 'already correct', computeContentHash('already correct'))
+    const [out] = migration.up([correct])
+    expect(out).toBe(correct)
+  })
+
+  it('skips a statement-less row without throwing', () => {
+    const blank = mk('ENG-7', '')
+    expect(() => migration.up([blank])).not.toThrow()
+    expect(hashOf(migration.up([blank])[0]!)).toBeUndefined()
+  })
+
+  it('agrees with repairContentHashes on every rule', () => {
+    // The cross-check that matters: for a mixed corpus, the set of rows the
+    // migration rewrites must equal the set repairContentHashes would repair,
+    // and the values must match. repairContentHashes skips unhashable rows and
+    // only writes when missing or stale — mirrored here without needing a Plur
+    // instance and a store lock.
+    const corpus = [
+      mk('ENG-A', 'развертывание должно', EMPTY_SHA), // stale  → repair
+      mk('ENG-B', 'plain ascii', computeContentHash('plain ascii')), // correct → skip
+      mk('ENG-C', 'déploiement rapide'), // missing → repair
+      mk('ENG-D', '!!! ???', EMPTY_SHA), // unhashable → skip
+    ]
+
+    const out = migration.up(corpus)
+    const rewritten = out.filter((e, i) => e !== corpus[i]).map(e => e.id)
+
+    const wouldRepair = corpus
+      .filter(e => e.statement && isHashable(e.statement))
+      .filter(e => hashOf(e) !== computeContentHash(e.statement))
+      .map(e => e.id)
+
+    expect(rewritten).toEqual(wouldRepair)
+    expect(rewritten).toEqual(['ENG-A', 'ENG-C'])
+    for (const e of out) {
+      if (e.statement && isHashable(e.statement)) {
+        expect(hashOf(e), e.id).toBe(computeContentHash(e.statement))
+      }
+    }
+  })
+
+  it('down() is a no-op and says why', () => {
+    // v1 output is not recoverable from v2, so the only available "rollback"
+    // would be recomputing under the buggy normalizer — the bug, not a revert.
+    const engrams = [mk('ENG-8', 'развертывание должно', computeContentHash('развертывание должно'))]
+    expect(migration.down(engrams)).toBe(engrams)
+  })
+
+  it('the normalizer contract version is the one this migration carries', () => {
+    expect(HASH_NORMALIZER_VERSION).toBe(2)
+  })
+})


### PR DESCRIPTION
The migration-only PR that #909's review called for — with one correction found in self-audit (`96f2d8c`): **this does not close #911, because #911 is already closed**, and the PR now says so honestly.

## The #911 relationship, stated precisely

#911 asked for the stale-hash repair to be *discoverable*, offered three options, and was closed 2026-08-17 by the two it suggested:

| #911 option | Status |
|---|---|
| **A** — CHANGELOG + release note naming the affected population and the command | ✅ shipped (the 0.18.0 migration note) |
| **B** — detect and prompt via `plur doctor` | ✅ shipped (#919 — `staleContentHashes` count + advisory) |
| **C** — rewrite automatically on first load | ❌ **rejected in #911 itself**: "a write during a read", the exact class `repairContentHashes` was just moved under a lock to avoid |

What this PR adds is a fourth path #911 never listed: folding the repair into **`plur migrate`** — the step an upgrading user runs anyway, surfaced by `plur migrate status`. And it is **not** the rejected option C: `plur migrate` is an explicit write command that runs under the corpus lock, takes a backup first, and rolls back on failure (`runner.ts`). No write happens on any read path.

The first push's "Closes #911" framing was the same error class @crtahlin's #909 review opens with — claiming to close an issue that is already closed. Caught in self-audit before review rather than by the reviewer this time. The migration's `description` string also said "closes #911"; that would have been wrong in perpetuity once shipped, and is now `(#896, #911)`.

## Second amendment: the doctor advisory now agrees with this PR

`plur doctor`'s stale-hash advisory (#919) named exactly one remedy: `plur reindex-hashes --apply`. The moment this migration exists, doctor and the migration system would disagree about the fix. The advisory now offers `plur migrate` first (backup + rollback) with `reindex-hashes --apply` as the repair-alone alternative. No test asserts the old text; `doctor.test.ts` + `quiet.test.ts` pass 33/33.

## What the migration is (unchanged from the first push)

| From #909 | Status here |
|---|---|
| `migrations/20260813-006-…` | **kept**, with the `isHashable` guard the review required |
| `migrations/runner.ts` registration | **kept** |
| `HASH_NORMALIZER_VERSION` | **kept**, comment expanded |
| `content-hash.ts` normalizer | **dropped** — duplicate that regressed `main` (`_` removed from the class, changing `snake_case` hashes) |
| `index.ts` hunk, `sp1` test additions | **dropped** — already on `main` |

**Agreement with `repairContentHashes` is the design constraint.** Both repair the same corpus from two entry points; divergence would make a store's hashes depend on which one the user happened to run. The migration mirrors all three rules: skip statement-less rows; skip **unhashable** statements (without this, `up()` stamps SHA-256("") onto everything that normalizes away — the #896 collapse re-inflicted from inside the repair; #900 measured 961 such rows); rewrite only when the value changes (ASCII v1 ≡ v2, so a correct store is untouched).

A SHA-256("") that migration 002 already stamped on an unhashable row is left in place, matching `repairContentHashes` — and it is unreachable: `_hashDedup` (`index.ts:1558`), the cross-scope recurrence path (`:1658`) and `learn`'s primary-delegate check (`:2413`) all refuse unhashable statements before comparing hashes.

## Tests

9 cases; the load-bearing one builds a mixed corpus (stale / correct / missing / unhashable) and asserts the set of rows the migration rewrites **equals** the set `repairContentHashes` would repair. Revert-checked: removing the `isHashable` guard fails 1 of 9; removing the unchanged-row skip fails 2 of 9.

Honest limitation: that agreement test *mirrors* `repairContentHashes`' rules rather than invoking the method, so a future change to the method's rules would not fail it — the doc comment in the migration tells the editor to change both together.

## Verification

```
branch                                   main + 2 commits
pnpm build                               clean
vitest migration-006 + migrations        26/26
vitest doctor + quiet (CLI)              33/33
vitest core + mcp (first push)           3277 passed, 38 skipped
```

cc @crtahlin — #909's rework spec, applied, with the closure claim corrected before it reached you.