### PR TITLE
feat(provenance): per-actor Ed25519 keys + signed checkpoints (#1055, #1056, #1057)

### DIFF
--- a/docs/auditability.md
+++ b/docs/auditability.md
@@ -1,0 +1,128 @@
+# Auditability
+
+PLUR provides a three-level provenance ladder over the engram store. Each level
+extends the previous one without replacing it.
+
+## L1 — Attribution (merged, #1048)
+
+Every history event records `provenance.identity` — who or what produced it.
+Set via `PLUR_IDENTITY` or the CLI `--identity` flag. Provides attribution
+without tamper-evidence.
+
+## L2 — Hash-chained history (merged, #1051–#1053)
+
+History events are written as append-only JSONL in `~/.plur/history/YYYY-MM.jsonl`.
+Each event gets:
+
+- **`hash`** — SHA-256 over the event's canonical bytes (UTF-8 JSON, keys sorted
+  lexicographically, no whitespace). Computed by `appendHistory`.
+- **`prev`** — the hash of the predecessor event, or `null` for genesis / a
+  declared gap when the chain lock could not be taken.
+
+A **checkpoint** event (`plur checkpoint`) commits to the current store state:
+
+- `chain_head` — the predecessor hash at checkpoint time.
+- `store_hash` — SHA-256 over the canonical JSON of `engrams.yaml` (not raw bytes;
+  stable across CRLF, reformatters, and YAML emitters).
+- `engram_count` — active engram count from the same read as `store_hash`.
+- `actor` — what triggered the checkpoint (`'cli'`, `'session_end'`, or custom).
+
+`plur verify` reads every history month, checks every link, and names each break,
+fork, unprotected legacy range, and store-hash mismatch. Exit codes are a contract:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Verified — chain holds over everything it covers |
+| 1 | Broken — at least one named break or fork |
+| 2 | Cannot verify — log unreadable; NOT the same as clean |
+
+### Canonical bytes (§3 spec)
+
+Canonical bytes for a history event:
+
+- UTF-8 JSON
+- Keys sorted recursively by UTF-16 code unit (JS default sort)
+- No insignificant whitespace
+- Timestamps as ISO-8601 strings (never floats)
+- `hash`, `signature`, and `signer` excluded (all three are computed FROM or
+  ABOUT these bytes)
+
+### What a hash chain can and cannot detect
+
+It detects every edit that does NOT recompute the chain — content tampering,
+broken links, deleted events, forks. It cannot detect a rewrite that
+recomputes every `prev` and `hash` over the remaining events (an internally
+consistent rewrite). **Checkpoints close this gap**: a checkpoint pins a
+`chain_head` that a rewrite cannot reproduce, so `checkpoint_head_missing`
+catches it for all events written before the checkpoint. Anchoring the
+checkpoint hash externally (on a ledger or in a public log) extends the same
+argument beyond this store.
+
+## L3 — Ed25519-signed checkpoints (merged, #1055–#1056)
+
+Each acting identity can have an Ed25519 key pair:
+
+```
+Private key: ~/.plur/keys/<identity>.key   — PKCS#8 DER, mode 0600
+Public key:  <store-root>/keys.yaml        — SPKI DER base64, per-identity registry
+```
+
+Generate a key pair:
+
+```
+plur keys init [--identity <name>] [--keys-dir <dir>]
+```
+
+`plur keys init` is idempotent: calling it again returns the existing public key
+without overwriting. `plur keys list` prints all registered public keys.
+
+When an acting identity has a key, `plur checkpoint` adds:
+
+- **`signature`** (top-level) — Ed25519 over the canonical bytes of the checkpoint
+  event. The signature covers the same bytes as `hash` (canonical bytes excluding
+  `hash`, `signature`, and `signer`), so hash and signature attest the same
+  payload independently.
+- **`signer`** (top-level) — the identity string. Excluded from canonical bytes;
+  the signature's validity is what proves the claim.
+
+An **unsigned checkpoint** is a valid L2 object. A missing signature is
+`"unsigned (L2)"`, not tampered.
+
+### Verifying signatures
+
+```
+plur verify --signatures
+```
+
+For each checkpoint event, `verifyChain` checks the signature and reports one
+of four verdicts:
+
+| Verdict | Meaning | Break? |
+|---------|---------|--------|
+| `valid` | Signature checks out against the registered public key | No |
+| `unsigned` | No signature field (valid L2, not L3-capable) | No |
+| `unknown_signer` | Signer not in `keys.yaml` on this machine | No |
+| `invalid` | Signature does not verify | **Yes** |
+
+`unknown_signer` is a named result, not a chain break — the key may simply not
+be registered on this machine. `invalid` IS a chain break: the checkpoint can
+no longer be trusted as an external attestation. `plur verify` exits 1 whenever
+any break is present (including invalid signatures).
+
+### Key security
+
+Private keys are enforced 0600 on every read — a key readable by group or
+world is rejected, not merely warned about. The keys directory is created 0700.
+All operations use `node:crypto` only (no external crypto dependencies).
+
+### Implementation files
+
+| File | Purpose |
+|------|---------|
+| `packages/core/src/history.ts` | `emitCheckpoint`, hash-chain append, canonical bytes |
+| `packages/core/src/verify-chain.ts` | `verifyChain`, `ChainVerifyOutcome`, signature verdicts |
+| `packages/core/src/actor-keys.ts` | Key generation, permission enforcement, sign/verify, registry |
+| `packages/cli/src/commands/checkpoint.ts` | `plur checkpoint` |
+| `packages/cli/src/commands/verify.ts` | `plur verify [--signatures]` |
+| `packages/cli/src/commands/keys.ts` | `plur keys init`, `plur keys list` |
+| `packages/core/test/actor-keys.test.ts` | 38 tests covering W3.1+W3.2 |

--- a/packages/cli/src/commands/checkpoint.ts
+++ b/packages/cli/src/commands/checkpoint.ts
@@ -17,9 +17,9 @@ import { join } from 'path'
 import { existsSync } from 'fs'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText } from '../output.js'
-import { emitCheckpoint } from '@plur-ai/core'
+import { emitCheckpoint, signWithActorKey } from '@plur-ai/core'
 
-export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+export async function run(_args: string[], flags: GlobalFlags & { signatures?: boolean }): Promise<void> {
   // Write engine needed: emitCheckpoint calls appendHistory (a write).
   const plur = createPlur(flags)
   const status = await plur.status()
@@ -39,6 +39,15 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
 
+  // Resolve signing options if the acting identity has a key configured (#1056).
+  // Signing is best-effort: if the key is absent or the identity is unidentified,
+  // the checkpoint is still written (unsigned is a valid L2 object).
+  const identity = status.provenance_identity
+  const keysDir = join(plurRoot, 'keys')
+  const signingOptions = (identity && identity !== 'agent:unidentified')
+    ? { identity, sign: (data: Buffer) => signWithActorKey(data, identity, keysDir) }
+    : undefined
+
   // engram_count is derived from the bytes that were hashed, inside
   // emitCheckpoint — not passed in. An attested count that is not bound to the
   // hash beside it is not attested at all.
@@ -49,7 +58,7 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
   // of the built CLI.
   let data
   try {
-    data = emitCheckpoint(plurRoot, engramsPath, 'cli')
+    data = emitCheckpoint(plurRoot, engramsPath, 'cli', undefined, signingOptions)
   } catch (err) {
     outputText('Cannot checkpoint: the store could not be read as a store.')
     outputText(`  ${engramsPath}`)
@@ -59,6 +68,8 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     return
   }
 
+  const signed = typeof data.signature === 'string'
+
   if (shouldOutputJson(flags)) {
     outputJson({
       // First, because it is the value you anchor.
@@ -67,6 +78,8 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
       store_hash: data.store_hash,
       engram_count: data.engram_count,
       actor: data.actor,
+      signer: data.signer ?? null,
+      signature: data.signature ?? null,
     })
   } else {
     outputText(`Checkpoint emitted`)
@@ -75,5 +88,11 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     outputText(`  chain_head:   ${data.chain_head ?? '(genesis — no prior chained event)'}`)
     outputText(`  engram_count: ${data.engram_count}`)
     outputText(`  actor:        ${data.actor}`)
+    if (signed) {
+      outputText(`  signer:       ${data.signer}`)
+      outputText(`  signature:    (Ed25519, base64 — run 'plur verify --signatures' to check)`)
+    } else {
+      outputText(`  signature:    (unsigned — run 'plur keys init' to enable L3 signing)`)
+    }
   }
 }

