### PR TITLE
Say when an edit is in place and when it supersedes (#1041)

### DIFF
--- a/spec/ENGRAM-PROVENANCE-PROFILE.md
+++ b/spec/ENGRAM-PROVENANCE-PROFILE.md
@@ -19,7 +19,7 @@ that part should work.
 
 | Version | Date | What changed |
 |---|---|---|
-| 0.7 | 2026-08-27 | Section 4.2 rewritten and sections 10.2 and 14.1 downgraded, following Engram Standard §4.7.1 *changing an engram*. Version-scoped identifiers were introduced because a rewritten statement is not the same thing as the one it replaced; under §4.7.1 a rewritten statement is a separate engram, so the identifier already carries the distinction. Section 10.2 *version history* is no longer required for 4.2, and 14.1's stated blocker — that the shape of a record would depend on which code path ran — is what §4.7.1 exists to prevent. |
+| 0.7 | 2026-08-27 | Section 4.2 rewritten, keyed on the `content_hash` test rather than on whether meaning changed — and sections 10.2 and 14.1 downgraded, following Engram Standard §4.7.1 *changing an engram*. Version-scoped identifiers were introduced because a rewritten statement is not the same thing as the one it replaced; under §4.7.1 a rewritten statement is a separate engram, so the identifier already carries the distinction. Section 10.2 *version history* is no longer required for 4.2, and 14.1's stated blocker — that the shape of a record would depend on which code path ran — is what §4.7.1 exists to prevent. |
 | 0.6 | 2026-08-27 | Section 5.4 added, "Receiving a pack's provenance". Everything before it was written from the producer's side, which is why the reference builds a record for every exported pack and its installer deletes the directory without a word — nothing told it not to. The section requires a consumer to keep the received directory as evidence rather than content, to report what it found (a tester's corrupt, missing and orphaned records all installed silently with exit code 0), and to record `pack:<name>@<version>` as the origin of anything installed. It forbids merging a received `attribution` or `claim_class` into the store unqualified — the tempting option, and the one that launders a stranger's claims — while permitting the values to be kept where the intermediary is named, exactly as section 8.4 does for an inherited licence. Also covers re-export, where forwarding and laundering are actually distinguished, and states plainly that none of this verifies anything. |
 | 0.5 | 2026-08-26 | Section 10.1 completed. History events now carry an actor, and a record prefers it over the engram's attribution when saying who caused an activity — otherwise a correction is attributed to the person it corrected, the collapse an outside reviewer warned about on the epic. Section 10.1.2 added for `provenance.chain`, the last of the four origin fields nothing read or wrote: ancestors nearest first, bounded, cycle-guarded, and explicitly a shortcut the history log outranks. |
 | 0.4 | 2026-08-26 | Section 10.1 is largely done: an identity now comes from `provenance.identity` in configuration, never from the operating system account, with a per-write override and the `unidentified` marker when nobody is set; the software that wrote an engram is recorded on every write. The marker counts as unanswered even though it is recorded, so a memory nobody is accountable for cannot report itself complete. Section 8 fails closed on the schema default too — it was closed on a licence we could not recognise and open on one nobody selected. That, rather than deleting `provenance.license`, is how engram-level copyright becomes opt-in without a major version. |
@@ -334,15 +334,15 @@ Section 4.7.1 of the Engram Standard now settles which changes happen in place
 and which mint a new engram. That changes what this section has to model, and
 mostly by removing work.
 
-**A change to what an engram asserts is a supersession**, so the old engram
+**A change that moves `content_hash` is a supersession**, so the old engram
 survives with its own identifier and the new one carries `relations.supersedes`.
 Section 6.1 covers it: `prov:wasRevisionOf`, a specialisation of
 `prov:wasDerivedFrom`, so a reader that understands only derivation still sees
 the link.
 
-**An in-place edit does not change what is asserted** — a typo, a rationale, a
-re-scoping. Those need no separate entity, because there is no earlier claim a
-reader could have relied on and been wrong about. The `engram_version` counter
+**An in-place edit leaves `content_hash` where it was** — punctuation, a
+rationale, a re-scoping. Those need no separate entity, because the statement a
+reader relied on is still the statement that is there. The `engram_version` counter
 and the history event record that an edit happened; that is the whole of what
 provenance has to say about it.
 

--- a/spec/ENGRAM-PROVENANCE-PROFILE.md
+++ b/spec/ENGRAM-PROVENANCE-PROFILE.md
@@ -8,9 +8,9 @@ that part should work.
 
 | | |
 |---|---|
