### PR TITLE
Actually compare the integrity value a pack shipped

### DIFF
--- a/packages/cli/src/commands/packs.ts
+++ b/packages/cli/src/commands/packs.ts
@@ -195,8 +195,22 @@ Options:
       // Install confirmation → suppressed by --quiet; security warnings and
       // conflicts below stay loud (#730).
       outputInfo(`Installed pack "${result.name}": ${result.installed} engrams`, flags)
-      if (result.registry) {
-        outputInfo(`  Integrity: ${result.registry.integrity}`, flags)
+      // Say what was CHECKED, with a verb. A bare "Integrity: sha256:…" was
+      // read by a tester as certification of the pack, and the caveat
+      // explaining it is nothing of the sort existed only in the piped JSON —
+      // so the people most likely to be misled were the only ones not shown it.
+      const check = result.integrity_check
+      if (check) {
+        const verdict = check.status === 'ok'
+          ? 'matches the value the pack shipped'
+          : check.status === 'modified'
+            ? 'DOES NOT MATCH the value the pack shipped'
+            : 'not checked — the pack shipped no value'
+        outputInfo(`  Integrity: ${verdict}`, flags)
+        outputInfo(`             ${check.computed}`, flags)
+        outputInfo(`  ${check.note}`, flags)
+      } else if (result.registry) {
+        outputInfo(`  Integrity (computed): ${result.registry.integrity}`, flags)
       }
 
       if (!result.security.clean) {

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -257,6 +257,8 @@ export interface PreviewResult {
   engrams: Array<{ id: string; type: string; statement: string; domain?: string; tags: string[] }>
   security: PrivacyScanResult
   warnings: string[]
+  /** Whether the contents match the integrity value the pack shipped (#987). */
+  integrity: IntegrityCheck
 }
 
 function _previewPackDir(source: string): PreviewResult {
@@ -264,6 +266,8 @@ function _previewPackDir(source: string): PreviewResult {
 
   const pack = loadPack(source)
   const security = scanPrivacy(pack.engrams)
+  // Check the SHIPPED value against the contents, before anything installs.
+  const integrity = verifyPackIntegrity(source)
 
   const warnings: string[] = []
   // Flag pinned engrams — they bypass the relevance gate (always injected).
@@ -292,6 +296,7 @@ function _previewPackDir(source: string): PreviewResult {
     })),
     security,
     warnings,
+    integrity,
   }
 }
 
