### PR TITLE
feat(cli): `plur dashboard` is the documented canonical; `ui` stays as alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 Your agents' memory, on a dashboard.
 
-- `plur ui` opens it locally
+- Open it: `plur dashboard`
 - Recall stats and written-per-day
 - Also inside DeepSeek Harness
 - `plur migrate` heals stale hashes
 
-**The memory dashboard.** `plur ui` opens a local web dashboard of everything your
+**The memory dashboard.** `plur dashboard` opens a local web view of everything your
 agents learned — every engram, what actually gets recalled and how often, and a
 written-per-day chart with the most-recalled list. It speaks English and
 中文, stays read-only and local-only by default, and the same dashboard rides
@@ -39,7 +39,7 @@ its dry-run (`plur reindex-hashes`, no flag) reports the count without writing.
 
 ### Added
 
-- **`plur ui` opens a local memory viewer** (alias: `plur dashboard`; `plur status`
+- **`plur dashboard` opens a local memory viewer** (alias: `plur ui`; `plur status`
   points at it) — every engram, what gets recalled and how
   often, a written-per-day chart, and the most-recalled list. Selecting a row expands the
   whole engram. Read-only: browsing memory never mutates it, including through a lazy write

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Ask your agent: *"What's my PLUR status?"* — it should call `plur_status` and 
 ### Read your memory
 
 ```bash
-plur ui
+plur dashboard
 ```
 
 Opens a local page listing every engram: what was learned, what actually gets

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -25,7 +25,7 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     // Discoverability, not decoration: the dashboard is on-demand by design
     // (it serves the whole store with no auth, so nothing auto-starts it),
     // which means the one place a user learns it exists is a hint like this.
-    outputInfo('  Browse it:    plur ui', flags)
+    outputInfo('  Browse it:    plur dashboard', flags)
     // A store PLUR could not read must be visible here above all places (audit
     // 2026-08-03, finding 14). Core reports these and the text surface dropped
     // them, so a corrupt registry printed as a healthy `Packs: 0` — the same

--- a/packages/cli/src/commands/ui.ts
+++ b/packages/cli/src/commands/ui.ts
@@ -52,7 +52,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     server.once('error', (error: NodeJS.ErrnoException) => {
       reject(error.code === 'EADDRINUSE'
-        ? new Error(`Port ${opts.port} is already in use. Try: plur ui --port ${opts.port + 1}`)
+        ? new Error(`Port ${opts.port} is already in use. Try: plur dashboard --port ${opts.port + 1}`)
         : error)
     })
     server.listen(opts.port, opts.host, resolve)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ Commands:
   capture <summary>       Record an episode
   timeline [query]        Query episode timeline
   status                  System health check
-  ui                      Open the memory dashboard in a browser (alias: dashboard)
+  dashboard               Open the memory dashboard in a browser (alias: ui)
   receipt [--days N]      What your memory retrieved for you
   sync                    Cross-device sync
   packs list              List installed packs
@@ -107,9 +107,9 @@ const COMMANDS: Record<string, string> = {
   timeline: './commands/timeline.js',
   status: './commands/status.js',
   ui: './commands/ui.js',
-  // `dashboard` is an alias for `ui` — the two names users guess first.
-  // mlflow made `ui` the convention for a local metrics viewer; minikube
-  // made `dashboard`. Both land here; `ui` stays the documented canonical.
+  // `dashboard` is the documented canonical; `ui` remains as an alias.
+  // Both names users guess land here — `dashboard` (minikube's convention,
+  // and the word the release copy teaches) and `ui` (mlflow's convention).
   dashboard: './commands/ui.js',
   receipt: './commands/receipt.js',
   sync: './commands/sync.js',


### PR DESCRIPTION
Per Gregor for the 0.18 release: the public face of the headline feature is **`plur dashboard`** — the word the release copy itself teaches. Both names keep working (same dispatch target); this flips which one the product says out loud: CLI usage line, `plur status` hint, port-conflict remediation, README quickstart, and the CHANGELOG (tweet bullet now `Open it: \`plur dashboard\``, gate re-verified **268/270**; rich paragraph and Added entry lead with `dashboard`, `ui` noted as the alias).

CLI suite 462 passed; the one failure (`recall.test.ts` `--limit`) passes 4/4 in isolation — known parallel-load flake class, path untouched here.

Last change before the 0.18.0 cut.