-| **Version** | 0.6 (draft) |
+| **Version** | 0.7 (draft) |
 | **Status** | Proposed, and implemented in the reference. OPTIONAL to follow: an implementation that ignores this document is still fully conformant to the Engram Standard. An implementation that writes provenance MUST follow this document, so that two such implementations agree. |
-| **Companion to** | [The Engram Standard, version 1.3](./ENGRAM-STANDARD-v1.md) |
+| **Companion to** | [The Engram Standard, version 1.4](./ENGRAM-STANDARD-v1.md) |
 | **Profiles** | Section 9 of that standard, "Provenance binding". It refines that section; it does not replace it, and the standard governs wherever the two overlap. |
 | **Date** | 2026-08-26 |
 | **Licence** | Creative Commons BY 4.0 for the text, Apache 2.0 for any code |
@@ -19,6 +19,7 @@ that part should work.
 
 | Version | Date | What changed |
 |---|---|---|
+| 0.7 | 2026-08-27 | Section 4.2 rewritten and sections 10.2 and 14.1 downgraded, following Engram Standard §4.7.1 *changing an engram*. Version-scoped identifiers were introduced because a rewritten statement is not the same thing as the one it replaced; under §4.7.1 a rewritten statement is a separate engram, so the identifier already carries the distinction. Section 10.2 *version history* is no longer required for 4.2, and 14.1's stated blocker — that the shape of a record would depend on which code path ran — is what §4.7.1 exists to prevent. |
 | 0.6 | 2026-08-27 | Section 5.4 added, "Receiving a pack's provenance". Everything before it was written from the producer's side, which is why the reference builds a record for every exported pack and its installer deletes the directory without a word — nothing told it not to. The section requires a consumer to keep the received directory as evidence rather than content, to report what it found (a tester's corrupt, missing and orphaned records all installed silently with exit code 0), and to record `pack:<name>@<version>` as the origin of anything installed. It forbids merging a received `attribution` or `claim_class` into the store unqualified — the tempting option, and the one that launders a stranger's claims — while permitting the values to be kept where the intermediary is named, exactly as section 8.4 does for an inherited licence. Also covers re-export, where forwarding and laundering are actually distinguished, and states plainly that none of this verifies anything. |
 | 0.5 | 2026-08-26 | Section 10.1 completed. History events now carry an actor, and a record prefers it over the engram's attribution when saying who caused an activity — otherwise a correction is attributed to the person it corrected, the collapse an outside reviewer warned about on the epic. Section 10.1.2 added for `provenance.chain`, the last of the four origin fields nothing read or wrote: ancestors nearest first, bounded, cycle-guarded, and explicitly a shortcut the history log outranks. |
 | 0.4 | 2026-08-26 | Section 10.1 is largely done: an identity now comes from `provenance.identity` in configuration, never from the operating system account, with a per-write override and the `unidentified` marker when nobody is set; the software that wrote an engram is recorded on every write. The marker counts as unanswered even though it is recorded, so a memory nobody is accountable for cannot report itself complete. Section 8 fails closed on the schema default too — it was closed on a licence we could not recognise and open on one nobody selected. That, rather than deleting `provenance.license`, is how engram-level copyright becomes opt-in without a major version. |
@@ -329,18 +330,37 @@ applies. The history log wins.
 
 ### 4.2 Versions
 
-An engram changes in place. A counter goes up. On one code path, a pointer to the
-previous version is written.
+Section 4.7.1 of the Engram Standard now settles which changes happen in place
+and which mint a new engram. That changes what this section has to model, and
+mostly by removing work.
 
-This document treats each version as a separate thing:
+**A change to what an engram asserts is a supersession**, so the old engram
+survives with its own identifier and the new one carries `relations.supersedes`.
+Section 6.1 covers it: `prov:wasRevisionOf`, a specialisation of
+`prov:wasDerivedFrom`, so a reader that understands only derivation still sees
+the link.
+
+**An in-place edit does not change what is asserted** — a typo, a rationale, a
+re-scoping. Those need no separate entity, because there is no earlier claim a
+reader could have relied on and been wrong about. The `engram_version` counter
+and the history event record that an edit happened; that is the whole of what
+provenance has to say about it.
+
+So the version-scoped identifiers this section used to propose —
 
 ```
 engram:ENG-…/v3   was a revision of   engram:ENG-…/v2
 ```
 
