### PR TITLE
Resolve six of the seven pack contradictions (#1019)

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -101,14 +101,31 @@ provenance:
 
 | Mode | What happens |
 |---|---|
-| `never` | Nothing is written. The default. |
-| `on_export` | A record is written when engrams leave, in a pack. **Recommended.** |
-| `always` | A record is written every time an engram is created. |
+| `never` | Nothing is written to your own store. The default. |
+| `on_export` | A record is written to your store when engrams leave in a pack. |
+| `always` | A record is written to your store every time an engram is created. |
 
 `never` is the default for two reasons. A record per engram repeats the history
 log, which already holds the same events. And a record only starts to matter when
 an engram **leaves** your machine — inside your own store it defends against
 almost nobody.
+
+> **This setting governs records kept in your own store. It does not govern what
+> a pack carries.**
+>
+> A pack ships provenance regardless of this setting, including on `never`. Turn
+> it off for one pack with `--no-provenance`.
+>
+> That is deliberate, and it follows from the same reasoning as the default. The
+> setting is `never` because a record inside your own store defends against
+> almost nobody — and a pack is the exact case where that stops being true. It is
+> the artifact that reaches somebody who was not there, so it is the one place a
+> record earns its keep. Every software supply chain settled on the same answer:
+> a bill of materials is produced as part of the build and travels inside the
+> artifact, rather than being something a publisher has to remember to ask for.
+>
+> A setting whose default is "off" should not quietly decide that packs go out
+> unattributed.
 
 ---
 

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -289,8 +289,16 @@ export interface PackProvenanceView {
   verified: boolean
   /** Why `verified` is false, in words a reader can act on. */
   verification_note: string
-  /** Distinct licences the pack's engrams carry, most common first. */
-  licences: Array<{ name: string; count: number; chosen: boolean }>
+  /**
+   * Distinct licences the pack's engrams carry, most common first.
+   *
+   * `chosen` answers the coarse question — did anybody decide this. `sources`
+   * carries the four-state `engram:licenseSource` values seen for this licence,
+   * so a reader can tell a licence picked for the engram from one inherited
+   * from the pack or taken from a configured default. Empty for records written
+   * before that field existed.
+   */
+  licences: Array<{ name: string; count: number; chosen: boolean; sources: string[] }>
   /** Engrams naming somebody answerable, out of those with a record. */
   attributed_count: number
   /** Distinct parties named as having asserted something. */
@@ -429,7 +437,7 @@ export function readPackProvenance(
   const packRecord = readJson('pack.jsonld')
   if (packRecord) view.pack_record = packRecord
 
-  const licences = new Map<string, { count: number; chosen: boolean }>()
+  const licences = new Map<string, { count: number; chosen: boolean; sources: string[] }>()
   const parties = new Set<string>()
 
   for (const engram of engrams) {
@@ -442,11 +450,35 @@ export function readPackProvenance(
 
     const licence = subject['engram:license']
     if (typeof licence === 'string') {
-      const chosen = subject['engram:licenseIsDefault'] !== true
+      // Read the four-state field, not the boolean beside it.
+      //
+      // `engram:licenseSource` says WHICH of four ways a licence was arrived at:
+      // chosen on the engram, inherited from the pack, the author's configured
+      // default, or the schema default nobody ever looked at. The profile
+      // replaced the boolean with it precisely because the last two are
+      // different facts — one is a decision made once in advance, the other is
+      // nobody's decision at all.
+      //
+      // Reading only `engram:licenseIsDefault` collapsed them again at the one
+      // surface a recipient sees. A preview reporting "chosen" could mean the
+      // author picked this licence for this memory, or that they set a config
+      // default years ago and have not thought about it since.
+      //
+      // Falls back to the boolean for records written before the four-state
+      // field existed.
+      const source = subject['engram:licenseSource'] as string | undefined
+      const chosen = source
+        ? (source === 'chosen' || source === 'configuredDefault')
+        : subject['engram:licenseIsDefault'] !== true
       const seen = licences.get(licence)
       // One engram that CHOSE a licence is enough to stop calling it defaulted.
-      if (seen) { seen.count++; seen.chosen = seen.chosen || chosen }
-      else licences.set(licence, { count: 1, chosen })
+      if (seen) {
+        seen.count++
+        seen.chosen = seen.chosen || chosen
+        if (source && !seen.sources.includes(source)) seen.sources.push(source)
+      } else {
+        licences.set(licence, { count: 1, chosen, sources: source ? [source] : [] })
+      }
     }
 
     const who = subject['prov:wasAttributedTo']?.['@id']
@@ -467,7 +499,7 @@ export function readPackProvenance(
   }
   view.asserted_by = [...parties].sort()
   view.licences = [...licences.entries()]
-    .map(([name, v]) => ({ name, count: v.count, chosen: v.chosen }))
+    .map(([name, v]) => ({ name, count: v.count, chosen: v.chosen, sources: v.sources.sort() }))
     .sort((a, b) => b.count - a.count)
 
   if (view.engrams_without_record > 0) {

--- a/packages/core/test/pack-provenance-preview.test.ts
+++ b/packages/core/test/pack-provenance-preview.test.ts
@@ -255,3 +255,71 @@ describe('a pack built to mislead', () => {
     expect(view.notes.join(' ')).not.toContain('records for individual engrams')
   })
 })
+
+describe('the preview can tell the four licence states apart (#1019)', () => {
+  // The profile replaced `engram:licenseIsDefault` with the four-state
+  // `engram:licenseSource` precisely because "the author configured this once"
+  // and "nobody ever chose it" are different facts. The preview read only the
+  // boolean, so it collapsed them again at the one surface a recipient sees.
+  let home: string
+  let out: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'plur-licsrc-home-'))
+    out = mkdtempSync(join(tmpdir(), 'plur-licsrc-out-'))
+  })
+  afterEach(() => {
+    for (const d of [home, out]) rmSync(d, { recursive: true, force: true })
+  })
+
+  /** Export a one-engram pack, then overwrite its record with the state under test. */
+  const previewWith = async (record: Record<string, unknown>) => {
+    const plur = new Plur({ path: home })
+    await plur.learn('Pools cap at 100 on the shared tier', {
+      type: 'architectural', visibility: 'public', domain: 'ops',
+    })
+    const engrams = await plur.list()
+    plur.exportPack(engrams, out, { name: 'licsrc', version: '1.0.0', license: 'apache-2.0' } as any)
+    const id = engrams[0].id
+    writeFileSync(join(out, 'provenance', `${id}.jsonld`), JSON.stringify({
+      '@graph': [{
+        '@id': `engram:${id}`,
+        '@type': ['prov:Entity', 'engram:Engram'],
+        'engram:license': 'cc-by-4.0',
+        ...record,
+      }],
+    }))
+    const { licences } = (await plur.previewPack(out)).provenance
+    return licences.find(l => l.name === 'cc-by-4.0')
+  }
+
+  const withSource = (source: string) => ({
+    'engram:licenseSource': source,
+    ...(source === 'chosen' || source === 'configuredDefault'
+      ? {} : { 'engram:licenseIsDefault': true }),
+  })
+
+  it('reports a configured default as decided, and names how', async () => {
+    const entry = await previewWith(withSource('configuredDefault'))
+    expect(entry?.chosen).toBe(true)
+    expect(entry?.sources).toContain('configuredDefault')
+  })
+
+  it('reports the schema default as nobody having decided', async () => {
+    const entry = await previewWith(withSource('schemaDefault'))
+    expect(entry?.chosen).toBe(false)
+    expect(entry?.sources).toContain('schemaDefault')
+  })
+
+  it('separates a pack-inherited licence from one chosen for the engram', async () => {
+    expect((await previewWith(withSource('inheritedFromPack')))?.chosen).toBe(false)
+    expect((await previewWith(withSource('chosen')))?.chosen).toBe(true)
+  })
+
+  it('still reads a record written before the four-state field existed', async () => {
+    // Records already in the wild carry only the boolean.
+    const entry = await previewWith({ 'engram:licenseIsDefault': true })
+    expect(entry?.chosen).toBe(false)
+    expect(entry?.sources).toEqual([])
+  })
+})

