### PR TITLE
fix(cli): doctor and migrate honour config.yaml backend for PGLite orphan check (#1061)

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process'
 import { existsSync, readFileSync, realpathSync, statSync, accessSync, constants } from 'fs'
-import { join, extname } from 'path'
+import { join, extname, dirname } from 'path'
 import { homedir, platform } from 'os'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { outputText, outputInfo, outputJson, shouldOutputJson } from '../output.js'
@@ -19,7 +19,7 @@ import { hasPlurCursorHooks, readCursorHooksConfig } from '../cursor-hooks.js'
 import { hasPlurCodexHooks, readCodexHooksConfig } from '../codex-hooks.js'
 import { hasPlurAgyHooks, readAgyHooksConfig } from '../antigravity-hooks.js'
 import { codexHome } from '../mcp-config.js'
-import { computeContentHash, detectPlurStorage, loadEngrams } from '@plur-ai/core'
+import { computeContentHash, detectPlurStorage, loadConfig, loadEngrams } from '@plur-ai/core'
 
 /**
  * plur doctor — diagnose a Claude Code / Claude Desktop / Cursor installation.
@@ -139,6 +139,15 @@ interface DoctorReport {
    * `plur reindex-hashes --apply`.
    */
   staleContentHashes: number
+  /**
+   * Whether a `store.pglite` directory exists but pglite is not the selected
+   * backend (neither `PLUR_BACKEND=pglite` nor `config.backend: pglite`). When
+   * true, the directory is an orphaned index from the pre-#1046 size-selection
+   * era and can be deleted safely (#1061).
+   *
+   * Advisory only: does not affect `overall`.
+   */
+  pgliteOrphanDetected: boolean
   overall: 'ok' | 'fail'
 }
 
@@ -774,11 +783,21 @@ function buildReport(skipHandshake: boolean, flags: GlobalFlags): Promise<Doctor
     // those engrams as dedup attractors. Advisory: does not fail overall.
     const staleContentHashes = countStaleContentHashes(flags)
 
+    // #1046/#1061: a store.pglite directory that exists while pglite is NOT the
+    // selected backend is an orphaned index. Check both selection routes (#1061
+    // fix: the pre-fix code checked PLUR_BACKEND only, missing config.backend).
+    const _reportPaths = detectPlurStorage(flags.path || process.env.PLUR_PATH || undefined)
+    const _reportConfig = loadConfig(_reportPaths.config)
+    const _pgliteSelected =
+      process.env.PLUR_BACKEND?.trim().toLowerCase() === 'pglite' || _reportConfig.backend === 'pglite'
+    const pgliteOrphanDetected =
+      existsSync(join(dirname(_reportPaths.engrams), 'store.pglite')) && !_pgliteSelected
+
     return {
       configs, hooksInstalled, mcpRegistered, datacoreCollision, staleNpxHooks, staleNpxMcp,
       hookShim, mcpShim, handshake, cursorHandshake, embedder,
       cursorProjectDetected, cursorWired, codexDetected, codexWired, agyDetected, agyWired,
-      pgliteGemmaReembedNeeded, staleContentHashes, overall,
+      pgliteGemmaReembedNeeded, staleContentHashes, pgliteOrphanDetected, overall,
     }
   })
 }