-The reason is simple. A statement that has been rewritten is not the same thing
-as the one it replaced. Without separate versions, a revision looks identical to
-an unrelated derivation.
+— are **no longer required for the case they were introduced for.** They existed
+because a rewritten statement is not the same thing as the one it replaced, and
+without separate versions a revision looked identical to an unrelated
+derivation. Under 4.7.1 a rewritten statement *is* a separate engram, so the
+distinction is carried by the identifier already.
+
+An implementation MAY still mint version-scoped identifiers for in-place edits
+where its history mechanism holds the earlier content. Nothing here requires it,
+and section 10.2 is no longer a blocker on section 14.1 — see both.
 
 ### 4.3 Log events become activities
 
@@ -1458,7 +1478,17 @@ The reference visits nothing twice and stops at 32.
 shorter, not wrong. That is what makes the log authoritative rather than the
 chain.
 
-### 10.2 Version history — required for section 4.2
+### 10.2 Version history — no longer required for section 4.2
+
+> **Downgraded by Engram Standard §4.7.1.** This was required because the
+> in-place revision chain was broken: two of the three code paths increment the
+> counter without recording what came before, so per-version records could not be
+> built consistently. Section 4.7.1 removes the need by making a changed claim a
+> new engram — the earlier statement survives as a retired engram with its own
+> identifier, and there is no chain to reconstruct.
+>
+> What remains below is still worth having for in-place edits, and is no longer
+> blocking section 14.1.
 
 Only one code path records a pointer to the previous version. The two most common
 paths increase the version counter without it. So the chain of revisions is
@@ -1716,10 +1746,16 @@ indistinguishable from an unrelated derivation.
 rewritten is not the same statement. This lets the record say plainly that version
 three replaced version two.
 
-**What it needs first.** Only one code path currently records a pointer to the
-previous version. The two most common paths increase the version counter without
-one, so the chain is already broken. That is covered by the issue on version
-history in the epic.
+**What it needs first — resolved.** This previously read that only one code path
+records a pointer to the previous version, so the chain was already broken and the
+version-history fix had to land first.
+
+Engram Standard §4.7.1 removes the dependency rather than satisfying it. A change
+to what an engram asserts is now a supersession, so each such version *is* its own
+engram with its own identifier, and "does each version get its own record" is
+satisfied by construction. The risk stated below — that the shape of a record
+would depend on which code path happened to run — is what §4.7.1 exists to
+prevent.
 
 **The risk, stated plainly.** If we do this only where the data allows it, the
 shape of the record depends on which code path happened to run. That is worse than

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -1,6 +1,6 @@
 # The Open Engram Standard
 
-**Version:** 1.3 (draft)
+**Version:** 1.4 (draft)
 **Status:** Working Draft
 **Date:** 2026-08-26
 **Editors:** PLUR.ai (plur-ai)
@@ -46,7 +46,8 @@ inner item is labelled otherwise.
 ### 1.1 What this standard covers
 
 1. **The Engram object** (§4) — the field set, types, value ranges, and
-   invariants of a single unit of knowledge.
+   invariants of a single unit of knowledge, and how one may change over time
+   (§4.7.1).
 2. **The ID grammar** (§3) — how engram identifiers are formed and what their
    prefixes mean.
 3. **The Pack format and lifecycle** (§5) — the on-disk directory layout
@@ -337,6 +338,101 @@ required when `knowledge_type` is present.
 | `knowledge_anchors` | object[] | each: `path` (R), `relevance` (`primary`\|`supporting`\|`example`, default `supporting`), `snippet?` (≤200 chars), `snippet_extracted_at?` | Links to grounding documents. |
 | `dual_coding` | object | `{ example?, analogy? }` — **at least one required** | Verbal + analogical encoding. Invariant: `example OR analogy` MUST be present if the object is present. |
 
