### PR TITLE
fix(dsh): log a warning when the engine fails to load (#941)

### DIFF
--- a/packages/dsh/src/engine.ts
+++ b/packages/dsh/src/engine.ts
@@ -49,7 +49,8 @@ async function loadEngine(
     const Plur = mod.Plur ?? mod.default?.Plur
     if (typeof Plur !== 'function') return undefined
     return new Plur({ path: config.path })
-  } catch {
+  } catch (error) {
+    console.warn(`[plur] memory engine unavailable, continuing without memory: ${error}`)
     return undefined
   }
 }

--- a/packages/dsh/test/engine.test.ts
+++ b/packages/dsh/test/engine.test.ts
@@ -40,6 +40,16 @@ describe('createEngine when core is unavailable', () => {
     await expect(engine.ready()).resolves.toBe(false)
   })
 
+  it('logs a warning when the engine fails to load (#941)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const engine = createEngine(config(), missing)
+    await engine.ready()
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toMatch(/memory engine unavailable/)
+    expect(warn.mock.calls[0][0]).toMatch(/ERR_MODULE_NOT_FOUND/)
+    warn.mockRestore()
+  })
+
   it('degrades every read to empty instead of taking the host down', async () => {
     const engine = createEngine(config(), missing)
     await expect(engine.recall!('x')).resolves.toEqual([])


### PR DESCRIPTION
## Summary

Closes #941.

`loadEngine` in `packages/dsh/src/engine.ts` had a bare `catch {}` that converted any load failure into silent inertness — the same pattern that hid the original inert-plugin bug before #918. This means a WASM init failure, partial install, or version skew produces a plugin that registers every surface and recalls nothing, with no operator-visible signal.

### Change

```ts
// before
} catch {
  return undefined
}

// after
} catch (error) {
  console.warn(`[plur] memory engine unavailable, continuing without memory: ${error}`)
  return undefined
}
```

The memoisation on `pending ??= loadEngine(...)` means the warning fires at most once per process. The degradation contract (`ready()` returns false, all reads return empty) is unchanged.

### Test

Added a test to `test/engine.test.ts` that spies on `console.warn` and asserts the warning fires with the expected message (including the error text) when `importCore` rejects.

## Test plan

- [x] `test/engine.test.ts` — 12 tests pass, including the new `logs a warning when the engine fails to load (#941)` case
- [x] No behaviour change for the success path