--- a/packages/mcp/packs/effective-memory/SKILL.md
+++ b/packages/mcp/packs/effective-memory/SKILL.md
@@ -11,11 +11,14 @@ x-datacore:
   match_terms: [memory, learn, remember, session, feedback, engram, forget, correction, preference, recall, verification, safety, plur]
   domain: plur.best-practices
   engram_count: 12
-  # Note: every engram in this pack carries `pinned: true` at the engram
-  # level, which is the actual "always-inject" mechanism (introduced in
-  # PLUR 0.9.4). Pack-level injection_policy: pinned is not a recognized
-  # value in 0.9.4 — keep it on_match here so loaders that respect it
-  # behave predictably; the per-engram pinned flags do the work.
+  # The engrams below still carry `pinned: true`, but INSTALL STRIPS IT.
+  # `sanitizePackEngrams` removes `pinned` and downgrades `commitment: locked`
+  # from every pack, this one included, because a pack is an archive from a
+  # stranger and its author does not get to decide what is always in front of
+  # the recipient's model. The flags are left in place so the intent is
+  # legible and so the behaviour returns if the host ever grows a way to
+  # grant it deliberately. `injection_policy: on_match` is what actually
+  # governs this pack. See plur-ai/plur#1019.
 ---
 
 # Effective Memory