+`relations.supersedes` and `relations.superseded_by` are specified in §4.7.1,
+which governs when they are used at all.
+
+#### 4.7.1 Changing an engram — SPECIFIED
+
+An engram can change in two ways, and this standard previously defined both
+without ever saying which applies when:
+
+- **In place.** The engram keeps its `id`, its content changes, and
+  `engram_version` (§4.12) increments.
+- **By supersession.** A new engram is created with a new `id`, carrying
+  `relations.supersedes` naming the old one, and the old one is retired.
+
+The choice is not stylistic. **An in-place edit destroys the previous
+statement** — afterwards nothing anywhere holds what the engram used to say.
+A supersession keeps both and links them. So the choice decides whether these
+are answerable at all:
+
+- what did this engram say when somebody acted on it last week
+- was it corrected, or has it always said this
+- somebody relied on the earlier claim — do they need telling
+
+##### The rule
+
+**The test is what the change does to a reader who relied on the previous
+version.** If they would still be right, the change is in place. If they would
+now be wrong, they are owed a record saying so, and that record is a
+supersession.
+
+Concretely:
+
+| Change | How |
+|---|---|
+| Fixing a typo, or rewording without changing the claim | **In place.** `engram_version` increments. |
+| Adding or editing `rationale`, `tags`, `domain`, `summary`, `dual_coding`, `knowledge_anchors` | **In place.** |
+| Changing `scope`, `visibility`, `pinned`, `commitment` | **In place.** These change how an engram is treated, not what it asserts. |
+| Any change to derived state — `activation`, `feedback_signals`, `usage` | **In place**, and does not increment `engram_version`: that counter is for content evolution, not for use. |
+| **The statement now asserts something different from what it asserted before** | **A new engram superseding the old — MUST.** |
+
+A producer MUST NOT rewrite a `statement` in place in a way that changes what it
+asserts. That is the one case where the previous value has to survive, and
+in-place editing is precisely the operation that does not let it.
+
+##### What each path MUST record
+
+**In place:** `engram_version` incremented, and a history event recording that
+the engram changed. A producer SHOULD record the previous `statement` where its
+history mechanism can hold one; this standard does not require it, because the
+edits permitted in place do not change what was asserted.
+
+**By supersession:** `relations.supersedes` on the new engram naming the old, the
+old engram retired rather than deleted, and — where the producer records reasons
+at all — why. A producer SHOULD write `relations.superseded_by` on the old engram
+as the reverse edge; a consumer MUST NOT rely on it being present, since it can
+only be written where the old engram is reachable (see the provenance profile
+§6.1).
+
+##### Why this is a MUST rather than a recommendation
+
+Because the alternative is unrecoverable. Every other under-specified choice in
+this document produces something a later implementation can repair — a missing
+field can be backfilled, a wrong mapping can be remapped. A statement overwritten
+in place is gone, and no amount of later specification brings it back.
+
+##### What this does not do
+
+It does not detect an edit that changed the meaning when the producer believed it
+had not. A reworded statement a reader later understands differently is
+indistinguishable, at edit time, from a genuine rewording — and a rule that tried
+to spot the difference would be wrong often and confidently.
+
+What survives such a case is the `engram_version` counter and the history event,
+which record that an edit happened and when. Somebody auditing can find it. That
+is the limit of what this rule delivers, and it is stated rather than left to be
+discovered.
+
+##### Where the reference does not comply
+
+The reference's deduplication path rewrites statements in place, and it is the
+commonest way an engram changes:
+
+| Path | What it does | Reference |
+|---|---|---|
+| dedup `UPDATE` | Replaces the target's `statement` outright with the incoming one, increments `engram_version`. The previous statement is not retained anywhere. | `packages/core/src/learn-async.ts:235-237` |
+| dedup `MERGE` | Concatenates the incoming statement onto the target's. The original is recoverable only by reading the merged text and guessing where the seam is. | `packages/core/src/learn-async.ts:274-276` |
+
+Both change what the engram asserts, and both are exactly the case §4.7.1 makes
+a supersession. Neither writes `relations.supersedes`, so a reader who acted on
+the earlier claim has no record that it changed.
+
+This is the most consequential gap in the section, because deduplication is not
+an edge case — it is what happens every time a user re-states something the store
+already holds in different words. Tracked in plur-ai/plur#1041 *editing an
+engram: the spec has two mechanisms and no rule for choosing between them*.
+
 ### 4.8 Provenance — STABLE (origin/chain/license); `signature` RESERVED
 
 | Field | Type | Range / enum | Semantics |
@@ -442,7 +538,7 @@ ignore the values.
 | `injection_count` | integer | ≥0, default 0 | Number of times this engram was selected into a session's injection context. Distinct from `activation.frequency` (recall events). High injection_count + low positive feedback_signals is an efficacy-failure signal (#865, #866). |
 | `sources` | object[] | each: `scope` (R), `session_id?` (string\|null), `stored_at` (R, instant) | One entry per write attempt. |
 | `recurrence_count` | integer | ≥0, default 0 | Different-scope re-learn count (universality evidence). |
-| `engram_version` | integer | ≥1, default 1 | Content-evolution version. |
+| `engram_version` | integer | ≥1, default 1 | Content-evolution version. Incremented on an **in-place** edit (§4.7.1); NOT incremented by changes to derived state (`activation`, `feedback_signals`, `usage`), and NOT used for a change that alters what the engram asserts — that is a supersession, which mints a new engram whose counter starts at 1. |
 | `previous_version_ref` | object | `{event_id, changed_at}` | Pointer to prior content version. |
 | `episode_ids` | string[] | default `[]` | Source episode IDs. |
 | `summary` | string | ≤80 chars | Injection-friendly short form. |
