### PR TITLE
Audit review follow-ups: bound existsById, the fifth validity site, UTC-pin naive timestamps, and make the write-contract guard bite

### DIFF
--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -193,6 +193,20 @@ const NEVER_STRIP = new Set(['visibility', 'pinned'])
 const warnedSalvages = new Set<string>()
 
 /**
+ * Thrown when a bounded request misses its deadline, at ANY phase.
+ *
+ * A distinct type rather than a message: `existsById()` has to re-word a
+ * timeout in its own terms, and matching on the text of another function's
+ * error is the kind of coupling that breaks silently when the wording changes.
+ */
+export class RemoteTimeoutError extends Error {
+  constructor(url: string, ms: number) {
+    super(`request to ${url} timed out after ${ms}ms`)
+    this.name = 'RemoteTimeoutError'
+  }
+}
+
+/**
  * A response whose body has already been read, inside the request deadline.
  *
  * `json` is present only for a 2xx (and is `undefined` when the payload would
@@ -325,7 +339,7 @@ export class RemoteStore {
     // clean; on failure the mark is refreshed.
     const ctrl = new AbortController()
     const timer = setTimeout(() => ctrl.abort(), LOAD_FETCH_TIMEOUT_MS)
-    const timedOut = () => new Error(`request to ${url} timed out after ${LOAD_FETCH_TIMEOUT_MS}ms`)
+    const timedOut = () => new RemoteTimeoutError(url, LOAD_FETCH_TIMEOUT_MS)
     try {
       let res: Response
       try {
@@ -745,25 +759,33 @@ export class RemoteStore {
    * budget is the same one `load()` uses, for the same reason.
    */
   async existsById(id: string): Promise<boolean> {
-    const ctrl = new AbortController()
-    const timer = setTimeout(() => ctrl.abort(), LOAD_FETCH_TIMEOUT_MS)
-    let r: Response
+    // Uses the shared helper (#1155). It carried its OWN AbortController with
+    // `clearTimeout` in a `finally` around only the `fetch`, so `await
+    // r.json()` ran after the deadline was gone — the exact defect #1152 fixed
+    // everywhere else, surviving in the one method that had opted out of the
+    // helper. With headers delivered and the body stalled it had still not
+    // settled 120 seconds past its 30-second bound.
+    //
+    // That matters more here than anywhere else: both callers run this INSIDE
+    // the primary store lock, one probe per configured remote. Unbounded, it
+    // inherits undici's 300s `headersTimeout`, which exceeds the 180s
+    // `DEFAULT_ACQUIRE_TIMEOUT` — so every waiting `plur_learn` throws "Failed
+    // to acquire lock" and the engram is silently never stored. A hang here is
+    // not slow, it is lost writes.
+    let r: BoundedResponse
     try {
-      r = await fetch(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
+      r = await this.fetchBounded(`${this.apiBase}/engrams/${encodeURIComponent(id)}`, {
         headers: this.headers(),
-        signal: ctrl.signal,
-      })
+      }, RemoteStore.readBounded)
     } catch (err) {
       // An abort is "cannot tell", not "absent" — the whole point of this
       // method — so it must surface as a throw like any other transport
       // failure, with a message that says which it was.
       throw new Error(
-        ctrl.signal.aborted
+        err instanceof RemoteTimeoutError
           ? `existence probe for ${id} timed out after ${LOAD_FETCH_TIMEOUT_MS}ms against ${this.apiBase}`
           : `existence probe for ${id} failed against ${this.apiBase}: ${(err as Error).message}`,
       )
-    } finally {
-      clearTimeout(timer)
     }
     if (r.status === 404) return false
     if (!r.ok) throw new Error(`HTTP ${r.status} from ${this.apiBase}`)
@@ -772,7 +794,7 @@ export class RemoteStore {
     // envelope payloads on routes they do not recognise, and inferring
     // existence from the status line alone would turn that into a false
     // collision report on every forget.
-    const row = await r.json().catch(() => null) as { id?: unknown } | null
+    const row = (r.json ?? null) as { id?: unknown } | null
     return typeof row?.id === 'string' && row.id === id
   }
 

