### PR TITLE
feat(core,cli): plur verify — structured chain verification, never a bare bool (#1053)

### DIFF
--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -23,7 +23,13 @@ import { shouldOutputJson, outputJson, outputText } from '../output.js'
 import { verifyChain, hashStoreFile } from '@plur-ai/core'
 
 export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
-  const plur = createPlur(flags)
+  // Read-only, like `plur ui`. Verification must not be able to write to the
+  // artefact it is examining — and a write-capable handle can, through a lazy
+  // path such as a daily backup or a migration that runs on construction.
+  // `readonly: true` wraps the store in ReadonlyStoreGuard and makes
+  // _assertWritable throw, so "verify never mutates" is enforced rather than
+  // assumed from the fact that this function does not call a write method.
+  const plur = createPlur(flags, { readonly: true })
   const root = plur.storageRoot
   const outcome = verifyChain(root)
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -57,6 +57,13 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
   outputText(`  chain head        : ${r.chain_head ?? '(none — no chained events)'}`)
   outputText(`  checkpoints       : ${r.checkpoints_checked}`)
 
+  if (r.torn_tail) {
+    outputText('')
+    outputText(`  in-flight write: ${r.torn_tail.month} line ${r.torn_tail.line} is incomplete.`)
+    outputText('  A writer was mid-append (or crashed mid-flush). Everything before')
+    outputText('  it verified — this is not corruption and not a break.')
+  }
+
   if (r.unprotected_legacy) {
     const { from, to, count } = r.unprotected_legacy
     outputText('')

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -81,6 +81,17 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       outputText('    A checkpoint pinned a chain head this log no longer contains,')
       outputText('    which means events below it were rewritten wholesale.')
     }
+    if (b.reason === 'store_hash_mismatch') {
+      outputText('    The newest checkpoint attests a store that is not the one on disk.')
+      outputText('    The chain itself is intact — engrams.yaml changed under it. That is')
+      outputText('    expected if you have learned anything since; run `plur checkpoint`')
+      outputText('    to attest the current state. If you have NOT, the store was replaced.')
+    }
+    if (b.reason === 'declared_gap') {
+      outputText('    A writer could not take the chain lock and declared a gap rather')
+      outputText('    than chaining from a tail it had not read under exclusion. This is a')
+      outputText('    concurrency artifact, NOT evidence of tampering.')
+    }
   }
 
   for (const f of r.forks) {

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,0 +1,96 @@
+/**
+ * `plur verify` — verify the history chain (#1053).
+ *
+ * Exit codes are the contract, and all three are distinct:
+ *
+ *   0  verified        the chain holds over everything it covers
+ *   1  broken          at least one break or fork, each one named
+ *   2  cannot verify   the log could not be read — NOT the same as clean
+ *
+ * The third code is the point. A verifier that answered 0 when it could not
+ * read the log would report "healthy" for a chain nobody checked, which is the
+ * failure this whole surface exists to refuse
+ * (docs/design/failure-must-be-distinguishable.md in the enterprise repo
+ * states the same rule for the audit chain).
+ *
+ * Usage:
+ *   plur verify           Human-readable report
+ *   plur verify --json    Full structured result
+ */
+import { join } from 'path'
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { shouldOutputJson, outputJson, outputText } from '../output.js'
+import { verifyChain, hashStoreFile } from '@plur-ai/core'
+
+export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+  const plur = createPlur(flags)
+  const root = plur.storageRoot
+  const outcome = verifyChain(root)
+
+  if (outcome.status === 'cannot_verify') {
+    if (shouldOutputJson(flags)) {
+      outputJson({ status: 'cannot_verify', reason: outcome.reason, month: outcome.month ?? null, line: outcome.line ?? null })
+    } else {
+      outputText('plur verify: CANNOT VERIFY')
+      outputText(`  reason: ${outcome.reason}`)
+      if (outcome.month) outputText(`  month:  ${outcome.month}${outcome.line ? ` (line ${outcome.line})` : ''}`)
+      outputText('')
+      outputText('  This is NOT a clean result. The log could not be read in full,')
+      outputText('  so nothing is asserted about the chain either way.')
+    }
+    process.exitCode = 2
+    return
+  }
+
+  const r = outcome.result
+  const storeHash = hashStoreFile(join(root, 'engrams.yaml'))
+
+  if (shouldOutputJson(flags)) {
+    outputJson({ status: outcome.status, store_hash: storeHash, ...r })
+    process.exitCode = outcome.status === 'verified' ? 0 : 1
+    return
+  }
+
+  outputText(outcome.status === 'verified' ? 'plur verify: OK' : 'plur verify: BROKEN')
+  outputText(`  events total      : ${r.total_events}`)
+  outputText(`  verified (chained): ${r.verified_events}`)
+  outputText(`  chain head        : ${r.chain_head ?? '(none — no chained events)'}`)
+  outputText(`  checkpoints       : ${r.checkpoints_checked}`)
+
+  if (r.unprotected_legacy) {
+    const { from, to, count } = r.unprotected_legacy
+    outputText('')
+    outputText(`  unprotected legacy range: events ${from}–${to} (${count})`)
+    outputText('  Written before the chain existed. They carry no hash and no prev,')
+    outputText('  so nothing here certifies them — that is expected, not a fault.')
+  }
+
+  for (const b of r.breaks) {
+    outputText('')
+    outputText(`  BREAK ${b.reason} at ${b.month} #${b.index} (${b.event_id})`)
+    if (b.expected !== null) outputText(`    expected: ${b.expected}`)
+    if (b.actual !== null)   outputText(`    actual  : ${b.actual}`)
+    if (b.reason === 'checkpoint_head_missing') {
+      outputText('    A checkpoint pinned a chain head this log no longer contains,')
+      outputText('    which means events below it were rewritten wholesale.')
+    }
+  }
+
+  for (const f of r.forks) {
+    outputText('')
+    outputText(`  FORK: ${f.claimed_by.length} events claim predecessor ${f.prev}`)
+    for (const c of f.claimed_by) outputText(`    ${c.month} #${c.index} ${c.event_id} -> ${c.hash}`)
+    outputText('    Two writers appended from the same predecessor. This is a')
+    outputText('    concurrency fault, not evidence of tampering.')
+  }
+
+  if (outcome.status === 'verified' && r.verified_events > 0) {
+    outputText('')
+    outputText('  Note: a hash chain detects edits that do not recompute it. A rewrite')
+    outputText('  that recomputes every prev and hash is internally consistent and is')
+    outputText('  not detectable from this log alone — an anchored checkpoint is what')
+    outputText('  closes that gap.')
+  }
+
+  process.exitCode = outcome.status === 'verified' ? 0 : 1
+}

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -74,8 +74,10 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     const { from, to, count } = r.unprotected_legacy
     outputText('')
     outputText(`  unprotected legacy range: events ${from}–${to} (${count})`)