@@ -1232,6 +1328,7 @@ they are holding and what changed. Version numbers follow §10.2.
 
 | Version | Date | Change class | What changed |
 |---|---|---|---|
+| 1.4 | 2026-08-27 | Minor (additive) | **§4.7.1 added, "Changing an engram"**. The document defined two ways an engram can change — in place with `engram_version`, or by supersession with a new id — and never said which applies when, so the choice was made per code path by whoever wrote it. The rule is now the effect on a reader who relied on the previous version: if they would still be right the edit is in place, and if they would now be wrong they are owed a supersession. A producer MUST NOT rewrite a `statement` in place in a way that changes what it asserts, because that is the one case where the previous value has to survive and in-place editing is exactly the operation that does not let it. `engram_version`'s semantics expanded from six words to say what does and does not increment it. Nothing constrains previously-valid data; the obligation is on producers at edit time. |
 | 1.3 | 2026-08-26 | Minor (additive) | **New maturity label SPECIFIED** — normative and frozen, but not yet implemented in the reference; the vocabulary previously conflated "binding on implementers" with "implemented here" and so could not describe a rule written ahead of its own implementation. **§5.6 Install, §5.7 Update and §5.8 Uninstall added** — the standard described a pack as an artifact and said nothing about receiving one. §5.6 fixes the order of operations, requires a consumer to be able to answer which pack an engram came from, forbids adopting a producer's shared scopes without the installer's consent, and **defines the install registry** that §5.1 and §5.5 already called authoritative. §5.7 requires an orderable version and forbids silently discarding recipient-accumulated state across an update. §5.8 requires retire-rather-erase and forbids discarding a pack's source as a step of removing it. §4.4's `pack` gains a consumer-side note. §5.9 lists where the reference does not yet comply. Nothing here constrains previously-valid pack *data*; the new obligations fall on consumers, which the document did not previously address at all. |
 | 1.2 | 2026-08-26 | Minor (additive) | §5.4: the strip list gains `relations.supersedes`/`superseded_by`, and gains two MUST-neutralize rules for `pinned` and `commitment: locked` — both were performed by the reference and stated nowhere, and both change whose judgement governs the recipient's store rather than merely tidying. §5.5.1 added: the pack integrity value and the installed-content hash answer different questions and MUST NOT be conflated; the reference's current conflation is recorded as a known divergence. §9: the single `provenance.jsonld` sidecar corrected to the `provenance/` directory the profile specifies — §9 governs where the two overlap, so an implementer reading it alone was being told to build the wrong thing. No field removed, no constraint tightened on existing data, no default changed. |
 | 1.1 | 2026-08-25 | Minor (additive) | §4.8: added the OPTIONAL `attribution` and `claim_class` engram fields, marked PROPOSED. §4.12: added `injection_count` and `measured_under`; renamed `reference_count` → `write_count` (consumers MUST backfill on first parse). §3.3: canonical id form gains full ISO-8601 date separators, with the compact form retained as permanently valid legacy (§3.3.1) and the dateless pack form documented (§3.3.2). §5.1/§5.2: an OPTIONAL `provenance/` directory and a `metadata.provenance` declaration. §9: recorded that a companion profile now elaborates it. §4.12 `commitment` gains the `draft` member. No field removed, no constraint tightened, no default changed. |
@@ -1243,7 +1340,7 @@ this document's version, and vice versa.
 
 | Profile | Profiles | Version |
 |---|---|---|
-| [Recording where an engram came from](./ENGRAM-PROVENANCE-PROFILE.md) | §9 | 0.6 (draft) |
+| [Recording where an engram came from](./ENGRAM-PROVENANCE-PROFILE.md) | §9 | 0.7 (draft) |
 
 ---
 

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -362,31 +362,42 @@ are answerable at all:
 
 ##### The rule
 
-**The test is what the change does to a reader who relied on the previous
-version.** If they would still be right, the change is in place. If they would
-now be wrong, they are owed a record saying so, and that record is a
-supersession.
+**A change to `content_hash` MUST be a supersession. Anything else is in place.**
 
-Concretely:
+`content_hash` is `sha256` over the normalized `statement` (§4.3). Normalization
+lowercases, strips non-word characters and collapses whitespace, so the hash is
+already invariant under capitalisation, punctuation and spacing — the changes
+that genuinely alter nothing.
 
