### PR TITLE
Harness adapters: Codex + Antigravity, hybrid injection, PGLite opt-in (#1031, #1033, #1040, #1046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,16 @@ fresh-process-per-hook model.
 after upgrading, selection moves to `sqlite` and builds `engrams.db`. Nothing is
 lost — YAML remains the source of truth.
 
-**Migration path:** run `plur migrate` once. It carries your embedding vectors out
-of the old PGLite store into the new tier's cache (verifying each against the
-engram's current text and the active embedder's dimension), so hybrid recall works
-immediately instead of re-embedding the corpus in the background. It then tells you
-the old `~/.plur/store.pglite/` directory (typically 60–500MB) is safe to delete;
-`plur doctor` flags it too. Skipping the migration loses nothing — stale or skipped
-vectors re-embed automatically — it just costs background CPU and a window of
-BM25-only recall.
+**Migration: nothing to do.** Recall keeps working immediately (BM25), and
+embeddings rebuild automatically — the first hybrid recalls re-embed the corpus,
+which takes a few minutes of background CPU on a large store and then it is done.
+The old `~/.plur/store.pglite/` directory (typically 60–500MB) is orphaned and safe
+to delete whenever convenient; `plur doctor` points it out.
+
+Optional shortcut for large stores: `plur migrate` carries the old store's
+embedding vectors straight into the new tier's cache (each verified against the
+engram's current text and the active embedder's dimension), skipping the rebuild
+window entirely.
 
 To keep the old behaviour set `backend: pglite` in `~/.plur/config.yaml` or
 `PLUR_BACKEND=pglite`; PGLite remains the right choice only where its pgvector/AGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## 0.19.0 (unreleased)
 
-Memory in every harness — Codex and Antigravity join Claude Code, Cursor, OpenClaw and Hermes.
+Codex and Antigravity join the family.
 
-- `plur init --codex` — hooks, MCP, AGENTS.md
-- `plur init --antigravity` — agy hooks, MCP, AGENTS.md
-- Hybrid injection (BM25 + embeddings) in hooks, with automatic BM25 fallback
-- PGLite is opt-in; the size ladder is now yaml → sqlite → postgres
+- `plur init --codex` / `--antigravity`
+- Hybrid recall in hooks
+- Size ladder: yaml → sqlite → postgres
 
 **Codex CLI adapter.** `plur init --codex` wires `~/.codex/hooks.json` (five lifecycle
 hooks), registers the MCP server via `codex mcp add`, and adds a PLUR section to
@@ -68,7 +67,7 @@ To keep the old behaviour set `backend: pglite` in `~/.plur/config.yaml` or
 capabilities are the point, and it now logs its per-process boot cost once at
 startup when explicitly selected.
 
-## 0.18.0 (unreleased)
+## 0.18.0
 
 Your agents' memory, on a dashboard.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 0.19.0 (unreleased)
+
+Memory in every harness — Codex and Antigravity join Claude Code, Cursor, OpenClaw and Hermes.
+
+- `plur init --codex` — hooks, MCP, AGENTS.md
+- `plur init --antigravity` — agy hooks, MCP, AGENTS.md
+- Hybrid injection (BM25 + embeddings) in hooks, with automatic BM25 fallback
+- PGLite is opt-in; the size ladder is now yaml → sqlite → postgres
+
+**Codex CLI adapter.** `plur init --codex` wires `~/.codex/hooks.json` (five lifecycle
+hooks), registers the MCP server via `codex mcp add`, and adds a PLUR section to
+`AGENTS.md`. One manual step: Codex refuses untrusted hooks *silently* — run `/hooks`
+in Codex once and trust the PLUR entries. `plur doctor` reports Codex wiring and
+repeats that caveat.
+
+**Antigravity CLI (agy) adapter.** `plur init --antigravity` wires agy's global config
+(`~/.gemini/config/`): a `plur-memory` hook set (PreInvocation injection + PreToolUse
+guard), the MCP server, and `AGENTS.md`. No trust step — restart agy and memory flows.
+Per-prompt recall reads the conversation transcript (agy's hook payload carries no
+prompt text), and each turn's memory is re-injected as an ephemeral message on every
+model invocation so it survives tool calls without accumulating in history. Google is
+transitioning Gemini CLI to Antigravity; Gemini CLI itself remains tools-only.
+
+**Hybrid injection in hooks.** Hook injection is now hybrid (BM25 + embeddings) with an
+automatic BM25 fallback on an 8s soft deadline — measured ~4.7s hybrid vs ~1.6s BM25 on
+a 5,775-engram store, with hybrid diverging most exactly on the vague prompts where
+memory matters. `PLUR_HOOK_HYBRID=0` forces BM25; `PLUR_HOOK_HYBRID_DEADLINE_MS` tunes
+the deadline (keep it under your harness's hook timeout: Codex 25s, agy 20s). Enabled
+by the `@huggingface/transformers` 3.8.1 → 4.2.0 upgrade, which fixes a SIGABRT during
+ONNX teardown (#1040) that made every embedder-touching process exit 134 — and, in
+3.8.1, could leave a truncated model file that permanently and silently degraded search
+to BM25 (#340's failure mode; 4.2.0 downloads atomically). Embedding vectors are
+bit-identical across the upgrade — no re-embed, caches stay valid.
+
+**PGLite sync is no longer quadratic with your session count.** `syncFromYaml` batches
+upserts (a 5,000-engram corpus builds in ~2s instead of 10+ minutes), records a
+fingerprint so an unchanged store skips the sync entirely, tolerates duplicate ids
+last-wins, and the CLI drains background index work before exiting so the index
+actually converges.
+
+### BREAKING — PGLite is opt-in, never selected by corpus size (#1046)
+
+The automatic ladder is now **yaml → sqlite → postgres**. Stores past 5,000 engrams
+select a SQLite metadata index (sub-millisecond opens measured to 500k engrams)
+instead of PGLite, which boots a full Postgres-in-WASM per process — measured at
+0.61s vs 300s+ per command on a 5,775-engram store under PLUR's
+fresh-process-per-hook model.
+
+**Who is affected:** any default install with more than 5,000 engrams. On first run
+after upgrading, selection moves to `sqlite` and builds `engrams.db`. Nothing is
+lost — YAML remains the source of truth — but the old `~/.plur/store.pglite/`
+directory (typically 60–500MB) is orphaned and can be deleted. `plur doctor` flags
+it. To keep the old behaviour set `backend: pglite` in `~/.plur/config.yaml` or
+`PLUR_BACKEND=pglite`; PLUR remains the right choice only where its pgvector/AGE
+capabilities are the point, and it now logs its per-process boot cost once at
+startup when explicitly selected.
+
 ## 0.18.0 (unreleased)
 
 Your agents' memory, on a dashboard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,19 @@ fresh-process-per-hook model.
 
 **Who is affected:** any default install with more than 5,000 engrams. On first run
 after upgrading, selection moves to `sqlite` and builds `engrams.db`. Nothing is
-lost — YAML remains the source of truth — but the old `~/.plur/store.pglite/`
-directory (typically 60–500MB) is orphaned and can be deleted. `plur doctor` flags
-it. To keep the old behaviour set `backend: pglite` in `~/.plur/config.yaml` or
-`PLUR_BACKEND=pglite`; PLUR remains the right choice only where its pgvector/AGE
+lost — YAML remains the source of truth.
+
+**Migration path:** run `plur migrate` once. It carries your embedding vectors out
+of the old PGLite store into the new tier's cache (verifying each against the
+engram's current text and the active embedder's dimension), so hybrid recall works
+immediately instead of re-embedding the corpus in the background. It then tells you
+the old `~/.plur/store.pglite/` directory (typically 60–500MB) is safe to delete;
+`plur doctor` flags it too. Skipping the migration loses nothing — stale or skipped
+vectors re-embed automatically — it just costs background CPU and a window of
+BM25-only recall.
+
+To keep the old behaviour set `backend: pglite` in `~/.plur/config.yaml` or
+`PLUR_BACKEND=pglite`; PGLite remains the right choice only where its pgvector/AGE
 capabilities are the point, and it now logs its per-process boot cost once at
 startup when explicitly selected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.19.0 (unreleased)
 
-Codex and Antigravity join the family.
+The memory layer forgot Codex. Awkward. Fixed — agy too.
 
 - `plur init --codex` / `--antigravity`
 - Hybrid recall in hooks

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ npx @plur-ai/cli init --codex
 
 Registers the MCP server via `codex mcp add`, writes lifecycle hooks to `~/.codex/hooks.json`, and adds a PLUR section to `AGENTS.md`. Auto-detected when `~/.codex/` exists.
 
-Injection uses hybrid search (BM25 + embeddings) with an automatic BM25 fallback if the embedder is slow or unavailable. Set `PLUR_CODEX_HYBRID=0` to force BM25.
+Injection uses hybrid search (BM25 + embeddings) with an automatic BM25 fallback if the embedder is slow or unavailable. Set `PLUR_HOOK_HYBRID=0` to force BM25 (applies to the Antigravity hooks too; `PLUR_CODEX_HYBRID` is honoured as an alias). `PLUR_HOOK_HYBRID_DEADLINE_MS` tunes the fallback deadline — keep it below your harness's hook timeout (Codex 25s, Antigravity 20s).
 
 **One manual step after install:** open Codex, run `/hooks`, and trust the PLUR entries. Codex fingerprints every hook and refuses to run untrusted ones — *silently*, with no warning and a zero exit code. Until you trust them, memory simply never loads. `plur doctor` says so too.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ npx @plur-ai/cli init --codex
 
 Registers the MCP server via `codex mcp add`, writes lifecycle hooks to `~/.codex/hooks.json`, and adds a PLUR section to `AGENTS.md`. Auto-detected when `~/.codex/` exists.
 
-Injection is BM25 by default. Hybrid (BM25 + embeddings) is implemented and opt-in via `PLUR_CODEX_HYBRID=1`, but off until [#1040](https://github.com/plur-ai/plur/issues/1040) is fixed — loading the embedder aborts the process on teardown, and Codex discards the output of any hook that exits non-zero.
+Injection uses hybrid search (BM25 + embeddings) with an automatic BM25 fallback if the embedder is slow or unavailable. Set `PLUR_CODEX_HYBRID=0` to force BM25.
 
 **One manual step after install:** open Codex, run `/hooks`, and trust the PLUR entries. Codex fingerprints every hook and refuses to run untrusted ones — *silently*, with no warning and a zero exit code. Until you trust them, memory simply never loads. `plur doctor` says so too.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/plur-ai/plur?style=social)](https://github.com/plur-ai/plur/stargazers)
 [![Glama score](https://glama.ai/mcp/servers/plur-ai/plur/badges/score.svg)](https://glama.ai/mcp/servers/plur-ai/plur)
 
-Persistent, **open** memory for AI agents — local-first, zero-cost, shared across MCP tools (Claude Code, Hermes, OpenClaw, Cursor). Your agent's memory is plain-text **engrams** you can read, correct, and delete — not weights you can't.
+Persistent, **open** memory for AI agents — local-first, zero-cost, shared across MCP tools (Claude Code, Codex, Cursor, Hermes, OpenClaw). Your agent's memory is plain-text **engrams** you can read, correct, and delete — not weights you can't.
 
 [plur.ai](https://plur.ai) · [Benchmark](https://plur.ai/benchmark.html) · [Engram Spec](https://plur.ai/spec.html) · [npm](https://www.npmjs.com/org/plur-ai) · [Comparisons](comparisons/)
 
@@ -104,6 +104,36 @@ npx @plur-ai/mcp init
 ```
 
 PLUR runs under a **lean tool profile** in Cursor (`PLUR_TOOL_PROFILE=cursor`) — Cursor caps the tools a workspace can expose, so PLUR surfaces a curated core set (learn / recall / inject / status) instead of all 42, with the rest reachable through `plur_admin`. Cursor support shipped in v0.13.
+
+### Codex
+
+```bash
+npx @plur-ai/cli init --codex
+```
+
+Registers the MCP server via `codex mcp add`, writes lifecycle hooks to `~/.codex/hooks.json`, and adds a PLUR section to `AGENTS.md`. Auto-detected when `~/.codex/` exists.
+
+**One manual step after install:** open Codex, run `/hooks`, and trust the PLUR entries. Codex fingerprints every hook and refuses to run untrusted ones — *silently*, with no warning and a zero exit code. Until you trust them, memory simply never loads. `plur doctor` says so too.
+
+### Which integration you get
+
+Every MCP client can call PLUR's tools. Only some have an *adapter* — the hooks
+and always-on context that make memory load automatically instead of waiting for
+the agent to think of it. Without one, recall and learning depend entirely on the
+model choosing to call the tools, which degrades badly under context pressure.
+
+| Harness | Tools | Auto-injection + enforcement |
+|---|---|---|
+| Claude Code | ✅ | ✅ hooks + `CLAUDE.md` |
+| Codex | ✅ | ✅ hooks + `AGENTS.md` (trust `/hooks` once) |
+| Cursor | ✅ | ✅ hooks + rules |
+| OpenClaw | ✅ | ✅ ContextEngine plugin |
+| Hermes | ✅ | ✅ plugin |
+| Windsurf, Gemini CLI, Antigravity, other MCP clients | ✅ | ❌ tools only — [#1033](https://github.com/plur-ai/plur/issues/1033) |
+
+If your harness is in the last row, paste the PLUR section from `CLAUDE.md` into
+its own context file (`AGENTS.md`, `GEMINI.md`, …) as an interim measure — that
+restores the instruction layer, though not automatic injection.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -131,11 +131,24 @@ model choosing to call the tools, which degrades badly under context pressure.
 | Cursor | ✅ | ✅ hooks + rules |
 | OpenClaw | ✅ | ✅ ContextEngine plugin |
 | Hermes | ✅ | ✅ plugin |
-| Windsurf, Gemini CLI, Antigravity, other MCP clients | ✅ | ❌ tools only — [#1033](https://github.com/plur-ai/plur/issues/1033) |
+| Antigravity CLI (`agy`) | ✅ | ✅ hooks + `AGENTS.md` |
+| Windsurf, Gemini CLI, other MCP clients | ✅ | ❌ tools only |
 
 If your harness is in the last row, paste the PLUR section from `CLAUDE.md` into
 its own context file (`AGENTS.md`, `GEMINI.md`, …) as an interim measure — that
 restores the instruction layer, though not automatic injection.
+
+### Antigravity CLI (agy)
+
+```bash
+npx @plur-ai/cli init --antigravity
+```
+
+Writes hooks and the MCP server into agy's global config (`~/.gemini/config/`) and adds a PLUR section to `AGENTS.md`. Auto-detected when `~/.gemini/antigravity-cli/` exists. No trust step — agy runs configured hooks on first invocation; just restart agy.
+
+Antigravity has no session-start event and no per-prompt hook, so PLUR drives everything from `PreInvocation`: per-prompt recall is read from the conversation transcript, and the turn's memory is re-injected as an ephemeral message on every model invocation so it survives tool calls without accumulating in history.
+
+Gemini CLI users: Google is transitioning Gemini CLI to Antigravity — install `agy` and run the command above. Gemini CLI itself remains tools-only.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ npx @plur-ai/cli init --codex
 
 Registers the MCP server via `codex mcp add`, writes lifecycle hooks to `~/.codex/hooks.json`, and adds a PLUR section to `AGENTS.md`. Auto-detected when `~/.codex/` exists.
 
+Injection is BM25 by default. Hybrid (BM25 + embeddings) is implemented and opt-in via `PLUR_CODEX_HYBRID=1`, but off until [#1040](https://github.com/plur-ai/plur/issues/1040) is fixed — loading the embedder aborts the process on teardown, and Codex discards the output of any hook that exits non-zero.
+
 **One manual step after install:** open Codex, run `/hooks`, and trust the PLUR entries. Codex fingerprints every hook and refuses to run untrusted ones — *silently*, with no warning and a zero exit code. Until you trust them, memory simply never loads. `plur doctor` says so too.
 
 ### Which integration you get

--- a/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
+++ b/docs/adr/ADR-0005-postgres-tier-and-vector-index-strategy.md
@@ -80,6 +80,36 @@ exactly the ones whose engram genuinely went away.
 
 `packages/core/src/backend-selection.ts` — a pure, total function:
 
+> ### Amendment — 2026-08-27 (#1046): PGLite is opt-in; the size-selected tier is SQLite
+>
+> The ladder below shipped as designed and then failed in the field: PGLite
+> boots a full Postgres-in-WASM **per process** (~1.3s fresh, ~244ms reopen),
+> and PLUR's CLI and hooks are a fresh process per invocation — measured at
+> 0.61s (sqlite) vs 300s+ (pglite) per command on a 5,775-engram store, the
+> latter compounded by an unawaited constructor-time full-corpus resync that
+> never converged. The per-query engine was never the problem (0.135ms,
+> faster than better-sqlite3 single-row inserts); the per-process boot is
+> structural and unfixable for this process model.
+>
+> The size ladder is now **yaml → sqlite → postgres**. `SQLITE_MIN_ENGRAMS`
+> replaces `PGLITE_MIN_ENGRAMS` at the same 5,000 (that threshold was always
+> "index vs brute-force scan", which stands). PGLite is reachable only via
+> `PLUR_BACKEND=pglite` / `backend: pglite` — a capability choice (pgvector,
+> AGE) and the Postgres adapter's CI test double, never a consequence of
+> growth. The `wanted: 'postgres'` loud-fallback now lands on sqlite.
+>
+> Honesty note carried from the review: the SQLite tier is a METADATA index.
+> Vector search remains brute-force JS cosine over the in-RAM embeddings
+> cache (~768 MB at 500k × 384d fp32, more as parsed JSON), so the eventual
+> escape from that memory curve is the postgres tier's HNSW — not a larger
+> local index. §1's original complaint (the default backend built no index at
+> all) recurred once during this change and is now pinned by
+> `pglite-backend-selection.test.ts`'s "materialises its index" test.
+>
+> The table and thresholds BELOW are preserved as written for the record; the
+> Verification section's claims about `pglite-backend-selection.test.ts` now
+> hold with sqlite in place of pglite.
+
 | Tier | Store | Query | Fits |
 |---|---|---|---|
 | `yaml` | YAML file | in-memory BM25 + exact cosine | a personal store |

--- a/packages/claw/src/index.ts
+++ b/packages/claw/src/index.ts
@@ -217,19 +217,22 @@ const plugin = {
       })
     }
 
-    // 6. Register MCP server via API if available (config fallback handled by setup.ts)
-    if (typeof api.registerMcpServer === 'function') {
-      try {
-        api.registerMcpServer('plur', {
-          command: 'npx',
-          args: ['-y', '@plur-ai/mcp'],
-          env: { PLUR_PATH: path },
-        })
-        api.logger.info('PLUR: registered MCP server for agent tools')
-      } catch (err: any) {
-        api.logger.debug(`PLUR: MCP server registration skipped: ${err.message}`)
-      }
-    }
+    // 6. MCP server registration is handled entirely by setup.ts, which writes
+    //    mcp.servers.plur into the OpenClaw config (see setup.ts, "Configure MCP
+    //    server for agent-callable tools").
+    //
+    //    There used to be an `api.registerMcpServer('plur', ...)` call here,
+    //    guarded by a `typeof === 'function'` check. It was removed because
+    //    `registerMcpServer` is not part of the OpenClaw plugin API — it is
+    //    absent from 2026.7.1 — so the guard never passed and the block was
+    //    dead code. Worse, it was not harmless: the ClawHub Plugin Inspector
+    //    scans the built bundle for registration names statically, cannot see
+    //    that the call is guarded, and refused to publish with
+    //    `unknown-registration-name: claw: fixture calls a registrar missing
+    //    from target OpenClaw`. That gate blocked the plugin's release.
+    //
+    //    setup.ts writes the identical descriptor (npx -y @plur-ai/mcp with
+    //    PLUR_PATH), so removing this changes nothing at runtime.
 
     // 7. CLI commands
     if (typeof api.registerCli === 'function') {

--- a/packages/cli/src/antigravity-hooks.ts
+++ b/packages/cli/src/antigravity-hooks.ts
@@ -1,0 +1,121 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+
+/**
+ * Support for Antigravity CLI's `hooks.json` (`~/.gemini/config/hooks.json`).
+ *
+ * A third config shape, different from both Claude Code/Codex (nested
+ * `hooks → Event → [{matcher, hooks}]`) and Cursor (flat `hooks → event →
+ * [spec]`): the top level is a map of NAMED HOOK SETS, each holding its
+ * events. Tool events (`PreToolUse`/`PostToolUse`) wrap handlers in a
+ * `{matcher, hooks: []}` group; lifecycle events (`PreInvocation`,
+ * `PostInvocation`, `Stop`) take a flat handler array. Source:
+ * `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/hooks.md`
+ * (the CLI's own bundled reference), confirmed live against agy 1.1.21.
+ *
+ * The named-set structure makes ownership trivial compared to the other
+ * harnesses: PLUR owns exactly one top-level key (`plur-memory`) and never
+ * touches any other. No command-string fingerprinting needed.
+ *
+ * Install location is the GLOBAL config dir, deliberately. Workspace
+ * discovery (`.agents/hooks.json`, walked up to the repo root) exists but
+ * did not load in `--print` mode during live probing — `loaded 0 named
+ * hooks` with `workspacePaths: []` — while `~/.gemini/config/hooks.json`
+ * loaded immediately. Global also matches how PLUR is installed everywhere
+ * else: one store, one memory, every project.
+ */
+
+/** PLUR's top-level key in hooks.json — the whole ownership story. */
+export const AGY_HOOK_SET_NAME = 'plur-memory'
+
+export interface AgyHookHandler {
+  type?: 'command'
+  command: string
+  timeout?: number
+}
+
+export interface AgyToolHookGroup {
+  matcher: string
+  hooks: AgyHookHandler[]
+}
+
+export interface AgyHookSet {
+  enabled?: boolean
+  PreInvocation?: AgyHookHandler[]
+  PostInvocation?: AgyHookHandler[]
+  Stop?: AgyHookHandler[]
+  PreToolUse?: AgyToolHookGroup[]
+  PostToolUse?: AgyToolHookGroup[]
+}
+
+export type AgyHooksConfig = Record<string, AgyHookSet>
+
+/**
+ * Build PLUR's hook set, given the resolved shim/CLI command.
+ *
+ * Two hooks only:
+ *
+ * - `PreInvocation` carries everything context-shaped: the session-open
+ *   batch, per-prompt recall (via the transcript — the payload has no prompt
+ *   text), and the periodic learn nudge. There is no SessionStart event and
+ *   no end-of-turn context channel, so this one event is the entire
+ *   injection surface.
+ * - `PreToolUse` is the session guard, and also where the sentinel is
+ *   marked when `plur_session_start` itself passes through — PostToolUse's
+ *   payload carries no tool name (`stepIdx` + `error` only, per the bundled
+ *   docs), so detection has to happen on the way IN.
+ *
+ * Deliberately absent: `PostToolUse` (can only output `{}` — nothing to do),
+ * and `Stop` (its only power is `decision: "continue"`, which BLOCKS
+ * termination and forces another loop — never acceptable for a memory
+ * nudge).
+ *
+ * Timeouts are SECONDS (agy default 30). PreInvocation gets 20 to cover
+ * injectWithFallback's bounded worst case (~10s hybrid deadline + BM25);
+ * hooks are synchronous-only in agy ("no async execution" — bundled docs),
+ * so the same no-async rule as Codex applies without needing a regression
+ * test: there is no flag to accidentally set.
+ */
+export function buildAgyHookSet(cmd: string): AgyHookSet {
+  return {
+    enabled: true,
+    PreInvocation: [
+      { type: 'command', command: `${cmd} hook-agy-pre-invocation`, timeout: 20 },
+    ],
+    PreToolUse: [
+      {
+        matcher: '*',
+        hooks: [{ type: 'command', command: `${cmd} hook-agy-guard`, timeout: 5 }],
+      },
+    ],
+  }
+}
+
+export function hasPlurAgyHooks(config: AgyHooksConfig): boolean {
+  return Object.prototype.hasOwnProperty.call(config, AGY_HOOK_SET_NAME)
+}
+
+/**
+ * Idempotent merge: replace PLUR's named set, touch nothing else. A user's
+ * own hook sets — whatever their names — pass through byte-identical.
+ */
+export function mergeAgyHooks(config: AgyHooksConfig, plurSet: AgyHookSet): AgyHooksConfig {
+  return { ...config, [AGY_HOOK_SET_NAME]: plurSet }
+}
+
+export function readAgyHooksConfig(path: string): AgyHooksConfig {
+  if (!existsSync(path)) return {}
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
+    return (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+      ? parsed as AgyHooksConfig
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+export function writeAgyHooksConfig(path: string, config: AgyHooksConfig): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(config, null, 2) + '\n')
+}

--- a/packages/cli/src/antigravity-hooks.ts
+++ b/packages/cli/src/antigravity-hooks.ts
@@ -71,7 +71,8 @@ export type AgyHooksConfig = Record<string, AgyHookSet>
  * nudge).
  *
  * Timeouts are SECONDS (agy default 30). PreInvocation gets 20 to cover
- * injectWithFallback's bounded worst case (~10s hybrid deadline + BM25);
+ * injectWithFallback's bounded worst case (8s hybrid deadline, then a BM25
+ * pass — ~10s total measured);
  * hooks are synchronous-only in agy ("no async execution" — bundled docs),
  * so the same no-async rule as Codex applies without needing a regression
  * test: there is no flag to accidentally set.

--- a/packages/cli/src/codex-hooks.ts
+++ b/packages/cli/src/codex-hooks.ts
@@ -60,7 +60,7 @@ export function buildCodexHooks(cmd: string): Record<string, CodexHookEntry[]> {
         hooks: [{
           type: 'command',
           command: `${cmd} hook-codex-session-start`,
-          timeout: 15,
+          timeout: 25,
           statusMessage: 'PLUR: loading memory',
         }],
       },
@@ -73,7 +73,7 @@ export function buildCodexHooks(cmd: string): Record<string, CodexHookEntry[]> {
         hooks: [{
           type: 'command',
           command: `${cmd} hook-codex-inject`,
-          timeout: 15,
+          timeout: 25,
           statusMessage: 'PLUR: recalling',
         }],
       },

--- a/packages/cli/src/codex-hooks.ts
+++ b/packages/cli/src/codex-hooks.ts
@@ -42,11 +42,10 @@ export interface CodexHooksConfig {
  * 0.149.1 (they were silently skipped in 0.146.0), but an async hook's
  * `additionalContext` is delivered at the "next safe point" — i.e. NOT to
  * the turn that triggered it. For a `codex exec` one-shot that means never.
- * Claude Code's `hook-inject` is async with a 90s timeout precisely because
- * hybrid search cold-starts the BGE embedder; that trade does not transfer.
- * These hooks are synchronous and BM25-only instead, the same call
- * `hook-cursor-session-start` makes for the same reason. `codex-hooks.test.ts`
- * asserts this invariant.
+ * Claude Code's `hook-inject` is async with a 90s timeout to absorb a slow
+ * hybrid pass; that trade does not transfer. These hooks are synchronous —
+ * hybrid-first with a BM25 fallback on a soft deadline (`injectWithFallback`)
+ * — and `codex-hooks.test.ts` asserts the no-async invariant.
  *
  * Timeouts are SECONDS here (Codex's unit), not the milliseconds Gemini CLI
  * uses. Codex's own default is 600s; ours are deliberately tight so a wedged
@@ -98,9 +97,12 @@ export function buildCodexHooks(cmd: string): Record<string, CodexHookEntry[]> {
       },
     ],
 
-    // Close the memory lifecycle. Codex clamps SessionEnd timeouts to 3s and
-    // forces them synchronous, so this must stay cheap — it captures the
-    // closing episode and cleans up the sentinel, nothing more.
+    // Session cleanup. Codex clamps SessionEnd timeouts to 3s and forces
+    // them synchronous, so this must stay cheap: it removes the sentinel and
+    // counters, NOTHING more — it deliberately does not capture a closing
+    // episode (being killed mid-write at the 3s clamp is worse than not
+    // writing; see hook-codex-session-end's docstring). Closing the memory
+    // lifecycle properly is the agent's job via plur_session_end.
     SessionEnd: [
       {
         hooks: [{ type: 'command', command: `${cmd} hook-codex-session-end`, timeout: 3 }],

--- a/packages/cli/src/codex-hooks.ts
+++ b/packages/cli/src/codex-hooks.ts
@@ -1,0 +1,194 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+
+/**
+ * Support for Codex's `~/.codex/hooks.json`.
+ *
+ * Structurally IDENTICAL to Claude Code's `.claude/settings.json` hooks
+ * section — `hooks[event]` is an array of `{matcher, hooks: [...]}` wrapper
+ * objects — which is why this file can be so much smaller than
+ * `cursor-hooks.ts` (Cursor nests one level shallower and needed its own
+ * merge implementation).
+ *
+ * Codex accepts hooks from either `~/.codex/hooks.json` or a `[hooks]` table
+ * in `~/.codex/config.toml`, and warns when both exist for the same layer
+ * ("loading hooks from both … prefer a single representation"). We write the
+ * JSON file: it needs no TOML dependency, it reuses the shape the Claude
+ * Code builders already emit, and it keeps PLUR's hooks out of the file the
+ * user hand-edits for models and MCP servers.
+ */
+
+export interface CodexHookSpec {
+  type: 'command'
+  command: string
+  timeout?: number
+  statusMessage?: string
+}
+
+export interface CodexHookEntry {
+  matcher?: string
+  hooks: CodexHookSpec[]
+}
+
+export interface CodexHooksConfig {
+  description?: string
+  hooks: Record<string, CodexHookEntry[]>
+}
+
+/**
+ * Build PLUR's Codex hook contribution, given the resolved shim/CLI command.
+ *
+ * NOTHING HERE MAY SET `async: true`. Codex does support async hooks as of
+ * 0.149.1 (they were silently skipped in 0.146.0), but an async hook's
+ * `additionalContext` is delivered at the "next safe point" — i.e. NOT to
+ * the turn that triggered it. For a `codex exec` one-shot that means never.
+ * Claude Code's `hook-inject` is async with a 90s timeout precisely because
+ * hybrid search cold-starts the BGE embedder; that trade does not transfer.
+ * These hooks are synchronous and BM25-only instead, the same call
+ * `hook-cursor-session-start` makes for the same reason. `codex-hooks.test.ts`
+ * asserts this invariant.
+ *
+ * Timeouts are SECONDS here (Codex's unit), not the milliseconds Gemini CLI
+ * uses. Codex's own default is 600s; ours are deliberately tight so a wedged
+ * hook cannot hang a turn.
+ */
+export function buildCodexHooks(cmd: string): Record<string, CodexHookEntry[]> {
+  return {
+    // Session open: mark the sentinel and inject an initial batch.
+    SessionStart: [
+      {
+        hooks: [{
+          type: 'command',
+          command: `${cmd} hook-codex-session-start`,
+          timeout: 15,
+          statusMessage: 'PLUR: loading memory',
+        }],
+      },
+    ],
+
+    // Per-prompt injection — the load-bearing hook. Verified reaching the
+    // model on codex-cli 0.149.1.
+    UserPromptSubmit: [
+      {
+        hooks: [{
+          type: 'command',
+          command: `${cmd} hook-codex-inject`,
+          timeout: 15,
+          statusMessage: 'PLUR: recalling',
+        }],
+      },
+    ],
+
+    // Session guard. Codex accepts `permissionDecision: "deny"` from a
+    // PreToolUse hook and surfaces the reason to the model (verified), but
+    // REJECTS "allow" and "ask" — so, exactly like the Cursor guard, this
+    // only ever denies or stays silent.
+    PreToolUse: [
+      {
+        matcher: '.*',
+        hooks: [{ type: 'command', command: `${cmd} hook-codex-guard`, timeout: 5 }],
+      },
+    ],
+
+    // Sentinel + periodic learn nudge.
+    PostToolUse: [
+      {
+        matcher: '.*',
+        hooks: [{ type: 'command', command: `${cmd} hook-codex-post-tool`, timeout: 10 }],
+      },
+    ],
+
+    // Close the memory lifecycle. Codex clamps SessionEnd timeouts to 3s and
+    // forces them synchronous, so this must stay cheap — it captures the
+    // closing episode and cleans up the sentinel, nothing more.
+    SessionEnd: [
+      {
+        hooks: [{ type: 'command', command: `${cmd} hook-codex-session-end`, timeout: 3 }],
+      },
+    ],
+  }
+}
+
+/** The exact set of subcommands `buildCodexHooks()` installs. */
+const PLUR_CODEX_SUBCOMMANDS = [
+  'hook-codex-session-start',
+  'hook-codex-inject',
+  'hook-codex-guard',
+  'hook-codex-post-tool',
+  'hook-codex-session-end',
+]
+
+/**
+ * A hook is PLUR's only if it BOTH names the PLUR binary AND invokes one of
+ * PLUR's exact subcommands — the same two-part test `cursor-hooks.ts` uses,
+ * and for the same reason: matching on a bare `hook-codex-` substring would
+ * claim a user's own `./scripts/hook-codex-lint.sh` and silently delete it
+ * on the next `plur init --codex`.
+ */
+function isPlurCodexHookSpec(spec: CodexHookSpec): boolean {
+  const cmd = spec?.command ?? ''
+  const isPlurBinary = cmd.includes('@plur-ai/cli') || cmd.includes('plur-hook')
+  if (!isPlurBinary) return false
+  return PLUR_CODEX_SUBCOMMANDS.some((sub) => cmd.includes(sub))
+}
+
+function entryIsPlurOwned(entry: CodexHookEntry): boolean {
+  return (entry?.hooks ?? []).some(isPlurCodexHookSpec)
+}
+
+export function hasPlurCodexHooks(config: CodexHooksConfig): boolean {
+  return Object.values(config.hooks ?? {}).some(entries => (entries ?? []).some(entryIsPlurOwned))
+}
+
+/**
+ * Drop PLUR's own entries, preserving everything else — including a
+ * user-authored hook that happens to sit in the same event array, and a
+ * mixed entry where only some specs are ours.
+ */
+function stripPlurCodexHooks(config: CodexHooksConfig): CodexHooksConfig {
+  const hooks: Record<string, CodexHookEntry[]> = {}
+  for (const [event, entries] of Object.entries(config.hooks ?? {})) {
+    const kept: CodexHookEntry[] = []
+    for (const entry of entries ?? []) {
+      const specs = (entry?.hooks ?? []).filter(s => !isPlurCodexHookSpec(s))
+      // An entry whose specs were ALL ours disappears; one that still has
+      // foreign specs survives with only those.
+      if (specs.length > 0) kept.push({ ...entry, hooks: specs })
+    }
+    if (kept.length > 0) hooks[event] = kept
+  }
+  return { ...config, hooks }
+}
+
+/** Idempotent — strips existing PLUR entries before adding the current set (upgrade-safe). */
+export function mergeCodexHooks(
+  config: CodexHooksConfig,
+  additions: Record<string, CodexHookEntry[]>,
+): CodexHooksConfig {
+  const clean = stripPlurCodexHooks(config)
+  const hooks = { ...(clean.hooks ?? {}) }
+  for (const [event, entries] of Object.entries(additions)) {
+    hooks[event] = [...(hooks[event] ?? []), ...entries]
+  }
+  return { ...clean, hooks }
+}
+
+export function readCodexHooksConfig(path: string): CodexHooksConfig {
+  if (!existsSync(path)) return { hooks: {} }
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<CodexHooksConfig>
+    return { ...parsed, hooks: parsed.hooks ?? {} }
+  } catch {
+    return { hooks: {} }
+  }
+}
+
+export function writeCodexHooksConfig(path: string, config: CodexHooksConfig): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const out: CodexHooksConfig = {
+    ...config,
+    description: config.description
+      ?? 'Hook configuration (PLUR memory hooks managed by `plur init --codex`)',
+  }
+  writeFileSync(path, JSON.stringify(out, null, 2) + '\n')
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -17,6 +17,7 @@ import {
 } from '../mcp-config.js'
 import { hasPlurCursorHooks, readCursorHooksConfig } from '../cursor-hooks.js'
 import { hasPlurCodexHooks, readCodexHooksConfig } from '../codex-hooks.js'
+import { hasPlurAgyHooks, readAgyHooksConfig } from '../antigravity-hooks.js'
 import { codexHome } from '../mcp-config.js'
 import { computeContentHash, detectPlurStorage, loadEngrams } from '@plur-ai/core'
 
@@ -107,6 +108,13 @@ interface DoctorReport {
    */
   codexDetected: boolean
   codexWired: boolean
+  /**
+   * Antigravity CLI (agy). Same machine-level detection rationale as Codex —
+   * reported as its own line, deliberately NOT folded into `overall`. Unlike
+   * Codex there is no trust caveat: agy runs configured hooks immediately.
+   */
+  agyDetected: boolean
+  agyWired: boolean
   /**
    * PGLite backend running the opt-in embedding-gemma embedder (#581). #483
    * corrected embedding-gemma's role prefixes and bumped the JSON embedding
@@ -280,6 +288,19 @@ function inspectConfigs(): ConfigFileReport[] {
         hasPlurMcp: false,
         hasDatacoreMcp: false,
         hasPlurHooks: hasPlurCursorHooks(hooksConfig),
+      }
+    }
+    if (cf.kind === 'agy-hooks') {
+      // agy's hooks.json is a map of NAMED hook sets — neither Claude Code's
+      // nested shape nor Cursor's flat one. PLUR-present = our named key exists.
+      const hooksConfig = readAgyHooksConfig(cf.path)
+      return {
+        label: cf.label,
+        path: cf.path,
+        exists: true,
+        hasPlurMcp: false,
+        hasDatacoreMcp: false,
+        hasPlurHooks: hasPlurAgyHooks(hooksConfig),
       }
     }
     if (cf.kind === 'codex-hooks') {
@@ -689,6 +710,15 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     codexTomlReport?.exists && codexTomlReport.hasPlurMcp,
   )
 
+  // Antigravity health, from agy's OWN two files only.
+  const agyDetected = existsSync(join(homedir(), '.gemini', 'antigravity-cli'))
+  const agyHooksReport = configs.find((c) => c.label === 'Antigravity (~/.gemini/config/hooks.json)')
+  const agyMcpReport = configs.find((c) => c.label === 'Antigravity (~/.gemini/config/mcp_config.json)')
+  const agyWired = Boolean(
+    agyHooksReport?.exists && agyHooksReport.hasPlurHooks &&
+    agyMcpReport?.exists && agyMcpReport.hasPlurMcp,
+  )
+
   const handshakePromise = skipHandshake
     ? Promise.resolve({ ok: false, error: 'skipped (--no-handshake)' })
     : mcpHandshake()
@@ -742,7 +772,7 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     return {
       configs, hooksInstalled, mcpRegistered, datacoreCollision, staleNpxHooks, staleNpxMcp,
       hookShim, mcpShim, handshake, cursorHandshake, embedder,
-      cursorProjectDetected, cursorWired, codexDetected, codexWired,
+      cursorProjectDetected, cursorWired, codexDetected, codexWired, agyDetected, agyWired,
       pgliteGemmaReembedNeeded, staleContentHashes, overall,
     }
   })
@@ -760,7 +790,7 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
 export function printText(report: DoctorReport, flags?: GlobalFlags): void {
   const tick = (b: boolean) => (b ? '✓' : '✗')
 
-  outputInfo('plur doctor — Claude Code / Claude Desktop / Cursor / Codex diagnostic', flags)
+  outputInfo('plur doctor — Claude Code / Claude Desktop / Cursor / Codex / Antigravity diagnostic', flags)
   outputInfo('', flags)
   outputText('Config files:')
   for (const c of report.configs) {
@@ -786,6 +816,15 @@ export function printText(report: DoctorReport, flags?: GlobalFlags): void {
       outputText('  A Claude Code config being healthy elsewhere does NOT cover Cursor —')
       outputText('  this project has a .cursor/ directory but its own config is incomplete.')
       outputText('  Fix: run `plur init --cursor` from this project.')
+    }
+  }
+
+  if (report.agyDetected) {
+    outputText(`${tick(report.agyWired)} Antigravity: ~/.gemini/config hooks.json + mcp_config.json wired to plur`)
+    if (!report.agyWired) {
+      outputText('  Antigravity CLI (agy) is installed but PLUR is not wired into it — it')
+      outputText('  would get no injection, enforcement, or learn nudges. If you use agy,')
+      outputText('  run `plur init --antigravity`. (Advisory: does not fail the check above.)')
     }
   }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -16,6 +16,8 @@ import {
   readConfig,
 } from '../mcp-config.js'
 import { hasPlurCursorHooks, readCursorHooksConfig } from '../cursor-hooks.js'
+import { hasPlurCodexHooks, readCodexHooksConfig } from '../codex-hooks.js'
+import { codexHome } from '../mcp-config.js'
 import { computeContentHash, detectPlurStorage, loadEngrams } from '@plur-ai/core'
 
 /**
@@ -86,6 +88,25 @@ interface DoctorReport {
    */
   cursorProjectDetected: boolean
   cursorWired: boolean
+  /**
+   * Whether Codex is installed on this machine (`~/.codex/` exists, honouring
+   * `CODEX_HOME`) and, if so, whether Codex's OWN two config files have PLUR
+   * wired in — `hooks.json` carrying our hooks, `config.toml` carrying the
+   * `[mcp_servers.plur]` table. Same rationale as `cursorWired`: a healthy
+   * Claude Code setup elsewhere says nothing about this harness.
+   *
+   * Reported as its own line and deliberately NOT folded into `overall` —
+   * see the comment at the `overall` computation for why a machine-level
+   * detection must not fail a project-level health check.
+   *
+   * NOTE: `codexWired: true` does NOT mean the hooks will actually run. Codex
+   * fingerprints every non-managed hook and skips it until reviewed via
+   * `/hooks`, with no warning and exit 0 when it doesn't — a state nothing on
+   * disk distinguishes from a trusted one. `printText` says so explicitly
+   * rather than letting a green tick imply more than it knows.
+   */
+  codexDetected: boolean
+  codexWired: boolean
   /**
    * PGLite backend running the opt-in embedding-gemma embedder (#581). #483
    * corrected embedding-gemma's role prefixes and bumped the JSON embedding
@@ -259,6 +280,39 @@ function inspectConfigs(): ConfigFileReport[] {
         hasPlurMcp: false,
         hasDatacoreMcp: false,
         hasPlurHooks: hasPlurCursorHooks(hooksConfig),
+      }
+    }
+    if (cf.kind === 'codex-hooks') {
+      const hooksConfig = readCodexHooksConfig(cf.path)
+      return {
+        label: cf.label,
+        path: cf.path,
+        exists: true,
+        hasPlurMcp: false,
+        hasDatacoreMcp: false,
+        hasPlurHooks: hasPlurCodexHooks(hooksConfig),
+      }
+    }
+    if (cf.kind === 'codex-toml') {
+      // config.toml is TOML, not JSON — readConfig() would return {} and the
+      // report would claim Codex has no MCP server registered even when it
+      // does. We only need one fact from this file (is there an
+      // `[mcp_servers.plur]` table?), which a targeted regex answers without
+      // pulling in a TOML parser. Deliberately narrow: a commented-out line
+      // must not count, and neither must `[mcp_servers.plurality]`.
+      let hasPlur = false
+      try {
+        const raw = readFileSync(cf.path, 'utf8')
+        hasPlur = /^\s*\[mcp_servers\.plur\]\s*$/m.test(raw)
+          || /^\s*\[mcp_servers\]/m.test(raw) && /^\s*plur\s*=/m.test(raw)
+      } catch { /* unreadable — report as absent */ }
+      return {
+        label: cf.label,
+        path: cf.path,
+        exists: true,
+        hasPlurMcp: hasPlur,
+        hasDatacoreMcp: false,
+        hasPlurHooks: false,
       }
     }
     const config = readConfig(cf.path)
@@ -626,6 +680,15 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     cursorHooksConfigReport?.exists && cursorHooksConfigReport.hasPlurHooks,
   )
 
+  // Codex health, from Codex's OWN two files only.
+  const codexDetected = existsSync(codexHome())
+  const codexHooksReport = configs.find((c) => c.label === 'Codex (~/.codex/hooks.json)')
+  const codexTomlReport = configs.find((c) => c.label === 'Codex (~/.codex/config.toml)')
+  const codexWired = Boolean(
+    codexHooksReport?.exists && codexHooksReport.hasPlurHooks &&
+    codexTomlReport?.exists && codexTomlReport.hasPlurMcp,
+  )
+
   const handshakePromise = skipHandshake
     ? Promise.resolve({ ok: false, error: 'skipped (--no-handshake)' })
     : mcpHandshake()
@@ -650,8 +713,18 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     // the overall doctor check (BM25 still works); it just signals semantic
     // recall is disabled until the model loads.
     const overall: 'ok' | 'fail' =
-      hooksInstalled && mcpRegistered && (skipHandshake || handshake.ok) && (!cursorProjectDetected || cursorWired)
+      hooksInstalled && mcpRegistered && (skipHandshake || handshake.ok) &&
+      (!cursorProjectDetected || cursorWired)
         ? 'ok' : 'fail'
+    // NOTE: codexWired is deliberately NOT in `overall`, unlike cursorWired.
+    // The two detections are not the same kind of signal. A `.cursor/`
+    // directory sits IN THIS PROJECT and says "the user works on this
+    // project in Cursor", so an unwired Cursor there is a genuine failure.
+    // `~/.codex/` is machine-level: it says the user has Codex installed
+    // somewhere, not that they use it here. Folding it into `overall` would
+    // turn doctor red for every Claude-Code-only user who once tried Codex —
+    // a false alarm on a check whose whole value is that a red result means
+    // something. It is reported as its own line instead.
     // #581: PGLite + embedding-gemma both opt-in via env (PLUR_BACKEND=pglite,
     // PLUR_EMBEDDER=embedding-gemma) — the documented activation for each. When
     // both are set, #483's prefix fix did not auto-rebuild the PGLite vectors
@@ -669,7 +742,8 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     return {
       configs, hooksInstalled, mcpRegistered, datacoreCollision, staleNpxHooks, staleNpxMcp,
       hookShim, mcpShim, handshake, cursorHandshake, embedder,
-      cursorProjectDetected, cursorWired, pgliteGemmaReembedNeeded, staleContentHashes, overall,
+      cursorProjectDetected, cursorWired, codexDetected, codexWired,
+      pgliteGemmaReembedNeeded, staleContentHashes, overall,
     }
   })
 }
@@ -686,7 +760,7 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
 export function printText(report: DoctorReport, flags?: GlobalFlags): void {
   const tick = (b: boolean) => (b ? '✓' : '✗')
 
-  outputInfo('plur doctor — Claude Code / Claude Desktop / Cursor diagnostic', flags)
+  outputInfo('plur doctor — Claude Code / Claude Desktop / Cursor / Codex diagnostic', flags)
   outputInfo('', flags)
   outputText('Config files:')
   for (const c of report.configs) {
@@ -712,6 +786,27 @@ export function printText(report: DoctorReport, flags?: GlobalFlags): void {
       outputText('  A Claude Code config being healthy elsewhere does NOT cover Cursor —')
       outputText('  this project has a .cursor/ directory but its own config is incomplete.')
       outputText('  Fix: run `plur init --cursor` from this project.')
+    }
+  }
+
+  if (report.codexDetected) {
+    outputText(`${tick(report.codexWired)} Codex: ~/.codex/hooks.json + config.toml wired to plur`)
+    if (!report.codexWired) {
+      outputText('  Codex is installed on this machine but PLUR is not wired into it — it')
+      outputText('  would get MCP tools with no injection, enforcement, or learn nudges.')
+      outputText('  If you use Codex, run `plur init --codex`. (Advisory: this does not')
+      outputText('  fail the check above — having Codex installed is not the same as')
+      outputText('  using it on this project.)')
+    } else {
+      // A green tick here is genuinely weaker than it looks, so say so every
+      // time rather than only on failure. Codex skips untrusted hooks with
+      // NO warning and exit 0, and nothing on disk distinguishes trusted
+      // from untrusted — so a config that reads as perfect can still be
+      // completely inert. This is the single most likely reason a user
+      // reports "I ran plur init --codex and nothing happens".
+      outputText('  Note: wired ≠ running. Codex skips hooks it has not been told to trust,')
+      outputText('  silently. If memory never loads, open Codex, run /hooks, and trust the')
+      outputText('  PLUR entries.')
     }
   }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -533,9 +533,14 @@ function resolveCliJsEntry(): string | null {
  *
  * Timeout: 60s default (#273). Cold model downloads (130MB for bge-small,
  * 325MB for embedding-gemma) need 60-300s on slow connections. Override via
- * PLUR_DOCTOR_TIMEOUT env var (in seconds) if 60s is still too short.
+ * PLUR_DOCTOR_TIMEOUT env var (in seconds) if 300s is still too short.
  */
-const DEFAULT_PROBE_TIMEOUT_MS = 60_000
+// 300s, not 60s (data-loss audit F6): on a FRESH install this probe is the
+// only sanctioned path that downloads the ~133MB embedding model — the hooks
+// race an 8s deadline and force-exit, so they can never complete it, and
+// there is no resume. 60s required >2.2MB/s; a slower connection made hybrid
+// permanently unavailable with nothing ever able to finish the fetch.
+const DEFAULT_PROBE_TIMEOUT_MS = 300_000
 
 /**
  * Resolve the probe timeout from PLUR_DOCTOR_TIMEOUT (seconds). Invalid values
@@ -816,6 +821,22 @@ export function printText(report: DoctorReport, flags?: GlobalFlags): void {
       outputText('  A Claude Code config being healthy elsewhere does NOT cover Cursor —')
       outputText('  this project has a .cursor/ directory but its own config is incomplete.')
       outputText('  Fix: run `plur init --cursor` from this project.')
+    }
+  }
+
+  {
+    // #1046 migration signal: PGLite is no longer size-selected, so a store
+    // that auto-built one now runs SQLite and the old directory is orphaned
+    // disk (60–500MB observed). This advisory is the only signal the
+    // affected cohort gets — the runtime opt-in log line deliberately fires
+    // only for explicit selections.
+    const pglitePath = join(process.env.PLUR_PATH || join(homedir(), '.plur'), 'store.pglite')
+    const pgliteExplicit = process.env.PLUR_BACKEND?.trim().toLowerCase() === 'pglite'
+    if (existsSync(pglitePath) && !pgliteExplicit) {
+      outputText('')
+      outputText(`ℹ  ${pglitePath} exists but PGLite is no longer selected by store size (v0.19).`)
+      outputText('   If you have not set backend: pglite deliberately, this directory is an')
+      outputText('   orphaned index and can be deleted — YAML remains the source of truth.')
     }
   }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -835,9 +835,9 @@ export function printText(report: DoctorReport, flags?: GlobalFlags): void {
     if (existsSync(pglitePath) && !pgliteExplicit) {
       outputText('')
       outputText(`ℹ  ${pglitePath} exists but PGLite is no longer selected by store size (v0.19).`)
-      outputText('   If you have not set backend: pglite deliberately, run `plur migrate` once —')
-      outputText('   it carries your embedding vectors into the new tier\'s cache (skipping the')
-      outputText('   background re-embed) — then delete the directory. YAML remains the source of truth.')
+      outputText('   Nothing to do — embeddings rebuild automatically — and this directory is an')
+      outputText('   orphaned index you can delete whenever convenient. YAML remains the source of')
+      outputText('   truth. (Optional: `plur migrate` ports the old vectors over, skipping the rebuild.)')
     }
   }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -835,8 +835,9 @@ export function printText(report: DoctorReport, flags?: GlobalFlags): void {
     if (existsSync(pglitePath) && !pgliteExplicit) {
       outputText('')
       outputText(`ℹ  ${pglitePath} exists but PGLite is no longer selected by store size (v0.19).`)
-      outputText('   If you have not set backend: pglite deliberately, this directory is an')
-      outputText('   orphaned index and can be deleted — YAML remains the source of truth.')
+      outputText('   If you have not set backend: pglite deliberately, run `plur migrate` once —')
+      outputText('   it carries your embedding vectors into the new tier\'s cache (skipping the')
+      outputText('   background re-embed) — then delete the directory. YAML remains the source of truth.')
     }
   }
 

--- a/packages/cli/src/commands/hook-agy-guard.ts
+++ b/packages/cli/src/commands/hook-agy-guard.ts
@@ -1,0 +1,96 @@
+import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+import {
+  readStdinJson,
+  runAgyHook,
+  isPlurSessionStartTool,
+  agyConversationId,
+  agyIsSessionStarted,
+  agyMarkSessionStarted,
+  agyIncrementCounter,
+  agyCounterPath,
+} from '../lib/agy-hook-io.js'
+
+/**
+ * plur hook-agy-guard — Antigravity `PreToolUse` hook.
+ *
+ * Session guard: deny tool calls until `plur_session_start` has run, with
+ * the same one-nudge-then-give-up deadlock protection as the Claude Code
+ * (#199), Cursor and Codex guards. Verified live on agy 1.1.21: a
+ * `{"decision":"deny","reason":...}` output blocks the tool and the reason
+ * reaches the model ("tool call denied by pre-tool hook: ...").
+ *
+ * Differences from the Codex guard worth knowing:
+ *
+ * - The verdict is FLAT `{decision, reason}` — no hookSpecificOutput
+ *   envelope — and agy accepts `allow`/`ask`/`force_ask` too. We still only
+ *   ever deny or stay silent: emitting `allow` would bypass agy's own
+ *   permission prompting for tools PLUR has no opinion about.
+ * - The sentinel is marked HERE when `plur_session_start` itself passes
+ *   through, because agy's PostToolUse payload carries no tool name
+ *   (stepIdx + error only) — there is no after-the-fact detection point.
+ *   Marking on the way in is slightly optimistic (the user could still
+ *   refuse the permission prompt), which costs at most one un-nudged
+ *   session — the same trade every guard in this codebase already makes.
+ * - In practice this guard rarely fires a deny at all: PreInvocation runs
+ *   before any tool call and already marks the session. Its job is the path
+ *   where PreInvocation somehow didn't run (hook disabled mid-session,
+ *   config raced) — belt, not braces.
+ * - Tool names are lowercased step types (`run_command`, `view_file`). How
+ *   MCP tools are named in `toolCall.name` is NOT yet verified against a
+ *   live MCP call; `isPlurSessionStartTool` matches on the
+ *   `plur_session_start` suffix, which survives any prefixing scheme.
+ *
+ * GATING: same install-is-the-opt-in rule as hook-agy-pre-invocation, and
+ * for the same reason — agy runs hooks with cwd = the hooks.json directory,
+ * where a project-config walk can never succeed. When the payload names a
+ * workspace, a project-level opt-out is honoured.
+ *
+ * Input:  camelCase JSON — { conversationId, toolCall: { name, args }, stepIdx, ... }
+ * Output: {"decision":"deny","reason":"..."} or nothing.
+ */
+
+const MAX_BLOCKS_BEFORE_FALLBACK = 1
+
+export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
+  await runAgyHook('agy guard', async () => {
+    const input = readStdinJson()
+
+    const workspaces = Array.isArray(input.workspacePaths) ? input.workspacePaths as string[] : []
+    if (workspaces.length > 0 && typeof workspaces[0] === 'string' && !isPlurConfigured(workspaces[0])) return
+
+    const toolCall = (input.toolCall && typeof input.toolCall === 'object')
+      ? input.toolCall as Record<string, unknown>
+      : {}
+    const toolName = String(toolCall.name ?? '')
+
+    const conversationId = agyConversationId(input)
+    if (!conversationId) return // can't track — allow through rather than block blind
+
+    if (isPlurSessionStartTool(toolName)) {
+      agyMarkSessionStarted(conversationId)
+      return
+    }
+
+    if (agyIsSessionStarted(conversationId)) return
+
+    const blockCount = agyIncrementCounter(agyCounterPath(conversationId, 'guard-count'))
+    if (blockCount > MAX_BLOCKS_BEFORE_FALLBACK) {
+      agyMarkSessionStarted(conversationId)
+      process.stderr.write(
+        `[plur] guard: allowing tools after ${MAX_BLOCKS_BEFORE_FALLBACK} nudge(s) without an ` +
+        'explicit session start. Marking the session started so memory can resume in degraded ' +
+        'mode. If plur_session_start never ran, the MCP server may be down — run `plur doctor`.\n',
+      )
+      return
+    }
+
+    process.stdout.write(JSON.stringify({
+      decision: 'deny',
+      reason:
+        'PLUR: call plur_session_start once with a short task description before using other ' +
+        'tools, so this session has memory. This stops blocking as soon as that call succeeds, ' +
+        'and only nudges once even if it does not.',
+    }))
+  })
+}

--- a/packages/cli/src/commands/hook-agy-pre-invocation.ts
+++ b/packages/cli/src/commands/hook-agy-pre-invocation.ts
@@ -1,4 +1,3 @@
-import { readFileSync, writeFileSync } from 'fs'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { isPlurConfigured } from '../lib/plur-configured.js'
 import {
@@ -9,6 +8,9 @@ import {
   agyMarkSessionStarted,
   agyCounterPath,
   agyIncrementCounter,
+  agyTextHash,
+  readAgyTurnCache,
+  writeAgyTurnCache,
   lastUserInput,
   emitInjectSteps,
 } from '../lib/agy-hook-io.js'
@@ -41,6 +43,17 @@ import { readProjectConfig } from '@plur-ai/core'
  *    turn — recall runs once per user message, visibility lasts the whole
  *    turn, and nothing accumulates in history because ephemerals never do.
  *
+ *    Turn identity is (step_index, text hash), not step_index alone: the
+ *    transcript is Antigravity's internal format, and if step_index ever
+ *    disappears or restarts, a step-only comparison freezes on turn one and
+ *    replays it forever (data-loss audit M6/F10). The text hash breaks that
+ *    tie — a different user message is a new turn regardless of what the
+ *    step counter says. When the transcript itself is unreadable, the cached
+ *    turn is replayed (there is no way to detect a turn boundary without
+ *    it), with a stderr line saying so — replaying stale-but-real memory
+ *    beats injecting nothing, and the log distinguishes it from healthy
+ *    mid-turn replay.
+ *
  * GATING: unlike the Claude Code/Cursor/Codex hooks, this does not silently
  * no-op when the cwd has no PLUR project config — agy runs hooks with cwd =
  * the directory containing hooks.json (~/.gemini/config), where
@@ -61,7 +74,8 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     const input = readStdinJson()
 
     const workspaces = Array.isArray(input.workspacePaths) ? input.workspacePaths as string[] : []
-    if (workspaces.length > 0 && typeof workspaces[0] === 'string' && !isPlurConfigured(workspaces[0])) return
+    const workspace = (workspaces.length > 0 && typeof workspaces[0] === 'string') ? workspaces[0] : null
+    if (workspace && !isPlurConfigured(workspace)) return
 
     const conversationId = agyConversationId(input)
     if (!conversationId) return
@@ -69,34 +83,46 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     // Which user message is the model about to act on?
     const transcriptPath = String(input.transcriptPath ?? '')
     const user = transcriptPath ? lastUserInput(transcriptPath) : null
+    const userHash = user ? agyTextHash(user.text) : ''
 
-    // One RECALL per user turn; one EMIT per invocation. The marker file
-    // holds {step, message} so mid-turn invocations replay the cached text
+    // One RECALL per user turn; one EMIT per invocation. The cache record
+    // holds this turn's rendered message so mid-turn invocations replay it
     // instead of re-running recall (which costs seconds) or staying silent
     // (which loses the memory the moment a tool result arrives — see the
-    // file comment).
-    const stepMarkerPath = agyCounterPath(conversationId, 'turncache')
-    let lastInjectedStep = -1
-    let cachedMessage = ''
-    try {
-      const cached = JSON.parse(readFileSync(stepMarkerPath, 'utf8')) as { step?: number; message?: string }
-      lastInjectedStep = typeof cached.step === 'number' ? cached.step : -1
-      cachedMessage = typeof cached.message === 'string' ? cached.message : ''
-    } catch { /* first turn */ }
+    // file comment). readAgyTurnCache validates the conversationId stored
+    // INSIDE the record, so a sanitized-path collision between two
+    // conversations reads as "no cache", never as another conversation's
+    // memory (F9).
+    const cached = readAgyTurnCache(conversationId)
 
-    const isFirst = Number(input.invocationNum ?? 0) === 0 && lastInjectedStep === -1
-    const isNewTurn = user !== null && user.stepIndex > lastInjectedStep
+    const isFirst = cached === null && Number(input.invocationNum ?? 0) === 0
+    // `cached === null` counts as a new turn when a user message exists: it
+    // covers both the genuine first turn and the fail-open path where the
+    // cache dir is unusable (writeAgyTurnCache no-ops). In the latter case
+    // every invocation re-recalls — slow, but memory keeps flowing, which is
+    // the right direction to degrade.
+    const isNewTurn = user !== null &&
+      (cached === null || user.stepIndex > cached.step || userHash !== cached.textHash)
     if (!isFirst && !isNewTurn) {
-      // Mid-turn invocation: replay this turn's memory so it survives tool
-      // calls. No recall, no counters — just the cached text.
-      if (cachedMessage) emitInjectSteps(cachedMessage)
+      // Mid-turn invocation — or an unreadable transcript, which is
+      // indistinguishable from one. Replay this turn's memory so it survives
+      // tool calls. No recall, no counters — just the cached text.
+      if (cached !== null && user === null && transcriptPath) {
+        process.stderr.write('[plur] agy: transcript unreadable — replaying the last turn\'s memory rather than re-recalling.\n')
+      }
+      if (cached?.message) emitInjectSteps(cached.message)
       return
     }
 
     agyMarkSessionStarted(conversationId)
 
     const plur = createPlur(flags)
-    const projectConfig = readProjectConfig()
+    // The workspace path, not process.cwd(): agy runs hooks with cwd = the
+    // hooks.json directory (~/.gemini/config), where the .plur.yaml walk can
+    // never succeed — cwd here would silently strip project scoping from
+    // every agy recall AND from the scope line the model is told to learn
+    // under (evaluator audit B1).
+    const projectConfig = readProjectConfig(workspace ?? process.cwd())
     const injectOpts = {
       budget: isFirst ? 3000 : 2000,
       ...(projectConfig.scope ? { scope: projectConfig.scope } : {}),
@@ -133,14 +159,19 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
         'Call plur_session_end before you finish.'
     }
 
-    if (!message) return
+    // Record BEFORE emitting, and record even when the message is empty:
+    // an empty result is still THIS turn's result, and skipping the write
+    // made every mid-turn invocation re-run a full recall (evaluator audit
+    // M5). A failed write degrades to exactly that — re-recall next
+    // invocation — which is the acceptable direction.
+    writeAgyTurnCache({
+      conversationId,
+      step: user?.stepIndex ?? 0,
+      textHash: userHash,
+      message,
+    })
 
-    // Record BEFORE emitting: a crash between write and emit costs one
-    // injection; the reverse order would re-run recall for the same turn
-    // forever if the marker write ever failed.
-    try {
-      writeFileSync(stepMarkerPath, JSON.stringify({ step: user?.stepIndex ?? 0, message }))
-    } catch { /* degrade to re-recall next invocation */ }
+    if (!message) return
 
     emitInjectSteps(message)
   })

--- a/packages/cli/src/commands/hook-agy-pre-invocation.ts
+++ b/packages/cli/src/commands/hook-agy-pre-invocation.ts
@@ -1,0 +1,147 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+import {
+  readStdinJson,
+  runAgyHook,
+  injectWithFallback,
+  agyConversationId,
+  agyMarkSessionStarted,
+  agyCounterPath,
+  agyIncrementCounter,
+  lastUserInput,
+  emitInjectSteps,
+} from '../lib/agy-hook-io.js'
+import { readProjectConfig } from '@plur-ai/core'
+
+/**
+ * plur hook-agy-pre-invocation — Antigravity `PreInvocation` hook.
+ *
+ * The whole injection surface for this harness in one event: agy has no
+ * SessionStart, no per-prompt event, and no end-of-turn context channel, so
+ * session-open batch, per-prompt recall and the learn nudge all ride here.
+ *
+ * TWO PROBLEMS this hook has to solve that the other harnesses hand us for
+ * free:
+ *
+ * 1. NO PROMPT IN THE PAYLOAD. PreInvocation's stdin is counters and paths
+ *    only. The user's text lives in the transcript JSONL the payload points
+ *    at (`transcriptPath`) — `lastUserInput()` digs it out. When the
+ *    transcript can't be read (format drift, torn write), we degrade to the
+ *    generic session batch rather than failing.
+ *
+ * 2. FIRES SEVERAL TIMES PER TURN. PreInvocation runs before EVERY model
+ *    invocation — planning, tool-result digestion, final answer — verified
+ *    live (one probe turn injected its marker twice). And ephemeral messages
+ *    are shown ONLY to the invocation they were injected into: verified live,
+ *    a model that quoted the memory block on invocation 0 reported "no PLUR
+ *    Memory block" after a tool call, because the ephemeral had expired with
+ *    the invocation that received it. So the turn's rendered message is
+ *    CACHED per conversation and re-emitted on every invocation of the SAME
+ *    turn — recall runs once per user message, visibility lasts the whole
+ *    turn, and nothing accumulates in history because ephemerals never do.
+ *
+ * GATING: unlike the Claude Code/Cursor/Codex hooks, this does not silently
+ * no-op when the cwd has no PLUR project config — agy runs hooks with cwd =
+ * the directory containing hooks.json (~/.gemini/config), where
+ * isPlurConfigured() can never be true (its walk deliberately skips
+ * $HOME-level configs, #247/#521). The install itself is the opt-in here:
+ * these hooks exist only because the user ran `plur init --antigravity`,
+ * and they fire only inside agy. When the payload names a workspace, we do
+ * respect a per-project opt-out by checking that path instead.
+ *
+ * Input:  camelCase JSON — { conversationId, invocationNum, transcriptPath, workspacePaths, ... }
+ * Output: {"injectSteps":[{"ephemeralMessage": "..."}]} or nothing.
+ */
+
+const TURNS_BETWEEN_NUDGES = 6
+
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  await runAgyHook('agy pre-invocation', async () => {
+    const input = readStdinJson()
+
+    const workspaces = Array.isArray(input.workspacePaths) ? input.workspacePaths as string[] : []
+    if (workspaces.length > 0 && typeof workspaces[0] === 'string' && !isPlurConfigured(workspaces[0])) return
+
+    const conversationId = agyConversationId(input)
+    if (!conversationId) return
+
+    // Which user message is the model about to act on?
+    const transcriptPath = String(input.transcriptPath ?? '')
+    const user = transcriptPath ? lastUserInput(transcriptPath) : null
+
+    // One RECALL per user turn; one EMIT per invocation. The marker file
+    // holds {step, message} so mid-turn invocations replay the cached text
+    // instead of re-running recall (which costs seconds) or staying silent
+    // (which loses the memory the moment a tool result arrives — see the
+    // file comment).
+    const stepMarkerPath = agyCounterPath(conversationId, 'turncache')
+    let lastInjectedStep = -1
+    let cachedMessage = ''
+    try {
+      const cached = JSON.parse(readFileSync(stepMarkerPath, 'utf8')) as { step?: number; message?: string }
+      lastInjectedStep = typeof cached.step === 'number' ? cached.step : -1
+      cachedMessage = typeof cached.message === 'string' ? cached.message : ''
+    } catch { /* first turn */ }
+
+    const isFirst = Number(input.invocationNum ?? 0) === 0 && lastInjectedStep === -1
+    const isNewTurn = user !== null && user.stepIndex > lastInjectedStep
+    if (!isFirst && !isNewTurn) {
+      // Mid-turn invocation: replay this turn's memory so it survives tool
+      // calls. No recall, no counters — just the cached text.
+      if (cachedMessage) emitInjectSteps(cachedMessage)
+      return
+    }
+
+    agyMarkSessionStarted(conversationId)
+
+    const plur = createPlur(flags)
+    const projectConfig = readProjectConfig()
+    const injectOpts = {
+      budget: isFirst ? 3000 : 2000,
+      ...(projectConfig.scope ? { scope: projectConfig.scope } : {}),
+    }
+    const task = user?.text ?? 'general session start'
+
+    let message: string
+    try {
+      const { result, mode } = await injectWithFallback(plur, task, injectOpts)
+      const body = result.count > 0
+        ? [result.directives, result.constraints, result.consider].filter(Boolean).join('\n')
+        : ''
+      const header = isFirst
+        ? `[PLUR Memory — session started, ${result.count} engrams injected via ${mode}]` +
+          (projectConfig.scope ? `\nProject scope: ${projectConfig.scope} — use this scope for plur_learn calls` : '')
+        : `[PLUR Memory — ${result.count} engrams recalled for this prompt via ${mode}]`
+      message = body ? `${header}\n\n${body}` : (isFirst ? header : '')
+    } catch (err: unknown) {
+      // Only worth a message on the FIRST turn — an honest "memory is broken"
+      // beats silence there. Mid-session, stderr is enough.
+      process.stderr.write(`[plur] agy injection failed: ${(err as Error)?.message ?? 'unknown error'}\n`)
+      message = isFirst
+        ? '[PLUR Memory — injection FAILED at session start] Recalled memory is unavailable; run `plur doctor` in a terminal.'
+        : ''
+    }
+
+    // Learn nudge, folded in here because no other agy event can carry
+    // model-visible text: PostInvocation/Stop can only retry or halt.
+    const turns = agyIncrementCounter(agyCounterPath(conversationId, 'turncount'))
+    if (turns % TURNS_BETWEEN_NUDGES === 0) {
+      message += (message ? '\n\n' : '') +
+        '[PLUR Memory] If anything this session is worth remembering — a correction, a ' +
+        'preference, a convention — call plur_learn now with an explicit domain and scope. ' +
+        'Call plur_session_end before you finish.'
+    }
+
+    if (!message) return
+
+    // Record BEFORE emitting: a crash between write and emit costs one
+    // injection; the reverse order would re-run recall for the same turn
+    // forever if the marker write ever failed.
+    try {
+      writeFileSync(stepMarkerPath, JSON.stringify({ step: user?.stepIndex ?? 0, message }))
+    } catch { /* degrade to re-recall next invocation */ }
+
+    emitInjectSteps(message)
+  })
+}