@@ -24,7 +27,9 @@ Your agent has memory. These habits make it actually useful.
 
 Without them, memory is a growing pile of assertions nobody retrieves. With them, memory compounds — each session builds on the last, corrections stick, and the agent gets measurably better over time.
 
-This pack is **pinned** in PLUR 0.9.4+. Engrams here bypass keyword gating and are always eligible for injection at session start. They cover the meta-rules every agent needs regardless of domain: how to capture corrections, when to recall before answering, what "verified" means, how to stay safe with destructive actions, and why never to type a weekday from memory.
+These engrams cover the meta-rules every agent needs regardless of domain: how to capture corrections, when to recall before answering, what "verified" means, how to stay safe with destructive actions, and why never to type a weekday from memory.
+
+They were written to be **pinned** — always eligible for injection, bypassing keyword gating. That is no longer what happens. Install strips `pinned` from every pack, this one included, so these engrams are matched on keywords like any other (`injection_policy: on_match`, with the `match_terms` above). The stripping is right — a pack author should not be able to occupy a recipient's context unconditionally — but it means this pack's meta-rules only surface when a session's wording happens to touch them.
 
 ## Install
 
@@ -46,9 +51,13 @@ npx @plur-ai/cli@0.9.4 packs install effective-memory
 - **Discipline** — read before edit; don't ask "want to continue?" mid-task.
 - **Time** — never type a day-of-week from memory.
 
-## Why pinned
+## Why these were written pinned, and what happens instead
 
-Pinned engrams (introduced in PLUR 0.9.4) bypass the keyword-relevance gate in `scoreEngram` and per-pack/per-domain caps in `fillTokenBudget`. They are always eligible for injection regardless of how the user's query keywords overlap with the engram statement. Use this for cross-cutting meta-rules only; pinning everything defeats the purpose.
+Pinned engrams bypass the keyword-relevance gate in `scoreEngram` and the per-pack and per-domain caps in `fillTokenBudget`. Cross-cutting meta-rules are the case that justifies it: "call `plur_learn` when corrected" is relevant to every session and keyword-matches almost none of them.
+
+**Install strips the flag**, so that is not the behaviour you get. `sanitizePackEngrams` removes `pinned` and downgrades `commitment: locked` from every installed pack, and it is right to — a pack is an archive from a stranger, and letting its author decide what is permanently in front of your model is a privilege no producer should take by shipping a YAML field.
+
+The consequence is that this pack's rules are keyword-gated, which is a weaker guarantee than they were designed for. Whether a host should be able to grant always-inject to a pack it trusts deliberately — as opposed to a pack claiming it — is an open question, tracked in plur-ai/plur#1019.
 
 ## Versioning
 