--- a/packages/core/src/tensions.ts
+++ b/packages/core/src/tensions.ts
@@ -1,5 +1,6 @@
 import type { Engram, MeasuredUnder } from './schemas/engram.js'
 import type { LlmFunction } from './types.js'
+import { isExpired, evaluationInstant } from './validity.js'
 import { ftsTokenize } from './fts.js'
 
 export interface TensionPair {
@@ -341,11 +342,6 @@ function supersedesLinked(a: Engram, b: Engram): boolean {
   )
 }
 
-/** True when the engram's validity window has closed (`temporal.valid_until` before `now`). */
-function validityExpired(e: Engram, now: string): boolean {
-  const until = e.temporal?.valid_until
-  return Boolean(until && until < now)
-}
 
 /** Confidence cap for measured-under pairs in `measured_under_pairs: 'floor'` mode (#869). */
 export const MEASURED_UNDER_CONFIDENCE_CAP = 0.1
@@ -517,13 +513,19 @@ export function getCandidatePairsDetailed(
   const snapshotMode = options?.snapshot_pairs ?? 'skip'
   const measuredUnderMode = options?.measured_under_pairs ?? 'skip'
   const skippedMeasuredUnder: string[] = []
-  const now = options?.now ?? new Date().toISOString().slice(0, 10)
+  // #1156: the last site still comparing a timestamp STRING against a date
+  // string. `'2026-09-07T01:00:00Z' < '2026-09-07'` is false at every hour of
+  // that day, so an engram whose window closed at 01:00 was still treated as
+  // live — the same defect as #1150, in the one place that fix did not reach.
+  // Smaller blast radius than injection (this only affects tension pairing),
+  // but the point of a shared evaluator is that there is no second opinion.
+  const nowMs = evaluationInstant(options?.now)
   const excludePairs = options?.exclude_pairs
 
   // Tokenize each engram once instead of once per pair (O(n) vs O(n²) passes).
   const subjectTokens = active.map(e => extractSubjectTokens(e.statement))
   const statementTokens = active.map(e => new Set(ftsTokenize(e.statement)))
-  const expired = active.map(e => validityExpired(e, now))
+  const expired = active.map(e => isExpired(e.temporal, nowMs))
 
   const scored: Array<{ pair: [Engram, Engram]; overlap: number }> = []
 

--- a/packages/core/src/validity.ts
+++ b/packages/core/src/validity.ts
@@ -155,3 +155,22 @@ export function isExpiredBeyondGrace(temporal: Temporal, nowMs: number, graceDay
 export function isCurrentlyValid(temporal: Temporal, nowMs: number): boolean {
   return !isNotYetValid(temporal, nowMs) && !isExpired(temporal, nowMs)
 }
+
+/**
+ * Interpret an "evaluate as of" parameter as an instant.
+ *
+ * Callers that expose a `now` option take a `YYYY-MM-DD` string. A whole day is
+ * not an instant, so it has to be resolved to one, and the END of the day is
+ * the resolution that preserves existing behaviour: under the old lexical
+ * comparison a date-only `valid_until` equal to `now` was NOT expired (the
+ * strings compared equal), which is the same answer end-of-day gives. Resolving
+ * to midnight instead would expire everything a day early.
+ *
+ * @param now - `YYYY-MM-DD`, or an RFC 3339 instant, or nothing for the
+ *   current moment.
+ */
+export function evaluationInstant(now?: string): number {
+  if (!now) return Date.now()
+  const ms = closesAt(now)
+  return ms === null ? Date.now() : ms
+}

--- a/packages/core/src/validity.ts
+++ b/packages/core/src/validity.ts
@@ -46,13 +46,39 @@ const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/
 
 const DAY_MS = 86_400_000
 
+/** A trailing `Z` or `±HH:MM` / `±HHMM` zone designator. */
+const HAS_ZONE = /(?:Z|[+-]\d{2}:?\d{2})$/i
+
+/**
+ * Pin a timestamp to UTC when it names no zone (#1157).
+ *
+ * `Date.parse('2026-09-07T01:00:00')` — no `Z`, no offset — resolves in the
+ * HOST's local time, so the same stored engram expires at different moments on
+ * different machines, and a team sharing a store disagrees about which rules
+ * are live. `TemporalSchema` accepts any string, and `salvageRemoteRow` copies
+ * server values verbatim, so a store emitting naive timestamps reaches this
+ * function unchanged.
+ *
+ * UTC is the right default rather than an arbitrary one: every timestamp this
+ * codebase MINTS is `toISOString()`, which is UTC, so a naive value is a
+ * foreign or hand-edited one and reading it as UTC agrees with the rest of the
+ * store instead of with whoever happens to be running the query.
+ *
+ * Exported for the regression test. The behavioural test can only tell the
+ * difference in a non-UTC timezone, and CI runs in UTC — so the mechanism has
+ * to be assertable directly, or a reintroduction ships green.
+ */
+export function pinToUtc(value: string): string {
+  return HAS_ZONE.test(value) ? value : `${value}Z`
+}
+
 /**
  * First instant a bound includes, in epoch ms; `null` when unparseable.
  *
  * A date-only value opens at midnight UTC of that day.
  */
 function opensAt(value: string): number | null {
-  const ms = Date.parse(DATE_ONLY.test(value) ? `${value}T00:00:00.000Z` : value)
+  const ms = Date.parse(DATE_ONLY.test(value) ? `${value}T00:00:00.000Z` : pinToUtc(value))
   return Number.isNaN(ms) ? null : ms
 }
 
@@ -64,7 +90,7 @@ function opensAt(value: string): number | null {
  * date-only `valid_until` must not be treated as midnight.
  */
 function closesAt(value: string): number | null {
-  const ms = Date.parse(DATE_ONLY.test(value) ? `${value}T23:59:59.999Z` : value)
+  const ms = Date.parse(DATE_ONLY.test(value) ? `${value}T23:59:59.999Z` : pinToUtc(value))
   return Number.isNaN(ms) ? null : ms
 }
 

--- a/packages/core/test/remote-exists-by-id.test.ts
+++ b/packages/core/test/remote-exists-by-id.test.ts
@@ -6,8 +6,10 @@
  * distinction: treating an unreachable store as "not there" is how an id
  * collision goes unnoticed and the wrong engram gets retired (#831).
  *
- * It shipped with NO test of its own, including when this branch added the
- * timeout. That mattered because both callers run it INSIDE the primary store
+ * It shipped with NO test of its own, and the timeout it later grew guarded
+ * only the handshake: `clearTimeout` sat in a `finally` around the `fetch`,
+ * so the body read ran unbounded (#1155). That mattered because both callers
+ * run it INSIDE the primary store
  * lock, one probe per configured remote. Unbounded, it inherits undici's 300s
  * `headersTimeout`, which exceeds the 180s `DEFAULT_ACQUIRE_TIMEOUT` — so a
  * host that completes its handshake and then stalls makes every waiting
@@ -197,14 +199,35 @@ describe('every RemoteStore request is bounded', () => {
     await expect(settled).resolves.toMatch(/timed out after 30000ms/)
   })
 
+  it('existsById settles at the deadline when the body stalls (#1155)', async () => {
+    // The method that had opted out of the helper, and the one where a hang is
+    // worst: both callers hold the primary store lock while it runs, so an
+    // unbounded probe turns into "Failed to acquire lock" for every waiting
+    // plur_learn and the engram is silently never stored.
+    vi.useFakeTimers()
+    globalThis.fetch = stallingBody(200)
+
+    const settled = store().existsById('ENG-X-001').then(() => 'resolved', (e: Error) => e.message)
+    await vi.advanceTimersByTimeAsync(31_000)
+
+    // In this method's own words — a timeout is "cannot tell", never "absent".
+    await expect(settled).resolves.toMatch(/existence probe for ENG-X-001 timed out after 30000ms/)
+  })
+
   it('the bound is one shared helper, so a new endpoint inherits it', () => {
     // The reason this is a helper and not six call-site fixes: a rule enforced
     // by convention at N sites holds at N-1 of them. Asserted against the
     // source so a seventh bare `fetch` fails here rather than in production.
     const src = readFileSync(join(__dirname, '..', 'src', 'store', 'remote-store.ts'), 'utf8')
     const bare = [...src.matchAll(/await fetch\(/g)]
-    // Exactly two remain by design: `fetchBounded` itself, and the two paths
-    // that build their own AbortController (`load`'s pager, `existsById`).
-    expect(bare.length, 'a bare fetch was added without a timeout').toBeLessThanOrEqual(3)
+    // Exactly TWO, and now the comment and the number agree. This said "exactly
+    // two" while naming three and asserting <= 3, and the exemption it granted
+    // was wrong: `load`'s pager does read its body inside its own timer,
+    // `existsById` did not (#1155). It now uses the shared helper, so the third
+    // exemption is gone rather than documented.
+    //
+    // An equality assertion, not an upper bound: `<= 3` would have gone green
+    // for a NEW bare fetch the moment `existsById` stopped being one.
+    expect(bare.length, 'a bare fetch was added without a timeout').toBe(2)
   })
 })

--- a/packages/core/test/remote-write-contract.test.ts
+++ b/packages/core/test/remote-write-contract.test.ts
@@ -28,6 +28,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { EngramSchema } from '../src/schemas/engram.js'
+import { RemoteStore } from '../src/store/remote-store.js'
 import { Plur } from '../src/index.js'
 
 /** Sent to the server, because it is engram CONTENT that a reader needs. */
@@ -115,6 +116,117 @@ describe('the remote write contract covers every schema field (#1151)', () => {
     const stale = [...TRANSMITTED, ...FLATTENED.keys(), ...LOCAL.keys(), ...NOT_MODELLED]
       .filter(f => !known.has(f))
     expect(stale, 'a classified field is gone from the schema — drop it from this list').toEqual([])
+  })
+})
+
+/**
+ * The classification guard checks that every field was CLASSIFIED. On its own
+ * that is not enough (#1158): it is set membership over a hand-written list, so
+ * deleting the three field spreads from `appendAndGetServerId`'s body leaves it
+ * green. The very defect it was built to prevent could recur and pass it.
+ *
+ * So the sets have to be checked against the REQUEST, not only against each
+ * other: everything in TRANSMITTED must actually appear on the wire when it is
+ * set. That is the assertion that ties the list to the code.
+ */
+describe('every TRANSMITTED field actually reaches the wire (#1158)', () => {
+  const SCOPE = 'group:acme/eng'
+  let dir: string
+  let server: Server
+  let posted: Record<string, unknown> | undefined
+  let plur: Plur
+
+  beforeEach(async () => {
+    posted = undefined
+    server = createServer(async (req, res) => {
+      const chunks: Buffer[] = []
+      for await (const chunk of req) chunks.push(chunk as Buffer)
+      const body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString()) : undefined
+      res.setHeader('Content-Type', 'application/json')
+      if (req.method === 'POST') {
+        posted = body
+        return res.end(JSON.stringify({ id: 'ENG-2026-0907-777' }))
+      }
+      res.end(JSON.stringify({ rows: [], total_count: 0 }))
+    })
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+
+    dir = mkdtempSync(join(tmpdir(), 'plur-wire-coverage-'))
+    writeFileSync(join(dir, 'engrams.yaml'), 'engrams: []\n')
+    writeFileSync(join(dir, 'config.yaml'),
+      `stores:\n  - scope: "${SCOPE}"\n    url: "${url}"\n    token: "t"\n`)
+    plur = new Plur({ path: dir })
+    await plur.ready()
+  })
+
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true })
+    server.closeAllConnections()
+    await new Promise<void>(r => server.close(() => r()))
+  })
+
+  it('sends every field named in TRANSMITTED when all of them are set', async () => {
+    // Driven through `RemoteStore.appendAndGetServerId` with a fully-populated
+    // engram, NOT through `learnRouted`. The wire contract is a property of the
+    // store driver; routing it through learn would test the context->engram
+    // mapping at the same time and blame the wrong layer. Written the other way
+    // round first, this reported `locked_reason` and `provenance` as missing —
+    // both were the test's fault (`locked_reason` survives only when
+    // `commitment: 'locked'`, and `provenance` is not a learn parameter at all).
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+    const driver = new RemoteStore(url, 't', SCOPE)
+
+    const full = EngramSchema.parse({
+      id: 'ENG-2026-0907-777',
+      statement: 'Median vector lookup latency was 18 ms in the synthetic benchmark.',
+      type: 'architectural', scope: SCOPE, status: 'active',
+      domain: 'plur.engineering.search',
+      tags: ['bench', 'latency'],
+      pinned: true,
+      rationale: 'The measurement is only meaningful with its conditions attached.',
+      commitment: 'locked',
+      locked_reason: 'benchmark baseline',
+      source: 'bench/results.json',
+      provenance: { origin: 'measurement' },
+      measured_under: { hardware: '8-core', dataset: '100 rows', source_type: 'bench', date: '2026-09-07' },
+      knowledge_anchors: [{ path: 'bench/results.json', relevance: 'primary', snippet: 'Median 18 ms.' }],
+      dual_coding: { example: 'Applies to the measured dataset and machine.' },
+    })
+
+    await driver.appendAndGetServerId(full as never)
+
+    const sent = new Set(Object.keys(posted!))
+    const missing = [...TRANSMITTED].filter(f => !sent.has(f))
+
+    // The assertion the membership guard cannot make. Delete a field spread
+    // from appendAndGetServerId and this goes red, while the classification
+    // suite above stays green — which is exactly how #768 and #1151 shipped.
+    expect(missing,
+      'a field is classified TRANSMITTED but never reaches the request body. '
+      + 'Either add it to appendAndGetServerId, or reclassify it with a reason.',
+    ).toEqual([])
+  })
+
+  it('sends the flattened keys the nested fields map to', async () => {
+    // `temporal` and `relations` are classified FLATTENED, meaning they travel
+    // as top-level keys rather than as the nested object. Nothing checked that
+    // the flattening still happened.
+    await plur.learnRouted('A claim with a validity window and a supersession.', {
+      scope: SCOPE,
+      type: 'behavioral',
+      valid_from: '2026-09-01',
+      valid_until: '2026-12-31',
+      supersedes: ['ENG-2026-0101-001'],
+    } as never)
+
+    expect(posted!.valid_from).toBe('2026-09-01')
+    expect(posted!.valid_until).toBe('2026-12-31')
+    expect(posted!.supersedes).toEqual(['ENG-2026-0101-001'])
+    // The nested containers themselves must NOT ride along.
+    expect(Object.keys(posted!)).not.toContain('temporal')
+    expect(Object.keys(posted!)).not.toContain('relations')
   })
 })
 

