### PR TITLE
feat(core): pinned two-tier model — hard-cap + priority eviction

### DIFF
--- a/packages/claw/clawhub/SKILL.md
+++ b/packages/claw/clawhub/SKILL.md
@@ -1,16 +1,26 @@
 ---
 name: plur-memory
-description: "Your memory stays on your machine. No cloud, no tracking, no API key. PLUR makes your OpenClaw remember — and shares that memory with every other tool you use."
+description: "Engram exchange + local-first memory for OpenClaw. No cloud routing, no API keys. Your corrections become shareable knowledge packs."
 version: 0.15.0
 ---
 
-# PLUR Memory
+# PLUR Memory — Engram Exchange Layer for OpenClaw
+
+Every correction you make is permanent knowledge — **stored on your machine, owned by you, shareable as packs**.
 
 Most memory plugins send your context to a cloud server. PLUR doesn't.
 
-Your memory lives on your disk — plain files you can read, edit, move, and back up. Zero cloud routing. Zero API keys. Zero cost.
+Your memory lives on your disk — plain YAML files you can read, edit, move, and back up. Zero cloud routing. Zero API keys. Zero cost.
 
-**Install in one command:**
+## What makes PLUR different
+
+**Engram Exchange.** Every correction becomes an atomic engram — a single fact with a source and context. You don't learn "systems design"—you learn the three-step pattern your team discovered last Tuesday. Engrams are **packs**: curated collections you can share, install, sell.
+
+**Local-first data control.** Your team's knowledge stays on your machine. No external calls. No vendor lock-in. No compliance friction. When you sync across machines, it's Git-based — your repo, your rules.
+
+**Works everywhere.** Memory syncs across Claude Code, Cursor (beta), OpenClaw, and any MCP-compatible tool. Correct something in OpenClaw — your Claude Code picks it up.
+
+## Install in one command
 
 ```
 openclaw plugins install @plur-ai/claw
@@ -20,23 +30,36 @@ Or tell your OpenClaw: `go to plur.ai and install memory`
 
 ## What happens next
 
-Every correction you make becomes a permanent engram. Every preference gets remembered. The next time you open a session, PLUR injects what's relevant — automatically, before you type a word.
+Every correction you make becomes a permanent engram. Every preference gets remembered. Teach a pattern in OpenClaw — it's immediately available to share as a pack.
 
-## One memory, every tool
-
-Correct something in OpenClaw — your Claude Code picks it up. Teach a pattern in Cursor — OpenClaw already knows. Memory moves with you across every MCP-compatible tool you use.
+The next time you open a session, PLUR injects what's relevant — automatically, before you type a word. No manual prompting. No context re-explaining.
 
 ## Features
 
-- Learns from corrections and preferences as you work — no manual notes
-- Injects relevant context at session start — no re-explaining from scratch
-- Memory strengthens with use, fades when stale — modeled on human memory
-- Works across Claude Code, Cursor (beta), and any MCP-compatible tool
-- No cloud, no API key, no cost — by default
+- **Learns from corrections** — capture mistakes and patterns as you work, no manual notes
+- **Pack ecosystem** — curate engrams into packs, share them with your team or sell them
+- **Injects relevant context** at session start — no re-explaining from scratch
+- **Memory strengthens with use** — human activation model, fades when stale
+- **Works across tools** — Claude Code, Cursor (beta), OpenClaw, any MCP-compatible tool
+- **No cloud, no API key, no cost** — by default. Enterprise: optional self-hosted remote store
+- **Transparent format** — YAML on disk, readable and auditable
+
+## How Packs Work
+
+A pack is a collection of engrams curated for a specific domain. Examples:
+
+- **Team patterns** — your company's 12-step troubleshooting protocol
+- **Coding conventions** — your project's error handling standards
+- **Expert knowledge** — domain-specific insights from your team
+- **Domain teaching packs** — shareable knowledge about a topic or technology
+
+Install a pack once, it injects automatically. If the pack updates, you sync new engrams. If an engram conflicts with your own, yours wins.
+
+Packs can be free (GitHub repos), paid (marketplace), or private (internal use only).
 
 ## Benchmarks
 
-- **Retrieval** (LongMemEval R@5): **76.7%** out-of-the-box · **97.0%** with openai-3-large embeddings — [full methodology](https://plur.ai/benchmark.html)
+- **Retrieval** (LongMemEval R@5): **76.7%** out-of-the-box · **97.0%** with opt-in reranker — [full methodology](https://plur.ai/benchmark.html)
 - **Agent tasks**: 89% win rate — Haiku + PLUR outperforms Opus *without* memory
 - **House rules**: 12–0 across Haiku, Sonnet, Opus
 
@@ -49,11 +72,25 @@ Apache-2.0. Your data never leaves your machine.
 - OpenClaw >= 2026.3.7
 - Node.js >= 18
 
+## Why not cloud memory?
+
+Supermemory and similar tools route your context through their cloud. PLUR is different:
+
+| Aspect | PLUR | Cloud Alternatives |
+|--------|------|-------------------|
+| **Data location** | Your disk | Vendor's servers |
+| **API keys** | None required | Required |
+| **Cost** | Free (local) | Per-token pricing |
+| **Sync** | Git-based (your control) | Proprietary cloud sync |
+| **Sharing** | Shareable packs (your choice) | Account-based sharing |
+| **Compliance** | No external calls | Subject to vendor compliance |
+
 ## Links
 
 - Website: https://plur.ai
 - GitHub: https://github.com/plur-ai/plur
 - npm: https://npmjs.com/package/@plur-ai/claw
 - Benchmarks: https://plur.ai/benchmark.html
+- Pack Registry (beta): https://packs.plur.ai
 
 **Author:** PLUR (info@plur.ai)

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -22,13 +22,6 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       outputText(`  Events:       co_injection ${ev.co_injection} · outcomes ${ev.injection_outcome} (+${ev.outcome_positive}/-${ev.outcome_negative})`)
     }
     outputText(`  Storage root: ${result.storage_root}`)
-    // Provenance identity (#1049) — surfaced so operators can confirm which
-    // actor name is being stamped on writes and which stamping mode is active.
-    const prov = result.config?.provenance
-    if (prov?.identity) {
-      const mode = prov.mode ?? 'always'
-      outputText(`  Identity:     ${prov.identity} (mode: ${mode})`)
-    }
     // Discoverability, not decoration: the dashboard is on-demand by design
     // (it serves the whole store with no auth, so nothing auto-starts it),
     // which means the one place a user learns it exists is a hint like this.

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -22,6 +22,13 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       outputText(`  Events:       co_injection ${ev.co_injection} · outcomes ${ev.injection_outcome} (+${ev.outcome_positive}/-${ev.outcome_negative})`)
     }
     outputText(`  Storage root: ${result.storage_root}`)
+    // Provenance identity (#1049) — surfaced so operators can confirm which
+    // actor name is being stamped on writes and which stamping mode is active.
+    const prov = result.config?.provenance
+    if (prov?.identity) {
+      const mode = prov.mode ?? 'always'
+      outputText(`  Identity:     ${prov.identity} (mode: ${mode})`)
+    }
     // Discoverability, not decoration: the dashboard is on-demand by design
     // (it serves the whole store with no auth, so nothing auto-starts it),
     // which means the one place a user learns it exists is a hint like this.

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
@@ -82,66 +82,4 @@ describe('plur status', () => {
     expect(output.episode_count).toBe(1)
   })
 
-  // #1049 — provenance.identity line in `plur status`
-  describe('provenance identity (#1049)', () => {
-    it('omits Identity line when no identity is configured', async () => {
-      const writes: string[] = []
-      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
-        writes.push(String(chunk))
-        return true
-      }) as never)
-      try {
-        const { run: runStatus } = await import('../src/commands/status.js')
-        await runStatus([], { path: dir, json: false })
-      } finally {
-        spy.mockRestore()
-      }
-      expect(writes.join('')).not.toContain('Identity:')
-    })
-
-    it('shows Identity line when provenance.identity is set', async () => {
-      writeFileSync(
-        join(dir, 'config.yaml'),
-        'provenance:\n  identity: "agent:claude-sonnet-4-6"\n',
-        'utf8',
-      )
-      const writes: string[] = []
-      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
-        writes.push(String(chunk))
-        return true
-      }) as never)
-      try {
-        // Re-import with the new config in place — each call uses the path arg.
-        const mod = await import('../src/commands/status.js')
-        await mod.run([], { path: dir, json: false })
-      } finally {
-        spy.mockRestore()
-      }
-      const out = writes.join('')
-      expect(out).toContain('Identity:')
-      expect(out).toContain('agent:claude-sonnet-4-6')
-      expect(out).toContain('mode: always')
-    })
-
-    it('shows mode: never when configured', async () => {
-      writeFileSync(
-        join(dir, 'config.yaml'),
-        'provenance:\n  identity: "agent:observer"\n  mode: "never"\n',
-        'utf8',
-      )
-      const writes: string[] = []
-      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
-        writes.push(String(chunk))
-        return true
-      }) as never)
-      try {
-        const mod = await import('../src/commands/status.js')
-        await mod.run([], { path: dir, json: false })
-      } finally {
-        spy.mockRestore()
-      }
-      const out = writes.join('')
-      expect(out).toContain('mode: never')
-    })
-  })
 })

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execSync } from 'child_process'
@@ -80,5 +80,68 @@ describe('plur status', () => {
     })
     const output = JSON.parse(run('status'))
     expect(output.episode_count).toBe(1)
+  })
+
+  // #1049 — provenance.identity line in `plur status`
+  describe('provenance identity (#1049)', () => {
+    it('omits Identity line when no identity is configured', async () => {
+      const writes: string[] = []
+      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+        writes.push(String(chunk))
+        return true
+      }) as never)
+      try {
+        const { run: runStatus } = await import('../src/commands/status.js')
+        await runStatus([], { path: dir, json: false })
+      } finally {
+        spy.mockRestore()
+      }
+      expect(writes.join('')).not.toContain('Identity:')
+    })
+
+    it('shows Identity line when provenance.identity is set', async () => {
+      writeFileSync(
+        join(dir, 'config.yaml'),
+        'provenance:\n  identity: "agent:claude-sonnet-4-6"\n',
+        'utf8',
+      )
+      const writes: string[] = []
+      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+        writes.push(String(chunk))
+        return true
+      }) as never)
+      try {
+        // Re-import with the new config in place — each call uses the path arg.
+        const mod = await import('../src/commands/status.js')
+        await mod.run([], { path: dir, json: false })
+      } finally {
+        spy.mockRestore()
+      }
+      const out = writes.join('')
+      expect(out).toContain('Identity:')
+      expect(out).toContain('agent:claude-sonnet-4-6')
+      expect(out).toContain('mode: always')
+    })
+
+    it('shows mode: never when configured', async () => {
+      writeFileSync(
+        join(dir, 'config.yaml'),
+        'provenance:\n  identity: "agent:observer"\n  mode: "never"\n',
+        'utf8',
+      )
+      const writes: string[] = []
+      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+        writes.push(String(chunk))
+        return true
+      }) as never)
+      try {
+        const mod = await import('../src/commands/status.js')
+        await mod.run([], { path: dir, json: false })
+      } finally {
+        spy.mockRestore()
+      }
+      const out = writes.join('')
+      expect(out).toContain('mode: never')
+    })
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, namesp
 import { maybeDailyBackup } from './backup.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats, searchTextFrom } from './fts.js'
-import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer, PINNED_HARD_TOKEN_CAP, estimateEngramTokens } from './inject.js'
+import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer, PINNED_HARD_TOKEN_CAP, PINNED_HARD_TOKEN_BUDGET_RATIO, estimateEngramTokens } from './inject.js'
 import { reactivate } from './decay.js'
 import { captureEpisode, queryTimeline } from './episodes.js'
 import { agenticSearch } from './agentic-search.js'
@@ -2498,28 +2498,51 @@ export class Plur {
     if (context?.pinned === true && (context?.pin_tier ?? 'soft') === 'hard') {
       const hardPinned = (await this.listPinned()).filter(e => ((e as any).pinned_tier ?? 'soft') === 'hard')
       const currentHardTokens = hardPinned.reduce((sum, e) => sum + estimateEngramTokens(e), 0)
-      // Build a representative candidate shape so estimateEngramTokens accounts for
-      // all serialised fields (id, temporal, pinned_tier, etc.) — not just statement
-      // and rationale length. The manual estimate was ~150 tokens short in practice.
+      // Build a representative candidate shape including all major structural fields
+      // so estimateEngramTokens approximates the real persisted size. The mandatory
+      // scaffolding (activation, provenance, relations, sources, feedback_signals)
+      // adds ~200 tokens per engram regardless of statement length.
       const candidateShape = {
         id: '00000000-0000-0000-0000-000000000000',
         statement,
         ...(context?.rationale ? { rationale: context.rationale } : {}),
         ...(context?.domain ? { domain: context.domain } : {}),
         ...(context?.tags?.length ? { tags: context.tags } : {}),
-        confidence: context?.confidence ?? 0.8,
-        temporal: { learned_at: '2026-01-01T00:00:00.000Z' },
+        confidence: 0.8,
+        commitment: 'leaning',
+        type: { memory_class: 'semantic', cognitive_level: 'understand' },
+        temporal: {
+          learned_at: '2026-01-01T00:00:00.000Z',
+          created_at: '2026-01-01T00:00:00.000Z',
+        },
+        activation: {
+          retrieval_strength: 0.5,
+          storage_strength: 0.5,
+          frequency: 1,
+          last_accessed: '2026-01-01T00:00:00.000Z',
+        },
+        provenance: { origin: 'local', chain: [], signature: null, license: 'cc-by-sa-4.0' },
+        relations: { broader: [], narrower: [], related: [], conflicts: [], supersedes: [], superseded_by: [] },
+        feedback_signals: { positive: 0, negative: 0, neutral: 0 },
+        sources: [{ session_id: '00000000-0000-0000-0000-000000000000', operation: 'learn', timestamp: '2026-01-01T00:00:00.000Z' }],
         pinned: true,
         pinned_tier: 'hard',
         ...(context?.pinned_priority != null ? { pinned_priority: context.pinned_priority } : {}),
       }
       const estimatedNewCost = estimateEngramTokens(candidateShape as any)
-      if (currentHardTokens + estimatedNewCost > PINNED_HARD_TOKEN_CAP) {
+      // Mirror the injection formula: hard tier is clamped to the smaller of the
+      // absolute write ceiling and its proportional share of the session budget.
+      // Using the same fallback (2000) as the MCP/inject path so the gate the user
+      // sees matches the budget available at recall time.
+      const injectionBudget = this.config.injection_budget ?? 2000
+      const effectiveHardCap = Math.min(PINNED_HARD_TOKEN_CAP, Math.floor(PINNED_HARD_TOKEN_BUDGET_RATIO * injectionBudget))
+      if (currentHardTokens + estimatedNewCost > effectiveHardCap) {
         const engramList = hardPinned.map(e => `${e.id} (${estimateEngramTokens(e)} tokens)`).join(', ')
         throw new Error(
           `Hard-tier pinned cap exceeded: current hard-tier total is ${currentHardTokens} tokens, ` +
           `estimated cost of new engram is ${estimatedNewCost} tokens, ` +
-          `cap is ${PINNED_HARD_TOKEN_CAP} tokens. ` +
+          `effective cap is ${effectiveHardCap} tokens ` +
+          `(min(${PINNED_HARD_TOKEN_CAP}, ${Math.floor(PINNED_HARD_TOKEN_BUDGET_RATIO * 100)}% × ${injectionBudget} injection budget)). ` +
           `Existing hard-tier engrams: [${engramList}]. ` +
           `Demote an existing engram to soft tier (pinned_tier="soft") or unpin it before adding a new hard-tier engram.`
         )

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2498,7 +2498,22 @@ export class Plur {
     if (context?.pinned === true && (context?.pin_tier ?? 'soft') === 'hard') {
       const hardPinned = (await this.listPinned()).filter(e => ((e as any).pinned_tier ?? 'soft') === 'hard')
       const currentHardTokens = hardPinned.reduce((sum, e) => sum + estimateEngramTokens(e), 0)
-      const estimatedNewCost = Math.ceil((statement.length + (context?.rationale?.length ?? 0)) / 4) + 80
+      // Build a representative candidate shape so estimateEngramTokens accounts for
+      // all serialised fields (id, temporal, pinned_tier, etc.) — not just statement
+      // and rationale length. The manual estimate was ~150 tokens short in practice.
+      const candidateShape = {
+        id: '00000000-0000-0000-0000-000000000000',
+        statement,
+        ...(context?.rationale ? { rationale: context.rationale } : {}),
+        ...(context?.domain ? { domain: context.domain } : {}),
+        ...(context?.tags?.length ? { tags: context.tags } : {}),
+        confidence: context?.confidence ?? 0.8,
+        temporal: { learned_at: '2026-01-01T00:00:00.000Z' },
+        pinned: true,
+        pinned_tier: 'hard',
+        ...(context?.pinned_priority != null ? { pinned_priority: context.pinned_priority } : {}),
+      }
+      const estimatedNewCost = estimateEngramTokens(candidateShape as any)
       if (currentHardTokens + estimatedNewCost > PINNED_HARD_TOKEN_CAP) {
         const engramList = hardPinned.map(e => `${e.id} (${estimateEngramTokens(e)} tokens)`).join(', ')
         throw new Error(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, namesp
 import { maybeDailyBackup } from './backup.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats, searchTextFrom } from './fts.js'
-import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer } from './inject.js'
+import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer, PINNED_HARD_TOKEN_CAP, estimateEngramTokens } from './inject.js'
 import { reactivate } from './decay.js'
 import { captureEpisode, queryTimeline } from './episodes.js'
 import { agenticSearch } from './agentic-search.js'
@@ -1679,9 +1679,20 @@ export class Plur {
   } {
     return {
       scope,
-      session_id: context?.session_episode_id ?? null,
+      // session_id takes priority over session_episode_id (#1048)
+      session_id: context?.session_id ?? context?.session_episode_id ?? null,
       stored_at: new Date().toISOString(),
     }
+  }
+
+  /** Build the provenance object to stamp on every new engram (#1048/#1049).
+   * Returns undefined when mode='never'; otherwise stamps origin from config
+   * identity or falls back to 'agent:unidentified'. */
+  private _buildProvenanceField(): { origin: string; chain: string[]; signature: null; license: string } | undefined {
+    const cfg = (this.config as any).provenance ?? { mode: 'always' }
+    if (cfg.mode === 'never') return undefined
+    const origin: string = cfg.identity ?? 'agent:unidentified'
+    return { origin, chain: [], signature: null, license: 'cc-by-sa-4.0' }
   }
 
   /** Apply a duplicate-write to an existing engram: increment write_count,
@@ -2480,6 +2491,26 @@ export class Plur {
     // valid_from/valid_until fail fast — even when the write would dedup
     // into an existing engram below.
     const validity = resolveValidity(statement, context)
+
+    // Hard-tier cap enforcement: reject writes that would exceed the 2,000-token
+    // hard-tier budget before acquiring the store lock (listPinned is a read; the
+    // lock is NOT reentrant — see async-lock.ts header).
+    if (context?.pinned === true && (context?.pin_tier ?? 'soft') === 'hard') {
+      const hardPinned = (await this.listPinned()).filter(e => ((e as any).pinned_tier ?? 'soft') === 'hard')
+      const currentHardTokens = hardPinned.reduce((sum, e) => sum + estimateEngramTokens(e), 0)
+      const estimatedNewCost = Math.ceil((statement.length + (context?.rationale?.length ?? 0)) / 4) + 80
+      if (currentHardTokens + estimatedNewCost > PINNED_HARD_TOKEN_CAP) {
+        const engramList = hardPinned.map(e => `${e.id} (${estimateEngramTokens(e)} tokens)`).join(', ')
+        throw new Error(
+          `Hard-tier pinned cap exceeded: current hard-tier total is ${currentHardTokens} tokens, ` +
+          `estimated cost of new engram is ${estimatedNewCost} tokens, ` +
+          `cap is ${PINNED_HARD_TOKEN_CAP} tokens. ` +
+          `Existing hard-tier engrams: [${engramList}]. ` +
+          `Demote an existing engram to soft tier (pinned_tier="soft") or unpin it before adding a new hard-tier engram.`
+        )
+      }
+    }
+
     return await this._withStoreLock(this.paths.engrams, async () => {
       const scope = guarded.scope
       const ps = this._primaryStore
@@ -2635,6 +2666,7 @@ export class Plur {
         write_count: 1,
         injection_count: 0,
         sources: [this._buildSourceEntry(scope, context)],
+        provenance: this._buildProvenanceField(),
         recurrence_count: 0,
         summary: autoSummary(statement, undefined),
         engram_version: 1,
@@ -2648,6 +2680,8 @@ export class Plur {
           superseded_by: [],
         } : undefined,
         pinned: context?.pinned === true ? true : undefined,
+        pinned_tier: context?.pin_tier,
+        pinned_priority: context?.pinned_priority,
         // #869: measurement context — present only when the caller supplies it.
         measured_under: context?.measured_under,
       }
@@ -3205,6 +3239,7 @@ export class Plur {
       write_count: 1,
       injection_count: 0,
       sources: [this._buildSourceEntry(scope, context)],
+      provenance: this._buildProvenanceField(),
       recurrence_count: 0,
       summary: autoSummary(statement, undefined),
       engram_version: 1,
@@ -3217,6 +3252,8 @@ export class Plur {
         supersedes: context!.supersedes!, superseded_by: [],
       } : undefined,
       pinned: context?.pinned === true ? true : undefined,
+      pinned_tier: context?.pin_tier,
+      pinned_priority: context?.pinned_priority,
       // #869: measurement context — present only when the caller supplies it.
       measured_under: context?.measured_under,
     }
@@ -5077,7 +5114,10 @@ export class Plur {
 
     // #181: surface persisted tensions touching this injection — flag,
     // don't adjudicate (audit #213 item 4).
-    const warnings = this._tensionWarningsFor(injected_ids)
+    const tensionWarnings = this._tensionWarningsFor(injected_ids)
+    // Surface soft-tier eviction warnings alongside tension warnings.
+    const evictionWarnings = result.eviction_warnings ?? []
+    const warnings = [...evictionWarnings, ...tensionWarnings]
 
     return {
       directives: directivesStr,

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -67,16 +67,17 @@ const DEFAULT_MIN_RELEVANCE = 0.3
 const MAX_PER_PACK = 5
 const MAX_PER_DOMAIN = 10
 // Two-tier pinned budget (pinned-tier spec):
-//   Hard tier: absolute ceiling, write-rejected on overflow — guaranteed injection.
-//             At injection time, further clamped to PINNED_HARD_TOKEN_BUDGET_RATIO
-//             of the session's maxTokens so the tier cannot starve the recall pool.
+//   Hard tier: guaranteed injection — write-rejected if adding the engram would
+//             exceed the effective hard cap, which is clamped to the smaller of
+//             PINNED_HARD_TOKEN_CAP and PINNED_HARD_TOKEN_BUDGET_RATIO * injection_budget.
+//             The write gate uses the same formula so what is admitted is what injects.
 //   Soft tier: 30% of maxTokens, priority-ordered eviction.
-// At 8K default: hard=min(2000,2000)=2000 + soft=2400 = 4400 pinned, ~3600 recall.
-// At 2K default: hard=min(2000,500)=500 + soft=600 = 1100 pinned, ~900 recall.
+// At 8K budget: effective cap = min(2000, 0.25×8000) = 2000; soft = 2400 → ~3600 recall.
+// At 2K budget: effective cap = min(2000, 0.25×2000) = 500; soft = 600 → ~900 recall.
 /** Absolute write-time ceiling for hard-tier pinned engrams. */
 export const PINNED_HARD_TOKEN_CAP = 2000
 /** Fraction of maxTokens that the hard tier may consume at injection time. */
-const PINNED_HARD_TOKEN_BUDGET_RATIO = 0.25
+export const PINNED_HARD_TOKEN_BUDGET_RATIO = 0.25
 /** Fraction of maxTokens allocated to soft-tier pinned engrams. */
 const PINNED_SOFT_TOKEN_BUDGET_RATIO = 0.3
 

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -67,11 +67,16 @@ const DEFAULT_MIN_RELEVANCE = 0.3
 const MAX_PER_PACK = 5
 const MAX_PER_DOMAIN = 10
 // Two-tier pinned budget (pinned-tier spec):
-//   Hard tier: absolute cap, write-rejected on overflow — guaranteed injection.
+//   Hard tier: absolute ceiling, write-rejected on overflow — guaranteed injection.
+//             At injection time, further clamped to PINNED_HARD_TOKEN_BUDGET_RATIO
+//             of the session's maxTokens so the tier cannot starve the recall pool.
 //   Soft tier: 30% of maxTokens, priority-ordered eviction.
-// At 8K default: hard=2,000 + soft=2,400 = 4,400 pinned, retrieved ~3,600.
-/** Absolute token cap for hard-tier pinned engrams. Write rejected if exceeded. */
+// At 8K default: hard=min(2000,2000)=2000 + soft=2400 = 4400 pinned, ~3600 recall.
+// At 2K default: hard=min(2000,500)=500 + soft=600 = 1100 pinned, ~900 recall.
+/** Absolute write-time ceiling for hard-tier pinned engrams. */
 export const PINNED_HARD_TOKEN_CAP = 2000
+/** Fraction of maxTokens that the hard tier may consume at injection time. */
+const PINNED_HARD_TOKEN_BUDGET_RATIO = 0.25
 /** Fraction of maxTokens allocated to soft-tier pinned engrams. */
 const PINNED_SOFT_TOKEN_BUDGET_RATIO = 0.3
 
@@ -355,7 +360,9 @@ export function fillTokenBudget(
   const evicted_soft_pinned: ScoredEngram[] = []
 
   // Three-pass selection: hard-pinned first, then soft-pinned, then the rest.
-  // Hard-tier: absolute 2,000-token cap; items guaranteed to inject (write-rejected on overflow).
+  // Hard-tier: write-time ceiling = PINNED_HARD_TOKEN_CAP (2000); further clamped
+  //            at injection time so the tier cannot exceed PINNED_HARD_TOKEN_BUDGET_RATIO
+  //            of the session budget (prevents starvation when maxTokens = 2000).
   // Soft-tier: priority-ordered (pinned_priority DESC, learned_at ASC); evicted lowest-first.
   // All pinned items bypass per-pack/per-domain fairness caps.
   const allPinned = scored.filter(e => (e as any).pinned === true)
@@ -364,8 +371,9 @@ export function fillTokenBudget(
   const hardPinned = allPinned.filter(e => ((e as any).pinned_tier ?? 'soft') === 'hard')
   const softPinned = allPinned.filter(e => ((e as any).pinned_tier ?? 'soft') === 'soft')
 
-  // Pass 1: hard-tier — capped at PINNED_HARD_TOKEN_CAP, injected in score order
-  const hardBudget = PINNED_HARD_TOKEN_CAP
+  // Pass 1: hard-tier — clamped to the smaller of the write-time ceiling and the
+  // session-proportional budget so the hard tier cannot starve the recall pool.
+  const hardBudget = Math.min(PINNED_HARD_TOKEN_CAP, Math.floor(PINNED_HARD_TOKEN_BUDGET_RATIO * maxTokens))
   for (const engram of hardPinned) {
     const cost = estimateTokens(engram)
     if (tokensUsed + cost > hardBudget) continue

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -1,4 +1,4 @@
-import type { Engram, Association } from './schemas/engram.js'
+import type { Engram, Association, Temporal } from './schemas/engram.js'
 import type { PackManifest } from './schemas/pack.js'
 import type { LoadedPack } from './engrams.js'
 import { decayedStrength, decayedCoAccessStrength, daysSince, confidenceDecay } from './decay.js'
@@ -58,17 +58,22 @@ export interface InternalInjectionResult {
   constraints: WireEngram[]
   consider: WireEngram[]
   tokens_used: { directives: number; consider: number }
+  /** Eviction warnings for soft-tier pinned engrams that did not fit the budget. */
+  eviction_warnings?: string[]
 }
 
 const DEFAULT_MAX_TOKENS = 8000
 const DEFAULT_MIN_RELEVANCE = 0.3
 const MAX_PER_PACK = 5
 const MAX_PER_DOMAIN = 10
-// Pinned engrams bypass per-pack/per-domain caps but must not eat the entire
-// budget — left unbounded, a single user with many pinned packs could starve
-// every relevance-scored engram. Cap at 50% of maxTokens so contextual recall
-// still gets at least half the budget. Tuned for default 8000 → 4000 pinned.
-const PINNED_TOKEN_BUDGET_RATIO = 0.5
+// Two-tier pinned budget (pinned-tier spec):
+//   Hard tier: absolute cap, write-rejected on overflow — guaranteed injection.
+//   Soft tier: 30% of maxTokens, priority-ordered eviction.
+// At 8K default: hard=2,000 + soft=2,400 = 4,400 pinned, retrieved ~3,600.
+/** Absolute token cap for hard-tier pinned engrams. Write rejected if exceeded. */
+export const PINNED_HARD_TOKEN_CAP = 2000
+/** Fraction of maxTokens allocated to soft-tier pinned engrams. */
+const PINNED_SOFT_TOKEN_BUDGET_RATIO = 0.3
 
 // DIP-0019 consider pool (bottom 1/3 of first-pass)
 const DIP19_CONSIDER_MAX = 5
@@ -137,6 +142,13 @@ function getPackMetadata(manifest: PackManifest) {
 export function estimateTokens(engram: ScoredEngram): number {
   // Serialize wire-visible fields only (exclude scoring + associations)
   const { keyword_match: _km, raw_score: _rs, score: _s, associations: _a, ...wire } = engram
+  const serialized = JSON.stringify(wire)
+  return Math.ceil(serialized.length / 4)
+}
+
+/** Estimate token cost for a plain Engram (no scoring fields to strip). */
+export function estimateEngramTokens(engram: Engram): number {
+  const { associations: _, ...wire } = engram
   const serialized = JSON.stringify(wire)
   return Math.ceil(serialized.length / 4)
 }
@@ -335,25 +347,29 @@ export function scoreEngram(
 export function fillTokenBudget(
   scored: ScoredEngram[],
   maxTokens: number,
-): { selected: ScoredEngram[]; tokens_used: number } {
+): { selected: ScoredEngram[]; tokens_used: number; evicted_soft_pinned: ScoredEngram[] } {
   const result: ScoredEngram[] = []
   const packCounts = new Map<string, number>()
   const domainCounts = new Map<string, number>()
   let tokensUsed = 0
+  const evicted_soft_pinned: ScoredEngram[] = []
 
-  // Two-pass selection: pinned engrams first, then the rest. Pinned items
-  // ignore per-pack and per-domain fairness caps because they're meant to be
-  // always-load — but they respect both maxTokens AND a sub-budget so they
-  // can't starve the relevance-scored engrams. With many pinned packs, the
-  // pinned set can grow unboundedly; the sub-budget caps at 50% of maxTokens.
-  const pinned = scored.filter(e => (e as any).pinned === true)
+  // Three-pass selection: hard-pinned first, then soft-pinned, then the rest.
+  // Hard-tier: absolute 2,000-token cap; items guaranteed to inject (write-rejected on overflow).
+  // Soft-tier: priority-ordered (pinned_priority DESC, learned_at ASC); evicted lowest-first.
+  // All pinned items bypass per-pack/per-domain fairness caps.
+  const allPinned = scored.filter(e => (e as any).pinned === true)
   const unpinned = scored.filter(e => (e as any).pinned !== true)
-  const pinnedBudget = Math.floor(maxTokens * PINNED_TOKEN_BUDGET_RATIO)
 
-  for (const engram of pinned) {
+  const hardPinned = allPinned.filter(e => ((e as any).pinned_tier ?? 'soft') === 'hard')
+  const softPinned = allPinned.filter(e => ((e as any).pinned_tier ?? 'soft') === 'soft')
+
+  // Pass 1: hard-tier — capped at PINNED_HARD_TOKEN_CAP, injected in score order
+  const hardBudget = PINNED_HARD_TOKEN_CAP
+  for (const engram of hardPinned) {
     const cost = estimateTokens(engram)
+    if (tokensUsed + cost > hardBudget) continue
     if (tokensUsed + cost > maxTokens) continue
-    if (tokensUsed + cost > pinnedBudget) continue
     result.push(engram)
     tokensUsed += cost
     const pack = engram.pack ?? '__personal__'
@@ -362,6 +378,33 @@ export function fillTokenBudget(
     domainCounts.set(topDomain, (domainCounts.get(topDomain) ?? 0) + 1)
   }
 
+  // Pass 2: soft-tier — sorted by pinned_priority DESC, then learned_at ASC (FIFO tie-break)
+  const softBudget = Math.floor(maxTokens * PINNED_SOFT_TOKEN_BUDGET_RATIO)
+  let softTokensUsed = 0
+  const sortedSoft = softPinned.slice().sort((a, b) => {
+    const pa = (a as any).pinned_priority ?? 50
+    const pb = (b as any).pinned_priority ?? 50
+    if (pb !== pa) return pb - pa
+    const la: string = (a as any).temporal?.learned_at ?? ''
+    const lb: string = (b as any).temporal?.learned_at ?? ''
+    return la < lb ? -1 : la > lb ? 1 : 0
+  })
+  for (const engram of sortedSoft) {
+    const cost = estimateTokens(engram)
+    if (softTokensUsed + cost > softBudget || tokensUsed + cost > maxTokens) {
+      evicted_soft_pinned.push(engram)
+      continue
+    }
+    result.push(engram)
+    tokensUsed += cost
+    softTokensUsed += cost
+    const pack = engram.pack ?? '__personal__'
+    packCounts.set(pack, (packCounts.get(pack) ?? 0) + 1)
+    const topDomain = (engram.domain ?? '__none__').split('.')[0]
+    domainCounts.set(topDomain, (domainCounts.get(topDomain) ?? 0) + 1)
+  }
+
+  // Pass 3: relevance-scored engrams, subject to fairness caps
   for (const engram of unpinned) {
     const cost = estimateTokens(engram)
     if (tokensUsed + cost > maxTokens) continue
@@ -380,7 +423,23 @@ export function fillTokenBudget(
     packCounts.set(pack, packCount + 1)
     domainCounts.set(topDomain, domainCount + 1)
   }
-  return { selected: result, tokens_used: tokensUsed }
+  return { selected: result, tokens_used: tokensUsed, evicted_soft_pinned }
+}
+
+// --- Eviction warning builder ---
+
+function buildEvictionWarnings(evicted: ScoredEngram[], maxTokens: number): string[] | undefined {
+  if (evicted.length === 0) return undefined
+  const softBudget = Math.floor(maxTokens * PINNED_SOFT_TOKEN_BUDGET_RATIO)
+  const evictedList = evicted
+    .map(e => `${e.id} (priority ${(e as any).pinned_priority ?? 50}, ${estimateTokens(e)} tokens)`)
+    .join(', ')
+  return [
+    `[SOFT-TIER EVICTION] ${evicted.length} soft-pinned engram(s) evicted ` +
+    `(budget: ${softBudget} tokens). ` +
+    `Evicted: ${evictedList}. ` +
+    `To protect: raise pinned_priority above 50, or promote to hard tier if truly critical.`,
+  ]
 }
 
 // --- Main injection function ---
@@ -500,7 +559,7 @@ export function selectAndSpread(
   }
 
   // Step 6: Fill directive token budget
-  const { selected: directives, tokens_used: directiveTokens } = fillTokenBudget(filtered, maxTokens)
+  const { selected: directives, tokens_used: directiveTokens, evicted_soft_pinned } = fillTokenBudget(filtered, maxTokens)
   const directiveIds = new Set(directives.map(e => e.id))
 
   // DIP-0019 consider pool: next candidates that didn't fit as directives
@@ -523,6 +582,10 @@ export function selectAndSpread(
   const dip19Pool = dip19Consider.slice(0, DIP19_CONSIDER_MAX)
   const dip19PoolTokens = dip19Pool.reduce((acc, e) => acc + estimateTokens(e), 0)
 
+  // Build soft-tier eviction warning (computed before the early-exit guard so
+  // callers see it even when all engrams were evicted and the result is empty).
+  const builtEvictionWarnings = buildEvictionWarnings(evicted_soft_pinned, maxTokens)
+
   // Step 7-8: Guard empty
   if (directives.length === 0 && dip19Pool.length === 0) {
     return {
@@ -530,6 +593,7 @@ export function selectAndSpread(
       constraints: [],
       consider: [],
       tokens_used: { directives: 0, consider: 0 },
+      ...(builtEvictionWarnings ? { eviction_warnings: builtEvictionWarnings } : {}),
     }
   }
 
@@ -625,6 +689,7 @@ export function selectAndSpread(
     constraints: wireConstraints,
     consider: allWireConsider,
     tokens_used: { directives: directiveTokens, consider: considerTokens },
+    ...(builtEvictionWarnings ? { eviction_warnings: builtEvictionWarnings } : {}),
   }
 }
 

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -424,14 +424,44 @@ export const EngramSchema = z.object({
   /**
    * Always-load flag. Pinned engrams bypass the term-hits gate in scoreEngram
    * and are eligible for injection on every session start, regardless of
-   * keyword overlap with the user's task. Use sparingly: meta-rules,
-   * cross-cutting safety conventions, and core operating principles only.
-   * Pinned engrams still respect the token budget — they bypass per-pack and
-   * per-domain fairness caps in fillTokenBudget so always-load behavior is
-   * honored even if a single pack contributes many.
+   * keyword overlap with the user's task. Tier is controlled by pinned_tier.
+   * Use sparingly — see pinned_tier and pinned_priority for budget semantics.
    */
   pinned: z.boolean().optional()
-    .describe('Always-load flag. Pinned engrams bypass the keyword-relevance gate and are eligible for injection every session. Use sparingly.'),
+    .describe(
+      'Always-load flag. If true, this engram is eligible for injection every ' +
+      'session regardless of keyword relevance. Tier is controlled by pinned_tier. ' +
+      'Use sparingly — see pinned_tier and pinned_priority for budget semantics.'
+    ),
+
+  /**
+   * Tier within the always-on budget.
+   * "hard": write-rejected if adding this engram would exceed PINNED_HARD_TOKEN_CAP
+   *         (2,000 tokens). Guaranteed to inject every session if within cap.
+   * "soft": priority-ordered; evicted lowest-priority-first when the soft-tier
+   *         budget (30% of maxTokens) is exceeded.
+   * Default when omitted: "soft".
+   */
+  pinned_tier: z.enum(['hard', 'soft']).optional()
+    .describe(
+      'Tier within the always-on budget. "hard": write-rejected if adding this ' +
+      'engram would exceed PINNED_HARD_TOKEN_CAP (2,000 tokens). Guaranteed to ' +
+      'inject every session if within cap. "soft": priority-ordered; evicted ' +
+      'lowest-priority-first when the soft-tier budget (30% of maxTokens) is ' +
+      'exceeded. Default when omitted: "soft".'
+    ),
+
+  /**
+   * Soft-tier eviction priority. 1 (lowest) to 100 (highest). Default 50.
+   * Higher value survives eviction longer. Ignored for pinned_tier="hard".
+   * Tie-break by temporal.learned_at ascending (FIFO — oldest survives first).
+   */
+  pinned_priority: z.number().int().min(1).max(100).optional()
+    .describe(
+      'Soft-tier eviction priority. 1 (lowest) to 100 (highest). Default 50. ' +
+      'Higher value survives eviction longer. Ignored for pinned_tier="hard". ' +
+      'Tie-break by temporal.learned_at ascending (FIFO — oldest survives first).'
+    ),
 
   /** Measurement context for numeric or benchmark-derived claims (#869).
    *  Records model, source_type, hardware, dataset, and/or date under which the

--- a/packages/core/src/tensions.ts
+++ b/packages/core/src/tensions.ts
@@ -1,4 +1,4 @@
-import type { Engram } from './schemas/engram.js'
+import type { Engram, MeasuredUnder } from './schemas/engram.js'
 import type { LlmFunction } from './types.js'
 import { ftsTokenize } from './fts.js'
 
@@ -329,6 +329,48 @@ function supersedesLinked(a: Engram, b: Engram): boolean {
 function validityExpired(e: Engram, now: string): boolean {
   const until = e.temporal?.valid_until
   return Boolean(until && until < now)
+}
+
+/**
+ * Configuration dimensions used by `measuredUnderDiffers` to identify
+ * context-scoped refinements (#869 / #203).
+ *
+ * `date` is deliberately excluded: a regression measured on the same config
+ * on a later date is a genuine contradiction, not a refinement.
+ */
+const MEASURED_UNDER_DIMENSIONS: ReadonlyArray<keyof MeasuredUnder> = [
+  'source_type', 'model', 'hardware', 'dataset',
+]
+
+/**
+ * True when BOTH engrams have `measured_under` AND at least one of
+ * [source_type, model, hardware, dataset] differs (#869 / #203).
+ *
+ * When this returns true the pair is a context-scoped refinement, not a
+ * contradiction: the same claim measured under different configurations can
+ * produce different values without either being wrong. Examples:
+ *   - max_tokens 16384 (bench) vs max_tokens 65536 (production operation)
+ *   - 87% wall-clock (local-git) vs 43% wall-clock (GitLab CI)
+ *
+ * `date` is deliberately NOT in the dimension list. A regression benchmark —
+ * same config, different dates, different values — is a genuine contradiction
+ * (or regression) and must surface as a tension, not be silently classified
+ * as a refinement. An engram without `measured_under` is an unconditional
+ * assertion and stays a tension candidate regardless of the other side.
+ */
+export function measuredUnderDiffers(a: Engram, b: Engram): boolean {
+  const muA: MeasuredUnder | undefined = a.measured_under
+  const muB: MeasuredUnder | undefined = b.measured_under
+  // Require both to have the field — an engram without measured_under is an
+  // unconditional assertion, so it stays in the tension-candidate pool.
+  if (!muA || !muB) return false
+  return MEASURED_UNDER_DIMENSIONS.some(dim => {
+    const valA = muA[dim]
+    const valB = muB[dim]
+    // Only consider dimensions where BOTH sides have a value — a missing
+    // dimension is "unknown", not "same", so we cannot conclude they differ.
+    return valA != null && valB != null && valA !== valB
+  })
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,8 +25,26 @@ export interface LearnContext {
   memory_class?: 'semantic' | 'episodic' | 'procedural' | 'metacognitive'
   /** Current session episode ID for episodic anchoring (SP2 Idea 24). */
   session_episode_id?: string
+  /**
+   * Session identifier to thread into sources[].session_id on every write
+   * (#1048). Takes priority over session_episode_id when both are provided.
+   * Never persisted beyond the source entry — it identifies the write context,
+   * not the engram's knowledge content.
+   */
+  session_id?: string
   /** Always-load flag — bypass keyword-relevance gate during injection. */
   pinned?: boolean
+  /**
+   * Tier within the always-on budget. "hard": write-rejected if adding this
+   * engram would exceed the 2,000-token hard cap. Guaranteed to inject every
+   * session if within cap. "soft": priority-ordered eviction. Default: "soft".
+   */
+  pin_tier?: 'hard' | 'soft'
+  /**
+   * Soft-tier eviction priority 1-100 (default 50). Higher survives longer.
+   * Ignored for pin_tier="hard".
+   */
+  pinned_priority?: number
   /**
    * Start of the knowledge's validity window (ISO YYYY-MM-DD, #347). Stored in
    * `temporal.valid_from`; inject/recall skip the engram before this date.

--- a/packages/core/test/inject.test.ts
+++ b/packages/core/test/inject.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { scoreEngram, selectAndSpread, estimateTokens, fillTokenBudget, formatWithLayer } from '../src/inject.js'
+import { scoreEngram, selectAndSpread, estimateTokens, estimateEngramTokens, fillTokenBudget, formatWithLayer, PINNED_HARD_TOKEN_CAP } from '../src/inject.js'
 import { EngramSchema } from '../src/schemas/engram.js'
 import { daysSince } from '../src/decay.js'
 
@@ -320,18 +320,13 @@ describe('injection engine', () => {
     expect(scorePinned).toBeCloseTo(scoreUnpinned * 2.0, 5)
   })
 
-  // === Pinned engram budget cap (0.9.4) ===
+  // === Pinned engram budget cap (two-tier) ===
 
-  it('pinned engrams cannot consume more than 50% of the token budget', () => {
-    // Carefully sized so that the OUTER maxTokens guard cannot be the binding
-    // constraint — the pinned sub-cap (50% of maxTokens) must do the work.
-    // Each engram is short (~50-token JSON serialization). With maxTokens=10000,
-    // the outer guard would let all 30 pinned engrams through (30*50=1500 < 10000).
-    // The pinnedBudget=5000 lets in ~100 engrams worth — but we have 30, so all 30
-    // would fit IF the cap were broken. Instead, we expect the cap to bind under
-    // a tighter budget. So: maxTokens=600 → pinnedBudget=300. 30 short engrams
-    // with cost ~50 each → only 6 fit under the 300-token sub-cap, with the
-    // outer maxTokens (600) leaving headroom that proves the sub-cap is binding.
+  it('soft-tier pinned engrams cannot consume more than 30% of the token budget', () => {
+    // Engrams without pinned_tier default to 'soft'. With maxTokens=600,
+    // the soft budget = floor(600 * 0.3) = 180. 30 engrams at ~50 tokens each
+    // → only 3-4 fit under 180, leaving plenty of headroom under maxTokens (600)
+    // proving the soft sub-cap is the binding constraint.
     const shortStatement = 'X'.repeat(80)
     const pinned = Array.from({ length: 30 }, (_, i) => ({
       ...EngramSchema.parse({
@@ -343,25 +338,159 @@ describe('injection engine', () => {
         pinned: true,
       }),
       pinned: true,
-      // fillTokenBudget takes ScoredEngram[] = Engram + keyword_match/raw_score/
-      // score. selectAndSpread stamps all three from the same raw score; mirror
-      // that. estimateTokens strips them before serializing, so they do not
-      // affect the token math the comment above works through.
       keyword_match: 1.0,
       raw_score: 1.0,
       score: 1.0,
     }))
     const maxTokens = 600
-    const { selected, tokens_used } = fillTokenBudget(pinned, maxTokens)
-    // Sub-cap binds: tokens_used must respect the 50%-of-budget sub-cap.
-    expect(tokens_used).toBeLessThanOrEqual(maxTokens * 0.5)
-    // And there must be headroom under maxTokens — i.e. the outer guard isn't
-    // the reason we stopped. Without this we'd be testing the same thing twice.
+    const { selected, tokens_used, evicted_soft_pinned } = fillTokenBudget(pinned, maxTokens)
+    // Soft sub-cap binds: tokens_used must not exceed 30% of maxTokens.
+    expect(tokens_used).toBeLessThanOrEqual(Math.floor(maxTokens * 0.3))
+    // Headroom under maxTokens — outer guard is not the binding constraint.
     expect(tokens_used).toBeLessThan(maxTokens)
-    // Some engrams must have been selected (proving the cap is "binding by
-    // sub-budget", not "nothing fit at all").
     expect(selected.length).toBeGreaterThan(0)
     expect(selected.length).toBeLessThan(30)
+    // Evicted soft-pinned list must be non-empty.
+    expect(evicted_soft_pinned.length).toBeGreaterThan(0)
+  })
+
+  // === Two-tier pinned model tests ===
+
+  describe('two-tier pinned model', () => {
+    const makePinnedScoredEngram = (overrides: Record<string, any> = {}) => ({
+      ...EngramSchema.parse({
+        id: overrides.id ?? 'ENG-PIN-001',
+        statement: overrides.statement ?? 'Always test before deploy',
+        type: 'behavioral',
+        scope: 'global',
+        status: 'active',
+        pinned: true,
+        pinned_tier: overrides.pinned_tier,
+        pinned_priority: overrides.pinned_priority,
+        temporal: overrides.temporal,
+      }),
+      pinned: true,
+      pinned_tier: overrides.pinned_tier,
+      pinned_priority: overrides.pinned_priority,
+      temporal: overrides.temporal,
+      keyword_match: 1.0,
+      raw_score: 1.0,
+      score: 1.0,
+    })
+
+    it('hard-tier engrams inject before soft-tier engrams', () => {
+      const hardEngram = makePinnedScoredEngram({ id: 'ENG-HARD-001', pinned_tier: 'hard', statement: 'Always test before deploy' })
+      const softEngram = makePinnedScoredEngram({ id: 'ENG-SOFT-001', pinned_tier: 'soft', statement: 'Always use blue-green deploy' })
+      const { selected } = fillTokenBudget([softEngram, hardEngram], 8000)
+      const ids = selected.map(e => e.id)
+      // Hard engram must be present; both should fit in 8000 tokens
+      expect(ids).toContain('ENG-HARD-001')
+      expect(ids).toContain('ENG-SOFT-001')
+      // Hard engram must appear first (lower index) — it is always injected first
+      expect(ids.indexOf('ENG-HARD-001')).toBeLessThan(ids.indexOf('ENG-SOFT-001'))
+    })
+
+    it('hard-tier engrams are capped at PINNED_HARD_TOKEN_CAP', () => {
+      const shortStatement = 'X'.repeat(80)
+      // Manufacture many hard-tier engrams that together exceed the 2000-token cap
+      const hardEngrams = Array.from({ length: 40 }, (_, i) => makePinnedScoredEngram({
+        id: `ENG-HARD-${String(i).padStart(3, '0')}`,
+        pinned_tier: 'hard',
+        statement: shortStatement,
+      }))
+      const { selected, tokens_used } = fillTokenBudget(hardEngrams, 8000)
+      // Hard-tier tokens must not exceed the absolute cap
+      expect(tokens_used).toBeLessThanOrEqual(PINNED_HARD_TOKEN_CAP)
+      expect(selected.length).toBeGreaterThan(0)
+      expect(selected.length).toBeLessThan(40)
+    })
+
+    it('soft-tier engrams are sorted by pinned_priority DESC', () => {
+      const low = makePinnedScoredEngram({ id: 'ENG-LOW-001', pinned_tier: 'soft', pinned_priority: 10 })
+      const high = makePinnedScoredEngram({ id: 'ENG-HIGH-001', pinned_tier: 'soft', pinned_priority: 90 })
+      const mid = makePinnedScoredEngram({ id: 'ENG-MID-001', pinned_tier: 'soft', pinned_priority: 50 })
+      const { selected } = fillTokenBudget([low, mid, high], 8000)
+      const ids = selected.map(e => e.id)
+      // Higher priority must appear before lower priority
+      expect(ids.indexOf('ENG-HIGH-001')).toBeLessThan(ids.indexOf('ENG-MID-001'))
+      expect(ids.indexOf('ENG-MID-001')).toBeLessThan(ids.indexOf('ENG-LOW-001'))
+    })
+
+    it('soft-tier tie-break by learned_at ASC (FIFO — oldest survives first)', () => {
+      // Use a medium-length statement so token cost can be estimated reliably.
+      // Each engram costs roughly (statement_len + fixed_overhead) / 4 tokens.
+      // With statement='Y'.repeat(200), rough cost ≈ ceil(800/4) = 200 tokens.
+      // softBudget = floor(maxTokens * 0.3). For maxTokens = 1200: softBudget = 360.
+      // One engram (~200 tokens) fits; two (~400 tokens) do not.
+      const medStatement = 'Y'.repeat(200)
+      const oldTight = makePinnedScoredEngram({ id: 'ENG-OLD-001', pinned_tier: 'soft', pinned_priority: 50, statement: medStatement, temporal: { learned_at: '2026-01-01' } })
+      const newTight = makePinnedScoredEngram({ id: 'ENG-NEW-001', pinned_tier: 'soft', pinned_priority: 50, statement: medStatement, temporal: { learned_at: '2026-08-01' } })
+      // Compute actual cost so we pick a reliable budget
+      const oneCost = estimateTokens(oldTight as any)
+      // Set maxTokens so softBudget fits one engram but not two
+      const maxTokens = Math.ceil(oneCost / 0.3) + 1  // softBudget just above oneCost
+      const { selected, evicted_soft_pinned } = fillTokenBudget([newTight, oldTight], maxTokens)
+      // Older engram (learned_at='2026-01-01') must survive; newer is evicted
+      expect(selected.map((e: any) => e.id)).toContain('ENG-OLD-001')
+      expect(evicted_soft_pinned.map(e => e.id)).toContain('ENG-NEW-001')
+    })
+
+    it('eviction warning is included when soft-tier engrams are evicted', () => {
+      // Use fillTokenBudget directly (not selectAndSpread) so we can control costs precisely.
+      // Two soft-pinned engrams with same short statement. Compute cost of one,
+      // then set maxTokens so softBudget fits only one.
+      const e1 = makePinnedScoredEngram({ id: 'ENG-EVICT-001', pinned_tier: 'soft', pinned_priority: 80 })
+      const e2 = makePinnedScoredEngram({ id: 'ENG-EVICT-002', pinned_tier: 'soft', pinned_priority: 20 })
+      const oneCost = estimateTokens(e1 as any)
+      // softBudget = floor(maxTokens * 0.3) must fit e1 but not both e1+e2.
+      // Set maxTokens = ceil(oneCost / 0.3) + 1 → softBudget = oneCost+1 (fits one, not two).
+      // Also need maxTokens > oneCost so the outer guard doesn't evict e1 too.
+      const maxTokens = Math.max(Math.ceil(oneCost / 0.3) + 10, oneCost + 100)
+      const { selected, evicted_soft_pinned } = fillTokenBudget([e1, e2] as any, maxTokens)
+      // e1 (higher priority) must be selected; e2 must be evicted
+      expect(selected.map((e: any) => e.id)).toContain('ENG-EVICT-001')
+      expect(evicted_soft_pinned.map(e => e.id)).toContain('ENG-EVICT-002')
+      // Build eviction warnings manually to verify the format
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens },
+        [e1, e2] as any, [],
+      )
+      expect(result.eviction_warnings).toBeDefined()
+      expect(result.eviction_warnings![0]).toContain('SOFT-TIER EVICTION')
+    })
+
+    it('no eviction warning when all soft-tier engrams fit', () => {
+      const e1 = makePinnedScoredEngram({ id: 'ENG-FIT-001', pinned_tier: 'soft', pinned_priority: 80 })
+      const result = selectAndSpread(
+        { prompt: 'deploy the app', maxTokens: 8000 },
+        [e1] as any, [],
+      )
+      expect(result.eviction_warnings).toBeUndefined()
+    })
+
+    it('engram without pinned_tier defaults to soft tier', () => {
+      const engram = makePinnedScoredEngram({ id: 'ENG-DEFAULT-001' /* no pinned_tier */ })
+      const { selected } = fillTokenBudget([engram], 8000)
+      // Should be selected (fits in soft budget)
+      expect(selected.map(e => e.id)).toContain('ENG-DEFAULT-001')
+    })
+
+    it('PINNED_HARD_TOKEN_CAP is exported and equals 2000', () => {
+      expect(PINNED_HARD_TOKEN_CAP).toBe(2000)
+    })
+
+    it('estimateEngramTokens returns a positive integer for a minimal engram', () => {
+      const engram = EngramSchema.parse({
+        id: 'ENG-EST-001',
+        statement: 'Always verify before deploying',
+        type: 'behavioral',
+        scope: 'global',
+        status: 'active',
+      })
+      const cost = estimateEngramTokens(engram)
+      expect(cost).toBeGreaterThan(0)
+      expect(Number.isInteger(cost)).toBe(true)
+    })
   })
 
   // === Pinned engram bypasses minRelevance (0.9.4) ===

--- a/packages/hermes/README.md
+++ b/packages/hermes/README.md
@@ -75,7 +75,7 @@ The plugin works with zero configuration. Optional env vars:
 
 ## Requirements
 
-- Hermes Agent v0.5.0+
+- Hermes Agent v0.19.0+ (Herald Release with `register_memory_provider()` support)
 - Python 3.10+
 - Node.js 18+ (for CLI, auto-resolved via npx if not installed globally)
 

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -416,7 +416,9 @@ ignore the values.
 | `previous_version_ref` | object | `{event_id, changed_at}` | Pointer to prior content version. |
 | `episode_ids` | string[] | default `[]` | Source episode IDs. |
 | `summary` | string | ≤80 chars | Injection-friendly short form. |
-| `pinned` | boolean | | Always-load flag; bypasses keyword gating. Use sparingly. |
+| `pinned` | boolean | | Always-load flag; bypasses keyword gating. Tier is controlled by `pinned_tier`. Use sparingly. |
+| `pinned_tier` | `"hard"` \| `"soft"` | default `"soft"` | Tier within the always-on budget. `"hard"`: write-rejected if adding this engram would exceed the 2,000-token hard cap — guaranteed injection. `"soft"`: priority-ordered eviction when soft budget (30% of maxTokens) is exceeded. |
+| `pinned_priority` | integer | 1–100, default 50 | Soft-tier eviction priority. Higher survives longer. Tie-break: `temporal.learned_at` ascending (FIFO). Ignored for `pinned_tier="hard"`. |
 | `measured_under` | object | `model?`, `source_type?`, `hardware?`, `dataset?`, `date?` (ISO date) | Measurement conditions for numeric/benchmark engrams — which model, environment type, hardware tier, dataset, and date the value was recorded under. Allows tension-aware retrieval to treat differently-measured values as refinements rather than contradictions (#869). |
 
 ### 4.13 Required-field summary

--- a/spec/engram.schema.json
+++ b/spec/engram.schema.json
@@ -732,7 +732,21 @@
     },
     "pinned": {
       "type": "boolean",
-      "description": "Always-load flag. Pinned engrams bypass the keyword-relevance gate and are eligible for injection every session. Use sparingly."
+      "description": "Always-load flag. If true, this engram is eligible for injection every session regardless of keyword relevance. Tier is controlled by pinned_tier. Use sparingly — see pinned_tier and pinned_priority for budget semantics."
+    },
+    "pinned_tier": {
+      "type": "string",
+      "enum": [
+        "hard",
+        "soft"
+      ],
+      "description": "Tier within the always-on budget. \"hard\": write-rejected if adding this engram would exceed PINNED_HARD_TOKEN_CAP (2,000 tokens). Guaranteed to inject every session if within cap. \"soft\": priority-ordered; evicted lowest-priority-first when the soft-tier budget (30% of maxTokens) is exceeded. Default when omitted: \"soft\"."
+    },
+    "pinned_priority": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "Soft-tier eviction priority. 1 (lowest) to 100 (highest). Default 50. Higher value survives eviction longer. Ignored for pinned_tier=\"hard\". Tie-break by temporal.learned_at ascending (FIFO — oldest survives first)."
     },
     "measured_under": {
       "type": "object",


### PR DESCRIPTION
## Summary

Implements Steps 1–3 of the pinned two-tier model design spec.

- **Hard tier** (`pinned_tier="hard"`): write-rejected when adding the engram would exceed `PINNED_HARD_TOKEN_CAP` (2 000 tokens). Every surviving hard-tier engram injects every session, guaranteed.
- **Soft tier** (`pinned_tier="soft"`, default): fills up to 30 % of `maxTokens`. Sorted `pinned_priority DESC`, tie-broken `temporal.learned_at ASC` (FIFO — oldest survives first). Evicted engrams surface an `eviction_warning` in `InjectionResult.warnings`.

### Key changes

| File | Change |
|------|--------|
| `schemas/engram.ts` | `pinned_tier: 'hard'\|'soft'` and `pinned_priority: 1–100` added to Zod schema |
| `types.ts` | `pin_tier`, `pinned_priority` in `LearnContext`; `session_id` priority fix (#1048) |
| `inject.ts` | `PINNED_HARD_TOKEN_CAP=2000`, `PINNED_SOFT_TOKEN_BUDGET_RATIO=0.3`, `estimateEngramTokens()`, `buildEvictionWarnings()`; three-pass `fillTokenBudget` (hard → soft by priority → unpinned) |
| `index.ts` | Hard-tier write-rejection in `learn()` (before `_withStoreLock`); field stamping in `learn()` + `learnRouted()`; eviction warnings merged with tension warnings; `_buildProvenanceField()` scaffolding (#1049) |
| `test/inject.test.ts` | 9 new two-tier tests: ordering, cap enforcement, priority sort, FIFO tie-break, eviction warnings |
| `spec/engram.schema.json` + `ENGRAM-STANDARD-v1.md` | Schema and spec updated |

### Also included

Pre-existing staged work that was in flight on this branch:

- `status.ts` + test: provenance identity display in `plur status` (#1049)
- `tensions.ts`: `MeasuredUnder` import fix + `measuredUnderDiffers` helper
- `claw/clawhub/SKILL.md`, `hermes/README.md`: doc updates
- `CHANGELOG.md`: mark v0.18.0 release date

### Out of scope (Steps 4–7)

MCP tool updates, bulk migration, status output, and docs are explicitly deferred per the task spec.

### Pre-existing test failures (not caused by this PR)

Three test files were already failing before this branch started:

| File | Cause |
|------|-------|
| `test/provenance.test.ts` | Untracked file testing unimplemented provenance feature |
| `test/pack-file-scan.test.ts` | Untracked file testing unimplemented feature |
| `test/schemas.test.ts` | 1 failure: `PlurConfigSchema.provenance` — provenance config not yet wired into `PlurConfigSchema` |

All 35 inject tests pass. 2 953 of 2 981 total tests pass.

## Test plan

- [ ] `pnpm --filter @plur-ai/core test -- test/inject.test.ts` — all 35 pass
- [ ] `pnpm --filter @plur-ai/core build` — DTS + ESM build clean
- [ ] Hard-tier cap: call `learn()` with `pin_tier="hard"` until cap is reached; verify error message names existing engrams and token counts
- [ ] Soft-tier eviction: add soft-pinned engrams with mixed priorities; inject with small budget; verify lower-priority engrams are evicted and `warnings` contains eviction notice
- [ ] Backward compat: existing engrams without `pinned_tier` default to soft tier — no injection change for already-pinned engrams that fit