@@ -825,14 +844,13 @@ export function printText(report: DoctorReport, flags?: GlobalFlags): void {
   }
 
   {
-    // #1046 migration signal: PGLite is no longer size-selected, so a store
-    // that auto-built one now runs SQLite and the old directory is orphaned
-    // disk (60–500MB observed). This advisory is the only signal the
-    // affected cohort gets — the runtime opt-in log line deliberately fires
-    // only for explicit selections.
-    const pglitePath = join(process.env.PLUR_PATH || join(homedir(), '.plur'), 'store.pglite')
-    const pgliteExplicit = process.env.PLUR_BACKEND?.trim().toLowerCase() === 'pglite'
-    if (existsSync(pglitePath) && !pgliteExplicit) {
+    // #1046/#1061: advisory for an orphaned store.pglite directory. The check
+    // lives in buildReport (report.pgliteOrphanDetected) so it is testable
+    // through the JSON report and the two backend-selection routes (#1061: env
+    // var AND config.backend) are both covered there.
+    if (report.pgliteOrphanDetected) {
+      const _paths = detectPlurStorage(flags?.path || process.env.PLUR_PATH || undefined)
+      const pglitePath = join(dirname(_paths.engrams), 'store.pglite')
       outputText('')
       outputText(`ℹ  ${pglitePath} exists but PGLite is no longer selected by store size (v0.19).`)
       outputText('   Nothing to do — embeddings rebuild automatically — and this directory is an')

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,4 +1,4 @@
-import { runMigrations, rollbackMigrations, getSchemaVersion, CURRENT_SCHEMA_VERSION, exportPgliteEmbeddingsToCache } from '@plur-ai/core'
+import { runMigrations, rollbackMigrations, getSchemaVersion, CURRENT_SCHEMA_VERSION, exportPgliteEmbeddingsToCache, loadConfig } from '@plur-ai/core'
 import { existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { createPlur, type GlobalFlags } from '../plur.js'
@@ -42,7 +42,9 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
       // and harmless to re-run (existing cache entries win).
       const storageRoot = dirname(paths.engrams)
       const pgliteDir = join(storageRoot, 'store.pglite')
-      const pgliteExplicit = process.env.PLUR_BACKEND?.trim().toLowerCase() === 'pglite'
+      const _config = loadConfig(paths.config)
+      const pgliteExplicit =
+        process.env.PLUR_BACKEND?.trim().toLowerCase() === 'pglite' || _config.backend === 'pglite'
       let embeddingsReport: Awaited<ReturnType<typeof exportPgliteEmbeddingsToCache>> | null = null
       if (existsSync(pgliteDir) && !pgliteExplicit) {
         embeddingsReport = await exportPgliteEmbeddingsToCache(storageRoot, paths.engrams, pgliteDir)

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -647,4 +647,62 @@ describe('plur doctor', () => {
     // Advisory only — must not drive overall to fail on its own.
     expect(report.overall).toBe('ok')
   })
+
+  // ── PGLite orphan detection — config.yaml route (#1061) ─────────────────
+
+  it('pgliteOrphanDetected=false when config.yaml selects pglite (#1061)', () => {
+    // Red case (before the fix): doctor only checked PLUR_BACKEND, so a
+    // config.yaml-selected pglite store was wrongly reported as orphaned.
+    mkdirSync(join(home, '.plur', 'store.pglite'), { recursive: true })
+    writeFileSync(join(home, '.plur', 'config.yaml'), 'backend: pglite\n')
+
+    let stdout = ''
+    try {
+      stdout = execSync(`node ${CLI} doctor --no-handshake --json`, {
+        encoding: 'utf-8',
+        timeout: 15000,
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          PLUR_PATH: join(home, '.plur'),
+          PLUR_DISABLE_EMBEDDINGS: '1',
+          // Explicitly unset PLUR_BACKEND — the fix must work via config alone.
+          PLUR_BACKEND: '',
+        },
+        cwd: home,
+      })
+    } catch (err: any) { stdout = err.stdout?.toString() ?? '' }
+
+    const report = JSON.parse(stdout)
+    expect(report.pgliteOrphanDetected).toBe(false)
+    // Advisory must never drive overall to fail.
+    expect(report.overall).toBe('fail') // empty env → hooks/MCP missing
+  })
+
+  it('pgliteOrphanDetected=true when store.pglite exists and pglite not selected (#1061)', () => {
+    // Contrasting case: store.pglite exists but no backend selection → orphan.
+    mkdirSync(join(home, '.plur', 'store.pglite'), { recursive: true })
+
+    let stdout = ''
+    try {
+      stdout = execSync(`node ${CLI} doctor --no-handshake --json`, {
+        encoding: 'utf-8',
+        timeout: 15000,
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          PLUR_PATH: join(home, '.plur'),
+          PLUR_DISABLE_EMBEDDINGS: '1',
+          PLUR_BACKEND: '',
+        },
+        cwd: home,
+      })
+    } catch (err: any) { stdout = err.stdout?.toString() ?? '' }
+
+    const report = JSON.parse(stdout)
+    expect(report.pgliteOrphanDetected).toBe(true)
+    expect(report.overall).toBe('fail') // advisory must not drive overall
+  })
 })

--- a/packages/cli/test/migrate-pglite.test.ts
+++ b/packages/cli/test/migrate-pglite.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+const CLI = join(__dirname, '..', 'dist', 'index.js')
+
+describe('plur migrate — PGLite orphan export skipped when config selects pglite (#1061)', () => {
+  let storeDir: string
+
+  beforeEach(() => {
+    storeDir = mkdtempSync(join(tmpdir(), 'plur-migrate-1061-'))
+    // Create the pglite directory (simulates a store that exists on disk)
+    mkdirSync(join(storeDir, 'store.pglite'), { recursive: true })
+    // Minimal engrams.yaml so migrate has something to operate on
+    writeFileSync(join(storeDir, 'engrams.yaml'), '# plur engrams\nengrams: []\n')
+  })
+
+  afterEach(() => {
+    rmSync(storeDir, { recursive: true, force: true })
+  })
+
+  it('skips pglite_embeddings export when config.yaml has backend: pglite', () => {
+    // Red case (before the fix): migrate only checked PLUR_BACKEND env var, so a
+    // config.yaml-selected pglite store was treated as orphaned and the export ran.
+    writeFileSync(join(storeDir, 'config.yaml'), 'backend: pglite\n')
+
+    const stdout = execSync(`node ${CLI} migrate --json`, {
+      encoding: 'utf-8',
+      timeout: 15000,
+      env: {
+        ...process.env,
+        PLUR_PATH: storeDir,
+        // Explicitly unset PLUR_BACKEND — the fix must work via config alone.
+        PLUR_BACKEND: '',
+      },
+    })
+
+    const report = JSON.parse(stdout)
+    // pglite_embeddings must be absent — the export path must not run.
+    expect(report).not.toHaveProperty('pglite_embeddings')
+  })
+
+  it('runs pglite_embeddings export when pglite dir exists and pglite is NOT selected', () => {
+    // Contrasting case: no backend in config → the export path IS triggered.
+    // (The export will fail on an empty dir, but the field still appears.)
+    writeFileSync(join(storeDir, 'config.yaml'), '# no backend selection\n')
+
+    let stdout = ''
+    try {
+      stdout = execSync(`node ${CLI} migrate --json`, {
+        encoding: 'utf-8',
+        timeout: 15000,
+        env: {
+          ...process.env,
+          PLUR_PATH: storeDir,
+          PLUR_BACKEND: '',
+        },
+      })
+    } catch (err: any) { stdout = err.stdout?.toString() ?? '' }
+
+    const report = JSON.parse(stdout)
+    expect(report).toHaveProperty('pglite_embeddings')
+  })
+})

--- a/packages/cli/test/quiet.test.ts
+++ b/packages/cli/test/quiet.test.ts
@@ -183,6 +183,7 @@ describe('doctor --quiet (#730)', () => {
       agyWired: false,
       pgliteGemmaReembedNeeded: false,
       staleContentHashes: 0,
+      pgliteOrphanDetected: false,
       overall: 'fail',
     }
   }


### PR DESCRIPTION
Closes plur-ai/plur#1061.

## Problem

`plur doctor` and `plur migrate` decided whether a `store.pglite` directory was orphaned by checking `process.env.PLUR_BACKEND` alone. The 0.19.0 changelog documents two activation routes: `PLUR_BACKEND=pglite` **or** `backend: pglite` in `config.yaml`. `resolveBackendTier` honours both; these two consumers honoured only one.

A user with `backend: pglite` in config.yaml but no env var saw:
- `plur doctor`: orphan advisory telling them the store.pglite can be deleted
- `plur migrate`: the embedding-export path running against their active store

## Fix

Both call-sites now read `config.backend` via `loadConfig` in addition to the env var. The check becomes:
```
env-var === 'pglite' || config.backend === 'pglite'
```

`buildReport` in `doctor.ts` also gains `pgliteOrphanDetected` in the JSON report so the check is directly testable without a PTY (piped stdout forces JSON mode, making the text-mode advisory untestable directly).

## Tests

Red-first: both new tests were confirmed failing against the unfixed code.

- `doctor.test.ts`: `pgliteOrphanDetected=false` when config.yaml selects pglite with no env var; `pgliteOrphanDetected=true` when store.pglite exists and neither route selects it
- `migrate-pglite.test.ts`: `pglite_embeddings` absent from migrate output when config.yaml selects pglite (export skipped); present when no selection (export runs, fails gracefully on empty dir)