### PR TITLE
docs: correct full tool count from 42/43 to 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Run init from your project root — it sets up Cursor's `.cursor/mcp.json` (plus
 npx @plur-ai/mcp init
 ```
 
-PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 44, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
+PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 43, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Run init from your project root — it sets up Cursor's `.cursor/mcp.json` (plus
 npx @plur-ai/mcp init
 ```
 
-PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 42, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
+PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 44, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
 
 ### OpenClaw
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -63,7 +63,7 @@ By default (lean profile), your agent gets 12 tools. Everything else is reachabl
 | `plur_tensions_purge` | Clear stale/resolved tensions |
 | `plur_admin` | Dispatch to any other tool: `{ action: "plur_packs_install", args: {...} }` |
 
-Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 44 tools directly.
+Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 43 tools directly.
 
 A `plur_*` name missing from `tools/list` means it moved behind the gateway, not that the server is down. `plur_admin { action: "help" }` returns every action with a one-line description and its argument schema; `plur_doctor` reports the same inventory as `tool_surface`.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -63,7 +63,7 @@ By default (lean profile), your agent gets 12 tools. Everything else is reachabl
 | `plur_tensions_purge` | Clear stale/resolved tensions |
 | `plur_admin` | Dispatch to any other tool: `{ action: "plur_packs_install", args: {...} }` |
 
-Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 43 tools directly.
+Less commonly needed tools (`plur_recall_hybrid`, `plur_inject_hybrid`, `plur_learn_batch`, `plur_ingest`, `plur_sync`, `plur_packs_install`, `plur_packs_list`, `plur_capture`, `plur_timeline`, and more) are all reachable via `plur_admin`. Set `PLUR_TOOL_PROFILE=full` to expose all 44 tools directly.
 
 A `plur_*` name missing from `tools/list` means it moved behind the gateway, not that the server is down. `plur_admin { action: "help" }` returns every action with a one-line description and its argument schema; `plur_doctor` reports the same inventory as `tool_surface`.
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -681,7 +681,7 @@ export type ToolProfile = 'full' | 'lean' | 'cursor'
 // `destructiveHint: true` — everything else (packs install/list, sync,
 // timeline, meta-engrams, ingest, capture, ...) is reachable through
 // plur_admin instead of its own top-level tool slot. Cursor caps a workspace
-// at ~40 MCP tools total across every server, and PLUR's full 44-tool
+// at ~40 MCP tools total across every server, and PLUR's full 43-tool
 // surface alone would consume ~110% of that budget.
 //
 // Destructive tools are kept OUT of plur_admin's dispatch specifically

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -681,8 +681,8 @@ export type ToolProfile = 'full' | 'lean' | 'cursor'
 // `destructiveHint: true` — everything else (packs install/list, sync,
 // timeline, meta-engrams, ingest, capture, ...) is reachable through
 // plur_admin instead of its own top-level tool slot. Cursor caps a workspace
-// at ~40 MCP tools total across every server, and PLUR's full 39-tool
-// surface alone would consume ~97.5% of that budget.
+// at ~40 MCP tools total across every server, and PLUR's full 44-tool
+// surface alone would consume ~110% of that budget.
 //
 // Destructive tools are kept OUT of plur_admin's dispatch specifically
 // (audit fix — evaluator review, 2026-07-08; ENFORCED in the handler since


### PR DESCRIPTION
## Summary

- README.md: corrects "all 42" → "all 44" in the Cursor section
- packages/mcp/README.md: corrects "all 43 tools directly" → "all 44 tools directly"  
- packages/mcp/src/tools.ts: corrects stale "39-tool surface" comment → "44-tool surface"

`grep -c "name: 'plur_" packages/mcp/src/tools.ts` is the authoritative count (44 as of origin/main). Docs said 42, 43, and 39 in three different places — all stale from before recent tool additions.

🤖 heartbeat — cmo.docs-review