### PR TITLE
fix(remote-store): carry provenance on team push (#983)

### DIFF
--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -434,6 +434,9 @@ export class RemoteStore implements EngramStore {
       // that don't model `source` ignore the field, and it is omitted entirely
       // when unset so the historical body is byte-identical without it.
       ...(e.source != null                  ? { source: e.source }             : {}),
+      // #983: carry provenance records so the receiving store can answer
+      // origin/chain/licence questions. Omitted when unset.
+      ...(e.provenance != null              ? { provenance: e.provenance }     : {}),
     })
     const r = await this.fetchBounded(`${this.apiBase}/engrams`, {
       method: 'POST',

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -116,6 +116,22 @@ describe('RemoteStore against stub server', () => {
     expect('valid_from' in sent).toBe(false)
     expect('valid_until' in sent).toBe(false)
     expect('supersedes' in sent).toBe(false)
+    expect('provenance' in sent).toBe(false)
+  })
+
+  it('#983 append carries provenance when present', async () => {
+    const store = new RemoteStore(baseUrl, TOKEN, 'group:test', { ttlMs: 0 })
+    const prov = { origin: 'user-correction', chain: ['ENG-001'], licence: 'Apache-2.0' }
+    await store.append({
+      id: 'tmp',
+      scope: 'group:test',
+      status: 'active',
+      statement: 'provenance round-trip test',
+      provenance: prov,
+    } as any)
+
+    const sent = server.lastAppendBody!
+    expect(sent.provenance).toEqual(prov)
   })
 
   it('#768 load maps flat server-row validity (valid_from/valid_until) into nested temporal', async () => {


### PR DESCRIPTION
## Summary

Partial fix for #983 — `RemoteStore.append()` builds the outbound body by hand but omits the `provenance` field. Engrams pushed to a team store arrive stripped of origin, chain, and licence information.

## Fix

Add `provenance` to the outbound body, omitted when unset so the historical wire body is byte-identical without it. Same additive pattern as `source` (#676) — servers that don't model the field ignore it.

## What this does NOT fix

`attribution` and `claim_class` are not yet in the engram schema (#963). This carries the one provenance field that exists today. When #963 lands, those fields should be added to the outbound body in a follow-up.

## Changes

- `packages/core/src/store/remote-store.ts` — add provenance to outbound body (+2 lines)
- `packages/core/test/remote-integration.test.ts` — round-trip test + omission assertion (+12 lines)

## Testing

All 50 remote-integration tests pass, including the new `#983 append carries provenance when present` test.