### PR TITLE
Four defects from the 2026-09-07 audit: remote unpin, validity instants, dropped metadata, unbounded body reads

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ import type { TensionRecord, TensionStatus } from './schemas/tension.js'
 import type { TensionPair } from './tensions.js'
 import { engramDate } from './tensions.js'
 import { resolveValidity, buildTemporal, normalizeIsoDate, type ResolvedValidity } from './expiry.js'
+import { isCurrentlyValid } from './validity.js'
 import { decodeJwtExpiry, decodeJwtPayload } from './jwt.js'
 import { RemoteStore, normalizeEndpointUrl } from './store/remote-store.js'
 import {
@@ -3944,12 +3945,11 @@ export class Plur {
   private _applyResidualFilters(engrams: Engram[], options?: RecallOptions & { include_expired?: boolean }): Engram[] {
     let out = engrams
     if (!options?.include_expired) {
-      const today = new Date().toISOString().slice(0, 10)
-      out = out.filter(e => {
-        if (e.temporal?.valid_until && e.temporal.valid_until < today) return false
-        if (e.temporal?.valid_from && e.temporal.valid_from > today) return false
-        return true
-      })
+      // #1150: instants compared as instants. The lexical form this replaces
+      // read `valid_until: 2026-09-07T01:00:00Z` as still valid at noon that
+      // day, and a `valid_from` of the same shape as not yet reached.
+      const nowMs = Date.now()
+      out = out.filter(e => isCurrentlyValid(e.temporal, nowMs))
     }
     if (options?.min_strength !== undefined) {
       out = out.filter(e => e.activation.retrieval_strength >= options.min_strength!)
@@ -4508,12 +4508,9 @@ export class Plur {
     // with learn()'s content-hash gate (which ignores temporal validity,
     // e.g. the migration import engine, #441) must see the full active set.
     if (!options?.include_expired) {
-      const today = new Date().toISOString().slice(0, 10)
-      engrams = engrams.filter(e => {
-        if (e.temporal?.valid_until && e.temporal.valid_until < today) return false
-        if (e.temporal?.valid_from && e.temporal.valid_from > today) return false
-        return true
-      })
+      // #1150: one evaluator, shared with _applyResidualFilters and injection.
+      const nowMs = Date.now()
+      engrams = engrams.filter(e => isCurrentlyValid(e.temporal, nowMs))
     }
     if (options?.min_strength !== undefined) {
       engrams = engrams.filter(e => e.activation.retrieval_strength >= options.min_strength!)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5537,7 +5537,23 @@ export class Plur {
         // The justification was that `setPinned` had to keep a synchronous
         // signature. It is `async` since the 0.16 flip, so that reason is gone
         // and the honest version costs nothing.
-        const patched = await driver.patch(serverId, { pinned: pinned === true ? true : undefined })
+        // Send the BOOLEAN, including an explicit `false` (#1149).
+        //
+        // This read `pinned === true ? true : undefined`, mirroring the local
+        // branch above — but the two representations exist for opposite
+        // reasons. Locally the engram is rewritten WHOLE, so `undefined`
+        // drops the key and keeps unpinned rows out of the YAML. Here the
+        // object is a PARTIAL update, and `JSON.stringify` omits `undefined`,
+        // so the unpin left as `{}` — a server applying ordinary PATCH
+        // semantics changed nothing and returned the still-pinned row, which
+        // this method then reported as success.
+        //
+        // Measured on a loopback server against the real serializer: PATCH
+        // body `{}`, engram still pinned afterwards, no error raised. An
+        // unpin the user was told had worked had not happened on any other
+        // machine — and with the pinned set now quota-enforced at pin time,
+        // it also held budget nobody could reclaim.
+        const patched = await driver.patch(serverId, { pinned })
         if (patched) return patched
       } catch (err) {
         if (serverId !== id) throw err

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -6,6 +6,7 @@ import { classifyPolarity } from './polarity.js'
 import { computeConfidence } from './confidence.js'
 import { freshTailBoost } from './fresh-tail.js'
 import { makeVisibilityPredicate } from './scope-util.js'
+import { isNotYetValid, isExpired, isExpiredBeyondGrace } from './validity.js'
 
 /**
  * D1-RECALL/INJECT-ASYMMETRY (#353). When an inject is given an EXPLICIT
@@ -99,19 +100,24 @@ const DEFAULT_GRACE_DAYS = 30
 /**
  * True when the engram must be skipped for temporal validity. Not-yet-valid
  * engrams (`valid_from` in the future) are always skipped; expired engrams
- * are skipped in hard mode, and in soft mode once past the grace cutoff.
+ * are skipped in hard mode, and in soft mode once past the grace window.
+ *
+ * Delegates to `validity.ts` (#1150). This used to compare timestamp STRINGS
+ * against today's DATE string, which read every RFC 3339 instant backwards —
+ * so an engram that expired hours ago was still injected, and one that became
+ * valid hours ago was not.
  */
 function skipForValidity(
   engram: Engram,
-  today: string,
+  nowMs: number,
   mode: 'hard' | 'soft',
-  graceCutoff: string,
+  graceDays: number,
 ): boolean {
   const t = engram.temporal
-  if (t?.valid_from && t.valid_from > today) return true
-  if (t?.valid_until && t.valid_until < today) {
+  if (isNotYetValid(t, nowMs)) return true
+  if (isExpired(t, nowMs)) {
     if (mode !== 'soft') return true
-    if (t.valid_until < graceCutoff) return true
+    if (isExpiredBeyondGrace(t, nowMs, graceDays)) return true
   }
   return false
 }
@@ -120,10 +126,14 @@ function skipForValidity(
  * "⚠ EXPIRED <date> — verify before use: " prefix for an engram whose
  * `valid_until` is in the past. Only soft-expiry mode lets expired engrams
  * reach the formatters, so in hard mode this never fires.
+ *
+ * Uses the same evaluator as the filter that let it through (#1150). When these
+ * disagreed, a soft-mode engram inside its grace window could be delivered
+ * WITHOUT the marker that is the entire point of soft mode.
  */
 function expiredMarker(engram: WireEngram): string {
   const until = engram.temporal?.valid_until
-  if (until && until < new Date().toISOString().slice(0, 10)) {
+  if (until && isExpired(engram.temporal, Date.now())) {
     return `⚠ EXPIRED ${until} — verify before use: `
   }
   return ''
@@ -406,10 +416,9 @@ export function selectAndSpread(
   const promptWords = new Set(promptLower.split(/\W+/).filter(w => w.length > 2))
   const maxTokens = ctx.maxTokens ?? DEFAULT_MAX_TOKENS
   const minRelevance = ctx.minRelevance ?? DEFAULT_MIN_RELEVANCE
-  const today = new Date().toISOString().slice(0, 10)
+  const nowMs = Date.now()
   const expiryMode = config?.expiry?.mode ?? 'hard'
   const graceDays = config?.expiry?.grace_days ?? DEFAULT_GRACE_DAYS
-  const graceCutoff = new Date(Date.now() - graceDays * 86400000).toISOString().slice(0, 10)
 
   // Step 0: Build engram map for spreading activation.
   // `nonActiveIds` tracks personal engrams that exist locally but are not active
@@ -423,7 +432,7 @@ export function selectAndSpread(
 
   for (const engram of personalEngrams) {
     if (engram.status !== 'active') { nonActiveIds.add(engram.id); continue }
-    if (skipForValidity(engram, today, expiryMode, graceCutoff)) continue
+    if (skipForValidity(engram, nowMs, expiryMode, graceDays)) continue
     engramMap.set(engram.id, engram)
     let raw = scoreEngram(engram, promptLower, promptWords, [], ctx.scope, false, ctx.grantedScopes)
     // Embedding boost: semantically similar engrams with zero keyword hits still get scored.
@@ -454,7 +463,7 @@ export function selectAndSpread(
     const matchTerms = packMeta.match_terms
     for (const engram of pack.engrams) {
       if (engram.status !== 'active') continue
-      if (skipForValidity(engram, today, expiryMode, graceCutoff)) continue
+      if (skipForValidity(engram, nowMs, expiryMode, graceDays)) continue
       engramMap.set(engram.id, engram)
       let raw = scoreEngram(engram, promptLower, promptWords, matchTerms, ctx.scope, true, ctx.grantedScopes)
       const embBoost = embeddingBoosts?.get(engram.id) ?? 0

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -651,6 +651,21 @@ export class RemoteStore {
       // #983: carry provenance records so the receiving store can answer
       // origin/chain/licence questions. Omitted when unset.
       ...(e.provenance != null              ? { provenance: e.provenance }     : {}),
+      // #1151: the conditions a measurement was taken under, the material that
+      // supports it, and its worked example. All three were accepted by
+      // `learnRouted()`, returned to the caller, and never sent.
+      //
+      // `measured_under` is the one that does real damage. It exists (#869) so
+      // a measured claim carries what makes it true — hardware, dataset,
+      // source, date. Dropping it on the way to a SHARED store is the worst
+      // case for that field: a result that held on one machine, one dataset,
+      // one day arrives at a teammate as an unconditional fact. The immediate
+      // return value hid it, because `learnRouted()` answers from the local
+      // shape plus the server-assigned id rather than from a persisted record.
+      ...(e.measured_under != null          ? { measured_under: e.measured_under } : {}),
+      ...(Array.isArray(e.knowledge_anchors) && e.knowledge_anchors.length > 0
+        ? { knowledge_anchors: e.knowledge_anchors } : {}),
+      ...(e.dual_coding != null             ? { dual_coding: e.dual_coding }   : {}),
     })
     const r = await this.fetchBounded(`${this.apiBase}/engrams`, {
       method: 'POST',

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -192,6 +192,21 @@ const NEVER_STRIP = new Set(['visibility', 'pinned'])
 /** Per-process dedupe for salvage warnings: one line per (store, field-set), on BOTH read paths (audit finding 5). */
 const warnedSalvages = new Set<string>()
 
+/**
+ * A response whose body has already been read, inside the request deadline.
+ *
+ * `json` is present only for a 2xx (and is `undefined` when the payload would
+ * not parse); `text` only for a non-2xx, already sanitised. Keeping both off
+ * the same object as a live `Response` is what stops a caller reading a body
+ * after the deadline has been cleared (#1152).
+ */
+interface BoundedResponse {
+  readonly ok: boolean
+  readonly status: number
+  readonly json?: unknown
+  readonly text?: string
+}
+
 export function salvageRemoteRow(
   candidate: Record<string, unknown>,
   logContext?: { url: string; rowId?: unknown },
@@ -261,7 +276,46 @@ export class RemoteStore {
    * keeps relearning: a rule enforced by convention at N sites is a rule that
    * holds at N-1 of them. A seventh endpoint added later inherits the bound.
    */
-  private async fetchBounded(url: string, init: RequestInit = {}): Promise<Response> {
+  /**
+   * A response whose body has ALREADY been read, inside the request deadline.
+   *
+   * Returned instead of a `Response` so that no caller can be handed a live
+   * body to read after the timer has been cleared — which is the shape of
+   * #1152. Callers branch on `ok`/`status` exactly as before; the payload is
+   * simply already here.
+   */
+  private static async readBounded(res: Response): Promise<BoundedResponse> {
+    // 2xx carries the payload; anything else carries an error body that gets
+    // sanitised before it can reach a log line or an exception message.
+    return res.ok
+      ? { ok: true, status: res.status, json: await res.json().catch(() => undefined) }
+      : { ok: false, status: res.status, text: sanitiseResponseBody(await res.text().catch(() => '')) }
+  }
+
+  /**
+   * Run a request AND read its body under ONE deadline.
+   *
+   * `fetch()` resolves when response HEADERS arrive, so the timer this used to
+   * clear on return stopped guarding the part that actually streams. Callers
+   * then awaited `r.json()` or `r.text()` with no bound at all: a peer that
+   * sent headers and stalled the body held `me()` open indefinitely against a
+   * 30s limit — measured at 31s, settling only once the body was released
+   * (#1152).
+   *
+   * #525 fixed this same shape in `load()`, by giving that one method's body
+   * read its own timer. That closed the instance; every other caller of the
+   * shared helper kept the gap, and it resurfaced in six of them. Owning the
+   * read is what makes the bound structural rather than a rule each new caller
+   * has to remember — so this takes a reader instead of returning a `Response`.
+   *
+   * @param consume - reads the body. Runs INSIDE the deadline, and the abort
+   *   signal is wired to the response stream, so a stalled read rejects.
+   */
+  private async fetchBounded<T>(
+    url: string,
+    init: RequestInit,
+    consume: (res: Response) => Promise<T>,
+  ): Promise<T> {
     // #1069: a network-level failure here MARKS the host down (so the passive
     // read path fast-fails), but this method never fast-fails itself. It
     // carries writes, /me and explicit retries — an outbox flush the user just
@@ -271,17 +325,37 @@ export class RemoteStore {
     // clean; on failure the mark is refreshed.
     const ctrl = new AbortController()
     const timer = setTimeout(() => ctrl.abort(), LOAD_FETCH_TIMEOUT_MS)
+    const timedOut = () => new Error(`request to ${url} timed out after ${LOAD_FETCH_TIMEOUT_MS}ms`)
     try {
-      const res = await fetch(url, { ...init, signal: ctrl.signal })
+      let res: Response
+      try {
+        res = await fetch(url, { ...init, signal: ctrl.signal })
+      } catch (err) {
+        // fetch only throws on network-level failures (and our abort) — an HTTP
+        // error status resolves normally — so any throw here marks the host.
+        markRemoteHostDown(url)
+        throw ctrl.signal.aborted ? timedOut() : (err as Error)
+      }
       clearRemoteHostDown(url) // the host answered — any HTTP status is a live host
-      return res
-    } catch (err) {
-      // fetch only throws on network-level failures (and our abort) — an HTTP
-      // error status resolves normally — so any throw here marks the host.
-      markRemoteHostDown(url)
-      throw ctrl.signal.aborted
-        ? new Error(`request to ${url} timed out after ${LOAD_FETCH_TIMEOUT_MS}ms`)
-        : (err as Error)
+      try {
+        const out = await consume(res)
+        // The SIGNAL is the authority on whether the deadline was met, not the
+        // shape of what came back. A reader that tolerates a malformed payload
+        // — `readBounded` returns `json: undefined` rather than throwing — will
+        // otherwise swallow an abort and hand back an empty body as if the
+        // request had succeeded. That failure mode is worse than the one this
+        // method exists to fix: a stalled `/me` would return zero scopes,
+        // silently, instead of timing out.
+        if (ctrl.signal.aborted) throw timedOut()
+        return out
+      } catch (err) {
+        // Deliberately NOT a host-down mark. The peer answered; a 5xx body, a
+        // decode failure or a stalled stream says nothing about reachability,
+        // and tripping the breaker on them would fast-fail a live host. Only
+        // the deadline is reinterpreted, so a stalled body reports as the
+        // timeout it is rather than as a bare AbortError.
+        throw ctrl.signal.aborted ? timedOut() : (err as Error)
+      }
     } finally {
       clearTimeout(timer)
     }
@@ -362,12 +436,9 @@ export class RemoteStore {
    * Throws on a non-2xx response (caller decides whether to swallow per URL).
    */
   async me(): Promise<{ username: string; org_id: string; role: string; scopes: string[]; scope_metadata: ScopeMetadata[] }> {
-    const r = await this.fetchBounded(`${this.apiBase}/me`, { headers: this.headers() })
-    if (!r.ok) {
-      const text = sanitiseResponseBody(await r.text().catch(() => ''))
-      throw new Error(`Remote /me failed: ${r.status} ${text}`)
-    }
-    const body = await r.json().catch(() => ({})) as Partial<{ username: string; org_id: string; role: string; scopes: unknown[]; scope_metadata: unknown[] }>
+    const r = await this.fetchBounded(`${this.apiBase}/me`, { headers: this.headers() }, RemoteStore.readBounded)
+    if (!r.ok) throw new Error(`Remote /me failed: ${r.status} ${r.text}`)
+    const body = (r.json ?? {}) as Partial<{ username: string; org_id: string; role: string; scopes: unknown[]; scope_metadata: unknown[] }>
     const scopes = Array.isArray(body.scopes)
       // Validate every /me scope to a safe grammar at the trust boundary:
       //  - #427: a non-string element would later throw in isSharedScope's
@@ -585,12 +656,9 @@ export class RemoteStore {
       method: 'POST',
       headers: this.headers({ 'Content-Type': 'application/json' }),
       body,
-    })
-    if (!r.ok) {
-      const text = sanitiseResponseBody(await r.text().catch(() => ''))
-      throw new Error(`Remote store append failed: ${r.status} ${text}`)
-    }
-    const data = await r.json().catch(() => ({})) as { id?: unknown }
+    }, RemoteStore.readBounded)
+    if (!r.ok) throw new Error(`Remote store append failed: ${r.status} ${r.text}`)
+    const data = (r.json ?? {}) as { id?: unknown }
     // #404: validate the server-assigned id's SHAPE, not just truthiness. It
     // becomes this engram's id (cached, rendered, used as a key), so a non-string,
     // empty, over-long, or control-char-bearing id from a buggy/hostile endpoint
@@ -627,11 +695,13 @@ export class RemoteStore {
 
   async getById(id: string): Promise<Engram | null> {
     try {
-      const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, { headers: this.headers() })
+      const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, { headers: this.headers() }, RemoteStore.readBounded)
       if (r.status === 404) return null
       if (!r.ok) return null
-      const row = await r.json() as any
-      return this.reshape(row)
+      // An unparseable 2xx body arrives as `undefined` rather than throwing;
+      // same outcome as before, where the throw was swallowed by the catch.
+      if (r.json === undefined) return null
+      return this.reshape(r.json as any)
     } catch {
       return null
     }
@@ -707,18 +777,18 @@ export class RemoteStore {
    * the failure modes are split out.
    */
   async probeById(id: string): Promise<'owned' | 'absent' | 'unknown'> {
-    let r: Response
+    let r: BoundedResponse
     try {
       r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
         headers: this.headers(),
-      })
+      }, RemoteStore.readBounded)
     } catch {
       return 'unknown'
     }
     if (r.status === 404) return 'absent'
     // Any other non-ok says nothing about whether the row exists.
     if (!r.ok) return 'unknown'
-    const row = await r.json().catch(() => null)
+    const row = r.json ?? null
     if (row === null) return 'unknown'
     return this.reshape(row as { id?: unknown; scope?: unknown; status?: unknown; data?: unknown })
       ? 'owned' : 'absent'
@@ -729,7 +799,7 @@ export class RemoteStore {
     const r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
       method: 'DELETE',
       headers: this.headers(),
-    })
+    }, RemoteStore.readBounded)
     if (!r.ok) return false
     this.cache = null
     return true
@@ -748,11 +818,8 @@ export class RemoteStore {
       method: 'POST',
       headers: this.headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify({ signal }),
-    })
-    if (!r.ok) {
-      const text = sanitiseResponseBody(await r.text().catch(() => ''))
-      throw new Error(`Remote feedback failed: ${r.status} ${text}`)
-    }
+    }, RemoteStore.readBounded)
+    if (!r.ok) throw new Error(`Remote feedback failed: ${r.status} ${r.text}`)
     this.cache = null
   }
 
@@ -780,19 +847,16 @@ export class RemoteStore {
       method: 'PATCH',
       headers: this.headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(updates),
-    })
+    }, RemoteStore.readBounded)
     if (r.status === 404) return null
-    if (!r.ok) {
-      const text = sanitiseResponseBody(await r.text().catch(() => ''))
-      throw new Error(`Remote patch failed: ${r.status} ${text}`)
-    }
+    if (!r.ok) throw new Error(`Remote patch failed: ${r.status} ${r.text}`)
     // #327: the server confirmed the write (2xx). Capture the pre-write row
     // from the cache BEFORE invalidating so the fallback below can merge it.
     const prev = this.cache?.engrams.find(e => e.id === id) ?? null
     this.cache = null
     // Server returns {engram: {id, scope, status, data: {...}, ...}}; reshape
     // to top-level Engram (same as load() does for rows[]).
-    const body = await r.json().catch(() => null) as { engram?: { id: string; scope: string; status: string; data?: any } } | null
+    const body = (r.json ?? null) as { engram?: { id: string; scope: string; status: string; data?: any } } | null
     const reshaped = body?.engram ? this.reshape(body.engram) : null
     if (reshaped) return reshaped
     // #327: 2xx but the echoed row was missing or failed validation. Returning

--- a/packages/core/src/validity.ts
+++ b/packages/core/src/validity.ts
@@ -1,0 +1,131 @@
+/**
+ * One evaluator for engram validity windows, shared by retrieval and injection.
+ *
+ * ## The defect this replaces
+ *
+ * Validity was decided by comparing a timestamp STRING against today's DATE
+ * string, in four places that each rewrote the same two lines. Lexically
+ * `'2026-09-07T01:00:00Z' > '2026-09-07'` is true at every hour of that day,
+ * because the `T` sorts after the end of the shorter string — so an RFC 3339
+ * instant was read backwards in both directions.
+ *
+ * Measured at a fixed clock of 2026-09-07T12:00:00Z (#1150):
+ *
+ * | stored                              | should be | was       |
+ * | ----------------------------------- | --------- | --------- |
+ * | `valid_from: 2026-09-07T01:00:00Z`  | eligible  | hidden    |
+ * | `valid_until: 2026-09-07T01:00:00Z` | expired   | eligible  |
+ *
+ * The same wrong pair appeared in `list()`, in `recall()` and in injection,
+ * because the comparison was duplicated rather than shared. The expiry
+ * direction is the one that matters: an instruction that lapsed hours ago still
+ * entered the agent's context, and reads exactly like a current one.
+ *
+ * `spec/ENGRAM-STANDARD-v1.md` requires accepting both forms and
+ * `TemporalSchema` does accept both, so these were valid stored records rather
+ * than malformed input.
+ *
+ * ## The rule
+ *
+ * A bare `YYYY-MM-DD` denotes a whole DAY — that is the documented behaviour and
+ * it is preserved exactly. An RFC 3339 value denotes an INSTANT and is compared
+ * as one, offset included. So `valid_from` opens at the start of its day (or at
+ * its instant), and `valid_until` closes at the END of its day (or at its
+ * instant) — which is why a date-only expiry of `2026-09-06` is still valid all
+ * through the 6th and expired on the 7th.
+ *
+ * @module
+ */
+import type { Engram } from './schemas/engram.js'
+
+/** The `temporal` block, or nothing. */
+type Temporal = Engram['temporal'] | undefined
+
+/** A bare calendar date, as opposed to an RFC 3339 instant. */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/
+
+const DAY_MS = 86_400_000
+
+/**
+ * First instant a bound includes, in epoch ms; `null` when unparseable.
+ *
+ * A date-only value opens at midnight UTC of that day.
+ */
+function opensAt(value: string): number | null {
+  const ms = Date.parse(DATE_ONLY.test(value) ? `${value}T00:00:00.000Z` : value)
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * Last instant a bound includes, in epoch ms; `null` when unparseable.
+ *
+ * A date-only value closes at the END of that day — the whole-day semantics the
+ * lexical comparison happened to get right for this form, and the reason a
+ * date-only `valid_until` must not be treated as midnight.
+ */
+function closesAt(value: string): number | null {
+  const ms = Date.parse(DATE_ONLY.test(value) ? `${value}T23:59:59.999Z` : value)
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * True when `valid_from` has not yet been reached.
+ *
+ * An unparseable bound is treated as ABSENT rather than as a bound that has not
+ * arrived: `TemporalSchema` validates these fields, so a value that fails to
+ * parse is a data error, and hiding content because of one is the worse
+ * outcome of the two.
+ *
+ * @param temporal - the engram's temporal block.
+ * @param nowMs - the evaluation instant, in epoch ms.
+ */
+export function isNotYetValid(temporal: Temporal, nowMs: number): boolean {
+  const from = temporal?.valid_from
+  if (!from) return false
+  const opens = opensAt(from)
+  return opens === null ? false : nowMs < opens
+}
+
+/**
+ * True when `valid_until` has passed.
+ *
+ * @param temporal - the engram's temporal block.
+ * @param nowMs - the evaluation instant, in epoch ms.
+ */
+export function isExpired(temporal: Temporal, nowMs: number): boolean {
+  const until = temporal?.valid_until
+  if (!until) return false
+  const closes = closesAt(until)
+  return closes === null ? false : nowMs > closes
+}
+
+/**
+ * True when the engram expired longer ago than the soft-expiry grace window.
+ *
+ * Same bound interpretation as {@link isExpired}, so soft mode cannot disagree
+ * with hard mode about when something lapsed — they differ only in what they do
+ * about it.
+ *
+ * @param temporal - the engram's temporal block.
+ * @param nowMs - the evaluation instant, in epoch ms.
+ * @param graceDays - days an expired engram stays eligible, marked.
+ */
+export function isExpiredBeyondGrace(temporal: Temporal, nowMs: number, graceDays: number): boolean {
+  const until = temporal?.valid_until
+  if (!until) return false
+  const closes = closesAt(until)
+  return closes === null ? false : closes < nowMs - graceDays * DAY_MS
+}
+
+/**
+ * True when the engram is inside its validity window right now.
+ *
+ * The retrieval-side question: `list()` and `recall()` hide anything this
+ * rejects unless `include_expired` is set.
+ *
+ * @param temporal - the engram's temporal block.
+ * @param nowMs - the evaluation instant, in epoch ms.
+ */
+export function isCurrentlyValid(temporal: Temporal, nowMs: number): boolean {
+  return !isNotYetValid(temporal, nowMs) && !isExpired(temporal, nowMs)
+}

--- a/packages/core/test/remote-exists-by-id.test.ts
+++ b/packages/core/test/remote-exists-by-id.test.ts
@@ -165,6 +165,38 @@ describe('every RemoteStore request is bounded', () => {
     await expect(settled, 'the call never returned — it would hold the store lock').resolves.toBe('settled')
   })
 
+  /**
+   * Headers arrive, the body never does — the #1152 shape.
+   *
+   * The `stalling` helper above never resolves `fetch` itself, so it only ever
+   * exercised the handshake. That is why the gap survived: the deadline was
+   * cleared the moment headers landed, and every caller then read the body
+   * outside it. Measured against a real loopback server, `me()` was still
+   * pending after 31 seconds under a 30-second bound, and settled only when
+   * the body was finally released.
+   */
+  const stallingBody = (status: number) => vi.fn((_u: string, init?: { signal?: AbortSignal }) => {
+    const never = <T>() => new Promise<T>((_res, rej) => {
+      init?.signal?.addEventListener('abort', () => rej(new Error('aborted')))
+    })
+    return Promise.resolve({ ok: status >= 200 && status < 300, status, json: never, text: never })
+  }) as never
+
+  it.each([
+    ['a 2xx whose JSON never completes', 200],
+    ['an error response whose text never completes', 500],
+  ])('settles at the deadline on %s (#1152)', async (_name, status) => {
+    vi.useFakeTimers()
+    globalThis.fetch = stallingBody(status)
+
+    const settled = store().me().then(() => 'resolved', (e: Error) => e.message)
+    await vi.advanceTimersByTimeAsync(31_000)
+
+    // Not merely "settled": it must settle through the DOCUMENTED timeout, not
+    // as a bare AbortError leaking from the body read.
+    await expect(settled).resolves.toMatch(/timed out after 30000ms/)
+  })
+
   it('the bound is one shared helper, so a new endpoint inherits it', () => {
     // The reason this is a helper and not six call-site fixes: a rule enforced
     // by convention at N sites holds at N-1 of them. Asserted against the

--- a/packages/core/test/remote-write-contract.test.ts
+++ b/packages/core/test/remote-write-contract.test.ts
@@ -1,0 +1,196 @@
+/**
+ * What a remote write is allowed to lose, stated explicitly.
+ *
+ * `appendAndGetServerId()` builds its POST body from an explicit allowlist.
+ * That is the right shape — a blind `JSON.stringify(engram)` would ship local
+ * counters and decay state to a shared server — but an allowlist extended by
+ * hand is only correct until someone adds a schema field and forgets, and
+ * nothing failed when they did.
+ *
+ * It has now happened twice. #768 fixed it for pinned/rationale/tags/commitment/
+ * validity/supersedes. #1151 is the same defect for `measured_under`,
+ * `knowledge_anchors` and `dual_coding` — lost from the moment #869 shipped the
+ * first of them, and invisible because `learnRouted()` returns the local shape
+ * plus the server-assigned id rather than a persisted record, so the caller is
+ * shown the fields that were never sent.
+ *
+ * Adding three names to the allowlist fixes today and guarantees a third
+ * occurrence. This file is the guard instead: every field of `EngramSchema` must
+ * be classified, so adding one forces a decision rather than a silent default.
+ * Modelled on `packages/migrate/test/method-list.test.ts`, which does the same
+ * for async methods.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createServer, type Server } from 'http'
+import { once } from 'events'
+import type { AddressInfo } from 'net'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { EngramSchema } from '../src/schemas/engram.js'
+import { Plur } from '../src/index.js'
+
+/** Sent to the server, because it is engram CONTENT that a reader needs. */
+const TRANSMITTED = new Set([
+  'statement', 'scope', 'domain', 'type', 'tags', 'pinned', 'rationale',
+  'commitment', 'locked_reason', 'source', 'provenance',
+  // #1151.
+  'measured_under', 'knowledge_anchors', 'dual_coding',
+])
+
+/** Sent as flattened top-level keys, not as the nested object. */
+const FLATTENED = new Map([
+  ['temporal', 'valid_from / valid_until (#347)'],
+  ['relations', 'supersedes (#240)'],
+])
+
+/**
+ * Deliberately local: server-assigned, or state that describes THIS install's
+ * relationship with the engram rather than the engram.
+ */
+const LOCAL = new Map([
+  ['id', 'the server assigns its own; the local id is namespaced on read'],
+  ['status', 'server owns the lifecycle — DELETE soft-retires'],
+  ['version', 'local record version'],
+  ['engram_version', 'local record version'],
+  ['previous_version_ref', 'local version chain'],
+  ['consolidated', 'output of the local consolidation pass'],
+  ['content_hash', 'recomputed from content; shipping it would let a stale hash travel'],
+  ['activation', 'this install\'s decay and recall state'],
+  ['usage', 'local usage telemetry'],
+  ['write_count', 'local counter'],
+  ['injection_count', 'local counter'],
+  ['derivation_count', 'local counter'],
+  ['recurrence_count', 'local counter'],
+  ['episode_ids', 'local episode store references'],
+  ['feedback_signals', 'local feedback log; the server owns remote feedback (POST /feedback)'],
+  ['associations', 'local co-access graph'],
+  ['source_patterns', 'local derivation bookkeeping'],
+  ['pack', 'local pack membership'],
+  ['abstract', 'local abstraction bookkeeping'],
+  ['derived_from', 'local derivation bookkeeping'],
+])
+
+/**
+ * Not modelled by the wire contract, and not yet argued either way — tracked,
+ * not decided.
+ *
+ * Being in this set is NOT a claim that losing the field is correct. Two of
+ * them are rendered straight to the model: `summary` is the entire payload of a
+ * layer-1 entry, and `contraindications` is the "does NOT apply when" clause a
+ * constraint is qualified by. Losing those on a shared store is the same class
+ * of defect as #1151, reached through a different field.
+ *
+ * They are separated from LOCAL so the distinction stays visible: LOCAL says
+ * "we decided", this says "we have not".
+ */
+const NOT_MODELLED = new Set([
+  'visibility', 'contraindications', 'knowledge_type', 'entities', 'episodic',
+  'exchange', 'structured_data', 'insight', 'polarity', 'locked_at', 'sources',
+  'summary',
+])
+
+describe('the remote write contract covers every schema field (#1151)', () => {
+  const fields = Object.keys(EngramSchema.shape)
+
+  it('classifies every field of EngramSchema', () => {
+    const unclassified = fields.filter(f =>
+      !TRANSMITTED.has(f) && !FLATTENED.has(f) && !LOCAL.has(f) && !NOT_MODELLED.has(f))
+
+    expect(unclassified,
+      'a field was added to EngramSchema without deciding whether a remote write should carry it. '
+      + 'Add it to TRANSMITTED (and to appendAndGetServerId\'s body), or to LOCAL / NOT_MODELLED with a reason. '
+      + 'This is the check that #768 and #1151 both needed and neither had.',
+    ).toEqual([])
+  })
+
+  it('classifies each field exactly once', () => {
+    const dupes = fields.filter(f =>
+      [TRANSMITTED.has(f), FLATTENED.has(f), LOCAL.has(f), NOT_MODELLED.has(f)].filter(Boolean).length > 1)
+    expect(dupes).toEqual([])
+  })
+
+  it('names no field that the schema does not have', () => {
+    const known = new Set(fields)
+    const stale = [...TRANSMITTED, ...FLATTENED.keys(), ...LOCAL.keys(), ...NOT_MODELLED]
+      .filter(f => !known.has(f))
+    expect(stale, 'a classified field is gone from the schema — drop it from this list').toEqual([])
+  })
+})
+
+describe('measured_under and its neighbours survive a remote write (#1151)', () => {
+  const SCOPE = 'group:acme/eng'
+  let dir: string
+  let server: Server
+  let posted: Record<string, unknown> | undefined
+  let stored: Record<string, unknown> | undefined
+  let plur: Plur
+
+  const CONTEXT = {
+    scope: SCOPE,
+    type: 'architectural' as const,
+    measured_under: {
+      hardware: '8-core test machine', dataset: '100 synthetic records',
+      source_type: 'bench', date: '2026-09-07',
+    },
+    knowledge_anchors: [{ path: 'bench/results.json', relevance: 'primary', snippet: 'Median latency was 18 ms.' }],
+    dual_coding: { example: 'This result applies to the measured dataset and machine.' },
+  }
+
+  beforeEach(async () => {
+    posted = undefined
+    stored = undefined
+    server = createServer(async (req, res) => {
+      const chunks: Buffer[] = []
+      for await (const chunk of req) chunks.push(chunk as Buffer)
+      const body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString()) : undefined
+      res.setHeader('Content-Type', 'application/json')
+      if (req.method === 'POST') {
+        posted = body
+        // Persist exactly what arrived — no server-side field filter, so any
+        // loss observed below is the client's.
+        stored = body
+        return res.end(JSON.stringify({ id: 'ENG-2026-0907-501' }))
+      }
+      if (req.url?.includes('/engrams/')) {
+        return res.end(JSON.stringify({ id: 'ENG-2026-0907-501', scope: SCOPE, status: 'active', data: stored }))
+      }
+      res.end(JSON.stringify({ rows: [], total_count: 0 }))
+    })
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+
+    dir = mkdtempSync(join(tmpdir(), 'plur-write-contract-'))
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+    writeFileSync(join(dir, 'config.yaml'),
+      `stores:\n  - scope: "${SCOPE}"\n    url: "${url}"\n    token: "t"\n`)
+    plur = new Plur({ path: dir })
+    await plur.ready()
+  })
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true })
+    server.closeAllConnections()
+    await new Promise<void>(r => server.close(() => r()))
+  })
+
+  it('transmits the measurement conditions, not just the claim', async () => {
+    await plur.learnRouted('Median vector lookup latency was 18 ms in the synthetic benchmark.', CONTEXT)
+    // The POST carried exactly ["statement","scope","type","commitment"] before.
+    expect(posted!.measured_under).toEqual(CONTEXT.measured_under)
+  })
+
+  it('transmits knowledge_anchors and dual_coding', async () => {
+    await plur.learnRouted('Median vector lookup latency was 18 ms in the synthetic benchmark.', CONTEXT)
+    expect(posted!.knowledge_anchors).toEqual(CONTEXT.knowledge_anchors)
+    expect(posted!.dual_coding).toEqual(CONTEXT.dual_coding)
+  })
+
+  it('omits them entirely when unset, so the body stays byte-identical without them', async () => {
+    await plur.learnRouted('A claim with no measurement behind it.', { scope: SCOPE, type: 'behavioral' })
+    expect(Object.keys(posted!)).not.toContain('measured_under')
+    expect(Object.keys(posted!)).not.toContain('knowledge_anchors')
+    expect(Object.keys(posted!)).not.toContain('dual_coding')
+  })
+})

--- a/packages/core/test/set-pinned-remote.test.ts
+++ b/packages/core/test/set-pinned-remote.test.ts
@@ -17,6 +17,9 @@
  * It has been `async` since the 0.16 flip.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createServer, type Server } from 'http'
+import { once } from 'events'
+import type { AddressInfo } from 'net'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -105,11 +108,21 @@ describe('setPinned() against a remote store', () => {
     expect(a).toEqual(b)
   })
 
-  it('unpinning sends pinned: undefined and returns the server engram', async () => {
+  it('unpinning sends an explicit false, and it survives JSON (#1149)', async () => {
+    // Was `expect(seen).toEqual({ pinned: undefined })` — an assertion that was
+    // true of the object and false of the request. `JSON.stringify` drops an
+    // undefined property, so the PATCH serialized to `{}`, the server applied
+    // nothing, and the still-pinned row came back reported as a successful
+    // unpin. `patch()`'s own optimistic-merge branch already says as much:
+    // "only defined update values are applied, mirroring what JSON.stringify
+    // actually sent to the server".
     let seen: Record<string, unknown> | undefined
     patchImpl = async (_id, body) => { seen = body; return serverEngram(false) }
     const res = await plur.setPinned('ENG-2026-0728-500', false)
-    expect(seen).toEqual({ pinned: undefined })
+    expect(seen).toEqual({ pinned: false })
+    // The assertion the old one could not make: it is still there after a round
+    // trip through the serializer the driver actually uses.
+    expect(JSON.parse(JSON.stringify(seen))).toEqual({ pinned: false })
     expect(res!.pinned).toBeUndefined()
   })
 })
@@ -235,5 +248,86 @@ describe('forget() when the remote refuses the delete', () => {
   it('a successful remote retire still succeeds', async () => {
     removeResult = true
     await expect(plur.forget('ENG-2026-0728-500', 'obsolete')).resolves.toBeUndefined()
+  })
+})
+
+/**
+ * The same unpin, over a real socket through the real serializer (#1149).
+ *
+ * The suite above stubs `_getRemoteDriver`, so the body it inspects is a
+ * JavaScript object that never meets `JSON.stringify`. That is precisely the
+ * blind spot that let `{ pinned: undefined }` stand as an unpin for a release:
+ * the assertion was true of the object and false of the request, and no test
+ * looked at the request.
+ *
+ * These take the body off the wire and read the row back from the server, so a
+ * fix has to change what the server stores, not only what the caller passes.
+ */
+describe('setPinned() unpin over HTTP (#1149)', () => {
+  const ID = 'ENG-2026-0728-500'
+  const SCOPE = 'group:acme/eng'
+
+  let dir: string
+  let server: Server
+  let seen: Array<{ method: string; body: unknown }>
+  let stored: Record<string, unknown>
+  let plur: Plur
+
+  beforeEach(async () => {
+    seen = []
+    stored = { ...(serverEngram(true) as unknown as Record<string, unknown>) }
+
+    server = createServer(async (req, res) => {
+      const chunks: Buffer[] = []
+      for await (const chunk of req) chunks.push(chunk as Buffer)
+      const body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString()) : undefined
+      seen.push({ method: req.method!, body })
+      res.setHeader('Content-Type', 'application/json')
+      if (req.method === 'PATCH') {
+        // Ordinary partial-update semantics: apply exactly what arrived.
+        Object.assign(stored, body)
+      }
+      res.end(JSON.stringify({ engram: { id: ID, scope: SCOPE, status: 'active', data: stored } }))
+    })
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+
+    dir = mkdtempSync(join(tmpdir(), 'plur-setpinned-http-'))
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+    writeFileSync(join(dir, 'config.yaml'),
+      `stores:\n  - scope: "${SCOPE}"\n    url: "${url}"\n    token: "t"\n`)
+    plur = new Plur({ path: dir })
+    await plur.ready()
+  })
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true })
+    server.closeAllConnections()
+    await new Promise<void>(r => server.close(() => r()))
+  })
+
+  const patchBody = () => seen.find(s => s.method === 'PATCH')?.body
+
+  it('transmits pinned: false and leaves the server row unpinned', async () => {
+    await plur.setPinned(ID, false)
+    // The body was `{}` before: an unpin that asked the server for nothing.
+    expect(patchBody()).toEqual({ pinned: false })
+    expect(stored.pinned).toBe(false)
+  })
+
+  it('setPinnedAsync unpins over the wire too — the two must not drift', async () => {
+    await plur.setPinnedAsync(ID, false)
+    expect(patchBody()).toEqual({ pinned: false })
+    expect(stored.pinned).toBe(false)
+  })
+
+  it('still transmits pinned: true when pinning', async () => {
+    // The control. Without it, "send the field unconditionally" and "send the
+    // right value" are indistinguishable.
+    stored.pinned = undefined
+    await plur.setPinned(ID, true)
+    expect(patchBody()).toEqual({ pinned: true })
+    expect(stored.pinned).toBe(true)
   })
 })

--- a/packages/core/test/validity-instants.test.ts
+++ b/packages/core/test/validity-instants.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Validity windows expressed as RFC 3339 instants (#1150).
+ *
+ * The comparison these guard used to be lexical: a timestamp STRING against
+ * today's DATE string. `'2026-09-07T01:00:00Z' > '2026-09-07'` is true at every
+ * hour of that day, so an instant window was read backwards in BOTH directions
+ * — a rule that came into force at 01:00 stayed hidden all day, and one that
+ * lapsed at 01:00 stayed eligible all day.
+ *
+ * The expiry direction is the one that matters: an instruction that lapsed
+ * hours ago still entered the agent's context, and reads exactly like a current
+ * one.
+ *
+ * The date-only cases are controls. They behaved correctly before, and the
+ * whole-day semantics they depend on is documented behaviour — a fix that
+ * treats `valid_until: 2026-09-06` as midnight would expire it a day early and
+ * break them.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  isCurrentlyValid, isNotYetValid, isExpired, isExpiredBeyondGrace,
+} from '../src/validity.js'
+import { Plur } from '../src/index.js'
+import { selectAndSpread } from '../src/inject.js'
+import { EngramSchema } from '../src/schemas/engram.js'
+
+const NOON = Date.parse('2026-09-07T12:00:00Z')
+
+describe('validity evaluator', () => {
+  it.each([
+    // [name, temporal, expected isCurrentlyValid]
+    ['an instant start already passed today', { valid_from: '2026-09-07T01:00:00Z' }, true],
+    ['an instant expiry already passed today', { valid_until: '2026-09-07T01:00:00Z' }, false],
+    ['a date-only start of today', { valid_from: '2026-09-07' }, true],
+    ['a date-only expiry of yesterday', { valid_until: '2026-09-06' }, false],
+    // The other side of each: still-future starts and not-yet expiries.
+    ['an instant start later today', { valid_from: '2026-09-07T23:00:00Z' }, false],
+    ['an instant expiry later today', { valid_until: '2026-09-07T23:00:00Z' }, true],
+    // Whole-day semantics for the date-only form — the control that a naive
+    // "parse as midnight" fix breaks.
+    ['a date-only expiry of TODAY is still valid all day', { valid_until: '2026-09-07' }, true],
+    ['a date-only start of tomorrow', { valid_from: '2026-09-08' }, false],
+    ['no window at all', {}, true],
+  ])('%s', (_name, temporal, expected) => {
+    expect(isCurrentlyValid(temporal as never, NOON)).toBe(expected)
+  })
+
+  it('compares equivalent instants written with different offsets as equal', () => {
+    // 2026-09-07T12:00:00Z === 14:00+02:00 === 07:00-05:00. Lexically these
+    // three sort differently; as instants they are the same moment.
+    for (const at of ['2026-09-07T13:00:00Z', '2026-09-07T15:00:00+02:00', '2026-09-07T08:00:00-05:00']) {
+      expect(isNotYetValid({ valid_from: at } as never, NOON), at).toBe(true)
+      expect(isExpired({ valid_until: at } as never, NOON), at).toBe(false)
+    }
+  })
+
+  it('treats the boundary instant as still included', () => {
+    const at = '2026-09-07T12:00:00Z'
+    // valid_from exactly now: reached, not "not yet".
+    expect(isNotYetValid({ valid_from: at } as never, NOON)).toBe(false)
+    // valid_until exactly now: the last instant it covers, so not yet expired.
+    expect(isExpired({ valid_until: at } as never, NOON)).toBe(false)
+    expect(isExpired({ valid_until: at } as never, NOON + 1)).toBe(true)
+  })
+
+  it('applies the same bound to the grace window as to expiry', () => {
+    // Expired 10 days ago: inside a 30-day grace, outside a 5-day one. If the
+    // two used different interpretations, soft mode could disagree with hard
+    // mode about when something lapsed.
+    const t = { valid_until: '2026-08-28T12:00:00Z' } as never
+    expect(isExpired(t, NOON)).toBe(true)
+    expect(isExpiredBeyondGrace(t, NOON, 30)).toBe(false)
+    expect(isExpiredBeyondGrace(t, NOON, 5)).toBe(true)
+  })
+
+  it('treats an unparseable bound as absent rather than as hiding the engram', () => {
+    expect(isCurrentlyValid({ valid_from: 'not-a-date' } as never, NOON)).toBe(true)
+    expect(isCurrentlyValid({ valid_until: 'not-a-date' } as never, NOON)).toBe(true)
+  })
+})
+
+describe('list(), recall() and injection agree, at instant granularity (#1150)', () => {
+  let dir: string
+  let plur: Plur
+
+  const engram = (id: string, temporal: Record<string, string>) => EngramSchema.parse({
+    id, statement: `Audit policy ${id} applies to the release.`,
+    type: 'behavioral', scope: 'global', status: 'active', pinned: true,
+    temporal: { learned_at: '2026-09-06T00:00:00Z', ...temporal },
+  })
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(NOON)
+    dir = mkdtempSync(join(tmpdir(), 'plur-validity-'))
+    writeFileSync(join(dir, 'engrams.yaml'), JSON.stringify({
+      engrams: [
+        engram('ENG-active-instant', { valid_from: '2026-09-07T01:00:00Z' }),
+        engram('ENG-expired-instant', { valid_until: '2026-09-07T01:00:00Z' }),
+        engram('ENG-active-date-control', { valid_from: '2026-09-07' }),
+        engram('ENG-expired-date-control', { valid_until: '2026-09-06' }),
+      ],
+    }) + '\n')
+    writeFileSync(join(dir, 'config.yaml'), 'backend: yaml\n')
+    plur = new Plur({ path: dir, autoDiscover: false })
+    await plur.ready()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** What every path should agree on at 2026-09-07T12:00:00Z. */
+  const EXPECTED = ['ENG-active-date-control', 'ENG-active-instant']
+
+  it('list() hides the expired instant and shows the active one', async () => {
+    expect((await plur.list()).map(e => e.id).sort()).toEqual(EXPECTED)
+  })
+
+  it('recall() agrees with list()', async () => {
+    expect((await plur.recall('audit policy release')).map(e => e.id).sort()).toEqual(EXPECTED)
+  })
+
+  it('injection agrees, in hard-expiry mode', async () => {
+    const stored = await plur.list({ include_expired: true })
+    expect(stored, 'all four are stored — this is filtering, not ingestion').toHaveLength(4)
+    const r = selectAndSpread(
+      { prompt: 'audit policy release', maxTokens: 8000 },
+      stored, [], { expiry: { mode: 'hard' } } as never,
+    )
+    const ids = [...r.directives, ...r.constraints, ...r.consider].map(e => e.id).sort()
+    // The one that mattered: an instruction that lapsed at 01:00 was reaching
+    // the agent's context at noon, indistinguishable from a current rule.
+    expect(ids).not.toContain('ENG-expired-instant')
+    expect(ids).toContain('ENG-active-instant')
+  })
+})


### PR DESCRIPTION
Closes #1149. Closes #1150. Closes #1151. Closes #1152.

Four defects from the 2026-09-07 external audit. One commit each, bisectable,
each with a regression test verified to fail without its fix.

**All four were re-confirmed against current `main` (`c036d750`) before filing** —
the audit ran against `1557e14f` and `main` had moved four merges since, so
nothing here is a stale finding.

| | Defect | Impact |
| --- | --- | --- |
| #1149 | `setPinned(id, false)` PATCHes `{}` | an unpin the user is told succeeded never happened |
| #1150 | validity instants compared lexically | expired instructions inject; live ones stay hidden |
| #1151 | remote append drops `measured_under` et al. | a conditional result reaches a teammate as unconditional |
| #1152 | deadline cleared before the body is read | a stalled body outlives the 30s bound indefinitely |

### Two of these are recurrences, so two commits are about the guard, not the fix

**#1151 is the second time** (after #768, July) that a schema field was silently
dropped from the remote write allowlist, because the allowlist is extended by
hand and nothing fails when someone forgets. Adding three names fixes today and
guarantees a third occurrence, so the substance is
`remote-write-contract.test.ts`: every field of `EngramSchema` must be
classified TRANSMITTED / FLATTENED / LOCAL / NOT_MODELLED, and a new field that
is none of them fails the suite. Modelled on
`packages/migrate/test/method-list.test.ts`.

That classification surfaced **#1153** — twelve fields nobody has decided on,
two of which (`summary`, `contraindications`) are rendered straight to the
model. `NOT_MODELLED` is deliberately kept separate from `LOCAL`: one means we
decided, the other means we have not.

**#1152 is the second time too** (after #525, July). That fix gave `load()`'s
body read its own timer — closing the instance and leaving the shared helper
alone, so the same gap sat in six other callers. `fetchBounded()` now owns the
read and returns a body that is already consumed, so no caller can be handed a
live one after the timer is gone.

### Something the new tests caught in my own fix

`readBounded` tolerates a malformed payload by returning `json: undefined`
rather than throwing. On its own that **swallowed the abort**: a stalled `/me`
would have returned zero scopes, silently, instead of timing out — worse than
the bug being fixed, because it is wrong data rather than a hang. The abort
signal is now authoritative over the shape of what came back.

### Scope notes

- `#1150` replaces four hand-written copies of one comparison with a single
  evaluator. Date-only values keep their documented whole-day semantics — the
  reason `valid_until: 2026-09-06` closes at the END of the 6th, not at
  midnight; a "parse as midnight" fix would expire it a day early. Controls for
  that are in the suite.
- Deliberately **not** fixed here: `resolveValidity()` still restricts new
  `learn()` parameters to `YYYY-MM-DD`, so the read path accepts a form the
  write path refuses. That is a contract question for the standard, not a
  filtering bug.
- Host-down/breaker semantics in `fetchBounded` are unchanged: only the fetch
  phase marks a host down. A 5xx or a decode failure says nothing about
  reachability.

### Verification

- Full monorepo suite on the branch head: **352 files passed, 15 skipped, 0 failed.**
- Each fix reverted in turn to confirm its test fails: `expected {} to deeply
  equal { pinned: false }` (#1149), `expected undefined to deeply equal {…}`
  (#1151), stalled-body timeout (#1152).
- The audit's own probe, which asserts the *buggy* behaviour, now aborts on its
  first assertion against this branch — the intended signal that the finding is
  closed.

### Note for whoever merges

`#1138` adds `created_at` / `updated_at` to `EngramSchema`. The new guard will
fail for whichever of the two lands second, until those two fields are
classified. That is the guard doing its job rather than a conflict — the fix is
two lines in `TRANSMITTED` or `LOCAL` with a reason.
