### PR TITLE
fix(mcp,core): apply readIdFor in learn catch-block; throw on namespaced-id remote miss (#1109)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6051,12 +6051,17 @@ export class Plur {
       // remote was walked past and the engram reported as simply not found —
       // absence the walk never verified, which is #831's harm by another route.
       //
-      // The walk CONTINUES on `unknown` rather than refusing: `forget handles
-      // remote server error gracefully` (#84) asserts a degraded fleet does
-      // not stop a retire, and that availability is worth keeping. What
-      // changes is only that the store is recorded, so the terminal message
-      // below stops claiming knowledge it does not have. Same resolution
-      // `feedback` already uses.
+      // For bare IDs the walk CONTINUES on `unknown`: `forget handles remote
+      // server error gracefully` (#84) asserts a degraded fleet does not stop
+      // a retire — availability is worth keeping for the ambiguous case. What
+      // changes is only that the store is recorded so the terminal message
+      // stops claiming knowledge it does not have. Same resolution `feedback`
+      // already uses.
+      //
+      // For namespaced IDs (ENG-GPL-...), the prefix was stripped above — meaning
+      // we KNOW this store is the intended target. An unreachable store is not
+      // absence; continuing and reporting "not found" is actively misleading
+      // (#1109). Throw immediately so the caller gets the scope to retry with.
       // Optional capability: a driver without `probeById` (an injected stub, a
       // third-party implementation) keeps the previous two-state behaviour
       // rather than crashing. Absence of the capability is not a reason to
@@ -6065,6 +6070,14 @@ export class Plur {
         ? await driver.probeById(serverId)
         : ((await driver.getById(serverId)) ? 'owned' : 'absent')
       if (ownership === 'unknown') {
+        const isNamespaced = id !== serverId
+        if (isNamespaced) {
+          throw new Error(
+            `Cannot reach "${entry.scope ?? entry.url}" to retire "${id}" — `
+            + `the token may be expired or the server unavailable. `
+            + `Retry once access is restored, or pass scope: "${entry.scope ?? entry.url}" to target this store directly.`,
+          )
+        }
         unreachedStores.push(entry.scope ?? entry.url!)
         logger.warning(
           `[plur] could not reach "${entry.scope ?? entry.url}" while looking for ${id} — `

--- a/packages/core/test/remote-routing.test.ts
+++ b/packages/core/test/remote-routing.test.ts
@@ -199,6 +199,41 @@ describe('learn() — remote routing (issue #25)', () => {
     expect(found!.structured_data?._outbox).toBeDefined()
     expect(found!.structured_data._outbox.target_scope).toBe('group:plur/plur-ai/engineering')
   })
+
+  // #1109 — learnRouted catch-block gap: the fallback path (plur.learn inside
+  // the catch) returned engram.id raw, the same collision risk as before #914
+  // if learnRouted throws and learn falls back for a remote-backed scope.
+  // readIdFor must be applied here too so the returned ID matches recall.
+  it('readIdFor returns namespaced form for a remote-backed scope', async () => {
+    mockSuccessfulAppend()
+
+    writeStoresConfig(primaryDir, [
+      {
+        url: 'https://plur.example.com/sse',
+        token: 'plur_sk_test',
+        scope: 'group:plur/plur-ai/engineering',
+        shared: true,
+        readonly: false,
+      },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    // learnRouted returns the server's raw ID; readIdFor converts it to the
+    // namespaced form that recall surfaces so both sides agree on the key.
+    const engram = await plur.learnRouted('test for readIdFor namespacing', {
+      scope: 'group:plur/plur-ai/engineering',
+    })
+    // Wait for the async push to settle before reading the returned id.
+    await new Promise(r => setTimeout(r, 100))
+
+    const readId = plur.readIdFor(engram)
+    // storePrefix('group:plur/plur-ai/engineering') → 'GPL'
+    expect(readId).toMatch(/^ENG-GPL-/)
+    // The raw engram.id is the server-assigned bare form.
+    expect(engram.id).not.toMatch(/^ENG-GPL-/)
+    // The namespaced form differs from the raw form.
+    expect(readId).not.toBe(engram.id)
+  })
 })
 
 /**
@@ -595,6 +630,74 @@ describe('forget() — remote routing (issue #84)', () => {
 
     // RemoteStore.getById catches errors and returns null, so this falls through to "not found"
     await expect(plur.forget('ENG-NETERR-001')).rejects.toThrow('Engram not found')
+  })
+
+  // #1109 — a namespaced ID (ENG-GTE-...) unambiguously identifies one store.
+  // forget() must strip the prefix and DELETE the server-side id from that store.
+  // storePrefix('group:test') === 'GTE'.
+  it('forget(namespaced-id) strips prefix and deletes from the correct remote', async () => {
+    const serverId = 'ENG-2026-09-01-036'
+    const namespaced = 'ENG-GTE-2026-09-01-036'
+
+    fetchMock.mockImplementation((async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && typeof url === 'string' && url.includes(`/engrams/${serverId}`)) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ id: serverId, scope: 'group:test', status: 'active', data: { statement: 'remote engram' } }),
+          text: async () => '',
+        } as Response
+      }
+      if (method === 'DELETE' && typeof url === 'string' && url.includes(`/engrams/${serverId}`)) {
+        return {
+          ok: true, status: 200,
+          json: async () => ({ id: serverId, status: 'retired' }),
+          text: async () => '',
+        } as Response
+      }
+      return {
+        ok: true, status: 200,
+        json: async () => ({ rows: [], total_count: 0 }),
+        text: async () => '',
+      } as Response
+    }) as any)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    await plur.forget(namespaced, 'no longer needed')
+
+    const dels = deleteCalls()
+    expect(dels.length).toBe(1)
+    // The DELETE hits the bare server-side id, not the namespaced caller-facing id.
+    expect(dels[0][0]).toContain(`/engrams/${serverId}`)
+    expect(dels[0][0]).not.toContain('GTE')
+  })
+
+  // #1109 — when the target store is unreachable (expired token, network down)
+  // and the id is namespaced, forget() must throw an actionable error naming the
+  // scope and the escape hatch — NOT the generic "Engram not found" that leaves
+  // the caller with no path forward.
+  it('forget(namespaced-id) with unreachable remote throws actionable error, not "Engram not found"', async () => {
+    const namespaced = 'ENG-GTE-2026-09-01-099'
+
+    fetchMock.mockImplementation((async () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:443')
+    }) as any)
+
+    writeStoresConfig(primaryDir, [
+      { url: 'https://plur.example.com/sse', token: 'tok', scope: 'group:test', shared: true, readonly: false },
+    ])
+    const plur = new Plur({ path: primaryDir })
+
+    // Must throw with the scope name so the caller knows where to retry.
+    await expect(plur.forget(namespaced)).rejects.toThrow(/Cannot reach/)
+    await expect(plur.forget(namespaced)).rejects.toThrow(/group:test/)
+    // Must NOT emit the generic "Engram not found" — that implies absence,
+    // which was never verified when the store was unreachable.
+    await expect(plur.forget(namespaced)).rejects.not.toThrow(/^Engram not found/)
   })
 })
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1170,7 +1170,11 @@ function getAllToolDefinitions(): ToolDefinition[] {
           // Opt-in, content-free engagement counter (default-off; no statement text).
           recordTelemetry('learn')
           return {
-            id: engram.id, statement: engram.statement,
+            // Mirror the happy-path fix (#914): report the namespaced form so a
+            // caller holding this id can pass it to plur_forget / plur_feedback
+            // without hitting the collision the id form mismatch causes.
+            // Outbox engrams stay local-form (same rule as line 1149).
+            id: isOutbox ? engram.id : plur.readIdFor(engram), statement: engram.statement,
             scope: engram.scope, type: engram.type, decision: 'ADD',
             ...temporalEcho(engram),
             ...scopeHint(engram.scope, !!routedFallback),


### PR DESCRIPTION
## Summary

Closes #1109. Fixes two gaps that remained after #914 landed.

## What changed

### 1. `packages/mcp/src/tools.ts` — catch-block at ~line 1173

`learnRouted` saves to the local outbox on remote failure, so the `catch` block is defence-in-depth. But when it did fire, it called `plur.learn()` and returned `engram.id` raw — the same collision risk as the original incident. Any write to a remote-backed scope produced a local-form ID (`ENG-2026-…`) while the engram lived remotely under `ENG-GPL-2026-…`.

**Fix:** apply `plur.readIdFor(engram)` with the same outbox exception as the happy-path fix at line 1149:

```
id: isOutbox ? engram.id : plur.readIdFor(engram)
```

### 2. `packages/core/src/index.ts` — forget() remote walk at ~line 6082

When `probeById` returned `'unknown'` (expired token, network down) and the caller ID was namespaced (`ENG-GPL-…`), the walk logged a warning and continued. The terminal error was "Engram not found: … but 1 store could not be reached" — which still starts with "Engram not found" and implies absence it could never verify.

The namespaced case is different: `_stripRemotePrefix` already stripped the store prefix (`id !== serverId`), so we **know** this store is the intended target. Continuing past it is misleading.

**Fix:** when `id !== serverId` (prefix was stripped → ID was namespaced to this store) and `ownership === 'unknown'`, throw immediately:

```
Cannot reach "group:test" to retire "ENG-GTE-…" — the token may be expired
or the server unavailable. Retry once access is restored, or pass scope:
"group:test" to target this store directly.
```

Bare-ID walk (`id === serverId`, no stripping happened) preserves the existing `#84` graceful-degradation contract — the existing `'forget handles remote server error gracefully'` test still passes unchanged.

## Safety claim — only two places in tools.ts return `id:` from a learn result

```
$ grep -n "id: .*engram\.id\|id: isOutbox" packages/mcp/src/tools.ts
1149:            id: isOutbox ? engram.id : plur.readIdFor(engram), statement: engram.statement,
1173:            id: isOutbox ? engram.id : plur.readIdFor(engram), statement: engram.statement,
```

Both now apply `readIdFor`. `plur_learn_batch` (lines 1284/1331) uses `engram.id` because the batch path is documented as LOCAL-only (`learnRouted` is not applied per item — see tool description). `plur_forget` at line 1605 returns the ID from a local `getById`, so local-form is correct.

## Regression tests

**R4 — test (c) fails against pre-fix code (confirmed by stash + run + pop):**

```
- Expected:  /Cannot reach/
+ Received:  "Engram not found: ENG-GTE-2026-09-01-099 — but 1 store(s) could not be reached (group:test)…"
```

**All 36 tests in `remote-routing.test.ts` pass with the fix.**

3 new tests:
- `readIdFor returns namespaced form for a remote-backed scope` — anchors the MCP catch-block fix by testing the core primitive
- `forget(namespaced-id) strips prefix and deletes from the correct remote` — confirms the existing forget routing works end-to-end with a prefixed ID (cold cache, reachable remote)
- `forget(namespaced-id) with unreachable remote throws actionable error, not "Engram not found"` — the regression test for fix #2; fails before, passes after

## Base

Branched off `origin/main` (ae11182f). `git diff origin/main...HEAD --name-only`:

```
packages/core/src/index.ts
packages/core/test/remote-routing.test.ts
packages/mcp/src/tools.ts
```

No unrelated changes in the diff.