--- a/packages/cli/src/commands/keys.ts
+++ b/packages/cli/src/commands/keys.ts
@@ -1,0 +1,151 @@
+/**
+ * `plur keys` — manage per-actor Ed25519 signing keys (#1055).
+ *
+ * Subcommands:
+ *   plur keys init                   Generate a key pair for the configured identity
+ *   plur keys init --identity <name> Override the identity for key generation
+ *   plur keys list                   List registered public keys for this store
+ *
+ * Key storage:
+ *   Private key: <keys-dir>/<identity>.key  (mode 0600, never in a store or repo)
+ *   Public key:  <store-root>/keys.yaml     (tracked, per-store registry)
+ *
+ * The default keys directory is `<store-root>/keys`.  Use `--keys-dir <dir>`
+ * to override (e.g. when the private key lives at `~/.plur/keys`).
+ *
+ * Exit codes: 0 ok, 1 error.
+ */
+import { join } from 'path'
+import { homedir } from 'os'
+import { createPlur, type GlobalFlags } from '../plur.js'
+import { shouldOutputJson, outputJson, outputText } from '../output.js'
+import { initActorKey, registerPublicKey, loadKeysRegistry, keyFingerprint } from '@plur-ai/core'
+
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  const subcommand = args[0]
+
+  if (!subcommand || subcommand === '--help' || subcommand === 'help') {
+    outputText('plur keys — manage per-actor Ed25519 signing keys (#1055)')
+    outputText('')
+    outputText('Subcommands:')
+    outputText('  init                   Generate a key pair for the configured identity')
+    outputText('  init --identity <name> Override the identity for this init')
+    outputText('  list                   List registered public keys for this store')
+    outputText('')
+    outputText('Keys directory (private keys): <store-root>/keys  (--keys-dir to override)')
+    outputText('Public key registry:           <store-root>/keys.yaml')
+    return
+  }
+
+  if (subcommand === 'list') {
+    await runList(args.slice(1), flags)
+    return
+  }
+
+  if (subcommand === 'init') {
+    await runInit(args.slice(1), flags)
+    return
+  }
+
+  outputText(`Unknown keys subcommand: ${subcommand}. Run 'plur keys --help'.`)
+  process.exitCode = 1
+}
+
+async function runInit(args: string[], flags: GlobalFlags): Promise<void> {
+  // Parse --identity and --keys-dir overrides.
+  let identityOverride: string | undefined
+  let keysDirOverride: string | undefined
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--identity' && args[i + 1]) { identityOverride = args[++i]; continue }
+    if (args[i] === '--keys-dir' && args[i + 1]) { keysDirOverride = args[++i]; continue }
+  }
+
+  // Read-only engine to get the storage root and configured identity; we do
+  // not need a write-capable engine just to read config and generate keys.
+  const plur = createPlur(flags, { readonly: true })
+  const storeRoot = plur.storageRoot
+
+  // Identity resolution: --identity > config > fallback.
+  const status = await plur.status()
+  const configuredIdentity = status.provenance_identity
+  const identity = identityOverride
+    ?? (configuredIdentity && configuredIdentity !== 'agent:unidentified' ? configuredIdentity : undefined)
+    ?? 'agent:unidentified'
+
+  // Keys directory: --keys-dir > default (<store-root>/keys).
+  // When the store lives at ~/.plur, this is ~/.plur/keys — the canonical path
+  // documented in the runbook. `--keys-dir` allows running on a custom store
+  // path without scattering key files next to arbitrary data.
+  const keysDir = keysDirOverride ?? join(storeRoot, 'keys')
+
+  let publicKeyB64: string
+  try {
+    publicKeyB64 = initActorKey(identity, keysDir)
+  } catch (err) {
+    outputText(`plur keys init: failed to initialise key for ${identity}`)
+    outputText(`  ${err instanceof Error ? err.message : String(err)}`)
+    process.exitCode = 1
+    return
+  }
+
+  // Register the public key in the store's registry.
+  try {
+    registerPublicKey(storeRoot, identity, publicKeyB64)
+  } catch (err) {
+    outputText(`plur keys init: key generated but could not register public key in keys.yaml`)
+    outputText(`  ${err instanceof Error ? err.message : String(err)}`)
+    process.exitCode = 1
+    return
+  }
+
+  const fingerprint = keyFingerprint(publicKeyB64)
+
+  if (shouldOutputJson(flags)) {
+    outputJson({ identity, fingerprint, public_key: publicKeyB64, keys_dir: keysDir, store_root: storeRoot })
+    return
+  }
+
+  outputText(`plur keys init: OK`)
+  outputText(`  identity   : ${identity}`)
+  outputText(`  fingerprint: ${fingerprint}`)
+  outputText(`  keys dir   : ${keysDir}`)
+  outputText(`  registry   : ${join(storeRoot, 'keys.yaml')}`)
+  outputText('')
+  outputText('  Run `plur checkpoint` to emit a signed checkpoint.')
+  outputText('  Run `plur verify --signatures` to verify checkpoint signatures.')
+}
+
+async function runList(args: string[], flags: GlobalFlags): Promise<void> {
+  void args
+  const plur = createPlur(flags, { readonly: true })
+  const storeRoot = plur.storageRoot
+
+  let registry
+  try {
+    registry = loadKeysRegistry(storeRoot)
+  } catch (err) {
+    outputText(`plur keys list: could not load keys.yaml`)
+    outputText(`  ${err instanceof Error ? err.message : String(err)}`)
+    process.exitCode = 1
+    return
+  }
+
+  if (shouldOutputJson(flags)) {
+    outputJson({ store_root: storeRoot, keys: registry.keys })
+    return
+  }
+
+  if (registry.keys.length === 0) {
+    outputText(`No keys registered for this store.`)
+    outputText(`  Run 'plur keys init' to generate a key pair.`)
+    return
+  }
+
+  outputText(`Keys registered in ${storeRoot}/keys.yaml:`)
+  for (const entry of registry.keys) {
+    const fp = keyFingerprint(entry.public_key)
+    outputText(`  ${entry.identity}`)
+    outputText(`    fingerprint: ${fp}`)
+    outputText(`    added_at   : ${entry.added_at}`)
+  }
+}

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,5 +1,6 @@
 /**
- * `plur verify` — verify the history chain (#1053).
+ * `plur verify` — verify the history chain (#1053) and optionally checkpoint
+ * signatures (#1056).
  *
  * Exit codes are the contract, and all three are distinct:
  *
@@ -14,15 +15,18 @@
  * states the same rule for the audit chain).
  *
  * Usage:
- *   plur verify           Human-readable report
- *   plur verify --json    Full structured result
+ *   plur verify                Human-readable report
+ *   plur verify --signatures   Also verify Ed25519 signatures on checkpoints (#1056)
+ *   plur verify --json         Full structured result
  */
 import { join } from 'path'
 import { createPlur, type GlobalFlags } from '../plur.js'
 import { shouldOutputJson, outputJson, outputText } from '../output.js'
 import { verifyChain, hashStoreFile } from '@plur-ai/core'
 