--- a/packages/cli/src/commands/hook-codex-guard.ts
+++ b/packages/cli/src/commands/hook-codex-guard.ts
@@ -1,0 +1,76 @@
+import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+import {
+  readStdinJson,
+  runCodexHook,
+  codexSessionId,
+  isPlurSessionStartTool,
+  isSessionStarted,
+  markSessionStarted,
+  incrementCounter,
+  counterPath,
+} from '../lib/codex-hook-io.js'
+
+/**
+ * plur hook-codex-guard — Codex `PreToolUse` hook.
+ *
+ * Codex accepts `permissionDecision: "deny"` with a
+ * `permissionDecisionReason` and surfaces that reason to the model —
+ * verified on codex-cli 0.149.1, where denying a shell call made the model
+ * go looking for `plur_session_start`. It REJECTS `"allow"` and `"ask"`
+ * from a hook ("PreToolUse hook returned unsupported permissionDecision"),
+ * so this hook only ever denies or stays silent; it can never wave a tool
+ * through that Codex's own approval policy would have stopped.
+ *
+ * In practice this rarely fires: SessionStart writes the sentinel before the
+ * first tool call. It exists for the paths where SessionStart does not run.
+ *
+ * Deadlock prevention, same rule as Claude Code's hook-session-guard (#199)
+ * and the Cursor guard: nudge once, then give up and mark the session
+ * started anyway. A wedged or missing MCP server must not be able to lock
+ * the agent into a state where the only permitted tool is one it cannot
+ * reach.
+ *
+ * Input:  JSON on stdin — { session_id, tool_name, tool_input, ... }
+ * Output: JSON on stdout — a deny decision, or nothing.
+ */
+
+const MAX_BLOCKS_BEFORE_FALLBACK = 1
+
+export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
+  await runCodexHook('codex guard', async () => {
+    if (!isPlurConfigured()) return
+
+    const input = readStdinJson()
+    const toolName = String(input.tool_name ?? '')
+    if (isPlurSessionStartTool(toolName)) return
+
+    const sessionId = codexSessionId(input)
+    if (!sessionId) return // can't track — allow through rather than block blind
+
+    if (isSessionStarted(sessionId)) return
+
+    const blockCount = incrementCounter(counterPath(sessionId, 'guard-count'))
+    if (blockCount > MAX_BLOCKS_BEFORE_FALLBACK) {
+      markSessionStarted(sessionId)
+      process.stderr.write(
+        `[plur] guard: allowing tools after ${MAX_BLOCKS_BEFORE_FALLBACK} nudge(s) without an ` +
+        'explicit session start. Marking the session started so memory reminders can resume in ' +
+        'degraded mode. If plur_session_start never ran, the MCP server may be down — run ' +
+        '`plur doctor`.\n',
+      )
+      return
+    }
+
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason:
+          'PLUR: call plur_session_start once with a short task description before using other ' +
+          'tools, so this session has memory. This stops blocking as soon as that call succeeds, ' +
+          'and only nudges once even if it does not.',
+      },
+    }))
+  })
+}

--- a/packages/cli/src/commands/hook-codex-inject.ts
+++ b/packages/cli/src/commands/hook-codex-inject.ts
@@ -1,0 +1,60 @@
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+import { readStdinJson, runCodexHook, codexSessionId, markSessionStarted, emitContext } from '../lib/codex-hook-io.js'
+import { readProjectConfig } from '@plur-ai/core'
+
+/**
+ * plur hook-codex-inject — Codex `UserPromptSubmit` hook.
+ *
+ * The load-bearing hook: recalls engrams relevant to THIS prompt and returns
+ * them as `additionalContext`, which Codex appends to the turn. Verified
+ * reaching the model on codex-cli 0.149.1.
+ *
+ * Synchronous and BM25-only — see `codex-hooks.ts` for why async is the
+ * wrong trade here even though Codex now supports it.
+ *
+ * Also marks the session sentinel. In `codex exec` (a one-shot, no TUI)
+ * SessionStart and UserPromptSubmit both fire, but a resumed or forked
+ * session may deliver only one of them; whichever arrives first should stop
+ * the guard from nagging.
+ *
+ * Input:  JSON on stdin — { session_id, turn_id, cwd, hook_event_name, prompt, ... }
+ * Output: JSON on stdout — { hookSpecificOutput: { hookEventName, additionalContext } }
+ *         or nothing at all when there is nothing worth saying.
+ */
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  await runCodexHook('codex inject', async () => {
+    if (!isPlurConfigured()) return
+
+    const input = readStdinJson()
+    const sessionId = codexSessionId(input)
+    const prompt = String(input.prompt ?? '').trim()
+
+    if (sessionId) markSessionStarted(sessionId)
+
+    // No prompt text means nothing to search on. Staying silent is a valid
+    // hook result; emitting an empty context block would just burn tokens.
+    if (!prompt) return
+
+    try {
+      const plur = createPlur(flags)
+      const projectConfig = readProjectConfig()
+      const injectOpts = { budget: 2000, ...(projectConfig.scope ? { scope: projectConfig.scope } : {}) }
+
+      const result = await plur.inject(prompt, injectOpts)
+      if (result.count === 0) return
+
+      const body = [result.directives, result.constraints, result.consider].filter(Boolean).join('\n')
+      if (!body) return
+
+      emitContext(
+        'UserPromptSubmit',
+        `[PLUR Memory — ${result.count} engrams recalled for this prompt]\n\n${body}`,
+      )
+    } catch (err: unknown) {
+      // Diagnostics go to stderr: Codex parses stdout as the hook result, and
+      // a non-JSON byte there would invalidate the whole output.
+      process.stderr.write(`[plur] codex inject failed: ${(err as Error)?.message ?? 'unknown error'}\n`)
+    }
+  })
+}

