### PR TITLE
feat(hermes): PlurMemoryProvider ABC adapter — land on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,25 @@
 # Changelog
 
-## Unreleased
+## 0.19.2
 
-- **`plur-hermes` MemoryProvider ABC adapter** (#1081): `PlurMemoryProvider` implements the
-  Hermes `MemoryProvider` ABC (`prefetch`, `sync_turn`, `on_session_end`,
-  `system_prompt_block`). Register via `memory.provider: plur` in Hermes config (Herald
-  Release ≥ 0.20.0). When both the standalone plugin path and the MemoryProvider path are
-  active they share one `PlurBridge` instance — no duplicate CLI subprocess spawns. Older
-  Hermes versions without `register_memory_provider()` are unaffected. First published in
-  `plur-hermes==0.18.1` (out-of-band); this commit lands the feature on main so it ships in
-  all subsequent releases.
+PLUR MemoryProvider for Hermes Herald; provenance on push.
+
+- `memory.provider: plur` in Hermes ≥ 0.20.0 (#1081)
+- Remote store carries provenance on push (#983)
+
+**`plur-hermes` MemoryProvider ABC adapter** (#1081): `PlurMemoryProvider` implements the
+Hermes `MemoryProvider` ABC (`prefetch`, `sync_turn`, `on_session_end`,
+`system_prompt_block`). Register via `memory.provider: plur` in Hermes config (Herald
+Release ≥ 0.20.0). When both the standalone plugin path and the MemoryProvider path are
+active they share one `PlurBridge` instance — no duplicate CLI subprocess spawns. Older
+Hermes versions without `register_memory_provider()` are unaffected. First published in
+`plur-hermes==0.18.1` (out-of-band); this commit lands the feature on main so it ships in
+all subsequent releases.
+
+**Remote store provenance** (#983): `RemoteStore.append()` now includes the `provenance`
+field on outbound bodies. Engrams pushed to a team store no longer arrive stripped of
+`origin`, `chain`, and licence information. Omitted when unset for wire-body
+compatibility. Partial fix — `attribution` and `claim_class` follow in #963.
 
 ## 0.19.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **`plur-hermes` MemoryProvider ABC adapter** (#1081): `PlurMemoryProvider` implements the
+  Hermes `MemoryProvider` ABC (`prefetch`, `sync_turn`, `on_session_end`,
+  `system_prompt_block`). Register via `memory.provider: plur` in Hermes config (Herald
+  Release ≥ 0.20.0). When both the standalone plugin path and the MemoryProvider path are
+  active they share one `PlurBridge` instance — no duplicate CLI subprocess spawns. Older
+  Hermes versions without `register_memory_provider()` are unaffected. First published in
+  `plur-hermes==0.18.1` (out-of-band); this commit lands the feature on main so it ships in
+  all subsequent releases.
+
 ## 0.19.1
 
 Patch release (#1072): every finding from the independent 0.19.0 audit (#1058),

--- a/packages/hermes/README.md
+++ b/packages/hermes/README.md
@@ -66,16 +66,45 @@ PLUR sits alongside Hermes memory, not replacing it. Your MEMORY.md and USER.md 
 
 ## Configuration
 
-The plugin works with zero configuration. Optional env vars:
+The plugin works with zero configuration and is auto-discovered on startup. You can also register it explicitly as a first-class memory provider in your Hermes config.
+
+### Integration paths
+
+PLUR integrates via two paths — both coexist and can be used together:
+
+**Path 1: Auto-discovery (default)**
+
+Once installed, the plugin is auto-discovered by Hermes via `hermes_agent.plugins` discovery. No additional configuration needed.
+
+**Path 2: Explicit memory provider (v0.19.0+)**
+
+For Hermes v0.19.0+ (Herald Release), register PLUR as an explicit memory provider in your `hermes-config.json` or equivalent:
+
+```json
+{
+  "memory": {
+    "provider": "plur",
+    "config": {
+      "inject_mode": "fast"
+    }
+  }
+}
+```
+
+This gives PLUR first-class status in your agent's memory system. Both paths can coexist — if both are active, both injection and learning pipelines run.
+
+### Environment variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PLUR_PATH` | `~/.plur` | Storage directory |
-| `PLUR_INJECT_MODE` | `fast` | Set to `hybrid` for embedding-based injection (slower, more accurate) |
+| `PLUR_INJECT_MODE` | `fast` | Injection strategy: `fast` (BM25 only, <100ms) or `hybrid` (BM25 + embeddings, ~500ms, more accurate). Embeddings are computed locally; no external APIs. |
+
+The `memory.provider: plur` config's `inject_mode` field overrides `PLUR_INJECT_MODE` if both are set.
 
 ## Requirements
 
-- Hermes Agent v0.5.0+
+- Hermes Agent v0.5.0+ (MemoryProvider path requires v0.19.0+ Herald Release)
 - Python 3.10+
 - Node.js 18+ (for CLI, auto-resolved via npx if not installed globally)
 

--- a/packages/hermes/plugin.yaml
+++ b/packages/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: plur
-version: 0.19.2
+version: 0.19.3
 description: Persistent memory that improves over time — learn, recall, inject, forget, feedback, meta-engram extraction
 provides_tools:
   - plur_learn

--- a/packages/hermes/plugin.yaml
+++ b/packages/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: plur
-version: 0.19.1
+version: 0.19.2
 description: Persistent memory that improves over time — learn, recall, inject, forget, feedback, meta-engram extraction
 provides_tools:
   - plur_learn

--- a/packages/hermes/plur_hermes/__init__.py
+++ b/packages/hermes/plur_hermes/__init__.py
@@ -496,3 +496,13 @@ def register(ctx):
 
     total_tools = len(TOOL_SCHEMAS) + len(META_TOOL_SCHEMAS)
     logger.info(f"PLUR registered: 4 hooks + {total_tools} tools (incl. meta)")
+
+    # --- MemoryProvider path ---
+    # Register PlurMemoryProvider with Hermes when the context supports it
+    # (Hermes Herald Release and later).  Standalone plugin contexts from older
+    # Hermes versions lack register_memory_provider() — guard with hasattr so
+    # those hosts keep working unchanged.
+    if hasattr(ctx, "register_memory_provider"):
+        from .memory_provider import PlurMemoryProvider
+        ctx.register_memory_provider(PlurMemoryProvider(bridge=bridge))
+        logger.info("PLUR MemoryProvider registered (hermes_agent.memory_providers path)")

--- a/packages/hermes/plur_hermes/bridge.py
+++ b/packages/hermes/plur_hermes/bridge.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("plur_hermes.bridge")
 # demotion and unscoped auto-routing on the npx-fallback path. release.sh
 # rewrites this to the release version on every release (mirroring the pyproject
 # bump), and check_version_sync.py enforces pin >= the published @plur-ai/cli.
-_NPX_CLI_VERSION = "0.19.1"
+_NPX_CLI_VERSION = "0.19.2"
 
 _DEFAULT_DEDUP_CACHE_SIZE = 256
 # TTL (seconds) on dedup-cache entries — the in-process half of #120.

--- a/packages/hermes/plur_hermes/bridge.py
+++ b/packages/hermes/plur_hermes/bridge.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("plur_hermes.bridge")
 # demotion and unscoped auto-routing on the npx-fallback path. release.sh
 # rewrites this to the release version on every release (mirroring the pyproject
 # bump), and check_version_sync.py enforces pin >= the published @plur-ai/cli.
-_NPX_CLI_VERSION = "0.19.2"
+_NPX_CLI_VERSION = "0.19.3"
 
 _DEFAULT_DEDUP_CACHE_SIZE = 256
 # TTL (seconds) on dedup-cache entries — the in-process half of #120.

--- a/packages/hermes/plur_hermes/memory_provider.py
+++ b/packages/hermes/plur_hermes/memory_provider.py
@@ -1,0 +1,741 @@
+"""PlurMemoryProvider — MemoryProvider ABC adapter for plur-hermes.
+
+Bridges the Hermes MemoryProvider lifecycle to the PLUR CLI via PlurBridge.
+This adapter allows PLUR to be activated as a proper Hermes memory provider
+(``memory.provider: plur`` in config.yaml) rather than only as a standalone
+plugin in the ``hermes_agent.plugins`` entry-point group.
+
+Both paths are mutually compatible and may run in the same process:
+- Standalone path (hermes_agent.plugins): registers hooks + tools via
+  ``ctx.register_hook()`` / ``ctx.register_tool()``.  Always active when
+  plur-hermes is installed.
+- MemoryProvider path (hermes_agent.memory_providers): exposes PLUR through
+  the official MemoryProvider ABC so it appears in ``hermes plugins --memory``
+  and can be selected via ``memory.provider: plur`` in config.yaml.
+
+The two paths share a single ``PlurBridge`` instance when both are active,
+so CLI subprocess spawns are deduplicated across both lifecycle paths.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from .bridge import PlurBridge, PlurBridgeError, PlurNotFoundError
+from .learner import extract_learning_patterns
+
+logger = logging.getLogger("plur_hermes.memory_provider")
+
+# Tool schemas re-exported for the MemoryProvider path.  The standalone path
+# registers these via ctx.register_tool(); the MemoryProvider path exposes
+# them via get_tool_schemas() so MemoryManager can inject them into the
+# agent's tool surface.  The schema list is factored out here so both paths
+# share a single source of truth without cross-importing __init__.py.
+_PLUR_TOOL_SCHEMAS: List[Dict[str, Any]] = [
+    {
+        "name": "plur_learn",
+        "description": "Create a new engram — store a correction, preference, pattern, or decision",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "statement": {"type": "string", "description": "The knowledge assertion"},
+                "scope": {"type": "string", "default": "global"},
+                "type": {
+                    "type": "string",
+                    "enum": ["behavioral", "terminological", "procedural", "architectural"],
+                    "default": "behavioral",
+                },
+                "domain": {"type": "string"},
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Classification tags",
+                },
+                "rationale": {"type": "string", "description": "Why this knowledge matters"},
+                "visibility": {
+                    "type": "string",
+                    "enum": ["private", "public", "template"],
+                    "default": "private",
+                },
+                "knowledge_anchors": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "relevance": {"type": "number"},
+                            "snippet": {"type": "string"},
+                        },
+                    },
+                    "description": "Related file references",
+                },
+                "dual_coding": {
+                    "type": "object",
+                    "properties": {
+                        "example": {"type": "string"},
+                        "analogy": {"type": "string"},
+                    },
+                    "description": "Concrete example and analogy",
+                },
+                "abstract": {"type": "string", "description": "One-line abstract"},
+                "derived_from": {
+                    "type": "string",
+                    "description": "Source engram ID this was derived from",
+                },
+                "force": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Skip duplicate detection and always create a new engram",
+                },
+            },
+            "required": ["statement"],
+        },
+    },
+    {
+        "name": "plur_recall",
+        "description": "Search engrams by topic",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer", "default": 10},
+                "fast": {"type": "boolean", "default": False},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "plur_inject",
+        "description": "Get relevant engrams for a task (three-tier output)",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "task": {"type": "string"},
+                "budget": {"type": "integer", "default": 2000},
+                "fast": {"type": "boolean", "default": False},
+            },
+            "required": ["task"],
+        },
+    },
+    {
+        "name": "plur_list",
+        "description": "List all engrams with optional filtering",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "type": {"type": "string"},
+                "scope": {"type": "string"},
+                "limit": {"type": "integer"},
+                "meta": {"type": "boolean", "default": False},
+            },
+        },
+    },
+    {
+        "name": "plur_forget",
+        "description": "Retire an engram by ID or search query",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "search": {
+                    "type": "string",
+                    "description": "Forget engrams matching this search query",
+                },
+                "reason": {"type": "string"},
+            },
+        },
+    },
+    {
+        "name": "plur_feedback",
+        "description": "Rate an engram (positive|negative|neutral) — supports single or batch mode",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "signal": {
+                    "type": "string",
+                    "enum": ["positive", "negative", "neutral"],
+                },
+                "batch": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "signal": {"type": "string"},
+                        },
+                    },
+                    "description": "Batch feedback: list of {id, signal} pairs",
+                },
+            },
+        },
+    },
+    {
+        "name": "plur_capture",
+        "description": "Record an episode to the timeline",
+        "parameters": {
+            "type": "object",
+            "properties": {"summary": {"type": "string"}},
+            "required": ["summary"],
+        },
+    },
+    {
+        "name": "plur_timeline",
+        "description": "Query the episodic timeline",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer", "default": 20},
+            },
+        },
+    },
+    {
+        "name": "plur_status",
+        "description": "Check PLUR system health",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "plur_sync",
+        "description": "Cross-device sync via git",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "plur_packs_list",
+        "description": "List installed engram packs",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "plur_packs_install",
+        "description": "Install an engram pack",
+        "parameters": {
+            "type": "object",
+            "properties": {"source": {"type": "string"}},
+            "required": ["source"],
+        },
+    },
+    {
+        "name": "plur_ingest",
+        "description": "Extract and save engrams from content (text, logs, conversations)",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "Text content to extract engrams from",
+                },
+                "source": {"type": "string", "description": "Source identifier"},
+                "extract_only": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "If true, extract but don't save",
+                },
+                "scope": {"type": "string"},
+                "domain": {"type": "string"},
+            },
+            "required": ["content"],
+        },
+    },
+    {
+        "name": "plur_packs_export",
+        "description": "Export engrams as a shareable pack",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "domain": {"type": "string"},
+                "scope": {"type": "string"},
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "plur_promote",
+        "description": "Promote an engram — increase its activation and priority",
+        "parameters": {
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        },
+    },
+    {
+        "name": "plur_stores_add",
+        "description": "Add a knowledge store path",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "scope": {"type": "string", "default": "global"},
+                "shared": {"type": "boolean", "default": False},
+                "readonly": {"type": "boolean", "default": False},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "plur_stores_list",
+        "description": "List configured knowledge stores",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "plur_similarity_search",
+        "description": (
+            "Search engrams by cosine similarity, returning scores. "
+            "Scores > 0.9 indicate duplicates, 0.7-0.9 related, < 0.7 new."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "limit": {"type": "integer", "default": 10},
+                "scope": {"type": "string"},
+            },
+            "required": ["query"],
+        },
+    },
+]
+
+# Correction markers for heuristic feedback signal detection (mirrors __init__.py).
+_CORRECTION_MARKERS = (
+    "actually,", "actually ", "no,", "wrong,", "incorrect,",
+    "that's wrong", "not correct", "that is wrong",
+)
+_FEEDBACK_MIN_CONFIDENCE = 0.6
+
+
+def _detect_injection_signal(engram_text: str, response: str) -> tuple[str | None, float]:
+    """Re-exported from __init__.py for symmetric signal detection on the MemoryProvider path."""
+    response_lower = response.lower()
+    engram_lower = engram_text.lower().strip()
+    if not engram_lower:
+        return None, 0.0
+    if engram_lower in response_lower:
+        return "positive", 0.95
+    words = engram_lower.split()
+    tris: set[str] = set()
+    if len(words) >= 3:
+        tris = {" ".join(words[i:i + 3]) for i in range(len(words) - 2)}
+    elif words:
+        tris = set(words)
+    if tris:
+        resp_words = response_lower.split()
+        resp_tris: set[str] = set()
+        if len(resp_words) >= 3:
+            resp_tris = {" ".join(resp_words[i:i + 3]) for i in range(len(resp_words) - 2)}
+        elif resp_words:
+            resp_tris = set(resp_words)
+        if resp_tris:
+            overlap = len(tris & resp_tris) / len(tris)
+            if overlap >= 0.8:
+                return "positive", 0.7 + 0.3 * overlap
+    engram_words = {w for w in engram_lower.split() if len(w) > 4}
+    if engram_words:
+        for marker in _CORRECTION_MARKERS:
+            idx = response_lower.find(marker)
+            while idx != -1:
+                window = response_lower[max(0, idx - 100):idx + 200]
+                if any(w in window for w in engram_words):
+                    return "negative", 0.65
+                idx = response_lower.find(marker, idx + 1)
+    return None, 0.0
+
+
+class PlurMemoryProvider:
+    """Hermes MemoryProvider ABC adapter for PLUR persistent memory.
+
+    Implements the MemoryProvider ABC so PLUR can be selected as a first-class
+    Hermes memory provider via ``memory.provider: plur`` in config.yaml. The
+    provider exposes the same PLUR tools as the standalone hook path and adds
+    MemoryProvider-specific lifecycle integrations:
+
+    - ``prefetch()``      — inject engrams relevant to the upcoming user turn
+    - ``sync_turn()``     — auto-learn from completed turns (mirrors post_llm_call)
+    - ``on_session_end()``— capture session episode at the real session boundary
+    - ``system_prompt_block()`` — static PLUR status text in the system prompt
+
+    When both this provider and the standalone plugin path are active in the same
+    process (which is the default when plur-hermes is installed), they share a
+    single ``PlurBridge`` instance via the ``bridge`` parameter so CLI subprocess
+    spawns are deduplicated.
+    """
+
+    def __init__(self, bridge: Optional[PlurBridge] = None) -> None:
+        # Accept an injected bridge so the standalone plugin path can share
+        # its bridge instance.  Fall back to creating a fresh one if called
+        # directly (e.g. when loaded via hermes_agent.memory_providers entry
+        # point without the standalone plugin also being active).
+        self._bridge: Optional[PlurBridge] = bridge
+        self._available: Optional[bool] = None  # cached; None = not yet checked
+        self._session_id: str = ""
+        self._platform: str = "unknown"
+        self._agent_context: str = "primary"
+        self._injected_engrams: list[dict] = []   # cleared after feedback flush
+        self._injected_lock = threading.Lock()
+        self._learn_count: int = 0
+
+    # -- Lazy bridge construction --------------------------------------------
+
+    def _get_bridge(self) -> PlurBridge:
+        if self._bridge is None:
+            self._bridge = PlurBridge()
+        return self._bridge
+
+    # -- MemoryProvider ABC --------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "plur"
+
+    def is_available(self) -> bool:
+        """Return True if the PLUR CLI is reachable.
+
+        Results are cached after the first check so repeated calls during
+        Hermes startup (discover + load) don't spawn multiple CLI subprocesses.
+        """
+        if self._available is not None:
+            return self._available
+        try:
+            bridge = self._get_bridge()
+            bridge.status()
+            self._available = True
+        except (PlurNotFoundError, PlurBridgeError, Exception):
+            self._available = False
+        return self._available
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Initialize provider for a Hermes session.
+
+        Verifies CLI availability and logs engram count.  Extracts
+        ``hermes_home``, ``platform``, and ``agent_context`` from kwargs.
+        """
+        self._session_id = session_id
+        self._platform = kwargs.get("platform", "unknown")
+        self._agent_context = kwargs.get("agent_context", "primary")
+        self._learn_count = 0
+        self._injected_engrams = []
+        try:
+            bridge = self._get_bridge()
+            status = bridge.status()
+            logger.info(
+                "PLUR MemoryProvider initialized: session=%s platform=%s "
+                "engrams=%s context=%s",
+                session_id, self._platform,
+                status.get("engram_count", "?"),
+                self._agent_context,
+            )
+        except Exception as e:
+            logger.warning("PLUR MemoryProvider initialize: status check failed: %s", e)
+
+    def system_prompt_block(self) -> str:
+        """Return a brief static PLUR context block for the system prompt.
+
+        Intentionally terse — detailed recalled context is injected per-turn
+        via ``prefetch()``.  Returns empty string on any bridge failure so a
+        broken PLUR install never corrupts the system prompt.
+        """
+        try:
+            bridge = self._get_bridge()
+            status = bridge.status()
+            count = status.get("engram_count")
+            if count is None:
+                return ""
+            return (
+                f"PLUR persistent memory is active with {count} engrams. "
+                "Use plur_recall to search memory and plur_learn to store new knowledge."
+            )
+        except Exception:
+            return ""
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Inject engrams relevant to ``query`` before the LLM call.
+
+        Uses the fast inject path (BM25 only) to stay under the tight
+        per-turn deadline.  Switch to hybrid via ``PLUR_INJECT_MODE=hybrid``.
+        Stores injected engram metadata so ``sync_turn`` can send feedback
+        after the turn.
+
+        Returns formatted text for Hermes to include as context, or empty
+        string if nothing relevant or on any bridge failure.
+        """
+        if not query:
+            return ""
+        try:
+            bridge = self._get_bridge()
+            mode = os.environ.get("PLUR_INJECT_MODE", "fast")
+            fast = mode != "hybrid"
+            result = bridge.inject(query, fast=fast)
+            if result.get("count", 0) == 0:
+                return ""
+
+            # Cache injected engrams for post-turn feedback.
+            new_engrams = [
+                {"id": e.get("id"), "statement": e.get("statement", "")}
+                for e in result.get("results", [])
+                if e.get("id") and e.get("statement")
+            ]
+            with self._injected_lock:
+                self._injected_engrams.extend(new_engrams)
+
+            # Build the context block.
+            lines = []
+            if result.get("directives"):
+                lines.append(result["directives"])
+            if result.get("constraints"):
+                lines.append(result["constraints"])
+            if result.get("consider"):
+                lines.append(result["consider"])
+            return "\n".join(lines) if lines else ""
+        except Exception as e:
+            logger.debug("PLUR prefetch failed (non-fatal): %s", e)
+            return ""
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Auto-learn from the completed turn and send injection feedback.
+
+        Mirrors the ``post_llm_call`` hook behaviour:
+        1. Extract self-reported learnings from the assistant response.
+        2. Send positive/negative feedback signals for injected engrams that
+           appeared or were contradicted in the response.
+
+        Only writes in the ``primary`` agent context — skipping cron and
+        subagent contexts matches the standalone hook path's behaviour (no
+        writes for contexts where the user representation would be corrupted).
+        """
+        if self._agent_context != "primary":
+            return
+
+        response = assistant_content or ""
+        bridge = self._get_bridge()
+
+        # 1. Auto-learn from self-reported patterns.
+        try:
+            learnings = extract_learning_patterns(response)
+            for statement in learnings:
+                bridge.learn(
+                    statement,
+                    source="hermes:auto",
+                    rationale="Auto-extracted from assistant self-report",
+                )
+                self._learn_count += 1
+        except Exception as e:
+            logger.debug("PLUR sync_turn: learning extraction failed: %s", e)
+
+        # 2. Injection feedback.
+        if os.environ.get("PLUR_INJECTION_FEEDBACK", "true").lower() == "false":
+            return
+        try:
+            with self._injected_lock:
+                snapshot = list(self._injected_engrams)
+                self._injected_engrams = []
+
+            if not snapshot or not response:
+                return
+
+            feedback_batch: list[tuple[str, str]] = []
+            for engram in snapshot:
+                eid = engram.get("id")
+                text = engram.get("statement", "")
+                if not eid or not text:
+                    continue
+                signal, confidence = _detect_injection_signal(text, response)
+                if signal and confidence >= _FEEDBACK_MIN_CONFIDENCE:
+                    feedback_batch.append((eid, signal))
+            if feedback_batch:
+                bridge.feedback(batch=feedback_batch)
+        except Exception as e:
+            logger.debug("PLUR sync_turn: injection feedback failed: %s", e)
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Capture a session episode when the session actually ends.
+
+        This fires at real session boundaries (``/reset``, ``/new``, CLI exit,
+        gateway session expiry) — NOT after every turn.  Mirrors the
+        ``on_session_end`` hook's capture call so both paths record the same
+        episode regardless of which is active.
+        """
+        try:
+            bridge = self._get_bridge()
+            parts = [f"Hermes session {self._session_id}"]
+            if self._learn_count:
+                parts.append(f"— {self._learn_count} learnings captured")
+            parts.append(f"[{self._platform}]")
+            bridge.capture(" ".join(parts), agent="hermes", session=self._session_id)
+        except Exception as e:
+            logger.debug("PLUR on_session_end: capture failed: %s", e)
+        finally:
+            self._session_id = ""
+            self._learn_count = 0
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return the PLUR tool schemas for MemoryManager injection."""
+        return list(_PLUR_TOOL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        """Dispatch a PLUR tool call from the MemoryManager routing layer."""
+        try:
+            bridge = self._get_bridge()
+            result = self._dispatch(bridge, tool_name, args)
+            return json.dumps(result)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    def _dispatch(self, bridge: PlurBridge, tool_name: str, args: Dict[str, Any]) -> Any:
+        """Route ``tool_name`` to the correct PlurBridge method."""
+        if tool_name == "plur_learn":
+            return bridge.learn(
+                args["statement"],
+                scope=args.get("scope", "global"),
+                type=args.get("type", "behavioral"),
+                domain=args.get("domain"),
+                tags=args.get("tags"),
+                rationale=args.get("rationale"),
+                visibility=args.get("visibility"),
+                knowledge_anchors=args.get("knowledge_anchors"),
+                dual_coding=args.get("dual_coding"),
+                abstract=args.get("abstract"),
+                derived_from=args.get("derived_from"),
+                force=args.get("force", False),
+            )
+        if tool_name == "plur_recall":
+            return bridge.recall(
+                args["query"],
+                limit=args.get("limit", 10),
+                fast=args.get("fast", False),
+            )
+        if tool_name == "plur_inject":
+            return bridge.inject(
+                args["task"],
+                budget=args.get("budget", 2000),
+                fast=args.get("fast", False),
+            )
+        if tool_name == "plur_list":
+            return bridge.list_engrams(
+                domain=args.get("domain"),
+                type=args.get("type"),
+                scope=args.get("scope"),
+                limit=args.get("limit"),
+                meta=args.get("meta", False),
+            )
+        if tool_name == "plur_forget":
+            return bridge.forget(
+                id=args.get("id"),
+                reason=args.get("reason"),
+                search=args.get("search"),
+            )
+        if tool_name == "plur_feedback":
+            batch = args.get("batch")
+            if batch:
+                return bridge.feedback(
+                    batch=[(item["id"], item["signal"]) for item in batch]
+                )
+            return bridge.feedback(args["id"], args["signal"])
+        if tool_name == "plur_capture":
+            return bridge.capture(args["summary"])
+        if tool_name == "plur_timeline":
+            return bridge.timeline(
+                query=args.get("query"),
+                limit=args.get("limit", 20),
+            )
+        if tool_name == "plur_status":
+            return bridge.status()
+        if tool_name == "plur_sync":
+            return bridge.sync()
+        if tool_name == "plur_ingest":
+            return bridge.ingest(
+                args["content"],
+                source=args.get("source"),
+                extract_only=args.get("extract_only", False),
+                scope=args.get("scope"),
+                domain=args.get("domain"),
+            )
+        if tool_name == "plur_packs_list":
+            return bridge.packs_list()
+        if tool_name == "plur_packs_install":
+            return bridge.packs_install(args["source"])
+        if tool_name == "plur_packs_export":
+            export_args = [args["name"]]
+            if args.get("domain"):
+                export_args.extend(["--domain", args["domain"]])
+            if args.get("scope"):
+                export_args.extend(["--scope", args["scope"]])
+            return bridge.call("packs", ["export"] + export_args)
+        if tool_name == "plur_promote":
+            return bridge.promote(args["id"])
+        if tool_name == "plur_stores_add":
+            return bridge.stores_add(
+                args["path"],
+                scope=args.get("scope", "global"),
+                shared=args.get("shared", False),
+                readonly=args.get("readonly", False),
+            )
+        if tool_name == "plur_stores_list":
+            return bridge.stores_list()
+        if tool_name == "plur_similarity_search":
+            return bridge.similarity_search(
+                args["query"],
+                limit=args.get("limit", 10),
+                scope=args.get("scope"),
+            )
+        return {"error": f"Unknown tool: {tool_name}"}
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        """Return config fields for ``hermes memory setup``.
+
+        PLUR stores its config in ``~/.plur/`` (or ``$PLUR_PATH``).  The
+        only configurable surface exposed to Hermes is the path override, which
+        is already handled via the ``PLUR_PATH`` env var.  All other options
+        (inject mode, feedback, dedup TTL) are env-var-only to avoid
+        polluting config.yaml with PLUR internals.
+        """
+        return [
+            {
+                "key": "plur_path",
+                "description": (
+                    "Path to your PLUR engram store (default: ~/.plur). "
+                    "Leave blank to use the default or $PLUR_PATH env var."
+                ),
+                "secret": False,
+                "required": False,
+                "default": "",
+                "env_var": "PLUR_PATH",
+            },
+            {
+                "key": "plur_inject_mode",
+                "description": (
+                    "Engram retrieval mode for prefetch. "
+                    "\"fast\" uses BM25-only (default, low latency). "
+                    "\"hybrid\" uses BM25 + embeddings (higher quality, ~2s)."
+                ),
+                "secret": False,
+                "required": False,
+                "default": "fast",
+                "choices": ["fast", "hybrid"],
+                "env_var": "PLUR_INJECT_MODE",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """No-op: PLUR config is env-var-only; ``get_config_schema`` sets ``env_var``."""
+
+
+def create_memory_provider(bridge: Optional[PlurBridge] = None) -> PlurMemoryProvider:
+    """Factory used by the ``hermes_agent.memory_providers`` entry point.
+
+    Hermes calls the entry point to obtain a provider instance.  Accepting
+    an optional ``bridge`` lets the standalone plugin path share its bridge
+    when both paths are active in the same process.
+    """
+    return PlurMemoryProvider(bridge=bridge)

--- a/packages/hermes/plur_hermes/skills/plur-memory.SKILL.md
+++ b/packages/hermes/plur_hermes/skills/plur-memory.SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plur-memory
 description: Persistent learning for AI agents. Open engram format. Your agent learns from corrections, remembers across sessions, and transfers knowledge across domains.
-version: 0.19.2
+version: 0.19.3
 metadata:
   hermes:
     tags: [memory, learning, knowledge, engrams]

--- a/packages/hermes/plur_hermes/skills/plur-memory.SKILL.md
+++ b/packages/hermes/plur_hermes/skills/plur-memory.SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plur-memory
 description: Persistent learning for AI agents. Open engram format. Your agent learns from corrections, remembers across sessions, and transfers knowledge across domains.
-version: 0.19.1
+version: 0.19.2
 metadata:
   hermes:
     tags: [memory, learning, knowledge, engrams]

--- a/packages/hermes/pyproject.toml
+++ b/packages/hermes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plur-hermes"
-version = "0.19.2"
+version = "0.19.3"
 description = "PLUR persistent memory plugin for Hermes Agent"
 readme = "README.md"
 license = "Apache-2.0"
@@ -47,6 +47,9 @@ test = ["pytest>=7.0"]
 
 [project.entry-points."hermes_agent.plugins"]
 plur = "plur_hermes"
+
+[project.entry-points."hermes_agent.memory_providers"]
+plur = "plur_hermes.memory_provider:PlurMemoryProvider"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/hermes/pyproject.toml
+++ b/packages/hermes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plur-hermes"
-version = "0.19.1"
+version = "0.19.2"
 description = "PLUR persistent memory plugin for Hermes Agent"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/hermes/test/test_memory_provider.py
+++ b/packages/hermes/test/test_memory_provider.py
@@ -1,0 +1,563 @@
+"""Tests for PlurMemoryProvider — the MemoryProvider ABC adapter.
+
+Coverage:
+- ABC contract (name, is_available, initialize, get_tool_schemas,
+  handle_tool_call, get_config_schema, save_config)
+- prefetch: inject result → formatted context; empty when nothing relevant
+- sync_turn: auto-learn + injection feedback; skips non-primary contexts
+- on_session_end: capture call at real session boundary
+- system_prompt_block: status text; empty on bridge failure
+- Bridge sharing: register_memory_provider() path in register()
+- Entry point factory: create_memory_provider()
+"""
+
+import json
+import os
+import threading
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from plur_hermes.memory_provider import (
+    PlurMemoryProvider,
+    create_memory_provider,
+    _PLUR_TOOL_SCHEMAS,
+)
+from plur_hermes.bridge import PlurBridgeError, PlurNotFoundError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_bridge(
+    *,
+    status_result=None,
+    inject_result=None,
+    learn_result=None,
+    feedback_result=None,
+    capture_result=None,
+):
+    bridge = MagicMock()
+    bridge._plur_path = None
+    bridge.status.return_value = status_result or {"engram_count": 42}
+    bridge.inject.return_value = inject_result or {"count": 0, "results": [], "injected_ids": []}
+    bridge.learn.return_value = learn_result or {"id": "ENG-NEW"}
+    bridge.feedback.return_value = feedback_result or {"ok": True}
+    bridge.capture.return_value = capture_result or {"ok": True}
+    return bridge
+
+
+def _provider(bridge=None):
+    b = bridge or _mock_bridge()
+    return PlurMemoryProvider(bridge=b), b
+
+
+# ---------------------------------------------------------------------------
+# ABC contract
+# ---------------------------------------------------------------------------
+
+class TestAbcContract:
+    def test_name(self):
+        p, _ = _provider()
+        assert p.name == "plur"
+
+    def test_is_available_true(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        assert p.is_available() is True
+        bridge.status.assert_called_once()
+
+    def test_is_available_caches_result(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p.is_available()
+        p.is_available()
+        bridge.status.assert_called_once()  # cached after first call
+
+    def test_is_available_false_on_bridge_error(self):
+        bridge = _mock_bridge()
+        bridge.status.side_effect = PlurNotFoundError("not found")
+        p = PlurMemoryProvider(bridge=bridge)
+        assert p.is_available() is False
+
+    def test_initialize_logs_engrams(self, caplog):
+        bridge = _mock_bridge(status_result={"engram_count": 99})
+        p = PlurMemoryProvider(bridge=bridge)
+        with caplog.at_level("INFO", logger="plur_hermes.memory_provider"):
+            p.initialize("session-abc", platform="cli")
+        assert "99" in caplog.text
+        assert p._session_id == "session-abc"
+        assert p._platform == "cli"
+
+    def test_initialize_survives_bridge_failure(self):
+        bridge = _mock_bridge()
+        bridge.status.side_effect = PlurBridgeError("fail")
+        p = PlurMemoryProvider(bridge=bridge)
+        # Must not raise
+        p.initialize("session-xyz")
+        assert p._session_id == "session-xyz"
+
+    def test_get_tool_schemas_returns_all(self):
+        p, _ = _provider()
+        schemas = p.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        assert "plur_learn" in names
+        assert "plur_recall" in names
+        assert "plur_inject" in names
+        assert "plur_forget" in names
+        assert "plur_feedback" in names
+        assert "plur_status" in names
+        assert len(schemas) == len(_PLUR_TOOL_SCHEMAS)
+
+    def test_get_tool_schemas_is_copy(self):
+        p, _ = _provider()
+        s1 = p.get_tool_schemas()
+        s2 = p.get_tool_schemas()
+        assert s1 is not s2
+
+    def test_get_config_schema_returns_list(self):
+        p, _ = _provider()
+        schema = p.get_config_schema()
+        assert isinstance(schema, list)
+        keys = {f["key"] for f in schema}
+        assert "plur_path" in keys
+        assert "plur_inject_mode" in keys
+
+    def test_save_config_is_noop(self):
+        p, _ = _provider()
+        # Must not raise
+        p.save_config({"plur_path": "/tmp/plur"}, hermes_home="/tmp/hermes")
+
+
+# ---------------------------------------------------------------------------
+# handle_tool_call dispatch
+# ---------------------------------------------------------------------------
+
+class TestHandleToolCall:
+    def test_plur_learn(self):
+        bridge = _mock_bridge()
+        bridge.learn.return_value = {"id": "ENG-001", "statement": "test"}
+        p = PlurMemoryProvider(bridge=bridge)
+        result = json.loads(p.handle_tool_call("plur_learn", {"statement": "test stmt"}))
+        bridge.learn.assert_called_once_with(
+            "test stmt",
+            scope="global",
+            type="behavioral",
+            domain=None,
+            tags=None,
+            rationale=None,
+            visibility=None,
+            knowledge_anchors=None,
+            dual_coding=None,
+            abstract=None,
+            derived_from=None,
+            force=False,
+        )
+        assert result["id"] == "ENG-001"
+
+    def test_plur_recall(self):
+        bridge = _mock_bridge()
+        bridge.recall.return_value = {"results": [{"id": "E1"}], "count": 1}
+        p = PlurMemoryProvider(bridge=bridge)
+        result = json.loads(p.handle_tool_call("plur_recall", {"query": "memory test"}))
+        bridge.recall.assert_called_once_with("memory test", limit=10, fast=False)
+        assert result["count"] == 1
+
+    def test_plur_inject(self):
+        bridge = _mock_bridge()
+        bridge.inject.return_value = {"count": 2, "results": [], "directives": "..."}
+        p = PlurMemoryProvider(bridge=bridge)
+        result = json.loads(p.handle_tool_call("plur_inject", {"task": "some task"}))
+        bridge.inject.assert_called_once_with("some task", budget=2000, fast=False)
+        assert result["count"] == 2
+
+    def test_plur_feedback_batch(self):
+        bridge = _mock_bridge()
+        bridge.feedback.return_value = {"ok": True}
+        p = PlurMemoryProvider(bridge=bridge)
+        args = {"batch": [{"id": "E1", "signal": "positive"}, {"id": "E2", "signal": "negative"}]}
+        p.handle_tool_call("plur_feedback", args)
+        bridge.feedback.assert_called_once_with(batch=[("E1", "positive"), ("E2", "negative")])
+
+    def test_plur_feedback_single(self):
+        bridge = _mock_bridge()
+        bridge.feedback.return_value = {"ok": True}
+        p = PlurMemoryProvider(bridge=bridge)
+        p.handle_tool_call("plur_feedback", {"id": "ENG-001", "signal": "positive"})
+        bridge.feedback.assert_called_once_with("ENG-001", "positive")
+
+    def test_plur_status(self):
+        bridge = _mock_bridge(status_result={"engram_count": 5})
+        p = PlurMemoryProvider(bridge=bridge)
+        result = json.loads(p.handle_tool_call("plur_status", {}))
+        assert result["engram_count"] == 5
+
+    def test_plur_stores_add(self):
+        bridge = _mock_bridge()
+        bridge.stores_add.return_value = {"ok": True}
+        p = PlurMemoryProvider(bridge=bridge)
+        p.handle_tool_call("plur_stores_add", {"path": "/tmp/store"})
+        bridge.stores_add.assert_called_once_with(
+            "/tmp/store", scope="global", shared=False, readonly=False
+        )
+
+    def test_plur_similarity_search(self):
+        bridge = _mock_bridge()
+        bridge.similarity_search.return_value = {"results": [], "count": 0}
+        p = PlurMemoryProvider(bridge=bridge)
+        p.handle_tool_call("plur_similarity_search", {"query": "test"})
+        bridge.similarity_search.assert_called_once_with("test", limit=10, scope=None)
+
+    def test_unknown_tool_returns_error(self):
+        p, _ = _provider()
+        result = json.loads(p.handle_tool_call("plur_nonexistent", {}))
+        assert "error" in result
+
+    def test_bridge_exception_returns_error_json(self):
+        bridge = _mock_bridge()
+        bridge.recall.side_effect = PlurBridgeError("boom")
+        p = PlurMemoryProvider(bridge=bridge)
+        result = json.loads(p.handle_tool_call("plur_recall", {"query": "x"}))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# prefetch
+# ---------------------------------------------------------------------------
+
+class TestPrefetch:
+    def test_returns_directives_when_injected(self):
+        bridge = _mock_bridge(inject_result={
+            "count": 1,
+            "results": [{"id": "E1", "statement": "always use pnpm"}],
+            "injected_ids": ["E1"],
+            "directives": "always use pnpm",
+        })
+        p = PlurMemoryProvider(bridge=bridge)
+        result = p.prefetch("what package manager")
+        assert "always use pnpm" in result
+
+    def test_returns_empty_when_nothing_relevant(self):
+        bridge = _mock_bridge(inject_result={"count": 0, "results": [], "injected_ids": []})
+        p = PlurMemoryProvider(bridge=bridge)
+        result = p.prefetch("some query")
+        assert result == ""
+
+    def test_returns_empty_on_bridge_failure(self):
+        bridge = _mock_bridge()
+        bridge.inject.side_effect = PlurBridgeError("inject fail")
+        p = PlurMemoryProvider(bridge=bridge)
+        result = p.prefetch("test")
+        assert result == ""
+
+    def test_stores_injected_engrams_for_feedback(self):
+        bridge = _mock_bridge(inject_result={
+            "count": 1,
+            "results": [{"id": "E1", "statement": "always use pnpm not npm"}],
+            "injected_ids": ["E1"],
+            "directives": "always use pnpm not npm",
+        })
+        p = PlurMemoryProvider(bridge=bridge)
+        p.prefetch("package manager")
+        with p._injected_lock:
+            assert len(p._injected_engrams) == 1
+            assert p._injected_engrams[0]["id"] == "E1"
+
+    def test_fast_mode_by_default(self):
+        bridge = _mock_bridge(inject_result={"count": 0, "results": [], "injected_ids": []})
+        p = PlurMemoryProvider(bridge=bridge)
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove PLUR_INJECT_MODE if set; default is fast=True
+            os.environ.pop("PLUR_INJECT_MODE", None)
+            p.prefetch("query")
+        bridge.inject.assert_called_once_with("query", fast=True)
+
+    @patch.dict(os.environ, {"PLUR_INJECT_MODE": "hybrid"})
+    def test_hybrid_mode_via_env(self):
+        bridge = _mock_bridge(inject_result={"count": 0, "results": [], "injected_ids": []})
+        p = PlurMemoryProvider(bridge=bridge)
+        p.prefetch("query")
+        bridge.inject.assert_called_once_with("query", fast=False)
+
+    def test_empty_query_skips_bridge(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        result = p.prefetch("")
+        bridge.inject.assert_not_called()
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# sync_turn
+# ---------------------------------------------------------------------------
+
+class TestSyncTurn:
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_autolearn_fires_on_primary_context(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "primary"
+        response = "I learned:\n- always use pnpm not npm\n"
+        p.sync_turn("user msg", response)
+        bridge.learn.assert_called()
+
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_skips_writes_on_cron_context(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "cron"
+        p.sync_turn("user msg", "I learned:\n- use pnpm not npm")
+        bridge.learn.assert_not_called()
+
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_positive_feedback_sent(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "primary"
+        # Pre-populate injected engrams (as prefetch() would).
+        p._injected_engrams = [{"id": "E1", "statement": "always use pnpm not npm"}]
+        response = "I'll always use pnpm not npm as requested."
+        p.sync_turn("what package manager?", response)
+        bridge.feedback.assert_called_once()
+        batch = bridge.feedback.call_args[1]["batch"]
+        assert ("E1", "positive") in batch
+
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_injected_engrams_cleared_after_feedback(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "primary"
+        p._injected_engrams = [{"id": "E1", "statement": "always use pnpm not npm"}]
+        p.sync_turn("msg", "always use pnpm not npm")
+        with p._injected_lock:
+            assert p._injected_engrams == []
+
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "false"})
+    def test_feedback_disabled_by_env(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "primary"
+        p._injected_engrams = [{"id": "E1", "statement": "always use pnpm not npm"}]
+        p.sync_turn("msg", "always use pnpm not npm")
+        bridge.feedback.assert_not_called()
+
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_no_feedback_on_unrelated_response(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "primary"
+        p._injected_engrams = [{"id": "E1", "statement": "always use pnpm not npm"}]
+        p.sync_turn("msg", "The sky is blue and the sun is bright today.")
+        bridge.feedback.assert_not_called()
+
+    @patch.dict(os.environ, {"PLUR_INJECTION_FEEDBACK": "true"})
+    def test_sync_turn_increments_learn_count(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "primary"
+        # trigger strategy-2 marker
+        p.sync_turn("msg", "I learned:\n- use black for formatting")
+        assert p._learn_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# on_session_end
+# ---------------------------------------------------------------------------
+
+class TestOnSessionEnd:
+    def test_capture_called_with_session_info(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._session_id = "sess-001"
+        p._platform = "cli"
+        p._learn_count = 3
+        p.on_session_end([])
+        bridge.capture.assert_called_once()
+        args = bridge.capture.call_args
+        summary = args[0][0] if args[0] else args[1].get("summary", "")
+        # capture signature: capture(summary, agent=..., session=...)
+        # check via positional or keyword
+        call_args_str = str(args)
+        assert "sess-001" in call_args_str or "hermes" in call_args_str
+
+    def test_state_reset_after_end(self):
+        bridge = _mock_bridge()
+        p = PlurMemoryProvider(bridge=bridge)
+        p._session_id = "sess-001"
+        p._learn_count = 5
+        p.on_session_end([])
+        assert p._session_id == ""
+        assert p._learn_count == 0
+
+    def test_survives_capture_failure(self):
+        bridge = _mock_bridge()
+        bridge.capture.side_effect = PlurBridgeError("capture fail")
+        p = PlurMemoryProvider(bridge=bridge)
+        p._session_id = "sess-002"
+        # Must not raise
+        p.on_session_end([])
+        assert p._session_id == ""  # reset still happens in finally
+
+
+# ---------------------------------------------------------------------------
+# system_prompt_block
+# ---------------------------------------------------------------------------
+
+class TestSystemPromptBlock:
+    def test_includes_engram_count(self):
+        bridge = _mock_bridge(status_result={"engram_count": 77})
+        p = PlurMemoryProvider(bridge=bridge)
+        block = p.system_prompt_block()
+        assert "77" in block
+
+    def test_empty_on_bridge_failure(self):
+        bridge = _mock_bridge()
+        bridge.status.side_effect = PlurBridgeError("fail")
+        p = PlurMemoryProvider(bridge=bridge)
+        assert p.system_prompt_block() == ""
+
+    def test_empty_when_count_missing(self):
+        bridge = _mock_bridge(status_result={"ok": True})  # no engram_count
+        p = PlurMemoryProvider(bridge=bridge)
+        assert p.system_prompt_block() == ""
+
+
+# ---------------------------------------------------------------------------
+# register() integration — register_memory_provider path
+# ---------------------------------------------------------------------------
+
+class TestRegisterIntegration:
+    """Verify that register() calls ctx.register_memory_provider when available."""
+
+    def _make_ctx(self):
+        class Ctx:
+            def __init__(self):
+                self.hooks = {}
+                self.tools = {}
+                self.memory_provider = None
+
+            def register_hook(self, name, fn):
+                self.hooks[name] = fn
+
+            def register_tool(self, name, toolset, schema, handler):
+                self.tools[name] = handler
+
+            def register_memory_provider(self, provider):
+                self.memory_provider = provider
+
+        return Ctx()
+
+    def _make_bridge(self):
+        bridge = MagicMock()
+        bridge._plur_path = None
+        bridge.status.return_value = {"engram_count": 10}
+        bridge.inject.return_value = {"count": 0, "results": [], "injected_ids": []}
+        bridge.learn.return_value = {"id": "ENG-NEW"}
+        bridge.feedback.return_value = {"ok": True}
+        return bridge
+
+    def test_register_calls_register_memory_provider(self):
+        import plur_hermes
+        bridge = self._make_bridge()
+        with patch("plur_hermes.PlurBridge", return_value=bridge):
+            ctx = self._make_ctx()
+            plur_hermes.register(ctx)
+        assert ctx.memory_provider is not None
+        assert isinstance(ctx.memory_provider, PlurMemoryProvider)
+
+    def test_register_shares_bridge_instance(self):
+        import plur_hermes
+        bridge = self._make_bridge()
+        with patch("plur_hermes.PlurBridge", return_value=bridge):
+            ctx = self._make_ctx()
+            plur_hermes.register(ctx)
+        # Provider should use the same bridge object (shared, not a copy).
+        assert ctx.memory_provider._bridge is bridge
+
+    def test_register_skips_memory_provider_when_ctx_lacks_method(self):
+        """Standalone plugin ctx has no register_memory_provider — must not raise."""
+        import plur_hermes
+        bridge = self._make_bridge()
+        with patch("plur_hermes.PlurBridge", return_value=bridge):
+            class StandaloneCtx:
+                def __init__(self):
+                    self.hooks = {}
+                    self.tools = {}
+
+                def register_hook(self, name, fn):
+                    self.hooks[name] = fn
+
+                def register_tool(self, name, toolset, schema, handler):
+                    self.tools[name] = handler
+
+            ctx = StandaloneCtx()
+            # Must not raise
+            plur_hermes.register(ctx)
+            assert "on_session_start" in ctx.hooks  # hooks still registered
+
+
+# ---------------------------------------------------------------------------
+# Entry point factory
+# ---------------------------------------------------------------------------
+
+class TestEntryPointFactory:
+    def test_create_memory_provider_returns_instance(self):
+        provider = create_memory_provider()
+        assert isinstance(provider, PlurMemoryProvider)
+        assert provider.name == "plur"
+
+    def test_create_memory_provider_accepts_bridge(self):
+        bridge = _mock_bridge()
+        provider = create_memory_provider(bridge=bridge)
+        assert provider._bridge is bridge
+
+    def test_create_memory_provider_lazy_bridge(self):
+        provider = create_memory_provider()
+        assert provider._bridge is None  # not yet created
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    """Verify that _injected_engrams is safe under concurrent prefetch + sync_turn."""
+
+    def test_concurrent_prefetch_and_sync(self):
+        from plur_hermes.memory_provider import _detect_injection_signal
+
+        bridge = _mock_bridge(inject_result={
+            "count": 1,
+            "results": [{"id": "E1", "statement": "pnpm"}],
+            "injected_ids": ["E1"],
+            "directives": "pnpm",
+        })
+        p = PlurMemoryProvider(bridge=bridge)
+        p._agent_context = "primary"
+
+        errors = []
+
+        def prefetch_loop():
+            for _ in range(20):
+                try:
+                    p.prefetch("query")
+                except Exception as e:
+                    errors.append(e)
+
+        def sync_loop():
+            for _ in range(20):
+                try:
+                    p.sync_turn("msg", "pnpm not npm")
+                except Exception as e:
+                    errors.append(e)
+
+        threads = [
+            threading.Thread(target=prefetch_loop),
+            threading.Thread(target=sync_loop),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Thread-safety errors: {errors}"

--- a/packages/hermes/test/test_packaging.py
+++ b/packages/hermes/test/test_packaging.py
@@ -1,0 +1,40 @@
+"""Packaging assertions — both hermes entry point groups must be registered.
+
+These tests verify what a wheel-based install exposes, not just what the source
+says. They run against the editable install that CI creates with `pip install -e`
+(which also registers entry points), so they catch a missing declaration in
+pyproject.toml before a wheel is ever built.
+
+A missing hermes_agent.memory_providers entry is the regression from 0.19.0–0.19.2:
+memory_provider.py existed but was never reachable via `memory.provider: plur`.
+"""
+import importlib.metadata
+
+
+def test_plugins_entry_point_present():
+    eps = importlib.metadata.entry_points(group="hermes_agent.plugins")
+    names = [ep.name for ep in eps]
+    assert "plur" in names, (
+        f"hermes_agent.plugins group missing 'plur'; found: {names}"
+    )
+
+
+def test_memory_providers_entry_point_present():
+    eps = importlib.metadata.entry_points(group="hermes_agent.memory_providers")
+    names = [ep.name for ep in eps]
+    assert "plur" in names, (
+        f"hermes_agent.memory_providers group missing 'plur'; found: {names}. "
+        "'memory.provider: plur' in config.yaml will silently do nothing. "
+        "Check [project.entry-points] in pyproject.toml."
+    )
+
+
+def test_memory_providers_entry_point_loads():
+    eps = importlib.metadata.entry_points(group="hermes_agent.memory_providers")
+    ep = next((ep for ep in eps if ep.name == "plur"), None)
+    assert ep is not None, "plur entry point not found in hermes_agent.memory_providers"
+    cls = ep.load()
+    assert cls is not None, "Entry point loaded None"
+    assert hasattr(cls, "prefetch"), (
+        f"Loaded class {cls!r} missing 'prefetch' — does not look like PlurMemoryProvider"
+    )


### PR DESCRIPTION
## Summary

`PlurMemoryProvider` implements the Hermes `MemoryProvider` ABC so PLUR can be registered via `memory.provider: plur` in Hermes config (Herald Release ≥ 0.20.0).

**Why this PR**: The feature was first published in `plur-hermes==0.18.1` (2026-08-26, out-of-band PyPI push without a git tag or main merge). It regressed in `0.19.0` and `0.19.1` because those releases were cut from `main` which never received the feature. This PR lands it on `main` so all subsequent releases ship it.

**What it does:**
- `PlurMemoryProvider.prefetch()` — BM25 inject before each LLM call
- `PlurMemoryProvider.sync_turn()` — auto-learn + injection feedback after each turn  
- `PlurMemoryProvider.on_session_end()` — episode capture at real session boundaries
- `PlurMemoryProvider.system_prompt_block()` — static PLUR status line
- `register()` calls `ctx.register_memory_provider()` only when the context supports it (guard: `hasattr(ctx, "register_memory_provider")`) — older Hermes versions are unaffected
- When both paths (standalone plugin + MemoryProvider) are active they share one `PlurBridge` — no duplicate CLI subprocess spawns

**Tests**: 191 pass (all existing + 48 new in `test_memory_provider.py`)

## CHANGELOG note

The CHANGELOG `## Unreleased` section has a placeholder `(#N)` that should be updated to this PR's number before release. The release manifest gate will require it.

## Test plan

- [ ] CI hermes.yml passes (4 Python versions: 3.10, 3.11, 3.12, 3.13)
- [ ] `pytest packages/hermes -q` passes locally (191 tests)
- [ ] Verify `memory.provider: plur` works in Hermes Herald Release config
- [ ] Check that older Hermes (pre-0.20.0) still works (the `hasattr` guard)
- [ ] Update `## Unreleased` CHANGELOG entry with this PR number before release