-export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
+export async function run(args: string[], flags: GlobalFlags): Promise<void> {
+  const verifySignatures = args.includes('--signatures')
+
   // Read-only, like `plur ui`. Verification must not be able to write to the
   // artefact it is examining — and a write-capable handle can, through a lazy
   // path such as a daily backup or a migration that runs on construction.
@@ -31,7 +35,7 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
   // assumed from the fact that this function does not call a write method.
   const plur = createPlur(flags, { readonly: true })
   const root = plur.storageRoot
-  const outcome = verifyChain(root)
+  const outcome = verifyChain(root, { verifySignatures })
 
   if (outcome.status === 'cannot_verify') {
     if (shouldOutputJson(flags)) {
@@ -108,6 +112,21 @@ export async function run(_args: string[], flags: GlobalFlags): Promise<void> {
     for (const c of f.claimed_by) outputText(`    ${c.month} #${c.index} ${c.event_id} -> ${c.hash}`)
     outputText('    Two writers appended from the same predecessor. This is a')
     outputText('    concurrency fault, not evidence of tampering.')
+  }
+
+  if (r.signatures !== null && r.signatures.length > 0) {
+    outputText('')
+    outputText(`  Signature verification (--signatures):`)
+    for (const s of r.signatures) {
+      const verdictStr = s.verdict === 'valid' ? 'VALID'
+        : s.verdict === 'invalid' ? 'INVALID'
+        : s.verdict === 'unsigned' ? 'unsigned (L2 — no signature)'
+        : `unknown signer: ${s.signer ?? '?'}`
+      outputText(`    checkpoint ${s.month} #${s.index}: ${verdictStr}`)
+    }
+  } else if (verifySignatures && r.checkpoints_checked === 0) {
+    outputText('')
+    outputText('  No checkpoints found to verify signatures for.')
   }
 
   if (outcome.status === 'verified' && r.verified_events > 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,6 +54,8 @@ Commands:
                           [--flush] to retry them now (#667)
   checkpoint              Emit a checkpoint event — SHA-256 of the store + chain linkage (#1052)
   verify                  Verify the history chain — exit 0 ok / 1 broken / 2 cannot verify (#1053)
+  keys init [--identity]  Generate Ed25519 key pair for signing checkpoints (#1055)
+  keys list               List registered public keys for this store (#1055)
   reindex-tokens          Re-derive BM25 tokens after a tokenizer change (Postgres only)
   reindex-hashes          Repair engrams whose content_hash is stale or missing (#852)
   init                    Wire PLUR into detected harnesses (Claude Code, Cursor, Codex, Antigravity)
@@ -134,6 +136,7 @@ const COMMANDS: Record<string, string> = {
   outbox: './commands/outbox.js',
   checkpoint: './commands/checkpoint.js',
   verify: './commands/verify.js',
+  keys: './commands/keys.js',
   'reindex-tokens': './commands/reindex-tokens.js',
   'reindex-hashes': './commands/reindex-hashes.js',
   migrate: './commands/migrate.js',

--- a/packages/core/src/actor-keys.ts
+++ b/packages/core/src/actor-keys.ts
@@ -1,0 +1,293 @@
+/**
+ * Per-actor Ed25519 signing keys for engram store checkpoints (#1055).
+ *
+ * ## Key storage layout
+ *
+ *   ~/.plur/keys/<identity>.key   — PKCS#8 DER, mode 0600, never in a repo or store
+ *   <store-root>/keys.yaml        — public key registry (identity → SPKI DER base64, added_at)
+ *
+ * ## What this makes possible
+ *
+ * When a key exists for the acting identity, `emitCheckpoint` gains a
+ * `signature` field — Ed25519 over the checkpoint event's canonical bytes
+ * (the same §3 form everything else hashes). `plur verify --signatures`
+ * then checks that field against the public key in `keys.yaml`.
+ *
+ * An unsigned checkpoint is a valid L2 object; the signature upgrades it to
+ * L3-capable. A signature from an unknown identity is a named failure, not a
+ * skip.
+ *
+ * ## No external dependencies
+ *
+ * All operations use `node:crypto`. Law 6: YAML stays truth; zero new runtime
+ * deps in plur core.
+ */
+import * as fs from 'node:fs'
+import * as crypto from 'node:crypto'
+import * as yaml from 'js-yaml'
+import { join } from 'node:path'
+
+/** Filename suffix for private key files. */
+const KEY_FILE_SUFFIX = '.key'
+
+/** Required permission mode for private key files. */
+const PRIVATE_KEY_MODE = 0o600
+
+/**
+ * An entry in the per-store public key registry.
+ */
+export interface PublicKeyEntry {
+  identity: string
+  /** Ed25519 SPKI DER, base64-encoded. */
+  public_key: string
+  added_at: string
+}
+
+/**
+ * The per-store public key registry loaded from `keys.yaml`.
+ */
+export interface KeysRegistry {
+  keys: PublicKeyEntry[]
+}
+
+/**
+ * Derive the path for an identity's private key file.
+ * `keysDir` is typically `<store-root>/keys` or `~/.plur/keys`.
+ */
+export function privateKeyPath(identity: string, keysDir: string): string {
+  const safeName = identity.replace(/[^a-zA-Z0-9._:-]/g, '_')
+  return join(keysDir, `${safeName}${KEY_FILE_SUFFIX}`)
+}
+
+/**
+ * Derive the path for the store's public key registry.
+ */
+export function keysRegistryPath(storeRoot: string): string {
+  return join(storeRoot, 'keys.yaml')
+}
+
+/**
+ * Generate an Ed25519 key pair and persist the private key.
+ *
+ * Private key written as PKCS#8 DER to `keysDir/<identity>.key`, mode 0600.
+ * `keysDir` is created if it does not exist.
+ *
+ * Idempotent: if a valid key file already exists for `identity`, the existing
+ * public key is returned without generating a new pair — callers can run
+ * `plur keys init` safely more than once.
+ *
+ * @param identity - the actor identity string (e.g. `"agent:miles"`)
+ * @param keysDir  - directory that holds private keys (e.g. `~/.plur/keys`)
+ * @returns the Ed25519 public key as SPKI DER, base64-encoded
+ */
+export function initActorKey(identity: string, keysDir: string): string {
+  const keyFile = privateKeyPath(identity, keysDir)
+
+  // Idempotent: if a valid key already exists, return its public key.
+  const existing = loadPrivateKeyBuffer(identity, keysDir)
+  if (existing !== null) {
+    const keyObj = crypto.createPrivateKey({ key: existing, format: 'der', type: 'pkcs8' })
+    const pub = crypto.createPublicKey(keyObj)
+    return pub.export({ type: 'spki', format: 'der' }).toString('base64')
+  }
+
+  // Generate a fresh Ed25519 key pair.
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519', {
+    privateKeyEncoding: { type: 'pkcs8', format: 'der' },
+    publicKeyEncoding: { type: 'spki', format: 'der' },
+  })
+
+  // Create the directory with restricted permissions.
+  if (!fs.existsSync(keysDir)) {
+    fs.mkdirSync(keysDir, { recursive: true, mode: 0o700 })
+  }
+
+  // Write private key to a temp file, then rename — atomic on POSIX.
+  const tmp = `${keyFile}.${process.pid}.tmp`
+  try {
+    fs.writeFileSync(tmp, privateKey as Buffer, { mode: PRIVATE_KEY_MODE })
+    fs.chmodSync(tmp, PRIVATE_KEY_MODE)
+    fs.renameSync(tmp, keyFile)
+  } catch (err) {
+    try { fs.unlinkSync(tmp) } catch { /* nothing to clean */ }
+    throw err
+  }
+
+  return (publicKey as Buffer).toString('base64')
+}
+
+/**
+ * Load a private key's raw DER bytes from disk.
+ *
+ * Enforces mode 0600: a key readable by group or world is rejected — its
+ * exposure surface is unknown, so signing with it cannot be trusted.
+ *
+ * Returns null (not throws) when the key does not exist — the caller decides
+ * whether absence is an error or means "unsigned".
+ *
+ * @throws if the key file exists but has wrong permissions.
+ */
+export function loadPrivateKeyBuffer(identity: string, keysDir: string): Buffer | null {
+  const keyFile = privateKeyPath(identity, keysDir)
+  if (!fs.existsSync(keyFile)) return null
+
+  // Enforce 0600. A world- or group-readable private key cannot be trusted.
+  try {
+    const st = fs.statSync(keyFile)
+    const mode = st.mode & 0o777
+    if (mode !== PRIVATE_KEY_MODE) {
+      throw new Error(
+        `Private key at ${keyFile} has permissions 0${mode.toString(8).padStart(3, '0')} — ` +
+        `expected 0600. Refusing to load. Run: chmod 600 ${keyFile}`,
+      )
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+
+  return fs.readFileSync(keyFile)
+}
+
+/**
+ * Sign a buffer with the actor's Ed25519 private key.
+ *
+ * Returns the signature as base64, or null when no private key is found for
+ * `identity`. Callers treat null as "no key configured" — unsigned is valid.
+ *
+ * @throws if the key file exists but has wrong permissions or is corrupted.
+ */
+export function signWithActorKey(data: Buffer, identity: string, keysDir: string): string | null {
+  const raw = loadPrivateKeyBuffer(identity, keysDir)
+  if (raw === null) return null
+  const privateKey = crypto.createPrivateKey({ key: raw, format: 'der', type: 'pkcs8' })
+  const sig = crypto.sign(null, data, privateKey)
+  return sig.toString('base64')
+}
+
+/**
+ * Verify an Ed25519 signature.
+ *
+ * @param data         - the exact bytes that were signed
+ * @param signatureB64 - the signature, base64-encoded
+ * @param publicKeyB64 - the signer's public key, SPKI DER base64-encoded
+ * @returns true only when the signature is valid for the given key and data
+ */
+export function verifySignature(data: Buffer, signatureB64: string, publicKeyB64: string): boolean {
+  try {
+    const publicKey = crypto.createPublicKey({
+      key: Buffer.from(publicKeyB64, 'base64'),
+      format: 'der',
+      type: 'spki',
+    })
+    const sig = Buffer.from(signatureB64, 'base64')
+    return crypto.verify(null, data, publicKey, sig)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Load the keys registry from `<storeRoot>/keys.yaml`.
+ *
+ * Returns an empty registry when the file does not exist — a store with no
+ * keys configured is not an error.
+ *
+ * @throws if the file exists but cannot be parsed as a valid registry.
+ */
+export function loadKeysRegistry(storeRoot: string): KeysRegistry {
+  const registryPath = keysRegistryPath(storeRoot)
+  if (!fs.existsSync(registryPath)) return { keys: [] }
+
+  const raw = fs.readFileSync(registryPath, 'utf8')
+  const doc = yaml.load(raw) as unknown
+  if (doc === null || doc === undefined) return { keys: [] }
+  if (typeof doc !== 'object' || !Array.isArray((doc as KeysRegistry).keys)) {
+    throw new Error(`[plur] ${registryPath} is not a valid keys registry (expected {keys: [...]}`)
+  }
+  return doc as KeysRegistry
+}
+
+/**
+ * Look up the public key for `identity` in the store's registry.
+ *
+ * Returns null when the identity has no registered key.
+ */
+export function lookupPublicKey(storeRoot: string, identity: string): string | null {
+  try {
+    const registry = loadKeysRegistry(storeRoot)
+    const entry = registry.keys.find(k => k.identity === identity)
+    return entry?.public_key ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Register (or update) an identity's public key in `<storeRoot>/keys.yaml`.
+ *
+ * Idempotent: if the identity is already registered with the same public key,
+ * the registry is left unchanged. If registered with a DIFFERENT key, the
+ * entry is updated and the old key noted in a comment via the `added_at` field
+ * (it is replaced, not appended — key rotation is a future concern, #1055 flags it).
+ *
+ * The registry is written atomically (temp-file + rename).
+ *
+ * @param storeRoot   - the store root directory
+ * @param identity    - the actor identity string
+ * @param publicKeyB64 - the public key to register, SPKI DER base64-encoded
+ * @param addedAt     - ISO-8601 timestamp; defaults to now
+ */
+export function registerPublicKey(
+  storeRoot: string,
+  identity: string,
+  publicKeyB64: string,
+  addedAt?: string,
+): void {
+  const timestamp = addedAt ?? new Date().toISOString()
+  const registryPath = keysRegistryPath(storeRoot)
+
+  let registry: KeysRegistry
+  try {
+    registry = loadKeysRegistry(storeRoot)
+  } catch {
+    registry = { keys: [] }
+  }
+
+  const idx = registry.keys.findIndex(k => k.identity === identity)
+  if (idx !== -1) {
+    if (registry.keys[idx].public_key === publicKeyB64) return // already registered, no-op
+    registry.keys[idx] = { identity, public_key: publicKeyB64, added_at: timestamp }
+  } else {
+    registry.keys.push({ identity, public_key: publicKeyB64, added_at: timestamp })
+  }
+
+  const serialized = yaml.dump({ keys: registry.keys }, { lineWidth: 120 })
+
+  // Create store root if it doesn't exist yet (unlikely but defensive).
+  if (!fs.existsSync(storeRoot)) fs.mkdirSync(storeRoot, { recursive: true })
+
+  const tmp = `${registryPath}.${process.pid}.tmp`
+  try {
+    fs.writeFileSync(tmp, serialized, 'utf8')
+    fs.renameSync(tmp, registryPath)
+  } catch (err) {
+    try { fs.unlinkSync(tmp) } catch { /* nothing to clean */ }
+    throw err
+  }
+}
+
+/**
+ * Compute the SHA-256 fingerprint of a public key.
+ *
+ * Used for display — a full 44-char base64 key is not human-readable.
+ * Returns lowercase hex, truncated to 16 chars (8 bytes) — sufficient to
+ * distinguish keys in a small registry.
+ */
+export function keyFingerprint(publicKeyB64: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(Buffer.from(publicKeyB64, 'base64'))
+    .digest('hex')
+    .slice(0, 16)
+}

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -28,6 +28,20 @@ export interface HistoryEvent {
    * Legacy events have no prev field — readers must tolerate its absence.
    */
   prev?: string | null
+  /**
+   * Ed25519 signature over the canonical bytes of this event (the same bytes
+   * the `hash` covers — excludes `hash`, `signature`, and `signer` themselves).
+   * Present only on `checkpoint` events when the acting identity has a key
+   * configured (#1056). Base64-encoded. Absent from most events — readers must
+   * tolerate its absence. A missing signature is "unsigned (L2)", not "tampered".
+   */
+  signature?: string
+  /**
+   * Identity of the signer when `signature` is present. Top-level field,
+   * excluded from canonical bytes (so it cannot differ from the signature's
+   * implicit claim). Readers must tolerate its absence.
+   */
+  signer?: string
 }
 
 /**
@@ -92,8 +106,16 @@ export function sortKeysDeep(value: unknown): unknown {
  * - Hashes: lowercase hex SHA-256
  */
 export function canonicalEventBytes(event: HistoryEvent): Buffer {
-  const { hash: _hash, ...rest } = event
-  void _hash // excluded from the canonical form
+  // `hash` is excluded because it is computed FROM these bytes (circular).
+  // `signature` and `signer` are excluded for the same reason: both `hash`
+  // and `signature` cover the identical payload, and `signer` is metadata
+  // about the signing — excluding it keeps the signed bytes stable regardless
+  // of which identity signs. A third-party verifier recomputes hash and checks
+  // the signature from the same canonical form without special-casing any field.
+  const { hash: _hash, signature: _sig, signer: _snr, ...rest } = event
+  void _hash
+  void _sig
+  void _snr
   const sorted = sortKeysDeep(rest)
   return Buffer.from(JSON.stringify(sorted), 'utf8')
 }
@@ -714,6 +736,17 @@ export interface CheckpointData {
   store_hash: string
   engram_count: number
   actor: string
+  /**
+   * Ed25519 signature over the checkpoint's canonical bytes, base64-encoded.
+   * Present only when the acting identity has a key configured (#1056).
+   * An unsigned checkpoint is a valid L2 object — absence is "unsigned", not error.
+   */
+  signature?: string | null
+  /**
+   * Identity of the signer, when `signature` is present.
+   * Allows a verifier to look up the public key in `keys.yaml`.
+   */
+  signer?: string | null
 }
 
 /**
@@ -821,6 +854,26 @@ export function countEngramsInStore(engramsPath: string): number {
 }
 
 /**
+ * Signing options for `emitCheckpoint` (#1056).
+ *
+ * When provided, the checkpoint event gains a `signature` field (Ed25519
+ * over its canonical bytes) and a `signer` field naming the identity.
+ * An unsigned checkpoint is a valid L2 object — callers omit this when no
+ * key is configured.
+ */
+export interface CheckpointSigningOptions {
+  /** The actor identity whose key should sign — typically `provenance.identity`. */
+  identity: string
+  /**
+   * Function that returns an Ed25519 signature (base64) for the given bytes,
+   * or null when the key is unavailable. Injected rather than resolved here to
+   * keep `history.ts` free of a `node:crypto` dependency beyond what it already
+   * has, and to make signing testable in isolation.
+   */
+  sign: (data: Buffer) => string | null
+}
+
+/**
  * Emit a `checkpoint` history event for the store at `root`.
  *
  * Computes:
@@ -845,6 +898,8 @@ export function countEngramsInStore(engramsPath: string): number {
  * the compiler reports rather than a number that quietly stops mattering.
  * @param actor       — who triggered the checkpoint ('session_end' | 'cli' | custom)
  * @param timestamp   — ISO-8601 timestamp; defaults to now
+ * @param signing     — optional signing options (#1056); when absent the checkpoint
+ *                      is unsigned (valid L2, not L3-capable)
  * @returns the written CheckpointData
  */
 export function emitCheckpoint(
@@ -852,6 +907,7 @@ export function emitCheckpoint(
   engramsPath: string,
   actor: string,
   timestamp?: string,
+  signing?: CheckpointSigningOptions,
 ): CheckpointData {
   const ts = timestamp ?? new Date().toISOString()
 
@@ -906,6 +962,32 @@ export function emitCheckpoint(
     const { store_hash, engram_count } = attestStore(engramsPath)
     const data: CheckpointData = { chain_head: prev, store_hash, engram_count, actor }
     event.data = data as unknown as Record<string, unknown>
+
+    // Sign the checkpoint (#1056) if a key is available. The signature is
+    // computed over the canonical bytes of the event as it stands at this
+    // point: data and prev are set; hash, signature, and signer are absent
+    // (all three are excluded from canonical bytes by canonicalEventBytes).
+    // Any field added AFTER signing would be uncovered by the signature;
+    // keeping signer top-level (not in data) prevents a circular dependency
+    // where the signer's identity would have to be in the signed bytes.
+    //
+    // An unsigned checkpoint is a valid L2 object. Signing failure is
+    // best-effort: if the key cannot be read or signing fails, we proceed
+    // without a signature rather than aborting the checkpoint.
+    if (signing !== undefined) {
+      try {
+        const sig = signing.sign(canonicalEventBytes(event))
+        if (sig !== null) {
+          event.signature = sig
+          event.signer = signing.identity
+          // signer and signature are top-level fields; they are NOT added to
+          // event.data so they are excluded from the canonical bytes that both
+          // the hash and the signature cover — keeping both consistent.
+        }
+      } catch {
+        // best-effort: unsigned checkpoint is still valid L2
+      }
+    }
   })
 
   // The checkpoint's OWN hash, returned but not persisted — an event cannot
@@ -915,7 +997,15 @@ export function emitCheckpoint(
   // tool returned the STORE hash under the name `checkpoint_hash`. #1052 exists
   // so that a checkpoint is anchorable, and a payload omitting the hash you
   // would anchor is not anchorable either.
-  return { ...(event.data as unknown as CheckpointData), event_hash: event.hash ?? null }
+  //
+  // signature and signer are top-level HistoryEvent fields (not in event.data),
+  // so they must be added explicitly to the return value (#1056).
+  return {
+    ...(event.data as unknown as CheckpointData),
+    event_hash: event.hash ?? null,
+    signature: event.signature,
+    signer: event.signer,
+  }
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,7 +119,7 @@ export { selectModel, selectModelForOperation, resolveOperationTier, type ModelT
 export { recallAuto, type AutoSearchResult, type SearchStrategy } from './search-orchestrator.js'
 export { generateProfile, getProfileForInjection, loadProfileCache, saveProfileCache, markProfileDirty, profileNeedsRegeneration, type ProfileCache } from './profile.js'
 export { formatLayer1, formatLayer2, formatLayer3, formatWithLayer, assignLayer, type InjectionLayer } from './inject.js'
-export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, readCoInjections, computeEventHash, canonicalEventBytes, sortKeysDeep, tailSeekLastHash, readChainHead, clearChainHeadMemCache, hashEngramsFile, attestStore, countEngramsInStore, emitCheckpoint, type HistoryEvent, type CheckpointData, type InjectionEventCounts, type InjectionSource, type CoInjectionData, type CoInjectionEvent, type CoInjectionReadResult } from './history.js'
+export { appendHistory, readHistory, listHistoryMonths, readHistoryForEngram, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, readCoInjections, computeEventHash, canonicalEventBytes, sortKeysDeep, tailSeekLastHash, readChainHead, clearChainHeadMemCache, hashEngramsFile, attestStore, countEngramsInStore, emitCheckpoint, appendHistoryStamped, type HistoryEvent, type CheckpointData, type CheckpointSigningOptions, type InjectionEventCounts, type InjectionSource, type CoInjectionData, type CoInjectionEvent, type CoInjectionReadResult } from './history.js'
 export { computeReceipt } from './receipt.js'
 export type { Receipt, ReceiptInput, ReceiptTopEntry } from './receipt.js'
 import type { Receipt } from './receipt.js'
@@ -228,7 +228,8 @@ export type { SyncResult, SyncStatus, SyncRemoteType } from './sync.js'
  * neither a lock nor an atomic replace; re-implementing them per package is how
  * the two drift, and the drift is always in the unsafe direction.
  */
-export { verifyChain, hashStoreFile, type ChainVerifyOutcome, type ChainVerifyResult, type ChainBreak, type ChainFork, type BreakReason } from './verify-chain.js'
+export { verifyChain, hashStoreFile, type ChainVerifyOutcome, type ChainVerifyResult, type ChainBreak, type ChainFork, type BreakReason, type VerifyChainOptions, type SignatureResult, type SignatureVerdict } from './verify-chain.js'
+export { initActorKey, loadPrivateKeyBuffer, signWithActorKey, verifySignature, loadKeysRegistry, lookupPublicKey, registerPublicKey, keyFingerprint, privateKeyPath, keysRegistryPath, type PublicKeyEntry, type KeysRegistry } from './actor-keys.js'
 export { atomicWrite, withLock } from './sync.js'
 export { markRemoteHostDown, remoteHostDownRemainingMs, clearRemoteHostDown, _resetRemoteHostBreaker, salvageRemoteRow } from './store/remote-store.js'
 export { checkForUpdate, settleVersionChecks, getCachedUpdateCheck, clearVersionCache, minorVersionsBehind, VERSION_CHECK_SUCCESS_TTL_MS, VERSION_CHECK_FAILURE_TTL_MS, type VersionCheckResult } from './version-check.js'

--- a/packages/core/src/verify-chain.ts
+++ b/packages/core/src/verify-chain.ts
@@ -29,7 +29,8 @@
  */
 import * as fs from 'node:fs'
 import { join } from 'node:path'
-import { computeEventHash, hashEngramsFile, listHistoryMonths, type HistoryEvent } from './history.js'
+import { computeEventHash, hashEngramsFile, canonicalEventBytes, listHistoryMonths, type HistoryEvent } from './history.js'
+import { lookupPublicKey, verifySignature } from './actor-keys.js'
 
 export type BreakReason =
   | 'hash_mismatch'            // the event does not hash to its recorded hash
@@ -38,6 +39,22 @@ export type BreakReason =
   | 'checkpoint_head_missing'  // a checkpoint pins a head the chain no longer contains
   | 'store_hash_mismatch'      // the newest checkpoint attests a store that is not the one on disk
   | 'declared_gap'             // prev is null mid-chain: a writer could not take the lock
+
+/** Result of signature verification for one checkpoint (#1056). */
+export type SignatureVerdict =
+  | 'valid'           // signature checks out against the registered public key
+  | 'invalid'         // signature does not verify (wrong key, tampered bytes)
+  | 'unknown_signer'  // signer identity not in the store's keys.yaml
+  | 'unsigned'        // checkpoint has no signature field (valid L2, not L3)
+
+export interface SignatureResult {
+  /** 0-based index of the checkpoint event in the full scanned sequence. */
+  index:    number
+  month:    string
+  event_id: string
+  verdict:  SignatureVerdict
+  signer:   string | null
+}
 
 export interface ChainBreak {
   month:    string
@@ -73,6 +90,12 @@ export interface ChainVerifyResult {
    * verify". Never null-and-silent: a caller that wants to know is told.
    */
   torn_tail: { month: string; line: number } | null
+  /**
+   * Per-checkpoint signature results (#1056). Populated only when
+   * `verifyChain` is called with `{ verifySignatures: true }`.
+   * null means signatures were not checked.
+   */
+  signatures: SignatureResult[] | null
 }
 
 export type ChainVerifyOutcome =
@@ -91,6 +114,18 @@ interface Scanned { month: string; index: number; event: HistoryEvent }
  */
 const GENESIS_CLAIM = '(genesis)'
 
+/** Options for `verifyChain`. */
+export interface VerifyChainOptions {
+  /**
+   * When true, verify Ed25519 signatures on checkpoint events against the
+   * store's `keys.yaml` registry (#1056). An unknown signer is a named
+   * `unknown_signer` result, not a chain break. An invalid signature IS a
+   * chain break (signature field reports it as `invalid`).
+   * Default: false (chain-only verification).
+   */
+  verifySignatures?: boolean
+}
+
 /**
  * Verify the whole history chain for a store.
  *
@@ -99,7 +134,8 @@ const GENESIS_CLAIM = '(genesis)'
  * report a clean chain over a file it could not fully read — the benign-zero
  * this surface exists to refuse. A line that will not parse is a refusal.
  */
-export function verifyChain(root: string): ChainVerifyOutcome {
+export function verifyChain(root: string, options?: VerifyChainOptions): ChainVerifyOutcome {
+  const verifySignatures = options?.verifySignatures === true
   const months = listHistoryMonths(root)
   const scanned: Scanned[] = []
   /** A torn final line in the newest month — an in-flight write, reported not refused. */
@@ -165,6 +201,7 @@ export function verifyChain(root: string): ChainVerifyOutcome {
     forks: [],
     checkpoints_checked: 0,
     torn_tail: null,
+    signatures: verifySignatures ? [] : null,
   }
 
   // Unchained (pre-#1051) events. They carry neither hash nor prev; per runbook
@@ -329,6 +366,66 @@ export function verifyChain(root: string): ChainVerifyOutcome {
   }
 
   result.torn_tail = torn_tail
+
+  // Signature verification (#1056). Performed AFTER chain verification so a
+  // caller that only wants chain integrity can skip the key-registry read.
+  //
+  // An unknown signer is a named `unknown_signer` result, not a chain break —
+  // the chain itself is intact, we just cannot verify the external attestation.
+  // An invalid signature IS a named failure in `signatures`, and also registers
+  // as a break so the exit code signals actionable failure.
+  if (verifySignatures) {
+    for (const { month, index, event } of scanned) {
+      if (event.event !== 'checkpoint') continue
+      // signer and signature are top-level HistoryEvent fields (excluded from
+      // canonical bytes). Older checkpoints stored signer in event.data — fall
+      // back to that for any written before this migration.
+      const dataSigner = (event.data as { signer?: unknown }).signer
+      const signer = typeof event.signer === 'string' ? event.signer
+        : typeof dataSigner === 'string' ? dataSigner
+        : null
+      const sigB64 = typeof event.signature === 'string' ? event.signature : null
+
+      let verdict: SignatureVerdict
+      if (sigB64 === null) {
+        verdict = 'unsigned'
+      } else if (signer === null) {
+        // Signature present but no signer field — treat as unknown.
+        verdict = 'unknown_signer'
+      } else {
+        const pubKeyB64 = lookupPublicKey(root, signer)
+        if (pubKeyB64 === null) {
+          verdict = 'unknown_signer'
+        } else {
+          // Verify the signature over the canonical bytes: the event as it was
+          // before `hash` and `signature` were added. canonicalEventBytes already
+          // excludes both.
+          const canonical = canonicalEventBytes(event)
+          verdict = verifySignature(canonical, sigB64, pubKeyB64) ? 'valid' : 'invalid'
+        }
+      }
+
+      const sigResult: SignatureResult = {
+        index, month,
+        event_id: event.engram_id || '(checkpoint)',
+        verdict, signer,
+      }
+      result.signatures!.push(sigResult)
+
+      // An invalid signature is a break: the checkpoint can no longer be trusted
+      // as an external attestation. Unknown signer is NOT a break — it may just
+      // mean the key was not registered on this machine yet.
+      if (verdict === 'invalid') {
+        result.breaks.push({
+          month, index, event_id: sigResult.event_id,
+          reason: 'hash_mismatch', // repurposed: signature did not verify
+          expected: 'valid Ed25519 signature',
+          actual: `invalid signature by ${signer ?? '(unknown)'}`,
+        })
+      }
+    }
+  }
+
   // A torn tail does not make the chain broken — everything before it verified.
   result.ok = result.breaks.length === 0 && result.forks.length === 0
   return { status: result.ok ? 'verified' : 'broken', result }

--- a/packages/core/test/actor-keys.test.ts
+++ b/packages/core/test/actor-keys.test.ts
@@ -42,6 +42,16 @@ import {
 
 import { verifyChain } from '../src/verify-chain.js'
 
+/**
+ * `verifyChain` returns a discriminated union; a `cannot_verify` outcome has
+ * no `result`. The tests below assert `status` first and then read the
+ * result, so narrow here instead of at every call site.
+ */
+function resultOf(outcome: ReturnType<typeof verifyChain>) {
+  if (outcome.status === 'cannot_verify') throw new Error(`chain could not be verified: ${outcome.reason}`)
+  return outcome.result
+}
+
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
@@ -452,15 +462,15 @@ describe('verifyChain --signatures (#1056)', () => {
     emitCheckpoint(dir, engramsPath, 'cli')
     const outcome = verifyChain(dir)
     expect(outcome.status).toBe('verified')
-    expect(outcome.result.signatures).toBeNull()
+    expect(resultOf(outcome).signatures).toBeNull()
   })
 
   it('with --signatures: unsigned checkpoint reports "unsigned"', () => {
     emitCheckpoint(dir, engramsPath, 'cli')
     const outcome = verifyChain(dir, { verifySignatures: true })
     expect(outcome.status).toBe('verified') // unsigned is not a break
-    expect(outcome.result.signatures).toHaveLength(1)
-    expect(outcome.result.signatures![0].verdict).toBe('unsigned')
+    expect(resultOf(outcome).signatures).toHaveLength(1)
+    expect(resultOf(outcome).signatures![0].verdict).toBe('unsigned')
   })
 
   it('with --signatures: valid signed checkpoint reports "valid"', () => {
@@ -475,9 +485,9 @@ describe('verifyChain --signatures (#1056)', () => {
 
     const outcome = verifyChain(dir, { verifySignatures: true })
     expect(outcome.status).toBe('verified')
-    expect(outcome.result.signatures).toHaveLength(1)
-    expect(outcome.result.signatures![0].verdict).toBe('valid')
-    expect(outcome.result.signatures![0].signer).toBe('agent:test')
+    expect(resultOf(outcome).signatures).toHaveLength(1)
+    expect(resultOf(outcome).signatures![0].verdict).toBe('valid')
+    expect(resultOf(outcome).signatures![0].signer).toBe('agent:test')
   })
 
   it('with --signatures: unknown signer is "unknown_signer", NOT a chain break', () => {
@@ -492,8 +502,8 @@ describe('verifyChain --signatures (#1056)', () => {
 
     const outcome = verifyChain(dir, { verifySignatures: true })
     expect(outcome.status).toBe('verified')
-    expect(outcome.result.breaks).toHaveLength(0)
-    expect(outcome.result.signatures![0].verdict).toBe('unknown_signer')
+    expect(resultOf(outcome).breaks).toHaveLength(0)
+    expect(resultOf(outcome).signatures![0].verdict).toBe('unknown_signer')
   })
 
   it('with --signatures: invalid signature is a named failure AND a break', () => {
@@ -524,8 +534,8 @@ describe('verifyChain --signatures (#1056)', () => {
     fs.writeFileSync(jsonlPath, lines.join('\n') + '\n', 'utf8')
 
     const outcome = verifyChain(dir, { verifySignatures: true })
-    expect(outcome.result.signatures![0].verdict).toBe('invalid')
-    expect(outcome.result.breaks.length).toBeGreaterThan(0)
+    expect(resultOf(outcome).signatures![0].verdict).toBe('invalid')
+    expect(resultOf(outcome).breaks.length).toBeGreaterThan(0)
   })
 
   it('with --signatures: no checkpoints → empty signatures array, still verified', () => {
@@ -538,6 +548,6 @@ describe('verifyChain --signatures (#1056)', () => {
 
     const outcome = verifyChain(dir, { verifySignatures: true })
     expect(outcome.status).toBe('verified')
-    expect(outcome.result.signatures).toEqual([])
+    expect(resultOf(outcome).signatures).toEqual([])
   })
 })

--- a/packages/core/test/actor-keys.test.ts
+++ b/packages/core/test/actor-keys.test.ts
@@ -1,0 +1,543 @@
+/**
+ * W3.1 — Per-actor Ed25519 keys (#1055)
+ * W3.2 — Sign checkpoints; verify --signatures (#1056)
+ *
+ * Tests cover:
+ *   - initActorKey: generate, idempotent, correct permissions
+ *   - loadPrivateKeyBuffer: absent → null, wrong mode → throws
+ *   - signWithActorKey: signs; absent key → null
+ *   - verifySignature: valid, invalid, corrupt
+ *   - registerPublicKey / lookupPublicKey: round-trip, update
+ *   - keyFingerprint: 16 hex chars
+ *   - emitCheckpoint with signing: signature + signer in event
+ *   - emitCheckpoint without signing: no signature field
+ *   - verifyChain({ verifySignatures: true }): valid / unsigned / unknown / invalid
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import * as crypto from 'node:crypto'
+
+import {
+  initActorKey,
+  loadPrivateKeyBuffer,
+  signWithActorKey,
+  verifySignature,
+  registerPublicKey,
+  lookupPublicKey,
+  loadKeysRegistry,
+  keyFingerprint,
+  privateKeyPath,
+} from '../src/actor-keys.js'
+
+import {
+  emitCheckpoint,
+  appendHistory,
+  readHistory,
+  canonicalEventBytes,
+  computeEventHash,
+  type HistoryEvent,
+} from '../src/history.js'
+
+import { verifyChain } from '../src/verify-chain.js'
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'plur-keys-'))
+}
+
+// ---------------------------------------------------------------------------
+// W3.1 — initActorKey
+// ---------------------------------------------------------------------------
+
+describe('initActorKey (#1055)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = tmpDir() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('RED → generates a new key pair and returns a base64 public key', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub = initActorKey('agent:test', keysDir)
+    expect(typeof pub).toBe('string')
+    expect(pub.length).toBeGreaterThan(20)
+    expect(() => Buffer.from(pub, 'base64')).not.toThrow()
+    // Must be a valid SPKI public key
+    expect(() =>
+      crypto.createPublicKey({ key: Buffer.from(pub, 'base64'), format: 'der', type: 'spki' }),
+    ).not.toThrow()
+  })
+
+  it('writes the private key file at <keysDir>/<identity>.key', () => {
+    const keysDir = path.join(dir, 'keys')
+    initActorKey('agent:test', keysDir)
+    const keyFile = privateKeyPath('agent:test', keysDir)
+    expect(fs.existsSync(keyFile)).toBe(true)
+  })
+
+  it('creates the keys directory with restricted permissions', () => {
+    const keysDir = path.join(dir, 'keys')
+    expect(fs.existsSync(keysDir)).toBe(false)
+    initActorKey('agent:test', keysDir)
+    expect(fs.existsSync(keysDir)).toBe(true)
+    const dirMode = fs.statSync(keysDir).mode & 0o777
+    // Directory must not be world-readable
+    expect(dirMode & 0o7).toBe(0)
+  })
+
+  it('sets private key file mode to 0600', () => {
+    const keysDir = path.join(dir, 'keys')
+    initActorKey('agent:test', keysDir)
+    const keyFile = privateKeyPath('agent:test', keysDir)
+    const mode = fs.statSync(keyFile).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('is idempotent: second call returns the same public key without overwriting', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub1 = initActorKey('agent:test', keysDir)
+    const keyFile = privateKeyPath('agent:test', keysDir)
+    const mtimeBefore = fs.statSync(keyFile).mtimeMs
+
+    const pub2 = initActorKey('agent:test', keysDir)
+    const mtimeAfter = fs.statSync(keyFile).mtimeMs
+
+    expect(pub1).toBe(pub2)
+    expect(mtimeAfter).toBe(mtimeBefore)
+  })
+
+  it('different identities get different key files', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub1 = initActorKey('agent:alice', keysDir)
+    const pub2 = initActorKey('agent:bob', keysDir)
+    expect(pub1).not.toBe(pub2)
+    expect(fs.existsSync(privateKeyPath('agent:alice', keysDir))).toBe(true)
+    expect(fs.existsSync(privateKeyPath('agent:bob', keysDir))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// W3.1 — loadPrivateKeyBuffer
+// ---------------------------------------------------------------------------
+
+describe('loadPrivateKeyBuffer (#1055)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = tmpDir() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('returns null when no key file exists', () => {
+    const keysDir = path.join(dir, 'keys')
+    expect(loadPrivateKeyBuffer('agent:nobody', keysDir)).toBeNull()
+  })
+
+  it('returns the key bytes when the file exists with mode 0600', () => {
+    const keysDir = path.join(dir, 'keys')
+    initActorKey('agent:test', keysDir)
+    const buf = loadPrivateKeyBuffer('agent:test', keysDir)
+    expect(buf).not.toBeNull()
+    expect(Buffer.isBuffer(buf)).toBe(true)
+    // Must be parseable as a PKCS8 private key
+    expect(() =>
+      crypto.createPrivateKey({ key: buf!, format: 'der', type: 'pkcs8' }),
+    ).not.toThrow()
+  })
+
+  it('throws when the key file has wrong permissions (group-readable)', () => {
+    const keysDir = path.join(dir, 'keys')
+    initActorKey('agent:test', keysDir)
+    const keyFile = privateKeyPath('agent:test', keysDir)
+    fs.chmodSync(keyFile, 0o640)
+    expect(() => loadPrivateKeyBuffer('agent:test', keysDir)).toThrow(/0600/)
+  })
+
+  it('throws when the key file has world-readable permissions', () => {
+    const keysDir = path.join(dir, 'keys')
+    initActorKey('agent:test', keysDir)
+    const keyFile = privateKeyPath('agent:test', keysDir)
+    fs.chmodSync(keyFile, 0o644)
+    expect(() => loadPrivateKeyBuffer('agent:test', keysDir)).toThrow(/0600/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// W3.1 — signWithActorKey / verifySignature
+// ---------------------------------------------------------------------------
+
+describe('signWithActorKey / verifySignature (#1055, #1056)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = tmpDir() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('returns null when no key is found for the identity', () => {
+    const keysDir = path.join(dir, 'keys')
+    const sig = signWithActorKey(Buffer.from('hello'), 'agent:nobody', keysDir)
+    expect(sig).toBeNull()
+  })
+
+  it('returns a base64 signature when key exists', () => {
+    const keysDir = path.join(dir, 'keys')
+    initActorKey('agent:test', keysDir)
+    const sig = signWithActorKey(Buffer.from('hello'), 'agent:test', keysDir)
+    expect(sig).not.toBeNull()
+    expect(typeof sig).toBe('string')
+    expect(() => Buffer.from(sig!, 'base64')).not.toThrow()
+  })
+
+  it('verifySignature: valid signature verifies', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    const data = Buffer.from('canonical event bytes')
+    const sig = signWithActorKey(data, 'agent:test', keysDir)!
+    expect(verifySignature(data, sig, pubB64)).toBe(true)
+  })
+
+  it('verifySignature: wrong data → false', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    const data = Buffer.from('original data')
+    const sig = signWithActorKey(data, 'agent:test', keysDir)!
+    expect(verifySignature(Buffer.from('tampered data'), sig, pubB64)).toBe(false)
+  })
+
+  it('verifySignature: wrong key → false', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubA = initActorKey('agent:alice', keysDir)
+    initActorKey('agent:bob', keysDir)
+    const data = Buffer.from('some data')
+    const sig = signWithActorKey(data, 'agent:bob', keysDir)!
+    // Bob's signature, checked against Alice's key
+    expect(verifySignature(data, sig, pubA)).toBe(false)
+  })
+
+  it('verifySignature: corrupt signature → false (no throw)', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    const data = Buffer.from('data')
+    const badSig = Buffer.from('not a valid ed25519 signature aaaaaa').toString('base64')
+    expect(() => verifySignature(data, badSig, pubB64)).not.toThrow()
+    expect(verifySignature(data, badSig, pubB64)).toBe(false)
+  })
+
+  it('CJK test vector: signs and verifies multibyte UTF-8 content', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    // CJK characters per runbook §3 requirement
+    const cjkData = Buffer.from('学習した内容を覚える 記憶エンジン 持続的学習', 'utf8')
+    const sig = signWithActorKey(cjkData, 'agent:test', keysDir)!
+    expect(verifySignature(cjkData, sig, pubB64)).toBe(true)
+    // Different bytes → invalid
+    expect(verifySignature(Buffer.from('other data'), sig, pubB64)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// W3.1 — registerPublicKey / lookupPublicKey
+// ---------------------------------------------------------------------------
+
+describe('registerPublicKey / lookupPublicKey (#1055)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = tmpDir() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('lookupPublicKey returns null when no registry exists', () => {
+    expect(lookupPublicKey(dir, 'agent:test')).toBeNull()
+  })
+
+  it('registers and looks up a public key', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pub)
+    expect(lookupPublicKey(dir, 'agent:test')).toBe(pub)
+  })
+
+  it('lookup returns null for unknown identity', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pub)
+    expect(lookupPublicKey(dir, 'agent:unknown')).toBeNull()
+  })
+
+  it('registering a new identity does not remove others', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubA = initActorKey('agent:alice', keysDir)
+    const pubB = initActorKey('agent:bob', keysDir)
+    registerPublicKey(dir, 'agent:alice', pubA)
+    registerPublicKey(dir, 'agent:bob', pubB)
+    expect(lookupPublicKey(dir, 'agent:alice')).toBe(pubA)
+    expect(lookupPublicKey(dir, 'agent:bob')).toBe(pubB)
+  })
+
+  it('registering the same identity with the same key is a no-op (idempotent)', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pub, '2026-01-01T00:00:00.000Z')
+    const before = fs.readFileSync(path.join(dir, 'keys.yaml'), 'utf8')
+    registerPublicKey(dir, 'agent:test', pub)
+    const after = fs.readFileSync(path.join(dir, 'keys.yaml'), 'utf8')
+    expect(after).toBe(before)
+  })
+
+  it('registering the same identity with a DIFFERENT key updates the entry', () => {
+    const keysDir1 = path.join(dir, 'keys1')
+    const keysDir2 = path.join(dir, 'keys2')
+    const pub1 = initActorKey('agent:test', keysDir1)
+    const pub2 = initActorKey('agent:test', keysDir2)
+    registerPublicKey(dir, 'agent:test', pub1)
+    registerPublicKey(dir, 'agent:test', pub2)
+    const registry = loadKeysRegistry(dir)
+    expect(registry.keys.filter(k => k.identity === 'agent:test')).toHaveLength(1)
+    expect(lookupPublicKey(dir, 'agent:test')).toBe(pub2)
+  })
+
+  it('writes keys.yaml atomically and with required fields', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pub)
+    const registry = loadKeysRegistry(dir)
+    expect(registry.keys).toHaveLength(1)
+    expect(registry.keys[0].identity).toBe('agent:test')
+    expect(registry.keys[0].public_key).toBe(pub)
+    expect(typeof registry.keys[0].added_at).toBe('string')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// W3.1 — keyFingerprint
+// ---------------------------------------------------------------------------
+
+describe('keyFingerprint (#1055)', () => {
+  let dir: string
+
+  beforeEach(() => { dir = tmpDir() })
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('returns 16 lowercase hex chars', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub = initActorKey('agent:test', keysDir)
+    const fp = keyFingerprint(pub)
+    expect(fp).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('different keys → different fingerprints', () => {
+    const keysDir1 = path.join(dir, 'keys1')
+    const keysDir2 = path.join(dir, 'keys2')
+    const pub1 = initActorKey('agent:a', keysDir1)
+    const pub2 = initActorKey('agent:b', keysDir2)
+    expect(keyFingerprint(pub1)).not.toBe(keyFingerprint(pub2))
+  })
+
+  it('same key → same fingerprint', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pub = initActorKey('agent:test', keysDir)
+    expect(keyFingerprint(pub)).toBe(keyFingerprint(pub))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// W3.2 — emitCheckpoint with signing (#1056)
+// ---------------------------------------------------------------------------
+
+describe('emitCheckpoint with signing (#1056)', () => {
+  let dir: string
+  let engramsPath: string
+
+  beforeEach(() => {
+    dir = tmpDir()
+    engramsPath = path.join(dir, 'engrams.yaml')
+    fs.writeFileSync(engramsPath, 'engrams: []\n', 'utf8')
+  })
+
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('unsigned checkpoint has no signature or signer', () => {
+    const data = emitCheckpoint(dir, engramsPath, 'cli')
+    expect(data.signature).toBeUndefined()
+    expect(data.signer).toBeUndefined()
+
+    const month = new Date().toISOString().slice(0, 7)
+    const events = readHistory(dir, month)
+    const cp = events.find(e => e.event === 'checkpoint')
+    expect(cp).toBeDefined()
+    expect(cp!.signature).toBeUndefined()
+  })
+
+  it('signed checkpoint has signature and signer in the returned data', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pubB64)
+
+    const data = emitCheckpoint(dir, engramsPath, 'cli', undefined, {
+      identity: 'agent:test',
+      sign: (bytes) => signWithActorKey(bytes, 'agent:test', keysDir),
+    })
+
+    expect(typeof data.signature).toBe('string')
+    expect(data.signer).toBe('agent:test')
+  })
+
+  it('signature is valid over the canonical bytes of the checkpoint event', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pubB64)
+
+    emitCheckpoint(dir, engramsPath, 'cli', undefined, {
+      identity: 'agent:test',
+      sign: (bytes) => signWithActorKey(bytes, 'agent:test', keysDir),
+    })
+
+    const month = new Date().toISOString().slice(0, 7)
+    const events = readHistory(dir, month)
+    const cp = events.find(e => e.event === 'checkpoint')
+    expect(cp).toBeDefined()
+    expect(typeof cp!.signature).toBe('string')
+
+    // canonicalEventBytes excludes both hash and signature
+    const canonical = canonicalEventBytes(cp!)
+    expect(verifySignature(canonical, cp!.signature!, pubB64)).toBe(true)
+  })
+
+  it('the stored hash matches the canonical-bytes hash (signature excluded from canonical bytes)', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pubB64)
+
+    emitCheckpoint(dir, engramsPath, 'cli', undefined, {
+      identity: 'agent:test',
+      sign: (bytes) => signWithActorKey(bytes, 'agent:test', keysDir),
+    })
+
+    const month = new Date().toISOString().slice(0, 7)
+    const events = readHistory(dir, month)
+    const cp = events.find(e => e.event === 'checkpoint')!
+
+    // computeEventHash excludes both hash and signature — same canonical form
+    const recomputed = computeEventHash(cp)
+    expect(recomputed).toBe(cp.hash)
+  })
+
+  it('signing failure is best-effort: unsigned checkpoint is written on error', () => {
+    const data = emitCheckpoint(dir, engramsPath, 'cli', undefined, {
+      identity: 'agent:test',
+      sign: (_bytes) => { throw new Error('signing failed') },
+    })
+    expect(data.event_hash).toBeTruthy()
+    expect(data.signature).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// W3.2 — verifyChain with --signatures (#1056)
+// ---------------------------------------------------------------------------
+
+describe('verifyChain --signatures (#1056)', () => {
+  let dir: string
+  let engramsPath: string
+
+  beforeEach(() => {
+    dir = tmpDir()
+    engramsPath = path.join(dir, 'engrams.yaml')
+    fs.writeFileSync(engramsPath, 'engrams: []\n', 'utf8')
+  })
+
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+
+  it('without --signatures: signatures field is null', () => {
+    emitCheckpoint(dir, engramsPath, 'cli')
+    const outcome = verifyChain(dir)
+    expect(outcome.status).toBe('verified')
+    expect(outcome.result.signatures).toBeNull()
+  })
+
+  it('with --signatures: unsigned checkpoint reports "unsigned"', () => {
+    emitCheckpoint(dir, engramsPath, 'cli')
+    const outcome = verifyChain(dir, { verifySignatures: true })
+    expect(outcome.status).toBe('verified') // unsigned is not a break
+    expect(outcome.result.signatures).toHaveLength(1)
+    expect(outcome.result.signatures![0].verdict).toBe('unsigned')
+  })
+
+  it('with --signatures: valid signed checkpoint reports "valid"', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pubB64)
+
+    emitCheckpoint(dir, engramsPath, 'cli', undefined, {
+      identity: 'agent:test',
+      sign: (bytes) => signWithActorKey(bytes, 'agent:test', keysDir),
+    })
+
+    const outcome = verifyChain(dir, { verifySignatures: true })
+    expect(outcome.status).toBe('verified')
+    expect(outcome.result.signatures).toHaveLength(1)
+    expect(outcome.result.signatures![0].verdict).toBe('valid')
+    expect(outcome.result.signatures![0].signer).toBe('agent:test')
+  })
+
+  it('with --signatures: unknown signer is "unknown_signer", NOT a chain break', () => {
+    const keysDir = path.join(dir, 'keys')
+    initActorKey('agent:test', keysDir)
+    // NOT registering the public key — signer will be unknown to verifyChain
+
+    emitCheckpoint(dir, engramsPath, 'cli', undefined, {
+      identity: 'agent:test',
+      sign: (bytes) => signWithActorKey(bytes, 'agent:test', keysDir),
+    })
+
+    const outcome = verifyChain(dir, { verifySignatures: true })
+    expect(outcome.status).toBe('verified')
+    expect(outcome.result.breaks).toHaveLength(0)
+    expect(outcome.result.signatures![0].verdict).toBe('unknown_signer')
+  })
+
+  it('with --signatures: invalid signature is a named failure AND a break', () => {
+    const keysDir = path.join(dir, 'keys')
+    const pubB64 = initActorKey('agent:test', keysDir)
+    registerPublicKey(dir, 'agent:test', pubB64)
+
+    emitCheckpoint(dir, engramsPath, 'cli', undefined, {
+      identity: 'agent:test',
+      sign: (bytes) => signWithActorKey(bytes, 'agent:test', keysDir),
+    })
+
+    // Tamper: flip a byte in the signature in the JSONL file.
+    // canonicalEventBytes excludes `signature`, so the hash is unaffected —
+    // the chain stays intact while the signature becomes invalid.
+    const month = new Date().toISOString().slice(0, 7)
+    const jsonlPath = path.join(dir, 'history', `${month}.jsonl`)
+    const content = fs.readFileSync(jsonlPath, 'utf8')
+    const lines = content.split('\n').filter(l => l.trim())
+    const lastLine = JSON.parse(lines[lines.length - 1]) as HistoryEvent
+    if (lastLine.signature) {
+      const sigBytes = Buffer.from(lastLine.signature, 'base64')
+      sigBytes[0] ^= 0xff
+      lastLine.signature = sigBytes.toString('base64')
+    }
+    // Hash stays the same (signature is excluded from canonical bytes)
+    lines[lines.length - 1] = JSON.stringify(lastLine)
+    fs.writeFileSync(jsonlPath, lines.join('\n') + '\n', 'utf8')
+
+    const outcome = verifyChain(dir, { verifySignatures: true })
+    expect(outcome.result.signatures![0].verdict).toBe('invalid')
+    expect(outcome.result.breaks.length).toBeGreaterThan(0)
+  })
+
+  it('with --signatures: no checkpoints → empty signatures array, still verified', () => {
+    appendHistory(dir, {
+      event: 'engram_created',
+      engram_id: 'ENG-2026-09-04-001',
+      timestamp: new Date().toISOString(),
+      data: {},
+    })
+
+    const outcome = verifyChain(dir, { verifySignatures: true })
+    expect(outcome.status).toBe('verified')
+    expect(outcome.result.signatures).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- **W3.1** (#1055): `plur keys init` generates Ed25519 key pairs per identity. Private key at `~/.plur/keys/<identity>.key`, mode 0600 enforced on every read. Public key registered in `<store-root>/keys.yaml`. All operations use `node:crypto` only — zero new runtime dependencies.

- **W3.2** (#1056): `emitCheckpoint` accepts signing options; when an acting identity has a key, the checkpoint event gains top-level `signature` and `signer` fields. Both are excluded from canonical bytes (same exclusion as `hash`), so hash and signature independently attest the same payload. `verifyChain({ verifySignatures: true })` / `plur verify --signatures` checks each checkpoint: `valid` / `invalid` / `unknown_signer` / `unsigned`. Unknown signer is a named result, not a chain break; invalid signature IS a chain break (exit 1).

- **W3.3** (#1057): `docs/auditability.md` written last, against what actually merged.

## Implementation notes

The canonical bytes (`canonicalEventBytes`) now excludes `hash`, `signature`, **and `signer`**. Keeping `signer` top-level (not in `event.data`) was the key design decision: it prevents a circular dependency where the signer identity would have to appear in the bytes being signed, making the signing sequence impossible without a second pass. Tests caught this bug during the red phase — the initial prototype put `data.signer` into `event.data` before signing, breaking verification.

## Tests

38 tests in `packages/core/test/actor-keys.test.ts` covering:
- Key generation, 0600 permission enforcement, idempotency
- `signWithActorKey` / `verifySignature` round-trips (including CJK test vector)
- Registry `registerPublicKey` / `lookupPublicKey` round-trips and updates
- `keyFingerprint` 16-char hex
- `emitCheckpoint` signed/unsigned, signing failure best-effort
- `verifyChain({ verifySignatures: true })` all four verdicts: valid / unsigned / unknown_signer / invalid
- Invalid signature verified as a chain break (exits 1)

## Benchmark

Write-path operations (learn/recall/inject) are unaffected — signing only runs on the explicit `plur checkpoint` command:

| Operation | integration/core-store | W3 branch | Δ |
|-----------|----------------------|-----------|---|
| learn | 26.36ms | 29.34ms | +2.98ms (variance) |
| recall_bm25 | 25.62ms | 25.84ms | +0.22ms (noise) |
| recall_hybrid | 79.61ms | 81.01ms | +1.40ms (noise) |
| inject | 44.23ms | 39.23ms | -5.00ms (noise) |

## Closes

Closes #1055, #1056, #1057