--- a/spec/ENGRAM-PROVENANCE-PROFILE.md
+++ b/spec/ENGRAM-PROVENANCE-PROFILE.md
@@ -10,7 +10,7 @@ that part should work.
 |---|---|
 | **Version** | 0.5 (draft) |
 | **Status** | Proposed, and implemented in the reference. OPTIONAL to follow: an implementation that ignores this document is still fully conformant to the Engram Standard. An implementation that writes provenance MUST follow this document, so that two such implementations agree. |
-| **Companion to** | [The Engram Standard, version 1.1](./ENGRAM-STANDARD-v1.md) |
+| **Companion to** | [The Engram Standard, version 1.2](./ENGRAM-STANDARD-v1.md) |
 | **Profiles** | Section 9 of that standard, "Provenance binding". It refines that section; it does not replace it, and the standard governs wherever the two overlap. |
 | **Date** | 2026-08-26 |
 | **Licence** | Creative Commons BY 4.0 for the text, Apache 2.0 for any code |

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -1,8 +1,8 @@
 # The Open Engram Standard
 
-**Version:** 1.1 (draft)
+**Version:** 1.2 (draft)
 **Status:** Working Draft
-**Date:** 2026-08-25
+**Date:** 2026-08-26
 **Editors:** PLUR.ai (plur-ai)
 **License:** This specification is licensed under CC-BY-4.0. Reference code is Apache-2.0.
 **Companion profiles:** [Recording where an engram came from](./ENGRAM-PROVENANCE-PROFILE.md)
@@ -578,10 +578,32 @@ When producing a pack from a live store, a producer MUST exclude:
 
 A producer SHOULD also strip store-local state that is meaningless to a
 recipient: cross-reference `relations.related`/`relations.conflicts`,
-`associations`, local `knowledge_anchors`, and SHOULD reset `activation`
-(fresh `retrieval_strength`, `frequency: 0`) and `feedback_signals` to zero so
-the recipient builds their own usage history. (This mirrors the reference
-`exportPack`.)
+**`relations.supersedes`/`relations.superseded_by`**, `associations`, local
+`knowledge_anchors`, and SHOULD reset `activation` (fresh `retrieval_strength`,
+`frequency: 0`) and `feedback_signals` to zero so the recipient builds their own
+usage history. (This mirrors the reference `exportPack`.)
+
+Supersession edges are store-local in the same way the other cross-references
+are: they name engram ids that mean nothing in the recipient's store, and a stale
+edge landing on an id collision would suppress tension detection between
+unrelated engrams.
+
+A producer MUST also neutralize fields by which a pack could override the
+recipient's own behaviour:
+
+- **`pinned` MUST be removed.** A pinned engram bypasses the relevance gate and
+  is injected unconditionally. A pack is an archive from a stranger, and letting
+  its author decide what is always in front of the recipient's model is a
+  privilege no producer may take.
+- **`commitment: locked` MUST be downgraded to `decided`,** and `locked_at` and
+  `locked_reason` removed with it. A locked engram resists dedup and correction,
+  so shipping one hands the producer a claim the recipient cannot revise.
+
+These two are stated as MUST rather than SHOULD because, unlike the strip list
+above, leaving them in place is not merely untidy — it changes whose judgement
+governs the recipient's store. A consumer SHOULD enforce both on import as well
+rather than trusting the producer, since a hostile pack will not comply
+(see §5.6).
 
 ### 5.5 Pack integrity — STABLE
 
@@ -609,6 +631,37 @@ H = SHA256( bytes(SKILL.md)  ||  bytes(engrams.yaml) )
 > identical hash — `computePackChecksum` delegates to `computePackHash` — so they
 > cannot diverge. Hashing is over **raw file bytes**, so producers and consumers
 > MUST NOT re-serialize before hashing.
