### PR TITLE
test: extend the serial pools to the flakers that keep aborting release.sh

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -29,6 +29,15 @@ export const SPAWN_SUITES = [
   'test/hook-session-guard.test.ts',
   'test/list.test.ts',
   'test/tensions-lifecycle.test.ts',
+  // Added 2026-08-18: the next members of the same family, observed blowing
+  // their 5s spawn budgets across two release-gate runs and one review run,
+  // each passing in isolation. Same remedy as #793/#889, for the same reason.
+  'test/import.test.ts',
+  'test/readonly-commands.test.ts',
+  'test/recall.test.ts',
+  'test/rescope.test.ts',
+  'test/sync.test.ts',
+  'test/timeline.test.ts',
 ]
 
 export default defineConfig({

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -23,6 +23,13 @@ export const PGLITE_SUITES = [
   // Not named pglite, but PGLite-backed (it uses the same PGLITE_TIMEOUT) and
   // fails in the same way under load.
   'test/sync-index-error.test.ts',
+  // Same again: boots PGLite AND cold-loads the embedder per case. Blew its
+  // timeouts on three different cases across two 2026-08-18 release runs while
+  // passing 14/14 alone — the exact pattern this pool exists for.
+  'test/embedding-staleness-812.test.ts',
+  // Pack install with a local HTTP stub server plus embedding of the pack's
+  // engrams; starved under the same load, failed the same way, passes alone.
+  'test/packs-url.test.ts',
   // Server-Postgres suite (ADR-0005). Same reason, one step further: it talks
   // to a real database and boots PGLite alongside it for the cross-adapter
   // parity check. Skips entirely unless PLUR_TEST_POSTGRES_URL is set.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,6 +55,12 @@ export default defineConfig({
             'test/hook-session-guard.test.ts',
             'test/list.test.ts',
             'test/tensions-lifecycle.test.ts',
+            'test/import.test.ts',
+            'test/readonly-commands.test.ts',
+            'test/recall.test.ts',
+            'test/rescope.test.ts',
+            'test/sync.test.ts',
+            'test/timeline.test.ts',
           ],
           // The whole point: one file at a time, so no two batches of CLI
           // processes are spawning concurrently.
@@ -72,7 +78,13 @@ export default defineConfig({
           root: 'packages/core',
           globals: true,
           // Keep in sync with PGLITE_SUITES in packages/core/vitest.config.ts.
-          include: ['test/pglite-*.test.ts', 'test/sync-index-error.test.ts', 'test/postgres-*.test.ts'],
+          include: [
+            'test/pglite-*.test.ts',
+            'test/sync-index-error.test.ts',
+            'test/postgres-*.test.ts',
+            'test/embedding-staleness-812.test.ts',
+            'test/packs-url.test.ts',
+          ],
           // The whole point: one file at a time, so no two WASM Postgres
           // instances are booting concurrently.
           fileParallelism: false,


### PR DESCRIPTION
Unblocks the 0.18.0 cut. Two release attempts today hit the hard test gate with 12 then 5 failures — **different files each run, every one passing in isolation, all under ambient machine load**. That is verbatim the pattern both serial pools document, whose comments name *"release.sh randomly unable to ship a legitimate release"* as the harm they exist to prevent. Today's flakers are the next members of the same two families, never added:

- **core-pglite** gains `embedding-staleness-812.test.ts` (boots PGLite + cold-loads the embedder per case, but doesn't match the `pglite-*` glob — blew timeouts on three *different* cases across the two runs, 14/14 alone) and `packs-url.test.ts` (HTTP stub + embedding, same starvation).
- **cli-spawn** gains the six observed spawn flakers: `import`, `readonly-commands`, `recall`, `rescope`, `sync`, `timeline`. Same remedy as #793/#889, for the same stated reason — serial, **not** bigger timeouts.

All three "keep in sync" lists updated together (root projects, `PGLITE_SUITES`, `SPAWN_SUITES`). Verified both directions: the moved files run in their pools (31/31 + 27/27 after a full build) and report "No test files found" in the parallel projects — nothing runs twice, nothing is dropped.

Config only; no test content changes.