### PR TITLE
docs(changelog): tweet-shape the 0.18.0 intro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,21 @@
 
 ## 0.18.0 (unreleased)
 
-**The memory dashboard.** `plur ui` opens a local web dashboard of everything your
-agents learned — every engram, what actually gets recalled and how often, what is
-most relied on, and how much of the store just sits there. Memory you could only
-trust before, you can now look at.
+Your agents' memory, on a dashboard.
 
-- `plur ui` — engram browser, recall frequency, a written-per-day chart, and the
-  most-recalled list. Read-only, local-only by default.
-- The same dashboard rides inside DeepSeek Harness as `/plur-memory`, via the new
-  native `@plur-ai/dsh` plugin — engrams land in the system prompt, no tool call.
-- English and 中文.
-- Upgrades self-repair: `plur migrate` now recomputes stale content hashes, and
-  `plur doctor` counts them. `plur_learn` records measurement conditions.
+- `plur ui` opens it locally
+- Recall stats and written-per-day
+- Also inside DeepSeek Harness
+- `plur migrate` heals stale hashes
+
+**The memory dashboard.** `plur ui` opens a local web dashboard of everything your
+agents learned — every engram, what actually gets recalled and how often, and a
+written-per-day chart with the most-recalled list. It speaks English and
+中文, stays read-only and local-only by default, and the same dashboard rides
+inside DeepSeek Harness as `/plur-memory` via the new native `@plur-ai/dsh`
+plugin — engrams land in the system prompt, no tool call. Upgrades self-repair:
+`plur migrate` recomputes stale content hashes, `plur doctor` counts them, and
+`plur_learn` records measurement conditions.
 
 ### Migration note — non-ASCII stores
 


### PR DESCRIPTION
Release-copy iteration driven by the release script's own gate. `release.sh 0.18.0 --preview-tweet` failed the dashboard-centered intro at **643/270** — the tweet is generated verbatim from the section's first paragraph + first four top-level bullets, and wrapped bullets are cut at the first physical line (the preview literally showed `…and the` / `…via the new` as bullet text).

Restructured to the shape 0.17.2 established: one-line headline + four telegraphic single-line bullets for the tweet, full dashboard paragraph kept directly below for changelog readers. **Gate now green at 269/270:**

```
🚀 New release: PLUR 0.18.0

Your agents' memory, on a dashboard.

✅ `plur ui` opens it locally
✅ Recall stats and written-per-day
✅ Also inside DeepSeek Harness
✅ `plur migrate` heals stale hashes

Tell your agent to update.
github.com/plur-ai/plur/releases/tag/v0.18.0
```

Accuracy trim while here: "dormancy" / "how much of the store just sits there" described `plur_receipt`, not the ui — the ui's documented surface is engram browser, recall frequency, written-per-day chart, most-recalled list. The copy now claims exactly that.

Docs-only; verified with `--preview-tweet` (no mutations, no network).