+
+#### 5.5.1 Two hashes, two questions
+
+The rule above is about the **pack integrity value**: the hash of the bytes a
+producer shipped, recorded in `INTEGRITY`, and the only value a recipient can
+compare against what they received. It answers *"did this arrive as it was sent?"*
+and it MUST be computed over the received bytes, unmodified.
+
+A consumer that alters content on import — as §5.4's MUST-neutralize rules
+require it to, and as §5.6 permits for sanitisation — then holds something that is
+no longer those bytes. The hash of *that* is a second and different value,
+answering *"has the installed copy been altered since it was installed?"*
+
+**These MUST NOT be conflated.** An implementation that stores the post-import
+hash under the name of the pack integrity value has lost the ability to answer
+the first question at all, and a recipient comparing it against the producer's
+`INTEGRITY` will see a mismatch that means nothing.
+
+An implementation that neutralizes on import therefore records both, named
+distinctly: the shipped value as received, and the installed-content value it
+computes itself. §5.1's statement that "the authoritative integrity record at
+install time is the registry entry" refers to the second — the record of what is
+installed — and does not license overwriting the first.
+
+> **Known divergence in the reference, as of this revision.** `_installPackDir`
+> re-serializes `engrams.yaml` after neutralizing `pinned` and `locked`, then
+> records the hash of the rewritten file as the registry's `integrity`. So for any
+> pack containing a pinned or locked engram, the recorded value is the
+> installed-content hash carrying the pack-integrity name, and the shipped value is
+> compared at the gate and then discarded. Tracked in #1019; the fix is to record
+> both.
 
 ---
 
@@ -828,8 +881,20 @@ Map engram/pack concepts onto [W3C PROV-O]:
 | `sources[].stored_at`, `temporal.learned_at` | `prov:generatedAtTime` |
 | `producer` (capsule) | `prov:wasAttributedTo` / `prov:wasGeneratedBy` |
 
-A pack MAY carry a sidecar `provenance.jsonld` (PROV-O in JSON-LD) inside the
-capsule payload, or reference an external PROV document by URI.
+A pack MAY carry PROV-O records in JSON-LD, or reference an external PROV
+document by URI.
+
+> **Corrected in 1.2.** This paragraph previously read *"A pack MAY carry a
+> sidecar `provenance.jsonld` (PROV-O in JSON-LD) inside the capsule payload"* —
+> a single file, because it was drafted with one engram in mind. A pack needs one
+> record per engram plus one for the pack itself, which a single file cannot hold.
+>
+> The layout is **a `provenance/` directory** containing `pack.jsonld` and one
+> `<engram-id>.jsonld` per engram, specified in §5.3.1 of
+> [the provenance profile](./ENGRAM-PROVENANCE-PROFILE.md) and reflected in §5.1
+> above. The correction is recorded here rather than made silently because §9 of
+> this document governs where it and the profile overlap, so an implementer
+> reading §9 alone was being told to build the wrong thing.
 
 ### 9.3 Swarm anchor (proposed)
 
@@ -914,6 +979,7 @@ they are holding and what changed. Version numbers follow §10.2.
 
 | Version | Date | Change class | What changed |
 |---|---|---|---|
+| 1.2 | 2026-08-26 | Minor (additive) | §5.4: the strip list gains `relations.supersedes`/`superseded_by`, and gains two MUST-neutralize rules for `pinned` and `commitment: locked` — both were performed by the reference and stated nowhere, and both change whose judgement governs the recipient's store rather than merely tidying. §5.5.1 added: the pack integrity value and the installed-content hash answer different questions and MUST NOT be conflated; the reference's current conflation is recorded as a known divergence. §9: the single `provenance.jsonld` sidecar corrected to the `provenance/` directory the profile specifies — §9 governs where the two overlap, so an implementer reading it alone was being told to build the wrong thing. No field removed, no constraint tightened on existing data, no default changed. |
 | 1.1 | 2026-08-25 | Minor (additive) | §4.8: added the OPTIONAL `attribution` and `claim_class` engram fields, marked PROPOSED. §4.12: added `injection_count` and `measured_under`; renamed `reference_count` → `write_count` (consumers MUST backfill on first parse). §3.3: canonical id form gains full ISO-8601 date separators, with the compact form retained as permanently valid legacy (§3.3.1) and the dateless pack form documented (§3.3.2). §5.1/§5.2: an OPTIONAL `provenance/` directory and a `metadata.provenance` declaration. §9: recorded that a companion profile now elaborates it. §4.12 `commitment` gains the `draft` member. No field removed, no constraint tightened, no default changed. |
 | 1.0 | 2026-06-14 | — | Initial working draft. |
 