@@ -322,6 +327,12 @@ export interface InstallResult {
   conflicts: ConflictItem[]
   security: PrivacyScanResult
   registry: RegistryEntry
+  /**
+   * What checking the shipped integrity value found (#987). Reported even when
+   * it passed, so a caller can tell "matched" from "there was nothing to match
+   * against" — the distinction the old `integrity_ok: true` erased.
+   */
+  integrity_check: IntegrityCheck
 }
 
 export interface ConflictItem {
@@ -386,6 +397,12 @@ function detectConflicts(newEngrams: Engram[], existingEngrams: Engram[]): Confl
 export interface InstallOptions {
   /** Override the prompt-injection block. Secrets are ALWAYS blocked regardless. */
   allowInjection?: boolean
+  /**
+   * Install even though the contents do not match the integrity value the pack
+   * shipped (#987). Off by default: a pack that changed after it was built is
+   * exactly the case somebody should have to look at before proceeding.
+   */
+  allowModified?: boolean
 }
 
 /**
@@ -447,6 +464,23 @@ function _installPackDir(
 
   // Security scan BEFORE copying — always runs, not opt-out
   const preview = _previewPackDir(source)
+
+  // Does the pack still match the integrity value its author shipped? This was
+  // never checked: install recomputed a hash, recorded it, and reported success,
+  // so a pack edited after it was built installed silently and `plur packs list`
+  // then called it `integrity_ok: true`.
+  //
+  // Blocking is the right default. Unlike the injection scan, there is no
+  // legitimate reason for a pack to differ from its own recorded hash — either
+  // it was damaged in transit or somebody changed it, and both deserve a look.
+  if (preview.integrity.status === 'modified' && !opts.allowModified) {
+    throw new Error(
+      `This pack does not match the integrity value it shipped.\n`
+      + `  shipped:  ${preview.integrity.shipped}\n`
+      + `  contents: ${preview.integrity.computed}\n`
+      + `It has been changed since it was built. Install it only if you know why it differs.`,
+    )
+  }
   const secretIssues = preview.security.issues.filter(i => i.type === 'secret')
   if (secretIssues.length > 0) {
     const details = secretIssues.map(i => `  ${i.engram_id}: ${i.detail}`).join('\n')
@@ -576,7 +610,14 @@ function _installPackDir(
   }
   addToRegistry(packsDir, registryEntry)
 
-  return { installed: newEngrams.length, name: sourceName, conflicts, security: preview.security, registry: registryEntry }
+  return {
+    installed: newEngrams.length,
+    name: sourceName,
+    conflicts,
+    security: preview.security,
+    registry: registryEntry,
+    integrity_check: preview.integrity,
+  }
 }
 
 /**
@@ -1139,6 +1180,71 @@ export function exportPack(
 }
 
 // --- Integrity ---
+
+/** What a pack's shipped integrity value says, checked against its contents. */
+export interface IntegrityCheck {
+  /** 'ok' — matched. 'modified' — did not match. 'absent' — the pack shipped none. */
+  status: 'ok' | 'modified' | 'absent'
+  /** The value the pack shipped, if it shipped one. */
+  shipped?: string
+  /** The value its contents actually hash to. */
+  computed: string
+  /** What to tell the person deciding whether to install it. */
+  note: string
+}
+
+/**
+ * Compare the integrity value a pack SHIPPED against what its contents hash to.
+ *
+ * Export writes the hash into an `INTEGRITY` file. Install recomputed its own
+ * hash, recorded that, and never once looked at the shipped value — so a pack
+ * edited after it was built installed cleanly, and `plur packs list` then
+ * reported `integrity_ok: true`. `integrity_ok` meant "we computed a hash", not
+ * "the hash matched", which is the opposite of what anybody reads it as.
+ *
+ * Hash the pack AS RECEIVED. Install later hashes the staged, sanitised copy,
+ * which legitimately differs when the privacy scan drops an engram; comparing
+ * against that would raise a mismatch on packs nobody touched.
+ *
+ * A pack that ships no `INTEGRITY` is 'absent', not 'ok'. Nothing was checked,
+ * and saying otherwise is how the original defect read.
+ *
+ * This detects accidental corruption and casual editing. It is NOT a defence
+ * against a determined sender, who edits the contents and the `INTEGRITY` file
+ * together — nothing here is signed. Say that plainly wherever this is shown.
+ */
+export function verifyPackIntegrity(packDir: string): IntegrityCheck {
+  const computed = `sha256:${computePackHash(packDir)}`
+  const file = path.join(packDir, 'INTEGRITY')
+
+  if (!fs.existsSync(file)) {
+    return {
+      status: 'absent',
+      computed,
+      note: 'This pack shipped no integrity value, so there was nothing to check it against.',
+    }
+  }
+
+  const shipped = fs.readFileSync(file, 'utf8').trim()
+  if (shipped === computed) {
+    return {
+      status: 'ok',
+      shipped,
+      computed,
+      note: 'The contents match the value the pack shipped. That means it arrived intact — '
+        + 'not that its contents are trustworthy, and not that the sender is who they say. '
+        + 'Packs are not signed, so somebody who edited the contents could edit this value too.',
+    }
+  }
+  return {
+    status: 'modified',
+    shipped,
+    computed,
+    note: 'The contents do NOT match the value the pack shipped. It has been changed since it '
+      + 'was built, by damage in transit or by somebody editing it. Do not install it unless '
+      + 'you know why it differs.',
+  }
+}
 
 /**
  * Compute SHA256 hash of pack contents per ENGRAM-STANDARD-v1.md §5.5:

--- a/packages/core/test/pack-integrity-verify.test.ts
+++ b/packages/core/test/pack-integrity-verify.test.ts
@@ -1,0 +1,108 @@
+/**
+ * A pack's shipped integrity value must actually be checked (#987).
+ *
+ * Export wrote the hash into an `INTEGRITY` file. Install recomputed its own
+ * hash, recorded that, and never looked at the shipped one — so a pack edited
+ * after it was built installed silently, and `plur packs list` then reported
+ * `integrity_ok: true`. That field meant "we computed a hash", not "the hash
+ * matched", which is the opposite of how anybody reads it.
+ *
+ * What this does and does not prove is load-bearing, so it is tested too.
+ * Matching means the pack ARRIVED INTACT. It does not mean the contents are
+ * trustworthy or that the sender is who they claim: nothing is signed, so
+ * somebody who edited the contents could edit the value beside it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EngramSchema } from '../src/schemas/engram.js'
+import { exportPack, installPack, previewPack, verifyPackIntegrity } from '../src/packs.js'
+
+const engram = (id = 'ENG-2026-08-23-001') => EngramSchema.parse({
+  id,
+  statement: 'Migrations run before deploys',
+  type: 'behavioral',
+  scope: 'global',
+  status: 'active',
+  visibility: 'public',
+  content_hash: 'a'.repeat(64),
+})
+
+describe('checking the integrity value a pack shipped', () => {
+  let out: string
+  let packs: string
+
+  beforeEach(() => {
+    out = mkdtempSync(join(tmpdir(), 'plur-integ-out-'))
+    packs = mkdtempSync(join(tmpdir(), 'plur-integ-packs-'))
+    exportPack([engram()], out, { name: 'honest', version: '1.0.0' })
+  })
+  afterEach(() => {
+    for (const d of [out, packs]) rmSync(d, { recursive: true, force: true })
+  })
+
+  const tamper = () => {
+    const p = join(out, 'engrams.yaml')
+    writeFileSync(p, readFileSync(p, 'utf8').replace('Migrations', 'Deployments'))
+  }
+
+  it('an untouched pack matches', () => {
+    expect(verifyPackIntegrity(out).status).toBe('ok')
+  })
+
+  it('an edited pack does not', () => {
+    tamper()
+    const check = verifyPackIntegrity(out)
+    expect(check.status).toBe('modified')
+    expect(check.shipped).not.toBe(check.computed)
+  })
+
+  it('a pack with no integrity value is "absent", never "ok"', () => {
+    // Nothing was checked. Reporting that as a pass is the original defect.
+    rmSync(join(out, 'INTEGRITY'))
+    const check = verifyPackIntegrity(out)
+    expect(check.status).toBe('absent')
+    expect(check.note).toContain('nothing to check it against')
+  })
+
+  it('never claims the contents are trustworthy, only that they arrived intact', () => {
+    // Matching says nothing about the sender. Packs are not signed.
+    const note = verifyPackIntegrity(out).note
+    expect(note).toContain('not that its contents are trustworthy')
+    expect(note).toContain('not signed')
+  })
+
+  it('surfaces the verdict in a preview, before anything installs', async () => {
+    tamper()
+    const preview = await previewPack(out)
+    expect(preview.integrity.status).toBe('modified')
+  })
+
+  it('refuses to install a pack that does not match', async () => {
+    tamper()
+    await expect(installPack(packs, out)).rejects.toThrow(/does not match the integrity value/)
+    // And nothing was installed.
+    expect(existsSync(join(packs, 'honest'))).toBe(false)
+  })
+
+  it('installs one that does, and says what was checked', async () => {
+    const result = await installPack(packs, out)
+    expect(result.installed).toBe(1)
+    expect(result.integrity_check.status).toBe('ok')
+  })
+
+  it('can be overridden deliberately, for somebody who knows why it differs', async () => {
+    tamper()
+    const result = await installPack(packs, out, undefined, { allowModified: true })
+    expect(result.installed).toBe(1)
+    // The verdict still travels: overriding must not rewrite what was found.
+    expect(result.integrity_check.status).toBe('modified')
+  })
+
+  it('reports "absent" through an install rather than inventing a pass', async () => {
+    rmSync(join(out, 'INTEGRITY'))
+    const result = await installPack(packs, out)
+    expect(result.integrity_check.status).toBe('absent')
+  })
+})


### PR DESCRIPTION
Closes part of #987.

## The defect

A pack ships an `INTEGRITY` file. Install recomputed its own hash from the contents, recorded that, and **never looked at the shipped value**.

A security reviewer edited a pack after export and installed it:

- `INTEGRITY` contained `sha256:482fd9ae…`
- install recomputed `sha256:f6c98321…`
- install reported the new hash and succeeded
- `plur packs list` then printed `"integrity_ok": true, "integrity_status": "ok"`

`integrity_ok` meant "we computed a hash", not "the hash matched" — the opposite of how anybody reads it.

## What this changes

The shipped value is compared against the pack **as received**, and a mismatch blocks the install.

Hashing the received pack rather than the staged copy matters: install later hashes the sanitised staging directory, which legitimately differs when the privacy scan drops an engram. Comparing there would raise a mismatch on packs nobody had touched.

Blocking is the default because, unlike the injection scan, there is no legitimate reason for a pack to differ from its own recorded hash. `allowModified` exists for somebody who knows why it differs, and overriding does not rewrite the reported verdict.

A pack shipping no `INTEGRITY` reports `absent`, never `ok`. Nothing was checked, and reporting that as a pass is the original defect in miniature.

## What it deliberately does not claim

Every place this appears says the same thing: a match means the pack **arrived intact** — not that its contents are trustworthy, and not that the sender is who they say. Nothing is signed, so somebody who edited the contents could edit the value beside them.

A test asserts that wording, because the honest sentence is most of the value here.

On the terminal the line now carries a verb. `Integrity: sha256:…` was read by a tester as certification of the pack, and the caveat explaining otherwise existed only in piped JSON — so the people most likely to be misled were the only ones never shown it.

## Testing

9 new tests: matched, modified, absent, the wording, the preview surface, the install refusal (asserting nothing was installed), the override, and that the verdict survives an override.

Full suite green apart from three pre-existing `sync-push-failure` failures, which are machine-local — `~/.gitignore_global` lists `engrams.yaml`, so the test's scratch repo stages nothing and its seed commit fails.

## Scope

Split out of the provenance epic (#958), where it was found. It is independent of provenance and reviewable on its own.
