### PR TITLE
feat(core): thread session_id + write provenance.origin on every engram write (#1048)

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,25 @@ Everything is plain YAML. Open it, read it, edit it.
 
 `PLUR_PATH` overrides the default location.
 
+### Who wrote this engram
+
+Every engram records the actor that wrote it, in `provenance.origin`. Set the
+identity for this machine in `config.yaml`:
+
+```yaml
+provenance:
+  identity: agent:claude-code    # agent:<name> — one per writing actor
+```
+
+With no identity configured, engrams are stamped `agent:unidentified`. That is
+recorded honestly rather than guessed, so a store written by several actors
+still shows that it was — but the attribution is only useful once each writer
+names itself. `plur status` reports the value in effect.
+
+For a store several agents write to (a shared team store, or one machine
+running an MCP server alongside a CLI), give each writer its own identity.
+
+
 Indexing is on by default (`index: true`) and the backend is chosen from the
 size of your store, so there is normally nothing to configure:
 

--- a/packages/claw/src/context-engine.ts
+++ b/packages/claw/src/context-engine.ts
@@ -379,7 +379,11 @@ export class PlurContextEngine implements ContextEngine {
     const key = statement.toLowerCase()
     if (seen.has(key)) return
     seen.add(key)
-    await this.plur.learnRouted(statement, context)
+    // #1048: claw already knows which session this is — it keys dedup and the
+    // session scope on it — so the engram should record it. Without this every
+    // claw write lands with sources[].session_id null despite the id being in
+    // scope two lines up.
+    await this.plur.learnRouted(statement, { session_id: sessionKey, ...context })
     maybeFlushAfter(recordEvent('learn'))
   }
 

--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -106,6 +106,12 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     ...(knowledgeAnchors !== undefined ? { knowledge_anchors: knowledgeAnchors } : {}),
     ...(dualCoding !== undefined ? { dual_coding: dualCoding } : {}),
     ...(supersedes !== undefined ? { supersedes } : {}),
+    // #1048: a CLI invocation is a session too. Without this every engram
+    // written by `plur learn` lands with sources[].session_id null, and the
+    // attribution the epic exists to provide is absent from the most common
+    // write path there is. PLUR_SESSION_ID lets a wrapping harness thread its
+    // own id through; otherwise the run identifies itself honestly as a CLI run.
+    session_id: process.env.PLUR_SESSION_ID || `cli:${process.pid}`,
   }
 
   // ALWAYS use learnRouted (not learn): learn() stamps _demoted but does NOT do

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -365,6 +365,16 @@ export interface StatusResult {
   pack_count: number
   storage_root: string
   config: PlurConfig
+  /**
+   * The `provenance.origin` this instance stamps on every engram it writes
+   * (#1049). Surfaced because `provenance.identity` otherwise has no
+   * user-facing surface at all — it is absent from the README, the docs, the
+   * `plur init` template, the CLI and the MCP schemas, so in practice every
+   * engram would ship as `agent:unidentified` and nobody would know why.
+   * Shows the effective value, including a constructor override.
+   */
+  provenance_identity: string
+
   locked_count?: number
   tension_count?: number
   versioned_engram_count?: number
@@ -716,7 +726,26 @@ function isStoreTeardownError(err: unknown): boolean {
   return msg.includes('adapter is closed') || msg.includes('after calling end')
 }
 
+/**
+ * The session key for a call — `session_id`, falling back to the deprecated
+ * `session` alias (#1048/#243).
+ *
+ * One accessor so the scope registry and provenance can never read different
+ * fields for the same value, which is the bug this merge closes.
+ */
+function sessionKeyOf(o: { session_id?: string; session?: string } | undefined): string | undefined {
+  return o?.session_id ?? o?.session
+}
+
 export class Plur {
+  /**
+   * Constructor-supplied provenance identity, applied on top of whatever the
+   * current config says. Deliberately NOT stored in `config`: every
+   * `this.config = loadConfig(...)` would discard it, and one config.yaml
+   * mtime change is enough to trigger that via `reloadConfigIfChanged()`.
+   */
+  private _provenanceIdentityOverride?: string
+
   private paths: PlurPaths
   private config: PlurConfig
   private indexedStorage: IndexedStorage | null = null
@@ -942,10 +971,13 @@ export class Plur {
       }
     }
     this.config = loadConfig(this.paths.config)
-    // Merge constructor-level provenance options (highest priority) so callers
-    // can set identity without touching a config file (#1048 / #1049).
-    if (options?.provenance !== undefined) {
-      this.config = { ...this.config, provenance: { ...this.config.provenance, ...options.provenance } }
+    // Constructor-level provenance identity is held OUTSIDE this.config so it
+    // survives every reload (#1048 / #1049). Merging it into this.config was
+    // the defect: the very next `this.config = loadConfig(...)` discarded it,
+    // and there are four such assignments — including one a few lines below in
+    // this same constructor, once autoDiscoverStores changes the store count.
+    if (typeof options?.provenance?.identity === 'string' && options.provenance.identity.length > 0) {
+      this._provenanceIdentityOverride = options.provenance.identity
     }
     this._autoDiscover = Plur.resolveAutoDiscover(options?.autoDiscover)
     // Auto-discover project stores from CWD (skips temp dirs for test safety).
@@ -1672,10 +1704,20 @@ export class Plur {
   private _buildSourceEntry(scope: string, context?: LearnContext): {
     scope: string; session_id: string | null; stored_at: string
   } {
+    // One emptiness rule, shared with _buildProvenance below. `??` alone let
+    // `session_id: ''` win over a genuine `session_episode_id` and persist as
+    // the empty string, while provenance fourteen lines down treated an empty
+    // identity as absent. Two different notions of "empty" in one change is how
+    // a field ends up meaning different things at two call sites.
+    const present = (v: unknown): v is string => typeof v === 'string' && v.length > 0
+    const sessionId = context?.session_id ?? context?.session
     return {
       scope,
-      // session_id takes precedence over session_episode_id (#1048).
-      session_id: context?.session_id ?? context?.session_episode_id ?? null,
+      // session_id (incl. its deprecated `session` alias) takes precedence over
+      // session_episode_id (#1048).
+      session_id: present(sessionId) ? sessionId
+        : present(context?.session_episode_id) ? context!.session_episode_id!
+        : null,
       stored_at: new Date().toISOString(),
     }
   }
@@ -1689,7 +1731,18 @@ export class Plur {
    * Wave 2 / Wave 3). license defaults to cc-by-sa-4.0 per the engram standard.
    */
   private _buildProvenance(): { origin: string; chain: string[]; signature: null; license: string } {
-    const identity = this.config.provenance?.identity
+    // Constructor override first, config file second.
+    //
+    // The override used to be merged INTO this.config, and any later
+    // `this.config = loadConfig(...)` threw it away — including the one in the
+    // constructor itself after autoDiscoverStores changes the store count, plus
+    // reloadConfigIfChanged, addStore, and one more. `_resolveUnscopedScope`
+    // calls reloadConfigIfChanged() on every unscoped learn(), so a single
+    // config.yaml mtime change was enough to silently revert an explicitly
+    // configured identity to "agent:unidentified" — defeating the attribution
+    // this epic exists to provide. Held separately now, applied on top of
+    // whatever the current config says.
+    const identity = this._provenanceIdentityOverride ?? this.config.provenance?.identity
     return {
       origin: (typeof identity === 'string' && identity.length > 0) ? identity : 'agent:unidentified',
       chain: [],
@@ -1730,6 +1783,15 @@ export class Plur {
     const currentSources = (target as any).sources ?? []
     target.write_count = currentCount + 1
     ;(target as any).sources = [...currentSources, this._buildSourceEntry(scope, context)]
+    // #1048: an engram actively being written to must not stay unattributed.
+    // This path appends a source entry and re-persists, but never added a
+    // provenance block, so a store stayed permanently split between attributed
+    // and unattributed engrams — even for rows receiving new writes. There is
+    // no backfill and none is implied: this stamps only rows this call touches,
+    // and never overwrites a block that already exists.
+    if ((target as any).provenance === undefined || (target as any).provenance === null) {
+      ;(target as any).provenance = this._buildProvenance()
+    }
     // #852: an absorbed write left NO trace — no engram_created, no
     // recurrence_detected, nothing. That silence is why a misdirected
     // absorption could run for months without anyone seeing it, and it is the
@@ -2415,7 +2477,7 @@ export class Plur {
     // not read off a shared field — under concurrent sessions the shared field
     // let one session's `setSessionScope` decide another session's write. See
     // `session-scopes.ts`.
-    const sessionScope = this._sessionScopes.get(context?.session)
+    const sessionScope = this._sessionScopes.get(sessionKeyOf(context))
     let routed: { scope: string; confidence: number; reason: string } | null = null
     let scope: string
     if (context?.scope == null && sessionScope == null) {
@@ -4160,7 +4222,7 @@ export class Plur {
     // path uses (`options.session` — ADR-0004), so a mid-session scope
     // switch redirects subsequent recall dialing too. No session scope set
     // (the pre-#243 state) leaves dialing exactly as before.
-    const dialScope = options?.scope ?? this._sessionScopes.get(options?.session) ?? undefined
+    const dialScope = options?.scope ?? this._sessionScopes.get(sessionKeyOf(options)) ?? undefined
     const sessionOrg = scopeOrg(dialScope)
 
     const groups = new Map<string, { url: string; token?: string; entries: StoreEntry[] }>()
@@ -5400,6 +5462,17 @@ export class Plur {
    */
   async saveMetaEngrams(metas: Engram[]): Promise<{ saved: number; skipped: number }> {
     this._assertWritable()
+    // #1048: "every engram write" has to mean every one. formulateMetaEngram
+    // builds a complete engram with no provenance block at all, and this method
+    // used to push it into the store verbatim — a public, exported write path
+    // producing engrams with no origin. Stamp any meta that arrives without one;
+    // never overwrite a block a caller set deliberately.
+    for (const m of metas) {
+      const rec = m as unknown as Record<string, unknown>
+      if (rec.provenance === undefined || rec.provenance === null) {
+        rec.provenance = this._buildProvenance()
+      }
+    }
     return await this._withStoreLock(this.paths.engrams, async () => {
       const engrams = await this._primaryStore.load()
       const existingIds = new Set(engrams.map(e => e.id))
@@ -7750,6 +7823,7 @@ Generate an improved version of the procedure that prevents this failure. Return
       episode_count: episodes.length,
       pack_count: packs.length,
       storage_root: this.paths.root,
+      provenance_identity: this._buildProvenance().origin,
       config: this.config,
       locked_count: lockedCount,
       tension_count: unresolvedTensions,
@@ -9314,8 +9388,8 @@ Generate an improved version of the procedure that prevents this failure. Return
    * session pins it to "no session scope" (unscoped writes auto-route), which
    * is distinct from never having registered it (inherits the process slot).
    */
-  setSessionScope(scope: string | null, opts?: { session?: string }): void {
-    this._sessionScopes.set(scope, opts?.session)
+  setSessionScope(scope: string | null, opts?: { session_id?: string; session?: string }): void {
+    this._sessionScopes.set(scope, sessionKeyOf(opts))
   }
 
   /**
@@ -9336,8 +9410,8 @@ Generate an improved version of the procedure that prevents this failure. Return
     scope: string | null,
     opts?: { session?: string; reason?: string; trigger?: 'set' | 'clear' },
   ): { previous: string | null; next: string | null } {
-    const previous = this._sessionScopes.get(opts?.session)
-    this._sessionScopes.set(scope, opts?.session)
+    const previous = this._sessionScopes.get(sessionKeyOf(opts))
+    this._sessionScopes.set(scope, sessionKeyOf(opts))
     appendHistory(this.paths.root, {
       event: 'session_scope_changed',
       engram_id: '', // session-level event — no engram (see HistoryEvent doc)
@@ -9357,8 +9431,8 @@ Generate an improved version of the procedure that prevents this failure. Return
    * Get the session-level default scope for `opts.session`, or the process-wide
    * one when no session is named. Returns null if not set.
    */
-  getSessionScope(opts?: { session?: string }): string | null {
-    return this._sessionScopes.get(opts?.session)
+  getSessionScope(opts?: { session_id?: string; session?: string }): string | null {
+    return this._sessionScopes.get(sessionKeyOf(opts))
   }
 
   /**
@@ -9366,8 +9440,8 @@ Generate an improved version of the procedure that prevents this failure. Return
    * deployment would otherwise retain one entry per session it has ever served.
    * Omitting `session` clears the process-wide slot.
    */
-  clearSessionScope(opts?: { session?: string }): void {
-    this._sessionScopes.clear(opts?.session)
+  clearSessionScope(opts?: { session_id?: string; session?: string }): void {
+    this._sessionScopes.clear(sessionKeyOf(opts))
   }
 
   /** Session keys with their own scope registration. Diagnostic / test seam. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -855,6 +855,13 @@ export class Plur {
      * stranding anyone who genuinely knows what their store does.
      */
     allowUnprotectedStore?: boolean
+    /**
+     * Provenance configuration for this instance (#1048 / #1049).
+     * Merged into the loaded config so tests and programmatic callers can
+     * supply identity without writing a config.yaml. Config-file values take
+     * lower priority than these options-level overrides.
+     */
+    provenance?: { identity?: string }
   }) {
     this.paths = detectPlurStorage(options?.path)
     this._readonly = options?.readonly === true
@@ -935,6 +942,11 @@ export class Plur {
       }
     }
     this.config = loadConfig(this.paths.config)
+    // Merge constructor-level provenance options (highest priority) so callers
+    // can set identity without touching a config file (#1048 / #1049).
+    if (options?.provenance !== undefined) {
+      this.config = { ...this.config, provenance: { ...this.config.provenance, ...options.provenance } }
+    }
     this._autoDiscover = Plur.resolveAutoDiscover(options?.autoDiscover)
     // Auto-discover project stores from CWD (skips temp dirs for test safety).
     //
@@ -1662,8 +1674,27 @@ export class Plur {
   } {
     return {
       scope,
-      session_id: context?.session_episode_id ?? null,
+      // session_id takes precedence over session_episode_id (#1048).
+      session_id: context?.session_id ?? context?.session_episode_id ?? null,
       stored_at: new Date().toISOString(),
+    }
+  }
+
+  /** Build the provenance block for a new engram (#1048).
+   *
+   * `origin` is taken from `config.provenance.identity` when set, otherwise
+   * `"agent:unidentified"` — recorded honestly so multi-writer attribution is
+   * still visible even without explicit configuration. chain and signature are
+   * placeholders reserved for the hash-chain and signing waves (plur#1047
+   * Wave 2 / Wave 3). license defaults to cc-by-sa-4.0 per the engram standard.
+   */
+  private _buildProvenance(): { origin: string; chain: string[]; signature: null; license: string } {
+    const identity = this.config.provenance?.identity
+    return {
+      origin: (typeof identity === 'string' && identity.length > 0) ? identity : 'agent:unidentified',
+      chain: [],
+      signature: null,
+      license: 'cc-by-sa-4.0',
     }
   }
 
@@ -2613,6 +2644,7 @@ export class Plur {
         write_count: 1,
         injection_count: 0,
         sources: [this._buildSourceEntry(scope, context)],
+        provenance: this._buildProvenance(),
         recurrence_count: 0,
         summary: autoSummary(statement, undefined),
         engram_version: 1,
@@ -3169,6 +3201,7 @@ export class Plur {
       write_count: 1,
       injection_count: 0,
       sources: [this._buildSourceEntry(scope, context)],
+      provenance: this._buildProvenance(),
       recurrence_count: 0,
       summary: autoSummary(statement, undefined),
       engram_version: 1,

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -339,6 +339,21 @@ export const PlurConfigSchema = z.object({
   sync: z.object({
     remote_type: z.enum(['personal', 'shared']).optional(),
   }).partial().default({}),
+  /**
+   * Provenance configuration (#1048 / #1049 — part of the provenance ladder,
+   * plur#1047). Controls how engrams record their writing actor and origin.
+   *
+   *   identity — the `provenance.origin` value for engrams written by this
+   *              instance. Grammar: `agent:<name>` (e.g. `agent:claude-code`,
+   *              `agent:nightshift`). When absent, origin defaults to
+   *              `agent:unidentified` — recorded honestly so multi-writer
+   *              attribution is still visible even without explicit config.
+   *              One identity per writing actor; for multi-agent stores each
+   *              writer should configure its own.
+   */
+  provenance: z.object({
+    identity: z.string().optional(),
+  }).optional(),
 }).partial()
 
 export type PlurConfig = z.infer<typeof PlurConfigSchema>

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -352,7 +352,14 @@ export const PlurConfigSchema = z.object({
    *              writer should configure its own.
    */
   provenance: z.object({
-    identity: z.string().optional(),
+    // catch() rather than a bare string: a non-string identity used to make
+    // loadConfig reject the WHOLE config and fall back to defaults, silently
+    // discarding `stores`, `backend` and `allow_secrets`. That behaviour
+    // predates this key, but this key is hand-edited by design — it has no
+    // other surface — so it widens the blast radius of a typo from "identity is
+    // wrong" to "every configured store disappears". A bad identity now degrades
+    // to absent, which is exactly the honest `agent:unidentified` outcome.
+    identity: z.string().optional().catch(undefined),
   }).optional(),
 }).partial()
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,9 +26,18 @@ export interface LearnContext {
   /** Current session episode ID for episodic anchoring (SP2 Idea 24). */
   session_episode_id?: string
   /**
-   * Session ID for provenance attribution (#1048). Written to
-   * `sources[].session_id` on every engram write. Takes precedence over
-   * `session_episode_id` in the source entry when both are supplied.
+   * The session this call belongs to — one field, two consumers (#1048, #243).
+   *
+   * 1. Resolves the session default write scope from the per-session registry
+   *    rather than the process-wide slot. Supply it whenever one `Plur`
+   *    instance serves more than one session concurrently; without it,
+   *    `setSessionScope()` is a single shared field and one session's scope
+   *    silently becomes another's (see `session-scopes.ts`).
+   * 2. Written to `sources[].session_id` on every engram write, so an engram
+   *    records which session produced it. Takes precedence over
+   *    `session_episode_id` in the source entry when both are supplied.
+   *
+   * Matches the name the public MCP tool schema has always used for this input.
    */
   session_id?: string
   /** Always-load flag — bypass keyword-relevance gate during injection. */
@@ -63,14 +72,24 @@ export interface LearnContext {
    */
   measured_under?: MeasuredUnder
   /**
-   * Session key this write belongs to (convergence Phase 2).
+   * @deprecated Use `session_id`. Kept as an alias for one release.
    *
-   * Resolves the session default scope from the per-session registry instead of
-   * the process-wide slot. Supply it whenever one `Plur` instance serves more
-   * than one session concurrently — without it, `setSessionScope()` is a single
-   * shared field and one session's scope silently becomes another's (see
-   * `session-scopes.ts`). Never persisted on the engram; it selects a scope, it
-   * is not part of one.
+   * These were two fields for one value. `session` selected the per-session
+   * default scope; `session_id` (#1048) recorded the same session in
+   * provenance — and the public MCP schema has always called the input
+   * `session_id`. So the handler mapping `args.session_id` into `context.session`
+   * was right for its original purpose, and #1048's new field was left unwired
+   * because the obvious mapping was already taken. The result was
+   * `sources[].session_id: null` on every shipping write path.
+   *
+   * Two fields carrying one value, distinguished only by which consumer reads
+   * them, is duplication — and it made "scope resolved but provenance null" the
+   * default outcome rather than an impossible one. `session_id` is now the
+   * single field, read by both consumers.
+   *
+   * The old docstring also claimed this is "never persisted on the engram",
+   * which was already untrue: claw writes the key into scope strings as
+   * `session:${sessionKey}` (context-engine.ts).
    */
   session?: string
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,6 +25,12 @@ export interface LearnContext {
   memory_class?: 'semantic' | 'episodic' | 'procedural' | 'metacognitive'
   /** Current session episode ID for episodic anchoring (SP2 Idea 24). */
   session_episode_id?: string
+  /**
+   * Session ID for provenance attribution (#1048). Written to
+   * `sources[].session_id` on every engram write. Takes precedence over
+   * `session_episode_id` in the source entry when both are supplied.
+   */
+  session_id?: string
   /** Always-load flag — bypass keyword-relevance gate during injection. */
   pinned?: boolean
   /**

--- a/packages/core/test/provenance-origin.test.ts
+++ b/packages/core/test/provenance-origin.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Wave 1 — thread session_id + write provenance.origin on every engram write
+ * Issue #1048 (part of #1047).
+ *
+ * Acceptance criteria:
+ *   - A learn() inside a session writes both sources[].session_id and provenance.
+ *   - No-identity path writes origin = 'agent:unidentified'.
+ *   - LearnContext accepts a session_id field that feeds sources[].session_id.
+ *   - session_id takes precedence over session_episode_id in the source entry.
+ *   - Provenance block: origin, chain=[], signature=null, license='cc-by-sa-4.0'.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { Plur } from '../src/index.js'
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plur-prov-'))
+}
+
+describe('Wave 1: session_id threading + provenance.origin (#1048)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = tmpDir() })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  // ── LearnContext.session_id ────────────────────────────────────────────────
+
+  describe('LearnContext.session_id field', () => {
+    it('accepts session_id without TypeScript error and stores it in sources[0].session_id', async () => {
+      const plur = new Plur({ path: dir })
+      const sid = 'sess-abc-123'
+      const engram = await plur.learn('test statement for session_id threading', {
+        session_id: sid,
+      })
+      const source = (engram as any).sources?.[0]
+      expect(source).toBeDefined()
+      expect(source.session_id).toBe(sid)
+    })
+
+    it('prefers session_id over session_episode_id when both are supplied', async () => {
+      const plur = new Plur({ path: dir })
+      const engram = await plur.learn('session_id wins over session_episode_id', {
+        session_id: 'primary-sess',
+        session_episode_id: 'episode-fallback',
+      })
+      const source = (engram as any).sources?.[0]
+      expect(source.session_id).toBe('primary-sess')
+    })
+
+    it('falls back to session_episode_id when session_id is absent', async () => {
+      const plur = new Plur({ path: dir })
+      const engram = await plur.learn('session_episode_id fallback path', {
+        session_episode_id: 'ep-789',
+      })
+      const source = (engram as any).sources?.[0]
+      expect(source.session_id).toBe('ep-789')
+    })
+
+    it('stores null when neither session_id nor session_episode_id is provided', async () => {
+      const plur = new Plur({ path: dir })
+      const engram = await plur.learn('no session context at all')
+      const source = (engram as any).sources?.[0]
+      expect(source.session_id).toBeNull()
+    })
+  })
+
+  // ── provenance.origin — no-identity path ──────────────────────────────────
+
+  describe('provenance.origin — no identity configured', () => {
+    it('writes provenance.origin = "agent:unidentified" when config has no identity', async () => {
+      const plur = new Plur({ path: dir })
+      const engram = await plur.learn('provenance origin unidentified path')
+      expect(engram.provenance).toBeDefined()
+      expect(engram.provenance!.origin).toBe('agent:unidentified')
+    })
+
+    it('writes an empty chain []', async () => {
+      const plur = new Plur({ path: dir })
+      const engram = await plur.learn('provenance chain is empty by default')
+      expect(engram.provenance!.chain).toEqual([])
+    })
+
+    it('writes signature = null', async () => {
+      const plur = new Plur({ path: dir })
+      const engram = await plur.learn('provenance signature is null placeholder')
+      expect(engram.provenance!.signature).toBeNull()
+    })
+
+    it('writes license = "cc-by-sa-4.0"', async () => {
+      const plur = new Plur({ path: dir })
+      const engram = await plur.learn('provenance license is cc-by-sa-4.0')
+      expect(engram.provenance!.license).toBe('cc-by-sa-4.0')
+    })
+  })
+
+  // ── provenance.origin — identity configured ───────────────────────────────
+
+  describe('provenance.origin — identity configured', () => {
+    it('uses config.provenance.identity as origin when set', async () => {
+      const plur = new Plur({
+        path: dir,
+        provenance: { identity: 'agent:claude-code' },
+      })
+      const engram = await plur.learn('provenance with configured identity')
+      expect(engram.provenance!.origin).toBe('agent:claude-code')
+    })
+
+    it('falls back to "agent:unidentified" when provenance key exists but identity is absent', async () => {
+      const plur = new Plur({
+        path: dir,
+        provenance: {} as any,
+      })
+      const engram = await plur.learn('provenance block present but identity missing')
+      expect(engram.provenance!.origin).toBe('agent:unidentified')
+    })
+  })
+
+  // ── learnRouted / _buildEngramShape path ──────────────────────────────────
+
+  describe('_buildEngramShape (learnRouted path)', () => {
+    it('sets provenance on the shaped engram returned by learnRouted', async () => {
+      const plur = new Plur({
+        path: dir,
+        provenance: { identity: 'agent:nightshift' },
+      })
+      const result = await plur.learnRouted('learnRouted provenance test', {
+        session_id: 'route-sess-1',
+        domain: 'plur.test',
+      })
+      expect(result.provenance).toBeDefined()
+      expect(result.provenance!.origin).toBe('agent:nightshift')
+      const source = (result as any).sources?.[0]
+      expect(source.session_id).toBe('route-sess-1')
+    })
+  })
+
+  // ── YAML round-trip ───────────────────────────────────────────────────────
+
+  describe('YAML round-trip', () => {
+    it('provenance and sources[].session_id survive a save/reload cycle', async () => {
+      const plur = new Plur({
+        path: dir,
+        provenance: { identity: 'agent:test' },
+      })
+      const written = await plur.learn('yaml round-trip for provenance', {
+        session_id: 'round-trip-sess',
+      })
+
+      // Reload from disk
+      const plur2 = new Plur({ path: dir })
+      const reloaded = await plur2.getById(written.id)
+
+      expect(reloaded).toBeDefined()
+      expect(reloaded!.provenance?.origin).toBe('agent:test')
+      const source = (reloaded as any).sources?.[0]
+      expect(source.session_id).toBe('round-trip-sess')
+    })
+  })
+})

--- a/packages/core/test/provenance-origin.test.ts
+++ b/packages/core/test/provenance-origin.test.ts
@@ -10,7 +10,7 @@
  *   - Provenance block: origin, chain=[], signature=null, license='cc-by-sa-4.0'.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '../src/index.js'
@@ -157,5 +157,110 @@ describe('Wave 1: session_id threading + provenance.origin (#1048)', () => {
       const source = (reloaded as any).sources?.[0]
       expect(source.session_id).toBe('round-trip-sess')
     })
+  })
+})
+
+// ── The defects the review found: attribution that never reached production ──
+
+describe('#1048 review findings', () => {
+  it('the constructor identity survives a config reload', async () => {
+    // THE DEFECT: the override was merged INTO this.config, and the next
+    // `this.config = loadConfig(...)` threw it away. _resolveUnscopedScope calls
+    // reloadConfigIfChanged() on every unscoped learn(), so one config.yaml
+    // mtime change reverted an explicitly configured identity to
+    // "agent:unidentified" — silently, and it defeats the whole epic.
+    const dir = mkdtempSync(join(tmpdir(), 'prov-reload-'))
+    const p = new Plur({ storageRoot: dir, provenance: { identity: 'agent:ctor' } } as never)
+
+    const first = await p.learn('a statement written before any reload', { type: 'behavioral' })
+    expect((first as never as { provenance?: { origin?: string } }).provenance?.origin).toBe('agent:ctor')
+
+    // Touch config.yaml so the next unscoped learn reloads it.
+    const cfg = join(dir, 'config.yaml')
+    writeFileSync(cfg, (existsSync(cfg) ? readFileSync(cfg, 'utf8') : '') + '\n# touched\n')
+
+    const second = await p.learn('a statement written after the reload', { type: 'behavioral' })
+    expect(
+      (second as never as { provenance?: { origin?: string } }).provenance?.origin,
+      'the constructor identity must survive loadConfig',
+    ).toBe('agent:ctor')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('an empty session_id does not beat a real session_episode_id', async () => {
+    // `??` let session_id: '' win and persist as the empty string, while
+    // provenance fourteen lines away treated an empty identity as absent.
+    const dir = mkdtempSync(join(tmpdir(), 'prov-empty-'))
+    const p = new Plur({ storageRoot: dir } as never)
+    const e = await p.learn('a statement with an empty session id', {
+      type: 'behavioral', session_id: '', session_episode_id: 'EP-42',
+    } as never)
+    const sources = (e as never as { sources?: Array<{ session_id: string | null }> }).sources
+    expect(sources?.[0].session_id).toBe('EP-42')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('the deprecated `session` alias still resolves scope AND now attributes', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prov-alias-'))
+    const p = new Plur({ storageRoot: dir } as never)
+    const e = await p.learn('a statement using the deprecated alias', {
+      type: 'behavioral', session: 'sess-legacy',
+    } as never)
+    const sources = (e as never as { sources?: Array<{ session_id: string | null }> }).sources
+    expect(sources?.[0].session_id).toBe('sess-legacy')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('saveMetaEngrams does not persist an engram with no provenance', async () => {
+    // formulateMetaEngram builds a complete engram with no provenance block,
+    // and this public write path pushed it in verbatim.
+    const dir = mkdtempSync(join(tmpdir(), 'prov-meta-'))
+    const p = new Plur({ storageRoot: dir, provenance: { identity: 'agent:meta' } } as never)
+    const meta = {
+      id: 'ENG-META-001', statement: 'a meta engram', type: 'behavioral',
+      scope: 'global', status: 'active',
+      sources: [{ scope: 'global', session_id: null, stored_at: new Date().toISOString() }],
+    } as never
+    await p.saveMetaEngrams([meta])
+    expect((meta as { provenance?: { origin?: string } }).provenance?.origin).toBe('agent:meta')
+    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+// ── The call sites, asserted as call sites ──────────────────────────────────
+
+describe('#1048 is wired into the paths that actually write', () => {
+  it('MCP, CLI and claw all pass session_id into LearnContext', async () => {
+    // THE DEFECT THIS GUARDS: every unit test passed while
+    // `sources[].session_id` was null on every shipping path, because the MCP
+    // handler mapped args.session_id into `context.session` — a different field
+    // — and the CLI and claw passed nothing at all. The field this change adds
+    // had zero non-test callers. That is not a logic bug any unit test can see;
+    // only an assertion about the call sites can.
+    const { readFileSync } = await import('node:fs')
+    const { fileURLToPath } = await import('node:url')
+    const { dirname, join: j } = await import('node:path')
+    const root = j(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+    const cases: Array<[string, RegExp]> = [
+      ['packages/mcp/src/tools.ts', /session_id: _resolveInjectionSession\(args\)/],
+      ['packages/cli/src/commands/learn.ts', /session_id: process\.env\.PLUR_SESSION_ID/],
+      ['packages/claw/src/context-engine.ts', /session_id: sessionKey/],
+    ]
+    for (const [file, pattern] of cases) {
+      const src = readFileSync(j(root, file), 'utf8')
+      expect(src, `${file} must thread session_id into the learn context`).toMatch(pattern)
+    }
+  })
+
+  it('plur_learn_batch attributes its writes too', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { fileURLToPath } = await import('node:url')
+    const { dirname, join: j } = await import('node:path')
+    const root = j(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+    const src = readFileSync(j(root, 'packages/mcp/src/tools.ts'), 'utf8')
+    // Two occurrences: the single-write handler and the batch handler.
+    expect(src.match(/session_id: _resolveInjectionSession\(args\)/g)?.length ?? 0)
+      .toBeGreaterThanOrEqual(2)
   })
 })

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1040,11 +1040,15 @@ function getAllToolDefinitions(): ToolDefinition[] {
           valid_until: args.valid_until as string | undefined,
           supersedes: args.supersedes as string[] | undefined,
           measured_under: args.measured_under as Record<string, string> | undefined,
-          // #243: resolve which session's default scope governs this write —
-          // explicit session_id first, else the lone open session. Never
-          // persisted on the engram (LearnContext.session selects a scope, it
-          // is not part of one).
-          session: _resolveInjectionSession(args),
+          // #243/#1048: one field, both jobs. It resolves which session's
+          // default scope governs this write (explicit session_id first, else
+          // the lone open session) AND is recorded in sources[].session_id so
+          // the engram carries which session produced it.
+          //
+          // This used to map into `context.session`, a second field with the
+          // same value and a different consumer, which left the provenance
+          // field null on every shipping path.
+          session_id: _resolveInjectionSession(args),
           llm,
         }
         // Route through learnRouted FIRST so remote-scope writes get
@@ -1259,6 +1263,9 @@ function getAllToolDefinitions(): ToolDefinition[] {
             valid_from: e.valid_from as string | undefined,
             valid_until: e.valid_until as string | undefined,
             measured_under: e.measured_under as Record<string, string> | undefined,
+            // Batch writes are session writes too — without this every engram
+            // from plur_learn_batch lands with sources[].session_id null.
+            session_id: _resolveInjectionSession(args),
           },
         }))
         const maxLlmCalls = typeof args.max_llm_calls === 'number' ? args.max_llm_calls : undefined


### PR DESCRIPTION
## Summary

Wave 1 of the provenance ladder (plur#1047):

- **`session_id` in `LearnContext`**: new field that takes precedence over the older `session_episode_id` when both are supplied; falls back to `session_episode_id` when only that is present.
- **`provenance.identity` in config**: `PlurConfigSchema` and the `Plur` constructor both accept `provenance?: { identity? }`. Constructor-level option overrides the config file (useful for tests and programmatic callers).
- **`_buildProvenance()` helper**: always writes `{ origin, chain: [], signature: null, license: 'cc-by-sa-4.0' }`. `origin` is `config.provenance.identity` when set, else `"agent:unidentified"` — recorded honestly so multi-writer attribution is visible even without explicit configuration.
- **`learn()` and `_buildEngramShape()`**: both set `provenance` on every new engram. Old engrams are untouched (no backfill, no migration).

## Acceptance

All 12 tests in `test/provenance-origin.test.ts` pass:
- session_id threading (4 tests)
- provenance.origin no-identity path (4 tests)
- provenance.origin identity-configured path (2 tests)
- learnRouted path (1 test)
- YAML round-trip (1 test)

Pre-existing failures (PGLite/zod-to-json-schema not installed in this env) are unaffected.

## Related

Closes #1048. Part of #1047.