### PR TITLE
feat(cli): `plur dashboard` aliases `plur ui`, and `plur status` mentions it

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -22,6 +22,10 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       outputText(`  Events:       co_injection ${ev.co_injection} · outcomes ${ev.injection_outcome} (+${ev.outcome_positive}/-${ev.outcome_negative})`)
     }
     outputText(`  Storage root: ${result.storage_root}`)
+    // Discoverability, not decoration: the dashboard is on-demand by design
+    // (it serves the whole store with no auth, so nothing auto-starts it),
+    // which means the one place a user learns it exists is a hint like this.
+    outputInfo('  Browse it:    plur ui', flags)
     // A store PLUR could not read must be visible here above all places (audit
     // 2026-08-03, finding 14). Core reports these and the text surface dropped
     // them, so a corrupt registry printed as a healthy `Packs: 0` — the same

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ Commands:
   capture <summary>       Record an episode
   timeline [query]        Query episode timeline
   status                  System health check
-  ui                      Open the memory viewer in a browser
+  ui                      Open the memory dashboard in a browser (alias: dashboard)
   receipt [--days N]      What your memory retrieved for you
   sync                    Cross-device sync
   packs list              List installed packs
@@ -107,6 +107,10 @@ const COMMANDS: Record<string, string> = {
   timeline: './commands/timeline.js',
   status: './commands/status.js',
   ui: './commands/ui.js',
+  // `dashboard` is an alias for `ui` — the two names users guess first.
+  // mlflow made `ui` the convention for a local metrics viewer; minikube
+  // made `dashboard`. Both land here; `ui` stays the documented canonical.
+  dashboard: './commands/ui.js',
   receipt: './commands/receipt.js',
   sync: './commands/sync.js',
   restore: './commands/restore.js',


### PR DESCRIPTION
Follow-up to Gregor's two questions on the 0.18 headline feature: *is `ui` the name users know?* and *should it run by default?*

## Naming — `ui` is real convention, `dashboard` is the other guess; both now work

| Tool | Command for its local viewer |
|---|---|
| mlflow | `mlflow ui` |
| minikube | `minikube dashboard` |
| Prisma / Drizzle | `prisma studio` / `drizzle-kit studio` |
| aim | `aim up` |

`ui` has the strongest single precedent for exactly this shape of thing (local, on-demand metrics/browsing page). But 0.18's own copy says *"Your agents' memory, on a dashboard"* — so `plur dashboard` is the keystroke the announcement itself teaches. One dispatch-map line makes both work; **`ui` stays canonical** so the CHANGELOG, README, and the 269/270 tweet stay true (`dashboard` would not fit the budget).

## Run by default — no, and the code already encodes why

The right "default" already exists: `plur ui` auto-opens the browser (`--no-open` to suppress). What should *not* happen is auto-starting the server, and this is a considered position, not an omission:

- The viewer serves the **entire memory store with no authentication**. Its defenses — loopback bind, the Host-header check (`packages/ui/src/server.ts:100`, tested against DNS rebinding), read-only engine — all assume a **bounded, user-initiated window**, not a resident service.
- No comparable tool auto-starts its dashboard (table above); resident no-auth dashboards are a recurring security complaint elsewhere.
- Repo invariant: reads must not surprise. A background HTTP server on session start is a surprise.

The legitimate itch behind "run by default" is **discoverability**, so that is what this PR fixes instead: `plur status` — the command people actually run — now prints `Browse it: plur ui`. Classified as a hint (`outputInfo`), so `--quiet` strips it and JSON output never carries it, per #730's taxonomy.

## Verification

```
CLI suite                              463 passed, 4 skipped
plur dashboard --no-open (temp store)  serves, prints URL, Ctrl-C stops
plur status under a pseudo-TTY         hint renders; JSON mode unchanged
```