### PR TITLE
fix(dsh): log load failures in loadEngine instead of swallowing them (#941)

### DIFF
--- a/packages/dsh/src/engine.ts
+++ b/packages/dsh/src/engine.ts
@@ -36,11 +36,13 @@ export interface Engine extends PlurClient {
  *
  * @param config - supplies the optional store path.
  * @param importCore - overridable for tests.
+ * @param warn - called once on load failure; defaults to console.warn.
  * @returns the engine, or undefined when core cannot be loaded.
  */
 async function loadEngine(
   config: Config,
   importCore: () => Promise<unknown>,
+  warn: (msg: string) => void,
 ): Promise<PlurClient | undefined> {
   try {
     const mod = await importCore() as { Plur?: PlurCtor; default?: { Plur?: PlurCtor } }
@@ -49,7 +51,8 @@ async function loadEngine(
     const Plur = mod.Plur ?? mod.default?.Plur
     if (typeof Plur !== 'function') return undefined
     return new Plur({ path: config.path })
-  } catch {
+  } catch (error) {
+    warn(`[plur] memory engine unavailable, continuing without memory: ${error}`)
     return undefined
   }
 }
@@ -64,14 +67,16 @@ async function loadEngine(
  *
  * @param config - plugin configuration.
  * @param importCore - overridable module loader, for tests.
+ * @param warn - called once if the engine fails to load; defaults to console.warn.
  * @returns the facade.
  */
 export function createEngine(
   config: Config,
   importCore: () => Promise<unknown> = () => import('@plur-ai/core'),
+  warn: (msg: string) => void = (msg) => console.warn(msg),
 ): Engine {
   let pending: Promise<PlurClient | undefined> | undefined
-  const engine = (): Promise<PlurClient | undefined> => (pending ??= loadEngine(config, importCore))
+  const engine = (): Promise<PlurClient | undefined> => (pending ??= loadEngine(config, importCore, warn))
 
   return {
     ready: async () => (await engine()) !== undefined,

--- a/packages/dsh/test/engine.test.ts
+++ b/packages/dsh/test/engine.test.ts
@@ -68,6 +68,24 @@ describe('createEngine when core is unavailable', () => {
     }))
     await expect(engine.ready()).resolves.toBe(false)
   })
+
+  it('calls warn with the error when load fails (#941)', async () => {
+    const warn = vi.fn()
+    const engine = createEngine(config(), missing, warn)
+    await engine.ready()
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toMatch(/memory engine unavailable/)
+    expect(warn.mock.calls[0][0]).toMatch(/ERR_MODULE_NOT_FOUND/)
+  })
+
+  it('calls warn exactly once however many methods are called after a failed load (#941)', async () => {
+    const warn = vi.fn()
+    const engine = createEngine(config(), missing, warn)
+    await engine.ready()
+    await engine.list!()
+    await engine.recall!('x')
+    expect(warn).toHaveBeenCalledOnce()
+  })
 })
 
 describe('the facade shape', () => {


### PR DESCRIPTION
## What

Closes #941.

`loadEngine` in `packages/dsh/src/engine.ts` had a bare `catch` that discarded the error entirely:

```ts
} catch {
  return undefined
}
```

A WASM init failure, a partial install, or a version skew between the plugin and core produces a plugin that appears healthy — `ready()` returns `false`, every read returns empty, every write is a no-op — and nothing anywhere records why. An operator seeing a blank memory block has no thread to pull.

## Fix

Added an optional `warn` callback parameter to `createEngine` (third positional, defaults to `console.warn`). It is threaded to `loadEngine` and called once in the catch with the error. Because `pending` memoises the result, the callback fires at most once per process regardless of how many facade calls follow.

Production callers (`apply()`) inherit the default; tests can pass a `vi.fn()` spy. The `apply()` call site in `index.ts` is unchanged — future work could thread `ctx.logger?.warn` for structured output, but the default covers the immediate diagnostic gap.

## Tests

Two new cases in `test/engine.test.ts`:
- `warn` is called with a message matching `"memory engine unavailable"` and the original error string
- `warn` is called exactly once however many facade methods are called after a failed load

All 13 engine tests pass.