--- a/packages/cli/src/commands/hook-codex-inject.ts
+++ b/packages/cli/src/commands/hook-codex-inject.ts
@@ -1,6 +1,6 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { isPlurConfigured } from '../lib/plur-configured.js'
-import { readStdinJson, runCodexHook, codexSessionId, markSessionStarted, emitContext } from '../lib/codex-hook-io.js'
+import { readStdinJson, runCodexHook, codexSessionId, markSessionStarted, emitContext, injectWithFallback } from '../lib/codex-hook-io.js'
 import { readProjectConfig } from '@plur-ai/core'
 
 /**
@@ -10,8 +10,9 @@ import { readProjectConfig } from '@plur-ai/core'
  * them as `additionalContext`, which Codex appends to the turn. Verified
  * reaching the model on codex-cli 0.149.1.
  *
- * Synchronous and BM25-only — see `codex-hooks.ts` for why async is the
- * wrong trade here even though Codex now supports it.
+ * Synchronous, hybrid-first with a BM25 fallback on a soft deadline — see
+ * `injectWithFallback`. Async is the wrong trade here even though Codex
+ * supports it: its context lands on the NEXT turn, not this one.
  *
  * Also marks the session sentinel. In `codex exec` (a one-shot, no TUI)
  * SessionStart and UserPromptSubmit both fire, but a resumed or forked
@@ -41,7 +42,7 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       const projectConfig = readProjectConfig()
       const injectOpts = { budget: 2000, ...(projectConfig.scope ? { scope: projectConfig.scope } : {}) }
 
-      const result = await plur.inject(prompt, injectOpts)
+      const { result, mode } = await injectWithFallback(plur, prompt, injectOpts)
       if (result.count === 0) return
 
       const body = [result.directives, result.constraints, result.consider].filter(Boolean).join('\n')
@@ -49,7 +50,7 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
 
       emitContext(
         'UserPromptSubmit',
-        `[PLUR Memory — ${result.count} engrams recalled for this prompt]\n\n${body}`,
+        `[PLUR Memory — ${result.count} engrams recalled for this prompt via ${mode}]\n\n${body}`,
       )
     } catch (err: unknown) {
       // Diagnostics go to stderr: Codex parses stdout as the hook result, and

--- a/packages/cli/src/commands/hook-codex-post-tool.ts
+++ b/packages/cli/src/commands/hook-codex-post-tool.ts
@@ -1,0 +1,69 @@
+import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+import {
+  readStdinJson,
+  runCodexHook,
+  codexSessionId,
+  isPlurSessionStartTool,
+  markSessionStarted,
+  isSessionStarted,
+  incrementCounter,
+  counterPath,
+  emitContext,
+} from '../lib/codex-hook-io.js'
+
+/**
+ * plur hook-codex-post-tool — Codex `PostToolUse` hook.
+ *
+ * Two jobs:
+ *
+ * 1. SENTINEL. When the agent calls `plur_session_start` itself, mark the
+ *    session started so `hook-codex-guard` stops denying. This is the path
+ *    that matters when SessionStart never ran.
+ *
+ * 2. LEARN NUDGE. Codex has a `Stop` event, and Claude Code puts the nudge
+ *    there — but `Stop` output is `{decision, reason}` only: no
+ *    `additionalContext` (Codex explicitly warns "ignoring
+ *    additionalContextLimit … this event cannot emit additionalContext"),
+ *    and `decision: "block"` means "keep going", which would turn a gentle
+ *    reminder into a forced extra turn. PostToolUse CAN emit
+ *    additionalContext, so the nudge rides here on an every-Nth-tool
+ *    cadence instead — the same fatigue-avoidance shape as
+ *    `hook-learn-check`.
+ *
+ * Input:  JSON on stdin — { session_id, tool_name, tool_input, tool_response, ... }
+ * Output: JSON on stdout — an additionalContext nudge, or nothing.
+ */
+
+const TOOLS_BETWEEN_NUDGES = 12
+
+export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
+  await runCodexHook('codex post-tool', async () => {
+    if (!isPlurConfigured()) return
+
+    const input = readStdinJson()
+    const sessionId = codexSessionId(input)
+    if (!sessionId) return
+
+    const toolName = String(input.tool_name ?? '')
+
+    if (isPlurSessionStartTool(toolName)) {
+      markSessionStarted(sessionId)
+      return
+    }
+
+    // Don't nudge before the session has actually started — the guard is
+    // already saying something more specific at that point.
+    if (!isSessionStarted(sessionId)) return
+
+    const n = incrementCounter(counterPath(sessionId, 'tool-count'))
+    if (n % TOOLS_BETWEEN_NUDGES !== 0) return
+
+    emitContext(
+      'PostToolUse',
+      '[PLUR Memory] If anything in this session is worth remembering — a correction, a ' +
+      'preference, a convention you discovered — call plur_learn now with an explicit domain ' +
+      'and scope. Call plur_session_end before you finish.',
+    )
+  })
+}

--- a/packages/cli/src/commands/hook-codex-session-end.ts
+++ b/packages/cli/src/commands/hook-codex-session-end.ts
@@ -1,0 +1,47 @@
+import { unlinkSync } from 'fs'
+import { type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+import {
+  readStdinJson,
+  runCodexHook,
+  codexSessionId,
+  sentinelPath,
+  counterPath,
+  cleanupStaleSessionFiles,
+} from '../lib/codex-hook-io.js'
+
+/**
+ * plur hook-codex-session-end — Codex `SessionEnd` hook.
+ *
+ * Codex clamps SessionEnd timeouts (to 3s) and forces them to run
+ * synchronously even if declared async, so this stays deliberately cheap:
+ * it removes this session's sentinel and counters, and opportunistically
+ * sweeps stale ones. It does NOT try to capture a closing episode the way
+ * Claude Code's `hook-session-end` does — that call can take longer than
+ * the budget, and being killed mid-write is worse than not writing.
+ *
+ * Closing the memory lifecycle properly remains the agent's job via
+ * `plur_session_end`; the PostToolUse nudge reminds it.
+ *
+ * Input:  JSON on stdin — { session_id, reason, ... }
+ * Output: nothing.
+ */
+export async function run(_args: string[], _flags: GlobalFlags): Promise<void> {
+  await runCodexHook('codex session-end', async () => {
+    if (!isPlurConfigured()) return
+
+    const input = readStdinJson()
+    const sessionId = codexSessionId(input)
+    if (!sessionId) return
+
+    for (const p of [
+      sentinelPath(sessionId),
+      counterPath(sessionId, 'guard-count'),
+      counterPath(sessionId, 'tool-count'),
+    ]) {
+      try { unlinkSync(p) } catch { /* already gone */ }
+    }
+
+    cleanupStaleSessionFiles()
+  })
+}

--- a/packages/cli/src/commands/hook-codex-session-start.ts
+++ b/packages/cli/src/commands/hook-codex-session-start.ts
@@ -1,0 +1,67 @@
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { isPlurConfigured } from '../lib/plur-configured.js'
+import { readStdinJson, runCodexHook, codexSessionId, markSessionStarted, emitContext } from '../lib/codex-hook-io.js'
+import { readProjectConfig } from '@plur-ai/core'
+
+/**
+ * plur hook-codex-session-start — Codex `SessionStart` hook.
+ *
+ * Fires on startup, resume, clear and compact (the `source` field says
+ * which). Advisory: Codex never blocks session creation on a hook, so this
+ * only marks the sentinel and delivers an opening batch of engrams.
+ *
+ * Delivery is the ordinary `hookSpecificOutput.additionalContext` channel —
+ * verified reaching the model on codex-cli 0.149.1. No `.mdc`-style
+ * workaround is needed here; that exists only because Cursor drops
+ * `additional_context` at conversation-creation time.
+ *
+ * BM25-only, deliberately. Codex DOES support `async: true` as of 0.149.1,
+ * but an async hook's context is delivered at the next safe point rather
+ * than to the triggering turn, so going async would silently put memory one
+ * turn behind (and, in `codex exec`, drop it entirely). This hook has to
+ * just BE fast: hybrid search cold-starts the BGE embedder (~20s once the
+ * store passes a few thousand engrams — the failure PR #502 fixed for
+ * Claude Code); BM25 alone measured 0.74s against 4,290 engrams.
+ *
+ * Input:  JSON on stdin — { session_id, cwd, hook_event_name, model, permission_mode, source }
+ * Output: JSON on stdout — { hookSpecificOutput: { hookEventName, additionalContext } }
+ */
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  await runCodexHook('codex session-start', async () => {
+    if (!isPlurConfigured()) return
+
+    const input = readStdinJson()
+    const sessionId = codexSessionId(input)
+    if (!sessionId) return
+
+    markSessionStarted(sessionId)
+
+    // Wrapped like the Cursor equivalent: if inject() throws AFTER the
+    // sentinel is written, the guard has already stopped enforcing, so
+    // silence here would be indistinguishable from "0 engrams matched".
+    // Say so explicitly instead.
+    let context: string
+    try {
+      const plur = createPlur(flags)
+      const projectConfig = readProjectConfig()
+      const injectOpts = { budget: 3000, ...(projectConfig.scope ? { scope: projectConfig.scope } : {}) }
+
+      const result = await plur.inject('general session start', injectOpts)
+      const body = result.count > 0
+        ? [result.directives, result.constraints, result.consider].filter(Boolean).join('\n')
+        : ''
+
+      const header = `[PLUR Memory — session started, ${result.count} engrams injected]` +
+        (projectConfig.scope ? `\nProject scope: ${projectConfig.scope} — use this scope for plur_learn calls` : '')
+
+      context = body ? `${header}\n\n${body}` : header
+    } catch (err: unknown) {
+      context = '[PLUR Memory — injection FAILED at session start] ' +
+        `(${(err as Error)?.message ?? 'unknown error'}). Recalled memory is unavailable; run ` +
+        '`plur doctor` in a TERMINAL (the CLI command — it checks ~/.codex wiring and hook trust; ' +
+        'the plur_doctor MCP tool only checks the embedder/remote store, not this).'
+    }
+
+    emitContext('SessionStart', context)
+  })
+}

--- a/packages/cli/src/commands/hook-codex-session-start.ts
+++ b/packages/cli/src/commands/hook-codex-session-start.ts
@@ -1,6 +1,6 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { isPlurConfigured } from '../lib/plur-configured.js'
-import { readStdinJson, runCodexHook, codexSessionId, markSessionStarted, emitContext } from '../lib/codex-hook-io.js'
+import { readStdinJson, runCodexHook, codexSessionId, markSessionStarted, emitContext, injectWithFallback } from '../lib/codex-hook-io.js'
 import { readProjectConfig } from '@plur-ai/core'
 
 /**
@@ -46,12 +46,12 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       const projectConfig = readProjectConfig()
       const injectOpts = { budget: 3000, ...(projectConfig.scope ? { scope: projectConfig.scope } : {}) }
 
-      const result = await plur.inject('general session start', injectOpts)
+      const { result, mode } = await injectWithFallback(plur, 'general session start', injectOpts)
       const body = result.count > 0
         ? [result.directives, result.constraints, result.consider].filter(Boolean).join('\n')
         : ''
 
-      const header = `[PLUR Memory — session started, ${result.count} engrams injected]` +
+      const header = `[PLUR Memory — session started, ${result.count} engrams injected via ${mode}]` +
         (projectConfig.scope ? `\nProject scope: ${projectConfig.scope} — use this scope for plur_learn calls` : '')
 
       context = body ? `${header}\n\n${body}` : header

--- a/packages/cli/src/commands/hook-codex-session-start.ts
+++ b/packages/cli/src/commands/hook-codex-session-start.ts
@@ -15,13 +15,12 @@ import { readProjectConfig } from '@plur-ai/core'
  * workaround is needed here; that exists only because Cursor drops
  * `additional_context` at conversation-creation time.
  *
- * BM25-only, deliberately. Codex DOES support `async: true` as of 0.149.1,
- * but an async hook's context is delivered at the next safe point rather
- * than to the triggering turn, so going async would silently put memory one
- * turn behind (and, in `codex exec`, drop it entirely). This hook has to
- * just BE fast: hybrid search cold-starts the BGE embedder (~20s once the
- * store passes a few thousand engrams — the failure PR #502 fixed for
- * Claude Code); BM25 alone measured 0.74s against 4,290 engrams.
+ * Synchronous, hybrid-first with a BM25 fallback on a soft deadline — see
+ * `injectWithFallback`, which holds the measurements (4.7s hybrid / 1.6s
+ * BM25 on a 5,775-engram store, 2026-08-27) and the reason the old "~20s
+ * embedder cold start" figure was retired. Async would be worse, not
+ * faster: Codex delivers an async hook's context at the next safe point,
+ * NOT to the triggering turn — in `codex exec` that means never.
  *
  * Input:  JSON on stdin — { session_id, cwd, hook_event_name, model, permission_mode, source }
  * Output: JSON on stdout — { hookSpecificOutput: { hookEventName, additionalContext } }

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -10,8 +10,8 @@
  * the content-hash dedup gate and the secret guard apply — never raw-append.
  */
 import { readFileSync } from 'fs'
-import { Plur, importFrom, listImportSources, type FieldMapping, type MigrationReport } from '@plur-ai/core'
-import type { GlobalFlags } from '../plur.js'
+import { importFrom, listImportSources, type FieldMapping, type MigrationReport } from '@plur-ai/core'
+import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
 
 async function usage(): Promise<string> {
@@ -63,7 +63,12 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     }
   }
 
-  const plur = new Plur({ path: store || process.env.PLUR_PATH || undefined })
+  // Via createPlur, not `new Plur` directly (evaluator audit minor): the CLI
+  // entrypoint drains background index work through getLastPlurInstance()
+  // before exiting, and import — the one command with the largest bulk
+  // write — was the one command whose instance the drain could not see.
+  // createPlur honours --store by mapping it onto flags.path.
+  const plur = createPlur({ ...flags, path: store || flags.path })
   const report = await importFrom(plur, { from, path: file, mapping, dryRun, scope })
 
   if (shouldOutputJson(flags)) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs'
