### PR TITLE
docs(changelog): declare #944 in the 0.18.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,8 @@ its dry-run (`plur reindex-hashes`, no flag) reports the count without writing.
   counts both adapter entry points (#893).
 - The geo-visibility skill was added (#849) and removed (#926) within this
   cycle — net absent from 0.18.0.
+- The 0.18.0 notes themselves were audited against the shipped-PR manifest and
+  completed (#929, #944) — including entries this gate itself forced.
 
 ### Changed — operations that used to succeed can now refuse
 


### PR DESCRIPTION
The manifest gate flagged **#944 — the manifest-fix PR itself**: its squash subject got mangled by a nested heredoc in the commit command into a stray shell line, so the `docs(` type-curation could not exclude it. (The odd subject on `a7aeec8` is that accident; content unaffected.) One line declares it and terminates the loop. This PR's own commit is a clean `-m` docs-typed subject, so it curates itself out. Gate logic re-run locally against this tree: zero undeclared.