### PR TITLE
fix(recall): return bare operable engram IDs and enable remote forget (#1119)

### DIFF
--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -25,22 +25,19 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // If --search flag or doesn't look like an ID, use search mode
   if (!isSearch && /^(ENG|ABS|META)-/.test(target)) {
     const engram = await plur.getById(target)
-    if (engram?.status === 'retired') exit(1, `Already retired: ${target}`)
+    if (!engram) exit(1, `Engram not found: ${target}`)
+    if (engram.status === 'retired') exit(1, `Already retired: ${target}`)
     // force (#766): `plur forget` is an explicit user-facing forget — same
     // surface as MCP plur_forget. Without force, a multiply-learned engram
     // (reference_count > 1) only decrements and stays active, and a later
     // learn() at a different scope re-matches it and inherits the old scope.
-    try {
-      await plur.forget(target, reason, { force: true })
-      if (shouldOutputJson(flags)) {
-        outputJson({ success: true, retired: { id: target, ...(engram ? { statement: engram.statement } : {}) } })
-      } else {
-        outputInfo(`Retired: [${target}]${engram ? ` ${engram.statement}` : ''}`, flags)
-      }
-      return
-    } catch (err: any) {
-      exit(1, err.message || `Engram not found: ${target}`)
+    await plur.forget(target, reason, { force: true })
+    if (shouldOutputJson(flags)) {
+      outputJson({ success: true, retired: { id: target, statement: engram.statement } })
+    } else {
+      outputInfo(`Retired: [${target}] ${engram.statement}`, flags)
     }
+    return
   }
 
   // Search mode. remote:false (#776) — forget-by-search resolves LOCAL

--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -25,19 +25,22 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // If --search flag or doesn't look like an ID, use search mode
   if (!isSearch && /^(ENG|ABS|META)-/.test(target)) {
     const engram = await plur.getById(target)
-    if (!engram) exit(1, `Engram not found: ${target}`)
-    if (engram.status === 'retired') exit(1, `Already retired: ${target}`)
+    if (engram?.status === 'retired') exit(1, `Already retired: ${target}`)
     // force (#766): `plur forget` is an explicit user-facing forget — same
     // surface as MCP plur_forget. Without force, a multiply-learned engram
     // (reference_count > 1) only decrements and stays active, and a later
     // learn() at a different scope re-matches it and inherits the old scope.
-    await plur.forget(target, reason, { force: true })
-    if (shouldOutputJson(flags)) {
-      outputJson({ success: true, retired: { id: target, statement: engram.statement } })
-    } else {
-      outputInfo(`Retired: [${target}] ${engram.statement}`, flags)
+    try {
+      await plur.forget(target, reason, { force: true })
+      if (shouldOutputJson(flags)) {
+        outputJson({ success: true, retired: { id: target, ...(engram ? { statement: engram.statement } : {}) } })
+      } else {
+        outputInfo(`Retired: [${target}]${engram ? ` ${engram.statement}` : ''}`, flags)
+      }
+      return
+    } catch (err: any) {
+      exit(1, err.message || `Engram not found: ${target}`)
     }
-    return
   }
 
   // Search mode. remote:false (#776) — forget-by-search resolves LOCAL

--- a/packages/cli/src/commands/recall.ts
+++ b/packages/cli/src/commands/recall.ts
@@ -1,5 +1,6 @@
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText, exit } from '../output.js'
+import { bareEngramId } from '@plur-ai/core'
 
 export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   const plur = createPlur(flags)
@@ -35,7 +36,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson({
       results: engrams.map(e => ({
-        id: (e as any)._originalId ?? e.id.replace(/^(ENG|ABS|META)-[A-Z]{2,4}-(?=\d{4}-|[A-Za-z0-9])/, '$1-'),
+        id: (e as any)._originalId ?? bareEngramId(e.id),
         statement: e.statement,
         scope: e.scope,
         type: e.type,
@@ -46,7 +47,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     })
   } else {
     engrams.forEach((e, idx) => {
-      const displayId = (e as any)._originalId ?? e.id.replace(/^(ENG|ABS|META)-[A-Z]{2,4}-(?=\d{4}-|[A-Za-z0-9])/, '$1-')
+      const displayId = (e as any)._originalId ?? bareEngramId(e.id)
       outputText(`${idx + 1}. [${displayId}] ${e.statement}`)
       outputText(`   Scope: ${e.scope} | Type: ${e.type}${e.domain ? ` | Domain: ${e.domain}` : ''} | Strength: ${e.activation.retrieval_strength.toFixed(3)}`)
     })

--- a/packages/cli/src/commands/recall.ts
+++ b/packages/cli/src/commands/recall.ts
@@ -35,7 +35,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   if (shouldOutputJson(flags)) {
     outputJson({
       results: engrams.map(e => ({
-        id: e.id,
+        id: (e as any)._originalId ?? e.id.replace(/^(ENG|ABS|META)-[A-Z]{2,4}-(?=\d{4}-|[A-Za-z0-9])/, '$1-'),
         statement: e.statement,
         scope: e.scope,
         type: e.type,
@@ -46,7 +46,8 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     })
   } else {
     engrams.forEach((e, idx) => {
-      outputText(`${idx + 1}. [${e.id}] ${e.statement}`)
+      const displayId = (e as any)._originalId ?? e.id.replace(/^(ENG|ABS|META)-[A-Z]{2,4}-(?=\d{4}-|[A-Za-z0-9])/, '$1-')
+      outputText(`${idx + 1}. [${displayId}] ${e.statement}`)
       outputText(`   Scope: ${e.scope} | Type: ${e.type}${e.domain ? ` | Domain: ${e.domain}` : ''} | Strength: ${e.activation.retrieval_strength.toFixed(3)}`)
     })
   }

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -628,7 +628,7 @@ export function namespaceEngramId(id: string, scope: string): string {
  * E.g. 'ENG-GPL-2026-08-13-025' -> 'ENG-2026-08-13-025'.
  */
 export function bareEngramId(id: string): string {
-  return id.replace(/^(ENG|ABS|META)-[A-Z]{2,4}-(?=\d{4}-|[A-Za-z0-9])/, '$1-')
+  return id.replace(/^(ENG|ABS|META)-[A-Z]{2,4}-(?=\d{4}-)/, '$1-')
 }
 
 /** Derive a 3-char prefix from a store scope (e.g. 'datafund' → 'DFU', 'project:myapp' → 'PMY') */

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -623,6 +623,14 @@ export function namespaceEngramId(id: string, scope: string): string {
   return id.replace(/^(ENG|ABS|META)-/, `$1-${prefix}-`)
 }
 
+/**
+ * Strip any store namespace prefix from an ID to obtain its bare form (#1119).
+ * E.g. 'ENG-GPL-2026-08-13-025' -> 'ENG-2026-08-13-025'.
+ */
+export function bareEngramId(id: string): string {
+  return id.replace(/^(ENG|ABS|META)-[A-Z]{2,4}-(?=\d{4}-|[A-Za-z0-9])/, '$1-')
+}
+
 /** Derive a 3-char prefix from a store scope (e.g. 'datafund' → 'DFU', 'project:myapp' → 'PMY') */
 export function storePrefix(scope: string): string {
   const parts = scope.split(/[:\-_./]/).filter(Boolean)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1647,7 +1647,7 @@ export class Plur {
     if (nsPattern.test(id)) {
       return id.replace(nsPattern, '$1-')
     }
-    return bareEngramId(id)
+    return id
   }
 
   /** Content hash fast-path dedup. Scope-aware: same statement in a different

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ import { detectPlurStorage, type PlurPaths } from './storage.js'
 import { IndexedStorage } from './storage-indexed.js'
 import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
-import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, namespaceEngramId, initFilesystemStore } from './engrams.js'
+import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, namespaceEngramId, bareEngramId, initFilesystemStore } from './engrams.js'
 import { maybeDailyBackup } from './backup.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats, searchTextFrom } from './fts.js'
@@ -104,7 +104,7 @@ export { loadEngrams, saveEngrams } from './engrams.js'
 // The id-namespacing pair (#914). `readIdFor` is the API a surface should use;
 // these are exported so a caller (and the tests) can reason about the shape
 // without re-deriving the prefix rule a fourth time.
-export { storePrefix, namespaceEngramId } from './engrams.js'
+export { storePrefix, namespaceEngramId, bareEngramId } from './engrams.js'
 export {
   maybeDailyBackup,
   listBackups,
@@ -1647,7 +1647,7 @@ export class Plur {
     if (nsPattern.test(id)) {
       return id.replace(nsPattern, '$1-')
     }
-    return id
+    return bareEngramId(id)
   }
 
   /** Content hash fast-path dedup. Scope-aware: same statement in a different

--- a/packages/core/test/store-prefix.test.ts
+++ b/packages/core/test/store-prefix.test.ts
@@ -27,6 +27,12 @@ describe('bareEngramId (#1119)', () => {
     expect(bareEngramId('ABS-GPL-2026-08-13-025')).toBe('ABS-2026-08-13-025')
     expect(bareEngramId('META-GDA-2026-0501-001')).toBe('META-2026-0501-001')
   })
+
+  it('does not mangle server, cold, or pack engram shapes (#1119)', () => {
+    expect(bareEngramId('ENG-SRV-001')).toBe('ENG-SRV-001')
+    expect(bareEngramId('ENG-COLD-001')).toBe('ENG-COLD-001')
+    expect(bareEngramId('ENG-PACK-EM-006')).toBe('ENG-PACK-EM-006')
+  })
 })
 
 describe('storePrefix', () => {

--- a/packages/core/test/store-prefix.test.ts
+++ b/packages/core/test/store-prefix.test.ts
@@ -5,7 +5,29 @@
  * See: https://github.com/plur-ai/plur/issues/86
  */
 import { describe, it, expect } from 'vitest'
-import { storePrefix } from '../src/engrams.js'
+import { storePrefix, bareEngramId } from '../src/engrams.js'
+
+describe('bareEngramId (#1119)', () => {
+  it('strips group:plur GPL prefix to bare ID', () => {
+    expect(bareEngramId('ENG-GPL-2026-08-13-025')).toBe('ENG-2026-08-13-025')
+  })
+
+  it('strips other store prefixes (DFU, PMY, GBL)', () => {
+    expect(bareEngramId('ENG-DFU-2026-04-01-001')).toBe('ENG-2026-04-01-001')
+    expect(bareEngramId('ENG-PMY-2026-09-02-003')).toBe('ENG-2026-09-02-003')
+    expect(bareEngramId('ENG-GBL-2026-01-15-010')).toBe('ENG-2026-01-15-010')
+  })
+
+  it('leaves already bare IDs unchanged', () => {
+    expect(bareEngramId('ENG-2026-08-13-025')).toBe('ENG-2026-08-13-025')
+    expect(bareEngramId('ABS-2026-0501-001')).toBe('ABS-2026-0501-001')
+  })
+
+  it('works with ABS and META prefixes', () => {
+    expect(bareEngramId('ABS-GPL-2026-08-13-025')).toBe('ABS-2026-08-13-025')
+    expect(bareEngramId('META-GDA-2026-0501-001')).toBe('META-2026-0501-001')
+  })
+})
 
 describe('storePrefix', () => {
   it('group:plur/plur-ai/engineering → GPL', () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,7 +1,7 @@
 import { existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName, SUGGEST_DISPLAY_MIN_CONFIDENCE, mcpRemoteWarningLine, doctorRemoteRemediation, normalizeEndpointUrl, REMOTE_STATUS_TTL_MS, PROBE_CLEARABLE_STATES } from '@plur-ai/core'
+import { Plur, extractMetaEngrams, validateMetaEngram, confidenceBand, generateProfile, getProfileForInjection, markProfileDirty, selectModelForOperation, readHistoryForEngram, getCachedUpdateCheck, minorVersionsBehind, scanForTensions, CapabilityCanary, readProjectConfig, isSharedScope, resolveRerankerName, getReranker, classifyRerankerFailure, hfCacheDirName, SUGGEST_DISPLAY_MIN_CONFIDENCE, mcpRemoteWarningLine, doctorRemoteRemediation, normalizeEndpointUrl, REMOTE_STATUS_TTL_MS, PROBE_CLEARABLE_STATES, bareEngramId } from '@plur-ai/core'
 import type { LlmFunction, MetaField, TensionStatus, RerankerEvalResult, HistoryEvent, Receipt, RemoteStoreStatusEntry } from '@plur-ai/core'
 import { recordTelemetry } from './telemetry.js'
 import { VERSION } from './version.js'
@@ -138,7 +138,7 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
               .join(', ') + ']'
           : ''
         return {
-          id: e.id,
+          id: (raw._originalId as string | undefined) ?? bareEngramId(e.id),
           statement: e.statement + annotation + measuredAnnotation,
           type: e.type,
           scope: e.scope,
@@ -215,7 +215,7 @@ const recallHandler: ToolDefinition['handler'] = async (args, plur) => {
             .join(', ') + ']'
         : ''
       const base: Record<string, unknown> = {
-        id: e.id,
+        id: (raw._originalId as string | undefined) ?? bareEngramId(e.id),
         statement: e.statement + annotation + measuredAnnotation,
         type: e.type,
         scope: e.scope,

--- a/packages/mcp/test/remote-recall-surfacing.test.ts
+++ b/packages/mcp/test/remote-recall-surfacing.test.ts
@@ -90,6 +90,18 @@ describe('remote_stores block on plur_recall', () => {
     expect(res.results.some((r: any) => String(r.id).includes('2026-0731-080'))).toBe(true)
   })
 
+  it('serves bare operable engram ID in plur_recall results (#1119)', async () => {
+    stub.recallRows = [{ id: 'ENG-2026-0813-025', scope: SCOPE, status: 'active', statement: 'deploy checklist', score: 1 }]
+    const client = await makeClient(writeConfig(baseUrl))
+    const res = callResult(await client.callTool({
+      name: 'plur_recall',
+      arguments: { query: 'deploy checklist', scope: PROJECT },
+    }))
+    expect(res.results).toHaveLength(1)
+    expect(res.results[0].id).toBe('ENG-2026-0813-025')
+    expect(res.results[0].scope).toBe(SCOPE)
+  })
+
   it('is PRESENT with a prose warning when the host is unreachable', async () => {
     const client = await makeClient(writeConfig('http://127.0.0.1:1'))
     const res = callResult(await client.callTool({


### PR DESCRIPTION
Closes #1119

### Problem
When engrams from remote stores are recalled via MCP or the CLI, their IDs are displayed with namespaced store prefixes (e.g., \ENG-GPL-2026-08-13-025\). However, these prefixed IDs cannot be used with \plur forget\ because:
1. The remote store expects the original bare ID (\ENG-2026-08-13-025\).
2. The CLI \orget\ command previously checked only the local store (\plur.getById(target)\) and aborted immediately if not found locally, preventing remote store deletion requests from ever being dispatched.

### Solution
- **Core**: Exported \areEngramId(id: string)\ helper in \@plur-ai/core\ to strip store namespace prefixes (e.g. \ENG-GPL-...\ -> \ENG-...\). Updated \Plur._stripRemotePrefix()\ to utilize this fallback.
- **MCP**: In \packages/mcp/src/tools.ts\ (\ecallHandler\), output the operable bare ID (\aw._originalId ?? bareEngramId(e.id)\) so clients receive actionable IDs.
- **CLI**: In \packages/cli/src/commands/recall.ts\, surface bare IDs in both structured and formatted text output. In \packages/cli/src/commands/forget.ts\, allow \plur.forget()\ to attempt remote forget even if the engram is not present in the local store.
- **Tests**:
  - Added unit tests for \areEngramId()\ across all store prefixes (\packages/core/test/store-prefix.test.ts\).
  - Added integration test verifying bare engram IDs returned in \plur_recall\ (\packages/mcp/test/remote-recall-surfacing.test.ts\).