### PR TITLE
feat(core): instrument spreading-activation drop counters

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -395,6 +395,14 @@ export interface StatusResult {
   store_errors?: Record<string, string>
   /** @deprecated Use `store_errors.packs`. Kept so existing readers still work. */
   pack_registry_error?: string
+  /**
+   * Spreading-activation association edges dropped since process start, by reason.
+   * Accumulates across all `inject()` calls in this process — resets on restart.
+   * `dropped_unresolvable`: target id absent from local engramMap (remote-only or
+   * deleted engram). `dropped_retired`: target found but not active. Absent when
+   * both counts are zero.
+   */
+  spread_drops?: { dropped_unresolvable: number; dropped_retired: number }
 }
 
 /**
@@ -779,6 +787,8 @@ export class Plur {
    * event; findLatestInjectionFor covers the cross-process case.
    */
   private _lastInjectionByEngram: Map<string, string> = new Map()
+  /** Spreading-activation drop counters — accumulated in-memory, reset on process restart. */
+  private _spreadDrops = { dropped_unresolvable: 0, dropped_retired: 0 }
   /**
    * Timestamps (ms) of recent LLM failures, newest last (convergence Phase 2).
    *
@@ -4911,6 +4921,11 @@ export class Plur {
       embeddingBoosts,
     )
 
+    if (result.spread_drops) {
+      this._spreadDrops.dropped_unresolvable += result.spread_drops.dropped_unresolvable
+      this._spreadDrops.dropped_retired += result.spread_drops.dropped_retired
+    }
+
     const directivesStr = formatWithLayer(result.directives, assignLayer('directives'))
     const constraintsStr = formatWithLayer(result.constraints, assignLayer('constraints'))
     const considerStr = formatWithLayer(result.consider, assignLayer('consider'))
@@ -7727,6 +7742,9 @@ Generate an improved version of the procedure that prevents this failure. Return
       ...(Object.keys(storeErrors).length > 0 ? { store_errors: storeErrors } : {}),
       // Back-compat alias for the field this replaced.
       ...(storeErrors.packs ? { pack_registry_error: storeErrors.packs } : {}),
+      ...(this._spreadDrops.dropped_unresolvable > 0 || this._spreadDrops.dropped_retired > 0
+        ? { spread_drops: { ...this._spreadDrops } }
+        : {}),
     }
   }
 

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -58,6 +58,13 @@ export interface InternalInjectionResult {
   constraints: WireEngram[]
   consider: WireEngram[]
   tokens_used: { directives: number; consider: number }
+  /**
+   * Association edges dropped during spreading activation, by reason.
+   * `dropped_unresolvable`: target id not found in local engramMap (remote-only
+   * or deleted engram). `dropped_retired`: target found but status !== 'active'.
+   * Absent when both counts are zero.
+   */
+  spread_drops?: { dropped_unresolvable: number; dropped_retired: number }
 }
 
 const DEFAULT_MAX_TOKENS = 8000