### PR DESCRIPTION
Closes plur-ai/plur#1019 *resolve the seven pack contradictions between the specs, the schema and the reference* — six of the seven. The remaining one is left to the issue that owns it.

**Stacked on `feat/958-engram-provenance`** (PR #1002 *record where an engram came from*), because `spec/ENGRAM-PROVENANCE-PROFILE.md` does not exist on `main` — it is introduced by that PR. Merge order is this → the provenance branch → `main`.

## Why now

Two other implementations are building against §5 right now, and one of them is reading the document rather than our TypeScript:

- `plur-ai/encode#32` *export a conformant knowledge pack from a workspace* implements the pack format **directly in Python**, deliberately — a `python:3.12-slim` runtime, and a standing guarantee that a run needs neither a model nor a store.
- `plur-ai/enterprise#1050` *define the knowledge pack format, with optional provenance* adopts it for import.

Encode is the first party to implement this standard from the document alone. Anything under-specified surfaces there as a silent disagreement rather than a compile error — and one of the seven had already caught it.

## What changed

**§5.4, the export privacy rule.** The strip list gains `relations.supersedes` and `superseded_by`, which are store-local cross-references like the rest — a stale edge landing on an id collision suppresses tension detection between unrelated engrams.

More substantially, `pinned` and `commitment: locked` become **MUST NOT ship**. The reference has always removed them and the spec never said so. Unlike the rest of the list they do not leave untidy state behind: they decide whose judgement governs the recipient's store. A pack is an archive from a stranger, and letting its author pin content into the recipient's context is a privilege no producer takes by shipping a YAML field.

**§5.5.1, two hashes.** The spec required hashing over raw received bytes; install re-serialises after neutralising and hashes that. Both are correct, and they answer different questions — *did this arrive as it was sent*, and *has the installed copy changed since*. Naming them separately resolves the contradiction without changing behaviour. The reference currently records the second under the first's name, which is written down as a known divergence rather than quietly left.

**§9.** Still described a single `provenance.jsonld` sidecar inside the capsule payload. A pack needs one record per engram plus one for itself, which one file cannot hold. Since §9 governs where it and the profile overlap, an implementer reading §9 alone was being told to build the wrong thing. Corrected, and marked as a correction.

**The preview could not see the four licence states.** `readPackProvenance` read only `engram:licenseIsDefault`, so at the one surface a recipient sees, *the author configured this once* and *nobody ever chose it* looked identical — the exact distinction `engram:licenseSource` was introduced to draw. It now reads the four-state field and reports which states it saw, falling back to the boolean for older records. Four tests.

**`provenance.generate` does not govern what a pack carries**, and the guide said it did. The code is right: the setting defaults to `never` because a record inside your own store defends against nobody, and a pack is the one case where that stops being true. A setting whose default is off should not quietly decide that packs ship unattributed. The guide now says so.

**The bundled pack documented behaviour the installer strips.** Its `SKILL.md` promised pinned, always-injected engrams; `sanitizePackEngrams` removes `pinned` from every pack including that one. The documentation now describes what happens — and states plainly that the pack's meta-rules are keyword-gated as a result, which is a weaker guarantee than they were written for.

That last one turned out to matter rather than being a typo, and is filed separately as plur-ai/plur#1030 *stripping pinned from packs is right, and it silently disabled the bundled pack's whole purpose*.

## Not in this PR

**The manifest is not open-world.** Left to plur-ai/plur#1029 *the pack manifest is not open-world, though the standard requires it and Encode assumes it*, which owns it. The decision is not merely "add `.passthrough()`": the standard says unknown manifest fields MUST be preserved, the generated schema sets `additionalProperties: false` on `metadata` and `x-datacore`, and Encode is building against the prose. Either the schema follows the spec or §10.3 gains an exemption — but the two cannot keep disagreeing while a third party implements from one of them.

## Testing

Full suite: 4861 pass, 0 fail. Four new tests covering the four licence states and the pre-`licenseSource` fallback.

Standard to 1.2, additive per §10.2.

