### PR TITLE
perf(history): in-process hash cache + sidecar fast path — fix +24.7% p50 regression (#1051)

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -221,6 +221,21 @@ export function readChainHead(historyDir: string, currentMonthFile?: string): st
 }
 
 /**
+ * Drop every cached chain-head observation for `historyDir`.
+ *
+ * Used when we cannot bound what we just observed — an unlocked write, or a
+ * stat that failed. Both tiers go, including the on-disk sidecar: leaving a
+ * stale sidecar behind would let ANOTHER process trust an observation this one
+ * already knows is unreliable.
+ *
+ * @param historyDir - the history directory whose caches to drop.
+ */
+function invalidateChainHead(historyDir: string): void {
+  _chainHeadMem.delete(historyDir)
+  try { fs.unlinkSync(join(historyDir, CHAIN_HEAD_FILE)) } catch { /* already gone */ }
+}
+
+/**
  * Write the sidecar chain-head file. Best-effort: a write failure must not
  * propagate to the caller or fail the history append. The sidecar is advisory;
  * the JSONL is authoritative.
@@ -523,7 +538,7 @@ export function appendHistoryStamped(
     // the hash covers it (#1052 checkpoints).
     onPrev?.(predecessorHash)
     event.hash = computeEventHash(event) // canonical bytes exclude the hash field
-    writeEventLine(JSON.stringify(event) + '\n')
+    writeEventLine(JSON.stringify(event) + '\n', true)
   }
   // fsync the append (#813, audit finding 20). O_APPEND makes the write atomic
   // against concurrent writers, but not durable: a committed engram mutation
@@ -550,7 +565,25 @@ export function appendHistoryStamped(
   // restore` (it NAMES the engrams a restore cannot recover) and, since #816,
   // for id allocation. A store writing no history is degraded and the operator
   // needs to know — but the write itself must still land.
-  function writeEventLine(line: string): void {
+  /**
+   * Append one JSONL line, and record the chain head it establishes.
+   *
+   * `chained` is false on the lock-failure path. That distinction is
+   * load-bearing: the caches may only be updated by a writer holding the chain
+   * lock. An unlocked writer's `statSync` can observe a size that already
+   * includes a CONCURRENT writer's append, so it records
+   * `{hash: mine, size: combined}` — an observation that then PASSES the
+   * size+inode validation while naming the wrong tail, and the next writer
+   * chains from a head that is not the head. That is precisely the silent
+   * cross-process fork this sidecar was added to eliminate, reintroduced on the
+   * one path where exclusion is known to be absent.
+   *
+   * So the unlocked path INVALIDATES instead: drop the memory entry and remove
+   * the sidecar, forcing the next lookup down to the authoritative tail-seek.
+   * Slower and always right, which is the correct trade when we know we cannot
+   * bound what we just observed.
+   */
+  function writeEventLine(line: string, chained: boolean): void {
   try {
     const fd = fs.openSync(filePath, 'a')
     try {
@@ -568,16 +601,22 @@ export function appendHistoryStamped(
     // Record what we just observed: the hash, and the exact file state it
     // describes. Both tiers are validated against this on the next lookup, so
     // neither can outlive the state it was true of.
-    try {
-      const st = fs.statSync(filePath)
-      const rec: ChainHeadRecord = { hash: event.hash!, file: filePath, size: st.size, ino: st.ino }
-      _chainHeadMem.set(historyDir, rec)
-      writeChainHead(historyDir, rec)
-    } catch {
-      // Could not stat what we just wrote — drop the cache rather than record
-      // an observation we cannot bound. The next lookup tail-seeks, which is
-      // slower and always right.
-      _chainHeadMem.delete(historyDir)
+    if (!chained) {
+      // Wrote without the lock. Anything we observe now may already include
+      // another writer's append, so there is no observation worth keeping.
+      invalidateChainHead(historyDir)
+    } else {
+      try {
+        const st = fs.statSync(filePath)
+        const rec: ChainHeadRecord = { hash: event.hash!, file: filePath, size: st.size, ino: st.ino }
+        _chainHeadMem.set(historyDir, rec)
+        writeChainHead(historyDir, rec)
+      } catch {
+        // Could not stat what we just wrote — drop the cache rather than record
+        // an observation we cannot bound. The next lookup tail-seeks, which is
+        // slower and always right.
+        invalidateChainHead(historyDir)
+      }
     }
   } catch (err) {
     if (!warnedHistoryPaths.has(filePath)) {
@@ -608,7 +647,7 @@ export function appendHistoryStamped(
     event.prev = null
     onPrev?.(null)
     event.hash = computeEventHash(event)
-    writeEventLine(JSON.stringify(event) + '\n')
+    writeEventLine(JSON.stringify(event) + '\n', false)
   }
 }
 

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -128,6 +128,37 @@ const CHAIN_HEAD_FILE = '.chain-head'
 const HEX64 = /^[0-9a-f]{64}$/
 
 /**
+ * In-process cache of the last written chain-head hash, keyed by historyDir.
+ *
+ * Three-tier lookup in findPredecessorHash:
+ *   1. This map (zero disk I/O — eliminates the sidecar readFileSync on hot path)
+ *   2. Sidecar file (65-byte disk read — cross-process fast path)
+ *   3. JSONL tail-seek (8 KiB disk read + JSON.parse — slow fallback)
+ *
+ * Populated by appendHistory after every successful JSONL write. Only covers
+ * writes made by THIS process; another process writing to the same store is
+ * not visible here (the sidecar handles that case). Call
+ * clearChainHeadMemCache(historyDir) when the store is reloaded from disk so
+ * the next lookup falls through to the sidecar and picks up any external writes.
+ */
+const _chainHeadMem = new Map<string, string>()
+
+/**
+ * Clear the in-process chain-head cache for a specific history directory, or
+ * all directories when called with no argument. Call this whenever the store
+ * is reloaded from disk (e.g. after a sync or an explicit reload) so the next
+ * findPredecessorHash falls through to the sidecar file rather than returning
+ * a potentially stale in-memory value.
+ */
+export function clearChainHeadMemCache(historyDir?: string): void {
+  if (historyDir === undefined) {
+    _chainHeadMem.clear()
+  } else {
+    _chainHeadMem.delete(historyDir)
+  }
+}
+
+/**
  * Read the sidecar chain-head file. Returns the 64-char hex hash or null when
  * the file is absent, empty, or contains an invalid value.
  */
@@ -217,18 +248,23 @@ export function tailSeekLastHash(filePath: string): string | null {
  * history directory, looking at the current month file first and then scanning
  * backwards through prior months.
  *
- * Fast path: reads the sidecar `.chain-head` file (64 bytes) if present and
- * valid. This covers both same-month and cross-month predecessors with a single
- * cheap readFileSync, and works across process boundaries (an in-memory cache
- * would not). Falls back to tail-seeking the JSONL when the sidecar is absent
- * or invalid.
+ * Three-tier lookup (cheapest first):
+ *   1. In-process memory cache (_chainHeadMem) — zero disk I/O; covers the
+ *      common single-process write burst.
+ *   2. Sidecar `.chain-head` file (65-byte readFileSync) — cross-process fast
+ *      path; valid even when the in-memory cache is cold or has been cleared.
+ *   3. JSONL tail-seek (up to 8 KiB + JSON.parse) — slow fallback for cold
+ *      start or absent/corrupt sidecar.
  *
  * Returns null when no chained predecessor is found (genesis event, gap after
  * a legacy event, or unreadable files).
  */
 export function findPredecessorHash(historyDir: string, currentMonthFile: string): string | null {
-  // Fast path: sidecar file is cheaper than 8 KiB tail-seek + JSON.parse and
-  // is shared across processes. If it yields a valid hash, skip the JSONL read.
+  // Tier 1: in-process memory — zero disk I/O on the hot write path.
+  const memHash = _chainHeadMem.get(historyDir)
+  if (memHash !== undefined) return memHash
+
+  // Tier 2: sidecar file — cross-process fast path (65 bytes vs 8 KiB).
   const sidecarHash = readChainHead(historyDir)
   if (sidecarHash !== null) return sidecarHash
 
@@ -409,9 +445,13 @@ export function appendHistoryStamped(
     } finally {
       fs.closeSync(fd)
     }
-    // Update the sidecar after the JSONL write lands. Best-effort: a failure
-    // here leaves the sidecar stale; the next findPredecessorHash call falls
-    // back to tail-seeking the JSONL. writeChainHead never throws.
+    // Update both the in-process cache and the on-disk sidecar after the JSONL
+    // write lands. The memory cache eliminates disk I/O on the next same-process
+    // write; the sidecar keeps cross-process readers in sync. Both are
+    // best-effort: a sidecar write failure leaves the cache warm (fast path
+    // still works in-process) and the sidecar stale (cross-process fallback
+    // degrades to tail-seek on the next write from another process).
+    _chainHeadMem.set(historyDir, event.hash!)
     writeChainHead(historyDir, event.hash!)
   } catch (err) {
     if (!warnedHistoryPaths.has(filePath)) {

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -110,6 +110,50 @@ export function computeEventHash(event: HistoryEvent): string {
 }
 
 /**
+ * Sidecar file name inside the history directory. Written after every
+ * successful JSONL append; contains only the 64-char hex hash of the last
+ * chained event (plus a trailing newline). Reading 65 bytes is cheaper than
+ * reading TAIL_WINDOW bytes and parsing JSON, and the sidecar works across
+ * process boundaries (an in-memory cache does not).
+ *
+ * The JSONL files remain the authoritative source of truth. The sidecar is
+ * advisory: if absent, invalid, or suspect, readers fall back to tail-seeking
+ * the JSONL. A stale sidecar (written but not flushed before a crash) can
+ * create a chain gap on the next write — the same outcome as any other
+ * predecessor-read failure, which is already handled as a documented gap.
+ */
+const CHAIN_HEAD_FILE = '.chain-head'
+
+/** Hex-only, exactly 64 characters. */
+const HEX64 = /^[0-9a-f]{64}$/
+
+/**
+ * Read the sidecar chain-head file. Returns the 64-char hex hash or null when
+ * the file is absent, empty, or contains an invalid value.
+ */
+export function readChainHead(historyDir: string): string | null {
+  try {
+    const content = fs.readFileSync(join(historyDir, CHAIN_HEAD_FILE), 'utf8').trim()
+    return HEX64.test(content) ? content : null
+  } catch {
+    return null // ENOENT or any I/O error — fall back to tail-seek
+  }
+}
+
+/**
+ * Write the sidecar chain-head file. Best-effort: a write failure must not
+ * propagate to the caller or fail the history append. The sidecar is advisory;
+ * the JSONL is authoritative.
+ */
+function writeChainHead(historyDir: string, hash: string): void {
+  try {
+    fs.writeFileSync(join(historyDir, CHAIN_HEAD_FILE), `${hash}\n`, 'utf8')
+  } catch {
+    // best-effort — sidecar is advisory; JSONL is authoritative
+  }
+}
+
+/**
  * Tail-seek the last non-empty line of a JSONL file and extract the `hash`
  * field from the parsed JSON. Returns null if the file does not exist, cannot
  * be read, has no non-empty lines, or the last line lacks a `hash` field.
@@ -173,13 +217,25 @@ export function tailSeekLastHash(filePath: string): string | null {
  * history directory, looking at the current month file first and then scanning
  * backwards through prior months.
  *
- * Used by appendHistory for cross-month chain continuity: when the first event
- * of a new month is written, the predecessor is in the prior month's file.
+ * Fast path: reads the sidecar `.chain-head` file (64 bytes) if present and
+ * valid. This covers both same-month and cross-month predecessors with a single
+ * cheap readFileSync, and works across process boundaries (an in-memory cache
+ * would not). Falls back to tail-seeking the JSONL when the sidecar is absent
+ * or invalid.
  *
  * Returns null when no chained predecessor is found (genesis event, gap after
  * a legacy event, or unreadable files).
  */
 export function findPredecessorHash(historyDir: string, currentMonthFile: string): string | null {
+  // Fast path: sidecar file is cheaper than 8 KiB tail-seek + JSON.parse and
+  // is shared across processes. If it yields a valid hash, skip the JSONL read.
+  const sidecarHash = readChainHead(historyDir)
+  if (sidecarHash !== null) return sidecarHash
+
+  // Slow path (sidecar absent or invalid): fall back to JSONL tail-seek.
+  // This covers the cold-start case (no sidecar written yet) and any scenario
+  // where the sidecar cannot be trusted (e.g. stale after a crash).
+
   // If the current month file exists and has content, the predecessor (if any)
   // is within it. A null return means either: last event is a legacy event
   // (no hash — gap) or the file is empty/unreadable. We don't cross back to
@@ -353,6 +409,10 @@ export function appendHistoryStamped(
     } finally {
       fs.closeSync(fd)
     }
+    // Update the sidecar after the JSONL write lands. Best-effort: a failure
+    // here leaves the sidecar stale; the next findPredecessorHash call falls
+    // back to tail-seeking the JSONL. writeChainHead never throws.
+    writeChainHead(historyDir, event.hash!)
   } catch (err) {
     if (!warnedHistoryPaths.has(filePath)) {
       warnedHistoryPaths.add(filePath)

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -141,7 +141,46 @@ const HEX64 = /^[0-9a-f]{64}$/
  * clearChainHeadMemCache(historyDir) when the store is reloaded from disk so
  * the next lookup falls through to the sidecar and picks up any external writes.
  */
-const _chainHeadMem = new Map<string, string>()
+interface ChainHeadRecord {
+  /** Chain head hash as of the observation below. */
+  hash: string
+  /** Month file the hash was read from / written to. */
+  file: string
+  /** Byte size of that file at the moment the hash was recorded. */
+  size: number
+  /** Inode of that file, so a wiped-and-recreated store is not mistaken for it. */
+  ino: number
+}
+
+const _chainHeadMem = new Map<string, ChainHeadRecord>()
+
+/**
+ * Is a recorded observation still true of the file on disk?
+ *
+ * This one `statSync` is what makes both the memory cache and the sidecar safe
+ * to trust. Either can only be believed while the file it describes is byte-for-byte
+ * the length it was when the observation was made:
+ *
+ *  - another process appending changes the size, so a cross-process writer can
+ *    never be served a stale predecessor (the #1080 fork);
+ *  - a crash between the JSONL fsync and the sidecar write leaves the sidecar
+ *    describing a shorter file, so it is rejected rather than chained from
+ *    (the crash-window fork, which had no gap to give it away);
+ *  - a store wiped and recreated at the same path gets a new inode, so the
+ *    first event of a brand-new store cannot inherit a hash from the dead one.
+ *
+ * One stat instead of an 8 KiB read plus JSON.parse, and it fails CLOSED — any
+ * doubt falls through to the authoritative tail-seek.
+ */
+function observationHolds(rec: ChainHeadRecord, file: string): boolean {
+  if (rec.file !== file) return false
+  try {
+    const st = fs.statSync(file)
+    return st.size === rec.size && st.ino === rec.ino
+  } catch {
+    return false
+  }
+}
 
 /**
  * Clear the in-process chain-head cache for a specific history directory, or
@@ -162,12 +201,22 @@ export function clearChainHeadMemCache(historyDir?: string): void {
  * Read the sidecar chain-head file. Returns the 64-char hex hash or null when
  * the file is absent, empty, or contains an invalid value.
  */
-export function readChainHead(historyDir: string): string | null {
+export function readChainHead(historyDir: string, currentMonthFile?: string): string | null {
   try {
     const content = fs.readFileSync(join(historyDir, CHAIN_HEAD_FILE), 'utf8').trim()
-    return HEX64.test(content) ? content : null
+
+    // Legacy plain-hash sidecar (pre-record format). Trusted only when the
+    // caller does not care which file it describes — it carries no way to
+    // check itself, so a validating caller must reject it.
+    if (HEX64.test(content)) return currentMonthFile === undefined ? content : null
+
+    const rec = JSON.parse(content) as Partial<ChainHeadRecord>
+    if (typeof rec.hash !== 'string' || !HEX64.test(rec.hash)) return null
+    if (typeof rec.file !== 'string' || typeof rec.size !== 'number' || typeof rec.ino !== 'number') return null
+    if (currentMonthFile === undefined) return rec.hash
+    return observationHolds(rec as ChainHeadRecord, currentMonthFile) ? rec.hash : null
   } catch {
-    return null // ENOENT or any I/O error — fall back to tail-seek
+    return null // ENOENT, malformed, or any I/O error — fall back to tail-seek
   }
 }
 
@@ -176,11 +225,25 @@ export function readChainHead(historyDir: string): string | null {
  * propagate to the caller or fail the history append. The sidecar is advisory;
  * the JSONL is authoritative.
  */
-function writeChainHead(historyDir: string, hash: string): void {
+function writeChainHead(historyDir: string, rec: ChainHeadRecord): void {
+  const target = join(historyDir, CHAIN_HEAD_FILE)
+  const tmp = `${target}.${process.pid}.tmp`
   try {
-    fs.writeFileSync(join(historyDir, CHAIN_HEAD_FILE), `${hash}\n`, 'utf8')
+    // Temp-file-and-rename with an fsync, matching the care the JSONL append
+    // above already takes. A bare writeFileSync could be observed half-written
+    // by a concurrent reader, and the asymmetry — a carefully fsynced log next
+    // to a casually written pointer into it — was what widened the crash window.
+    const fd = fs.openSync(tmp, 'w')
+    try {
+      fs.writeSync(fd, JSON.stringify(rec) + '\n')
+      try { fs.fsyncSync(fd) } catch { /* durability is best-effort */ }
+    } finally {
+      fs.closeSync(fd)
+    }
+    fs.renameSync(tmp, target)
   } catch {
     // best-effort — sidecar is advisory; JSONL is authoritative
+    try { fs.unlinkSync(tmp) } catch { /* nothing to clean up */ }
   }
 }
 
@@ -260,12 +323,22 @@ export function tailSeekLastHash(filePath: string): string | null {
  * a legacy event, or unreadable files).
  */
 export function findPredecessorHash(historyDir: string, currentMonthFile: string): string | null {
-  // Tier 1: in-process memory — zero disk I/O on the hot write path.
-  const memHash = _chainHeadMem.get(historyDir)
-  if (memHash !== undefined) return memHash
+  // Tier 1: in-process memory, VALIDATED. The cached hash is accepted only
+  // while the month file is still exactly the length and inode it was when the
+  // hash was recorded — one statSync, no read, no parse.
+  //
+  // It used to be returned unconditionally, which is the #1080 blocking defect:
+  // a second process's appends were invisible, so two long-lived writers (an
+  // MCP server and a CLI against ~/.plur — the everyday configuration) each
+  // kept chaining from their own last write and the log forked into two
+  // parallel chains sharing one genesis.
+  const rec = _chainHeadMem.get(historyDir)
+  if (rec !== undefined && observationHolds(rec, currentMonthFile)) return rec.hash
 
-  // Tier 2: sidecar file — cross-process fast path (65 bytes vs 8 KiB).
-  const sidecarHash = readChainHead(historyDir)
+  // Tier 2: sidecar file — cross-process fast path, validated the same way.
+  // Passing currentMonthFile is what makes it reject a sidecar left stale by a
+  // crash between the JSONL fsync and the sidecar write.
+  const sidecarHash = readChainHead(historyDir, currentMonthFile)
   if (sidecarHash !== null) return sidecarHash
 
   // Slow path (sidecar absent or invalid): fall back to JSONL tail-seek.
@@ -397,6 +470,7 @@ export function appendHistoryStamped(
   // predecessor and the log forks. `withLock` is the synchronous twin of the
   // store's async lock — token-based release, stale detection, liveness check —
   // and `appendHistory` is synchronous, so it is the one that fits.
+  //
   // The critical section is read-tail -> compute -> WRITE, all three. Stamping
   // under the lock and appending after it is not enough: two writers can both
   // read the same tail, both release, and both then append from it — measured
@@ -451,8 +525,20 @@ export function appendHistoryStamped(
     // best-effort: a sidecar write failure leaves the cache warm (fast path
     // still works in-process) and the sidecar stale (cross-process fallback
     // degrades to tail-seek on the next write from another process).
-    _chainHeadMem.set(historyDir, event.hash!)
-    writeChainHead(historyDir, event.hash!)
+    // Record what we just observed: the hash, and the exact file state it
+    // describes. Both tiers are validated against this on the next lookup, so
+    // neither can outlive the state it was true of.
+    try {
+      const st = fs.statSync(filePath)
+      const rec: ChainHeadRecord = { hash: event.hash!, file: filePath, size: st.size, ino: st.ino }
+      _chainHeadMem.set(historyDir, rec)
+      writeChainHead(historyDir, rec)
+    } catch {
+      // Could not stat what we just wrote — drop the cache rather than record
+      // an observation we cannot bound. The next lookup tail-seeks, which is
+      // slower and always right.
+      _chainHeadMem.delete(historyDir)
+    }
   } catch (err) {
     if (!warnedHistoryPaths.has(filePath)) {
       warnedHistoryPaths.add(filePath)
@@ -466,11 +552,12 @@ export function appendHistoryStamped(
   }
 
   try {
-    // Tuned to the section, not to the default: this critical section is a
+    // Tuned to the section, not to the default. This critical section is a
     // tail-read, a hash and an append — microseconds — so the stock 100 ms
-    // first backoff has waiters sleeping orders of magnitude longer than the
-    // holder needs, and under real concurrency they starve and fall through to
-    // the gap path below.
+    // first backoff has a waiter sleeping orders of magnitude longer than the
+    // holder needs, and under real concurrency waiters starve and fall through
+    // to the gap path. Start at 2 ms and still back off exponentially if the
+    // contention turns out to be genuine.
     withLock(join(historyDir, 'chain'), stampAndWrite, { maxRetries: 12, baseDelay: 2 })
   } catch {
     // Could not take the lock. Do NOT chain from a tail we could not read

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -233,13 +233,13 @@ function writeChainHead(historyDir: string, rec: ChainHeadRecord): void {
     // above already takes. A bare writeFileSync could be observed half-written
     // by a concurrent reader, and the asymmetry — a carefully fsynced log next
     // to a casually written pointer into it — was what widened the crash window.
-    const fd = fs.openSync(tmp, 'w')
-    try {
-      fs.writeSync(fd, JSON.stringify(rec) + '\n')
-      try { fs.fsyncSync(fd) } catch { /* durability is best-effort */ }
-    } finally {
-      fs.closeSync(fd)
-    }
+    // Temp-file-and-rename so a reader can never observe a half-written
+    // sidecar. Deliberately NOT fsynced: the sidecar is advisory and now
+    // self-validating — a sidecar lost or left behind by a crash fails its own
+    // size/inode check and the lookup falls through to the authoritative
+    // tail-seek. Paying an fsync per append to durably persist a hint that is
+    // already safe to lose is the wrong trade on the hot write path.
+    fs.writeFileSync(tmp, JSON.stringify(rec) + '\n', 'utf8')
     fs.renameSync(tmp, target)
   } catch {
     // best-effort — sidecar is advisory; JSONL is authoritative

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,7 +119,7 @@ export { selectModel, selectModelForOperation, resolveOperationTier, type ModelT
 export { recallAuto, type AutoSearchResult, type SearchStrategy } from './search-orchestrator.js'
 export { generateProfile, getProfileForInjection, loadProfileCache, saveProfileCache, markProfileDirty, profileNeedsRegeneration, type ProfileCache } from './profile.js'
 export { formatLayer1, formatLayer2, formatLayer3, formatWithLayer, assignLayer, type InjectionLayer } from './inject.js'
-export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, readCoInjections, computeEventHash, canonicalEventBytes, sortKeysDeep, tailSeekLastHash, readChainHead, hashEngramsFile, emitCheckpoint, type HistoryEvent, type CheckpointData, type InjectionEventCounts, type InjectionSource, type CoInjectionData, type CoInjectionEvent, type CoInjectionReadResult } from './history.js'
+export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, readCoInjections, computeEventHash, canonicalEventBytes, sortKeysDeep, tailSeekLastHash, readChainHead, clearChainHeadMemCache, hashEngramsFile, emitCheckpoint, type HistoryEvent, type CheckpointData, type InjectionEventCounts, type InjectionSource, type CoInjectionData, type CoInjectionEvent, type CoInjectionReadResult } from './history.js'
 export { computeReceipt } from './receipt.js'
 export type { Receipt, ReceiptInput, ReceiptTopEntry } from './receipt.js'
 import type { Receipt } from './receipt.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,7 +119,7 @@ export { selectModel, selectModelForOperation, resolveOperationTier, type ModelT
 export { recallAuto, type AutoSearchResult, type SearchStrategy } from './search-orchestrator.js'
 export { generateProfile, getProfileForInjection, loadProfileCache, saveProfileCache, markProfileDirty, profileNeedsRegeneration, type ProfileCache } from './profile.js'
 export { formatLayer1, formatLayer2, formatLayer3, formatWithLayer, assignLayer, type InjectionLayer } from './inject.js'
-export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, readCoInjections, computeEventHash, canonicalEventBytes, sortKeysDeep, tailSeekLastHash, hashEngramsFile, emitCheckpoint, type HistoryEvent, type CheckpointData, type InjectionEventCounts, type InjectionSource, type CoInjectionData, type CoInjectionEvent, type CoInjectionReadResult } from './history.js'
+export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, readCoInjections, computeEventHash, canonicalEventBytes, sortKeysDeep, tailSeekLastHash, readChainHead, hashEngramsFile, emitCheckpoint, type HistoryEvent, type CheckpointData, type InjectionEventCounts, type InjectionSource, type CoInjectionData, type CoInjectionEvent, type CoInjectionReadResult } from './history.js'
 export { computeReceipt } from './receipt.js'
 export type { Receipt, ReceiptInput, ReceiptTopEntry } from './receipt.js'
 import type { Receipt } from './receipt.js'

--- a/packages/core/test/chain-head-sidecar.test.ts
+++ b/packages/core/test/chain-head-sidecar.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The chain-head caches may only be written by a writer holding the chain lock.
+ *
+ * The sidecar and the in-process map exist to avoid an 8 KiB tail-seek on every
+ * append. Both are validated on read against the month file's size and inode,
+ * which is what makes them safe to trust — but only if what they RECORD was
+ * observed under exclusion.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { appendHistory, readHistory } from '../src/history.js'
+
+// ── The unlocked fallback must not poison the caches ────────────────────────
+
+describe('a write that could not take the lock records no observation', () => {
+  /**
+   * writeEventLine ran on BOTH paths — under the chain lock, and in the
+   * lock-failure fallback — and updated the memory cache and the sidecar in
+   * both. On the unlocked path that is unsound: `statSync` after the append can
+   * observe a size that already includes a CONCURRENT writer's append, so the
+   * record is {hash: mine, size: combined}. That observation then PASSES the
+   * size+inode validation while naming the wrong tail, and the next writer
+   * chains from a head that is not the head — the silent cross-process fork
+   * this sidecar exists to eliminate, reintroduced on the one path where
+   * exclusion is known to be absent.
+   *
+   * INVARIANT: the chain-head caches are written only by a writer that held the
+   * chain lock. Anyone else invalidates.
+   */
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-sidecar-lock-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  /** Hold the chain lock so appendHistory is forced down the fallback path. */
+  function holdChainLock(historyDir: string): () => void {
+    mkdirSync(historyDir, { recursive: true })
+    const lockPath = join(historyDir, 'chain.lock')
+    writeFileSync(lockPath, JSON.stringify({ pid: process.pid, token: 'held-by-test', ts: Date.now() }), 'utf8')
+    return () => { try { rmSync(lockPath) } catch { /* already gone */ } }
+  }
+
+  it('leaves no sidecar behind when the lock could not be taken', () => {
+    const historyDir = join(dir, 'history')
+    const release = holdChainLock(historyDir)
+    try {
+      appendHistory(dir, {
+        event: 'engram_created', engram_id: 'ENG-001',
+        timestamp: '2026-01-01T00:00:00.000Z', data: {},
+      })
+      // The event itself must still land — history NAMES what a restore cannot
+      // recover, so dropping the record is not an option.
+      const events = readHistory(dir, '2026-01')
+      expect(events).toHaveLength(1)
+      expect(events[0].prev, 'unlocked write must declare a gap').toBeNull()
+
+      // But it must not have recorded a chain head it cannot vouch for.
+      expect(existsSync(join(historyDir, '.chain-head'))).toBe(false)
+    } finally { release() }
+  })
+
+  it('removes a PRE-EXISTING sidecar rather than leaving a stale one', () => {
+    // A stale sidecar is worse than none: another process would trust it.
+    const historyDir = join(dir, 'history')
+    appendHistory(dir, {
+      event: 'engram_created', engram_id: 'ENG-000',
+      timestamp: '2026-01-01T00:00:00.000Z', data: {},
+    })
+    expect(existsSync(join(historyDir, '.chain-head'))).toBe(true)
+
+    const release = holdChainLock(historyDir)
+    try {
+      appendHistory(dir, {
+        event: 'engram_created', engram_id: 'ENG-001',
+        timestamp: '2026-01-01T00:01:00.000Z', data: {},
+      })
+      expect(existsSync(join(historyDir, '.chain-head'))).toBe(false)
+    } finally { release() }
+  })
+
+  it('the next LOCKED write re-establishes the sidecar correctly', () => {
+    // Invalidation must be recoverable, not a permanent downgrade.
+    const historyDir = join(dir, 'history')
+    const release = holdChainLock(historyDir)
+    appendHistory(dir, {
+      event: 'engram_created', engram_id: 'ENG-001',
+      timestamp: '2026-01-01T00:00:00.000Z', data: {},
+    })
+    release()
+
+    appendHistory(dir, {
+      event: 'engram_created', engram_id: 'ENG-002',
+      timestamp: '2026-01-01T00:02:00.000Z', data: {},
+    })
+    expect(existsSync(join(historyDir, '.chain-head'))).toBe(true)
+
+    const events = readHistory(dir, '2026-01')
+    expect(events).toHaveLength(2)
+    // The recovered write chained onto the gapped one via tail-seek.
+    expect(events[1].prev).toBe(events[0].hash)
+  })
+})

--- a/packages/core/test/history-chain.test.ts
+++ b/packages/core/test/history-chain.test.ts
@@ -24,6 +24,7 @@ import {
   canonicalEventBytes,
   sortKeysDeep,
   tailSeekLastHash,
+  readChainHead,
   type HistoryEvent,
 } from '../src/history.js'
 
@@ -412,6 +413,175 @@ describe('hash-chain history (#1051)', () => {
       const events = readHistory(dir, '2026-01')
       expect(events[0].hash).toBe(cjkVector.sha256)
       expect(events[0].prev).toBe(null)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // .chain-head sidecar (#1051 follow-up)
+  // ---------------------------------------------------------------------------
+
+  describe('.chain-head sidecar', () => {
+    it('readChainHead returns null for a non-existent history dir', () => {
+      expect(readChainHead(path.join(dir, 'history'))).toBe(null)
+    })
+
+    it('readChainHead returns null when the sidecar file is absent', () => {
+      const historyDir = path.join(dir, 'history')
+      fs.mkdirSync(historyDir, { recursive: true })
+      expect(readChainHead(historyDir)).toBe(null)
+    })
+
+    it('readChainHead returns null for an empty sidecar', () => {
+      const historyDir = path.join(dir, 'history')
+      fs.mkdirSync(historyDir, { recursive: true })
+      fs.writeFileSync(path.join(historyDir, '.chain-head'), '', 'utf8')
+      expect(readChainHead(historyDir)).toBe(null)
+    })
+
+    it('readChainHead returns null for a 63-char (invalid) sidecar', () => {
+      const historyDir = path.join(dir, 'history')
+      fs.mkdirSync(historyDir, { recursive: true })
+      fs.writeFileSync(path.join(historyDir, '.chain-head'), 'a'.repeat(63), 'utf8')
+      expect(readChainHead(historyDir)).toBe(null)
+    })
+
+    it('readChainHead returns null for non-hex content', () => {
+      const historyDir = path.join(dir, 'history')
+      fs.mkdirSync(historyDir, { recursive: true })
+      fs.writeFileSync(path.join(historyDir, '.chain-head'), 'z'.repeat(64), 'utf8')
+      expect(readChainHead(historyDir)).toBe(null)
+    })
+
+    it('readChainHead returns the hash when the sidecar is valid (with trailing newline)', () => {
+      const historyDir = path.join(dir, 'history')
+      fs.mkdirSync(historyDir, { recursive: true })
+      const hash = 'a'.repeat(64)
+      fs.writeFileSync(path.join(historyDir, '.chain-head'), `${hash}\n`, 'utf8')
+      expect(readChainHead(historyDir)).toBe(hash)
+    })
+
+    it('readChainHead returns the hash when the sidecar has no trailing newline', () => {
+      const historyDir = path.join(dir, 'history')
+      fs.mkdirSync(historyDir, { recursive: true })
+      const hash = 'b'.repeat(64)
+      fs.writeFileSync(path.join(historyDir, '.chain-head'), hash, 'utf8')
+      expect(readChainHead(historyDir)).toBe(hash)
+    })
+
+    it('appendHistory writes .chain-head after the first event', () => {
+      const event: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, event)
+      const historyDir = path.join(dir, 'history')
+      const head = readChainHead(historyDir)
+      const [written] = readHistory(dir, '2026-04')
+      expect(head).toBe(written.hash)
+    })
+
+    it('appendHistory keeps .chain-head updated to the latest event hash', () => {
+      const e1: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      const e2: HistoryEvent = {
+        event: 'engram_updated',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T13:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, e1)
+      appendHistory(dir, e2)
+      const historyDir = path.join(dir, 'history')
+      const events = readHistory(dir, '2026-04')
+      // Sidecar must reflect the SECOND event, not the first
+      expect(readChainHead(historyDir)).toBe(events[1].hash)
+    })
+
+    it('appendHistory updates .chain-head across month boundaries', () => {
+      const eApril: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-30T23:59:59.000Z',
+        data: {},
+      }
+      const eMay: HistoryEvent = {
+        event: 'engram_updated',
+        engram_id: 'ENG-001',
+        timestamp: '2026-05-01T00:00:01.000Z',
+        data: {},
+      }
+      appendHistory(dir, eApril)
+      appendHistory(dir, eMay)
+      const historyDir = path.join(dir, 'history')
+      const mayEvents = readHistory(dir, '2026-05')
+      // Sidecar must reflect May's event (the final write)
+      expect(readChainHead(historyDir)).toBe(mayEvents[0].hash)
+    })
+
+    it('findPredecessorHash uses .chain-head instead of tail-seeking JSONL when sidecar is present', () => {
+      // Write two events to establish a chain
+      const e1: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      const e2: HistoryEvent = {
+        event: 'engram_updated',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T13:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, e1)
+      appendHistory(dir, e2)
+
+      // Corrupt the JSONL so tail-seek would return null; sidecar must still work
+      const historyDir = path.join(dir, 'history')
+      const jsonlPath = path.join(historyDir, '2026-04.jsonl')
+      fs.appendFileSync(jsonlPath, 'this-is-not-json\n')
+
+      // Third event: predecessor should come from sidecar, not the corrupt JSONL tail
+      const e3: HistoryEvent = {
+        event: 'engram_updated',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T14:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, e3)
+      const events = readHistory(dir, '2026-04')
+      // e3 is at index 2 (0=e1, 1=e2, 2=e3 — corrupt line is skipped)
+      const e3written = events.find(e => e.timestamp === '2026-04-01T14:00:00.000Z')!
+      const e2written = events.find(e => e.timestamp === '2026-04-01T13:00:00.000Z')!
+      // e3 must link back to e2 (via sidecar), not null
+      expect(e3written.prev).toBe(e2written.hash)
+    })
+
+    it('.chain-head does not break the concurrent-writer chain (sidecar survives two sequential writes)', () => {
+      // Simulates two sequential writes from the same process — the sidecar must
+      // track the latest after each write, keeping the chain linear.
+      const writes = 5
+      const events: HistoryEvent[] = Array.from({ length: writes }, (_, i) => ({
+        event: 'engram_created' as const,
+        engram_id: `ENG-${String(i).padStart(3, '0')}`,
+        timestamp: `2026-04-01T${String(i).padStart(2, '0')}:00:00.000Z`,
+        data: {},
+      }))
+      for (const ev of events) appendHistory(dir, ev)
+
+      const historyDir = path.join(dir, 'history')
+      const stored = readHistory(dir, '2026-04')
+      // Sidecar must match the final event
+      expect(readChainHead(historyDir)).toBe(stored[writes - 1].hash)
+      // Chain must be linear: each event's prev = previous event's hash
+      for (let i = 1; i < stored.length; i++) {
+        expect(stored[i].prev).toBe(stored[i - 1].hash)
+      }
     })
   })
 })

--- a/packages/core/test/history-chain.test.ts
+++ b/packages/core/test/history-chain.test.ts
@@ -526,45 +526,61 @@ describe('hash-chain history (#1051)', () => {
       expect(readChainHead(historyDir)).toBe(mayEvents[0].hash)
     })
 
-    it('findPredecessorHash uses .chain-head instead of tail-seeking JSONL when sidecar is present', () => {
-      // Write two events to establish a chain
+    it('findPredecessorHash serves the sidecar while the log is unchanged, and falls through once it is not', () => {
+      // The sidecar is a CACHE of an observation about the JSONL, so it may be
+      // trusted only while that observation still holds. The earlier version of
+      // this test proved the opposite: it appended garbage to the JSONL and then
+      // asserted the sidecar was still used, which is the #1080 defect written
+      // down as desired behaviour — a stale sidecar chained from is exactly the
+      // crash-window fork.
       const e1: HistoryEvent = {
-        event: 'engram_created',
-        engram_id: 'ENG-001',
-        timestamp: '2026-04-01T12:00:00.000Z',
-        data: {},
+        event: 'engram_created', engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z', data: {},
       }
       const e2: HistoryEvent = {
-        event: 'engram_updated',
-        engram_id: 'ENG-001',
-        timestamp: '2026-04-01T13:00:00.000Z',
-        data: {},
+        event: 'engram_updated', engram_id: 'ENG-001',
+        timestamp: '2026-04-01T13:00:00.000Z', data: {},
       }
       appendHistory(dir, e1)
       appendHistory(dir, e2)
 
-      // Corrupt the JSONL so tail-seek would return null; sidecar must still work
       const historyDir = path.join(dir, 'history')
       const jsonlPath = path.join(historyDir, '2026-04.jsonl')
-      fs.appendFileSync(jsonlPath, 'this-is-not-json\n')
 
-      // Third event: predecessor should come from sidecar, not the corrupt JSONL tail
+      // Unchanged log: the sidecar's observation still holds, so it answers.
+      expect(readChainHead(historyDir, jsonlPath)).toBe(e2.hash)
+
+      // Now the log changes underneath it. The sidecar describes a file that no
+      // longer exists in that state, so it must refuse rather than answer.
+      fs.appendFileSync(jsonlPath, 'this-is-not-json\n')
+      expect(readChainHead(historyDir, jsonlPath)).toBeNull()
+
+      // And the next append declares a GAP rather than inventing a link: the
+      // tail is unreadable, so there is no predecessor to be had. That is the
+      // documented contract — never a fabricated prev — and it is visible to
+      // `plur verify`, unlike the stale-sidecar answer it replaces.
       const e3: HistoryEvent = {
-        event: 'engram_updated',
-        engram_id: 'ENG-001',
-        timestamp: '2026-04-01T14:00:00.000Z',
-        data: {},
+        event: 'engram_updated', engram_id: 'ENG-001',
+        timestamp: '2026-04-01T14:00:00.000Z', data: {},
       }
       appendHistory(dir, e3)
-      const events = readHistory(dir, '2026-04')
-      // e3 is at index 2 (0=e1, 1=e2, 2=e3 — corrupt line is skipped)
-      const e3written = events.find(e => e.timestamp === '2026-04-01T14:00:00.000Z')!
-      const e2written = events.find(e => e.timestamp === '2026-04-01T13:00:00.000Z')!
-      // e3 must link back to e2 (via sidecar), not null
-      expect(e3written.prev).toBe(e2written.hash)
+      expect(e3.prev).toBeNull()
+
+      // One-time only: the torn line is no longer last, so the chain resumes.
+      const e4: HistoryEvent = {
+        event: 'engram_updated', engram_id: 'ENG-001',
+        timestamp: '2026-04-01T15:00:00.000Z', data: {},
+      }
+      appendHistory(dir, e4)
+      expect(e4.prev).toBe(e3.hash)
     })
 
-    it('.chain-head does not break the concurrent-writer chain (sidecar survives two sequential writes)', () => {
+    // NOTE: this exercises SEQUENTIAL writes in ONE process. It was previously
+    // named for the concurrent-writer case, which it does not test — a name that
+    // gave false assurance about precisely the risk the sidecar introduces. Real
+    // concurrency coverage lives in test/store-concurrent-chain.test.ts, which
+    // spawns separate processes.
+    it('.chain-head survives repeated sequential writes in one process', () => {
       // Simulates two sequential writes from the same process — the sidecar must
       // track the latest after each write, keeping the chain linear.
       const writes = 5
@@ -684,8 +700,16 @@ describe('hash-chain history (#1051)', () => {
       }
     })
 
-    it('memory cache hit means sidecar read is bypassed (chain remains correct even with a corrupted sidecar)', () => {
-      // Write an event to warm the cache, then corrupt the sidecar on disk
+    it('a still-valid cache is served, and a corrupted sidecar is then irrelevant', () => {
+      // Reframed. This used to be called "memory cache hit means sidecar read is
+      // bypassed", asserting cache-beats-sidecar as a desirable precedence rule.
+      // That framing IS the #1080 defect: an unconditional cache hit is what made
+      // a second process's appends invisible and forked the log.
+      //
+      // The property worth having is narrower: the cache is served only while the
+      // observation it recorded still holds of the file on disk. Here nothing has
+      // touched the JSONL, so it holds, and the state of the sidecar cannot matter.
+      // The companion test below covers the case where it does not hold.
       const historyDir = path.join(dir, 'history')
       const e1: HistoryEvent = {
         event: 'engram_created',
@@ -710,6 +734,38 @@ describe('hash-chain history (#1051)', () => {
       const all = readHistory(dir, '2026-04')
       // e2 must link back to e1 via the memory cache (not null from corrupt sidecar)
       expect(all[1].prev).toBe(written.hash)
+    })
+
+    it('a cache whose observation no longer holds is NOT served', () => {
+      // The other half, and the one that matters: once the log has changed
+      // underneath the cached observation — which is exactly what a second
+      // process appending looks like — the cache must refuse and the lookup must
+      // fall through. Without this the two writers each keep chaining from their
+      // own last write and the log becomes two parallel chains sharing a genesis.
+      const historyDir = path.join(dir, 'history')
+      const e1: HistoryEvent = {
+        event: 'engram_created', engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z', data: {},
+      }
+      appendHistory(dir, e1)
+
+      // Simulate another writer appending a real, well-formed event.
+      const foreign: HistoryEvent = {
+        event: 'engram_created', engram_id: 'ENG-OTHER',
+        timestamp: '2026-04-01T12:30:00.000Z', data: {}, prev: e1.hash!,
+      }
+      foreign.hash = computeEventHash(foreign)
+      fs.appendFileSync(path.join(historyDir, '2026-04.jsonl'), JSON.stringify(foreign) + '\n')
+
+      const e2: HistoryEvent = {
+        event: 'engram_updated', engram_id: 'ENG-001',
+        timestamp: '2026-04-01T13:00:00.000Z', data: {},
+      }
+      appendHistory(dir, e2)
+
+      // Must chain from the FOREIGN event, not from this process's own last write.
+      expect(e2.prev).toBe(foreign.hash)
+      expect(e2.prev).not.toBe(e1.hash)
     })
 
     it('cold cache (after clearChainHeadMemCache) falls back to sidecar, not tail-seek', () => {

--- a/packages/core/test/history-chain.test.ts
+++ b/packages/core/test/history-chain.test.ts
@@ -25,6 +25,8 @@ import {
   sortKeysDeep,
   tailSeekLastHash,
   readChainHead,
+  clearChainHeadMemCache,
+  findPredecessorHash,
   type HistoryEvent,
 } from '../src/history.js'
 
@@ -582,6 +584,151 @@ describe('hash-chain history (#1051)', () => {
       for (let i = 1; i < stored.length; i++) {
         expect(stored[i].prev).toBe(stored[i - 1].hash)
       }
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // In-process memory cache (#1051 perf regression fix)
+  // ---------------------------------------------------------------------------
+
+  describe('in-process chain-head memory cache', () => {
+    beforeEach(() => {
+      // Flush the module-level cache so each test starts cold.
+      clearChainHeadMemCache()
+    })
+
+    it('appendHistory populates the memory cache after the first write', () => {
+      const historyDir = path.join(dir, 'history')
+      const event: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, event)
+      const [written] = readHistory(dir, '2026-04')
+      // findPredecessorHash with a fresh month file returns the cached hash
+      // (would be the written hash if found via memory cache or sidecar)
+      const monthFile = path.join(historyDir, '2026-05.jsonl') // non-existent future month
+      const result = findPredecessorHash(historyDir, monthFile)
+      expect(result).toBe(written.hash)
+    })
+
+    it('memory cache is updated to the latest hash after each write', () => {
+      const historyDir = path.join(dir, 'history')
+      const e1: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      const e2: HistoryEvent = {
+        event: 'engram_updated',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T13:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, e1)
+      appendHistory(dir, e2)
+      const stored = readHistory(dir, '2026-04')
+      // After two writes the cache must reflect the second event
+      const monthFile = path.join(historyDir, '2026-05.jsonl')
+      expect(findPredecessorHash(historyDir, monthFile)).toBe(stored[1].hash)
+    })
+
+    it('clearChainHeadMemCache clears a specific historyDir', () => {
+      const historyDir = path.join(dir, 'history')
+      const event: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, event)
+      const [written] = readHistory(dir, '2026-04')
+      // Cache is warm — findPredecessorHash returns from memory
+      const monthFile = path.join(historyDir, '2026-05.jsonl')
+      expect(findPredecessorHash(historyDir, monthFile)).toBe(written.hash)
+
+      // Clear the cache for this specific dir
+      clearChainHeadMemCache(historyDir)
+
+      // After clearing, findPredecessorHash falls through to sidecar/tail-seek
+      // and still returns the correct hash (sidecar was written by appendHistory)
+      expect(findPredecessorHash(historyDir, monthFile)).toBe(written.hash)
+    })
+
+    it('clearChainHeadMemCache() with no argument clears all entries', () => {
+      // Write to two different store roots to populate two cache entries
+      const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-chain2-'))
+      try {
+        const event: HistoryEvent = {
+          event: 'engram_created',
+          engram_id: 'ENG-001',
+          timestamp: '2026-04-01T12:00:00.000Z',
+          data: {},
+        }
+        appendHistory(dir, { ...event })
+        appendHistory(dir2, { ...event })
+        // Both caches are warm — clear all
+        clearChainHeadMemCache()
+        // After clearing, both dirs fall through to sidecar (still correct)
+        const h1 = path.join(dir, 'history')
+        const h2 = path.join(dir2, 'history')
+        const [w1] = readHistory(dir, '2026-04')
+        const [w2] = readHistory(dir2, '2026-04')
+        expect(findPredecessorHash(h1, path.join(h1, '2026-05.jsonl'))).toBe(w1.hash)
+        expect(findPredecessorHash(h2, path.join(h2, '2026-05.jsonl'))).toBe(w2.hash)
+      } finally {
+        fs.rmSync(dir2, { recursive: true, force: true })
+      }
+    })
+
+    it('memory cache hit means sidecar read is bypassed (chain remains correct even with a corrupted sidecar)', () => {
+      // Write an event to warm the cache, then corrupt the sidecar on disk
+      const historyDir = path.join(dir, 'history')
+      const e1: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, e1)
+      const [written] = readHistory(dir, '2026-04')
+
+      // Corrupt the sidecar — an in-memory cache hit must bypass this entirely
+      fs.writeFileSync(path.join(historyDir, '.chain-head'), 'invalid\n', 'utf8')
+
+      // Second event: predecessor should come from memory cache, not the corrupt sidecar
+      const e2: HistoryEvent = {
+        event: 'engram_updated',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T13:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, e2)
+      const all = readHistory(dir, '2026-04')
+      // e2 must link back to e1 via the memory cache (not null from corrupt sidecar)
+      expect(all[1].prev).toBe(written.hash)
+    })
+
+    it('cold cache (after clearChainHeadMemCache) falls back to sidecar, not tail-seek', () => {
+      // Write to create sidecar, then clear the in-process cache
+      const historyDir = path.join(dir, 'history')
+      const event: HistoryEvent = {
+        event: 'engram_created',
+        engram_id: 'ENG-001',
+        timestamp: '2026-04-01T12:00:00.000Z',
+        data: {},
+      }
+      appendHistory(dir, event)
+      const [written] = readHistory(dir, '2026-04')
+      clearChainHeadMemCache(historyDir)
+
+      // Sidecar is intact; tail of JSONL is valid — both would return the right answer.
+      // Verify that findPredecessorHash still returns the correct hash after cache eviction.
+      const monthFile = path.join(historyDir, '2026-04.jsonl')
+      expect(findPredecessorHash(historyDir, monthFile)).toBe(written.hash)
     })
   })
 })

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -336,7 +336,7 @@ describe('forget() — remote routing (issue #84)', () => {
 
     // Check history file
     const historyDir = join(primaryDir, 'history')
-    const files = existsSync(historyDir) ? readdirSync(historyDir) : []
+    const files = existsSync(historyDir) ? readdirSync(historyDir).filter(f => f.endsWith('.jsonl')) : []
     expect(files.length).toBeGreaterThan(0)
 
     const historyContent = readFileSync(join(historyDir, files[0]), 'utf-8')
@@ -710,7 +710,7 @@ describe('feedback() — remote routing (issue #85)', () => {
     await plur.feedback('ENG-REMOTE-FB-002', 'negative')
 
     const historyDir = join(primaryDir, 'history')
-    const files = existsSync(historyDir) ? readdirSync(historyDir) : []
+    const files = existsSync(historyDir) ? readdirSync(historyDir).filter(f => f.endsWith('.jsonl')) : []
     expect(files.length).toBeGreaterThan(0)
 
     const historyContent = readFileSync(join(historyDir, files[0]), 'utf-8')


### PR DESCRIPTION
## Summary

Two-phase follow-up to the hash-chain regression introduced by #1051:

### Phase 1 — `.chain-head` sidecar (64-byte cross-process fast path)
- Adds a `.chain-head` sidecar file in the history directory, written after every successful JSONL append
- `findPredecessorHash` reads the sidecar first (64 bytes vs 8 KiB tail-seek + JSON.parse)
- Exports `readChainHead` from the public API

### Phase 2 — In-process memory cache (zero disk I/O on hot write path)
- Module-level `Map<historyDir, string>` as a third tier in front of the sidecar
- After every successful JSONL write, `appendHistory` sets the map entry — every subsequent write pays zero disk I/O for the predecessor lookup
- Exports `clearChainHeadMemCache(historyDir?)` for callers to evict after store reload

Three-tier lookup in `findPredecessorHash`:
1. In-process memory cache — zero disk I/O
2. Sidecar `.chain-head` — 65-byte disk read (cross-process fast path)
3. JSONL tail-seek — up to 8 KiB + JSON.parse (slow fallback)

## Motivation

PR #1051 introduced hash-chain linkage (`prev`/`hash` on every history event). The predecessor lookup — `tailSeekLastHash()` — ran on every `appendHistory()` call inside the store lock, reading up to 8 KiB and parsing JSON on each write. Benchmark: main p50=52.87ms → PR p50=65.93ms (+13.06ms, +24.7%).

Phase 1 reduced to a 64-byte sidecar read. Phase 2 eliminates the read entirely on the hot single-process path.

Design constraints:
- **Advisory, not authoritative** — JSONL files remain source of truth; stale/missing cache or sidecar falls back to tail-seek
- **Cross-process correct** — sidecar handles concurrent writers; in-process cache covers the common single-process burst
- **Best-effort** — `writeChainHead` and cache updates never propagate failures

## Tests (23 new)

Sidecar edge cases, integration with `appendHistory`, cross-month continuity, corrupt-JSONL bypass, in-process cache population/update/clear, corrupted-sidecar bypass (cache hit wins), cold-cache sidecar fallback.

Also: two `remote-routing.test.ts` assertions now filter `readdirSync(historyDir)` for `.jsonl` — the sidecar sorts before JSONL filenames (`.` < `2`), so `files[0]` was returning sidecar content and failing `toContain` assertions.

## Evidence

```
history-chain.test.ts:  43/43 passed ✓
remote-routing.test.ts: all passing after .jsonl filter fix ✓
Full suite: 190/191 test files pass (concurrency-auto-discover fails only in /tmp worktrees — /tmp guard in autoDiscoverStores, not caused by this PR)
```

Closes #1051 (performance regression).

---

## Rescoped 2026-08-31 (force-push)

Addressing the **Scope** section of the review — "9 commits and 21 files, of which 3 relate to
the stated purpose".

Rebuilt to carry only the three commits that do: the `.chain-head` sidecar, the in-process
cache, and the `readdir` `.jsonl` filter the sidecar requires. Dropped the Hermes
`MemoryProvider`, packs INTEGRITY (#987), the tensions gate (#869), and a ROADMAP edit.

**Now stacked**: base is `feat/1052-checkpoint-event` (#1073) rather than `main`, so the diff
is the perf work alone — **`+422 / -5` across 4 files**, down from 21 files. #1073 in turn
targets `integration/core-store`. A revert of the perf work no longer drags four unrelated
features with it.

The three blocking defects are **not** fixed by this push:

1. tier-1 returning the `Map` unconditionally → cross-process fork
2. the fsync/cache/sidecar crash window → fork with no gap
3. no invalidation when a store is recreated at the same path → dangling `prev`, false genesis

Those are next. The planned fix for (1) is your own suggestion — cache `{hash, jsonlSize}` and
accept it only while a single `statSync` on the month file still matches the recorded size,
failing closed to the sidecar the moment another writer appends.

The two tests you named will go with it: `history-chain.test.ts:687` currently writes
cache-beats-sidecar down as desired behaviour and would block the fix, and `:567` is named for
a concurrency it does not exercise.

`plur verify` (#1053) is being built first, since your review established that every one of
these failures is silent today.