@@ -404,14 +411,18 @@ export function selectAndSpread(
   const graceDays = config?.expiry?.grace_days ?? DEFAULT_GRACE_DAYS
   const graceCutoff = new Date(Date.now() - graceDays * 86400000).toISOString().slice(0, 10)
 
-  // Step 0: Build engram map for spreading activation
+  // Step 0: Build engram map for spreading activation.
+  // `nonActiveIds` tracks personal engrams that exist locally but are not active
+  // (status !== 'active') — so spreading activation can distinguish
+  // "locally known but inactive" from "absent entirely (remote-only or missing)".
   const engramMap = new Map<string, Engram>()
+  const nonActiveIds = new Set<string>()
 
   // Step 1-2: Score all active engrams
   const scored: ScoredEngram[] = []
 
   for (const engram of personalEngrams) {
-    if (engram.status !== 'active') continue
+    if (engram.status !== 'active') { nonActiveIds.add(engram.id); continue }
     if (skipForValidity(engram, today, expiryMode, graceCutoff)) continue
     engramMap.set(engram.id, engram)
     let raw = scoreEngram(engram, promptLower, promptWords, [], ctx.scope, false, ctx.grantedScopes)
@@ -541,6 +552,8 @@ export function selectAndSpread(
 
   const spreadCandidates: ScoredEngram[] = []
   let spreadTokens = 0
+  let droppedUnresolvable = 0
+  let droppedRetired = 0
 
   for (const directive of directives) {
     // Get associations (fall back to converting relations if associations empty)
@@ -553,7 +566,12 @@ export function selectAndSpread(
       if (visited.has(assoc.target)) continue
 
       const target = engramMap.get(assoc.target)
-      if (!target || target.status !== 'active') continue
+      if (!target) {
+        if (nonActiveIds.has(assoc.target)) droppedRetired++
+        else droppedUnresolvable++
+        continue
+      }
+      if (target.status !== 'active') { droppedRetired++; continue }
 
       // Apply decay to co_accessed associations at read time
       const effectiveStrength = assoc.type === 'co_accessed' && assoc.updated_at
@@ -625,6 +643,9 @@ export function selectAndSpread(
     constraints: wireConstraints,
     consider: allWireConsider,
     tokens_used: { directives: directiveTokens, consider: considerTokens },
+    ...(droppedUnresolvable > 0 || droppedRetired > 0
+      ? { spread_drops: { dropped_unresolvable: droppedUnresolvable, dropped_retired: droppedRetired } }
+      : {}),
   }
 }
 

--- a/packages/core/test/inject.test.ts
+++ b/packages/core/test/inject.test.ts
@@ -392,3 +392,76 @@ describe('injection engine', () => {
     }
   })
 })
+
+describe('spread_drops counter', () => {
+  const makeEngram = (overrides: Partial<any> = {}) => EngramSchema.parse({
+    id: 'ENG-2026-0319-001',
+    statement: 'deploy the system carefully',
+    type: 'behavioral',
+    scope: 'global',
+    status: 'active',
+    ...overrides,
+  })
+
+  it('absent when no associations exist', () => {
+    const e = makeEngram({ id: 'ENG-2026-0319-001', statement: 'always deploy carefully on every deploy' })
+    const result = selectAndSpread({ prompt: 'deploy', maxTokens: 5000 }, [e], [])
+    expect(result.spread_drops).toBeUndefined()
+  })
+
+  it('counts dropped_unresolvable for association targets not in engramMap', () => {
+    const e = makeEngram({
+      id: 'ENG-2026-0319-001',
+      statement: 'always deploy carefully on every deploy',
+      associations: [{ target_type: 'engram', target: 'ENG-GHOST-001', type: 'semantic', strength: 0.8 }],
+    })
+    const result = selectAndSpread({ prompt: 'deploy', maxTokens: 5000 }, [e], [])
+    expect(result.spread_drops?.dropped_unresolvable).toBe(1)
+    expect(result.spread_drops?.dropped_retired).toBe(0)
+  })
+
+  it('counts dropped_retired for association targets with non-active status', () => {
+    const directive = makeEngram({
+      id: 'ENG-2026-0319-001',
+      statement: 'always deploy carefully on every deploy',
+      associations: [{ target_type: 'engram', target: 'ENG-2026-0319-002', type: 'semantic', strength: 0.8 }],
+    })
+    const retired = makeEngram({
+      id: 'ENG-2026-0319-002',
+      statement: 'old deploy rule',
+      status: 'retired',
+    })
+    const result = selectAndSpread({ prompt: 'deploy', maxTokens: 5000 }, [directive, retired], [])
+    expect(result.spread_drops?.dropped_retired).toBe(1)
+    expect(result.spread_drops?.dropped_unresolvable).toBe(0)
+  })
+
+  it('counts both kinds independently when both occur', () => {
+    const directive = makeEngram({
+      id: 'ENG-2026-0319-001',
+      statement: 'always deploy carefully on every deploy',
+      associations: [
+        { target_type: 'engram', target: 'ENG-GHOST-001', type: 'semantic', strength: 0.8 },
+        { target_type: 'engram', target: 'ENG-2026-0319-002', type: 'semantic', strength: 0.7 },
+      ],
+    })
+    const retired = makeEngram({
+      id: 'ENG-2026-0319-002',
+      statement: 'old deploy rule',
+      status: 'retired',
+    })
+    const result = selectAndSpread({ prompt: 'deploy', maxTokens: 5000 }, [directive, retired], [])
+    expect(result.spread_drops?.dropped_unresolvable).toBe(1)
+    expect(result.spread_drops?.dropped_retired).toBe(1)
+  })
+
+  it('does not count non-engram association targets', () => {
+    const e = makeEngram({
+      id: 'ENG-2026-0319-001',
+      statement: 'always deploy carefully on every deploy',
+      associations: [{ target_type: 'document', target: '/docs/deploy.md', type: 'semantic', strength: 0.8 }],
+    })
+    const result = selectAndSpread({ prompt: 'deploy', maxTokens: 5000 }, [e], [])
+    expect(result.spread_drops).toBeUndefined()
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -2178,6 +2178,8 @@ function getAllToolDefinitions(): ToolDefinition[] {
           // Core reports these; this hand-built response dropped them, so an
           // agent asking for status saw a healthy-looking `pack_count: 0`.
           ...(status.store_errors ? { store_errors: status.store_errors } : {}),
+          // Spreading-activation drop counters — absent when both are zero.
+          ...(status.spread_drops ? { spread_drops: status.spread_drops } : {}),
           // Version check (issue #151)
           ...(versionCheck?.updateAvailable && versionCheck.latest ? {
             update_available: {


### PR DESCRIPTION
## Summary

- Adds `dropped_unresolvable` counter for spreading-activation edges silently dropped because the target engram id is absent from the local store (remote-only or deleted). Previously this bridge was completely dark with no observable signal.
- Adds `dropped_retired` counter (separate bucket) for edges where the target id exists locally but has `status !== 'active'`.
- Both counters accumulate on `Plur._spreadDrops` per process lifetime and surface via `plur_status` as `spread_drops: { dropped_unresolvable, dropped_retired }` (field absent when both are zero).

No behaviour change to injection itself — pure instrumentation.

## Changed files

| File | Change |
|------|--------|
| `packages/core/src/inject.ts` | Build `nonActiveIds` set alongside `engramMap`; split the silent `continue` into two counted cases; return `spread_drops` in `InternalInjectionResult` |
| `packages/core/src/index.ts` | Add `_spreadDrops` accumulator to `Plur`; add `spread_drops` to `StatusResult`; populate from `result.spread_drops` in `_injectEngramsCore`; return from `status()` |
| `packages/mcp/src/tools.ts` | Pass through `spread_drops` in `plur_status` handler |
| `packages/core/test/inject.test.ts` | 5 new tests covering: absent when no associations; unresolvable only; retired only; both kinds; document-target associations are not counted |

## Safety check: sibling sweep (R5)

The only write path changed is the split of one `continue` into two branches, each incrementing a counter. No other `engramMap.get` / association-resolution site exists — confirmed:

```
grep -n "engramMap.get\|assoc.target" packages/core/src/inject.ts
```

```
554:      const target = engramMap.get(assoc.target)
```

One call site, now instrumented.

## Test plan

- [x] `pnpm exec vitest run test/inject.test.ts` — 31/31 pass (5 new)
- [x] All inject-related test files — 82/82 pass
- [x] Full MCP test suite — 404/404 pass
- [x] Full core build — clean