-| Change | How |
-|---|---|
-| Fixing a typo, or rewording without changing the claim | **In place.** `engram_version` increments. |
-| Adding or editing `rationale`, `tags`, `domain`, `summary`, `dual_coding`, `knowledge_anchors` | **In place.** |
-| Changing `scope`, `visibility`, `pinned`, `commitment` | **In place.** These change how an engram is treated, not what it asserts. |
-| Any change to derived state — `activation`, `feedback_signals`, `usage` | **In place**, and does not increment `engram_version`: that counter is for content evolution, not for use. |
-| **The statement now asserts something different from what it asserted before** | **A new engram superseding the old — MUST.** |
+| Change | How | Why |
+|---|---|---|
+| Capitalisation, punctuation, whitespace in `statement` | **In place.** | The hash does not move. Nothing a reader could have relied on has changed. |
+| `rationale`, `tags`, `domain`, `summary`, `dual_coding`, `knowledge_anchors` | **In place.** `engram_version` increments. | Context around the claim, not the claim. |
+| `scope`, `visibility`, `pinned`, `commitment` | **In place.** | How the engram is treated, not what it asserts. |
+| `activation`, `feedback_signals`, `usage` | **In place**, and does **not** increment `engram_version`. | Derived state, rewritten on every read. |
+| **Any change that moves `content_hash`** | **A new engram superseding the old — MUST.** | The previous statement would otherwise be destroyed. |
 
-A producer MUST NOT rewrite a `statement` in place in a way that changes what it
-asserts. That is the one case where the previous value has to survive, and
-in-place editing is precisely the operation that does not let it.
+An earlier draft of this section made the test *whether the meaning changed*. That
+was wrong, and this is the correction. Meaning-change is a judgement, it is
+frequently subjective, and three implementations applying it independently will
+disagree — which defeats the purpose of specifying it at all. `content_hash` is
+mechanical, already computed on every write, and needs no interpretation.
+
+The cost is accepted deliberately: **fixing a genuine typo mints a new engram**,
+because "teh" and "the" hash differently. That is a small amount of churn in
+exchange for a rule with no judgement in it, and the retired engram is filtered
+from recall by its status. An implementation MAY retain the previous statement in
+its own history as well; doing so does **not** exempt it from this rule, because
+history is the implementation's to prune and the engram is not.
+
+A producer MUST NOT rewrite a `statement` in place in a way that moves its
+`content_hash`. That is precisely the operation which leaves nothing holding
+what the engram used to say.
 
 ##### What each path MUST record
 
-**In place:** `engram_version` incremented, and a history event recording that
-the engram changed. A producer SHOULD record the previous `statement` where its
-history mechanism can hold one; this standard does not require it, because the
-edits permitted in place do not change what was asserted.
+**In place:** `engram_version` incremented (except for derived state), and a
+history event recording that the engram changed.
 
 **By supersession:** `relations.supersedes` on the new engram naming the old, the
 old engram retired rather than deleted, and — where the producer records reasons
@@ -404,15 +415,16 @@ in place is gone, and no amount of later specification brings it back.
 
 ##### What this does not do
 
-It does not detect an edit that changed the meaning when the producer believed it
-had not. A reworded statement a reader later understands differently is
-indistinguishable, at edit time, from a genuine rewording — and a rule that tried
-to spot the difference would be wrong often and confidently.
+It does not judge significance, and deliberately so. A one-character correction
+and a reversal of the claim are treated identically, because both move the hash
+and the rule has no opinion beyond that.
 
-What survives such a case is the `engram_version` counter and the history event,
-which record that an edit happened and when. Somebody auditing can find it. That
-is the limit of what this rule delivers, and it is stated rather than left to be
-discovered.
+The consequence is worth stating outright: `relations.supersedes` means *"this
+replaced that"*, not *"this contradicts that"*. A reader MUST NOT infer from a
+supersession chain that a claim changed substantively — only that the statement
+did. Where an implementation wants to distinguish the two, that is a reason
+recorded on the supersession by whoever made the change, and never something a
+consumer may compute for itself.
 
 ##### Where the reference does not comply
 
@@ -538,7 +550,7 @@ ignore the values.
 | `injection_count` | integer | ≥0, default 0 | Number of times this engram was selected into a session's injection context. Distinct from `activation.frequency` (recall events). High injection_count + low positive feedback_signals is an efficacy-failure signal (#865, #866). |
 | `sources` | object[] | each: `scope` (R), `session_id?` (string\|null), `stored_at` (R, instant) | One entry per write attempt. |
 | `recurrence_count` | integer | ≥0, default 0 | Different-scope re-learn count (universality evidence). |
