### PR TITLE
fix(inject): strict priority ordering in pinned tier — stop on overflow, not skip (#1124)

### DIFF
--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -366,8 +366,7 @@ export function fillTokenBudget(
 
   for (const engram of pinned) {
     const cost = estimateTokens(engram)
-    if (tokensUsed + cost > maxTokens) continue
-    if (tokensUsed + cost > pinnedBudget) continue
+    if (tokensUsed + cost > pinnedBudget) break
     result.push(engram)
     tokensUsed += cost
     const pack = engram.pack ?? '__personal__'

--- a/packages/core/test/pinned-priority.test.ts
+++ b/packages/core/test/pinned-priority.test.ts
@@ -183,6 +183,58 @@ describe('pinned_priority: eviction order within the pinned tier', () => {
     )
     expect(minSelectedPriority).toBeGreaterThanOrEqual(maxEvictedPriority)
   })
+
+  it('strict ordering: a large high-priority engram that overflows the sub-budget blocks smaller low-priority ones', () => {
+    // This is the regression test for the greedy-vs-strict bug (#1124).
+    // With `continue`, a high-priority engram that does not fit is skipped and a
+    // smaller low-priority engram is admitted instead. With `break`, admission stops
+    // once the highest remaining priority engram cannot fit.
+    const largeStatement = 'L'.repeat(400) // ~120 tokens — intentionally large
+    const smallStatement = 'S'.repeat(20)  // ~10 tokens  — intentionally small
+
+    const large = makeScored({
+      id: 'ENG-PP-LARGE',
+      statement: largeStatement,
+      pinned: true,
+      pinned_priority: 100, // highest priority
+      keyword_match: 1.0,
+      raw_score: 1.0,
+      score: 1.0,
+      activation: { retrieval_strength: 0.8, storage_strength: 0.5, frequency: 0, last_accessed: '2026-01-01' },
+    }) as ScoredEngram
+    const small = makeScored({
+      id: 'ENG-PP-SMALL',
+      statement: smallStatement,
+      pinned: true,
+      pinned_priority: 1, // lowest priority
+      keyword_match: 1.0,
+      raw_score: 1.0,
+      score: 1.0,
+      activation: { retrieval_strength: 0.8, storage_strength: 0.5, frequency: 0, last_accessed: '2026-01-01' },
+    }) as ScoredEngram
+
+    const largeCost = estimateTokens(large)
+    const smallCost = estimateTokens(small)
+
+    // Budget: the small engram fits in the pinned sub-budget; the large one does not.
+    // pinnedBudget = maxTokens * 0.5. We need:
+    //   smallCost < pinnedBudget < largeCost
+    //   => maxTokens = (largeCost + smallCost) / 2 * 2  roughly
+    // Pick maxTokens so that pinnedBudget = maxTokens*0.5 is between the two costs.
+    const pinnedBudget = Math.floor((largeCost + smallCost) / 2)
+    const maxTokens = pinnedBudget * 2 // so pinnedBudget === maxTokens * 0.5
+
+    expect(smallCost).toBeLessThan(pinnedBudget)
+    expect(largeCost).toBeGreaterThan(pinnedBudget)
+
+    const { selected } = fillTokenBudget([large, small], maxTokens)
+    const ids = selected.map(e => e.id)
+
+    // Strict ordering: the large high-priority engram overflows the sub-budget, so
+    // admission stops — the small low-priority engram must NOT be included.
+    expect(ids).not.toContain('ENG-PP-LARGE')
+    expect(ids).not.toContain('ENG-PP-SMALL')
+  })
 })
 
 describe('pinned_priority: schema and learn() integration', () => {


### PR DESCRIPTION
## Problem

When a high-priority pinned engram exceeds the pinned sub-budget, the selection loop used `continue`, allowing smaller lower-priority engrams to sneak in after it. This violated the `ENGRAM-STANDARD-v1.md` guarantee that lower-priority engrams are evicted first.

Reproduction (from the issue): a priority-100 engram whose cost exceeds the pinned sub-budget is skipped; a priority-1 engram that fits is admitted. `fillTokenBudget` returns only the low-priority engram.

## Fix

Change `continue` to `break` in the pinned tier loop. The array is already sorted by `pinned_priority` descending (from #1121), so once the highest remaining priority engram cannot fit, no lower-priority engram should be admitted.

Also removes the now-redundant `maxTokens` check in the pinned loop — it was always subsumed by `pinnedBudget ≤ maxTokens`.

## Test

Added a regression test with deliberately unequal-size engrams:
- `ENG-PP-LARGE` (priority 100, ~120 tokens) exceeds the pinned sub-budget
- `ENG-PP-SMALL` (priority 1, ~10 tokens) fits the sub-budget

With the greedy `continue`, only the small low-priority engram was admitted. With the strict `break`, neither is admitted.

Closes #1124.
Base: #1121 (must merge first — the sort it introduces is what makes the break meaningful).