--- a/packages/core/test/tensions.test.ts
+++ b/packages/core/test/tensions.test.ts
@@ -364,6 +364,43 @@ describe('getCandidatePairs', () => {
     expect(pairs).toHaveLength(0)
   })
 
+  it('skips a pair whose engram expired at an INSTANT earlier the same day (#1156)', () => {
+    // The last site still comparing a timestamp string against a date string.
+    // `'2026-09-07T01:00:00Z' < '2026-09-07'` is false at every hour of that
+    // day, so an engram whose window closed at 01:00 was still treated as a
+    // live peer claim and lined up against a current one — a tension reported
+    // against something that had already lapsed.
+    const a = makeEngram({ id: 'E1', statement: 'plur search uses BM25.', scope: 'global' })
+    const b = makeEngram({
+      id: 'E2', statement: 'plur search uses embeddings.', scope: 'global',
+      temporal: { learned_at: '2026-09-06', valid_until: '2026-09-07T01:00:00Z' },
+    } as never)
+    expect(getCandidatePairs([a, b], { now: '2026-09-07' })).toHaveLength(0)
+  })
+
+  it('still pairs when the instant window has NOT closed yet', () => {
+    // The control. Without it, "skips expired" and "skips anything carrying a
+    // valid_until" are indistinguishable.
+    const a = makeEngram({ id: 'E1', statement: 'plur search uses BM25.', scope: 'global' })
+    const b = makeEngram({
+      id: 'E2', statement: 'plur search uses embeddings.', scope: 'global',
+      temporal: { learned_at: '2026-09-06', valid_until: '2026-09-30T01:00:00Z' },
+    } as never)
+    expect(getCandidatePairs([a, b], { now: '2026-09-07' })).toHaveLength(1)
+  })
+
+  it('keeps whole-day semantics for a date-only expiry', () => {
+    // A date-only valid_until equal to `now` is NOT expired — it closes at the
+    // END of that day. Resolving `now` to midnight instead would expire it a
+    // day early and silently drop real tension candidates.
+    const a = makeEngram({ id: 'E1', statement: 'plur search uses BM25.', scope: 'global' })
+    const b = makeEngram({
+      id: 'E2', statement: 'plur search uses embeddings.', scope: 'global',
+      temporal: { learned_at: '2026-09-06', valid_until: '2026-09-07' },
+    } as never)
+    expect(getCandidatePairs([a, b], { now: '2026-09-07' })).toHaveLength(1)
+  })
+
   it('skips inactive engrams', () => {
     const a = makeEngram({ id: 'E1', statement: 'plur search uses BM25.', scope: 'global' })
     const b = makeEngram({ id: 'E2', statement: 'plur search uses embeddings.', scope: 'global', status: 'retired' as any })

--- a/packages/core/test/validity-instants.test.ts
+++ b/packages/core/test/validity-instants.test.ts
@@ -128,6 +128,41 @@ describe('validity evaluator', () => {
   })
 })
 