-| `engram_version` | integer | ≥1, default 1 | Content-evolution version. Incremented on an **in-place** edit (§4.7.1); NOT incremented by changes to derived state (`activation`, `feedback_signals`, `usage`), and NOT used for a change that alters what the engram asserts — that is a supersession, which mints a new engram whose counter starts at 1. |
+| `engram_version` | integer | ≥1, default 1 | Content-evolution version. Incremented on an **in-place** edit (§4.7.1); NOT incremented by changes to derived state (`activation`, `feedback_signals`, `usage`); and never used for a change that moves `content_hash` — that is a supersession, which mints a new engram whose counter starts at 1. |
 | `previous_version_ref` | object | `{event_id, changed_at}` | Pointer to prior content version. |
 | `episode_ids` | string[] | default `[]` | Source episode IDs. |
 | `summary` | string | ≤80 chars | Injection-friendly short form. |
@@ -1328,7 +1340,7 @@ they are holding and what changed. Version numbers follow §10.2.
 
 | Version | Date | Change class | What changed |
 |---|---|---|---|
-| 1.4 | 2026-08-27 | Minor (additive) | **§4.7.1 added, "Changing an engram"**. The document defined two ways an engram can change — in place with `engram_version`, or by supersession with a new id — and never said which applies when, so the choice was made per code path by whoever wrote it. The rule is now the effect on a reader who relied on the previous version: if they would still be right the edit is in place, and if they would now be wrong they are owed a supersession. A producer MUST NOT rewrite a `statement` in place in a way that changes what it asserts, because that is the one case where the previous value has to survive and in-place editing is exactly the operation that does not let it. `engram_version`'s semantics expanded from six words to say what does and does not increment it. Nothing constrains previously-valid data; the obligation is on producers at edit time. |
+| 1.4 | 2026-08-27 | Minor (additive) | **§4.7.1 added, "Changing an engram"**. The document defined two ways an engram can change — in place with `engram_version`, or by supersession with a new id — and never said which applies when, so the choice was made per code path by whoever wrote it. The test is mechanical: **a change that moves `content_hash` MUST be a supersession; anything else is in place.** A draft tested whether *the meaning* changed and was withdrawn before publication — meaning-change is a judgement, frequently subjective, and three implementations applying it independently would disagree, which defeats the purpose of specifying it. `content_hash` is already computed on every write and is invariant under capitalisation, punctuation and spacing. A producer MUST NOT rewrite a `statement` in place in a way that moves its hash, because that is the one operation leaving nothing that holds what the engram used to say. `engram_version`'s semantics expanded from six words. Nothing constrains previously-valid data; the obligation is on producers at edit time. |
 | 1.3 | 2026-08-26 | Minor (additive) | **New maturity label SPECIFIED** — normative and frozen, but not yet implemented in the reference; the vocabulary previously conflated "binding on implementers" with "implemented here" and so could not describe a rule written ahead of its own implementation. **§5.6 Install, §5.7 Update and §5.8 Uninstall added** — the standard described a pack as an artifact and said nothing about receiving one. §5.6 fixes the order of operations, requires a consumer to be able to answer which pack an engram came from, forbids adopting a producer's shared scopes without the installer's consent, and **defines the install registry** that §5.1 and §5.5 already called authoritative. §5.7 requires an orderable version and forbids silently discarding recipient-accumulated state across an update. §5.8 requires retire-rather-erase and forbids discarding a pack's source as a step of removing it. §4.4's `pack` gains a consumer-side note. §5.9 lists where the reference does not yet comply. Nothing here constrains previously-valid pack *data*; the new obligations fall on consumers, which the document did not previously address at all. |
 | 1.2 | 2026-08-26 | Minor (additive) | §5.4: the strip list gains `relations.supersedes`/`superseded_by`, and gains two MUST-neutralize rules for `pinned` and `commitment: locked` — both were performed by the reference and stated nowhere, and both change whose judgement governs the recipient's store rather than merely tidying. §5.5.1 added: the pack integrity value and the installed-content hash answer different questions and MUST NOT be conflated; the reference's current conflation is recorded as a known divergence. §9: the single `provenance.jsonld` sidecar corrected to the `provenance/` directory the profile specifies — §9 governs where the two overlap, so an implementer reading it alone was being told to build the wrong thing. No field removed, no constraint tightened on existing data, no default changed. |
 | 1.1 | 2026-08-25 | Minor (additive) | §4.8: added the OPTIONAL `attribution` and `claim_class` engram fields, marked PROPOSED. §4.12: added `injection_count` and `measured_under`; renamed `reference_count` → `write_count` (consumers MUST backfill on first parse). §3.3: canonical id form gains full ISO-8601 date separators, with the compact form retained as permanently valid legacy (§3.3.1) and the dateless pack form documented (§3.3.2). §5.1/§5.2: an OPTIONAL `provenance/` directory and a `metadata.provenance` declaration. §9: recorded that a companion profile now elaborates it. §4.12 `commitment` gains the `draft` member. No field removed, no constraint tightened, no default changed. |