+import { execFileSync } from 'child_process'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
@@ -15,6 +16,8 @@ import {
   cursorProjectMcpConfigPath,
   cursorProjectHooksConfigPath,
   cursorRulesPath,
+  codexHome,
+  codexHooksConfigPath,
 } from '../mcp-config.js'
 import {
   buildCursorHooks,
@@ -23,6 +26,13 @@ import {
   mergeCursorHooks,
   hasPlurCursorHooks,
 } from '../cursor-hooks.js'
+import {
+  buildCodexHooks,
+  readCodexHooksConfig,
+  writeCodexHooksConfig,
+  mergeCodexHooks,
+  hasPlurCodexHooks,
+} from '../codex-hooks.js'
 
 /**
  * plur init — install Claude Code hooks AND register the plur MCP server.
@@ -651,6 +661,136 @@ function installCursor(cmd: string): string {
     `gitignored .cursor/rules/plur-context.mdc, .cursor/rules/plur-reminder.mdc`
 }
 
+// ── Codex ───────────────────────────────────────────────────────────────────
+
+function shouldSetupCodex(args: string[], env: NodeJS.ProcessEnv = process.env): boolean {
+  if (args.includes('--no-codex')) return false
+  if (args.includes('--codex')) return true
+  return existsSync(codexHome(env))
+}
+
+/**
+ * Register the plur MCP server with Codex by shelling out to `codex mcp add`
+ * rather than editing `config.toml` ourselves.
+ *
+ * Codex's config is TOML, and hand-writing TOML would mean either taking a
+ * dependency or doing string surgery on a file that also holds the user's
+ * model, profiles, projects and other MCP servers — the exact shape of edit
+ * that eats a hand-authored config when it goes wrong. `codex mcp add` is a
+ * supported, versioned interface that does it correctly.
+ *
+ * Returns a status string; never throws. If the `codex` binary is not on
+ * PATH (perfectly possible — `~/.codex/` can exist from a since-removed
+ * install), we say so and print the manual snippet instead of failing init.
+ */
+function installCodexMcp(): string {
+  const entry = buildMcpServerEntry()
+
+  let listed = ''
+  try {
+    listed = execFileSync('codex', ['mcp', 'list'], {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 15_000,
+    })
+  } catch (err: unknown) {
+    const code = (err as { code?: string }).code
+    if (code === 'ENOENT') {
+      return 'skipped — the `codex` binary is not on PATH. Install Codex, then re-run `plur init --codex`'
+    }
+    // `mcp list` can fail for reasons that don't block `mcp add` (an
+    // unrelated broken server entry, for one). Fall through and try to add.
+  }
+
+  // Codex has no "update this server" verb, and `add` on an existing name
+  // errors rather than replacing. Detecting the existing entry lets us
+  // report honestly instead of swallowing that error as a failure.
+  if (/(^|\s)plur(\s|$)/m.test(listed)) {
+    return 'already registered (run `codex mcp remove plur` first if you need to re-point it)'
+  }
+
+  try {
+    const args = ['mcp', 'add', 'plur']
+    if (entry.env) for (const [k, v] of Object.entries(entry.env)) args.push('--env', `${k}=${v}`)
+    args.push('--', entry.command, ...entry.args)
+    execFileSync('codex', args, { stdio: ['ignore', 'ignore', 'pipe'], timeout: 15_000 })
+    return 'registered via `codex mcp add`'
+  } catch (err: unknown) {
+    const stderr = String((err as { stderr?: Buffer }).stderr ?? '').trim()
+    return `FAILED (${stderr || (err as Error).message}) — add it by hand: ` +
+      `[mcp_servers.plur] command = "${entry.command}"`
+  }
+}
+
+function installCodex(cmd: string, env: NodeJS.ProcessEnv = process.env): string {
+  const hooksPath = codexHooksConfigPath(env)
+
+  // Same refusal as the Cursor path: readCodexHooksConfig() treats
+  // unparseable JSON as empty (a safe default for READING), but writing that
+  // back would destroy a hand-edited-but-malformed hooks.json along with any
+  // non-plur entries in it.
+  let hooksStatus: string
+  let hooksWritten = false
+  const exists = existsSync(hooksPath)
+  let parses = true
+  if (exists) {
+    try { JSON.parse(readFileSync(hooksPath, 'utf8')) } catch { parses = false }
+  }
+  if (exists && !parses) {
+    hooksStatus = `skipped — ${hooksPath} exists but is not valid JSON; fix it by hand, then re-run \`plur init --codex\``
+  } else {
+    const existing = readCodexHooksConfig(hooksPath)
+    const had = hasPlurCodexHooks(existing)
+    writeCodexHooksConfig(hooksPath, mergeCodexHooks(existing, buildCodexHooks(cmd)))
+    hooksStatus = had ? 'upgraded' : 'installed'
+    hooksWritten = true
+  }
+
+  const mcpStatus = installCodexMcp()
+  const agentsStatus = installAgentsMd()
+
+  return [
+    `Codex: hooks ${hooksStatus} (${hooksPath})`,
+    `  MCP server: ${mcpStatus}`,
+    `  AGENTS.md:  ${agentsStatus}`,
+    ...(hooksWritten ? [CODEX_TRUST_NOTICE] : []),
+  ].join('\n')
+}
+
+/**
+ * Codex fingerprints every non-managed hook and refuses to run it until it
+ * has been reviewed — and in `codex exec` there is no review UI, so an
+ * untrusted hook produces no output, no warning and exit 0. That is
+ * indistinguishable from a config Codex never read (verified on 0.149.1:
+ * the same hooks that worked under `--dangerously-bypass-hook-trust` were
+ * silently inert without it). Project `trust_level = "trusted"` does not
+ * cover hooks, and a hand-written `trusted_hash` that doesn't match is also
+ * skipped silently with no hint of the expected value — so there is nothing
+ * `plur init` can write to pre-trust these. The user has to do it once.
+ *
+ * This is why the Codex install report does not end on "restart Codex".
+ */
+const CODEX_TRUST_NOTICE =
+  '  ⚠ ONE MANUAL STEP: Codex will not run these hooks until you trust them.\n' +
+  '    Open Codex, run /hooks, and trust the PLUR entries. Until you do, they are\n' +
+  '    skipped SILENTLY — no warning, no error, memory simply never loads.'
+
+function installAgentsMd(cwd: string = process.cwd()): string {
+  const marker = '## PLUR Memory'
+  const projectAgents = join(cwd, 'AGENTS.md')
+  const globalAgents = join(codexHome(), 'AGENTS.md')
+  const target = existsSync(projectAgents) ? projectAgents
+    : existsSync(globalAgents) ? globalAgents
+    : projectAgents
+
+  if (existsSync(target)) {
+    const content = readFileSync(target, 'utf8')
+    if (content.includes(marker)) return `already in ${target}`
+    writeFileSync(target, content.trimEnd() + '\n\n' + CLAUDE_MD_SECTION)
+    return `added to ${target}`
+  }
+  writeFileSync(target, `# AGENTS.md\n\n${CLAUDE_MD_SECTION}`)
+  return `created ${target}`
+}
+
 function writeSettings(path: string, settings: Settings): void {
   mkdirSync(join(path, '..'), { recursive: true })
   writeFileSync(path, JSON.stringify(settings, null, 2) + '\n')
@@ -818,6 +958,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // Register in Claude Desktop too
   const desktopStatus = installDesktopMcp(args)
 
+  const codexStatus = shouldSetupCodex(args)
+    ? installCodex(cmd)
+    : 'skipped (no ~/.codex found — pass --codex to force, --no-codex to silence this)'
+
   const cursorStatus = shouldSetupCursor(args)
     ? installCursor(cmd)
     : 'skipped (no .cursor/ dir found — pass --cursor to force, --no-cursor to silence this)'
@@ -856,6 +1000,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   outputInfo(`Enforcement file: ${enforcementPath}`, flags)
   if (!samePath) outputInfo(`Injection file:   ${injectionPath}`, flags)
   outputInfo(`Claude Desktop:   ${desktopStatus}`, flags)
+  outputInfo(codexStatus, flags)
   outputInfo(cursorStatus, flags)
   if (shouldSetupCursor(args)) {
     // Audit fix (user evaluator): the 11-tools-instead-of-39 tradeoff and

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,6 +18,9 @@ import {
   cursorRulesPath,
   codexHome,
   codexHooksConfigPath,
+  agyConfigDir,
+  agyHooksConfigPath,
+  agyMcpConfigPath,
 } from '../mcp-config.js'
 import {
   buildCursorHooks,
@@ -33,6 +36,14 @@ import {
   mergeCodexHooks,
   hasPlurCodexHooks,
 } from '../codex-hooks.js'
+import {
+  buildAgyHookSet,
+  readAgyHooksConfig,
+  writeAgyHooksConfig,
+  mergeAgyHooks,
+  hasPlurAgyHooks,
+  AGY_HOOK_SET_NAME,
+} from '../antigravity-hooks.js'
 
 /**
  * plur init — install Claude Code hooks AND register the plur MCP server.
@@ -791,6 +802,76 @@ function installAgentsMd(cwd: string = process.cwd()): string {
   return `created ${target}`
 }
 
+// ── Antigravity CLI (agy) ───────────────────────────────────────────────────
+
+function shouldSetupAntigravity(args: string[]): boolean {
+  if (args.includes('--no-antigravity')) return false
+  if (args.includes('--antigravity') || args.includes('--agy')) return true
+  // Detect the CLI's own state dir, not just ~/.gemini — the old Gemini CLI
+  // also created ~/.gemini, and installing agy hooks for a user who only ever
+  // ran the sunsetted gemini binary would configure a harness they don't have.
+  return existsSync(join(homedir(), '.gemini', 'antigravity-cli'))
+}
+
+/**
+ * Wire PLUR into Antigravity CLI: hooks + MCP server + rules, all in the
+ * GLOBAL config dir (~/.gemini/config/). Global deliberately — workspace
+ * `.agents/hooks.json` discovery did not load in `--print` mode during live
+ * probing, while the global file loaded immediately, and global matches how
+ * PLUR installs everywhere else (one store, every project).
+ *
+ * No trust step, unlike Codex: agy runs configured hooks on first invocation
+ * (verified live on 1.1.21), so the install report can honestly end at
+ * "restart agy".
+ */
+function installAntigravity(cmd: string): string {
+  const hooksPath = agyHooksConfigPath()
+
+  // Same malformed-file refusal as the Cursor and Codex paths: reading treats
+  // unparseable JSON as empty, but WRITING that back would destroy a user's
+  // hand-edited-but-broken hooks.json along with every non-plur hook set in it.
+  let hooksStatus: string
+  const exists = existsSync(hooksPath)
+  let parses = true
+  if (exists) {
+    try { JSON.parse(readFileSync(hooksPath, 'utf8')) } catch { parses = false }
+  }
+  if (exists && !parses) {
+    hooksStatus = `skipped — ${hooksPath} exists but is not valid JSON; fix it by hand, then re-run \`plur init --antigravity\``
+  } else {
+    const existing = readAgyHooksConfig(hooksPath)
+    const had = hasPlurAgyHooks(existing)
+    writeAgyHooksConfig(hooksPath, mergeAgyHooks(existing, buildAgyHookSet(cmd)))
+    hooksStatus = had ? 'upgraded' : `installed (hook set "${AGY_HOOK_SET_NAME}")`
+  }
+
+  // MCP: agy's mcp_config.json uses the same { mcpServers: {...} } shape as
+  // Claude Desktop, so the shared helpers apply unchanged. agy's docs say env
+  // vars must be declared explicitly in the entry — buildMcpServerEntry's
+  // shim needs none, so the default entry is sufficient.
+  const mcpPath = agyMcpConfigPath()
+  const mcpConfig = readConfig(mcpPath)
+  let mcpStatus: string
+  if (hasPlurMcp(mcpConfig)) {
+    mcpStatus = 'already registered'
+  } else {
+    mergePlurMcp(mcpConfig)
+    writeConfig(mcpPath, mcpConfig)
+    mcpStatus = 'registered'
+  }
+
+  // Rules: agy loads AGENTS.md via directory walk-up, same file the Codex
+  // path maintains — reuse it so both harnesses share one instruction block.
+  const agentsStatus = installAgentsMd()
+
+  return [
+    `Antigravity: hooks ${hooksStatus} (${hooksPath})`,
+    `  MCP server: ${mcpStatus} (${mcpPath})`,
+    `  AGENTS.md:  ${agentsStatus}`,
+    '  No trust step needed — agy runs configured hooks on first invocation. Restart agy to pick this up.',
+  ].join('\n')
+}
+
 function writeSettings(path: string, settings: Settings): void {
   mkdirSync(join(path, '..'), { recursive: true })
   writeFileSync(path, JSON.stringify(settings, null, 2) + '\n')
@@ -958,6 +1039,10 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // Register in Claude Desktop too
   const desktopStatus = installDesktopMcp(args)
 
+  const agyStatus = shouldSetupAntigravity(args)
+    ? installAntigravity(cmd)
+    : 'skipped (no ~/.gemini/antigravity-cli found — pass --antigravity to force, --no-antigravity to silence this)'
+
   const codexStatus = shouldSetupCodex(args)
     ? installCodex(cmd)
     : 'skipped (no ~/.codex found — pass --codex to force, --no-codex to silence this)'
@@ -1001,6 +1086,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (!samePath) outputInfo(`Injection file:   ${injectionPath}`, flags)
   outputInfo(`Claude Desktop:   ${desktopStatus}`, flags)
   outputInfo(codexStatus, flags)
+  outputInfo(agyStatus, flags)
   outputInfo(cursorStatus, flags)
   if (shouldSetupCursor(args)) {
     // Audit fix (user evaluator): the 11-tools-instead-of-39 tradeoff and

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -60,12 +60,17 @@ import {
  *      created to avoid npx overhead and race conditions (#178).
  *
  * Usage:
- *   plur init              # default: creates .claude/settings.json in current directory
- *   plur init --global     # force global ~/.claude/settings.json
- *   plur init --project    # force project .claude/settings.json (same as default)
- *   plur init --no-desktop # skip Claude Desktop config registration
- *   plur init --domain X   # set default domain for this project (.plur.yaml)
- *   plur init --scope Y    # set default scope for this project (.plur.yaml)
+ *   plur init                 # default: creates .claude/settings.json in current directory
+ *   plur init --global        # force global ~/.claude/settings.json
+ *   plur init --project       # force project .claude/settings.json (same as default)
+ *   plur init --desktop / --no-desktop        # force / skip Claude Desktop registration
+ *   plur init --cursor / --no-cursor          # force / skip Cursor (auto: .cursor/ exists)
+ *   plur init --codex / --no-codex            # force / skip Codex (auto: ~/.codex exists)
+ *   plur init --antigravity | --agy / --no-antigravity
+ *                             # force / skip Antigravity (auto: ~/.gemini/antigravity-cli exists)
+ *   plur init --no-prompt     # never ask interactive questions (telemetry opt-in)
+ *   plur init --domain X      # set default domain for this project (.plur.yaml)
+ *   plur init --scope Y       # set default scope for this project (.plur.yaml)
  *
  * For multi-project setups (Issue #19):
  *   cd ~/projects/my-app
@@ -418,6 +423,52 @@ When the user corrects you ("no, use X not Y", "that's wrong"):
 3. Then continue with the corrected approach
 `
 
+/**
+ * The instruction block written to AGENTS.md for Codex and Antigravity.
+ *
+ * A separate constant, not CLAUDE_MD_SECTION, because two of that block's
+ * claims are Claude-Code-only and were being shipped verbatim into harnesses
+ * where they are false (evaluator audit M11): the "SessionEnd hook
+ * auto-closes the lifecycle if you forget" promise (Codex's SessionEnd hook
+ * only removes sentinels — the 3s clamp forbids an episode capture — and agy
+ * has no session-end hook at all), and the ToolSearch bootstrap flow, which
+ * is a Claude Code mechanism neither harness has. Telling the model a safety
+ * net exists precisely where it does not undoes the nudges that compensate.
+ */
+const AGENTS_MD_SECTION = `## PLUR Memory
+
+You have persistent memory via PLUR. Corrections, preferences, and conventions persist across sessions as engrams.
+
+PLUR is installed **globally** — one MCP server, one engram store (\`~/.plur/\`), available in every project. The \`plur\` MCP server provides tools named \`plur_session_start\`, \`plur_learn\`, \`plur_recall\`, \`plur_feedback\`, \`plur_session_end\`. If you cannot find these tools, run \`plur doctor\` to diagnose. Do **not** substitute tools from other MCP servers.
+
+### Session Workflow
+
+1. **Start**: Call \`plur_session_start\` with a short task description — a guard hook nudges you if you skip it
+2. **Learn**: When corrected or discovering something new, call \`plur_learn\` immediately
+3. **Recall**: Before answering factual questions, call \`plur_recall\` — check memory first
+4. **Feedback**: Rate injected engrams with \`plur_feedback\` (positive/negative) — trains relevance
+5. **End**: Call \`plur_session_end\` with a summary and engram suggestions before finishing. There is NO automatic
+   fallback in this harness — if you skip this call, nothing captures the session's learnings.
+
+Relevant engrams are injected automatically by hooks; recalled context appears in your turns tagged \`[PLUR Memory — ...]\`.
+
+Do not ask permission to use these tools — they are your memory system.
+
+### Scope selection (set scope PER engram, by content)
+
+- **Team / shared knowledge** → the matching team scope (e.g. \`group:<org>/<team>\`) — \`plur_session_start\` lists the writable ones.
+- **This project's details** → \`project:<name>\` (a \`.plur.yaml\` with \`scope:\` makes this the default).
+- **Personal preferences / your own workflow** → leave at the default / local scope.
+- Reserve \`global\` for genuinely cross-project facts; team-relevant knowledge must not fall back to it.
+
+### When corrected
+
+When the user corrects you ("no, use X not Y"):
+1. Call \`plur_learn\` immediately — before continuing the task
+2. Call \`plur_feedback\` with negative signal on the wrong engram if one was injected
+3. Then continue with the corrected approach
+`
+
 const CURSOR_RULE_CONTENT = `---
 description: PLUR persistent memory — session workflow and tool usage
 alwaysApply: true
@@ -741,12 +792,20 @@ function installCodex(cmd: string, env: NodeJS.ProcessEnv = process.env): string
   let hooksStatus: string
   let hooksWritten = false
   const exists = existsSync(hooksPath)
-  let parses = true
+  // Parse AND shape check (adversarial audit F2): `12345`, `"text"` and
+  // `[...]` are valid JSON that readCodexHooksConfig flattens to an empty
+  // config — writing that back destroys whatever the user had, while the
+  // parse-only guard waves it through. Wrong shape gets the same refusal as
+  // wrong syntax.
+  let usable = true
   if (exists) {
-    try { JSON.parse(readFileSync(hooksPath, 'utf8')) } catch { parses = false }
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(hooksPath, 'utf8'))
+      usable = typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    } catch { usable = false }
   }
-  if (exists && !parses) {
-    hooksStatus = `skipped — ${hooksPath} exists but is not valid JSON; fix it by hand, then re-run \`plur init --codex\``
+  if (exists && !usable) {
+    hooksStatus = `skipped — ${hooksPath} exists but is not a JSON object; fix it by hand, then re-run \`plur init --codex\``
   } else {
     const existing = readCodexHooksConfig(hooksPath)
     const had = hasPlurCodexHooks(existing)
@@ -756,7 +815,7 @@ function installCodex(cmd: string, env: NodeJS.ProcessEnv = process.env): string
   }
 
   const mcpStatus = installCodexMcp()
-  const agentsStatus = installAgentsMd()
+  const agentsStatus = installAgentsMd(process.cwd(), join(codexHome(env), 'AGENTS.md'))
 
   return [
     `Codex: hooks ${hooksStatus} (${hooksPath})`,
@@ -784,21 +843,26 @@ const CODEX_TRUST_NOTICE =
   '    Open Codex, run /hooks, and trust the PLUR entries. Until you do, they are\n' +
   '    skipped SILENTLY — no warning, no error, memory simply never loads.'
 
-function installAgentsMd(cwd: string = process.cwd()): string {
+function installAgentsMd(cwd: string = process.cwd(), globalFallback: string | null = null): string {
   const marker = '## PLUR Memory'
   const projectAgents = join(cwd, 'AGENTS.md')
-  const globalAgents = join(codexHome(), 'AGENTS.md')
+  // The global fallback is HARNESS-SPECIFIC (evaluator audit M7): Codex
+  // reads ~/.codex/AGENTS.md, but agy walks up from the workspace and never
+  // looks there — so the agy path passes null and only ever touches the
+  // project file. Without this split, `plur init --antigravity` on a machine
+  // that also had Codex could write the block into ~/.codex/AGENTS.md,
+  // report success, and agy would never read a word of it.
   const target = existsSync(projectAgents) ? projectAgents
-    : existsSync(globalAgents) ? globalAgents
+    : (globalFallback && existsSync(globalFallback)) ? globalFallback
     : projectAgents
 
   if (existsSync(target)) {
     const content = readFileSync(target, 'utf8')
     if (content.includes(marker)) return `already in ${target}`
-    writeFileSync(target, content.trimEnd() + '\n\n' + CLAUDE_MD_SECTION)
+    writeFileSync(target, content.trimEnd() + '\n\n' + AGENTS_MD_SECTION)
     return `added to ${target}`
   }
-  writeFileSync(target, `# AGENTS.md\n\n${CLAUDE_MD_SECTION}`)
+  writeFileSync(target, `# AGENTS.md\n\n${AGENTS_MD_SECTION}`)
   return `created ${target}`
 }
 
@@ -832,12 +896,16 @@ function installAntigravity(cmd: string): string {
   // hand-edited-but-broken hooks.json along with every non-plur hook set in it.
   let hooksStatus: string
   const exists = existsSync(hooksPath)
-  let parses = true
+  // Same parse-AND-shape refusal as the Codex leg (adversarial audit F2).
+  let usable = true
   if (exists) {
-    try { JSON.parse(readFileSync(hooksPath, 'utf8')) } catch { parses = false }
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(hooksPath, 'utf8'))
+      usable = typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    } catch { usable = false }
   }
-  if (exists && !parses) {
-    hooksStatus = `skipped — ${hooksPath} exists but is not valid JSON; fix it by hand, then re-run \`plur init --antigravity\``
+  if (exists && !usable) {
+    hooksStatus = `skipped — ${hooksPath} exists but is not a JSON object; fix it by hand, then re-run \`plur init --antigravity\``
   } else {
     const existing = readAgyHooksConfig(hooksPath)
     const had = hasPlurAgyHooks(existing)
@@ -862,7 +930,8 @@ function installAntigravity(cmd: string): string {
 
   // Rules: agy loads AGENTS.md via directory walk-up, same file the Codex
   // path maintains — reuse it so both harnesses share one instruction block.
-  const agentsStatus = installAgentsMd()
+  // No global fallback: agy has no global AGENTS.md location (M7).
+  const agentsStatus = installAgentsMd(process.cwd(), null)
 
   return [
     `Antigravity: hooks ${hooksStatus} (${hooksPath})`,
@@ -1039,16 +1108,29 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // Register in Claude Desktop too
   const desktopStatus = installDesktopMcp(args)
 
+  // Each harness leg is contained (adversarial audit F3): a read-only file
+  // or an AGENTS.md-that-is-a-directory in ONE harness's config must not
+  // abort the others or suppress the whole report — before this, an EACCES
+  // in the agy leg (which runs first) hid the Codex trust notice and every
+  // path that had already been written.
+  const containLeg = (label: string, fn: () => string): string => {
+    try {
+      return fn()
+    } catch (err: unknown) {
+      return `${label}: FAILED (${(err as Error)?.message ?? 'unknown error'}) — other integrations were still attempted; fix and re-run plur init`
+    }
+  }
+
   const agyStatus = shouldSetupAntigravity(args)
-    ? installAntigravity(cmd)
+    ? containLeg('Antigravity', () => installAntigravity(cmd))
     : 'skipped (no ~/.gemini/antigravity-cli found — pass --antigravity to force, --no-antigravity to silence this)'
 
   const codexStatus = shouldSetupCodex(args)
-    ? installCodex(cmd)
+    ? containLeg('Codex', () => installCodex(cmd))
     : 'skipped (no ~/.codex found — pass --codex to force, --no-codex to silence this)'
 
   const cursorStatus = shouldSetupCursor(args)
-    ? installCursor(cmd)
+    ? containLeg('Cursor', () => installCursor(cmd))
     : 'skipped (no .cursor/ dir found — pass --cursor to force, --no-cursor to silence this)'
 
   // Write project config if --domain or --scope provided

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,4 +1,6 @@
-import { runMigrations, rollbackMigrations, getSchemaVersion, CURRENT_SCHEMA_VERSION } from '@plur-ai/core'
+import { runMigrations, rollbackMigrations, getSchemaVersion, CURRENT_SCHEMA_VERSION, exportPgliteEmbeddingsToCache } from '@plur-ai/core'
+import { existsSync } from 'fs'
+import { join, dirname } from 'path'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText, outputInfo, exit } from '../output.js'
 import { detectPlurStorage } from '@plur-ai/core'
@@ -31,10 +33,32 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (subcommand === 'up' || subcommand === undefined) {
     try {
       const result = runMigrations(paths.engrams, paths.config)
+
+      // #1046: if an orphaned PGLite store is sitting next to this corpus,
+      // carry its embedding vectors into the JSON cache the yaml/sqlite
+      // tiers read — otherwise the tier switch re-embeds the whole corpus
+      // in the background while hybrid recall silently runs BM25-only.
+      // Skipped when the user is explicitly ON pglite (nothing orphaned),
+      // and harmless to re-run (existing cache entries win).
+      const storageRoot = dirname(paths.engrams)
+      const pgliteDir = join(storageRoot, 'store.pglite')
+      const pgliteExplicit = process.env.PLUR_BACKEND?.trim().toLowerCase() === 'pglite'
+      let embeddingsReport: Awaited<ReturnType<typeof exportPgliteEmbeddingsToCache>> | null = null
+      if (existsSync(pgliteDir) && !pgliteExplicit) {
+        embeddingsReport = await exportPgliteEmbeddingsToCache(storageRoot, paths.engrams, pgliteDir)
+      }
       if (shouldOutputJson(flags)) {
-        outputJson(result)
+        outputJson(embeddingsReport ? { ...result, pglite_embeddings: embeddingsReport } : result)
       } else {
         // Confirmation of a requested mutation → suppressed by --quiet (#730).
+        if (embeddingsReport && embeddingsReport.status === 'done' && embeddingsReport.ported > 0) {
+          outputInfo(`Ported ${embeddingsReport.ported} embedding vector(s) from the orphaned PGLite store into the embeddings cache`, flags)
+          const skipped = embeddingsReport.stale + embeddingsReport.wrongDim
+          if (skipped > 0) outputInfo(`  (${skipped} skipped as stale or wrong-dimension — they re-embed automatically)`, flags)
+          outputInfo(`  ${pgliteDir} can now be deleted — YAML remains the source of truth.`, flags)
+        } else if (embeddingsReport && embeddingsReport.status === 'failed') {
+          outputText(`Warning: PGLite embeddings export failed (${embeddingsReport.error}) — the corpus will re-embed in the background instead.`)
+        }
         if (result.applied.length === 0) {
           outputInfo('Already up to date.', flags)
         } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,10 +54,10 @@ Commands:
                           [--flush] to retry them now (#667)
   reindex-tokens          Re-derive BM25 tokens after a tokenizer change (Postgres only)
   reindex-hashes          Repair engrams whose content_hash is stale or missing (#852)
-  init                    Install Claude Code hooks + register plur MCP server
+  init                    Wire PLUR into detected harnesses (Claude Code, Cursor, Codex, Antigravity)
   init-remote             Opt this project into recall from a PLUR Enterprise server
   login --status          Enterprise token validity per host (probe + expiry) (#587)
-  doctor                  Diagnose Claude Code / Claude Desktop integration
+  doctor                  Diagnose Claude Code / Claude Desktop / Cursor / Codex / Antigravity integration
   rerank-eval             Per-store reranker self-eval gate (advisory, #451)
                           [--reranker <name>] [--sample N] [--seed N] [--force]
   tensions [--scan]       List or scan for engram contradictions
@@ -194,17 +194,14 @@ if (!command || !COMMANDS[command]) {
 try {
   const mod = await import(COMMANDS[command])
   await mod.run(commandArgs, flags)
-  // #1046: the derived index syncs in the BACKGROUND from the Plur
-  // constructor, and every command except `sync` used to exit without waiting
-  // for it. On a store large enough to auto-select PGLite that meant each run
-  // started a full-corpus pass and abandoned it partway, so the index never
-  // converged — it was found 64MB on disk with no `engrams` table at all,
-  // having been rebuilt-and-abandoned on every invocation for months.
-  //
-  // Waiting costs nothing in the steady state: the fingerprint guard in
-  // syncFromYaml makes an unchanged YAML a no-op, so this only blocks on the
-  // first run after an actual write, and only for as long as that write's
-  // sync takes.
+  // #1046: background index work (the PGLite initial sync when that backend
+  // is opted into, and the Postgres auto-embed pass — both tracked on
+  // waitForIndex()) used to be abandoned by every command except `sync`,
+  // which on PGLite meant a full-corpus pass restarted and killed on every
+  // invocation: the index never converged, found 64MB on disk with no
+  // `engrams` table at all. The default SQLite tier does no constructor-time
+  // background sync, so for most installs this drain is a no-op; where it
+  // isn't, the fingerprint guard makes an unchanged YAML nearly free.
   await drainPendingIndexWork()
 } catch (err: any) {
   if (shouldOutputJson(flags)) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -167,6 +167,22 @@ const COMMANDS: Record<string, string> = {
   '_embedder-probe': './commands/embedder-probe.js',
 }
 
+/**
+ * Await any background derived-index work started during this process.
+ *
+ * Deliberately swallows failures: the index is derived, YAML is the source of
+ * truth, and a command that already produced correct output must not exit
+ * non-zero because a cache could not be warmed. Core records the failure for
+ * `plur doctor` either way.
+ */
+async function drainPendingIndexWork(): Promise<void> {
+  try {
+    const { getLastPlurInstance } = await import('./plur.js')
+    const plur = getLastPlurInstance?.()
+    if (plur && typeof plur.waitForIndex === 'function') await plur.waitForIndex()
+  } catch { /* derived index — never fail a command over it */ }
+}
+
 if (!command || !COMMANDS[command]) {
   exit(1, `Unknown command: ${command}. Run 'plur --help' for usage.`)
 }
@@ -174,6 +190,18 @@ if (!command || !COMMANDS[command]) {
 try {
   const mod = await import(COMMANDS[command])
   await mod.run(commandArgs, flags)
+  // #1046: the derived index syncs in the BACKGROUND from the Plur
+  // constructor, and every command except `sync` used to exit without waiting
+  // for it. On a store large enough to auto-select PGLite that meant each run
+  // started a full-corpus pass and abandoned it partway, so the index never
+  // converged — it was found 64MB on disk with no `engrams` table at all,
+  // having been rebuilt-and-abandoned on every invocation for months.
+  //
+  // Waiting costs nothing in the steady state: the fingerprint guard in
+  // syncFromYaml makes an unchanged YAML a no-op, so this only blocks on the
+  // first run after an actual write, and only for as long as that write's
+  // sync takes.
+  await drainPendingIndexWork()
 } catch (err: any) {
   if (shouldOutputJson(flags)) {
     outputJson({ error: err.message })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -80,6 +80,8 @@ Commands:
   hook-codex-guard       (internal) Codex PreToolUse hook handler
   hook-codex-post-tool   (internal) Codex PostToolUse hook handler
   hook-codex-session-end (internal) Codex SessionEnd hook handler
+  hook-agy-pre-invocation (internal) Antigravity PreInvocation hook handler
+  hook-agy-guard         (internal) Antigravity PreToolUse hook handler
 
 Global flags:
   --json       Force JSON output (auto-detected when piped)
@@ -161,6 +163,8 @@ const COMMANDS: Record<string, string> = {
   'hook-codex-guard': './commands/hook-codex-guard.js',
   'hook-codex-post-tool': './commands/hook-codex-post-tool.js',
   'hook-codex-session-end': './commands/hook-codex-session-end.js',
+  'hook-agy-pre-invocation': './commands/hook-agy-pre-invocation.js',
+  'hook-agy-guard': './commands/hook-agy-guard.js',
   // Hidden internal subcommand — spawned by `plur doctor` to isolate the
   // ONNX embedder probe (issue #197). If the probe crashes with SIGABRT
   // on libc++ thread pool cleanup, only the subprocess dies; doctor stays alive.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -75,6 +75,11 @@ Commands:
   hook-cursor-guard      (internal) Cursor preToolUse hook handler
   hook-cursor-post-tool  (internal) Cursor postToolUse hook handler
   hook-cursor-stop       (internal) Cursor stop hook handler
+  hook-codex-session-start (internal) Codex SessionStart hook handler
+  hook-codex-inject      (internal) Codex UserPromptSubmit hook handler
+  hook-codex-guard       (internal) Codex PreToolUse hook handler
+  hook-codex-post-tool   (internal) Codex PostToolUse hook handler
+  hook-codex-session-end (internal) Codex SessionEnd hook handler
 
 Global flags:
   --json       Force JSON output (auto-detected when piped)
@@ -151,6 +156,11 @@ const COMMANDS: Record<string, string> = {
   'hook-cursor-guard': './commands/hook-cursor-guard.js',
   'hook-cursor-post-tool': './commands/hook-cursor-post-tool.js',
   'hook-cursor-stop': './commands/hook-cursor-stop.js',
+  'hook-codex-session-start': './commands/hook-codex-session-start.js',
+  'hook-codex-inject': './commands/hook-codex-inject.js',
+  'hook-codex-guard': './commands/hook-codex-guard.js',
+  'hook-codex-post-tool': './commands/hook-codex-post-tool.js',
+  'hook-codex-session-end': './commands/hook-codex-session-end.js',
   // Hidden internal subcommand — spawned by `plur doctor` to isolate the
   // ONNX embedder probe (issue #197). If the probe crashes with SIGABRT
   // on libc++ thread pool cleanup, only the subprocess dies; doctor stays alive.

--- a/packages/cli/src/lib/agy-hook-io.ts
+++ b/packages/cli/src/lib/agy-hook-io.ts
@@ -1,0 +1,170 @@
+import { readFileSync, mkdirSync, writeFileSync, existsSync, statSync, readdirSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { safeSessionKey } from './session-key.js'
+
+/**
+ * Shared helpers for the hook-agy-* commands (Antigravity CLI, `agy`).
+ *
+ * Antigravity's hook contract is a THIRD shape — not Claude Code/Codex's and
+ * not Gemini CLI's (all facts below verified live against agy 1.1.21,
+ * 2026-08-27, or taken from the CLI's own bundled reference at
+ * `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/hooks.md`,
+ * which is the authoritative doc — the public web docs are thinner):
+ *
+ *   - stdin payloads are camelCase protojson: `conversationId`, `stepIdx`,
+ *     `toolCall`, `transcriptPath` — not snake_case.
+ *   - Injection is `{"injectSteps":[{"ephemeralMessage": "..."}]}` from
+ *     PreInvocation — there is no additionalContext field anywhere.
+ *   - PreToolUse verdicts are a FLAT `{decision, reason}` — no
+ *     hookSpecificOutput envelope — and unlike Codex, `allow`/`ask`/
+ *     `force_ask` are accepted alongside `deny`.
+ *   - There are only five events and NO session-start event; PreInvocation
+ *     fires before EVERY model invocation (several times per user turn), so
+ *     injection has to dedupe per user turn itself — see
+ *     `lastUserInput()` / the step marker in hook-agy-pre-invocation.
+ *   - Timeouts are seconds (default 30). Exit codes: 0 = parse stdout, 2 =
+ *     system block with stderr as reason, anything else = non-fatal warning.
+ *   - No trust gate: hooks run on first invocation (verified), unlike Codex.
+ *
+ * Sentinels live in their own directory, separate from the Claude Code,
+ * Cursor and Codex hook families: one project can be open in several
+ * harnesses at once, and two guards disagreeing about whether a session
+ * started is worse than each nudging once.
+ *
+ * Generic stdin/exit plumbing (readStdinJson, runCodexHook's exit-0
+ * guarantee, injectWithFallback) is imported from codex-hook-io.ts rather
+ * than duplicated — the #1034 HarnessAdapter refactor is where that file
+ * stops being the accidental home of the shared pieces.
+ */
+
+export { readStdinJson, runCodexHook as runAgyHook, injectWithFallback, isPlurSessionStartTool } from './codex-hook-io.js'
+
+const SESSION_DIR = join(tmpdir(), 'plur-agy-sessions')
+const STALE_SESSION_FILE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+function ensureDir(): void {
+  mkdirSync(SESSION_DIR, { recursive: true })
+}
+
+/** Test seam — the directory agy sentinels live in. */
+export function agySessionDir(): string {
+  return SESSION_DIR
+}
+
+/**
+ * Antigravity sends `conversationId` (camelCase) on every hook event —
+ * verified in live PreInvocation and PreToolUse payloads.
+ */
+export function agyConversationId(input: Record<string, unknown>): string {
+  const id = String(input.conversationId ?? '')
+  if (!id) {
+    process.stderr.write(
+      '[plur] agy hook: no conversationId in hook payload — skipping (memory ' +
+      'injection/enforcement inactive for this event). Run `plur doctor` if this persists.\n',
+    )
+  }
+  return id
+}
+
+export function agySentinelPath(conversationId: string): string {
+  return join(SESSION_DIR, `${safeSessionKey(conversationId)}.marker`)
+}
+
+export function agyCounterPath(conversationId: string, name: string): string {
+  return join(SESSION_DIR, `${safeSessionKey(conversationId)}.${name}`)
+}
+
+export function agyMarkSessionStarted(conversationId: string): void {
+  ensureDir()
+  writeFileSync(agySentinelPath(conversationId), new Date().toISOString())
+  cleanupStaleAgySessionFiles()
+}
+
+export function agyIsSessionStarted(conversationId: string): boolean {
+  return existsSync(agySentinelPath(conversationId))
+}
+
+/** Same fail-open contract as codex-hook-io's incrementCounter: an unpersistable counter reports itself as exceeded. */
+export function agyIncrementCounter(path: string): number {
+  ensureDir()
+  let n = 0
+  try {
+    n = parseInt(readFileSync(path, 'utf8').trim(), 10) || 0
+  } catch { /* first increment */ }
+  n += 1
+  try {
+    writeFileSync(path, String(n))
+  } catch {
+    return Number.MAX_SAFE_INTEGER
+  }
+  return n
+}
+
+export function cleanupStaleAgySessionFiles(now: number = Date.now(), dir: string = SESSION_DIR): void {
+  try {
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name)
+      try {
+        if (now - statSync(p).mtimeMs > STALE_SESSION_FILE_MAX_AGE_MS) unlinkSync(p)
+      } catch { /* raced with another hook — fine */ }
+    }
+  } catch { /* dir does not exist yet */ }
+}
+
+// ── Transcript access ───────────────────────────────────────────────────────
+
+export interface AgyUserInput {
+  stepIndex: number
+  text: string
+}
+
+/**
+ * The most recent user message in an Antigravity conversation transcript.
+ *
+ * PreInvocation's stdin payload carries NO prompt text — only counters and
+ * paths — so per-prompt recall has to come from the transcript file the
+ * payload points at (`transcriptPath`). The file is JSONL; user turns look
+ * like (captured live, 2026-08-27):
+ *
+ *   {"step_index": 0, "source": "USER_EXPLICIT", "type": "USER_INPUT",
+ *    "status": "DONE", "content": "<USER_REQUEST>\n...actual text...</USER_REQUEST>"}
+ *
+ * Returns the LAST such entry, with the <USER_REQUEST> wrapper stripped, or
+ * null when the file is missing/unreadable/contains no user turn. Callers
+ * treat null as "inject the generic session batch, or stay silent" — never
+ * as an error: the transcript format is Antigravity's internal file and can
+ * change under us, and a hook must degrade, not break.
+ */
+export function lastUserInput(transcriptPath: string): AgyUserInput | null {
+  let raw: string
+  try {
+    raw = readFileSync(transcriptPath, 'utf8')
+  } catch {
+    return null
+  }
+  let found: AgyUserInput | null = null
+  for (const line of raw.split('\n')) {
+    if (!line.includes('"USER_INPUT"')) continue // cheap pre-filter before JSON.parse
+    try {
+      const d = JSON.parse(line) as { type?: string; step_index?: number; content?: string }
+      if (d.type !== 'USER_INPUT' || typeof d.content !== 'string') continue
+      const text = d.content
+        .replace(/^\s*<USER_REQUEST>\s*/i, '')
+        .replace(/\s*<\/USER_REQUEST>\s*$/i, '')
+        .trim()
+      if (text) found = { stepIndex: d.step_index ?? -1, text }
+    } catch { /* partial line mid-write — skip */ }
+  }
+  return found
+}
+
+/**
+ * Emit a PreInvocation result injecting one ephemeral system message.
+ * Ephemeral messages are transient — shown to the model for this invocation,
+ * not persisted as conversation history — which is exactly right for
+ * recalled-memory context that the next turn will re-derive anyway.
+ */
+export function emitInjectSteps(ephemeralMessage: string): void {
+  process.stdout.write(JSON.stringify({ injectSteps: [{ ephemeralMessage }] }))
+}

--- a/packages/cli/src/lib/agy-hook-io.ts
+++ b/packages/cli/src/lib/agy-hook-io.ts
@@ -1,6 +1,7 @@
-import { readFileSync, mkdirSync, writeFileSync, existsSync, statSync, readdirSync, unlinkSync } from 'fs'
+import { readFileSync, mkdirSync, writeFileSync, existsSync, statSync, lstatSync, chmodSync, readdirSync, unlinkSync, openSync, readSync, closeSync, fstatSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { createHash } from 'crypto'
 import { safeSessionKey } from './session-key.js'
 
 /**
@@ -43,8 +44,47 @@ export { readStdinJson, runCodexHook as runAgyHook, injectWithFallback, isPlurSe
 const SESSION_DIR = join(tmpdir(), 'plur-agy-sessions')
 const STALE_SESSION_FILE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 
-function ensureDir(): void {
-  mkdirSync(SESSION_DIR, { recursive: true })
+/**
+ * Create — and vet — the session directory. Returns false when the directory
+ * cannot be trusted, and every writer treats that as "no persistence" (fail
+ * open: hooks keep working, they just re-derive instead of caching).
+ *
+ * The vetting exists because this directory holds RECALLED ENGRAM TEXT (the
+ * turn cache), not just timestamps, and it lives under os.tmpdir(), which on
+ * Linux is the world-writable /tmp (data-loss audit F8/F11). Two attacks the
+ * checks close:
+ *
+ *   - A pre-planted symlink at plur-agy-sessions/ pointing somewhere the
+ *     attacker can read or wants us to scribble on. mkdirSync({recursive})
+ *     happily accepts an existing symlink-to-dir, so lstat and refuse.
+ *   - A directory pre-created by another user (0777 or simply theirs), which
+ *     would let them read every conversation's recalled memory and rewrite
+ *     turn caches that we later feed to the model as context.
+ *
+ * The dir is created 0700 and files 0600 for the same reason. macOS tmpdirs
+ * are already per-user, so the checks only ever bite on shared-/tmp systems —
+ * which is exactly where they must.
+ */
+function ensureDir(): boolean {
+  try {
+    mkdirSync(SESSION_DIR, { recursive: true, mode: 0o700 })
+    if (process.platform !== 'win32') {
+      const st = lstatSync(SESSION_DIR)
+      if (st.isSymbolicLink() || !st.isDirectory()) return false
+      if (typeof process.getuid === 'function' && st.uid !== process.getuid()) return false
+      if ((st.mode & 0o077) !== 0) {
+        // Our own dir with loose modes is the UPGRADE case, not the attack
+        // case — every install prior to this hardening created it 0755
+        // (mkdirSync's default), and refusing it would permanently disable
+        // persistence for exactly the users who already had it working.
+        // Tighten in place; refuse only if that fails.
+        try { chmodSync(SESSION_DIR, 0o700) } catch { return false }
+      }
+    }
+    return true
+  } catch {
+    return false
+  }
 }
 
 /** Test seam — the directory agy sentinels live in. */
@@ -76,8 +116,10 @@ export function agyCounterPath(conversationId: string, name: string): string {
 }
 
 export function agyMarkSessionStarted(conversationId: string): void {
-  ensureDir()
-  writeFileSync(agySentinelPath(conversationId), new Date().toISOString())
+  if (!ensureDir()) return // fail open — an unmarkable session costs one extra nudge
+  try {
+    writeFileSync(agySentinelPath(conversationId), new Date().toISOString(), { mode: 0o600 })
+  } catch { /* same trade */ }
   cleanupStaleAgySessionFiles()
 }
 
@@ -87,18 +129,69 @@ export function agyIsSessionStarted(conversationId: string): boolean {
 
 /** Same fail-open contract as codex-hook-io's incrementCounter: an unpersistable counter reports itself as exceeded. */
 export function agyIncrementCounter(path: string): number {
-  ensureDir()
+  if (!ensureDir()) return Number.MAX_SAFE_INTEGER
   let n = 0
   try {
     n = parseInt(readFileSync(path, 'utf8').trim(), 10) || 0
   } catch { /* first increment */ }
   n += 1
   try {
-    writeFileSync(path, String(n))
+    writeFileSync(path, String(n), { mode: 0o600 })
   } catch {
     return Number.MAX_SAFE_INTEGER
   }
   return n
+}
+
+// ── Per-turn injection cache ────────────────────────────────────────────────
+
+/** Stable identity for a user message's text. 16 hex chars of sha256 is ample for same-vs-different. */
+export function agyTextHash(text: string): string {
+  return createHash('sha256').update(text).digest('hex').slice(0, 16)
+}
+
+export interface AgyTurnCache {
+  /** The conversation this cache belongs to — REQUIRED on read (F9). */
+  conversationId: string
+  step: number
+  textHash: string
+  message: string
+}
+
+/**
+ * Read this conversation's turn cache, or null.
+ *
+ * The conversationId check is load-bearing (data-loss audit F9):
+ * safeSessionKey maps every non-[A-Za-z0-9_-] byte to '_', so distinct ids
+ * ("conv/42", "conv.42") can collide on the same PATH. The id stored INSIDE
+ * the record is exact, so a collision reads as "no cache" instead of
+ * injecting another conversation's recalled memory into this one.
+ */
+export function readAgyTurnCache(conversationId: string): AgyTurnCache | null {
+  try {
+    const raw = JSON.parse(readFileSync(agyCounterPath(conversationId, 'turncache'), 'utf8')) as Partial<AgyTurnCache>
+    if (raw.conversationId !== conversationId) return null
+    // Number.isSafeInteger, not typeof: a poisoned step like 1e308 would pin
+    // every future step comparison false and freeze the cache on turn one
+    // (adversarial audit F4). The textHash tie-break already limits the
+    // damage, but a step no real transcript can produce is simply invalid.
+    if (typeof raw.step !== 'number' || !Number.isSafeInteger(raw.step) || typeof raw.message !== 'string') return null
+    return {
+      conversationId,
+      step: raw.step,
+      textHash: typeof raw.textHash === 'string' ? raw.textHash : '',
+      message: raw.message,
+    }
+  } catch {
+    return null // missing, torn, or corrupt — degrade to a fresh recall
+  }
+}
+
+export function writeAgyTurnCache(cache: AgyTurnCache): void {
+  if (!ensureDir()) return // fail open — the turn re-recalls instead of replaying
+  try {
+    writeFileSync(agyCounterPath(cache.conversationId, 'turncache'), JSON.stringify(cache), { mode: 0o600 })
+  } catch { /* same trade */ }
 }
 
 export function cleanupStaleAgySessionFiles(now: number = Date.now(), dir: string = SESSION_DIR): void {
@@ -136,10 +229,32 @@ export interface AgyUserInput {
  * as an error: the transcript format is Antigravity's internal file and can
  * change under us, and a hook must degrade, not break.
  */
+/**
+ * Never read more than this much transcript. A long agentic session's JSONL
+ * grows without bound, and the entry we want is by definition near the END —
+ * so past the cap, read only the trailing window. A user message larger than
+ * 4MB is not a realistic prompt; a 100MB transcript is a realistic session.
+ */
+const TRANSCRIPT_READ_CAP = 4 * 1024 * 1024
+
 export function lastUserInput(transcriptPath: string): AgyUserInput | null {
   let raw: string
   try {
-    raw = readFileSync(transcriptPath, 'utf8')
+    const fd = openSync(transcriptPath, 'r')
+    try {
+      const size = fstatSync(fd).size
+      if (size <= TRANSCRIPT_READ_CAP) {
+        raw = readFileSync(transcriptPath, 'utf8')
+      } else {
+        const buf = Buffer.alloc(TRANSCRIPT_READ_CAP)
+        const n = readSync(fd, buf, 0, TRANSCRIPT_READ_CAP, size - TRANSCRIPT_READ_CAP)
+        // The first line of the window is almost certainly torn; its
+        // JSON.parse fails and it is skipped, same as any mid-write line.
+        raw = buf.subarray(0, n).toString('utf8')
+      }
+    } finally {
+      closeSync(fd)
+    }
   } catch {
     return null
   }

--- a/packages/cli/src/lib/codex-hook-io.ts
+++ b/packages/cli/src/lib/codex-hook-io.ts
@@ -215,3 +215,102 @@ export async function runCodexHook(
   }
   process.exit(0)
 }
+
+const DEADLINE_MISSED = Symbol('plur.hybrid.deadline')
+
+/**
+ * Is hybrid injection allowed on this machine? Default NO — see #1040.
+ *
+ * Loading the ONNX embedder makes the process die with SIGABRT (exit 134) in
+ * native teardown, AFTER the JS work has finished and `process.exit(0)` has
+ * been called. Nothing in JS can trap it. Codex reads the exit code as the
+ * hook's verdict and DISCARDS the output of a non-zero hook, so hybrid on
+ * Codex produces a correct payload that is then thrown away — strictly worse
+ * than BM25, which exits 0 and gets delivered.
+ *
+ * The quality case for hybrid is real and measured (2026-08-27, 5,775-engram
+ * store): ~4.7s vs ~1.6s, and it diverges from BM25 on ~10% of the injected
+ * set for keyword-rich prompts, ~22% for vague ones — precisely the prompts
+ * where the user is leaning on memory rather than supplying keywords. So the
+ * implementation stays, switched off, rather than being deleted and rebuilt.
+ *
+ * Flip the default here once #1040 is fixed; the opt-in also lets anyone whose
+ * environment does not reproduce the crash turn it on today.
+ */
+export function hybridEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.PLUR_CODEX_HYBRID === '1'
+}
+
+/** Soft deadline for the hybrid leg before falling back to BM25. Override for tests/slow machines. */
+export const HYBRID_DEADLINE_MS =
+  parseInt(process.env.PLUR_CODEX_HYBRID_DEADLINE_MS ?? '', 10) || 8_000
+
+export interface InjectOutcome<R> {
+  result: R
+  mode: 'hybrid' | 'bm25'
+}
+
+/** The two inject entry points this helper races, structurally typed so `Plur` satisfies it. */
+export interface Injectable<O, R> {
+  inject: (task: string, opts: O) => Promise<R>
+  injectHybrid: (task: string, opts: O) => Promise<R>
+}
+
+/**
+ * Inject with hybrid search, falling back to BM25 if hybrid misses a soft deadline.
+ *
+ * Why hybrid at all, when the Cursor and Claude Code event hooks are
+ * deliberately BM25-only: their comments justify that with "the BGE embedder
+ * costs ~20s to load in a cold CLI process". Measured on 2026-08-27 against a
+ * 5,775-engram store, fresh node process per run, that is now ~4.7s for the
+ * whole hybrid inject versus ~1.6s for BM25 — a ~3s marginal cost, not 20s.
+ * The 20s figure predates several rounds of work on the load path and should
+ * not be inherited without re-measuring.
+ *
+ * Why it is worth 3s: on keyword-ish prompts hybrid and BM25 agree on ~90% of
+ * the injected set, but on vague, low-keyword prompts ("this keeps breaking in
+ * the same way", "what did we agree on") agreement drops to ~78% — exactly the
+ * prompts where a user is relying on memory rather than telling you the
+ * keywords. The divergence roughly doubles where recall matters most.
+ *
+ * Why a deadline rather than just calling injectHybrid: 4.7s is this machine
+ * and this store. A slower machine, a larger corpus, or a cold model download
+ * turns that into a hook Codex kills at its timeout — and a killed hook
+ * injects NOTHING, which is strictly worse than BM25 results. The race bounds
+ * the worst case at deadline + BM25 (~10s here) while keeping the typical case
+ * at hybrid speed. The abandoned hybrid promise is harmless: `runCodexHook`
+ * force-exits the process immediately afterwards.
+ */
+export async function injectWithFallback<O, R>(
+  plur: Injectable<O, R>,
+  task: string,
+  opts: O,
+  deadlineMs: number = HYBRID_DEADLINE_MS,
+): Promise<InjectOutcome<R>> {
+  if (!hybridEnabled()) return { result: await plur.inject(task, opts), mode: 'bm25' }
+
+  let timer: NodeJS.Timeout | undefined
+  try {
+    const deadline = new Promise<typeof DEADLINE_MISSED>((resolve) => {
+      timer = setTimeout(() => resolve(DEADLINE_MISSED), deadlineMs)
+      timer.unref?.()
+    })
+    // A sentinel, not null: R is unconstrained, so a legitimate hybrid result
+    // could itself be falsy and would otherwise read as a deadline miss.
+    const raced = await Promise.race([plur.injectHybrid(task, opts), deadline])
+    if (raced !== DEADLINE_MISSED) return { result: raced, mode: 'hybrid' }
+    process.stderr.write(
+      `[plur] hybrid injection exceeded ${deadlineMs}ms — falling back to BM25 for this turn. ` +
+      'Raise PLUR_CODEX_HYBRID_DEADLINE_MS if this is routine on your machine.\n',
+    )
+  } catch (err: unknown) {
+    // A hybrid-specific failure (embedder unavailable, index mid-rebuild) must
+    // not cost the turn its memory — BM25 needs neither.
+    process.stderr.write(
+      `[plur] hybrid injection failed (${(err as Error)?.message ?? 'unknown'}) — using BM25.\n`,
+    )
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+  return { result: await plur.inject(task, opts), mode: 'bm25' }
+}

--- a/packages/cli/src/lib/codex-hook-io.ts
+++ b/packages/cli/src/lib/codex-hook-io.ts
@@ -219,26 +219,28 @@ export async function runCodexHook(
 const DEADLINE_MISSED = Symbol('plur.hybrid.deadline')
 
 /**
- * Is hybrid injection allowed on this machine? Default NO — see #1040.
+ * Is hybrid injection allowed? Default YES since #1040 was fixed.
  *
- * Loading the ONNX embedder makes the process die with SIGABRT (exit 134) in
- * native teardown, AFTER the JS work has finished and `process.exit(0)` has
- * been called. Nothing in JS can trap it. Codex reads the exit code as the
- * hook's verdict and DISCARDS the output of a non-zero hook, so hybrid on
- * Codex produces a correct payload that is then thrown away — strictly worse
- * than BM25, which exits 0 and gets delivered.
+ * Hybrid is worth its cost — measured 2026-08-27 on a 5,775-engram store,
+ * fresh process per run: ~4.7s vs ~1.6s for BM25, and the injected set
+ * diverges from BM25 on ~10% of entries for keyword-rich prompts and ~22% for
+ * vague ones ("this keeps breaking in the same way"), which is precisely when
+ * the user is leaning on memory rather than supplying the keywords.
  *
- * The quality case for hybrid is real and measured (2026-08-27, 5,775-engram
- * store): ~4.7s vs ~1.6s, and it diverges from BM25 on ~10% of the injected
- * set for keyword-rich prompts, ~22% for vague ones — precisely the prompts
- * where the user is leaning on memory rather than supplying keywords. So the
- * implementation stays, switched off, rather than being deleted and rebuilt.
+ * It shipped switched OFF for one release because loading the ONNX embedder
+ * killed the process with SIGABRT (exit 134) during native teardown, after
+ * the JS work had finished and `process.exit(0)` had been called — and Codex
+ * DISCARDS the output of any hook that exits non-zero, so hybrid produced a
+ * correct payload that was then thrown away. That was `@huggingface/transformers`
+ * 3.8.1 / onnxruntime-node 1.21; 4.2.0 / 1.24.3 exits 0 with bit-identical
+ * embedding vectors. See #1040.
  *
- * Flip the default here once #1040 is fixed; the opt-in also lets anyone whose
- * environment does not reproduce the crash turn it on today.
+ * `PLUR_CODEX_HYBRID=0` forces BM25 — the escape hatch if a future runtime
+ * regresses the same way, or on a machine where the embedder is unavailable
+ * and the fallback's wasted attempt is not worth paying for.
  */
 export function hybridEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env.PLUR_CODEX_HYBRID === '1'
+  return env.PLUR_CODEX_HYBRID !== '0'
 }
 
 /** Soft deadline for the hybrid leg before falling back to BM25. Override for tests/slow machines. */

--- a/packages/cli/src/lib/codex-hook-io.ts
+++ b/packages/cli/src/lib/codex-hook-io.ts
@@ -1,0 +1,217 @@
+import { readSync, readFileSync, mkdirSync, writeFileSync, existsSync, statSync, readdirSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { safeSessionKey } from './session-key.js'
+
+/**
+ * Shared stdin-reading and sentinel helpers for the four hook-codex-*
+ * commands.
+ *
+ * Codex's hook contract is close to a straight port of Claude Code's — same
+ * nested `{ matcher, hooks: [...] }` config shape, same snake_case stdin
+ * payload, same `hookSpecificOutput.additionalContext` on stdout — so this
+ * file is deliberately much thinner than its Cursor counterpart. Cursor
+ * needed a whole `.mdc`-rewrite channel because `additional_context` from
+ * `sessionStart` is dropped by a race in Cursor's composer; Codex delivers
+ * it correctly (verified against codex-cli 0.149.1, 2026-08-27: strings
+ * emitted from both SessionStart and UserPromptSubmit were read back
+ * verbatim by the model in the same turn), so the standard channel is the
+ * only channel here.
+ *
+ * Sentinels live under a Codex-specific directory rather than sharing
+ * Claude Code's `~/.plur/sessions/` or the Cursor hooks' tmpdir namespace:
+ * a project can legitimately be open in more than one harness at once, and
+ * two guards disagreeing about whether a session has started is worse than
+ * two guards each nudging once.
+ */
+
+export function readStdinJson(): Record<string, unknown> {
+  try {
+    const chunks: Buffer[] = []
+    const buf = Buffer.alloc(65536)
+    for (;;) {
+      try {
+        const n = readSync(0, buf, 0, buf.length, null)
+        if (n === 0) break
+        chunks.push(Buffer.from(buf.subarray(0, n)))
+      } catch {
+        break
+      }
+    }
+    const raw = Buffer.concat(chunks).toString('utf8').trim()
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    return (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+      ? parsed as Record<string, unknown>
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Codex sends `session_id` on every hook event (verified on 0.149.1 across
+ * SessionStart, UserPromptSubmit and PreToolUse payloads). `conversation_id`
+ * is accepted as a fallback purely because Cursor uses that name and the two
+ * payloads are otherwise near-identical — cheap insurance against Codex
+ * renaming toward the same word, not evidence that it ever sends it.
+ */
+export function codexSessionId(input: Record<string, unknown>): string {
+  const id = String(input.session_id ?? input.conversation_id ?? '')
+  if (!id) {
+    process.stderr.write(
+      '[plur] codex hook: no session_id in hook payload — skipping (memory injection/' +
+      'enforcement inactive for this event). Run `plur doctor` if this persists.\n',
+    )
+  }
+  return id
+}
+
+/**
+ * Codex prefixes MCP tools with the server name. The exact separator is not
+ * pinned down across versions — there is a `non_prefixed_mcp_tool_names`
+ * feature flag in 0.149.1, which means the prefixing scheme is something
+ * Codex is actively changing — so match on the suffix rather than on any one
+ * spelling of the prefix, and accept the bare name for the unprefixed case
+ * that flag turns on.
+ */
+export function isPlurSessionStartTool(toolName: string): boolean {
+  if (toolName === 'plur_session_start') return true
+  return /(^|[^a-z0-9])plur_session_start$/.test(toolName)
+}
+
+const SESSION_DIR = join(tmpdir(), 'plur-codex-sessions')
+const STALE_SESSION_FILE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+function ensureDir(): void {
+  mkdirSync(SESSION_DIR, { recursive: true })
+}
+
+export function sentinelPath(sessionId: string): string {
+  return join(SESSION_DIR, `${safeSessionKey(sessionId)}.marker`)
+}
+
+/**
+ * Path for a named per-session counter file (guard block count, learn-nudge
+ * cadence). Built from the sanitized key rather than by string-munging
+ * `sentinelPath()`, so it stays correct on Windows path separators.
+ */
+export function counterPath(sessionId: string, name: string): string {
+  return join(SESSION_DIR, `${safeSessionKey(sessionId)}.${name}`)
+}
+
+export function markSessionStarted(sessionId: string): void {
+  ensureDir()
+  writeFileSync(sentinelPath(sessionId), new Date().toISOString())
+  cleanupStaleSessionFiles()
+}
+
+export function isSessionStarted(sessionId: string): boolean {
+  return existsSync(sentinelPath(sessionId))
+}
+
+/**
+ * Read-modify-write a small integer counter file. Used for the guard's
+ * block count and the learn-nudge cadence. Not atomic — two hooks racing on
+ * the same counter can lose an increment, which costs at most one extra
+ * nudge and is not worth a lock file.
+ */
+export function incrementCounter(path: string): number {
+  ensureDir()
+  let n = 0
+  try {
+    n = parseInt(readFileSync(path, 'utf8').trim(), 10) || 0
+  } catch { /* first increment */ }
+  n += 1
+  try { writeFileSync(path, String(n)) } catch { /* best effort */ }
+  return n
+}
+
+/**
+ * Delete session marker files older than STALE_SESSION_FILE_MAX_AGE_MS.
+ * Mirrors the equivalent cleanup in the Claude Code and Cursor hook
+ * families — without it every unique session_id leaves orphaned files in
+ * tmpdir forever.
+ */
+export function cleanupStaleSessionFiles(
+  now: number = Date.now(),
+  dir: string = SESSION_DIR,
+): void {
+  try {
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name)
+      try {
+        if (now - statSync(p).mtimeMs > STALE_SESSION_FILE_MAX_AGE_MS) unlinkSync(p)
+      } catch { /* raced with another hook — fine */ }
+    }
+  } catch { /* dir does not exist yet */ }
+}
+
+/** Test seam — the directory sentinels live in. */
+export function sessionDir(): string {
+  return SESSION_DIR
+}
+
+/**
+ * Emit a Codex hook result carrying model-visible context.
+ *
+ * `hookEventName` MUST match the firing event or Codex rejects the output
+ * ("hook returned invalid <event> JSON output"). Writing nothing at all is
+ * always a valid "no opinion" result, so callers with nothing to say should
+ * simply not call this.
+ */
+export function emitContext(hookEventName: string, additionalContext: string): void {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName, additionalContext },
+  }))
+}
+
+/**
+ * Run a Codex hook body and guarantee the process ends with exit code 0.
+ *
+ * Codex reads the exit code as the hook's verdict, and a non-zero one is not
+ * a warning — it DISCARDS the hook's output entirely (`hook: X Failed`), and
+ * on PreToolUse an exit code of 2 means BLOCK THE TOOL, with stderr as the
+ * blocking reason. So a crash in an unrelated part of the engine does not
+ * degrade to "no memory this turn"; it degrades to "every tool call is
+ * blocked by a hook that has nothing to say".
+ *
+ * That is not hypothetical. Verified 2026-08-27: on a machine whose PGLite
+ * index was corrupt, `plur status` and every hook exited 1 — PGLite's WASM
+ * layer aborts during teardown, long after the hook has already written
+ * perfectly good JSON to stdout. Codex reported `SessionStart Failed` and
+ * dropped the engrams, with the injected block sitting complete and unread
+ * in the discarded output.
+ *
+ * So: catch everything, report to stderr (never stdout — Codex parses that as
+ * the result), flush, and exit 0 explicitly rather than letting a background
+ * handle decide the exit code.
+ */
+export async function runCodexHook(
+  name: string,
+  body: () => Promise<void>,
+): Promise<void> {
+  try {
+    await body()
+  } catch (err: unknown) {
+    process.stderr.write(`[plur] ${name} failed: ${(err as Error)?.message ?? 'unknown error'}\n`)
+  }
+  // Flush before exiting: process.exit() truncates a pipe that has buffered
+  // writes pending, which would turn our valid JSON into a parse error —
+  // the same failure by a different route.
+  await new Promise<void>((resolve) => {
+    if (process.stdout.write('')) resolve()
+    else process.stdout.once('drain', () => resolve())
+  })
+
+  // The force-exit is the whole point of this wrapper, so it cannot be
+  // conditional on anything a user's environment might set by accident.
+  // Tests, which call run() in-process, would take the whole runner down
+  // with it — hence one explicit, purpose-named opt-out rather than
+  // sniffing for a test runner.
+  if (process.env.PLUR_HOOK_NO_EXIT === '1') {
+    process.exitCode = 0
+    return
+  }
+  process.exit(0)
+}

--- a/packages/cli/src/lib/codex-hook-io.ts
+++ b/packages/cli/src/lib/codex-hook-io.ts
@@ -247,17 +247,25 @@ const DEADLINE_MISSED = Symbol('plur.hybrid.deadline')
  * 3.8.1 / onnxruntime-node 1.21; 4.2.0 / 1.24.3 exits 0 with bit-identical
  * embedding vectors. See #1040.
  *
- * `PLUR_CODEX_HYBRID=0` forces BM25 — the escape hatch if a future runtime
+ * `PLUR_HOOK_HYBRID=0` forces BM25 — the escape hatch if a future runtime
  * regresses the same way, or on a machine where the embedder is unavailable
- * and the fallback's wasted attempt is not worth paying for.
+ * and the fallback's wasted attempt is not worth paying for. The Codex-named
+ * `PLUR_CODEX_HYBRID` is honoured as an alias because this helper also
+ * drives the ANTIGRAVITY hooks (via agy-hook-io's re-export) and the
+ * original name would be undiscoverable from there (evaluator audit M12).
+ * "Off" accepts the obvious spellings — an escape hatch someone reaches for
+ * mid-incident must not fail on `false` vs `0` (adversarial audit F5).
  */
 export function hybridEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env.PLUR_CODEX_HYBRID !== '0'
+  const raw = env.PLUR_HOOK_HYBRID ?? env.PLUR_CODEX_HYBRID
+  if (raw === undefined) return true
+  const v = raw.trim().toLowerCase()
+  return !(v === '0' || v === 'false' || v === 'off' || v === 'no')
 }
 
 /** Soft deadline for the hybrid leg before falling back to BM25. Override for tests/slow machines. */
 export const HYBRID_DEADLINE_MS =
-  parseInt(process.env.PLUR_CODEX_HYBRID_DEADLINE_MS ?? '', 10) || 8_000
+  parseInt(process.env.PLUR_HOOK_HYBRID_DEADLINE_MS ?? process.env.PLUR_CODEX_HYBRID_DEADLINE_MS ?? '', 10) || 8_000
 
 export interface InjectOutcome<R> {
   result: R
@@ -306,8 +314,14 @@ export async function injectWithFallback<O, R>(
   let timer: NodeJS.Timeout | undefined
   try {
     const deadline = new Promise<typeof DEADLINE_MISSED>((resolve) => {
+      // Deliberately NOT unref()'d (adversarial audit F1). If injectHybrid
+      // ever leaves the event loop with no other referenced handle, an
+      // unref'd timer cannot fire, the race never settles, and Node exits 13
+      // ("unsettled top-level await") BEFORE runCodexHook reaches its
+      // process.exit(0) — reintroducing exactly the discarded-output failure
+      // that wrapper exists to prevent. A referenced timer cannot linger
+      // either: every caller force-exits right after this returns.
       timer = setTimeout(() => resolve(DEADLINE_MISSED), deadlineMs)
-      timer.unref?.()
     })
     // A sentinel, not null: R is unconstrained, so a legitimate hybrid result
     // could itself be falsy and would otherwise read as a deadline miss.
@@ -315,7 +329,8 @@ export async function injectWithFallback<O, R>(
     if (raced !== DEADLINE_MISSED) return { result: raced, mode: 'hybrid' }
     process.stderr.write(
       `[plur] hybrid injection exceeded ${deadlineMs}ms — falling back to BM25 for this turn. ` +
-      'Raise PLUR_CODEX_HYBRID_DEADLINE_MS if this is routine on your machine.\n',
+      'If this is routine, raise PLUR_HOOK_HYBRID_DEADLINE_MS — and keep it below your ' +
+      'harness hook timeout (Codex 25s, Antigravity 20s), or the hook gets killed and injects nothing.\n',
     )
   } catch (err: unknown) {
     // A hybrid-specific failure (embedder unavailable, index mid-rebuild) must

--- a/packages/cli/src/lib/codex-hook-io.ts
+++ b/packages/cli/src/lib/codex-hook-io.ts
@@ -123,7 +123,19 @@ export function incrementCounter(path: string): number {
     n = parseInt(readFileSync(path, 'utf8').trim(), 10) || 0
   } catch { /* first increment */ }
   n += 1
-  try { writeFileSync(path, String(n)) } catch { /* best effort */ }
+  try {
+    writeFileSync(path, String(n))
+  } catch {
+    // Adversarial-audit finding (2026-08-27): this used to swallow the write
+    // failure and return 1 anyway. With an unwritable session dir that made
+    // every guard call read 0 and return 1 — never exceeding
+    // MAX_BLOCKS_BEFORE_FALLBACK — so the deadlock protection NEVER fired and
+    // the guard denied every tool call for the rest of the session. A counter
+    // that cannot be persisted cannot bound anything; report it as already
+    // exceeded so callers fail OPEN (the documented posture for these hooks)
+    // instead of failing closed forever.
+    return Number.MAX_SAFE_INTEGER
+  }
   return n
 }
 

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -26,8 +26,13 @@ export interface ConfigFile {
    * 'claude-code': mcpServers + hooks, Claude's nested {matcher, hooks:[]} shape.
    * 'claude-desktop' / Cursor mcp.json: mcpServers only, no hooks section.
    * 'cursor-hooks': Cursor's separate hooks.json, flat {event: [{command,...}]} shape.
+   * 'codex-hooks': Codex's ~/.codex/hooks.json — Claude Code's nested shape,
+   *   but under a top-level `hooks` key alongside a `description`, and read
+   *   by its own parser so a future divergence doesn't silently misreport.
+   * 'codex-toml': Codex's config.toml — NOT JSON. Read-only here; doctor
+   *   only greps it for an `[mcp_servers.plur]` table.
    */
-  kind: 'claude-code' | 'claude-desktop' | 'cursor-hooks'
+  kind: 'claude-code' | 'claude-desktop' | 'cursor-hooks' | 'codex-hooks' | 'codex-toml'
 }
 
 /**
@@ -108,6 +113,33 @@ export function cursorProjectHooksConfigPath(cwd: string = process.cwd()): strin
   return join(cwd, '.cursor', 'hooks.json')
 }
 
+/**
+ * Locate Codex's home directory. Honours `CODEX_HOME`, which Codex itself
+ * reads — without this, `plur init --codex` would write into `~/.codex`
+ * while a `CODEX_HOME`-using install looked somewhere else entirely.
+ */
+export function codexHome(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CODEX_HOME || join(homedir(), '.codex')
+}
+
+/**
+ * Locate Codex's hooks config.
+ *
+ * Codex accepts hooks from EITHER this file or a `[hooks]` table in
+ * `config.toml`, and warns when both exist for the same layer. We own the
+ * JSON file: no TOML dependency, the same nested shape the Claude Code hook
+ * builders already emit, and PLUR's hooks stay out of the file the user
+ * hand-edits for models and MCP servers.
+ */
+export function codexHooksConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(codexHome(env), 'hooks.json')
+}
+
+/** Codex's main config file — read (not written) by `plur doctor` to check MCP registration. */
+export function codexConfigTomlPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(codexHome(env), 'config.toml')
+}
+
 /** Locate the static PLUR rules file `plur init --cursor` writes once, at install time. */
 export function cursorRulesPath(cwd: string = process.cwd()): string {
   return join(cwd, '.cursor', 'rules', 'plur-memory.mdc')
@@ -154,6 +186,8 @@ export function knownConfigFiles(cwd: string = process.cwd()): ConfigFile[] {
   const desktop = claudeDesktopConfigPath()
   const cursorMcp = cursorProjectMcpConfigPath(cwd)
   const cursorHooks = cursorProjectHooksConfigPath(cwd)
+  const codexHooks = codexHooksConfigPath()
+  const codexToml = codexConfigTomlPath()
 
   return [
     { label: 'Claude Code (project)', path: projectSettings, exists: existsSync(projectSettings), kind: 'claude-code' },
@@ -162,6 +196,8 @@ export function knownConfigFiles(cwd: string = process.cwd()): ConfigFile[] {
     { label: 'Claude Desktop', path: desktop, exists: existsSync(desktop), kind: 'claude-desktop' },
     { label: 'Cursor (.cursor/mcp.json)', path: cursorMcp, exists: existsSync(cursorMcp), kind: 'claude-desktop' },
     { label: 'Cursor (.cursor/hooks.json)', path: cursorHooks, exists: existsSync(cursorHooks), kind: 'cursor-hooks' },
+    { label: 'Codex (~/.codex/hooks.json)', path: codexHooks, exists: existsSync(codexHooks), kind: 'codex-hooks' },
+    { label: 'Codex (~/.codex/config.toml)', path: codexToml, exists: existsSync(codexToml), kind: 'codex-toml' },
   ]
 }
 

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -31,8 +31,10 @@ export interface ConfigFile {
    *   by its own parser so a future divergence doesn't silently misreport.
    * 'codex-toml': Codex's config.toml — NOT JSON. Read-only here; doctor
    *   only greps it for an `[mcp_servers.plur]` table.
+   * 'agy-hooks': Antigravity's hooks.json — a map of NAMED hook sets; PLUR
+   *   owns the 'plur-memory' key and nothing else.
    */
-  kind: 'claude-code' | 'claude-desktop' | 'cursor-hooks' | 'codex-hooks' | 'codex-toml'
+  kind: 'claude-code' | 'claude-desktop' | 'cursor-hooks' | 'codex-hooks' | 'codex-toml' | 'agy-hooks'
 }
 
 /**
@@ -140,6 +142,29 @@ export function codexConfigTomlPath(env: NodeJS.ProcessEnv = process.env): strin
   return join(codexHome(env), 'config.toml')
 }
 
+/**
+ * Antigravity CLI's global config directory. Everything agy loads globally
+ * lives here: hooks.json, mcp_config.json, skills. (The CLI itself keeps
+ * runtime state in ~/.gemini/antigravity-cli/, which we never write.)
+ */
+export function agyConfigDir(): string {
+  return join(homedir(), '.gemini', 'config')
+}
+
+/** Antigravity's global hooks config — a map of named hook sets. */
+export function agyHooksConfigPath(): string {
+  return join(agyConfigDir(), 'hooks.json')
+}
+
+/**
+ * Antigravity's global MCP config. Same `{ mcpServers: { name: {...} } }`
+ * shape as Claude Desktop / Cursor, so the existing hasPlurMcp/mergePlurMcp
+ * helpers apply unchanged.
+ */
+export function agyMcpConfigPath(): string {
+  return join(agyConfigDir(), 'mcp_config.json')
+}
+
 /** Locate the static PLUR rules file `plur init --cursor` writes once, at install time. */
 export function cursorRulesPath(cwd: string = process.cwd()): string {
   return join(cwd, '.cursor', 'rules', 'plur-memory.mdc')
@@ -188,6 +213,8 @@ export function knownConfigFiles(cwd: string = process.cwd()): ConfigFile[] {
   const cursorHooks = cursorProjectHooksConfigPath(cwd)
   const codexHooks = codexHooksConfigPath()
   const codexToml = codexConfigTomlPath()
+  const agyHooks = agyHooksConfigPath()
+  const agyMcp = agyMcpConfigPath()
 
   return [
     { label: 'Claude Code (project)', path: projectSettings, exists: existsSync(projectSettings), kind: 'claude-code' },
@@ -198,6 +225,8 @@ export function knownConfigFiles(cwd: string = process.cwd()): ConfigFile[] {
     { label: 'Cursor (.cursor/hooks.json)', path: cursorHooks, exists: existsSync(cursorHooks), kind: 'cursor-hooks' },
     { label: 'Codex (~/.codex/hooks.json)', path: codexHooks, exists: existsSync(codexHooks), kind: 'codex-hooks' },
     { label: 'Codex (~/.codex/config.toml)', path: codexToml, exists: existsSync(codexToml), kind: 'codex-toml' },
+    { label: 'Antigravity (~/.gemini/config/hooks.json)', path: agyHooks, exists: existsSync(agyHooks), kind: 'agy-hooks' },
+    { label: 'Antigravity (~/.gemini/config/mcp_config.json)', path: agyMcp, exists: existsSync(agyMcp), kind: 'claude-desktop' },
   ]
 }
 

--- a/packages/cli/src/plur.ts
+++ b/packages/cli/src/plur.ts
@@ -30,7 +30,23 @@ export function parseGlobalFlags(argv: string[]): { flags: GlobalFlags; args: st
  * refresh. Read-only commands (`list`, `status`, `tensions` list mode) pass it
  * so lazy engine side-effects cannot mutate the store from a pure query.
  */
+/**
+ * The most recent Plur built in this process (#1046).
+ *
+ * The CLI entrypoint needs a handle on it to drain background index work
+ * before exiting, and commands construct their own instance rather than
+ * receiving one. Last-wins is right here: a CLI process runs one command, and
+ * the commands that build more than one build them against the same store.
+ */
+let lastInstance: Plur | null = null
+
+/** The last Plur constructed in this process, or null if none was. */
+export function getLastPlurInstance(): Plur | null {
+  return lastInstance
+}
+
 export function createPlur(flags: GlobalFlags, options?: { readonly?: boolean }): Plur {
   const path = flags.path || process.env.PLUR_PATH || undefined
-  return new Plur({ path, readonly: options?.readonly })
+  lastInstance = new Plur({ path, readonly: options?.readonly })
+  return lastInstance
 }

--- a/packages/cli/src/plur.ts
+++ b/packages/cli/src/plur.ts
@@ -23,20 +23,14 @@ export function parseGlobalFlags(argv: string[]): { flags: GlobalFlags; args: st
 }
 
 /**
- * Create Plur instance from flags.
- *
- * `readonly: true` opens a write-guarded engine (#731): reads work, every
- * mutation throws `ReadonlyStoreError`, and recall skips its activation
- * refresh. Read-only commands (`list`, `status`, `tensions` list mode) pass it
- * so lazy engine side-effects cannot mutate the store from a pure query.
- */
-/**
  * The most recent Plur built in this process (#1046).
  *
  * The CLI entrypoint needs a handle on it to drain background index work
  * before exiting, and commands construct their own instance rather than
- * receiving one. Last-wins is right here: a CLI process runs one command, and
- * the commands that build more than one build them against the same store.
+ * receiving one. Last-wins is the working assumption: a CLI process runs one
+ * command, and the commands that build more than one build them against the
+ * same store — `import` with `--store` routes through createPlur precisely
+ * so this stays true.
  */
 let lastInstance: Plur | null = null
 
@@ -45,6 +39,14 @@ export function getLastPlurInstance(): Plur | null {
   return lastInstance
 }
 
+/**
+ * Create Plur instance from flags.
+ *
+ * `readonly: true` opens a write-guarded engine (#731): reads work, every
+ * mutation throws `ReadonlyStoreError`, and recall skips its activation
+ * refresh. Read-only commands (`list`, `status`, `tensions` list mode) pass it
+ * so lazy engine side-effects cannot mutate the store from a pure query.
+ */
 export function createPlur(flags: GlobalFlags, options?: { readonly?: boolean }): Plur {
   const path = flags.path || process.env.PLUR_PATH || undefined
   lastInstance = new Plur({ path, readonly: options?.readonly })

--- a/packages/cli/test/agy-hook-io.test.ts
+++ b/packages/cli/test/agy-hook-io.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { rmSync, writeFileSync, statSync, existsSync, utimesSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  agySessionDir,
+  agySentinelPath,
+  agyCounterPath,
+  agyMarkSessionStarted,
+  agyIsSessionStarted,
+  agyIncrementCounter,
+  cleanupStaleAgySessionFiles,
+  agyTextHash,
+  readAgyTurnCache,
+  writeAgyTurnCache,
+} from '../src/lib/agy-hook-io.js'
+
+/**
+ * Pins for the agy copies of behaviours codex-hook-io.test.ts already pins
+ * (evaluator audit M15: deliberate duplication with no drift detector is
+ * duplication waiting to drift), plus the turn-cache validation rules all
+ * three audits converged on.
+ */
+
+const SID = 'agy-io-test-conversation'
+
+function clean() {
+  for (const n of ['a', 'b', 'turncache']) rmSync(agyCounterPath(SID, n), { force: true })
+  rmSync(agySentinelPath(SID), { force: true })
+}
+beforeEach(clean)
+afterEach(clean)
+
+describe('sentinel + counters (drift pins vs codex-hook-io)', () => {
+  it('marks and detects a started session', () => {
+    expect(agyIsSessionStarted(SID)).toBe(false)
+    agyMarkSessionStarted(SID)
+    expect(agyIsSessionStarted(SID)).toBe(true)
+  })
+
+  it('sanitizes ids so a traversal attempt cannot escape the session dir', () => {
+    const p = agySentinelPath('../../etc/passwd')
+    expect(p.startsWith(agySessionDir())).toBe(true)
+    expect(p).not.toContain('..')
+  })
+
+  it('treats a corrupt counter file as zero rather than NaN', () => {
+    agyMarkSessionStarted(SID) // ensures the dir exists
+    writeFileSync(agyCounterPath(SID, 'b'), 'not a number')
+    expect(agyIncrementCounter(agyCounterPath(SID, 'b'))).toBe(1)
+  })
+
+  it('reports an unwritable counter as exceeded so guards fail open', () => {
+    const unwritable = join(agySessionDir(), 'no-such-dir', 'nested', 'counter')
+    expect(agyIncrementCounter(unwritable)).toBe(Number.MAX_SAFE_INTEGER)
+  })
+
+  it('sweeps stale files and keeps fresh ones', () => {
+    agyMarkSessionStarted(SID)
+    const stale = agyCounterPath(SID, 'a')
+    writeFileSync(stale, '1')
+    const old = Date.now() / 1000 - 8 * 24 * 60 * 60
+    utimesSync(stale, old, old)
+    cleanupStaleAgySessionFiles()
+    expect(existsSync(stale)).toBe(false)
+    expect(existsSync(agySentinelPath(SID))).toBe(true)
+  })
+
+  it('does not throw when the session dir does not exist', () => {
+    const missing = join(tmpdir(), 'plur-agy-sessions-does-not-exist')
+    rmSync(missing, { recursive: true, force: true })
+    expect(() => cleanupStaleAgySessionFiles(Date.now(), missing)).not.toThrow()
+  })
+})
+
+describe('turn cache validation', () => {
+  const sample = () => ({
+    conversationId: SID,
+    step: 4,
+    textHash: agyTextHash('hello'),
+    message: '[PLUR Memory] recalled text',
+  })
+
+  it('round-trips', () => {
+    writeAgyTurnCache(sample())
+    expect(readAgyTurnCache(SID)).toEqual(sample())
+  })
+
+  // Data-loss audit F8: this file holds recalled engram content. World- or
+  // group-readable modes on shared /tmp expose every conversation's memory.
+  it('writes the cache file 0600 on POSIX', () => {
+    if (process.platform === 'win32') return
+    writeAgyTurnCache(sample())
+    expect(statSync(agyCounterPath(SID, 'turncache')).mode & 0o777).toBe(0o600)
+  })
+
+  it('rejects a record whose embedded conversationId differs (path collision, F9)', () => {
+    writeAgyTurnCache({ ...sample(), conversationId: 'agy-io-test.conversation' })
+    // Same sanitized path, different exact id → must read as no cache.
+    expect(readAgyTurnCache(SID)).toBeNull()
+  })
+
+  it.each([
+    ['poisoned step 1e308', { step: 1e308 }],
+    ['string step', { step: '4' }],
+    ['missing message', { message: undefined }],
+    ['numeric message', { message: 42 }],
+  ])('rejects an invalid record: %s', (_label, patch) => {
+    agyMarkSessionStarted(SID)
+    writeFileSync(
+      agyCounterPath(SID, 'turncache'),
+      JSON.stringify({ ...sample(), ...patch }),
+    )
+    expect(readAgyTurnCache(SID)).toBeNull()
+  })
+
+  it('treats a torn file as no cache', () => {
+    agyMarkSessionStarted(SID)
+    writeFileSync(agyCounterPath(SID, 'turncache'), '{"conversationId":"' + SID + '","step)')
+    expect(readAgyTurnCache(SID)).toBeNull()
+  })
+})

--- a/packages/cli/test/antigravity-hooks.test.ts
+++ b/packages/cli/test/antigravity-hooks.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  buildAgyHookSet,
+  mergeAgyHooks,
+  hasPlurAgyHooks,
+  readAgyHooksConfig,
+  writeAgyHooksConfig,
+  AGY_HOOK_SET_NAME,
+} from '../src/antigravity-hooks.js'
+import { lastUserInput } from '../src/lib/agy-hook-io.js'
+
+const SHIM = '/home/u/.plur/bin/plur-hook'
+
+let dir: string
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-agy-hooks-')) })
+afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+describe('buildAgyHookSet', () => {
+  it('uses exactly the two events the adapter needs', () => {
+    const set = buildAgyHookSet(SHIM)
+    expect(Object.keys(set).sort()).toEqual(['PreInvocation', 'PreToolUse', 'enabled'])
+    expect(set.enabled).toBe(true)
+  })
+
+  it('shapes tool events with a matcher group and lifecycle events flat — agy rejects the other way round', () => {
+    const set = buildAgyHookSet(SHIM)
+    // PreInvocation: flat handler array, straight to {type, command}.
+    expect(set.PreInvocation![0].command).toContain('hook-agy-pre-invocation')
+    expect(set.PreInvocation![0]).not.toHaveProperty('matcher')
+    expect(set.PreInvocation![0]).not.toHaveProperty('hooks')
+    // PreToolUse: {matcher, hooks:[]} wrapper.
+    expect(set.PreToolUse![0].matcher).toBe('*')
+    expect(set.PreToolUse![0].hooks[0].command).toContain('hook-agy-guard')
+  })
+
+  // agy's Stop can only BLOCK termination (decision:"continue" re-enters the
+  // loop) and PostToolUse can only output {} — neither can carry a nudge, and
+  // wiring them anyway would either force extra turns or do nothing.
+  it('never registers Stop or PostToolUse', () => {
+    const set = buildAgyHookSet(SHIM)
+    expect(set.Stop).toBeUndefined()
+    expect(set.PostToolUse).toBeUndefined()
+  })
+
+  it('keeps timeouts within agy seconds semantics and the hybrid worst case', () => {
+    const set = buildAgyHookSet(SHIM)
+    expect(set.PreInvocation![0].timeout).toBeGreaterThanOrEqual(15)
+    expect(set.PreInvocation![0].timeout).toBeLessThanOrEqual(30)
+    expect(set.PreToolUse![0].hooks[0].timeout).toBeLessThanOrEqual(10)
+  })
+})
+
+describe('mergeAgyHooks — ownership is the named key, nothing else', () => {
+  it('is idempotent', () => {
+    const once = mergeAgyHooks({}, buildAgyHookSet(SHIM))
+    const twice = mergeAgyHooks(once, buildAgyHookSet(SHIM))
+    expect(twice).toEqual(once)
+  })
+
+  it('replaces a stale PLUR set on upgrade rather than duplicating', () => {
+    const old = mergeAgyHooks({}, buildAgyHookSet('/old/plur-hook'))
+    const upgraded = mergeAgyHooks(old, buildAgyHookSet(SHIM))
+    expect(Object.keys(upgraded)).toEqual([AGY_HOOK_SET_NAME])
+    expect(upgraded[AGY_HOOK_SET_NAME].PreInvocation![0].command).toContain(SHIM)
+  })
+
+  it('passes a user’s own hook sets through byte-identical', () => {
+    const mine = {
+      'my-linter': {
+        PostToolUse: [{ matcher: 'run_command', hooks: [{ command: './lint.sh' }] }],
+      },
+      'safety-gate': { enabled: false, PreToolUse: [{ matcher: '*', hooks: [{ command: './gate.sh' }] }] },
+    }
+    const merged = mergeAgyHooks(mine as never, buildAgyHookSet(SHIM))
+    expect(merged['my-linter']).toEqual(mine['my-linter'])
+    expect(merged['safety-gate']).toEqual(mine['safety-gate'])
+    expect(hasPlurAgyHooks(merged)).toBe(true)
+  })
+
+  it('does not claim a user set that happens to mention plur in a command', () => {
+    const mine = { 'my-thing': { PreInvocation: [{ command: 'echo plur-memory' }] } }
+    expect(hasPlurAgyHooks(mine as never)).toBe(false)
+  })
+})
+
+describe('read/write round trip', () => {
+  it('reads back what it wrote', () => {
+    const p = join(dir, 'hooks.json')
+    const config = mergeAgyHooks({}, buildAgyHookSet(SHIM))
+    writeAgyHooksConfig(p, config)
+    expect(readAgyHooksConfig(p)).toEqual(config)
+    expect(() => JSON.parse(readFileSync(p, 'utf8'))).not.toThrow()
+  })
+
+  it('treats malformed and wrong-shaped files as empty when reading', () => {
+    const p = join(dir, 'hooks.json')
+    writeFileSync(p, '{ not json')
+    expect(readAgyHooksConfig(p)).toEqual({})
+    writeFileSync(p, '["an", "array"]')
+    expect(readAgyHooksConfig(p)).toEqual({})
+    writeFileSync(p, '"a string"')
+    expect(readAgyHooksConfig(p)).toEqual({})
+  })
+})
+
+describe('lastUserInput — transcript parsing', () => {
+  function transcript(lines: unknown[]): string {
+    const p = join(dir, 'transcript.jsonl')
+    writeFileSync(p, lines.map(l => typeof l === 'string' ? l : JSON.stringify(l)).join('\n'))
+    return p
+  }
+
+  it('finds the LAST user turn and strips the USER_REQUEST wrapper', () => {
+    const p = transcript([
+      { step_index: 0, type: 'USER_INPUT', content: '<USER_REQUEST>\nfirst question\n</USER_REQUEST>' },
+      { step_index: 1, type: 'PLANNER_RESPONSE', content: 'thinking...' },
+      { step_index: 5, type: 'USER_INPUT', content: '<USER_REQUEST>\nsecond question\n</USER_REQUEST>' },
+      { step_index: 6, type: 'EPHEMERAL_MESSAGE', content: 'USER_INPUT mentioned here as a decoy' },
+    ])
+    expect(lastUserInput(p)).toEqual({ stepIndex: 5, text: 'second question' })
+  })
+
+  it('returns null for a missing file — the caller degrades, never throws', () => {
+    expect(lastUserInput(join(dir, 'nope.jsonl'))).toBeNull()
+  })
+
+  it('returns null when no user turn exists', () => {
+    expect(lastUserInput(transcript([{ step_index: 0, type: 'PLANNER_RESPONSE', content: 'x' }]))).toBeNull()
+  })
+
+  it('survives a torn final line — the file is written live by agy', () => {
+    const p = transcript([
+      { step_index: 0, type: 'USER_INPUT', content: '<USER_REQUEST>real question</USER_REQUEST>' },
+      '{"step_index": 3, "type": "USER_INPUT", "content": "<USER_REQ', // torn mid-write
+    ])
+    expect(lastUserInput(p)).toEqual({ stepIndex: 0, text: 'real question' })
+  })
+
+  it('handles content without the wrapper', () => {
+    const p = transcript([{ step_index: 2, type: 'USER_INPUT', content: 'bare text' }])
+    expect(lastUserInput(p)).toEqual({ stepIndex: 2, text: 'bare text' })
+  })
+})

--- a/packages/cli/test/codex-hook-io.test.ts
+++ b/packages/cli/test/codex-hook-io.test.ts
@@ -14,6 +14,8 @@ import {
   sessionDir,
   emitContext,
   runCodexHook,
+  injectWithFallback,
+  hybridEnabled,
 } from '../src/lib/codex-hook-io.js'
 
 const SID = 'codex-io-test-session'
@@ -202,5 +204,86 @@ describe('runCodexHook', () => {
       hookSpecificOutput: { additionalContext: 'partial but useful' },
     })
     out.mockRestore()
+  })
+})
+
+/**
+ * Hybrid-first injection with a bounded BM25 fallback. The point is that a
+ * turn NEVER loses its memory: a slow or broken hybrid leg degrades to BM25
+ * rather than to a hook Codex kills at its timeout (which injects nothing).
+ */
+describe('injectWithFallback', () => {
+  const R = (count: number, tag: string) =>
+    ({ directives: tag, constraints: '', consider: '', count })
+
+  beforeEach(() => { process.env.PLUR_CODEX_HYBRID = '1' })
+  afterEach(() => { delete process.env.PLUR_CODEX_HYBRID })
+
+  it('uses hybrid when it beats the deadline', async () => {
+    const plur = {
+      injectHybrid: async () => R(5, 'hybrid'),
+      inject: async () => R(3, 'bm25'),
+    }
+    const out = await injectWithFallback(plur, 'q', {}, 1000)
+    expect(out.mode).toBe('hybrid')
+    expect(out.result.count).toBe(5)
+  })
+
+  it('falls back to BM25 when hybrid misses the deadline', async () => {
+    const err = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const plur = {
+      injectHybrid: () => new Promise<never>(() => { /* never settles */ }),
+      inject: async () => R(3, 'bm25'),
+    }
+    const out = await injectWithFallback(plur, 'q', {}, 20)
+    expect(out.mode).toBe('bm25')
+    expect(out.result.count).toBe(3)
+    expect(String(err.mock.calls.at(-1)?.[0])).toContain('falling back to BM25')
+    err.mockRestore()
+  })
+
+  it('falls back to BM25 when hybrid throws — a dead embedder must not cost the turn', async () => {
+    const err = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const plur = {
+      injectHybrid: async () => { throw new Error('embedder unavailable') },
+      inject: async () => R(3, 'bm25'),
+    }
+    const out = await injectWithFallback(plur, 'q', {}, 1000)
+    expect(out.mode).toBe('bm25')
+    expect(String(err.mock.calls.at(-1)?.[0])).toContain('embedder unavailable')
+    err.mockRestore()
+  })
+
+  it('does not leave the deadline timer holding the event loop open', async () => {
+    // The timer is unref()ed and cleared; a leaked one would delay every hook
+    // exit by the full deadline.
+    const plur = { injectHybrid: async () => R(1, 'h'), inject: async () => R(1, 'b') }
+    const t0 = Date.now()
+    await injectWithFallback(plur, 'q', {}, 30_000)
+    expect(Date.now() - t0).toBeLessThan(1_000)
+  })
+})
+
+describe('hybridEnabled (#1040 kill switch)', () => {
+  it('is off unless explicitly opted in', () => {
+    expect(hybridEnabled({})).toBe(false)
+    expect(hybridEnabled({ PLUR_CODEX_HYBRID: '0' })).toBe(false)
+    expect(hybridEnabled({ PLUR_CODEX_HYBRID: 'true' })).toBe(false)
+    expect(hybridEnabled({ PLUR_CODEX_HYBRID: '1' })).toBe(true)
+  })
+
+  it('injectWithFallback never touches injectHybrid while the switch is off', async () => {
+    // The crash is caused by LOADING the embedder, not by using its result —
+    // so "call it and fall back" is not a safe posture. It must not be called.
+    delete process.env.PLUR_CODEX_HYBRID
+    let hybridCalled = false
+    const plur = {
+      injectHybrid: async () => { hybridCalled = true; return { count: 9 } },
+      inject: async () => ({ count: 3 }),
+    }
+    const out = await injectWithFallback(plur, 'q', {}, 5000)
+    expect(hybridCalled).toBe(false)
+    expect(out.mode).toBe('bm25')
+    expect(out.result.count).toBe(3)
   })
 })

--- a/packages/cli/test/codex-hook-io.test.ts
+++ b/packages/cli/test/codex-hook-io.test.ts
@@ -216,7 +216,6 @@ describe('injectWithFallback', () => {
   const R = (count: number, tag: string) =>
     ({ directives: tag, constraints: '', consider: '', count })
 
-  beforeEach(() => { process.env.PLUR_CODEX_HYBRID = '1' })
   afterEach(() => { delete process.env.PLUR_CODEX_HYBRID })
 
   it('uses hybrid when it beats the deadline', async () => {
@@ -264,24 +263,25 @@ describe('injectWithFallback', () => {
   })
 })
 
-describe('hybridEnabled (#1040 kill switch)', () => {
-  it('is off unless explicitly opted in', () => {
-    expect(hybridEnabled({})).toBe(false)
-    expect(hybridEnabled({ PLUR_CODEX_HYBRID: '0' })).toBe(false)
-    expect(hybridEnabled({ PLUR_CODEX_HYBRID: 'true' })).toBe(false)
+describe('hybridEnabled (#1040 escape hatch)', () => {
+  it('is on by default and only "0" disables it', () => {
+    expect(hybridEnabled({})).toBe(true)
     expect(hybridEnabled({ PLUR_CODEX_HYBRID: '1' })).toBe(true)
+    expect(hybridEnabled({ PLUR_CODEX_HYBRID: '0' })).toBe(false)
   })
 
-  it('injectWithFallback never touches injectHybrid while the switch is off', async () => {
-    // The crash is caused by LOADING the embedder, not by using its result —
-    // so "call it and fall back" is not a safe posture. It must not be called.
-    delete process.env.PLUR_CODEX_HYBRID
+  it('injectWithFallback never touches injectHybrid when disabled', async () => {
+    // #1040's crash came from LOADING the embedder, not from using its result,
+    // so the switch has to guard the call site — "call it and fall back" would
+    // not have helped. Kept that way in case a future runtime regresses.
+    process.env.PLUR_CODEX_HYBRID = '0'
     let hybridCalled = false
     const plur = {
       injectHybrid: async () => { hybridCalled = true; return { count: 9 } },
       inject: async () => ({ count: 3 }),
     }
     const out = await injectWithFallback(plur, 'q', {}, 5000)
+    delete process.env.PLUR_CODEX_HYBRID
     expect(hybridCalled).toBe(false)
     expect(out.mode).toBe('bm25')
     expect(out.result.count).toBe(3)

--- a/packages/cli/test/codex-hook-io.test.ts
+++ b/packages/cli/test/codex-hook-io.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { rmSync, existsSync, writeFileSync, mkdirSync, utimesSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  codexSessionId,
+  isPlurSessionStartTool,
+  sentinelPath,
+  counterPath,
+  markSessionStarted,
+  isSessionStarted,
+  incrementCounter,
+  cleanupStaleSessionFiles,
+  sessionDir,
+  emitContext,
+  runCodexHook,
+} from '../src/lib/codex-hook-io.js'
+
+const SID = 'codex-io-test-session'
+
+function clean() {
+  for (const p of [sentinelPath(SID), counterPath(SID, 'a'), counterPath(SID, 'b')]) {
+    try { rmSync(p, { force: true }) } catch { /* ignore */ }
+  }
+}
+beforeEach(clean)
+afterEach(clean)
+
+describe('codexSessionId', () => {
+  it('reads session_id — the field Codex actually sends', () => {
+    expect(codexSessionId({ session_id: 'abc' })).toBe('abc')
+  })
+
+  it('falls back to conversation_id', () => {
+    expect(codexSessionId({ conversation_id: 'xyz' })).toBe('xyz')
+  })
+
+  it('prefers session_id when both are present', () => {
+    expect(codexSessionId({ session_id: 'a', conversation_id: 'b' })).toBe('a')
+  })
+
+  it('returns empty and warns on stderr when neither is present', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    expect(codexSessionId({})).toBe('')
+    expect(spy).toHaveBeenCalledOnce()
+    expect(String(spy.mock.calls[0][0])).toContain('no session_id')
+    spy.mockRestore()
+  })
+})
+
+describe('isPlurSessionStartTool', () => {
+  it('matches the bare name', () => {
+    expect(isPlurSessionStartTool('plur_session_start')).toBe(true)
+  })
+
+  // Codex prefixes MCP tools with the server name and is actively changing
+  // the scheme (there is a `non_prefixed_mcp_tool_names` feature flag), so
+  // the match is on the suffix rather than any one spelling of the prefix.
+  it.each([
+    'plur__plur_session_start',
+    'mcp__plur__plur_session_start',
+    'plur.plur_session_start',
+    'plur/plur_session_start',
+  ])('matches the prefixed form %s', (name) => {
+    expect(isPlurSessionStartTool(name)).toBe(true)
+  })
+
+  it.each([
+    'plur_session_end',
+    'plur_learn',
+    'plur_session_started',
+    'superplur_session_start',
+    '',
+  ])('does not match %s', (name) => {
+    // `plur_session_started` and `superplur_session_start` are the two that
+    // matter: the suffix anchor must not fire on a longer identifier that
+    // merely contains the name, in either direction.
+    expect(isPlurSessionStartTool(name)).toBe(false)
+  })
+})
+
+describe('sentinel + counters', () => {
+  it('marks and detects a started session', () => {
+    expect(isSessionStarted(SID)).toBe(false)
+    markSessionStarted(SID)
+    expect(isSessionStarted(SID)).toBe(true)
+  })
+
+  it('sanitizes ids so a traversal attempt cannot escape the session dir', () => {
+    const p = sentinelPath('../../etc/passwd')
+    expect(p.startsWith(sessionDir())).toBe(true)
+    expect(p).not.toContain('..')
+  })
+
+  it('builds counter paths without string-munging the sentinel path', () => {
+    expect(counterPath(SID, 'guard-count')).toBe(join(sessionDir(), `${SID}.guard-count`))
+  })
+
+  it('increments from absent, then monotonically', () => {
+    const p = counterPath(SID, 'a')
+    expect(incrementCounter(p)).toBe(1)
+    expect(incrementCounter(p)).toBe(2)
+    expect(incrementCounter(p)).toBe(3)
+  })
+
+  it('treats a corrupt counter file as zero rather than NaN', () => {
+    const p = counterPath(SID, 'b')
+    mkdirSync(sessionDir(), { recursive: true })
+    writeFileSync(p, 'not a number')
+    expect(incrementCounter(p)).toBe(1)
+  })
+})
+
+describe('cleanupStaleSessionFiles', () => {
+  it('deletes markers past the age limit and keeps fresh ones', () => {
+    markSessionStarted(SID)
+    const stale = counterPath(SID, 'a')
+    writeFileSync(stale, '1')
+    const old = Date.now() / 1000 - 8 * 24 * 60 * 60
+    utimesSync(stale, old, old)
+
+    cleanupStaleSessionFiles()
+
+    expect(existsSync(stale)).toBe(false)
+    expect(existsSync(sentinelPath(SID))).toBe(true)
+  })
+
+  // Points at a path that does not exist rather than deleting the shared
+  // session dir: other hook test files run in parallel against the same
+  // tmpdir, and nuking it out from under them made their sentinels vanish
+  // mid-assertion.
+  it('does not throw when the session dir does not exist', () => {
+    const missing = join(tmpdir(), 'plur-codex-sessions-does-not-exist')
+    rmSync(missing, { recursive: true, force: true })
+    expect(() => cleanupStaleSessionFiles(Date.now(), missing)).not.toThrow()
+  })
+})
+
+describe('emitContext', () => {
+  it('writes the exact envelope Codex expects, and nothing else', () => {
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    emitContext('UserPromptSubmit', 'hello')
+    expect(spy).toHaveBeenCalledOnce()
+    // Codex parses stdout as the whole hook result — a stray byte around the
+    // JSON invalidates the output ("hook returned invalid ... JSON output").
+    expect(JSON.parse(String(spy.mock.calls[0][0]))).toEqual({
+      hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: 'hello' },
+    })
+    spy.mockRestore()
+  })
+})
+
+/**
+ * The exit-code guarantee. Codex reads a hook's exit code as its verdict: a
+ * non-zero code discards the output entirely, and on PreToolUse an exit code
+ * of 2 BLOCKS the tool with stderr as the reason. Verified 2026-08-27 that an
+ * unrelated engine fault (a corrupt PGLite index aborting during WASM
+ * teardown) made every plur command exit 1 — long after the hook had written
+ * valid JSON. Without this wrapper that reads to Codex as "SessionStart
+ * Failed", and the engrams are dropped.
+ */
+describe('runCodexHook', () => {
+  it('swallows a throwing body and reports it on stderr, never stdout', async () => {
+    process.env.PLUR_HOOK_NO_EXIT = '1'
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const err = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    await runCodexHook('codex test', async () => { throw new Error('engine exploded') })
+
+    expect(String(err.mock.calls.at(-1)?.[0])).toContain('engine exploded')
+    // Only the zero-length flush may reach stdout — anything else would be
+    // parsed by Codex as the hook result.
+    expect(out.mock.calls.every(c => String(c[0]).length === 0)).toBe(true)
+    out.mockRestore(); err.mockRestore()
+  })
+
+  it('forces exitCode to 0 even when something else set it non-zero', async () => {
+    process.env.PLUR_HOOK_NO_EXIT = '1'
+    process.exitCode = 1
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    await runCodexHook('codex test', async () => { /* clean run */ })
+
+    expect(process.exitCode).toBe(0)
+    out.mockRestore()
+  })
+
+  it('still delivers output written before the body threw', async () => {
+    process.env.PLUR_HOOK_NO_EXIT = '1'
+    const chunks: string[] = []
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(((c: unknown) => {
+      if (String(c).length) chunks.push(String(c))
+      return true
+    }) as never)
+
+    await runCodexHook('codex test', async () => {
+      emitContext('SessionStart', 'partial but useful')
+      throw new Error('failed after writing')
+    })
+
+    expect(JSON.parse(chunks[0])).toMatchObject({
+      hookSpecificOutput: { additionalContext: 'partial but useful' },
+    })
+    out.mockRestore()
+  })
+})

--- a/packages/cli/test/codex-hook-io.test.ts
+++ b/packages/cli/test/codex-hook-io.test.ts
@@ -287,3 +287,13 @@ describe('hybridEnabled (#1040 escape hatch)', () => {
     expect(out.result.count).toBe(3)
   })
 })
+
+describe('incrementCounter with an unwritable path', () => {
+  // Adversarial-audit repro: an unwritable counter used to return 1 forever,
+  // so the guard's give-up threshold was never crossed and every tool call
+  // was denied for the rest of the session. Unpersistable = already exceeded.
+  it('reports the counter as exceeded so the guard fails open, not closed', () => {
+    const unwritable = join(sessionDir(), 'no-such-dir', 'nested', 'counter')
+    expect(incrementCounter(unwritable)).toBe(Number.MAX_SAFE_INTEGER)
+  })
+})

--- a/packages/cli/test/codex-hooks.test.ts
+++ b/packages/cli/test/codex-hooks.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  buildCodexHooks,
+  readCodexHooksConfig,
+  writeCodexHooksConfig,
+  mergeCodexHooks,
+  hasPlurCodexHooks,
+  type CodexHooksConfig,
+} from '../src/codex-hooks.js'
+
+const SHIM = '/home/u/.plur/bin/plur-hook'
+
+let dir: string
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-codex-hooks-')) })
+afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+describe('buildCodexHooks', () => {
+  it('covers the five events the adapter needs', () => {
+    const hooks = buildCodexHooks(SHIM)
+    expect(Object.keys(hooks).sort()).toEqual([
+      'PostToolUse', 'PreToolUse', 'SessionEnd', 'SessionStart', 'UserPromptSubmit',
+    ])
+  })
+
+  it('emits Claude Code’s nested {matcher, hooks:[]} shape', () => {
+    const hooks = buildCodexHooks(SHIM)
+    for (const entries of Object.values(hooks)) {
+      expect(Array.isArray(entries)).toBe(true)
+      for (const entry of entries) {
+        expect(Array.isArray(entry.hooks)).toBe(true)
+        for (const spec of entry.hooks) {
+          expect(spec.type).toBe('command')
+          expect(spec.command).toContain(SHIM)
+        }
+      }
+    }
+  })
+
+  // THE regression test for this adapter. Codex supports `async: true` as of
+  // 0.149.1, but an async hook's additionalContext is delivered at the "next
+  // safe point" rather than to the turn that triggered it — so in `codex exec`
+  // it is dropped entirely, and interactively memory runs a turn behind.
+  // Claude Code's buildInjectionHooks() DOES use async (correctly, for its own
+  // harness); anyone porting more of that map across must not bring the flag.
+  it('never marks a hook async', () => {
+    const hooks = buildCodexHooks(SHIM)
+    const specs = Object.values(hooks).flatMap(e => e.flatMap(x => x.hooks))
+    expect(specs.length).toBeGreaterThan(0)
+    for (const spec of specs) {
+      expect(spec).not.toHaveProperty('async')
+    }
+  })
+
+  it('keeps SessionEnd inside the 3s ceiling Codex clamps to', () => {
+    const spec = buildCodexHooks(SHIM).SessionEnd[0].hooks[0]
+    expect(spec.timeout).toBeLessThanOrEqual(3)
+  })
+
+  it('gives tool events a matcher and lifecycle events none', () => {
+    const hooks = buildCodexHooks(SHIM)
+    expect(hooks.PreToolUse[0].matcher).toBe('.*')
+    expect(hooks.PostToolUse[0].matcher).toBe('.*')
+    expect(hooks.SessionStart[0].matcher).toBeUndefined()
+    expect(hooks.UserPromptSubmit[0].matcher).toBeUndefined()
+  })
+})
+
+describe('mergeCodexHooks', () => {
+  it('is idempotent — re-running init does not duplicate entries', () => {
+    const once = mergeCodexHooks({ hooks: {} }, buildCodexHooks(SHIM))
+    const twice = mergeCodexHooks(once, buildCodexHooks(SHIM))
+    expect(twice).toEqual(once)
+  })
+
+  it('replaces stale PLUR entries on upgrade rather than stacking them', () => {
+    const old = mergeCodexHooks({ hooks: {} }, buildCodexHooks('/old/path/plur-hook'))
+    const upgraded = mergeCodexHooks(old, buildCodexHooks(SHIM))
+    const commands = upgraded.hooks.SessionStart.flatMap(e => e.hooks.map(h => h.command))
+    expect(commands).toHaveLength(1)
+    expect(commands[0]).toContain(SHIM)
+  })
+
+  it('preserves a user’s own hooks in the same event array', () => {
+    const mine: CodexHooksConfig = {
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: './scripts/my-banner.sh' }] }],
+      },
+    }
+    const merged = mergeCodexHooks(mine, buildCodexHooks(SHIM))
+    const commands = merged.hooks.SessionStart.flatMap(e => e.hooks.map(h => h.command))
+    expect(commands).toContain('./scripts/my-banner.sh')
+    expect(commands.some(c => c.includes('hook-codex-session-start'))).toBe(true)
+  })
+
+  it('preserves foreign specs inside an entry that also holds a PLUR spec', () => {
+    const mixed: CodexHooksConfig = {
+      hooks: {
+        PreToolUse: [{
+          matcher: '.*',
+          hooks: [
+            { type: 'command', command: `${SHIM} hook-codex-guard` },
+            { type: 'command', command: './scripts/audit.sh' },
+          ],
+        }],
+      },
+    }
+    const merged = mergeCodexHooks(mixed, buildCodexHooks(SHIM))
+    const commands = merged.hooks.PreToolUse.flatMap(e => e.hooks.map(h => h.command))
+    expect(commands).toContain('./scripts/audit.sh')
+    expect(commands.filter(c => c.includes('hook-codex-guard'))).toHaveLength(1)
+  })
+
+  // Same class of bug the Cursor adapter had to fix: matching a bare
+  // `hook-codex-` substring would claim a user's own script and delete it.
+  it('does not claim a foreign script whose name merely contains hook-codex-', () => {
+    const mine: CodexHooksConfig = {
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: 'command', command: './scripts/hook-codex-lint.sh' }] }],
+      },
+    }
+    expect(hasPlurCodexHooks(mine)).toBe(false)
+    const merged = mergeCodexHooks(mine, buildCodexHooks(SHIM))
+    const commands = merged.hooks.PreToolUse.flatMap(e => e.hooks.map(h => h.command))
+    expect(commands).toContain('./scripts/hook-codex-lint.sh')
+  })
+
+  it('does not claim a PLUR-binary invocation of a non-PLUR subcommand', () => {
+    const mine: CodexHooksConfig = {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: `${SHIM} some-other-thing` }] }] },
+    }
+    expect(hasPlurCodexHooks(mine)).toBe(false)
+  })
+
+  it('recognises the npx fallback form as PLUR-owned', () => {
+    const npx: CodexHooksConfig = {
+      hooks: {
+        SessionStart: [{
+          hooks: [{ type: 'command', command: 'npx @plur-ai/cli hook-codex-session-start' }],
+        }],
+      },
+    }
+    expect(hasPlurCodexHooks(npx)).toBe(true)
+  })
+})
+
+describe('read/write round trip', () => {
+  it('writes valid JSON that reads back identically', () => {
+    const path = join(dir, 'hooks.json')
+    const config = mergeCodexHooks({ hooks: {} }, buildCodexHooks(SHIM))
+    writeCodexHooksConfig(path, config)
+    expect(existsSync(path)).toBe(true)
+    expect(() => JSON.parse(readFileSync(path, 'utf8'))).not.toThrow()
+    expect(readCodexHooksConfig(path).hooks).toEqual(config.hooks)
+  })
+
+  it('adds a description so a human opening the file knows who owns it', () => {
+    const path = join(dir, 'hooks.json')
+    writeCodexHooksConfig(path, { hooks: buildCodexHooks(SHIM) })
+    expect(JSON.parse(readFileSync(path, 'utf8')).description).toMatch(/PLUR/)
+  })
+
+  it('does not overwrite a description the user already set', () => {
+    const path = join(dir, 'hooks.json')
+    writeCodexHooksConfig(path, { description: 'mine', hooks: {} })
+    expect(JSON.parse(readFileSync(path, 'utf8')).description).toBe('mine')
+  })
+
+  it('treats a malformed file as empty when READING (init refuses to write over it)', () => {
+    const path = join(dir, 'hooks.json')
+    writeFileSync(path, '{ not json')
+    expect(readCodexHooksConfig(path)).toEqual({ hooks: {} })
+  })
+
+  it('reads a config with no hooks key without throwing', () => {
+    const path = join(dir, 'hooks.json')
+    writeFileSync(path, JSON.stringify({ description: 'empty' }))
+    expect(readCodexHooksConfig(path).hooks).toEqual({})
+  })
+})

--- a/packages/cli/test/doctor-timeout.test.ts
+++ b/packages/cli/test/doctor-timeout.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { resolveProbeTimeoutMs } from '../src/commands/doctor.js'
 
 // PLUR_DOCTOR_TIMEOUT parsing (#273, PR #303). Invalid values must fall back
-// to the 60s default: a NaN setTimeout delay is coerced to 1ms by Node, which
+// to the 300s default: a NaN setTimeout delay is coerced to 1ms by Node, which
 // would instantly fail the probe with "probe timeout after NaNms" — the exact
 // symptom the configurable timeout exists to fix.
 describe('resolveProbeTimeoutMs (PLUR_DOCTOR_TIMEOUT)', () => {
-  it('defaults to 60s when the env var is unset', () => {
-    expect(resolveProbeTimeoutMs(undefined)).toBe(60_000)
+  it('defaults to 300s when the env var is unset', () => {
+    expect(resolveProbeTimeoutMs(undefined)).toBe(300_000)
   })
 
   it('converts a valid value from seconds to milliseconds', () => {
@@ -15,17 +15,17 @@ describe('resolveProbeTimeoutMs (PLUR_DOCTOR_TIMEOUT)', () => {
     expect(resolveProbeTimeoutMs('5')).toBe(5_000)
   })
 
-  it('falls back to 60s on garbage input', () => {
-    expect(resolveProbeTimeoutMs('abc')).toBe(60_000)
+  it('falls back to 300s on garbage input', () => {
+    expect(resolveProbeTimeoutMs('abc')).toBe(300_000)
   })
 
-  it('falls back to 60s on empty string (PLUR_DOCTOR_TIMEOUT= in shell/CI)', () => {
-    expect(resolveProbeTimeoutMs('')).toBe(60_000)
+  it('falls back to 300s on empty string (PLUR_DOCTOR_TIMEOUT= in shell/CI)', () => {
+    expect(resolveProbeTimeoutMs('')).toBe(300_000)
   })
 
-  it('falls back to 60s on zero and negative values', () => {
-    expect(resolveProbeTimeoutMs('0')).toBe(60_000)
-    expect(resolveProbeTimeoutMs('-30')).toBe(60_000)
+  it('falls back to 300s on zero and negative values', () => {
+    expect(resolveProbeTimeoutMs('0')).toBe(300_000)
+    expect(resolveProbeTimeoutMs('-30')).toBe(300_000)
   })
 
   it('tolerates trailing junk the way parseInt does (e.g. "90s")', () => {

--- a/packages/cli/test/hook-agy-guard.test.ts
+++ b/packages/cli/test/hook-agy-guard.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { rmSync } from 'fs'
+import { run as runGuard } from '../src/commands/hook-agy-guard.js'
+import {
+  agySentinelPath,
+  agyCounterPath,
+  agyMarkSessionStarted,
+  agyIsSessionStarted,
+} from '../src/lib/agy-hook-io.js'
+
+/**
+ * Enforcement logic for the agy guard. Like the Codex guard tests, these
+ * prove the process emits the right verdicts and can never deadlock the
+ * agent — they cannot prove agy honours a deny, which was verified live
+ * (agy 1.1.21: "tool call denied by pre-tool hook: ..." reached the model).
+ */
+
+const SID = 'agy-guard-test-conversation'
+
+// runAgyHook force-exits 0 (same wrapper as the Codex hooks); suppress in-process.
+process.env.PLUR_HOOK_NO_EXIT = '1'
+
+let written: string[]
+let stdout: ReturnType<typeof vi.spyOn>
+let stderr: ReturnType<typeof vi.spyOn>
+
+function setStdin(payload: Record<string, unknown>): void {
+  ;(globalThis as Record<string, unknown>).__plurCodexStdin = payload
+}
+
+// The agy hooks share readStdinJson with the Codex family (re-exported from
+// codex-hook-io), so the same mock hook covers both.
+vi.mock('../src/lib/codex-hook-io.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/codex-hook-io.js')>()
+  return {
+    ...actual,
+    readStdinJson: () => (globalThis as Record<string, unknown>).__plurCodexStdin ?? {},
+  }
+})
+
+function emitted(): unknown | null {
+  const last = written.at(-1)
+  return last ? JSON.parse(last) : null
+}
+
+function clean() {
+  for (const p of [agySentinelPath(SID), agyCounterPath(SID, 'guard-count'), agyCounterPath(SID, 'laststep'), agyCounterPath(SID, 'turncount')]) {
+    rmSync(p, { force: true })
+  }
+}
+
+beforeEach(() => {
+  clean()
+  written = []
+  stdout = vi.spyOn(process.stdout, 'write').mockImplementation(((c: unknown) => {
+    if (String(c).length > 0) written.push(String(c))
+    return true
+  }) as never)
+  stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+})
+
+afterEach(() => {
+  stdout.mockRestore()
+  stderr.mockRestore()
+  clean()
+})
+
+describe('hook-agy-guard', () => {
+  it('denies the first tool call before the session starts, with agy’s FLAT verdict shape', async () => {
+    setStdin({ conversationId: SID, toolCall: { name: 'run_command', args: {} } })
+    await runGuard([], {} as never)
+    const out = emitted() as { decision: string; reason: string }
+    // Flat {decision, reason} — no hookSpecificOutput envelope. agy parses
+    // nothing else.
+    expect(out.decision).toBe('deny')
+    expect(out.reason).toContain('plur_session_start')
+    expect(out).not.toHaveProperty('hookSpecificOutput')
+  })
+
+  it('never emits allow — silence must not bypass agy’s own permission prompts', async () => {
+    agyMarkSessionStarted(SID)
+    setStdin({ conversationId: SID, toolCall: { name: 'run_command' } })
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+  })
+
+  it('marks the sentinel when plur_session_start passes through — PostToolUse has no tool name, so this is the only detection point', async () => {
+    setStdin({ conversationId: SID, toolCall: { name: 'plur_session_start' } })
+    await runGuard([], {} as never)
+    expect(agyIsSessionStarted(SID)).toBe(true)
+    expect(written).toEqual([])
+  })
+
+  it('recognises a prefixed MCP spelling of plur_session_start', async () => {
+    setStdin({ conversationId: SID, toolCall: { name: 'mcp_plur_plur_session_start' } })
+    await runGuard([], {} as never)
+    expect(agyIsSessionStarted(SID)).toBe(true)
+  })
+
+  it('gives up after one nudge and marks the session started — the deadlock rule', async () => {
+    setStdin({ conversationId: SID, toolCall: { name: 'run_command' } })
+    await runGuard([], {} as never)
+    expect((emitted() as { decision: string }).decision).toBe('deny')
+
+    written = []
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+    expect(agyIsSessionStarted(SID)).toBe(true)
+  })
+
+  it('allows through rather than blocking blind without a conversationId', async () => {
+    setStdin({ toolCall: { name: 'run_command' } })
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+  })
+
+  it('tolerates a payload with no toolCall at all', async () => {
+    setStdin({ conversationId: SID })
+    await runGuard([], {} as never)
+    // No tool name → not plur_session_start → session not started → denies.
+    // The point is it must not THROW on the missing field.
+    expect((emitted() as { decision: string }).decision).toBe('deny')
+  })
+})

--- a/packages/cli/test/hook-agy-guard.test.ts
+++ b/packages/cli/test/hook-agy-guard.test.ts
@@ -44,7 +44,7 @@ function emitted(): unknown | null {
 }
 
 function clean() {
-  for (const p of [agySentinelPath(SID), agyCounterPath(SID, 'guard-count'), agyCounterPath(SID, 'laststep'), agyCounterPath(SID, 'turncount')]) {
+  for (const p of [agySentinelPath(SID), agyCounterPath(SID, 'guard-count'), agyCounterPath(SID, 'turncache'), agyCounterPath(SID, 'turncount')]) {
     rmSync(p, { force: true })
   }
 }

--- a/packages/cli/test/hook-agy-pre-invocation.test.ts
+++ b/packages/cli/test/hook-agy-pre-invocation.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { rmSync, mkdtempSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { run } from '../src/commands/hook-agy-pre-invocation.js'
+import {
+  agySentinelPath,
+  agyCounterPath,
+  readAgyTurnCache,
+  writeAgyTurnCache,
+  agyTextHash,
+} from '../src/lib/agy-hook-io.js'
+
+/**
+ * Command-level tests for the agy injection hook — the most stateful code in
+ * either adapter (evaluator audit M15 flagged it as having zero coverage).
+ * Injection itself is stubbed: what is under test is the TURN-CACHE state
+ * machine — when recall runs, when the cached message replays, and when
+ * nothing is emitted — because that is where all three audits found bugs
+ * (M5 empty-message re-recall, M6/F4 step freezes, F9 id collisions, B1
+ * scope loss).
+ */
+
+const SID = 'agy-preinv-test-conversation'
+
+process.env.PLUR_HOOK_NO_EXIT = '1'
+
+// ── stubs ───────────────────────────────────────────────────────────────────
+
+let injectCalls: Array<{ task: string; opts: Record<string, unknown> }>
+let injectResult: { count: number; directives: string; constraints: string; consider: string }
+let projectConfigCalls: string[]
+let stubbedScope: string | undefined
+
+vi.mock('../src/lib/codex-hook-io.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/codex-hook-io.js')>()
+  return {
+    ...actual,
+    readStdinJson: () => (globalThis as Record<string, unknown>).__plurAgyStdin ?? {},
+    injectWithFallback: async (_plur: unknown, task: string, opts: Record<string, unknown>) => {
+      injectCalls.push({ task, opts })
+      return { result: injectResult, mode: 'hybrid' }
+    },
+  }
+})
+
+vi.mock('../src/plur.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/plur.js')>()
+  return { ...actual, createPlur: () => ({}) as never }
+})
+
+vi.mock('@plur-ai/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@plur-ai/core')>()
+  return {
+    ...actual,
+    readProjectConfig: (startDir?: string) => {
+      projectConfigCalls.push(startDir ?? '(default)')
+      return stubbedScope ? { scope: stubbedScope } : {}
+    },
+  }
+})
+
+function setStdin(payload: Record<string, unknown>): void {
+  ;(globalThis as Record<string, unknown>).__plurAgyStdin = payload
+}
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+let dir: string
+let written: string[]
+let stdout: ReturnType<typeof vi.spyOn>
+let stderr: ReturnType<typeof vi.spyOn>
+
+function transcript(...turns: Array<{ step: number; text: string }>): string {
+  const p = join(dir, 'transcript.jsonl')
+  writeFileSync(p, turns.map(t => JSON.stringify({
+    step_index: t.step, type: 'USER_INPUT', content: `<USER_REQUEST>\n${t.text}\n</USER_REQUEST>`,
+  })).join('\n'))
+  return p
+}
+
+function emittedMessage(): string | null {
+  const last = written.at(-1)
+  if (!last) return null
+  const parsed = JSON.parse(last) as { injectSteps?: Array<{ ephemeralMessage?: string }> }
+  return parsed.injectSteps?.[0]?.ephemeralMessage ?? null
+}
+
+function clean() {
+  for (const n of ['turncache', 'turncount', 'guard-count']) rmSync(agyCounterPath(SID, n), { force: true })
+  rmSync(agySentinelPath(SID), { force: true })
+}
+
+beforeEach(() => {
+  clean()
+  dir = mkdtempSync(join(tmpdir(), 'plur-agy-preinv-'))
+  written = []
+  injectCalls = []
+  projectConfigCalls = []
+  stubbedScope = undefined
+  injectResult = { count: 2, directives: 'DIRECTIVE-LINE', constraints: '', consider: '' }
+  stdout = vi.spyOn(process.stdout, 'write').mockImplementation(((c: unknown) => {
+    if (String(c).length > 0) written.push(String(c))
+    return true
+  }) as never)
+  stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+})
+
+afterEach(() => {
+  stdout.mockRestore()
+  stderr.mockRestore()
+  rmSync(dir, { recursive: true, force: true })
+  clean()
+})
+
+// ── the state machine ───────────────────────────────────────────────────────
+
+describe('hook-agy-pre-invocation', () => {
+  it('first turn: recalls once, emits, and caches the rendered message', async () => {
+    setStdin({ conversationId: SID, invocationNum: 0, transcriptPath: transcript({ step: 0, text: 'first question' }) })
+    await run([], {} as never)
+
+    expect(injectCalls).toHaveLength(1)
+    expect(injectCalls[0].task).toBe('first question')
+    expect(emittedMessage()).toContain('DIRECTIVE-LINE')
+
+    const cache = readAgyTurnCache(SID)
+    expect(cache?.message).toContain('DIRECTIVE-LINE')
+    expect(cache?.textHash).toBe(agyTextHash('first question'))
+  })
+
+  it('mid-turn invocation replays the cached message WITHOUT re-recalling', async () => {
+    const t = transcript({ step: 0, text: 'first question' })
+    setStdin({ conversationId: SID, invocationNum: 0, transcriptPath: t })
+    await run([], {} as never)
+    expect(injectCalls).toHaveLength(1)
+
+    written = []
+    setStdin({ conversationId: SID, invocationNum: 1, transcriptPath: t })
+    await run([], {} as never)
+
+    expect(injectCalls).toHaveLength(1) // no second recall
+    expect(emittedMessage()).toContain('DIRECTIVE-LINE') // but the memory is re-shown
+  })
+
+  it('a new user message is a new turn — new recall, new cache', async () => {
+    setStdin({ conversationId: SID, invocationNum: 0, transcriptPath: transcript({ step: 0, text: 'first question' }) })
+    await run([], {} as never)
+
+    injectResult = { count: 1, directives: 'SECOND-TURN', constraints: '', consider: '' }
+    written = []
+    setStdin({
+      conversationId: SID, invocationNum: 3,
+      transcriptPath: transcript({ step: 0, text: 'first question' }, { step: 5, text: 'second question' }),
+    })
+    await run([], {} as never)
+
+    expect(injectCalls).toHaveLength(2)
+    expect(injectCalls[1].task).toBe('second question')
+    expect(emittedMessage()).toContain('SECOND-TURN')
+  })
+
+  // Evaluator audit M6 / adversarial audit F4: step_index is Antigravity's
+  // internal counter. If it disappears (all -1) or restarts, a step-only
+  // comparison freezes on turn one forever. The text hash breaks the tie.
+  it('detects a new turn by TEXT when step_index does not advance', async () => {
+    setStdin({ conversationId: SID, invocationNum: 0, transcriptPath: transcript({ step: 0, text: 'alpha' }) })
+    await run([], {} as never)
+
+    written = []
+    setStdin({ conversationId: SID, invocationNum: 4, transcriptPath: transcript({ step: 0, text: 'beta' }) })
+    await run([], {} as never)
+
+    expect(injectCalls).toHaveLength(2)
+    expect(injectCalls[1].task).toBe('beta')
+  })
+
+  // Evaluator audit M5: an empty injection result is still THIS turn's
+  // result. Not caching it made every mid-turn invocation re-run a full
+  // (multi-second) recall.
+  it('caches an empty result so mid-turn invocations do not re-recall', async () => {
+    injectResult = { count: 0, directives: '', constraints: '', consider: '' }
+    const t = transcript({ step: 2, text: 'question with no matches' })
+
+    setStdin({ conversationId: SID, invocationNum: 1, transcriptPath: t })
+    await run([], {} as never)
+    expect(injectCalls).toHaveLength(1)
+    expect(written).toEqual([]) // nothing worth emitting
+
+    setStdin({ conversationId: SID, invocationNum: 2, transcriptPath: t })
+    await run([], {} as never)
+    expect(injectCalls).toHaveLength(1) // and no re-recall either
+  })
+
+  // Data-loss audit F9: sanitized ids collide on the cache PATH; the id
+  // stored inside the record must keep conversations apart.
+  it('never replays another conversation’s cache after a sanitized-id collision', async () => {
+    writeAgyTurnCache({
+      conversationId: 'agy-preinv-test.conversation', // collides with SID on path
+      step: 99,
+      textHash: 'whatever',
+      message: 'OTHER CONVERSATION MEMORY',
+    })
+
+    setStdin({ conversationId: SID, invocationNum: 0, transcriptPath: transcript({ step: 0, text: 'mine' }) })
+    await run([], {} as never)
+
+    expect(injectCalls).toHaveLength(1) // treated as no cache → fresh recall
+    expect(emittedMessage()).not.toContain('OTHER CONVERSATION MEMORY')
+  })
+
+  // Evaluator audit B1: agy runs hooks with cwd = ~/.gemini/config, where a
+  // project-config walk can never succeed. The workspace path from the
+  // payload is the only correct root for .plur.yaml discovery.
+  it('resolves project config from the workspace path, not process.cwd()', async () => {
+    stubbedScope = 'project:from-workspace'
+    writeFileSync(join(dir, '.plur.yaml'), 'scope: project:from-workspace\n')
+    setStdin({
+      conversationId: SID, invocationNum: 0,
+      transcriptPath: transcript({ step: 0, text: 'scoped question' }),
+      workspacePaths: [dir],
+    })
+    await run([], {} as never)
+
+    expect(projectConfigCalls).toEqual([dir])
+    expect(injectCalls[0].opts.scope).toBe('project:from-workspace')
+    expect(emittedMessage()).toContain('project:from-workspace')
+  })
+
+  it('replays the cached turn when the transcript becomes unreadable, and says so on stderr', async () => {
+    setStdin({ conversationId: SID, invocationNum: 0, transcriptPath: transcript({ step: 0, text: 'alpha' }) })
+    await run([], {} as never)
+
+    written = []
+    setStdin({ conversationId: SID, invocationNum: 2, transcriptPath: join(dir, 'gone.jsonl') })
+    await run([], {} as never)
+
+    expect(injectCalls).toHaveLength(1)
+    expect(emittedMessage()).toContain('DIRECTIVE-LINE')
+    expect(stderr.mock.calls.some(c => String(c[0]).includes('transcript unreadable'))).toBe(true)
+  })
+
+  it('emits nothing and recalls nothing without a conversationId', async () => {
+    setStdin({ invocationNum: 0, transcriptPath: transcript({ step: 0, text: 'x' }) })
+    await run([], {} as never)
+    expect(injectCalls).toEqual([])
+    expect(written).toEqual([])
+  })
+})

--- a/packages/cli/test/hook-agy-pre-invocation.test.ts
+++ b/packages/cli/test/hook-agy-pre-invocation.test.ts
@@ -237,7 +237,7 @@ describe('hook-agy-pre-invocation', () => {
 
     expect(injectCalls).toHaveLength(1)
     expect(emittedMessage()).toContain('DIRECTIVE-LINE')
-    expect(stderr.mock.calls.some(c => String(c[0]).includes('transcript unreadable'))).toBe(true)
+    expect(stderr.mock.calls.some((c: unknown[]) => String(c[0]).includes('transcript unreadable'))).toBe(true)
   })
 
   it('emits nothing and recalls nothing without a conversationId', async () => {

--- a/packages/cli/test/hook-codex-guard.test.ts
+++ b/packages/cli/test/hook-codex-guard.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { rmSync, mkdtempSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { run as runGuard } from '../src/commands/hook-codex-guard.js'
+import { run as runPostTool } from '../src/commands/hook-codex-post-tool.js'
+import {
+  sentinelPath,
+  counterPath,
+  markSessionStarted,
+  isSessionStarted,
+} from '../src/lib/codex-hook-io.js'
+
+/**
+ * These exercise the ENFORCEMENT logic, which is the part that can wedge a
+ * user's session. They cannot prove Codex honours the deny — only a live
+ * `codex exec` run can, and that was done manually against codex-cli 0.149.1
+ * (a denied shell call, with the reason reaching the model). What they do
+ * prove is that this process emits the right envelope, and never emits one
+ * that would deadlock the agent.
+ */
+
+const SID = 'codex-guard-test-session'
+
+// runCodexHook force-exits 0 so a background crash can never make Codex
+// discard a hook's output (or, on PreToolUse, block the tool). In-process
+// tests need that suppressed or the runner exits mid-suite.
+process.env.PLUR_HOOK_NO_EXIT = '1'
+
+let projectDir: string
+let cwdSpy: ReturnType<typeof vi.spyOn>
+let stdout: ReturnType<typeof vi.spyOn>
+let stderr: ReturnType<typeof vi.spyOn>
+
+/** Make isPlurConfigured() true by putting a .plur.yaml in a scratch cwd. */
+function makePlurProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plur-codex-guard-'))
+  writeFileSync(join(dir, '.plur.yaml'), 'scope: project:test\n')
+  return dir
+}
+
+let written: string[]
+
+function emitted(): unknown | null {
+  const last = written.at(-1)
+  return last ? JSON.parse(last) : null
+}
+
+beforeEach(() => {
+  written = []
+  projectDir = makePlurProject()
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(projectDir)
+  // Record only non-empty writes. runCodexHook flushes with a zero-length
+  // write before exiting; that is not output, and counting it would make
+  // every "stays silent" assertion fail on a hook that said nothing.
+  stdout = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+    if (String(chunk).length > 0) written.push(String(chunk))
+    return true
+  }) as never)
+  stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  for (const p of [sentinelPath(SID), counterPath(SID, 'guard-count'), counterPath(SID, 'tool-count')]) {
+    rmSync(p, { force: true })
+  }
+})
+
+afterEach(() => {
+  cwdSpy.mockRestore()
+  stdout.mockRestore()
+  stderr.mockRestore()
+  rmSync(projectDir, { recursive: true, force: true })
+  for (const p of [sentinelPath(SID), counterPath(SID, 'guard-count'), counterPath(SID, 'tool-count')]) {
+    rmSync(p, { force: true })
+  }
+})
+
+/**
+ * The hook commands read stdin via readSync(0, ...). Rather than fight fd 0
+ * inside the test runner, stub the shared reader the way the Cursor hook
+ * tests do: mock the module's readStdinJson through vi.mock at import time.
+ */
+vi.mock('../src/lib/codex-hook-io.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/lib/codex-hook-io.js')>()
+  return {
+    ...actual,
+    readStdinJson: () => (globalThis as Record<string, unknown>).__plurCodexStdin ?? {},
+  }
+})
+
+function setStdin(payload: Record<string, unknown>): void {
+  ;(globalThis as Record<string, unknown>).__plurCodexStdin = payload
+}
+
+describe('hook-codex-guard', () => {
+  it('stays silent when the session has already started', async () => {
+    markSessionStarted(SID)
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+  })
+
+  it('denies the first tool call before the session starts', async () => {
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    await runGuard([], {} as never)
+    expect(emitted()).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+      },
+    })
+  })
+
+  it('always pairs a deny with a non-empty reason', async () => {
+    // Codex rejects the output otherwise: "PreToolUse hook returned
+    // permissionDecision:deny without a non-empty permissionDecisionReason".
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    await runGuard([], {} as never)
+    const out = emitted() as { hookSpecificOutput: { permissionDecisionReason?: string } }
+    expect(out.hookSpecificOutput.permissionDecisionReason).toBeTruthy()
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain('plur_session_start')
+  })
+
+  it('never emits allow or ask — Codex rejects both from a hook', async () => {
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    await runGuard([], {} as never)
+    const out = JSON.stringify(emitted())
+    expect(out).not.toContain('"allow"')
+    expect(out).not.toContain('"ask"')
+  })
+
+  it('never denies plur_session_start itself', async () => {
+    setStdin({ session_id: SID, tool_name: 'plur__plur_session_start' })
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+  })
+
+  // The deadlock guard (#199's rule, ported). A wedged MCP server must not be
+  // able to lock the agent into a state where the only permitted tool is one
+  // it cannot reach.
+  it('gives up after one nudge and marks the session started anyway', async () => {
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    await runGuard([], {} as never)
+    expect(emitted()).toMatchObject({ hookSpecificOutput: { permissionDecision: 'deny' } })
+
+    written = []
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+    expect(isSessionStarted(SID)).toBe(true)
+    expect(String(stderr.mock.calls.at(-1)?.[0])).toContain('degraded mode')
+  })
+
+  it('allows through rather than blocking blind when there is no session id', async () => {
+    setStdin({ tool_name: 'shell' })
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+  })
+
+  it('stays silent entirely in a project that has no plur config', async () => {
+    const bare = mkdtempSync(join(tmpdir(), 'no-plur-'))
+    mkdirSync(join(bare, 'sub'), { recursive: true })
+    cwdSpy.mockReturnValue(join(bare, 'sub'))
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    await runGuard([], {} as never)
+    expect(written).toEqual([])
+    rmSync(bare, { recursive: true, force: true })
+  })
+})
+
+describe('hook-codex-post-tool', () => {
+  it('marks the sentinel when the agent calls plur_session_start itself', async () => {
+    setStdin({ session_id: SID, tool_name: 'plur__plur_session_start' })
+    await runPostTool([], {} as never)
+    expect(isSessionStarted(SID)).toBe(true)
+    // Marking is the whole job here — no nudge on the same call.
+    expect(written).toEqual([])
+  })
+
+  it('does not nudge before the session has started', async () => {
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    await runPostTool([], {} as never)
+    expect(written).toEqual([])
+  })
+
+  it('nudges once every N tools, not on every tool', async () => {
+    markSessionStarted(SID)
+    setStdin({ session_id: SID, tool_name: 'shell' })
+
+    let nudges = 0
+    for (let i = 0; i < 24; i++) {
+      written = []
+      await runPostTool([], {} as never)
+      if (written.length > 0) {
+        nudges++
+        expect(emitted()).toMatchObject({
+          hookSpecificOutput: { hookEventName: 'PostToolUse' },
+        })
+      }
+    }
+    expect(nudges).toBe(2)
+  })
+
+  it('mentions plur_learn and plur_session_end in the nudge', async () => {
+    markSessionStarted(SID)
+    setStdin({ session_id: SID, tool_name: 'shell' })
+    for (let i = 0; i < 12; i++) await runPostTool([], {} as never)
+    const out = emitted() as { hookSpecificOutput: { additionalContext: string } }
+    expect(out.hookSpecificOutput.additionalContext).toContain('plur_learn')
+    expect(out.hookSpecificOutput.additionalContext).toContain('plur_session_end')
+  })
+})

--- a/packages/cli/test/init-codex.test.ts
+++ b/packages/cli/test/init-codex.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { codexHome, codexHooksConfigPath, knownConfigFiles } from '../src/mcp-config.js'
+import { buildCodexHooks, mergeCodexHooks, writeCodexHooksConfig, readCodexHooksConfig } from '../src/codex-hooks.js'
+
+describe('codexHome', () => {
+  it('honours CODEX_HOME so a relocated install is not written past', () => {
+    expect(codexHome({ CODEX_HOME: '/somewhere/else' })).toBe('/somewhere/else')
+  })
+
+  it('falls back to ~/.codex', () => {
+    expect(codexHome({})).toMatch(/\.codex$/)
+  })
+
+  it('derives the hooks path from the same home', () => {
+    expect(codexHooksConfigPath({ CODEX_HOME: '/x' })).toBe('/x/hooks.json')
+  })
+})
+
+describe('knownConfigFiles', () => {
+  it('reports on both Codex files so doctor can see them', () => {
+    const labels = knownConfigFiles().map(c => c.label)
+    expect(labels).toContain('Codex (~/.codex/hooks.json)')
+    expect(labels).toContain('Codex (~/.codex/config.toml)')
+  })
+
+  it('marks config.toml as TOML, not JSON', () => {
+    // doctor must not run readConfig() on it — that returns {} for TOML and
+    // would report "no plur MCP" on a correctly-registered install.
+    const toml = knownConfigFiles().find(c => c.label === 'Codex (~/.codex/config.toml)')
+    expect(toml?.kind).toBe('codex-toml')
+  })
+})
+
+describe('install into a scratch CODEX_HOME', () => {
+  let home: string
+  beforeEach(() => { home = mkdtempSync(join(tmpdir(), 'codex-home-')) })
+  afterEach(() => { rmSync(home, { recursive: true, force: true }) })
+
+  it('produces a hooks.json Codex can parse, in the shape it expects', () => {
+    const path = join(home, 'hooks.json')
+    writeCodexHooksConfig(path, mergeCodexHooks(readCodexHooksConfig(path), buildCodexHooks('/bin/plur-hook')))
+
+    const raw = JSON.parse(readFileSync(path, 'utf8'))
+    expect(raw).toHaveProperty('hooks')
+    // Codex's own shape: hooks[event] is an array of {matcher?, hooks: []}.
+    for (const [event, entries] of Object.entries(raw.hooks as Record<string, unknown[]>)) {
+      expect(event).toMatch(/^[A-Z]/)
+      for (const entry of entries as Array<{ hooks: unknown[] }>) {
+        expect(Array.isArray(entry.hooks)).toBe(true)
+      }
+    }
+  })
+
+  it('leaves an unrelated Codex hook alone across an upgrade', () => {
+    const path = join(home, 'hooks.json')
+    writeFileSync(path, JSON.stringify({
+      description: 'my hooks',
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: './notify.sh' }] }],
+      },
+    }))
+
+    writeCodexHooksConfig(path, mergeCodexHooks(readCodexHooksConfig(path), buildCodexHooks('/bin/plur-hook')))
+    const raw = JSON.parse(readFileSync(path, 'utf8'))
+    expect(raw.description).toBe('my hooks')
+    expect(raw.hooks.Stop[0].hooks[0].command).toBe('./notify.sh')
+    expect(raw.hooks.SessionStart).toBeDefined()
+  })
+})
+
+/**
+ * The trust step is the difference between an install that works and one that
+ * looks perfect and does nothing. Verified on codex-cli 0.149.1: hooks that
+ * ran under --dangerously-bypass-hook-trust were silently inert without it —
+ * no output, no warning, exit 0. Nothing on disk distinguishes the two states,
+ * so the only defence is telling the user.
+ */
+describe('trust notice', () => {
+  it('is present in the init source and names /hooks', async () => {
+    const src = readFileSync(new URL('../src/commands/init.ts', import.meta.url), 'utf8')
+    expect(src).toContain('/hooks')
+    expect(src).toMatch(/trust/i)
+    expect(src).toMatch(/SILENTLY|silently/)
+  })
+})

--- a/packages/cli/test/quiet.test.ts
+++ b/packages/cli/test/quiet.test.ts
@@ -179,6 +179,8 @@ describe('doctor --quiet (#730)', () => {
       cursorWired: false,
       codexDetected: false,
       codexWired: false,
+      agyDetected: false,
+      agyWired: false,
       pgliteGemmaReembedNeeded: false,
       staleContentHashes: 0,
       overall: 'fail',
@@ -189,7 +191,7 @@ describe('doctor --quiet (#730)', () => {
     const { printText } = await import('../src/commands/doctor.js')
     printText(await report(), { quiet: true })
     const text = out.join('')
-    expect(text).not.toContain('plur doctor — Claude Code / Claude Desktop / Cursor / Codex diagnostic')
+    expect(text).not.toContain('plur doctor — Claude Code / Claude Desktop / Cursor / Codex / Antigravity diagnostic')
     expect(text).toContain('✗ Hooks installed')
     expect(text).toContain('✓ plur MCP server registered')
     expect(text).toContain('✗ Hook shim: shim not found')
@@ -199,6 +201,6 @@ describe('doctor --quiet (#730)', () => {
   it('prints the banner without --quiet', async () => {
     const { printText } = await import('../src/commands/doctor.js')
     printText(await report(), { quiet: false })
-    expect(out.join('')).toContain('plur doctor — Claude Code / Claude Desktop / Cursor / Codex diagnostic')
+    expect(out.join('')).toContain('plur doctor — Claude Code / Claude Desktop / Cursor / Codex / Antigravity diagnostic')
   })
 })

--- a/packages/cli/test/quiet.test.ts
+++ b/packages/cli/test/quiet.test.ts
@@ -177,6 +177,8 @@ describe('doctor --quiet (#730)', () => {
       embedder: { available: true, loaded: true, lastError: null, modelLoaded: true, disabled: false, disabledReason: null },
       cursorProjectDetected: false,
       cursorWired: false,
+      codexDetected: false,
+      codexWired: false,
       pgliteGemmaReembedNeeded: false,
       staleContentHashes: 0,
       overall: 'fail',
@@ -187,7 +189,7 @@ describe('doctor --quiet (#730)', () => {
     const { printText } = await import('../src/commands/doctor.js')
     printText(await report(), { quiet: true })
     const text = out.join('')
-    expect(text).not.toContain('plur doctor — Claude Code / Claude Desktop / Cursor diagnostic')
+    expect(text).not.toContain('plur doctor — Claude Code / Claude Desktop / Cursor / Codex diagnostic')
     expect(text).toContain('✗ Hooks installed')
     expect(text).toContain('✓ plur MCP server registered')
     expect(text).toContain('✗ Hook shim: shim not found')
@@ -197,6 +199,6 @@ describe('doctor --quiet (#730)', () => {
   it('prints the banner without --quiet', async () => {
     const { printText } = await import('../src/commands/doctor.js')
     printText(await report(), { quiet: false })
-    expect(out.join('')).toContain('plur doctor — Claude Code / Claude Desktop / Cursor diagnostic')
+    expect(out.join('')).toContain('plur doctor — Claude Code / Claude Desktop / Cursor / Codex diagnostic')
   })
 })

--- a/packages/core/mig-seed.mjs
+++ b/packages/core/mig-seed.mjs
@@ -1,0 +1,18 @@
+import { writeFileSync } from 'fs'
+import { join } from 'path'
+import yaml from 'js-yaml'
+import { createHash } from 'crypto'
+import { PGLiteAdapter, engramSearchText } from '/Users/gregor/Data/5-plur/2-projects/plur/packages/core/dist/index.js'
+const dir = process.argv[2]
+const mk = (id, statement) => ({ id, statement, type: 'behavioral', scope: 'global', status: 'active', tags: [],
+  activation: { retrieval_strength: 1, storage_strength: 1, frequency: 0, last_accessed: '2026-08-27' },
+  feedback_signals: { positive: 0, negative: 0, neutral: 0 } })
+const engrams = [mk('ENG-1','alpha'), mk('ENG-2','beta'), mk('ENG-3','gamma')]
+writeFileSync(join(dir,'engrams.yaml'), yaml.dump({ engrams }))
+const a = new PGLiteAdapter(join(dir,'engrams.yaml'), join(dir,'store.pglite'), { vectorDim: 384 })
+await a.syncFromYaml()
+for (const [i,e] of engrams.entries()) {
+  const hash = i === 2 ? 'stale-hash' : createHash('md5').update(engramSearchText(e)).digest('hex')
+  await a.upsertEmbedding(e.id, new Float32Array(384).fill(0.1*(i+1)), hash)
+}
+await a.close(); console.log('seeded'); process.exit(0)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "zod": "^3.23.0"
   },
   "optionalDependencies": {
-    "@huggingface/transformers": "^3.8.1",
+    "@huggingface/transformers": "^4.2.0",
     "better-sqlite3": "^12.0.0",
     "pg": "^8.16.3"
   },

--- a/packages/core/pgprobe.mjs
+++ b/packages/core/pgprobe.mjs
@@ -1,0 +1,1 @@
+import { PGLiteAdapter } from './dist/index.js'

--- a/packages/core/pgprobe.mjs
+++ b/packages/core/pgprobe.mjs
@@ -1,1 +1,0 @@
-import { PGLiteAdapter } from './dist/index.js'

--- a/packages/core/src/backend-selection.ts
+++ b/packages/core/src/backend-selection.ts
@@ -61,7 +61,6 @@ export type BackendTier = 'yaml' | 'sqlite' | 'pglite' | 'postgres'
 /** Every tier name, for validating env/config input. */
 export const BACKEND_TIERS: readonly BackendTier[] = ['yaml', 'sqlite', 'pglite', 'postgres'] as const
 
-/** Estimated engram count at or above which the PGLite index earns its cost. */
 /**
  * Engram count at or above which the SQLite index earns its cost.
  *
@@ -115,7 +114,7 @@ export interface BackendSelection {
   /**
    * Set when the size estimate asked for a tier that could not be given, and
    * names the tier it wanted. Today the only case is `'postgres'` with no
-   * connection string configured, which falls back to `'pglite'`. A caller
+   * connection string configured, which falls back to `'sqlite'`. A caller
    * SHOULD surface this — it is the difference between "this deployment is
    * sized for a server" and "this deployment is fine".
    */
@@ -126,7 +125,13 @@ export interface BackendSelection {
 
 function asTier(value: string | undefined): BackendTier | null {
   if (!value) return null
-  return (BACKEND_TIERS as readonly string[]).includes(value) ? (value as BackendTier) : null
+  // Normalise case and whitespace (adversarial audit): `PLUR_BACKEND=SQLITE`
+  // or a trailing newline from `export PLUR_BACKEND=$(...)` used to fall
+  // silently through to size selection — an override the operator set being
+  // disregarded contradicts this module's own "overrides always win". Still
+  // total: anything unrecognised after normalisation is ignored, not fatal.
+  const v = value.trim().toLowerCase()
+  return (BACKEND_TIERS as readonly string[]).includes(v) ? (v as BackendTier) : null
 }
 
 /**

--- a/packages/core/src/backend-selection.ts
+++ b/packages/core/src/backend-selection.ts
@@ -26,23 +26,27 @@
  *
  * ## The thresholds, and why these numbers
  *
- * {@link PGLITE_MIN_ENGRAMS} = 5,000. The brute-force tier's cost is linear in
+ * {@link SQLITE_MIN_ENGRAMS} = 5,000. The brute-force tier's cost is linear in
  * corpus size and paid per process, and the measured pain point is ~4,700
  * engrams / ~350 MB. 5,000 sits just past it: below, an index costs more (WASM
  * boot, a second copy of the data on disk) than the scan it replaces; above, the
  * scan is the dominant cost.
  *
- * {@link POSTGRES_MIN_ENGRAMS} = 50,000. Not a performance cliff — PGLite is
- * still competent there — but the point past which a *single-process WASM*
- * engine is the wrong shape: PGLite is one writer, in one process, with no
- * shared buffer cache, so N agent processes pay the index cost N times. A
- * server hands all of them one engine. 10x the PGLite threshold, chosen as an
- * order of magnitude rather than a measurement, and deliberately conservative:
- * escalating to a network store is a much bigger operational change than
- * building a local index, so the automatic path should be reluctant.
+ * {@link POSTGRES_MIN_ENGRAMS} = 50,000, and only when a connection string is
+ * actually configured — otherwise the store stays on SQLite. This is not a
+ * SQLite limit: it answers indexed reads in ~1ms at 500,000 engrams. It is the
+ * point past which a SHARED engine starts to matter more than a local file —
+ * many agent processes, concurrent writers, one cache.
  *
- * Both are round numbers standing in for a range. They are not tuned constants
- * and should not be treated as if a 10% move either way mattered.
+ * PGLite is deliberately absent from both rules (#1046). It is a capability
+ * choice — pgvector's ANN index, Apache AGE's graph queries — reachable only
+ * by setting `PLUR_BACKEND=pglite` or `backend: pglite`. Selecting it by
+ * corpus size moved users onto a backend that boots a Postgres in WASM on
+ * every process, which is the wrong shape for a per-invocation CLI no matter
+ * how large the corpus gets.
+ *
+ * These are round numbers standing in for a range. They are not tuned
+ * constants and should not be treated as if a 10% move either way mattered.
  *
  * ## Overrides always win
  *
@@ -58,6 +62,21 @@ export type BackendTier = 'yaml' | 'sqlite' | 'pglite' | 'postgres'
 export const BACKEND_TIERS: readonly BackendTier[] = ['yaml', 'sqlite', 'pglite', 'postgres'] as const
 
 /** Estimated engram count at or above which the PGLite index earns its cost. */
+/**
+ * Engram count at or above which the SQLite index earns its cost.
+ *
+ * This is the tier that used to be PGLite's. SQLite pays ~1ms to open and
+ * answers indexed reads in under a millisecond well past 500,000 engrams, so
+ * it is the right default everywhere the corpus is large enough for a
+ * brute-force YAML scan to hurt.
+ */
+export const SQLITE_MIN_ENGRAMS = 5_000
+
+/**
+ * @deprecated Since #1046 PGLite is opt-in only and this constant selects
+ * nothing. Kept exported so an external caller referencing it still compiles;
+ * `resolveBackendTier` no longer reads it.
+ */
 export const PGLITE_MIN_ENGRAMS = 5_000
 
 /** Estimated engram count at or above which a server Postgres is the right shape. */
@@ -129,17 +148,41 @@ export function resolveBackendTier(input: BackendSelectionInput): BackendSelecti
   const fromConfig = asTier(input.config)
   if (fromConfig) return { tier: fromConfig, reason: 'config-override', engramCount: count }
 
+  // PGLite is NEVER selected by size (#1046). It is reachable only through the
+  // env/config overrides handled above — a capability choice the operator makes
+  // deliberately, not something a growing corpus does to them silently.
+  //
+  // The old rule promoted any store past 5,000 engrams onto PGLite. Measured
+  // 2026-08-27 on a 5,775-engram store, `plur status` took 0.61s on sqlite and
+  // over 300s on pglite. The cost is structural, not a bug we can tune away:
+  // PGLite boots a real Postgres in WASM per process (~1.3s fresh, ~244ms
+  // reopening), and PLUR's CLI and hooks are a fresh process every invocation,
+  // so that toll is paid on every single command. Its per-query cost is
+  // genuinely good — 0.135ms, faster than better-sqlite3's single-row inserts —
+  // which is exactly why it suits a long-lived process and not this one.
+  //
+  // Nor was 5,000 near any SQLite limit. Same machine, synthetic corpora:
+  //
+  //     engrams   open+count   indexed filter   full scan
+  //       5,000          1ms              0ms         3ms
+  //      50,000          1ms              0ms        29ms
+  //     200,000          1ms              1ms       217ms
+  //     500,000          3ms              1ms       342ms
+  //
+  // SQLite is still opening in single-digit milliseconds two orders of
+  // magnitude past the threshold that was promoting people off it.
   if (count >= POSTGRES_MIN_ENGRAMS) {
     if (input.postgresConfigured) {
       return { tier: 'postgres', reason: 'size', engramCount: count }
     }
-    // Sized for a server, told about no server. PGLite is the best available
-    // answer and the caller is told what it missed.
-    return { tier: 'pglite', reason: 'size', wanted: 'postgres', engramCount: count }
+    // Sized for a server, told about no server. SQLite is the best available
+    // answer; `wanted` keeps the fallback loud, because falling back is fine
+    // and falling back silently is the failure mode.
+    return { tier: 'sqlite', reason: 'size', wanted: 'postgres', engramCount: count }
   }
 
-  if (count >= PGLITE_MIN_ENGRAMS) {
-    return { tier: 'pglite', reason: 'size', engramCount: count }
+  if (count >= SQLITE_MIN_ENGRAMS) {
+    return { tier: 'sqlite', reason: 'size', engramCount: count }
   }
 
   return { tier: 'yaml', reason: 'size', engramCount: count }

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -321,6 +321,38 @@ function hashStatement(statement: string): string {
 }
 
 /**
+ * Merge externally-obtained vectors into the on-disk embeddings cache.
+ *
+ * The #1046 PGLite→SQLite migration's write half: vectors verified fresh
+ * against the CURRENT engram text are folded into the cache under this
+ * module's own key discipline (`hashStatement` of the search text), so the
+ * yaml/sqlite tiers serve them exactly as if they had been computed here.
+ * Lives in this file because the cache format — meta header, entry shape,
+ * hash function — is deliberately private to it.
+ *
+ * Existing entries win: an entry already in the cache was written by the
+ * live embed path against the same text and is at least as fresh as the
+ * import. Returns how many entries were written.
+ */
+export function mergeEmbeddingsIntoCache(
+  storagePath: string,
+  active: { name: string; dim: number },
+  imports: Array<{ engramId: string; searchText: string; embedding: number[] }>,
+): number {
+  const cachePath = join(storagePath, '.embeddings-cache.json')
+  const cache = loadCache(cachePath, active)
+  let written = 0
+  for (const imp of imports) {
+    if (imp.embedding.length !== active.dim) continue
+    if (cache.entries[imp.engramId]) continue
+    cache.entries[imp.engramId] = { hash: hashStatement(imp.searchText), embedding: imp.embedding }
+    written++
+  }
+  if (written > 0) saveCache(cachePath, cache)
+  return written
+}
+
+/**
  * Semantic search using embeddings.
  * Computes embedding for query, compares against cached engram embeddings.
  * Returns engrams sorted by cosine similarity (descending).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1023,7 +1023,20 @@ export class Plur {
         this._recordIndexError('initial-sync', err)
         logger.warning(`[plur] PGLite initial sync failed: ${(err as Error).message}. Run 'plur sync --full' to rebuild.`)
       })
-    } else if (this.config.index) {
+    } else if (indexTier === 'sqlite' ? this.config.index !== false : this.config.index) {
+      // The `indexTier === 'sqlite'` arm exists because of the bug ADR-0005 §1
+      // documents and #1046 nearly reintroduced. `PlurConfigSchema` is
+      // `.partial()`, which NEUTRALISES Zod defaults — so `config.index` is
+      // `undefined` on a default install, and a plain `if (this.config.index)`
+      // silently builds nothing. That is how "the default backend does
+      // nothing" happened the first time: selection reported a tier, no index
+      // was built, and every recall brute-forced cosine over the whole corpus
+      // (~350 MB resident at ~4,700 engrams, per process).
+      //
+      // When selection ASKED for sqlite, an absent config value means "not
+      // configured", not "disabled" — only an explicit `index: false` opts
+      // out. The other arm keeps the historical behaviour for tiers that were
+      // never size-selected.
       this.indexedStorage = new IndexedStorage(this.paths.engrams, this.paths.db, this.config.stores)
     }
     // Wire config-level embeddings opt-out into the embedder module. The env

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -189,6 +189,7 @@ export {
   type BackendSelectionReason,
 } from './backend-selection.js'
 export { YamlStore, SqliteStore, createStore, migrateStore, type EngramStore, type StorageBackend, type StorageConfig } from './store/index.js'
+export { exportPgliteEmbeddingsToCache, type PgliteEmbeddingsExportReport } from './pglite-embeddings-export.js'
 export { YamlPrimaryStore, MemoryPrimaryStore, ReadonlyStoreGuard, ReadonlyStoreError, type PrimaryStore, type AsyncPrimaryStore, type PrimaryStoreKind } from './store/index.js'
 export { withAsyncLock, asyncAtomicWrite } from './store/index.js'
 // Embedding primitive — public so alternative store backends can compute

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -180,6 +180,7 @@ export {
 export {
   resolveBackendTier,
   BACKEND_TIERS,
+  SQLITE_MIN_ENGRAMS,
   PGLITE_MIN_ENGRAMS,
   POSTGRES_MIN_ENGRAMS,
   type BackendTier,
@@ -8227,7 +8228,14 @@ Generate an improved version of the procedure that prevents this failure. Return
     if (mtime === 0 || mtime === this.configMtimeMs) return false
     this.config = loadConfig(this.paths.config)
     this.configMtimeMs = mtime
-    if (this.config.index) {
+    // Same `.partial()`-neutralised-default rule as the constructor
+    // (evaluator audit M4): `config.index` is `undefined` on a default
+    // install, and with SQLite now the size-selected tier, a bare truthy
+    // check here means the refresh this method exists for (#307 — a store
+    // added by editing config.yaml out of process) never reaches
+    // indexedStorage on exactly the default installs that have one. Refresh
+    // whenever an index is actually active, or config asks for one.
+    if (this.indexedStorage !== null || this.config.index) {
       this.indexedStorage = new IndexedStorage(this.paths.engrams, this.paths.db, this.config.stores)
     }
     logger.info('[plur] Reloaded config.yaml (changed on disk since last load)')

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -972,7 +972,7 @@ export class Plur {
     } else if (selection.wanted === 'postgres') {
       logger.warning(
         `[plur] ~${selection.engramCount} engrams is past the Postgres threshold, but no connection string is `
-        + `configured (postgres.url / PLUR_POSTGRES_URL) — running the PGLite index instead.`,
+        + `configured (postgres.url / PLUR_POSTGRES_URL) — running the SQLite index instead.`,
       )
     }
     // A Postgres PRIMARY store answers its own queries — do not build a PGLite
@@ -993,6 +993,15 @@ export class Plur {
     const indexTier = hasPrimaryQueryStore
       ? 'none'
       : selection.tier === 'postgres' ? 'pglite' : selection.tier
+    if (indexTier === 'pglite' && selection.reason !== 'size') {
+      // #1046: PGLite is opt-in now. Say so on the way in, so an operator who
+      // set it months ago and forgot can see which engine they are on when a
+      // command feels slow — it boots Postgres in WASM on every process.
+      logger.warning(
+        `[plur] backend=pglite (${selection.reason}). PGLite boots Postgres in WASM per process; ` +
+        'it is for pgvector/AGE capabilities, not speed. Unset PLUR_BACKEND / backend: to use SQLite.',
+      )
+    }
     if (indexTier === 'pglite') {
       // PGLite path. Keep SQLite indexedStorage null so we don't double-index.
       // vector.precision (#223): unset = keep the store's existing column

--- a/packages/core/src/pglite-embeddings-export.ts
+++ b/packages/core/src/pglite-embeddings-export.ts
@@ -1,0 +1,174 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { loadEngrams } from './engrams.js'
+import { embeddingContentHash, engramSearchText } from './fts.js'
+import { mergeEmbeddingsIntoCache } from './embeddings.js'
+import { getEmbedder, resolveEmbedderName } from './embedders/index.js'
+import { logger } from './logger.js'
+
+/**
+ * #1046 migration: carry embedding vectors out of an orphaned PGLite store
+ * into the JSON embeddings cache the yaml/sqlite tiers read.
+ *
+ * When the size ladder stopped selecting PGLite, the one asset a former
+ * PGLite user could not get back for free was their vectors: the
+ * `engram_embeddings` table was that tier's only vector storage, so after
+ * the switch the embeddings cache is empty and the whole corpus re-embeds
+ * in the background — minutes of CPU, with hybrid recall silently degraded
+ * to BM25 until it finishes. This ports every vector that is still valid,
+ * making the tier switch seamless.
+ *
+ * "Still valid" is checked twice, because the two stores key vectors
+ * differently and neither key transfers:
+ *
+ *   - FRESHNESS: the PGLite row's `content_hash` (md5 of the engram's
+ *     search text, `embeddingContentHash`) must match the md5 of the
+ *     engram's CURRENT text in YAML. A vector computed from older text is
+ *     skipped — porting it would silently poison ranking, and the
+ *     background embed pass regenerates it anyway. Legacy rows with no
+ *     content_hash (pre-#812) are skipped for the same reason: they cannot
+ *     be verified.
+ *   - DIMENSION: the vector's length must match the ACTIVE embedder's dim.
+ *     A 768d bge-base store feeding a 384d bge-small cache would corrupt
+ *     every similarity score; the cache's own meta header would reject the
+ *     file wholesale, but checking per-vector gives an honest count
+ *     instead.
+ *
+ * The JSON cache then re-keys accepted vectors under its own discipline
+ * (sha256-16 of the search text) via `mergeEmbeddingsIntoCache` — the md5
+ * never enters the cache.
+ *
+ * Read-only with respect to the PGLite store: nothing is deleted here.
+ * Deleting `store.pglite/` afterwards is the user's call (doctor and the
+ * CLI report both say so). Safe to re-run — existing cache entries win.
+ */
+
+export interface PgliteEmbeddingsExportReport {
+  status: 'no-store' | 'no-embeddings' | 'done' | 'failed'
+  /** Vectors written into the cache. */
+  ported: number
+  /** Rows skipped because the engram's text changed since the vector was computed (or the row predates content hashes). */
+  stale: number
+  /** Rows skipped because their dimension does not match the active embedder. */
+  wrongDim: number
+  /** Rows whose engram no longer exists in YAML. */
+  orphaned: number
+  error?: string
+}
+
+/** Coerce the three shapes a PGLite embedding column read can produce. */
+function toNumberArray(value: unknown): number[] | null {
+  if (Array.isArray(value)) {
+    return value.every(n => typeof n === 'number' && Number.isFinite(n)) ? value as number[] : null
+  }
+  if (typeof value === 'string') {
+    // pgvector's wire format: "[0.1,0.2,...]"
+    try {
+      const parsed: unknown = JSON.parse(value)
+      return Array.isArray(parsed) && parsed.every(n => typeof n === 'number' && Number.isFinite(n))
+        ? parsed as number[]
+        : null
+    } catch {
+      return null
+    }
+  }
+  if (value instanceof Uint8Array) {
+    // BYTEA fallback: little-endian float32s.
+    if (value.byteLength % 4 !== 0) return null
+    const f = new Float32Array(value.buffer, value.byteOffset, value.byteLength / 4)
+    return Array.from(f)
+  }
+  return null
+}
+
+export async function exportPgliteEmbeddingsToCache(
+  storageRoot: string,
+  engramsPath: string = join(storageRoot, 'engrams.yaml'),
+  pglitePath: string = join(storageRoot, 'store.pglite'),
+): Promise<PgliteEmbeddingsExportReport> {
+  const report: PgliteEmbeddingsExportReport = { status: 'done', ported: 0, stale: 0, wrongDim: 0, orphaned: 0 }
+
+  if (!existsSync(pglitePath)) return { ...report, status: 'no-store' }
+
+  // Metadata-only: the embedder factory resolves name+dim without loading
+  // the model (same call the Plur constructor makes).
+  const active = getEmbedder(resolveEmbedderName())
+
+  interface MinimalDb {
+    query: (q: string) => Promise<{ rows: Array<Record<string, unknown>> }>
+    close: () => Promise<void>
+  }
+  let db: MinimalDb | null = null
+  try {
+    const { PGlite } = await import('@electric-sql/pglite')
+    // Open EXACTLY the way PGLiteAdapter does: the `file://` prefix and the
+    // vector extension. A bare path resolves to a DIFFERENT data directory
+    // in this PGlite version — an adapter-written store read back with
+    // `PGlite.create(barePath)` reports `relation "engram_embeddings" does
+    // not exist` while the data sits intact under the file:// form (this
+    // also explains the phantom-empty-store readings during the #1046
+    // investigation). And without the vector extension, a table whose
+    // column type is `vector(N)` cannot be read at all.
+    const extensions: Record<string, unknown> = {}
+    try {
+      const vec = await import('@electric-sql/pglite/vector') as { vector: unknown }
+      extensions.vector = vec.vector
+    } catch { /* BYTEA-fallback stores have no vector column to need it */ }
+    db = new (PGlite as unknown as new (dataDir: string, opts: { extensions: Record<string, unknown> }) => MinimalDb)(
+      `file://${pglitePath}`, { extensions },
+    )
+    await (db as unknown as { waitReady: Promise<void> }).waitReady
+
+    // Discover WHICH SCHEMA the table lives in rather than assuming public.
+    // When the adapter ran with the AGE extension loaded, AGE prepends
+    // ag_catalog to the search_path during its init, so every table the
+    // adapter created landed in `ag_catalog` — invisible to a plain
+    // search_path=public connection ("relation does not exist" on a store
+    // that plainly holds the data; found the hard way writing this
+    // migration). Stores built without AGE have it in public. Quoting via
+    // format() is unnecessary: pg_tables.schemaname is trusted catalog
+    // output, but quote_ident anyway since it is one function call.
+    const loc = await db.query(
+      "SELECT quote_ident(schemaname) AS s FROM pg_tables WHERE tablename = 'engram_embeddings' LIMIT 1",
+    )
+    if (loc.rows.length === 0) return { ...report, status: 'no-embeddings' }
+    const schema = String(loc.rows[0].s)
+
+    const res = await db.query(`SELECT engram_id, embedding, content_hash FROM ${schema}.engram_embeddings`)
+    if (res.rows.length === 0) return { ...report, status: 'no-embeddings' }
+
+    const byId = new Map<string, { embedding: unknown; content_hash: unknown }>()
+    for (const r of res.rows) {
+      byId.set(String(r.engram_id), { embedding: r.embedding, content_hash: r.content_hash })
+    }
+
+    const engrams = loadEngrams(engramsPath)
+    const present = new Set<string>()
+    const imports: Array<{ engramId: string; searchText: string; embedding: number[] }> = []
+
+    for (const engram of engrams) {
+      const row = byId.get(engram.id)
+      if (!row) continue
+      present.add(engram.id)
+      if (typeof row.content_hash !== 'string' || row.content_hash !== embeddingContentHash(engram)) {
+        report.stale++
+        continue
+      }
+      const vec = toNumberArray(row.embedding)
+      if (!vec || vec.length !== active.dim) {
+        report.wrongDim++
+        continue
+      }
+      imports.push({ engramId: engram.id, searchText: engramSearchText(engram), embedding: vec })
+    }
+    report.orphaned = byId.size - present.size
+
+    report.ported = mergeEmbeddingsIntoCache(storageRoot, { name: active.name, dim: active.dim }, imports)
+    return report
+  } catch (err: unknown) {
+    logger.warning(`[plur] PGLite embeddings export failed: ${(err as Error)?.message ?? 'unknown error'}`)
+    return { ...report, status: 'failed', error: (err as Error)?.message ?? 'unknown error' }
+  } finally {
+    await db?.close().catch(() => { /* export already done or failed; a close error changes nothing */ })
+  }
+}

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -24,7 +24,7 @@
  * in a future PR. We initialize the extension so it's ready for #200, but
  * the public adapter surface in this PR is relational + vector.
  */
-import { existsSync } from 'fs'
+import { existsSync, statSync } from 'fs'
 import type { Engram } from './schemas/engram.js'
 import { EngramSchemaPassthrough } from './schemas/engram.js'
 import { normalizeEngramInput } from './normalize-engram.js'
@@ -273,6 +273,14 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
     // cache the comment there says is preserved on purpose. Orphans left by
     // real removals are swept set-wise in `syncFromYaml` instead.
     await db.exec('ALTER TABLE engram_embeddings ADD COLUMN IF NOT EXISTS content_hash TEXT;')
+    // #1046: one row recording the YAML state this index was last synced from,
+    // so an unchanged file can skip the whole re-upsert. See syncFromYaml.
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS sync_state (
+        k TEXT PRIMARY KEY,
+        v TEXT NOT NULL
+      );
+    `)
     // AGE engram graph (#200 lands the actual edges; we just create the
     // graph here so the schema is ready).
     if (this.hasAge) {
@@ -501,6 +509,11 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
       try {
         await db.exec('DELETE FROM engrams')
         await this.insertEngramsTx(db)
+        // reindex() is the recovery path for a suspect index, so it must not
+        // inherit a fingerprint that would let the next syncFromYaml skip.
+        // Clearing (rather than setting) keeps the rebuild honest: the next
+        // sync re-derives it from the file it actually reads.
+        await db.exec("DELETE FROM sync_state WHERE k = 'yaml_fingerprint'").catch(() => {})
         await db.exec('COMMIT')
       } catch (err) {
         await db.exec('ROLLBACK').catch(() => {})
@@ -510,24 +523,65 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
   }
 
   /**
+   * Cheap identity for the YAML file: size + mtime, no read.
+   *
+   * Deliberately not a content hash. The point of the guard below is to avoid
+   * touching the corpus at all when nothing changed, and PLUR rewrites this
+   * file wholesale on every mutation, so stat is sufficient to notice. If it
+   * is ever wrong the index is stale, not corrupt — YAML stays the source of
+   * truth and `plur sync --full` (reindex) is the documented recovery, which
+   * clears this row.
+   */
+  private yamlFingerprint(): string | null {
+    try {
+      const st = statSync(this.yamlPath)
+      return `${st.size}:${st.mtimeMs}`
+    } catch {
+      return null // missing file — let the sync run and clear the table
+    }
+  }
+
+  private async readSyncedFingerprint(db: any): Promise<string | null> {
+    try {
+      const r = await db.query("SELECT v FROM sync_state WHERE k = 'yaml_fingerprint'")
+      return r.rows.length > 0 ? String(r.rows[0].v) : null
+    } catch {
+      return null // pre-#1046 store, table not created yet
+    }
+  }
+
+  /**
    * syncFromYaml: incremental — upsert what YAML says exists, delete
    * primary-source rows that YAML no longer contains.
    *
    * This is the steady-state write path called after every YAML mutation
-   * (see Plur._syncIndex).
+   * (see Plur._syncIndex), AND it runs unconditionally from the Plur
+   * constructor — which is what made #1046 expensive. "Incremental" here only
+   * ever meant "does not DROP the table first": the loop below re-upserts
+   * EVERY engram, one awaited round-trip each, so a 5,031-engram store paid
+   * 5,031 sequential WASM-Postgres statements on every single process start.
+   * For the hook family — a fresh process per hook — that is the whole budget,
+   * and it degraded from slow to a hang as the corpus grew.
+   *
+   * The fingerprint guard makes the unchanged case free. It cannot mask a real
+   * change: any write goes through the YAML file, which changes size or mtime.
    */
   async syncFromYaml(): Promise<void> {
     return this.mutex.run(async () => {
       const db = await this.getDb()
+
+      const fingerprint = this.yamlFingerprint()
+      if (fingerprint !== null && (await this.readSyncedFingerprint(db)) === fingerprint) {
+        return // index already reflects this exact YAML file
+      }
+
       await db.exec('BEGIN')
       try {
         const ids = new Set<string>()
         if (existsSync(this.yamlPath)) {
           const engrams = loadEngrams(this.yamlPath)
-          for (const e of engrams) {
-            await this.upsertEngramTx(db, e, 'primary')
-            ids.add(e.id)
-          }
+          await this.upsertEngramsTx(db, engrams, 'primary')
+          for (const e of engrams) ids.add(e.id)
         }
         // Drop primary-source rows that no longer exist in YAML.
         if (ids.size > 0) {
@@ -552,6 +606,17 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
         // whatever the removed engram used to say. Set-based and inside the same
         // transaction as the deletes above, so it costs one statement per sync.
         await db.exec('DELETE FROM engram_embeddings WHERE engram_id NOT IN (SELECT id FROM engrams)')
+        // Inside the transaction: a rollback must not leave the index claiming
+        // to be in sync with a file it never finished reading.
+        if (fingerprint !== null) {
+          await db.query(
+            `INSERT INTO sync_state (k, v) VALUES ('yaml_fingerprint', $1)
+             ON CONFLICT (k) DO UPDATE SET v = EXCLUDED.v`,
+            [fingerprint],
+          )
+        } else {
+          await db.exec("DELETE FROM sync_state WHERE k = 'yaml_fingerprint'")
+        }
         await db.exec('COMMIT')
       } catch (err) {
         await db.exec('ROLLBACK').catch(() => {})
@@ -562,9 +627,53 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
 
   private async insertEngramsTx(db: any): Promise<void> {
     if (!existsSync(this.yamlPath)) return
-    const engrams = loadEngrams(this.yamlPath)
-    for (const e of engrams) {
-      await this.upsertEngramTx(db, e, 'primary')
+    await this.upsertEngramsTx(db, loadEngrams(this.yamlPath), 'primary')
+  }
+
+  /**
+   * Upsert many engrams in chunked multi-row statements.
+   *
+   * The per-engram version below issues one awaited round-trip each, which is
+   * fine for a `learn()` of one engram and catastrophic for a full corpus
+   * pass: 5,031 engrams took over ten minutes, because the cost here is
+   * round-trips into WASM Postgres, not the inserts themselves. Batching turns
+   * that into ~11 statements.
+   *
+   * CHUNK is bounded by Postgres's 65,535-parameter ceiling: 7 params per row
+   * caps a single statement at 9,362 rows. 500 leaves an order of magnitude of
+   * headroom and keeps the parameter array small enough not to matter.
+   */
+  private async upsertEngramsTx(db: any, engrams: Engram[], source: string): Promise<void> {
+    const COLS = 7
+    const CHUNK = 500
+    for (let i = 0; i < engrams.length; i += CHUNK) {
+      const batch = engrams.slice(i, i + CHUNK)
+      const values: unknown[] = []
+      const tuples = batch.map((e, n) => {
+        const b = n * COLS
+        values.push(
+          e.id,
+          e.status,
+          e.scope,
+          e.domain ?? null,
+          e.activation?.last_accessed ?? null,
+          JSON.stringify(e),
+          source,
+        )
+        return `($${b + 1}, $${b + 2}, $${b + 3}, $${b + 4}, $${b + 5}, $${b + 6}::jsonb, $${b + 7})`
+      })
+      await db.query(
+        `INSERT INTO engrams (id, status, scope, domain, last_accessed, data, source)
+         VALUES ${tuples.join(', ')}
+         ON CONFLICT (id) DO UPDATE SET
+           status = EXCLUDED.status,
+           scope = EXCLUDED.scope,
+           domain = EXCLUDED.domain,
+           last_accessed = EXCLUDED.last_accessed,
+           data = EXCLUDED.data,
+           source = EXCLUDED.source`,
+        values,
+      )
     }
   }
 

--- a/packages/core/src/storage-pglite.ts
+++ b/packages/core/src/storage-pglite.ts
@@ -513,7 +513,14 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
         // inherit a fingerprint that would let the next syncFromYaml skip.
         // Clearing (rather than setting) keeps the rebuild honest: the next
         // sync re-derives it from the file it actually reads.
-        await db.exec("DELETE FROM sync_state WHERE k = 'yaml_fingerprint'").catch(() => {})
+        //
+        // NOT catch-swallowed (data-loss audit F4): this statement runs
+        // inside BEGIN/COMMIT, and a swallowed error here would leave the
+        // transaction aborted so the following COMMIT silently acts as
+        // ROLLBACK — reindex() reporting success having rebuilt nothing.
+        // ensureSchema guarantees the table exists; if this ever throws, the
+        // catch below rolls back loudly, which is the honest outcome.
+        await db.exec("DELETE FROM sync_state WHERE k = 'yaml_fingerprint'")
         await db.exec('COMMIT')
       } catch (err) {
         await db.exec('ROLLBACK').catch(() => {})
@@ -644,10 +651,21 @@ export class PGLiteAdapter implements DerivedIndexAdapter {
    * headroom and keeps the parameter array small enough not to matter.
    */
   private async upsertEngramsTx(db: any, engrams: Engram[], source: string): Promise<void> {
+    // De-dupe by id, last-wins, BEFORE batching (data-loss audit F7).
+    // parseEngramFile does not reject duplicate ids, and a multi-row
+    // `INSERT ... ON CONFLICT DO UPDATE` containing the same id twice is a
+    // Postgres ERROR ("cannot affect row a second time") — which turned a
+    // condition the old per-row loop silently tolerated into a permanently
+    // failing sync whose documented recovery (`plur sync --full`) hit the
+    // same error. Last-wins matches the per-row loop's observable behaviour.
+    const byId = new Map<string, Engram>()
+    for (const e of engrams) byId.set(e.id, e)
+    const unique = byId.size === engrams.length ? engrams : [...byId.values()]
+
     const COLS = 7
     const CHUNK = 500
-    for (let i = 0; i < engrams.length; i += CHUNK) {
-      const batch = engrams.slice(i, i + CHUNK)
+    for (let i = 0; i < unique.length; i += CHUNK) {
+      const batch = unique.slice(i, i + CHUNK)
       const values: unknown[] = []
       const tuples = batch.map((e, n) => {
         const b = n * COLS

--- a/packages/core/test/backend-selection.test.ts
+++ b/packages/core/test/backend-selection.test.ts
@@ -20,7 +20,7 @@ import yaml from 'js-yaml'
 import {
   resolveBackendTier,
   BACKEND_TIERS,
-  PGLITE_MIN_ENGRAMS,
+  SQLITE_MIN_ENGRAMS,
   POSTGRES_MIN_ENGRAMS,
   type BackendTier,
 } from '../src/backend-selection.js'
@@ -56,27 +56,46 @@ describe('resolveBackendTier — size-based selection', () => {
     expect(s.wanted).toBeUndefined()
   })
 
-  it('escalates to PGLite at the documented threshold, not one engram earlier', () => {
-    expect(resolveBackendTier({ engramCount: PGLITE_MIN_ENGRAMS - 1, postgresConfigured: false }).tier)
+  it('escalates to SQLite at the documented threshold, not one engram earlier', () => {
+    expect(resolveBackendTier({ engramCount: SQLITE_MIN_ENGRAMS - 1, postgresConfigured: false }).tier)
       .toBe('yaml')
-    expect(resolveBackendTier({ engramCount: PGLITE_MIN_ENGRAMS, postgresConfigured: false }).tier)
-      .toBe('pglite')
+    expect(resolveBackendTier({ engramCount: SQLITE_MIN_ENGRAMS, postgresConfigured: false }).tier)
+      .toBe('sqlite')
+  })
+
+  // #1046: PGLite used to be the size-selected tier, which silently moved
+  // users onto a backend that boots Postgres in WASM on every process — 0.61s
+  // vs 300s+ per command on a 5,775-engram store. It is a capability choice
+  // now (pgvector ANN, AGE graph queries), never a consequence of growth.
+  it('never selects PGLite by size, at any corpus size', () => {
+    for (const count of [SQLITE_MIN_ENGRAMS, POSTGRES_MIN_ENGRAMS, POSTGRES_MIN_ENGRAMS * 100]) {
+      for (const postgresConfigured of [true, false]) {
+        expect(resolveBackendTier({ engramCount: count, postgresConfigured }).tier).not.toBe('pglite')
+      }
+    }
+  })
+
+  it('still reaches PGLite when the operator asks for it explicitly', () => {
+    expect(resolveBackendTier({ env: 'pglite', engramCount: 0, postgresConfigured: false }))
+      .toMatchObject({ tier: 'pglite', reason: 'env-override' })
+    expect(resolveBackendTier({ config: 'pglite', engramCount: 0, postgresConfigured: false }))
+      .toMatchObject({ tier: 'pglite', reason: 'config-override' })
   })
 
   it('escalates to Postgres at its threshold when a connection string is configured', () => {
     const below = resolveBackendTier({ engramCount: POSTGRES_MIN_ENGRAMS - 1, postgresConfigured: true })
-    expect(below.tier).toBe('pglite')
+    expect(below.tier).toBe('sqlite')
     const at = resolveBackendTier({ engramCount: POSTGRES_MIN_ENGRAMS, postgresConfigured: true })
     expect(at.tier).toBe('postgres')
     expect(at.reason).toBe('size')
   })
 
-  it('caps at PGLite when the corpus wants Postgres but nothing is configured — and SAYS so', () => {
+  it('caps at SQLite when the corpus wants Postgres but nothing is configured — and SAYS so', () => {
     const s = resolveBackendTier({ engramCount: POSTGRES_MIN_ENGRAMS * 4, postgresConfigured: false })
     // The whole point of `wanted`: falling back is fine, falling back silently
     // is the failure mode. A caller can see it asked for a server and did not
     // get one.
-    expect(s.tier).toBe('pglite')
+    expect(s.tier).toBe('sqlite')
     expect(s.wanted).toBe('postgres')
     expect(s.engramCount).toBe(POSTGRES_MIN_ENGRAMS * 4)
   })

--- a/packages/core/test/pglite-backend-selection.test.ts
+++ b/packages/core/test/pglite-backend-selection.test.ts
@@ -197,3 +197,37 @@ describe('the Postgres tier degrades loudly, never silently', () => {
     expect(plur.primaryStore.kind).toBe('yaml')
   }, PGLITE_TIMEOUT)
 })
+
+/**
+ * Selection and construction must agree — the regression class that shipped
+ * TWICE on this branch's history. `resolveBackendTier` said 'sqlite' while
+ * the constructor's `else if (this.config.index)` arm never fired, because
+ * PlurConfigSchema is `.partial()` and that neutralises Zod defaults, so
+ * `config.index` is undefined on a default install. Every recall then
+ * brute-forced cosine over the whole corpus (ADR-0005 §1). The suite stayed
+ * green throughout, because selection tests and construction tests each
+ * passed separately. This is the test that fails when they disagree.
+ */
+describe('a size-selected tier materialises its index (#1046 follow-up)', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-tier-idx-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('default install past the threshold builds the SQLite index, no config needed', async () => {
+    const plur = new Plur({ path: dir, store: storeClaiming(SQLITE_MIN_ENGRAMS) })
+    await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
+    expect(plur.backendSelection().tier).toBe('sqlite')
+    // The assertion that was missing: the index OBJECT exists, not just the label.
+    expect((plur as unknown as { indexedStorage: unknown }).indexedStorage).toBeTruthy()
+  })
+
+  it('explicit index:false still opts out', async () => {
+    // Config comes from config.yaml on disk — the constructor takes no inline
+    // config, which is itself why the .partial() default-neutralisation bug
+    // was reachable at all.
+    writeFileSync(join(dir, 'config.yaml'), 'index: false\n')
+    const plur = new Plur({ path: dir, store: storeClaiming(SQLITE_MIN_ENGRAMS) })
+    await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
+    expect((plur as unknown as { indexedStorage: unknown }).indexedStorage).toBeNull()
+  })
+})

--- a/packages/core/test/pglite-backend-selection.test.ts
+++ b/packages/core/test/pglite-backend-selection.test.ts
@@ -3,7 +3,8 @@
  *
  * `backend-selection.test.ts` pins the resolver as a pure function. This file
  * pins the consequence: a store large enough to make brute-force scanning the
- * dominant cost really does get a PGLite index built for it, and the one tier
+ * dominant cost really does get an INDEX built for it — SQLite since #1046
+ * (PGLite is opt-in only; see the ADR-0005 amendment) — and the one tier
  * that cannot yet be wired — Postgres, because `Plur`'s write path is still
  * synchronous (ADR-0003) — degrades LOUDLY to the best tier that can.
  *

--- a/packages/core/test/pglite-backend-selection.test.ts
+++ b/packages/core/test/pglite-backend-selection.test.ts
@@ -18,7 +18,7 @@ import yaml from 'js-yaml'
 import { Plur } from '../src/index.js'
 import { logger } from '../src/logger.js'
 import { MemoryPrimaryStore } from '../src/store/memory-primary-store.js'
-import { PGLITE_MIN_ENGRAMS, POSTGRES_MIN_ENGRAMS } from '../src/backend-selection.js'
+import { SQLITE_MIN_ENGRAMS, POSTGRES_MIN_ENGRAMS } from '../src/backend-selection.js'
 import { AVG_YAML_BYTES_PER_ENGRAM } from '../src/store/yaml-primary-store.js'
 import type { PrimaryStore } from '../src/store/primary-store.js'
 
@@ -49,23 +49,24 @@ describe('size-based selection builds the index it selected', () => {
   })
 
   it('builds no index for a personal-sized store', async () => {
-    const plur = new Plur({ path: dir, store: storeClaiming(PGLITE_MIN_ENGRAMS - 1) })
+    const plur = new Plur({ path: dir, store: storeClaiming(SQLITE_MIN_ENGRAMS - 1) })
     await plur.learn('small stores pay for no index')
     await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
     expect(plur.backendSelection().tier).toBe('yaml')
     expect(existsSync(join(dir, 'store.pglite'))).toBe(false)
   }, PGLITE_TIMEOUT)
 
-  it('builds a PGLite index once the store crosses the threshold', async () => {
-    // This is the behaviour the old resolver could not produce at all: it
-    // returned 'sqlite' regardless of size, and with `config.index` undefined
-    // that meant no index — so a 5k+ engram store brute-forced cosine over the
-    // entire corpus on every recall, in every process.
-    const plur = new Plur({ path: dir, store: storeClaiming(PGLITE_MIN_ENGRAMS) })
+  it('builds a SQLite index once the store crosses the threshold', async () => {
+    // The property that matters is that a store past the threshold gets an
+    // INDEX rather than brute-forcing cosine over the whole corpus on every
+    // recall. #1046 changed which index: PGLite boots Postgres in WASM per
+    // process, which is the wrong shape for a per-invocation CLI at any size.
+    const plur = new Plur({ path: dir, store: storeClaiming(SQLITE_MIN_ENGRAMS) })
     await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
-    expect(plur.backendSelection().tier).toBe('pglite')
+    expect(plur.backendSelection().tier).toBe('sqlite')
     expect(plur.backendSelection().reason).toBe('size')
-    expect(existsSync(join(dir, 'store.pglite'))).toBe(true)
+    // Growth must never conjure a PGLite store on disk.
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(false)
   }, PGLITE_TIMEOUT)
 
   it('estimates from the YAML file itself, with no store injected', async () => {
@@ -75,7 +76,7 @@ describe('size-based selection builds the index it selected', () => {
     // materialising a full 12 MB corpus would be testing the wrong thing.
     const engrams = [{
       id: 'ENG-2026-0726-001',
-      statement: 'x'.repeat(AVG_YAML_BYTES_PER_ENGRAM * PGLITE_MIN_ENGRAMS),
+      statement: 'x'.repeat(AVG_YAML_BYTES_PER_ENGRAM * SQLITE_MIN_ENGRAMS),
       type: 'behavioral',
       scope: 'global',
       domain: 'plur.test',
@@ -88,8 +89,8 @@ describe('size-based selection builds the index it selected', () => {
 
     const plur = new Plur({ path: dir })
     await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
-    expect(plur.backendSelection().tier).toBe('pglite')
-    expect(existsSync(join(dir, 'store.pglite'))).toBe(true)
+    expect(plur.backendSelection().tier).toBe('sqlite')
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(false)
   }, PGLITE_TIMEOUT)
 })
 
@@ -141,11 +142,11 @@ describe('the Postgres tier degrades loudly, never silently', () => {
     const plur = new Plur({ path: dir, store: storeClaiming(POSTGRES_MIN_ENGRAMS) })
     await (plur as unknown as { waitForIndex: () => Promise<void> }).waitForIndex()
     const selection = plur.backendSelection()
-    expect(selection.tier).toBe('pglite')
+    expect(selection.tier).toBe('sqlite')
     expect(selection.wanted).toBe('postgres')
     expect(logs.join('\n')).toMatch(/past the Postgres threshold/)
     // Degraded, but still indexed — the fallback is a working backend, not none.
-    expect(existsSync(join(dir, 'store.pglite'))).toBe(true)
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(false)
   }, PGLITE_TIMEOUT)
 
   it('selects postgres when a DSN is configured, but never connects on its own', async () => {

--- a/packages/core/test/pglite-duplicate-ids.test.ts
+++ b/packages/core/test/pglite-duplicate-ids.test.ts
@@ -30,7 +30,7 @@ function mkEngram(id: string, statement: string): Engram {
     tags: [],
     activation: { retrieval_strength: 1.0, storage_strength: 1.0, frequency: 0, last_accessed: '2026-08-27' },
     feedback_signals: { positive: 0, negative: 0, neutral: 0 },
-  } as Engram
+  } as unknown as Engram
 }
 
 describe('duplicate ids in one YAML (F7)', () => {

--- a/packages/core/test/pglite-duplicate-ids.test.ts
+++ b/packages/core/test/pglite-duplicate-ids.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Duplicate ids in one engrams.yaml must not abort the PGLite sync
+ * (data-loss audit F7, a regression the batched upserts introduced).
+ *
+ * parseEngramFile does not reject duplicate ids, so both copies reach the
+ * upsert. The old per-row loop tolerated that last-wins; the batched
+ * multi-row `INSERT ... ON CONFLICT DO UPDATE` raised Postgres's "cannot
+ * affect row a second time" instead — permanently, because the documented
+ * recovery (`plur sync --full` → reindex) built the same statement and hit
+ * the same error. The user was told to run a command that could not help.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+const PGLITE_TIMEOUT = 60_000
+
+function mkEngram(id: string, statement: string): Engram {
+  return {
+    id,
+    statement,
+    type: 'behavioral',
+    scope: 'project:plur',
+    domain: 'plur.test',
+    status: 'active',
+    tags: [],
+    activation: { retrieval_strength: 1.0, storage_strength: 1.0, frequency: 0, last_accessed: '2026-08-27' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+  } as Engram
+}
+
+describe('duplicate ids in one YAML (F7)', () => {
+  let dir: string
+  let adapter: PGLiteAdapter
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-dup-ids-')) })
+  afterEach(async () => {
+    await adapter?.close?.()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('syncFromYaml tolerates duplicates last-wins, matching the old per-row loop', async () => {
+    const yamlPath = join(dir, 'engrams.yaml')
+    writeFileSync(yamlPath, yaml.dump({
+      engrams: [
+        mkEngram('ENG-DUP-1', 'first copy'),
+        mkEngram('ENG-OTHER', 'unrelated'),
+        mkEngram('ENG-DUP-1', 'second copy — must win'),
+      ],
+    }), 'utf8')
+
+    adapter = new PGLiteAdapter(yamlPath, join(dir, 'store.pglite'), { vectorDim: 384 })
+    await adapter.syncFromYaml() // used to throw "cannot affect row a second time"
+
+    const db = await (adapter as unknown as { getDb: () => Promise<{ query: (q: string) => Promise<{ rows: Array<Record<string, unknown>> }> }> }).getDb()
+    const rows = await db.query("SELECT id, data->>'statement' AS s FROM engrams ORDER BY id")
+    expect(rows.rows).toEqual([
+      { id: 'ENG-DUP-1', s: 'second copy — must win' },
+      { id: 'ENG-OTHER', s: 'unrelated' },
+    ])
+  }, PGLITE_TIMEOUT)
+
+  it('reindex — the documented recovery path — also tolerates duplicates', async () => {
+    const yamlPath = join(dir, 'engrams.yaml')
+    writeFileSync(yamlPath, yaml.dump({
+      engrams: [mkEngram('ENG-DUP-2', 'a'), mkEngram('ENG-DUP-2', 'b — must win')],
+    }), 'utf8')
+
+    adapter = new PGLiteAdapter(yamlPath, join(dir, 'store.pglite'), { vectorDim: 384 })
+    await adapter.reindex()
+
+    const db = await (adapter as unknown as { getDb: () => Promise<{ query: (q: string) => Promise<{ rows: Array<Record<string, unknown>> }> }> }).getDb()
+    const rows = await db.query("SELECT id, data->>'statement' AS s FROM engrams")
+    expect(rows.rows).toEqual([{ id: 'ENG-DUP-2', s: 'b — must win' }])
+  }, PGLITE_TIMEOUT)
+})

--- a/packages/core/test/pglite-embeddings-export.test.ts
+++ b/packages/core/test/pglite-embeddings-export.test.ts
@@ -32,7 +32,7 @@ function mkEngram(id: string, statement: string): Engram {
     tags: [],
     activation: { retrieval_strength: 1.0, storage_strength: 1.0, frequency: 0, last_accessed: '2026-08-27' },
     feedback_signals: { positive: 0, negative: 0, neutral: 0 },
-  } as Engram
+  } as unknown as Engram
 }
 
 function vec(seed: number): Float32Array {

--- a/packages/core/test/pglite-embeddings-export.test.ts
+++ b/packages/core/test/pglite-embeddings-export.test.ts
@@ -1,0 +1,114 @@
+/**
+ * #1046 migration path: vectors leave the orphaned PGLite store and land in
+ * the JSON embeddings cache — but ONLY the ones still valid.
+ *
+ * The two stores key vectors incompatibly (md5 vs sha256-16 of the search
+ * text), so the export re-verifies freshness against the engram's CURRENT
+ * text and re-keys under the cache's own discipline. A stale vector must
+ * never port: it would silently poison ranking, and the background embed
+ * pass regenerates it anyway.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import { PGLiteAdapter } from '../src/storage-pglite.js'
+import { exportPgliteEmbeddingsToCache } from '../src/pglite-embeddings-export.js'
+import { embeddingContentHash } from '../src/fts.js'
+import type { Engram } from '../src/schemas/engram.js'
+
+const PGLITE_TIMEOUT = 60_000
+const DIM = 384 // the default embedder's (bge-small) dimension — metadata only, no model load
+
+function mkEngram(id: string, statement: string): Engram {
+  return {
+    id,
+    statement,
+    type: 'behavioral',
+    scope: 'project:plur',
+    domain: 'plur.test',
+    status: 'active',
+    tags: [],
+    activation: { retrieval_strength: 1.0, storage_strength: 1.0, frequency: 0, last_accessed: '2026-08-27' },
+    feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+  } as Engram
+}
+
+function vec(seed: number): Float32Array {
+  const v = new Float32Array(DIM)
+  for (let i = 0; i < DIM; i++) v[i] = Math.sin(seed + i)
+  return v
+}
+
+describe('exportPgliteEmbeddingsToCache (#1046)', () => {
+  let dir: string
+  let adapter: PGLiteAdapter
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-emb-export-')) })
+  afterEach(async () => {
+    await adapter?.close?.()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('ports fresh vectors, skips stale and orphaned ones, and re-keys for the cache', async () => {
+    const yamlPath = join(dir, 'engrams.yaml')
+    const fresh = mkEngram('ENG-FRESH', 'unchanged since the vector was computed')
+    const edited = mkEngram('ENG-EDITED', 'text as it is NOW, after an edit')
+    writeFileSync(yamlPath, yaml.dump({ engrams: [fresh, edited] }), 'utf8')
+
+    adapter = new PGLiteAdapter(yamlPath, join(dir, 'store.pglite'), { vectorDim: DIM })
+    await adapter.syncFromYaml()
+    // Fresh: hash matches the current text. Stale: hash of some OLDER text.
+    await adapter.upsertEmbedding('ENG-FRESH', vec(1), embeddingContentHash(fresh))
+    await adapter.upsertEmbedding('ENG-EDITED', vec(2), 'md5-of-text-that-no-longer-exists')
+    // Orphaned: an id no longer present in YAML at all.
+    await adapter.upsertEmbedding('ENG-FRESH', vec(1), embeddingContentHash(fresh)) // idempotent re-upsert
+    const db = await (adapter as unknown as { getDb: () => Promise<{ query: (q: string, p?: unknown[]) => Promise<unknown> }> }).getDb()
+    await db.query(
+      "INSERT INTO engrams (id, status, scope, domain, last_accessed, data, source) VALUES ('ENG-GONE','active','global',NULL,NULL,'{}'::jsonb,'primary')",
+    )
+    await adapter.upsertEmbedding('ENG-GONE', vec(3), 'whatever')
+    await adapter.close()
+
+    const report = await exportPgliteEmbeddingsToCache(dir, yamlPath, join(dir, 'store.pglite'))
+
+    expect(report.status).toBe('done')
+    expect(report.ported).toBe(1)
+    expect(report.stale).toBe(1)
+    expect(report.orphaned).toBe(1)
+
+    const cache = JSON.parse(readFileSync(join(dir, '.embeddings-cache.json'), 'utf8')) as {
+      meta: { embedder_dim: number }
+      entries: Record<string, { hash: string; embedding: number[] }>
+    }
+    expect(Object.keys(cache.entries)).toEqual(['ENG-FRESH'])
+    expect(cache.entries['ENG-FRESH'].embedding).toHaveLength(DIM)
+    // Re-keyed: the cache hash is sha256-16, NOT the md5 PGLite stored.
+    expect(cache.entries['ENG-FRESH'].hash).toHaveLength(16)
+    expect(cache.entries['ENG-FRESH'].hash).not.toBe(embeddingContentHash(fresh))
+    expect(cache.meta.embedder_dim).toBe(DIM)
+  }, PGLITE_TIMEOUT)
+
+  it('is a no-op without a store, and safe to re-run without clobbering newer cache entries', async () => {
+    expect((await exportPgliteEmbeddingsToCache(dir)).status).toBe('no-store')
+
+    const yamlPath = join(dir, 'engrams.yaml')
+    const e = mkEngram('ENG-A', 'some statement')
+    writeFileSync(yamlPath, yaml.dump({ engrams: [e] }), 'utf8')
+    adapter = new PGLiteAdapter(yamlPath, join(dir, 'store.pglite'), { vectorDim: DIM })
+    await adapter.syncFromYaml()
+    await adapter.upsertEmbedding('ENG-A', vec(7), embeddingContentHash(e))
+    await adapter.close()
+
+    const first = await exportPgliteEmbeddingsToCache(dir, yamlPath, join(dir, 'store.pglite'))
+    expect(first.ported).toBe(1)
+    const before = readFileSync(join(dir, '.embeddings-cache.json'), 'utf8')
+
+    // Re-run: existing entries win, nothing rewritten.
+    const second = await exportPgliteEmbeddingsToCache(dir, yamlPath, join(dir, 'store.pglite'))
+    expect(second.ported).toBe(0)
+    expect(readFileSync(join(dir, '.embeddings-cache.json'), 'utf8')).toBe(before)
+    expect(existsSync(join(dir, 'store.pglite'))).toBe(true) // export never deletes
+  }, PGLITE_TIMEOUT)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         version: 3.25.2(zod@3.25.76)
     optionalDependencies:
       '@huggingface/transformers':
-        specifier: ^3.8.1
-        version: 3.8.1(@types/node@25.5.0)
+        specifier: ^4.2.0
+        version: 4.2.0(@types/node@25.5.0)
       better-sqlite3:
         specifier: ^12.0.0
         version: 12.11.1
@@ -731,8 +731,11 @@ packages:
     resolution: {integrity: sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==}
     engines: {node: '>=18'}
 
-  '@huggingface/transformers@3.8.1':
-    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1259,6 +1262,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2095,18 +2102,18 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onnxruntime-common@1.21.0:
-    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
 
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
 
-  onnxruntime-node@1.21.0:
-    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
     os: [win32, darwin, linux]
 
-  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
   openai@6.45.0:
     resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
@@ -3498,11 +3505,15 @@ snapshots:
   '@huggingface/jinja@0.5.6':
     optional: true
 
-  '@huggingface/transformers@3.8.1(@types/node@25.5.0)':
+  '@huggingface/tokenizers@0.1.3':
+    optional: true
+
+  '@huggingface/transformers@4.2.0(@types/node@25.5.0)':
     dependencies:
       '@huggingface/jinja': 0.5.6
-      onnxruntime-node: 1.21.0
-      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
       sharp: 0.35.3(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -3976,6 +3987,9 @@ snapshots:
       negotiator: 1.0.0
 
   acorn@8.16.0: {}
+
+  adm-zip@0.5.18:
+    optional: true
 
   agent-base@7.1.4: {}
 
@@ -4506,7 +4520,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.5
       serialize-error: 7.0.1
     optional: true
 
@@ -4804,25 +4818,25 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  onnxruntime-common@1.21.0:
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
     optional: true
 
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
+  onnxruntime-common@1.24.3:
     optional: true
 
-  onnxruntime-node@1.21.0:
+  onnxruntime-node@1.24.3:
     dependencies:
+      adm-zip: 0.5.18
       global-agent: 3.0.0
-      onnxruntime-common: 1.21.0
-      tar: 7.5.22
+      onnxruntime-common: 1.24.3
     optional: true
 
-  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     dependencies:
       flatbuffers: 25.9.23
       guid-typescript: 1.0.9
       long: 5.3.2
-      onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
       platform: 1.3.6
       protobufjs: 8.7.1
     optional: true


### PR DESCRIPTION
Closes #1031.

Codex users got an MCP server and nothing else — no injection, no enforcement, no learn nudges, no always-on instruction block. This adds the adapter, reusing the Claude Code shapes rather than inventing a third set.

## What lands

- `plur init --codex` (auto-detects `~/.codex/`, honours `CODEX_HOME`)
- `~/.codex/hooks.json` — five hooks: `SessionStart`, `UserPromptSubmit`, `PreToolUse` (guard), `PostToolUse` (sentinel + learn nudge), `SessionEnd`
- MCP via `codex mcp add` rather than hand-writing TOML
- `AGENTS.md` section, reusing `CLAUDE_MD_SECTION`
- `plur doctor`: `codexDetected` / `codexWired` + the trust caveat
- README: Codex section, plus a per-harness table separating "has tools" from "has auto-injection"

Hooks go in `hooks.json` rather than a `[hooks]` table in `config.toml`: Codex accepts either, the JSON file takes the exact nested `{matcher, hooks: []}` shape the Claude Code builders already emit, and it keeps PLUR out of the file users hand-maintain for models and MCP servers. No TOML dependency.

## Three findings from probing 0.146.0 and 0.149.1 that shaped this

**Injection is synchronous and BM25-only.** Codex supports `async: true` as of 0.149.1 (0.146.0 skipped async hooks silently), but an async hook's `additionalContext` is delivered at the "next safe point" — not to the turn that triggered it, and in `codex exec` never. Claude Code's `async: true, timeout: 90` on `hook-inject` does not transfer. There is a regression test asserting no emitted Codex hook carries `async`.

**A non-zero exit discards the hook's output** — and on `PreToolUse`, exit code 2 *blocks the tool* with stderr as the reason. This is not theoretical: on a machine with a corrupt PGLite index, every `plur` command exits 1 from a WASM abort during teardown, long after the hook has written valid JSON. Codex reported `SessionStart Failed` and dropped a complete, correct injection. `runCodexHook()` catches everything, keeps diagnostics on stderr (stdout is parsed as the result), flushes, and forces exit 0.

**Untrusted hooks are skipped in total silence** — no warning, no output, exit 0, indistinguishable from a config Codex never read. Project `trust_level = "trusted"` does not cover hooks, and `trusted_hash` cannot be pre-seeded (a wrong value also fails silently, and Codex will not reveal the expected one). So init ends on the `/hooks` trust step rather than "restart Codex", and doctor repeats the warning *under a green tick*, because a green tick genuinely does not mean the hooks run.

## One deliberate asymmetry

`codexWired` is **not** folded into doctor's `overall`, unlike `cursorWired`. A `.cursor/` directory is per-project evidence the user works on this project in Cursor; `~/.codex/` is machine-level and says only that Codex is installed somewhere. Gating `overall` on it would turn doctor red for every Claude-Code-only user who once tried Codex — a false alarm on a check whose whole value is that red means something.

## Verification

Verified end to end against codex-cli 0.149.1 on macOS: `plur init --codex` into a scratch `CODEX_HOME`, then `codex exec` reporting **9 injected engrams** and quoting their content back. `PreToolUse` deny was verified separately — it blocks the tool and the reason reaches the model.

59 new tests. Full suite run before and after: identical set of failing files (10, all pre-existing in core/mcp, from better-sqlite3/PGLite issues on this machine) — no new failures.

## Follow-ups

- #1032 — Codex `mcp_tool` hooks are a stub (parses, dispatches, never issues `tools/call`); do not design around it yet
- #1033 — Antigravity CLI + Gemini CLI adapter
- #1034 — extract a `HarnessAdapter` interface once there are enough adapters to generalise from