+/**
+ * The same question under a host that is NOT on UTC (#1157).
+ *
+ * Node re-reads `process.env.TZ` for each `Date` operation, so the timezone can
+ * be pinned for the duration of a test rather than only via the runner's
+ * environment. Worth doing explicitly: CI runs on UTC, where a naive timestamp
+ * and its explicit-Z twin are indistinguishable and every assertion below would
+ * pass with the defect present.
+ */
+describe('validity is host-timezone independent (#1157)', () => {
+  const REAL_TZ = process.env.TZ
+
+  afterEach(() => {
+    if (REAL_TZ === undefined) delete process.env.TZ
+    else process.env.TZ = REAL_TZ
+  })
+
+  it.each(['America/New_York', 'Asia/Tokyo', 'Pacific/Kiritimati', 'UTC'])(
+    'decides the same way in %s', (tz) => {
+      process.env.TZ = tz
+      // Sanity: the offset really did change for at least the non-UTC zones,
+      // so a green run cannot mean "TZ was ignored".
+      const shifted = new Date('2026-09-07T13:00:00').toISOString()
+      if (tz !== 'UTC') expect(shifted, tz).not.toBe('2026-09-07T13:00:00.000Z')
+
+      // 11:00 is the discriminating hour: it sits before NOON in UTC and after
+      // it in the western zones, so a host-local reading flips the answer.
+      expect(isNotYetValid({ valid_from: '2026-09-07T11:00:00' } as never, NOON), tz).toBe(false)
+      expect(isExpired({ valid_until: '2026-09-07T11:00:00' } as never, NOON), tz).toBe(true)
+      expect(isNotYetValid({ valid_from: '2026-09-07T13:00:00' } as never, NOON), tz).toBe(true)
+      expect(isExpired({ valid_until: '2026-09-07T13:00:00' } as never, NOON), tz).toBe(false)
+    },
+  )
+})
+
 describe('list(), recall() and injection agree, at instant granularity (#1150)', () => {
   let dir: string
   let plur: Plur

--- a/packages/core/test/validity-instants.test.ts
+++ b/packages/core/test/validity-instants.test.ts
@@ -21,7 +21,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
-  isCurrentlyValid, isNotYetValid, isExpired, isExpiredBeyondGrace,
+  isCurrentlyValid, isNotYetValid, isExpired, isExpiredBeyondGrace, pinToUtc,
 } from '../src/validity.js'
 import { Plur } from '../src/index.js'
 import { selectAndSpread } from '../src/inject.js'
@@ -74,6 +74,52 @@ describe('validity evaluator', () => {
     expect(isExpired(t, NOON)).toBe(true)
     expect(isExpiredBeyondGrace(t, NOON, 30)).toBe(false)
     expect(isExpiredBeyondGrace(t, NOON, 5)).toBe(true)
+  })
+
+  it('pins a zone-less timestamp to UTC, in any timezone (#1157)', () => {
+    // Asserted on the MECHANISM, not on behaviour, and deliberately so: the
+    // behavioural test below can only tell the difference when the host is not
+    // on UTC, and CI is on UTC. Left to that test alone, a reintroduction of
+    // this bug would ship green.
+    expect(pinToUtc('2026-09-07T11:00:00')).toBe('2026-09-07T11:00:00Z')
+    expect(pinToUtc('2026-09-07T11:00:00.500')).toBe('2026-09-07T11:00:00.500Z')
+    // Already zoned — must be left exactly as it is.
+    for (const zoned of [
+      '2026-09-07T11:00:00Z', '2026-09-07T11:00:00z',
+      '2026-09-07T11:00:00+02:00', '2026-09-07T11:00:00-05:00', '2026-09-07T11:00:00+0200',
+    ]) {
+      expect(pinToUtc(zoned), zoned).toBe(zoned)
+    }
+  })
+
+  it('reads a zone-less timestamp as UTC, not as host-local time (#1157)', () => {
+    // `Date.parse('2026-09-07T13:00:00')` resolves in the HOST's timezone, so
+    // the same stored engram would expire at different moments on different
+    // machines and a team sharing a store would disagree about which rules are
+    // live. TemporalSchema accepts any string and salvageRemoteRow copies
+    // server values verbatim, so naive timestamps do reach here.
+    //
+    // Asserted as an EQUIVALENCE to the explicit-Z form rather than against a
+    // hardcoded instant, so the test means the same thing in every timezone
+    // this suite runs in — including CI, which is UTC and would let the bug
+    // pass a naive assertion.
+    for (const [naive, zoned] of [
+      ['2026-09-07T13:00:00', '2026-09-07T13:00:00Z'],
+      ['2026-09-07T11:00:00', '2026-09-07T11:00:00Z'],
+      ['2026-09-07T13:00:00.500', '2026-09-07T13:00:00.500Z'],
+    ]) {
+      expect(isNotYetValid({ valid_from: naive } as never, NOON), naive)
+        .toBe(isNotYetValid({ valid_from: zoned } as never, NOON))
+      expect(isExpired({ valid_until: naive } as never, NOON), naive)
+        .toBe(isExpired({ valid_until: zoned } as never, NOON))
+    }
+  })
+
+  it('still honours an explicit offset rather than overriding it', () => {
+    // The guard must not blanket-append Z to values that already name a zone.
+    expect(isNotYetValid({ valid_from: '2026-09-07T15:00:00+02:00' } as never, NOON)).toBe(true)
+    expect(isNotYetValid({ valid_from: '2026-09-07T15:00:00+0200' } as never, NOON)).toBe(true)
+    expect(isNotYetValid({ valid_from: '2026-09-07T08:00:00-05:00' } as never, NOON)).toBe(true)
   })
 
   it('treats an unparseable bound as absent rather than as hiding the engram', () => {


### PR DESCRIPTION
Closes #1155. Closes #1156. Closes #1157. Closes #1158.

All four follow-ups from @crtahlin's review of #1154, plus the two smaller
inaccuracies noted there without an issue. One commit each, every fix verified
to go red when reverted.

### #1155 — the one that contradicted #1154's own claim

#1154 said the deadline had been made *structural* by giving the shared helper
ownership of the body read. `existsById()` was the counter-example: its own
AbortController, `clearTimeout` in a `finally` around only the `fetch`, and
`await r.json()` outside it. The review is right that this is the worst place
for it — both callers hold the primary store lock, and unbounded the probe
inherits undici's 300s `headersTimeout`, past the 180s `DEFAULT_ACQUIRE_TIMEOUT`,
so waiting `plur_learn` calls throw "Failed to acquire lock" and the engram is
silently never stored.

Now routed through `fetchBounded`. A timeout keeps this method's own wording,
because for an ambiguity probe "cannot tell" versus "absent" is the entire
point — carried by a typed `RemoteTimeoutError` rather than by matching on
another function's message text.

Reverting the fix makes the new test *hang* for the full 30s and fail, which is
the defect exactly.

### #1158 — the guard that could not catch what it was built for

The sharpest finding. The classification test was set membership over a
hand-written list with nothing tying it to the code, so deleting the three field
spreads left it green.

Now `TRANSMITTED` is asserted against the actual POST body, and `FLATTENED`
against the flattened keys. **Verified by deleting the `measured_under` spread —
simulating the #1151 recurrence exactly: the new assertion goes red naming the
field while the classification suite stays green.**

Driven through `RemoteStore.appendAndGetServerId` rather than `learnRouted`,
deliberately. Written the other way round first, it reported `locked_reason` and
`provenance` as missing — both were the test's fault, not the code's
(`locked_reason` survives only under `commitment: 'locked'`; `provenance` is not
a learn parameter). The wire contract belongs to the store driver; routing it
through learn tests the context mapping at the same time and blames the wrong
layer.

### #1156 — the fifth instance

`validityExpired()` deleted rather than fixed in place; tension pairing uses the
shared evaluator. `options.now` stays a `YYYY-MM-DD` string and resolves to the
END of that day, which is what preserves existing behaviour — under the old
lexical comparison a date-only `valid_until` equal to `now` compared equal and
so was not expired. Midnight would expire everything a day early, and there is a
control test for that.

### #1157 — and a second commit, because the first test was not good enough

Zone-less timestamps are pinned to UTC. UTC rather than an arbitrary choice:
every timestamp this codebase mints is `toISOString()`, so a naive value is
foreign or hand-edited, and reading it as UTC agrees with the rest of the store
rather than with whoever runs the query.

The first attempt asserted the mechanism plus a behavioural equivalence — and
that equivalence holds on a UTC host whether or not the fix is present, so on
CI it would have gone green through a reintroduction. The issue asked for a test
under a fixed non-UTC `TZ` and it was right to. Node re-reads `process.env.TZ`
per `Date` operation, so the second commit pins it inside the test across
America/New_York, Asia/Tokyo, Pacific/Kiritimati and UTC as control, each first
checking the offset really moved so a green run cannot mean "TZ was ignored".
Bypassing the fix turns all three non-UTC cases red and leaves UTC green.

### The two smaller things, no issue filed

Both were the previous change asserting something inaccurate about itself:

- The shared-helper test said "exactly two remain by design", then named three
  and asserted `<= 3`, and the exemption was wrong — `load`'s pager does read
  its body inside its own timer, `existsById` did not. Now `toBe(2)`. An upper
  bound would have gone green for a *new* bare fetch the moment this one stopped
  being one.
- The file header credited the branch that added the stalled-body tests with
  adding this method's timeout. It predates that branch, and guarded only the
  handshake — which is the whole finding.

### Verification

- `packages/core` typecheck clean; the seven affected suites pass.
- Each fix individually reverted and confirmed to go red: `existsById` hangs 30s
  (#1155), tension pairing returns 1 instead of 0 (#1156), three non-UTC zones
  disagree (#1157), `measured_under` reported missing from the body (#1158).
- Bare `await fetch(` in `remote-store.ts` is now exactly two, asserted by
  equality: `fetchBounded` itself and `load`'s pager, which owns its body read.