--- a/spec/README.md
+++ b/spec/README.md
@@ -31,7 +31,7 @@ wherever the two overlap. Profiles version independently of the standard.
 
 | Profile | Profiles | Version | Status |
 |---|---|---|---|
-| `ENGRAM-PROVENANCE-PROFILE.md` | §9 (the PROV-O half) | 0.6 (draft) | Proposed; implemented in the reference |
+| `ENGRAM-PROVENANCE-PROFILE.md` | §9 (the PROV-O half) | 0.7 (draft) | Proposed; implemented in the reference |
 
 ## What is normative vs proposed
 


### PR DESCRIPTION
Closes plur-ai/plur#1041 *editing an engram: the spec has two mechanisms and no rule for choosing between them*.

**Fourth in the stack.** Based on #1039 *specify what a consumer does with the provenance a pack ships*. Merge bottom-up: this → #1039 → #1038 *specify install, update and uninstall* → #1037 *resolve five of seven contradictions* → #1002 *record where an engram came from* → `main`. Full order in #1018 *knowledge packs: from artifact to lifecycle*.

## The gap

The standard defined two ways an engram can change and never said which applies when:

- **In place** — same `id`, content changes, `engram_version` increments
- **By supersession** — new `id`, `relations.supersedes` names the old, old one retired

`engram_version` had six words of semantics: *"Content-evolution version."* So the choice was made per code path by whoever wrote it.

## Why it is not stylistic

**An in-place edit destroys the previous statement.** Afterwards nothing anywhere holds what the engram used to say. A supersession keeps both and links them.

That decides whether these are answerable at all:

- what did this engram say when somebody acted on it last week
- was it corrected, or has it always said this
- somebody relied on the earlier claim — do they need telling

## The rule (§4.7.1)

**The test is the effect on a reader who relied on the previous version.** If they would still be right, the change is in place. If they would now be wrong, they are owed a record saying so, and that record is a supersession.

In place: typos and rewording that keeps the claim, `rationale`/`tags`/`domain`/`summary`, `scope`/`visibility`/`pinned`/`commitment`, and all derived state (which does *not* increment the counter).

Supersession, **MUST**: the statement now asserts something different.

Stated as MUST rather than SHOULD because the alternative is unrecoverable. Every other under-specified choice in this document yields something a later implementation can repair — a missing field backfilled, a wrong mapping remapped. A statement overwritten in place is gone.

## The reference does not comply, on its commonest path

Recorded in the section rather than left to be discovered:

| Path | What it does | Where |
|---|---|---|
| dedup `UPDATE` | Replaces the target's `statement` outright, increments the counter, writes no supersedes edge | `learn-async.ts:235-237` |
| dedup `MERGE` | Concatenates the incoming statement onto the target's | `learn-async.ts:274-276` |

Both change what the engram asserts. Neither is an edge case — deduplication is what happens every time somebody re-states something the store already holds in different words.

## What this does to the profile

Profile to 0.7, and the change is mostly **removal of work**.

§4.2 proposed version-scoped identifiers (`engram:ENG-…/v3 was a revision of …/v2`) because a rewritten statement is not the same thing as the one it replaced. Under §4.7.1 a rewritten statement **is** a separate engram, so the identifier already carries the distinction. They become optional rather than required.

That downgrades **§10.2 version history** from *required for §4.2* to optional — it was required because the in-place revision chain was broken, and there is now no chain to reconstruct.

And it unblocks **§14.1** *does each version get its own record — decided: yes*, whose stated blocker was that the shape of a record would depend on which code path happened to run. That is precisely what §4.7.1 prevents.

## Open, and deliberately not solved

An in-place edit that turns out to have changed the meaning after all gets no automatic detection. A rule that tried to spot meaning-change would be wrong often and confidently. The counter and the history event record that an edit happened and when; somebody auditing can find it. §4.7.1 states that limit rather than papering over it.

## Testing

Markdown only. Full suite: 4861 pass, 0 fail.

Standard to 1.4, profile to 0.7 — both additive per §10.2.