-    outputText('  Written before the chain existed. They carry no hash and no prev,')
-    outputText('  so nothing here certifies them — that is expected, not a fault.')
+    outputText('  Written by a build that did not chain. They carry no hash and no prev,')
+    outputText('  so nothing here certifies them — that is expected, not a fault. They')
+    outputText('  need not be contiguous: a chained build followed by any non-chaining')
+    outputText('  path interleaves them, which is the ordinary rollout shape.')
   }
 
   for (const b of r.breaks) {
@@ -102,7 +104,7 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
 
   for (const f of r.forks) {
     outputText('')
-    outputText(`  FORK: ${f.claimed_by.length} events claim predecessor ${f.prev}`)
+    outputText(`  FORK: ${f.claimed_by.length} events claim predecessor ${f.prev ?? '(genesis — no predecessor)'}`)
     for (const c of f.claimed_by) outputText(`    ${c.month} #${c.index} ${c.event_id} -> ${c.hash}`)
     outputText('    Two writers appended from the same predecessor. This is a')
     outputText('    concurrency fault, not evidence of tampering.')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,6 +53,7 @@ Commands:
   outbox                  Show team-scoped writes queued for an unreachable store
                           [--flush] to retry them now (#667)
   checkpoint              Emit a checkpoint event — SHA-256 of the store + chain linkage (#1052)
+  verify                  Verify the history chain — exit 0 ok / 1 broken / 2 cannot verify (#1053)
   reindex-tokens          Re-derive BM25 tokens after a tokenizer change (Postgres only)
   reindex-hashes          Repair engrams whose content_hash is stale or missing (#852)
   init                    Wire PLUR into detected harnesses (Claude Code, Cursor, Codex, Antigravity)
@@ -132,6 +133,7 @@ const COMMANDS: Record<string, string> = {
   scopes: './commands/scopes.js',
   outbox: './commands/outbox.js',
   checkpoint: './commands/checkpoint.js',
+  verify: './commands/verify.js',
   'reindex-tokens': './commands/reindex-tokens.js',
   'reindex-hashes': './commands/reindex-hashes.js',
   migrate: './commands/migrate.js',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,6 +228,7 @@ export type { SyncResult, SyncStatus, SyncRemoteType } from './sync.js'
  * neither a lock nor an atomic replace; re-implementing them per package is how
  * the two drift, and the drift is always in the unsafe direction.
  */
+export { verifyChain, hashStoreFile, type ChainVerifyOutcome, type ChainVerifyResult, type ChainBreak, type ChainFork, type BreakReason } from './verify-chain.js'
 export { atomicWrite, withLock } from './sync.js'
 export { markRemoteHostDown, remoteHostDownRemainingMs, clearRemoteHostDown, _resetRemoteHostBreaker, salvageRemoteRow } from './store/remote-store.js'
 export { checkForUpdate, settleVersionChecks, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, VERSION_CHECK_SUCCESS_TTL_MS, VERSION_CHECK_FAILURE_TTL_MS, type VersionCheckResult } from './version-check.js'

--- a/packages/core/src/verify-chain.ts
+++ b/packages/core/src/verify-chain.ts
@@ -1,0 +1,242 @@
+/**
+ * Chain verification for the history log (#1053).
+ *
+ * The gap this closes, in the reviewer's words: "Nothing anywhere in
+ * packages/core, packages/cli or packages/mcp ever verifies prev/hash
+ * linkage." #1051 writes a chain and #1052 checkpoints it, but nothing ever
+ * checked either, so a fork, a broken link or a deletion was silent. A chain
+ * nobody verifies is a chain that proves nothing.
+ *
+ * ## What this can and cannot establish
+ *
+ * It detects every edit that does NOT recompute the chain — content tampering
+ * (the event no longer hashes to its recorded `hash`), a broken link, a
+ * deleted event, a fork, a `prev` pointing at nothing.
+ *
+ * It cannot, from the log alone, detect a rewrite that recomputes every `prev`
+ * and `hash` over the remaining events: that file is internally consistent by
+ * construction. This is the ceiling of any self-contained hash chain and the
+ * reason checkpoints exist — a checkpoint pins a `chain_head` that a later
+ * rewrite cannot reproduce, so `checkpoint_head_missing` catches exactly that
+ * case for everything written before the checkpoint. Anchoring a checkpoint
+ * externally extends the same argument past the boundary of this file.
+ *
+ * Verification is never a bare bool. A bool is not anchorable and hides where
+ * the chain broke, so the result names each break, each fork, and the
+ * unprotected legacy range, and refusal is its own outcome distinct from both
+ * "verified" and "broken" — per docs/design/failure-must-be-distinguishable.md
+ * and the same rule the enterprise audit surface follows.
+ */
+import * as fs from 'node:fs'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { computeEventHash, listHistoryMonths, type HistoryEvent } from './history.js'
+
+export type BreakReason =
+  | 'hash_mismatch'            // the event does not hash to its recorded hash
+  | 'prev_mismatch'            // prev does not equal the predecessor's hash
+  | 'dangling_prev'            // prev names a hash no event in the log carries
+  | 'checkpoint_head_missing'  // a checkpoint pins a head the chain no longer contains
+
+export interface ChainBreak {
+  month:    string
+  index:    number
+  event_id: string
+  reason:   BreakReason
+  expected: string | null
+  actual:   string | null
+}
+
+export interface ChainFork {
+  prev: string
+  claimed_by: Array<{ month: string; index: number; event_id: string; hash: string }>
+}
+
+export interface ChainVerifyResult {
+  ok:                 boolean
+  chain_head:         string | null
+  total_events:       number
+  verified_events:    number
+  /** Contiguous leading run of pre-#1051 events carrying no hash/prev. */
+  unprotected_legacy: { from: number; to: number; count: number } | null
+  breaks:             ChainBreak[]
+  forks:              ChainFork[]
+  checkpoints_checked: number
+}
+
+export type ChainVerifyOutcome =
+  | { status: 'verified'; result: ChainVerifyResult }
+  | { status: 'broken';   result: ChainVerifyResult }
+  | { status: 'cannot_verify'; reason: string; month?: string; line?: number }
+
+interface Scanned { month: string; index: number; event: HistoryEvent }
+
+/**
+ * Verify the whole history chain for a store.
+ *
+ * Reads raw lines rather than going through `readHistory`, which silently
+ * skips malformed lines (history.ts:390). A verifier that skipped them would
+ * report a clean chain over a file it could not fully read — the benign-zero
+ * this surface exists to refuse. A line that will not parse is a refusal.
+ */
+export function verifyChain(root: string): ChainVerifyOutcome {
+  const months = listHistoryMonths(root)
+  const scanned: Scanned[] = []
+
+  let globalIndex = 0
+  for (const month of months) {
+    const filePath = join(root, 'history', `${month}.jsonl`)
+    let content: string
+    try {
+      content = fs.readFileSync(filePath, 'utf8')
+    } catch (err) {
+      return { status: 'cannot_verify', reason: `could not read history file: ${(err as Error).message}`, month }
+    }
+    const lines = content.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (line.trim().length === 0) continue
+      let event: HistoryEvent
+      try {
+        event = JSON.parse(line) as HistoryEvent
+      } catch (err) {
+        return {
+          status: 'cannot_verify',
+          reason: `could not parse history line as JSON: ${(err as Error).message}`,
+          month,
+          line: i + 1,
+        }
+      }
+      scanned.push({ month, index: globalIndex++, event })
+    }
+  }
+
+  const result: ChainVerifyResult = {
+    ok: true,
+    chain_head: null,
+    total_events: scanned.length,
+    verified_events: 0,
+    unprotected_legacy: null,
+    breaks: [],
+    forks: [],
+    checkpoints_checked: 0,
+  }
+
+  // Leading run of legacy events. Pre-#1051 events carry neither hash nor
+  // prev; per runbook law 8 that is an "unprotected legacy range", a
+  // first-class outcome, never an error and never silently upgraded.
+  let firstChained = 0
+  while (firstChained < scanned.length && scanned[firstChained].event.hash === undefined) firstChained++
+  if (firstChained > 0) {
+    result.unprotected_legacy = { from: 0, to: firstChained - 1, count: firstChained }
+  }
+
+  const byHash = new Map<string, Scanned>()
+  const prevClaims = new Map<string, Scanned[]>()
+  let expectedPrev: string | null = null
+  let sawFirstChained = false
+
+  for (let k = firstChained; k < scanned.length; k++) {
+    const { month, index, event } = scanned[k]
+    const id = event.engram_id || `(${event.event})`
+
+    // A legacy event appearing AFTER the chain started is not a legacy range —
+    // it is a hole in a region that is supposed to be chained.
+    if (event.hash === undefined) {
+      result.breaks.push({
+        month, index, event_id: id, reason: 'hash_mismatch',
+        expected: 'a chained event', actual: 'an event with no hash',
+      })
+      continue
+    }
+
+    const recorded = event.hash
+    const recomputed = computeEventHash(event)
+    if (recomputed !== recorded) {
+      result.breaks.push({
+        month, index, event_id: id, reason: 'hash_mismatch',
+        expected: recorded, actual: recomputed,
+      })
+      // Keep walking: the caller wants every break, not just the first.
+    } else {
+      result.verified_events++
+    }
+
+    const prev = event.prev ?? null
+    if (sawFirstChained && prev !== expectedPrev) {
+      result.breaks.push({
+        month, index, event_id: id, reason: 'prev_mismatch',
+        expected: expectedPrev, actual: prev,
+      })
+    }
+
+    if (prev !== null) {
+      const claims = prevClaims.get(prev) ?? []
+      claims.push(scanned[k])
+      prevClaims.set(prev, claims)
+    }
+
+    byHash.set(recorded, scanned[k])
+    expectedPrev = recorded
+    sawFirstChained = true
+    result.chain_head = recorded
+
+    if (event.event === 'checkpoint') result.checkpoints_checked++
+  }
+
+  // A prev that names a hash no event in the log carries. Distinct from
+  // prev_mismatch: the link is not merely to the wrong place, it is to nothing.
+  for (const [prev, claims] of prevClaims) {
+    if (byHash.has(prev)) continue
+    for (const c of claims) {
+      result.breaks.push({
+        month: c.month, index: c.index,
+        event_id: c.event.engram_id || `(${c.event.event})`,
+        reason: 'dangling_prev', expected: 'an event with this hash', actual: prev,
+      })
+    }
+  }
+
+  // Two events claiming one predecessor. Its own outcome, not tamper: it is
+  // what concurrent writers produce, and the fix is different.
+  for (const [prev, claims] of prevClaims) {
+    if (claims.length < 2) continue
+    result.forks.push({
+      prev,
+      claimed_by: claims.map(c => ({
+        month: c.month, index: c.index,
+        event_id: c.event.engram_id || `(${c.event.event})`,
+        hash: c.event.hash!,
+      })),
+    })
+  }
+
+  // Checkpoints pin a head. If the chain no longer contains it, everything
+  // below that checkpoint was rewritten — the one rewrite the linkage checks
+  // above cannot see.
+  for (const { month, index, event } of scanned) {
+    if (event.event !== 'checkpoint') continue
+    const head = (event.data as { chain_head?: unknown }).chain_head
+    if (typeof head !== 'string') continue
+    if (byHash.has(head)) continue
+    result.breaks.push({
+      month, index, event_id: `(checkpoint)`, reason: 'checkpoint_head_missing',
+      expected: head, actual: null,
+    })
+  }
+
+  result.ok = result.breaks.length === 0 && result.forks.length === 0
+  return { status: result.ok ? 'verified' : 'broken', result }
+}
+
+/**
+ * SHA-256 of a store's engrams.yaml bytes, or null when absent.
+ * Used to compare a checkpoint's recorded store_hash against the file today.
+ */
+export function hashStoreFile(engramsPath: string): string | null {
+  try {
+    return createHash('sha256').update(fs.readFileSync(engramsPath)).digest('hex')
+  } catch {
+    return null
+  }
+}

--- a/packages/core/src/verify-chain.ts
+++ b/packages/core/src/verify-chain.ts
@@ -62,6 +62,15 @@ export interface ChainVerifyResult {
   breaks:             ChainBreak[]
   forks:              ChainFork[]
   checkpoints_checked: number
+  /**
+   * An incomplete final line in the newest month file, if present.
+   *
+   * Reported rather than refused: it is a write that was still in flight (or a
+   * writer that crashed mid-flush), so the chain up to it is intact and the
+   * honest answer is "verified, and one append was in progress" — not "cannot
+   * verify". Never null-and-silent: a caller that wants to know is told.
+   */
+  torn_tail: { month: string; line: number } | null
 }
 
 export type ChainVerifyOutcome =
@@ -82,6 +91,8 @@ interface Scanned { month: string; index: number; event: HistoryEvent }
 export function verifyChain(root: string): ChainVerifyOutcome {
   const months = listHistoryMonths(root)
   const scanned: Scanned[] = []
+  /** A torn final line in the newest month — an in-flight write, reported not refused. */
+  let torn_tail: { month: string; line: number } | null = null
 
   let globalIndex = 0
   for (const month of months) {
@@ -93,6 +104,13 @@ export function verifyChain(root: string): ChainVerifyOutcome {
       return { status: 'cannot_verify', reason: `could not read history file: ${(err as Error).message}`, month }
     }
     const lines = content.split('\n')
+    // Index of the last non-empty line: a torn FINAL line is an in-flight
+    // write, not corruption.
+    let lastContentLine = -1
+    for (let i = lines.length - 1; i >= 0; i--) {
+      if (lines[i].trim().length > 0) { lastContentLine = i; break }
+    }
+
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
       if (line.trim().length === 0) continue
@@ -100,6 +118,21 @@ export function verifyChain(root: string): ChainVerifyOutcome {
       try {
         event = JSON.parse(line) as HistoryEvent
       } catch (err) {
+        // A writer that crashed, or one still flushing, leaves the file's LAST
+        // line incomplete. That is an in-flight write, and refusing on it would
+        // make every concurrent append a spurious "cannot verify" — an alarm
+        // that fires when nothing is wrong is an alarm that gets ignored.
+        // A malformed line ANYWHERE ELSE cannot be explained that way and is
+        // real corruption.
+        //
+        // This is the distinction .datacore/lib/ledger/log.py already draws:
+        // append() truncates a torn final line under the lock and read_events()
+        // skips it, while a bad line elsewhere raises CorruptLogError naming
+        // the file and its 1-based line number.
+        if (i === lastContentLine && month === months[months.length - 1]) {
+          torn_tail = { month, line: i + 1 }
+          continue
+        }
         return {
           status: 'cannot_verify',
           reason: `could not parse history line as JSON: ${(err as Error).message}`,
@@ -120,6 +153,7 @@ export function verifyChain(root: string): ChainVerifyOutcome {
     breaks: [],
     forks: [],
     checkpoints_checked: 0,
+    torn_tail: null,
   }
 
   // Leading run of legacy events. Pre-#1051 events carry neither hash nor
@@ -225,6 +259,8 @@ export function verifyChain(root: string): ChainVerifyOutcome {
     })
   }
 
+  result.torn_tail = torn_tail
+  // A torn tail does not make the chain broken — everything before it verified.
   result.ok = result.breaks.length === 0 && result.forks.length === 0
   return { status: result.ok ? 'verified' : 'broken', result }
 }

--- a/packages/core/src/verify-chain.ts
+++ b/packages/core/src/verify-chain.ts
@@ -29,14 +29,15 @@
  */
 import * as fs from 'node:fs'
 import { join } from 'node:path'
-import { createHash } from 'node:crypto'
-import { computeEventHash, listHistoryMonths, type HistoryEvent } from './history.js'
+import { computeEventHash, hashEngramsFile, listHistoryMonths, type HistoryEvent } from './history.js'
 
 export type BreakReason =
   | 'hash_mismatch'            // the event does not hash to its recorded hash
   | 'prev_mismatch'            // prev does not equal the predecessor's hash
   | 'dangling_prev'            // prev names a hash no event in the log carries
   | 'checkpoint_head_missing'  // a checkpoint pins a head the chain no longer contains
+  | 'store_hash_mismatch'      // the newest checkpoint attests a store that is not the one on disk
+  | 'declared_gap'             // prev is null mid-chain: a writer could not take the lock
 
 export interface ChainBreak {
   month:    string
@@ -198,8 +199,18 @@ export function verifyChain(root: string): ChainVerifyOutcome {
 
     const prev = event.prev ?? null
     if (sawFirstChained && prev !== expectedPrev) {
+      // A null prev mid-chain is what appendHistory writes when it cannot take
+      // the chain lock. #1052 calls that "a DECLARED GAP ... never mistaken for
+      // tampering", and it is the honest choice -- but reporting it as
+      // `prev_mismatch` IS mistaking it for tampering, because that is the
+      // reason a rewritten link produces. Under the contention #1052 itself
+      // measured, a busy machine would show BROKEN with a tampering reason for
+      // a log nobody touched, which is the alarm-that-cries-wolf this surface
+      // exists to avoid. Its own reason code, so an operator can tell a
+      // concurrency artifact from an edit.
       result.breaks.push({
-        month, index, event_id: id, reason: 'prev_mismatch',
+        month, index, event_id: id,
+        reason: prev === null ? 'declared_gap' : 'prev_mismatch',
         expected: expectedPrev, actual: prev,
       })
     }
@@ -259,6 +270,32 @@ export function verifyChain(root: string): ChainVerifyOutcome {
     })
   }
 
+  // The checkpoint's whole purpose is to attest the STORE, and nothing checked
+  // it: verifyChain read `chain_head` and ignored `store_hash`, so a store whose
+  // engrams.yaml had been replaced wholesale -- the chain left untouched --
+  // verified as OK. Compare the NEWEST checkpoint only: older ones attest older
+  // states and are expected to differ.
+  const newestCheckpoint = [...scanned].reverse().find(s => s.event.event === 'checkpoint')
+  if (newestCheckpoint) {
+    const attested = (newestCheckpoint.event.data as { store_hash?: unknown }).store_hash
+    if (typeof attested === 'string') {
+      const actual = hashStoreFile(join(root, 'engrams.yaml'))
+      // A store that cannot be read is not a mismatch: an absent store is a
+      // real state (nothing learned yet), and an unreadable one is a refusal
+      // the caller already sees through `cannot_verify` on the log itself.
+      if (actual !== null && actual !== attested) {
+        result.breaks.push({
+          month: newestCheckpoint.month,
+          index: newestCheckpoint.index,
+          event_id: '(checkpoint)',
+          reason: 'store_hash_mismatch',
+          expected: attested,
+          actual,
+        })
+      }
+    }
+  }
+
   result.torn_tail = torn_tail
   // A torn tail does not make the chain broken — everything before it verified.
   result.ok = result.breaks.length === 0 && result.forks.length === 0
@@ -266,12 +303,26 @@ export function verifyChain(root: string): ChainVerifyOutcome {
 }
 
 /**
- * SHA-256 of a store's engrams.yaml bytes, or null when absent.
- * Used to compare a checkpoint's recorded store_hash against the file today.
+ * The store's CANONICAL hash, or null when it cannot be computed.
+ *
+ * Must be the digest a checkpoint records, or the comparison is meaningless.
+ * This function used to hash the raw file bytes while `emitCheckpoint` recorded
+ * the canonical JSON of the parsed document -- two different preimages, so the
+ * value printed by `plur verify` could never equal the value in any checkpoint,
+ * and the doc comment claiming it was "used to compare a checkpoint's recorded
+ * store_hash against the file today" described something that could not happen.
+ * Raw-byte hashing was rejected on purpose in #1052 (LF vs CRLF, emitter, OS);
+ * reintroducing it in the verifier was the harder half of that bug to see.
+ *
+ * Null rather than throwing: a store may legitimately be absent (nothing has
+ * been learned yet), and that is not a verification failure.
+ *
+ * @param engramsPath - absolute path to engrams.yaml.
+ * @returns the canonical store hash, or null when absent or unparseable.
  */
 export function hashStoreFile(engramsPath: string): string | null {
   try {
-    return createHash('sha256').update(fs.readFileSync(engramsPath)).digest('hex')
+    return hashEngramsFile(engramsPath)
   } catch {
     return null
   }

--- a/packages/core/src/verify-chain.ts
+++ b/packages/core/src/verify-chain.ts
@@ -49,7 +49,8 @@ export interface ChainBreak {
 }
 
 export interface ChainFork {
-  prev: string
+  /** The predecessor these events claim, or null when they claim genesis. */
+  prev: string | null
   claimed_by: Array<{ month: string; index: number; event_id: string; hash: string }>
 }
 
@@ -58,7 +59,7 @@ export interface ChainVerifyResult {
   chain_head:         string | null
   total_events:       number
   verified_events:    number
-  /** Contiguous leading run of pre-#1051 events carrying no hash/prev. */
+  /** Pre-#1051 events carrying no hash/prev, wherever they appear in the log. */
   unprotected_legacy: { from: number; to: number; count: number } | null
   breaks:             ChainBreak[]
   forks:              ChainFork[]
@@ -80,6 +81,15 @@ export type ChainVerifyOutcome =
   | { status: 'cannot_verify'; reason: string; month?: string; line?: number }
 
 interface Scanned { month: string; index: number; event: HistoryEvent }
+
+/**
+ * Claims key for an event with no predecessor.
+ *
+ * Not a hash, and cannot be mistaken for one: every real key is 64 hex
+ * characters. Genesis events must share a key so that two of them are visible
+ * as a fork.
+ */
+const GENESIS_CLAIM = '(genesis)'
 
 /**
  * Verify the whole history chain for a store.
@@ -157,13 +167,25 @@ export function verifyChain(root: string): ChainVerifyOutcome {
     torn_tail: null,
   }
 
-  // Leading run of legacy events. Pre-#1051 events carry neither hash nor
-  // prev; per runbook law 8 that is an "unprotected legacy range", a
-  // first-class outcome, never an error and never silently upgraded.
-  let firstChained = 0
-  while (firstChained < scanned.length && scanned[firstChained].event.hash === undefined) firstChained++
-  if (firstChained > 0) {
-    result.unprotected_legacy = { from: 0, to: firstChained - 1, count: firstChained }
+  // Unchained (pre-#1051) events. They carry neither hash nor prev; per runbook
+  // law 8 that is an "unprotected legacy range" — a first-class outcome, never
+  // an error and never silently upgraded.
+  //
+  // Counted WHEREVER they appear, not only as a leading run. Treating a leading
+  // run as legacy and everything after it as tampering assumed a store crosses
+  // the chain boundary exactly once, which is not the ordinary rollout shape: a
+  // chained build runs, then any non-chaining path writes, and the store now
+  // interleaves. Reported as `hash_mismatch` ("content was edited") those
+  // events made a real pre-chain store return exit 1 with roughly 920 breaks
+  // citing tampering, with `unprotected_legacy: null` actively denying the
+  // legacy region existed. Nothing was edited.
+  const legacyIdx = scanned.map((s, i) => (s.event.hash === undefined ? i : -1)).filter(i => i >= 0)
+  if (legacyIdx.length > 0) {
+    result.unprotected_legacy = {
+      from: legacyIdx[0],
+      to: legacyIdx[legacyIdx.length - 1],
+      count: legacyIdx.length,
+    }
   }
 
   const byHash = new Map<string, Scanned>()
@@ -171,19 +193,21 @@ export function verifyChain(root: string): ChainVerifyOutcome {
   let expectedPrev: string | null = null
   let sawFirstChained = false
 
-  for (let k = firstChained; k < scanned.length; k++) {
+  // Every event, in order. Unchained ones are skipped inside the loop rather
+  // than by starting past a leading run — they can appear anywhere.
+  for (let k = 0; k < scanned.length; k++) {
     const { month, index, event } = scanned[k]
     const id = event.engram_id || `(${event.event})`
 
-    // A legacy event appearing AFTER the chain started is not a legacy range —
-    // it is a hole in a region that is supposed to be chained.
-    if (event.hash === undefined) {
-      result.breaks.push({
-        month, index, event_id: id, reason: 'hash_mismatch',
-        expected: 'a chained event', actual: 'an event with no hash',
-      })
-      continue
-    }
+    // An unchained event is not a break. It is uncovered, which is what
+    // `unprotected_legacy` reports, and `verified` already means "the chain
+    // holds over everything it covers" — not "everything is covered".
+    //
+    // It does NOT advance `expectedPrev`: the next chained event's predecessor
+    // is the last CHAINED event, because that is what appendHistory's tail-seek
+    // would have found. When the tail-seek instead returned null the next event
+    // carries prev:null, which is reported as a declared_gap.
+    if (event.hash === undefined) continue
 
     const recorded = event.hash
     const recomputed = computeEventHash(event)
@@ -215,11 +239,16 @@ export function verifyChain(root: string): ChainVerifyOutcome {
       })
     }
 
-    if (prev !== null) {
-      const claims = prevClaims.get(prev) ?? []
-      claims.push(scanned[k])
-      prevClaims.set(prev, claims)
-    }
+    // Genesis is a claim too. Excluding `prev: null` meant the ONE fork shape
+    // the lock-failure path can actually produce was the one not labelled a
+    // fork: two concurrent writers on an empty store both take the gap path,
+    // both write `prev: null`, and the result was `forks: []` plus a single
+    // prev_mismatch. Keyed under a sentinel that cannot collide with a hash —
+    // hashes are 64 hex characters, this is not.
+    const claimKey = prev ?? GENESIS_CLAIM
+    const claims = prevClaims.get(claimKey) ?? []
+    claims.push(scanned[k])
+    prevClaims.set(claimKey, claims)
 
     byHash.set(recorded, scanned[k])
     expectedPrev = recorded
@@ -232,6 +261,7 @@ export function verifyChain(root: string): ChainVerifyOutcome {
   // A prev that names a hash no event in the log carries. Distinct from
   // prev_mismatch: the link is not merely to the wrong place, it is to nothing.
   for (const [prev, claims] of prevClaims) {
+    if (prev === GENESIS_CLAIM) continue // genesis names no predecessor by design
     if (byHash.has(prev)) continue
     for (const c of claims) {
       result.breaks.push({
@@ -247,7 +277,9 @@ export function verifyChain(root: string): ChainVerifyOutcome {
   for (const [prev, claims] of prevClaims) {
     if (claims.length < 2) continue
     result.forks.push({
-      prev,
+      // Reported as null rather than the sentinel: the consumer's contract is
+      // "the predecessor these events claim", and for genesis that is nothing.
+      prev: prev === GENESIS_CLAIM ? null : prev,
       claimed_by: claims.map(c => ({
         month: c.month, index: c.index,
         event_id: c.event.engram_id || `(${c.event.event})`,

--- a/packages/core/test/checkpoint-store-binding.test.ts
+++ b/packages/core/test/checkpoint-store-binding.test.ts
@@ -72,9 +72,16 @@ describe('store_hash is bound to the chain_head beside it', () => {
     }
   })
 
-  it('the persisted chain_head equals the event own prev, always', () => {
-    // The binding this replaced (#1052 finding 2). Kept so a regression on
-    // either binding is caught.
+  it('the persisted chain_head is consistent with the event own prev', () => {
+    // HONEST SCOPE: this is a consistency check, NOT a drift detector, and the
+    // distinction matters because an existing test with a stronger-sounding
+    // name ("they cannot drift apart") was proven vacuous by mutation for
+    // exactly this reason. Single-threaded, both values come from the same
+    // read, so it passes with or without the fix.
+    //
+    // What actually guards the binding is the structural test below, which
+    // asserts the chain lock is held while onPrev runs. Kept anyway: it would
+    // still catch a payload that stopped being built from `prev` at all.
     writeStore(2)
     for (let i = 0; i < 10; i++) emitCheckpoint(dir, join(dir, 'engrams.yaml'), 'cli')
     for (const cp of checkpoints()) {

--- a/packages/core/test/verify-chain.test.ts
+++ b/packages/core/test/verify-chain.test.ts
@@ -160,8 +160,13 @@ describe('verifyChain — refusal is distinguishable from a finding', () => {
     // readHistory() silently skips malformed lines. A verifier that did the
     // same would report a clean chain over a file it could not fully read —
     // the benign-zero this whole surface exists to refuse.
+    //
+    // The corruption sits mid-file deliberately: a malformed line in the LAST
+    // position is an in-flight write and is tolerated (see the torn-tail block
+    // below). Only a bad line that a write-in-progress cannot explain refuses.
     writeChain('2026-01', 3)
-    writeLines('2026-01', [...readLines('2026-01'), '{not json'])
+    const lines = readLines('2026-01')
+    writeLines('2026-01', [lines[0], '{not json', lines[1], lines[2]])
 
     const out = verifyChain(root)
     expect(out.status).toBe('cannot_verify')
@@ -261,5 +266,47 @@ describe('verifyChain — the L2 ceiling, stated honestly', () => {
     expect(out.status).toBe('broken')
     if (out.status !== 'broken') return
     expect(out.result.breaks.some(b => b.reason === 'checkpoint_head_missing')).toBe(true)
+  })
+})
+
+describe('verifyChain — a torn final line is an in-flight write, not corruption', () => {
+  it('tolerates an incomplete last line and reports it', () => {
+    // THE DEFECT THIS GUARDS: refusing on ANY malformed line meant every
+    // concurrent append raced the verifier into a spurious "cannot_verify".
+    // An alarm that fires when nothing is wrong is an alarm that gets ignored.
+    // .datacore/lib/ledger/log.py already draws this line: a torn FINAL line
+    // is a write still in flight; a bad line anywhere else is corruption.
+    writeChain('2026-01', 3)
+    const raw = readFileSync(monthFile('2026-01'), 'utf8')
+    writeFileSync(monthFile('2026-01'), raw + '{"event":"engram_created","eng')
+
+    const out = verifyChain(root)
+    expect(out.status, 'the chain before the torn line is intact').toBe('verified')
+    if (out.status !== 'verified') return
+    expect(out.result.verified_events).toBe(3)
+    expect(out.result.torn_tail).toEqual({ month: '2026-01', line: 4 })
+  })
+
+  it('still refuses a malformed line that is NOT last', () => {
+    writeChain('2026-01', 3)
+    const lines = readLines('2026-01')
+    writeLines('2026-01', [lines[0], '{torn in the middle', lines[1], lines[2]])
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('cannot_verify')
+    if (out.status !== 'cannot_verify') return
+    expect(out.line).toBe(2)
+  })
+
+  it('refuses a torn line in an OLDER month — only the newest can be in flight', () => {
+    writeChain('2026-01', 2)
+    writeChain('2026-02', 2)
+    const raw = readFileSync(monthFile('2026-01'), 'utf8')
+    writeFileSync(monthFile('2026-01'), raw + '{"event":"trunc')
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('cannot_verify')
+    if (out.status !== 'cannot_verify') return
+    expect(out.month).toBe('2026-01')
   })
 })

--- a/packages/core/test/verify-chain.test.ts
+++ b/packages/core/test/verify-chain.test.ts
@@ -423,3 +423,113 @@ describe('verifyChain — a declared gap is not tampering', () => {
     } finally { rmSync(dir, { recursive: true, force: true }) }
   })
 })
+
+// ── An unchained event is uncovered, not tampered with ──────────────────────
+
+describe('verifyChain — legacy events anywhere are a legacy range, not a break', () => {
+  /**
+   * Treating a LEADING run as legacy and everything after it as tampering
+   * assumed a store crosses the chain boundary exactly once. That is not the
+   * ordinary rollout shape: a chained build runs, then any non-chaining path
+   * writes, and the store interleaves from then on.
+   *
+   * Reported as `hash_mismatch` — documented as "content was edited" — those
+   * events made a real pre-chain store return exit 1 with roughly 920 breaks
+   * citing tampering, while `unprotected_legacy` stayed null and actively
+   * denied the legacy region existed. Nothing was edited.
+   *
+   * `verified` means "the chain holds over everything it COVERS". Uncovered is
+   * reported, not alarmed on.
+   */
+  function legacyEvent(id: string, ts: string): HistoryEvent {
+    return { event: 'engram_created', engram_id: id, timestamp: ts, data: {} }
+  }
+
+  it('does not report tampering for legacy events after the chain started', () => {
+    const chained = writeChain('2026-01', 3)
+    const lines = chained.map(e => JSON.stringify(e))
+    for (let i = 0; i < 5; i++) lines.push(JSON.stringify(legacyEvent(`ENG-L-${i}`, '2026-01-02T00:00:00.000Z')))
+    writeFileSync(monthFile('2026-01'), lines.join('\n') + '\n', 'utf8')
+
+    const out = verifyChain(root)
+    const reasons = out.status === 'broken' ? out.result.breaks.map(b => b.reason) : []
+    expect(reasons, 'unchained events reported as tampering').not.toContain('hash_mismatch')
+    expect(out.status).toBe('verified')
+  })
+
+  it('reports the legacy events rather than denying they exist', () => {
+    const chained = writeChain('2026-01', 3)
+    const lines = chained.map(e => JSON.stringify(e))
+    for (let i = 0; i < 5; i++) lines.push(JSON.stringify(legacyEvent(`ENG-L-${i}`, '2026-01-02T00:00:00.000Z')))
+    writeFileSync(monthFile('2026-01'), lines.join('\n') + '\n', 'utf8')
+
+    const out = verifyChain(root)
+    const r = out.status === 'verified' ? out.result : out.status === 'broken' ? out.result : null
+    expect(r).not.toBeNull()
+    expect(r!.unprotected_legacy, 'legacy region reported as absent').not.toBeNull()
+    expect(r!.unprotected_legacy!.count).toBe(5)
+    // The chained prefix is still verified — coverage is reported, not lost.
+    expect(r!.verified_events).toBe(3)
+  })
+
+  it('still counts a leading legacy run', () => {
+    // The original case must keep working.
+    const lines: string[] = []
+    for (let i = 0; i < 4; i++) lines.push(JSON.stringify(legacyEvent(`ENG-P-${i}`, '2026-01-01T00:00:00.000Z')))
+    writeFileSync(monthFile('2026-01'), lines.join('\n') + '\n', 'utf8')
+    const out = verifyChain(root)
+    const r = out.status === 'verified' ? out.result : (out as { result: typeof out extends never ? never : any }).result
+    expect(r.unprotected_legacy?.count).toBe(4)
+    expect(out.status).toBe('verified')
+  })
+
+  it('still catches real tampering in the chained region', () => {
+    // The relaxation must not swallow an actual content edit.
+    const chained = writeChain('2026-01', 4)
+    const lines = chained.map(e => JSON.stringify(e))
+    const tampered = { ...chained[2], engram_id: 'ENG-EDITED' }
+    lines[2] = JSON.stringify(tampered)
+    writeFileSync(monthFile('2026-01'), lines.join('\n') + '\n', 'utf8')
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('broken')
+    const reasons = out.status === 'broken' ? out.result.breaks.map(b => b.reason) : []
+    expect(reasons).toContain('hash_mismatch')
+  })
+})
+
+// ── Genesis is a claim, so two of them are a fork ───────────────────────────
+
+describe('verifyChain — a genesis fork is a fork', () => {
+  it('names two events that both claim genesis', () => {
+    // The one fork shape the lock-failure path can actually produce: two
+    // concurrent writers on an empty store both take the gap path and both
+    // write prev:null. Excluding null from the claims map reported forks: []
+    // and a single prev_mismatch — the real fork, unlabelled.
+    const a: HistoryEvent = { event: 'engram_created', engram_id: 'ENG-A', timestamp: '2026-01-01T00:00:00.000Z', data: {}, prev: null }
+    a.hash = computeEventHash(a)
+    const b: HistoryEvent = { event: 'engram_created', engram_id: 'ENG-B', timestamp: '2026-01-01T00:00:01.000Z', data: {}, prev: null }
+    b.hash = computeEventHash(b)
+    writeFileSync(monthFile('2026-01'), [a, b].map(e => JSON.stringify(e)).join('\n') + '\n', 'utf8')
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('broken')
+    const r = out.status === 'broken' ? out.result : null
+    expect(r!.forks, 'a genesis fork was not reported as a fork').toHaveLength(1)
+    expect(r!.forks[0].prev, 'genesis should report a null predecessor').toBeNull()
+    expect(r!.forks[0].claimed_by).toHaveLength(2)
+  })
+
+  it('a single genesis event is not a fork and not dangling', () => {
+    // The sentinel must not leak into dangling_prev either.
+    const a: HistoryEvent = { event: 'engram_created', engram_id: 'ENG-A', timestamp: '2026-01-01T00:00:00.000Z', data: {}, prev: null }
+    a.hash = computeEventHash(a)
+    writeFileSync(monthFile('2026-01'), JSON.stringify(a) + '\n', 'utf8')
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('verified')
+    const r = out.status === 'verified' ? out.result : null
+    expect(r!.forks).toHaveLength(0)
+    expect(r!.breaks).toHaveLength(0)
+  })
+})

--- a/packages/core/test/verify-chain.test.ts
+++ b/packages/core/test/verify-chain.test.ts
@@ -22,8 +22,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { verifyChain } from '../src/verify-chain.js'
-import { computeEventHash, type HistoryEvent } from '../src/history.js'
+import { verifyChain, hashStoreFile } from '../src/verify-chain.js'
+import { appendHistory, computeEventHash, emitCheckpoint, type HistoryEvent } from '../src/history.js'
 
 let root: string
 const historyDir = () => join(root, 'history')
@@ -308,5 +308,118 @@ describe('verifyChain — a torn final line is an in-flight write, not corruptio
     expect(out.status).toBe('cannot_verify')
     if (out.status !== 'cannot_verify') return
     expect(out.month).toBe('2026-01')
+  })
+})
+
+// ── The attestation a checkpoint exists to make must actually be checked ─────
+
+describe('verifyChain — the checkpoint attests the STORE, so verify it', () => {
+  /**
+   * The gap: verifyChain read `chain_head` from checkpoint payloads and ignored
+   * `store_hash` entirely. A store whose engrams.yaml was replaced wholesale,
+   * with the history chain left untouched, verified as OK — the one thing the
+   * checkpoint exists to make detectable.
+   *
+   * Compounding it, `hashStoreFile` hashed RAW FILE BYTES while emitCheckpoint
+   * recorded the CANONICAL JSON of the parsed document. Different preimages, so
+   * the two could never be equal even if something had compared them.
+   */
+  function storeWith(dir: string, ids: string[]): void {
+    writeFileSync(
+      join(dir, 'engrams.yaml'),
+      'engrams:\n' + ids.map(id => `  - id: ${id}\n    status: active\n`).join(''),
+      'utf8',
+    )
+  }
+
+  it('hashStoreFile agrees with what a checkpoint records', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vc-attest-'))
+    try {
+      storeWith(dir, ['ENG-001'])
+      const cp = emitCheckpoint(dir, join(dir, 'engrams.yaml'), 'cli')
+      // The whole point: these are the same preimage.
+      expect(hashStoreFile(join(dir, 'engrams.yaml'))).toBe(cp.store_hash)
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('BREAKS when the store no longer matches the newest checkpoint', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vc-attest-'))
+    try {
+      storeWith(dir, ['ENG-001'])
+      emitCheckpoint(dir, join(dir, 'engrams.yaml'), 'cli')
+      expect(verifyChain(dir).status).toBe('verified')
+
+      // Replace the store wholesale, leaving the chain untouched.
+      storeWith(dir, ['ENG-666'])
+      const out = verifyChain(dir)
+      expect(out.status).toBe('broken')
+      const reasons = out.status === 'broken' ? out.result.breaks.map(b => b.reason) : []
+      expect(reasons).toContain('store_hash_mismatch')
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('does NOT break on formatting-only changes — it attests content', () => {
+    // A checkpoint attests the engrams, not the whitespace. Raw-byte hashing
+    // would fail here, which is why #1052 rejected it.
+    const dir = mkdtempSync(join(tmpdir(), 'vc-attest-'))
+    try {
+      writeFileSync(join(dir, 'engrams.yaml'), 'engrams:\n  - id: ENG-001\n    status: active\n', 'utf8')
+      emitCheckpoint(dir, join(dir, 'engrams.yaml'), 'cli')
+      // Same document, CRLF and an extra trailing newline.
+      writeFileSync(join(dir, 'engrams.yaml'), 'engrams:\r\n  - id: ENG-001\r\n    status: active\r\n\r\n', 'utf8')
+      expect(verifyChain(dir).status).toBe('verified')
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('compares only the NEWEST checkpoint — older ones attest older states', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vc-attest-'))
+    try {
+      storeWith(dir, ['ENG-001'])
+      emitCheckpoint(dir, join(dir, 'engrams.yaml'), 'cli')
+      storeWith(dir, ['ENG-001', 'ENG-002'])
+      emitCheckpoint(dir, join(dir, 'engrams.yaml'), 'cli')
+      // The first checkpoint legitimately describes a store that no longer
+      // exists. Only the newest is a claim about now.
+      expect(verifyChain(dir).status).toBe('verified')
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+
+  it('an absent store is not a mismatch', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vc-attest-'))
+    try {
+      storeWith(dir, ['ENG-001'])
+      emitCheckpoint(dir, join(dir, 'engrams.yaml'), 'cli')
+      rmSync(join(dir, 'engrams.yaml'))
+      expect(verifyChain(dir).status).toBe('verified')
+    } finally { rmSync(dir, { recursive: true, force: true }) }
+  })
+})
+
+describe('verifyChain — a declared gap is not tampering', () => {
+  it('reports prev:null mid-chain as declared_gap, not prev_mismatch', () => {
+    // appendHistory writes prev:null when it cannot take the chain lock, and
+    // #1052 promises that is "never mistaken for tampering". Reporting it as
+    // prev_mismatch — the reason a rewritten link produces — was exactly that
+    // mistake, and under real contention it would fire routinely.
+    const dir = mkdtempSync(join(tmpdir(), 'vc-gap-'))
+    try {
+      appendHistory(dir, { event: 'engram_created', engram_id: 'ENG-001', timestamp: '2026-01-01T00:00:00.000Z', data: {} })
+      appendHistory(dir, { event: 'engram_created', engram_id: 'ENG-002', timestamp: '2026-01-01T00:01:00.000Z', data: {} })
+
+      // Rewrite the second event with prev:null and a hash that matches it —
+      // exactly what the lock-failure path produces.
+      const file = join(dir, 'history', '2026-01.jsonl')
+      const lines = readFileSync(file, 'utf8').trim().split('\n').map(l => JSON.parse(l) as HistoryEvent)
+      const gapped: HistoryEvent = { ...lines[1], prev: null }
+      delete (gapped as { hash?: string }).hash
+      gapped.hash = computeEventHash(gapped)
+      writeFileSync(file, [lines[0], gapped].map(e => JSON.stringify(e)).join('\n') + '\n', 'utf8')
+
+      const out = verifyChain(dir)
+      expect(out.status).toBe('broken')
+      const reasons = out.status === 'broken' ? out.result.breaks.map(b => b.reason) : []
+      expect(reasons).toContain('declared_gap')
+      expect(reasons).not.toContain('prev_mismatch')
+    } finally { rmSync(dir, { recursive: true, force: true }) }
   })
 })

--- a/packages/core/test/verify-chain.test.ts
+++ b/packages/core/test/verify-chain.test.ts
@@ -1,0 +1,265 @@
+/**
+ * plur verify — structured chain verification (#1053).
+ *
+ * WHY THIS EXISTS. Črt's review of #1073 established the hole this closes:
+ * "Nothing anywhere in packages/core, packages/cli or packages/mcp ever
+ * verifies prev/hash linkage." He deleted a middle event, recomputed prev and
+ * hash over the remainder, and got a file with zero broken links and an
+ * unchanged store_hash. Until something checks the chain, the chain proves
+ * nothing — and #1051's forks and #1052's mismatched checkpoints are all
+ * silent in production.
+ *
+ * WHAT A HASH CHAIN CAN AND CANNOT DETECT. It detects edits that do NOT
+ * recompute the chain: content tampering, a broken link, a deletion, a fork.
+ * A full recomputation over the whole file is internally consistent and is
+ * NOT detectable from the file alone — that is the L2 ceiling, and the reason
+ * checkpoints exist. A checkpoint that recorded a chain head which the
+ * recomputed chain no longer contains is what catches it. These tests assert
+ * both halves, including the limitation, so no one reads more assurance into
+ * this than it provides.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { verifyChain } from '../src/verify-chain.js'
+import { computeEventHash, type HistoryEvent } from '../src/history.js'
+
+let root: string
+const historyDir = () => join(root, 'history')
+const monthFile = (m: string) => join(historyDir(), `${m}.jsonl`)
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'plur-verify-'))
+  mkdirSync(historyDir(), { recursive: true })
+})
+afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+/** Build a chained run of events and write them to `month`. */
+function writeChain(month: string, count: number, startPrev: string | null = null): HistoryEvent[] {
+  const events: HistoryEvent[] = []
+  let prev = startPrev
+  for (let i = 0; i < count; i++) {
+    const e: HistoryEvent = {
+      event: 'engram_created',
+      engram_id: `ENG-${month}-${String(i).padStart(3, '0')}`,
+      timestamp: `2026-01-0${(i % 9) + 1}T00:00:00.000Z`,
+      data: { n: i },
+      prev,
+    }
+    e.hash = computeEventHash(e)
+    events.push(e)
+    prev = e.hash
+  }
+  writeFileSync(monthFile(month), events.map(e => JSON.stringify(e)).join('\n') + '\n')
+  return events
+}
+
+function readLines(month: string): string[] {
+  return readFileSync(monthFile(month), 'utf8').split('\n').filter(l => l.trim())
+}
+function writeLines(month: string, lines: string[]): void {
+  writeFileSync(monthFile(month), lines.join('\n') + '\n')
+}
+
+describe('verifyChain — a clean chain', () => {
+  it('verifies and reports a structured result, never a bare bool', () => {
+    writeChain('2026-01', 5)
+    const out = verifyChain(root)
+    expect(out.status).toBe('verified')
+    if (out.status !== 'verified') return
+    expect(out.result.ok).toBe(true)
+    expect(out.result.verified_events).toBe(5)
+    expect(out.result.breaks).toEqual([])
+    expect(out.result.forks).toEqual([])
+    expect(out.result.chain_head).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('chains across a month boundary', () => {
+    const jan = writeChain('2026-01', 3)
+    writeChain('2026-02', 2, jan[jan.length - 1].hash!)
+    const out = verifyChain(root)
+    expect(out.status).toBe('verified')
+    if (out.status !== 'verified') return
+    expect(out.result.verified_events).toBe(5)
+  })
+})
+
+describe('verifyChain — tampering that does not recompute the chain', () => {
+  it('names a mid-chain content edit as a hash mismatch', () => {
+    writeChain('2026-01', 5)
+    const lines = readLines('2026-01')
+    const ev = JSON.parse(lines[2]) as HistoryEvent
+    ev.data = { n: 999 }                 // edited, hash left alone
+    lines[2] = JSON.stringify(ev)
+    writeLines('2026-01', lines)
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('broken')
+    if (out.status !== 'broken') return
+    expect(out.result.ok).toBe(false)
+    const b = out.result.breaks.find(x => x.reason === 'hash_mismatch')
+    expect(b, 'a content edit must be named a hash mismatch').toBeDefined()
+    expect(b!.event_id).toBe('ENG-2026-01-002')
+  })
+
+  it('names a deleted middle event as a broken link', () => {
+    writeChain('2026-01', 5)
+    const lines = readLines('2026-01')
+    lines.splice(2, 1)                   // remove one, recompute nothing
+    writeLines('2026-01', lines)
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('broken')
+    if (out.status !== 'broken') return
+    expect(out.result.breaks.some(b => b.reason === 'prev_mismatch')).toBe(true)
+  })
+
+  it('names a fork — two events claiming one predecessor', () => {
+    const evs = writeChain('2026-01', 3)
+    const forked: HistoryEvent = {
+      event: 'engram_created',
+      engram_id: 'ENG-FORK',
+      timestamp: '2026-01-09T00:00:00.000Z',
+      data: { n: 99 },
+      prev: evs[0].hash!,                // same prev as evs[1]
+    }
+    forked.hash = computeEventHash(forked)
+    writeLines('2026-01', [...readLines('2026-01'), JSON.stringify(forked)])
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('broken')
+    if (out.status !== 'broken') return
+    expect(out.result.forks.length).toBe(1)
+    expect(out.result.forks[0].prev).toBe(evs[0].hash)
+    expect(out.result.forks[0].claimed_by.length).toBe(2)
+  })
+
+  it('names a prev that references no known event', () => {
+    const evs = writeChain('2026-01', 2)
+    const dangling: HistoryEvent = {
+      event: 'engram_created',
+      engram_id: 'ENG-DANGLE',
+      timestamp: '2026-01-09T00:00:00.000Z',
+      data: {},
+      prev: 'f'.repeat(64),
+    }
+    dangling.hash = computeEventHash(dangling)
+    void evs
+    writeLines('2026-01', [...readLines('2026-01'), JSON.stringify(dangling)])
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('broken')
+    if (out.status !== 'broken') return
+    expect(out.result.breaks.some(b => b.reason === 'dangling_prev')).toBe(true)
+  })
+})
+
+describe('verifyChain — refusal is distinguishable from a finding', () => {
+  it('refuses on a corrupted JSONL line instead of skipping it', () => {
+    // readHistory() silently skips malformed lines. A verifier that did the
+    // same would report a clean chain over a file it could not fully read —
+    // the benign-zero this whole surface exists to refuse.
+    writeChain('2026-01', 3)
+    writeLines('2026-01', [...readLines('2026-01'), '{not json'])
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('cannot_verify')
+    if (out.status !== 'cannot_verify') return
+    expect(out.reason).toMatch(/parse/i)
+    expect(out.month).toBe('2026-01')
+  })
+
+  it('an empty store verifies rather than refusing — nothing there is a real answer', () => {
+    const out = verifyChain(root)
+    expect(out.status).toBe('verified')
+    if (out.status !== 'verified') return
+    expect(out.result.verified_events).toBe(0)
+    expect(out.result.chain_head).toBeNull()
+  })
+})
+
+describe('verifyChain — legacy events are a first-class outcome, not an error', () => {
+  it('reports an unchained region without failing', () => {
+    const legacy = [0, 1, 2].map(i => JSON.stringify({
+      event: 'engram_created', engram_id: `OLD-${i}`,
+      timestamp: '2025-12-01T00:00:00.000Z', data: {},
+    }))
+    writeLines('2026-01', legacy)
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('verified')
+    if (out.status !== 'verified') return
+    expect(out.result.ok).toBe(true)
+    expect(out.result.unprotected_legacy).toEqual({ from: 0, to: 2, count: 3 })
+    expect(out.result.verified_events).toBe(0)
+  })
+
+  it('a legacy prefix followed by a chained region verifies the chained part only', () => {
+    const legacy = JSON.stringify({
+      event: 'engram_created', engram_id: 'OLD-0',
+      timestamp: '2025-12-01T00:00:00.000Z', data: {},
+    })
+    writeChain('2026-01', 3)
+    writeLines('2026-01', [legacy, ...readLines('2026-01')])
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('verified')
+    if (out.status !== 'verified') return
+    expect(out.result.unprotected_legacy).toEqual({ from: 0, to: 0, count: 1 })
+    expect(out.result.verified_events).toBe(3)
+  })
+})
+
+describe('verifyChain — the L2 ceiling, stated honestly', () => {
+  it('CANNOT detect a full recomputation from the file alone', () => {
+    // Črt's probe. This asserts the LIMITATION on purpose: if this ever starts
+    // failing, someone has claimed a property a hash chain does not have.
+    writeChain('2026-01', 5)
+    const kept = readLines('2026-01').map(l => JSON.parse(l) as HistoryEvent)
+    kept.splice(2, 1)
+    let prev: string | null = null
+    for (const e of kept) {
+      e.prev = prev
+      delete e.hash
+      e.hash = computeEventHash(e)
+      prev = e.hash
+    }
+    writeLines('2026-01', kept.map(e => JSON.stringify(e)))
+
+    const out = verifyChain(root)
+    expect(out.status, 'a fully recomputed chain is internally consistent').toBe('verified')
+  })
+
+  it('DOES detect it once a checkpoint recorded the old head', () => {
+    // This is what makes checkpoints the anchorable object: they pin a head
+    // that a later rewrite cannot reproduce.
+    const evs = writeChain('2026-01', 5)
+    const cp: HistoryEvent = {
+      event: 'checkpoint',
+      engram_id: '',
+      timestamp: '2026-01-09T00:00:00.000Z',
+      data: { chain_head: evs[4].hash!, engram_count: 5, actor: 'cli' },
+      prev: evs[4].hash!,
+    }
+    cp.hash = computeEventHash(cp)
+    writeLines('2026-01', [...readLines('2026-01'), JSON.stringify(cp)])
+
+    // Now rewrite history below the checkpoint, recomputing everything.
+    const all = readLines('2026-01').map(l => JSON.parse(l) as HistoryEvent)
+    const rewritten = all.filter(e => e.event !== 'checkpoint')
+    rewritten.splice(2, 1)
+    let prev: string | null = null
+    for (const e of rewritten) {
+      e.prev = prev; delete e.hash; e.hash = computeEventHash(e); prev = e.hash
+    }
+    const keptCp = all.find(e => e.event === 'checkpoint')!
+    keptCp.prev = prev; delete keptCp.hash; keptCp.hash = computeEventHash(keptCp)
+    writeLines('2026-01', [...rewritten, keptCp].map(e => JSON.stringify(e)))
+
+    const out = verifyChain(root)
+    expect(out.status).toBe('broken')
+    if (out.status !== 'broken') return
+    expect(out.result.breaks.some(b => b.reason === 'checkpoint_head_missing')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

`plur verify` — structured verification of the hash-chained history log (#1053).

Opened **first**, ahead of the rest of Wave 2, because the review of #1073 established that
it is a prerequisite rather than a successor:

> Nothing anywhere in `packages/core`, `packages/cli` or `packages/mcp` ever verifies
> `prev`/`hash` linkage. Every failure mode above is silent, and so is deliberate tampering.

Until something checks the chain, #1051's forks and #1052's mismatched checkpoints cannot be
observed in production, and the L2 claim is not merely unproven — it is unfalsifiable. This is
the instrument the rest of Wave 2 is judged with.

## What it reports

`verifyChain(root)` returns a structured result, **never a bare bool** — a bool is not
anchorable and hides where the chain broke:

```
{ ok, chain_head, total_events, verified_events,
  unprotected_legacy: { from, to, count } | null,
  breaks: [...], forks: [...], checkpoints_checked }
```

Four break reasons, deliberately distinct:

| reason | meaning |
|---|---|
| `hash_mismatch` | the event no longer hashes to its recorded `hash` — content was edited |
| `prev_mismatch` | `prev` does not equal the predecessor's hash — a link or an event was removed |
| `dangling_prev` | `prev` names a hash no event in the log carries |
| `checkpoint_head_missing` | a checkpoint pinned a head the chain no longer contains |

**Forks are their own outcome**, not a kind of tampering: two events claiming one predecessor
is what concurrent writers produce, and the fix is different. **Unprotected legacy** is a
first-class outcome too — pre-#1051 events carry no `hash`/`prev`, and that is expected, never
an error and never silently upgraded.

## Exit codes — the third one is the point

```
0  verified       the chain holds over everything it covers
1  broken         at least one break or fork, each named with month/index/event
2  cannot verify  the log could not be read — NOT the same as clean
```

`readHistory()` silently skips malformed lines (`history.ts:390`). A verifier that did the same
would report a clean chain over a file it could not fully read — the benign-zero this surface
exists to refuse. So this reads raw lines and a line that will not parse is a refusal, naming
the month and line number.

Verified end to end through the **built** CLI against a real store:

```
clean 4-event chain              -> exit 0, verified_events 4
event 2 edited, hash left alone  -> exit 1, breaks [hash_mismatch ENG-2]
malformed JSONL line appended    -> exit 2, "could not parse ... 2026-01 line 5"
```

## The ceiling, stated honestly

A hash chain detects edits that do **not** recompute it. A rewrite that recomputes every `prev`
and `hash` over the remaining events is internally consistent and is **not** detectable from
the log alone — exactly the probe in the #1073 review, where deleting a middle event and
recomputing yielded zero broken links.

Two tests assert both halves:

- `CANNOT detect a full recomputation from the file alone` — asserts the **limitation** on
  purpose. If it ever starts failing, someone has claimed a property a hash chain does not have.
- `DOES detect it once a checkpoint recorded the old head` — the same rewrite is caught as
  `checkpoint_head_missing`.

That is what makes a checkpoint the anchorable object, and why anchoring one externally is the
rung beyond L3 rather than something this PR claims.

## Tests

12 red-first assertions in `packages/core/test/verify-chain.test.ts` — clean chain, month
boundary, mid-chain content edit, deleted event, fork, dangling prev, corrupted line, empty
store, legacy-only store, legacy prefix then chained region, and the two ceiling tests above.
The file failed to import before the module existed.

Full suite: **4741 passed, 159 skipped, 0 failed**. `pnpm build` clean.

## Stack

Based on `feat/1052-checkpoint-event` (#1073), which supplies the chain primitives, and through
it on `integration/core-store`. Part of #1047.
