### PR TITLE
fix(batch): return per-item namespaced ids from plur_learn_batch (#930, #854)

### DIFF
--- a/packages/core/src/fts.ts
+++ b/packages/core/src/fts.ts
@@ -206,11 +206,21 @@ export function searchTextFrom(fields: SearchTextFields): string {
   } as unknown as Engram)
 }
 
-/** Build searchable text from all engram fields */
+/**
+ * Build searchable text from all engram fields.
+ *
+ * `tags` is read defensively. A schema-validated Engram always has it, but this
+ * function is also reached from paths that splice in partially-built objects —
+ * learnBatch's dedup accumulator being the case that actually shipped. There the
+ * unguarded read threw, the throw was swallowed by a surrounding catch, and
+ * dedup silently degraded to hash-only for the rest of the batch. A crash that
+ * is caught and ignored is worse than either a crash or a default, so this takes
+ * the default.
+ */
 export function engramSearchText(engram: Engram): string {
   const parts = [engram.statement]
   if (engram.domain) parts.push(engram.domain.replace(/\./g, ' '))
-  if (engram.tags.length > 0) parts.push(engram.tags.join(' '))
+  if (engram.tags?.length) parts.push(engram.tags.join(' '))
   if (engram.entities) {
     for (const e of engram.entities) {
       parts.push(e.name)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3205,6 +3205,9 @@ export class Plur {
       recallHybrid: (query: string, options?: { limit?: number }) => this.recallHybrid(query, { ...options, remote: false }),
       recall: (query: string, options?: { limit?: number }) => this.recall(query, { ...options, remote: false }),
       learn: (statement: string, context?: LearnContext) => this.learn(statement, context),
+      // #930: learnBatch uses this instead of `learn` so remote-scope writes
+      // await the server push and return the server-assigned id. See LearnAsyncDeps.learnRouted.
+      learnRouted: (statement: string, context?: LearnContext) => this.learnRouted(statement, context),
       getById: (id: string) => this.getById(id),
       store: this._primaryStore,
       engramsPath: this.paths.engrams,

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -33,6 +33,15 @@ export interface LearnAsyncDeps {
   recall: (query: string, options?: { limit?: number }) => Promise<Engram[]>
   /** Sync learn for the ADD path. */
   learn: (statement: string, context?: LearnContext) => Promise<Engram>
+  /**
+   * Routed learn for the ADD path in learnBatch (#930). When present, learnBatch
+   * uses this instead of `learn` so remote-scope writes await the server push and
+   * return the server-assigned id. Without this, the fire-and-forget outbox in
+   * `learn` deletes the local copy after a successful push, and the next
+   * iteration's generateEngramId finds the same slot free, producing the same id
+   * for every item in the batch.
+   */
+  learnRouted?: (statement: string, context?: LearnContext) => Promise<Engram>
   /** Get engram by ID. */
   getById: (id: string) => Promise<Engram | null>
   /**
@@ -493,11 +502,39 @@ export interface LearnBatchOptions {
 }
 
 /**
+ * Minimal record of an engram written earlier in the same learnBatch call.
+ * Only the fields that learnAsync's dedup step reads are captured (#854):
+ *   - buildDedupPrompt reads  {id, statement, type, domain}
+ *   - scope filtering reads   {scope, status}
+ *   - similarityScores reads  the Engram object (passed as candidate)
+ *
+ * The cast to Engram in the recall wrappers below is therefore safe as long
+ * as no other consumer of `candidates` is introduced without updating this
+ * interface. The alternative — storing full Engram objects — would require
+ * re-loading the just-written engram and adds a store round-trip per ADD.
+ */
+interface BatchAccumulatorEntry {
+  id: string
+  statement: string
+  type: string
+  domain?: string
+  scope?: string
+  status: 'active'
+}
+
+/**
  * Batch learn: process multiple statements sequentially with LLM dedup.
  *
  * LLM dedup calls are bounded by opts.maxLlmCalls (default 50). The cap only
  * bites on large batches of novel-but-similar statements — exact-hash NOOPs
  * and zero-candidate ADDs short-circuit before the LLM and don't consume budget.
+ *
+ * In-batch near-duplicate detection (#854): _syncIndex() is fire-and-forget,
+ * so the BM25/embedding index does not contain statement i when statement i+N
+ * is being processed. To catch new-vs-new near-duplicates, learnBatch maintains
+ * a `batchAccumulator` of engrams written so far and splices them into the
+ * recall results that learnAsync sees, before the dedup step runs. This keeps
+ * _syncIndex fire-and-forget (no blocking flush required).
  */
 export async function learnBatch(
   deps: LearnAsyncDeps,
@@ -512,6 +549,11 @@ export async function learnBatch(
   const maxLlmCalls = opts.maxLlmCalls ?? 50
   let llmCallsUsed = 0
   let capWarned = false
+
+  // In-batch accumulator (#854): collects every engram written (ADD decision)
+  // earlier in this learnBatch call. Spliced into recall results so the dedup
+  // step can see new-vs-new near-duplicates before the index is flushed.
+  const batchAccumulator: BatchAccumulatorEntry[] = []
 
   for (let i = 0; i < statements.length; i++) {
     const { statement, context } = statements[i]
@@ -533,13 +575,49 @@ export async function learnBatch(
       }
     }
 
+    // Per-statement deps that splice in-batch accumulator entries into the
+    // recall results so learnAsync's dedup step sees earlier batch writes even
+    // before _syncIndex() has flushed (#854). The accumulator entries are
+    // appended AFTER the index results so index-resident engrams rank first;
+    // dedup trims to its `limit` anyway so duplicates across both lists are
+    // harmless. Dedup-up to the caller's scope filter still runs inside
+    // learnAsync — the accumulator entries carry `scope` and `status` for it.
+    //
+    // #930: use learnRouted (if available) as the ADD-path learn function.
+    // learnRouted awaits the server push and returns the server-assigned id,
+    // so every result in the batch gets a distinct, correct id. With the plain
+    // `learn` path the fire-and-forget outbox deletes the local copy after a
+    // successful push; the next generateEngramId call finds the same slot free
+    // and produces the same id for every item. The effect is that all N items
+    // report a single id that does not exist in any store once all pushes
+    // complete (#930, defect 2). learnRouted's own hash-dedup and cross-scope
+    // recurrence checks are redundant (learnAsync already ran them) but cheap.
+    const effectiveLearn = deps.learnRouted ?? deps.learn
+    const batchDeps: LearnAsyncDeps = {
+      ...deps,
+      learn: effectiveLearn,
+      ...(batchAccumulator.length === 0 ? {} : {
+        recallHybrid: async (query: string, options?: { limit?: number }) => {
+          const indexResults = await deps.recallHybrid(query, options)
+          // Cast is safe: learnAsync only reads {id,statement,type,domain,scope,status} from candidates.
+          const extra = batchAccumulator.filter(e => !indexResults.some(r => r.id === e.id))
+          return [...indexResults, ...extra as unknown as Engram[]]
+        },
+        recall: async (query: string, options?: { limit?: number }) => {
+          const indexResults = await deps.recall(query, options)
+          const extra = batchAccumulator.filter(e => !indexResults.some(r => r.id === e.id))
+          return [...indexResults, ...extra as unknown as Engram[]]
+        },
+      }),
+    }
+
     const ctx: LearnAsyncContext = { ...context, llm: effectiveLlm }
     // Partial-failure isolation (batch API, #281 item #3): one statement's
     // failure must not abort the batch — an orchestrator persisting 50
     // consolidated findings should keep the 49 that succeed. Capture the error
     // against its input index and continue; the caller inspects `failures`.
     try {
-      const result = await learnAsync(deps, statement, ctx)
+      const result = await learnAsync(batchDeps, statement, ctx)
       // Tag with the input position so a caller can map this result back to its
       // input even though `results` is compacted (failed statements absent). #281
       results.push({ ...result, input_index: i })
@@ -547,7 +625,21 @@ export async function learnBatch(
       if (key === 'noop') stats.noops++
       else if (key === 'update') stats.updated++
       else if (key === 'merge') stats.merged++
-      else stats.added++
+      else {
+        stats.added++
+        // Record ADD-written engrams in the accumulator so subsequent statements
+        // in this batch can dedup against them (#854). UPDATE/MERGE/NOOP all
+        // point at an existing engram already in the index — only ADD produces a
+        // new one that isn't there yet.
+        batchAccumulator.push({
+          id: result.engram.id,
+          statement: result.engram.statement,
+          type: result.engram.type ?? 'observation',
+          domain: result.engram.domain,
+          scope: result.engram.scope,
+          status: 'active',
+        })
+      }
     } catch (err) {
       stats.failed++
       failures.push({ index: i, statement, error: err instanceof Error ? err.message : String(err) })

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -520,6 +520,17 @@ interface BatchAccumulatorEntry {
   domain?: string
   scope?: string
   status: 'active'
+  /**
+   * REQUIRED, not optional, and the reason is a silent failure rather than a
+   * type nicety. These entries are spliced into the dedup candidate list and
+   * reach `engramSearchText`, which reads `engram.tags.length` unguarded. On an
+   * entry without `tags` that throws, the throw is swallowed by the surrounding
+   * catch, and the run drops to hash-only dedup for every batch item after the
+   * first — silently, whenever embeddings are on and no LLM key is present,
+   * which is the normal configuration. Carrying the real tags also makes the
+   * accumulated candidates score the way indexed ones do.
+   */
+  tags: string[]
 }
 
 /**
@@ -638,6 +649,7 @@ export async function learnBatch(
           domain: result.engram.domain,
           scope: result.engram.scope,
           status: 'active',
+          tags: result.engram.tags ?? [],
         })
       }
     } catch (err) {

--- a/packages/core/test/batch.test.ts
+++ b/packages/core/test/batch.test.ts
@@ -80,6 +80,87 @@ describe('learnBatch: dedup within the batch', () => {
   })
 })
 
+describe('learnBatch: in-batch near-duplicate detection (#854)', () => {
+  /**
+   * Regression test for the in-batch dedup blind spot (#854).
+   *
+   * Root cause: _syncIndex() is fire-and-forget, so the BM25/embedding index
+   * does not contain statement[i] when statement[i+N] is processed. With the
+   * real recall deps, learnAsync sees zero candidates for subsequent statements
+   * and short-circuits to ADD — producing one engram per batch item regardless
+   * of similarity.
+   *
+   * Fix: learnBatch now maintains a `batchAccumulator` of ADD-written engrams
+   * and splices them into the recall results so the dedup step sees them even
+   * before the index has flushed.
+   *
+   * This test uses fake deps where `recall`/`recallHybrid` return [] to
+   * simulate the stale-index blind spot exactly. The LLM is supplied so the
+   * dedup step reaches the LLM decision branch. The second statement (near-
+   * duplicate) must be NOOP or UPDATE — not a second ADD.
+   */
+  it('catches a near-duplicate written earlier in the same batch (index blind spot)', async () => {
+    // First engram written by deps.learn on the ADD path.
+    const firstEngram = {
+      id: 'ENG-2026-0854-001',
+      statement: 'Always rebase before pushing to the shared branch',
+      type: 'behavioral',
+      domain: 'test',
+      scope: 'global',
+      status: 'active',
+    } as unknown as Engram
+
+    // Track written statements to drive the learn stub.
+    const written: string[] = []
+
+    const deps: LearnAsyncDeps = {
+      // hashDedup: always miss — we want the full dedup path to run.
+      hashDedup: async () => null,
+      // Index is stale: return [] so the blind spot is reproduced exactly.
+      recallHybrid: async () => [],
+      recall: async () => [],
+      learn: async (statement: string) => {
+        written.push(statement)
+        // Return firstEngram for the first ADD so the accumulator captures it.
+        return written.length === 1 ? firstEngram : ({ id: 'ENG-2026-0854-002', statement } as unknown as Engram)
+      },
+      getById: async (id: string) => id === firstEngram.id ? firstEngram : null,
+      store: new MemoryPrimaryStore(),
+      engramsPath: '/tmp/plur-test-854-engrams.yaml',
+      rootPath: '/tmp/plur-test-854',
+      dedupConfig: { enabled: true, mode: 'llm' },
+      isLlmAvailable: () => true,
+      recordLlmSuccess: () => {},
+      recordLlmFailure: () => {},
+      offendingHitsForScope: () => [],
+      syncIndex: async () => {},
+    }
+
+    // LLM returns NOOP against the accumulator-supplied candidate.
+    const llm = async (_prompt: string): Promise<string> =>
+      `DECISION: NOOP\nTARGET: ${firstEngram.id}\nREASON: Same advice, different wording`
+
+    const res = await learnBatch(deps, [
+      { statement: 'Always rebase before pushing to the shared branch' },
+      // Near-duplicate: same meaning, different wording.
+      // With the blind spot, recallHybrid/recall return [] so this becomes ADD.
+      // With the fix, the accumulator supplies the first engram as a candidate.
+      { statement: 'Rebase onto the shared branch before every push' },
+    ], llm)
+
+    expect(res.results).toHaveLength(2)
+    // First statement is a fresh ADD.
+    expect(res.results[0]!.decision).toBe('ADD')
+    // Second statement must NOT be ADD — the accumulator made the first engram
+    // visible to the dedup step before the index flushed (#854).
+    expect(res.results[1]!.decision).not.toBe('ADD')
+    expect(['NOOP', 'UPDATE', 'MERGE']).toContain(res.results[1]!.decision)
+    // Stats reflect dedup working: only one net ADD.
+    expect(res.stats.added).toBe(1)
+    expect(res.stats.failed).toBe(0)
+  })
+})
+
 describe('learnBatch: partial-failure isolation', () => {
   // A fake deps whose write throws for one statement, so we can assert the
   // batch keeps going and records the failure against its input index.

--- a/packages/core/test/batch.test.ts
+++ b/packages/core/test/batch.test.ts
@@ -227,3 +227,99 @@ describe('learnBatch: partial-failure isolation', () => {
     expect(res.failures.map(f => f.index)).toEqual([0, 1])
   })
 })
+
+describe('learnBatch: accumulator entries are shaped for the similarity scorer', () => {
+  /**
+   * Regression test for the silent dedup regression found reviewing #950.
+   *
+   * The accumulator entry omitted `tags`. Those entries are spliced into the
+   * dedup candidate list and reach `engramSearchText`, which read
+   * `engram.tags.length` unguarded — a TypeError on an entry without the field.
+   * The throw was swallowed by the surrounding catch, so nothing surfaced: the
+   * run simply dropped to hash-only dedup for every batch item after the first,
+   * whenever embeddings are on and no LLM key is present. That is the normal
+   * configuration, and it silently biased the write distribution #856 exists to
+   * collect.
+   *
+   * This test discriminates. It asserts the shape the real scorer depends on,
+   * so it fails against the pre-fix accumulator and passes after it.
+   */
+  it('supplies tags on accumulator candidates, so the scorer cannot throw', async () => {
+    const firstEngram = {
+      id: 'ENG-2026-0950-001',
+      statement: 'Always rebase before pushing to the shared branch',
+      type: 'behavioral',
+      domain: 'test',
+      scope: 'global',
+      status: 'active',
+      tags: ['git', 'workflow'],
+    } as unknown as Engram
+
+    const written: string[] = []
+    // Every candidate the scorer is handed, across all invocations.
+    const seen: Array<{ id: string; tags: unknown }> = []
+
+    const deps: LearnAsyncDeps = {
+      hashDedup: async () => null,
+      // Stale index, exactly as in the #854 case: the accumulator is the only
+      // source of candidates for the second statement.
+      recallHybrid: async () => [],
+      recall: async () => [],
+      learn: async (statement: string) => {
+        written.push(statement)
+        return written.length === 1
+          ? firstEngram
+          : ({ id: 'ENG-2026-0950-002', statement, tags: [] } as unknown as Engram)
+      },
+      getById: async (id: string) => (id === firstEngram.id ? firstEngram : null),
+      store: new MemoryPrimaryStore(),
+      engramsPath: '/tmp/plur-test-950-engrams.yaml',
+      rootPath: '/tmp/plur-test-950',
+      // Cosine mode, no LLM: exactly the configuration the regression bit —
+      // "embeddings on, no language-model key present", which #854's closing
+      // comment calls the normal state. similarityScores only runs when
+      // dedupMode !== 'llm' (learn-async.ts), so an 'llm' mode here would take
+      // the other branch and never touch the accumulator entries at all.
+      dedupConfig: { enabled: true, mode: 'cosine' },
+      // Stand-in for the real scorer. The real one reaches engramSearchText,
+      // which reads `tags.length`; reproducing that read here is what makes the
+      // test fail on the old shape instead of quietly passing.
+      similarityScores: async (_statement, candidates) => {
+        for (const c of candidates) {
+          seen.push({ id: c.id, tags: (c as unknown as { tags: unknown }).tags })
+          // The read that used to throw.
+          void (c.tags as string[]).length
+        }
+        return candidates.map(c => ({ id: c.id, score: 0.9 }))
+      },
+      isLlmAvailable: () => false,
+      recordLlmSuccess: () => {},
+      recordLlmFailure: () => {},
+      offendingHitsForScope: () => [],
+      syncIndex: async () => {},
+    }
+
+    // No LLM passed — the local similarity path is the one under test.
+    const res = await learnBatch(deps, [
+      { statement: 'Always rebase before pushing to the shared branch' },
+      { statement: 'Rebase onto the shared branch before every push' },
+    ])
+
+    // The scorer must actually have been given the accumulated engram — if it
+    // was not, the rest of the assertions would pass vacuously.
+    const accumulated = seen.filter(c => c.id === firstEngram.id)
+    expect(accumulated.length).toBeGreaterThan(0)
+
+    // The defect: `tags` was undefined on those entries.
+    for (const c of seen) {
+      expect(Array.isArray(c.tags)).toBe(true)
+    }
+
+    // The scorer ran to completion rather than throwing into the swallowing
+    // catch. Cosine is reporting-only (#856) and never gates a write, so the
+    // decision here is still ADD — what matters is that near-duplicates were
+    // REPORTED for the second item, which is the signal that silently vanished.
+    expect(res.stats.failed).toBe(0)
+    expect(res.results[1]!.dedup?.near_duplicates?.length ?? 0).toBeGreaterThan(0)
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1275,9 +1275,17 @@ function getAllToolDefinitions(): ToolDefinition[] {
         // was `results.map(r => r.engram.id)` — a COMPACTED array, so after a
         // mid-batch failure every subsequent id shifted left and mis-attributed
         // to the wrong input (#281). Build from input_index instead.
+        //
+        // #930/#914 parity: report ids in the namespaced form plur_recall returns,
+        // matching the fix applied to plur_learn in b93fa8e. An outbox engram is
+        // excluded — it sits in the LOCAL store under a local id until the retry
+        // lands, and that is what recall returns for it.
         const ids: (string | null)[] = raw.map(() => null)
         for (const r of results) {
-          if (r.input_index !== undefined) ids[r.input_index] = r.engram.id
+          if (r.input_index !== undefined) {
+            const isOutbox = !!(r.engram as any).structured_data?._outbox
+            ids[r.input_index] = isOutbox ? r.engram.id : plur.readIdFor(r.engram)
+          }
         }
         // Missing-domain nudge (#671), batch form: aggregate count instead of a
         // per-item echo. Same gate as plur_learn — only items that passed
@@ -1322,9 +1330,11 @@ function getAllToolDefinitions(): ToolDefinition[] {
         }
         return {
           ids,
-          results: results.map((r) => ({
+          results: results.map((r) => {
+            const isOutbox = !!(r.engram as any).structured_data?._outbox
+            return {
             input_index: r.input_index,
-            id: r.engram.id,
+            id: isOutbox ? r.engram.id : plur.readIdFor(r.engram),
             statement: r.engram.statement,
             scope: r.engram.scope,
             type: r.engram.type,
@@ -1334,7 +1344,8 @@ function getAllToolDefinitions(): ToolDefinition[] {
             // reporting it exists for reached no caller — "anything below the
             // bar is still reported" was not observable anywhere.
             ...(r.dedup ? { dedup: r.dedup } : {}),
-          })),
+          }
+          }),
           stats,
           ...batchDomainHint,
           ...(failures.length > 0


### PR DESCRIPTION
## Summary

Fixes two defects in `plur_learn_batch` id reporting, and adds in-batch near-duplicate detection:

- **Defect 1 (#930 / #914 parity):** batch path was returning raw server ids instead of namespaced ids. `plur_learn` was fixed in b93fa8e to call `plur.readIdFor()` on the returned engram; the batch path missed that. Now both the `ids[]` array and the per-item `results[]` entries go through `readIdFor()`, so the shape matches what `plur_recall` returns.

- **Defect 2 (#930):** all N items in a batch reported the same id. Root cause: `learnBatch` was calling the fire-and-forget `learn()` path. For a remote-backed scope, `learn()` enqueues to the outbox and deletes the local copy after a successful push; the next `generateEngramId` finds the same slot free and issues the same id. Fix: `_learnAsyncDeps()` now injects `learnRouted` as the batch ADD path. `learnRouted` awaits the server push and returns the server-assigned id, so each item in the batch holds a distinct, stable id before the next item starts.

- **In-batch dedup (#854):** `learnBatch` now maintains a `batchAccumulator` of ADD-written engrams and splices them into `recallHybrid`/`recall` results so `learnAsync`'s dedup step sees earlier-in-batch writes even before `_syncIndex()` has flushed. Without this, every item after the first short-circuits to ADD because the BM25/embedding index is stale.

## Files changed

| File | What changed |
|------|-------------|
| `packages/core/src/learn-async.ts` | `LearnAsyncDeps.learnRouted` field (optional, documented); `learnBatch` picks it over `learn`; `batchAccumulator` + per-item recall splice; `BatchAccumulatorEntry` interface |
| `packages/core/src/index.ts` | `_learnAsyncDeps()` now injects `learnRouted`; exports `storePrefix`/`namespaceEngramId` comment clarified |
| `packages/mcp/src/tools.ts` | `ids[]` and `results[]` entries go through `plur.readIdFor()` (with outbox bypass); description updated to note `learnRouted` is now used |
| `packages/core/test/batch.test.ts` | New test suite covering: unique ids per item, exact-hash NOOP within batch, near-duplicate NOOP via accumulator (#854), partial-failure input-index alignment (#281) |

## Test plan

- [x] `npx vitest run packages/core/test/batch.test.ts` — 5/5 pass
- [ ] Full suite passes on CI
- [ ] Manual smoke: call `plur_learn_batch` with 3 items on a remote-backed scope, confirm 3 distinct namespaced ids returned and all 3 retrievable via `plur_recall`