### PR TITLE
fix(core): throw RangeError on unparseable evaluation instant (#1166)

### DIFF
--- a/packages/core/src/validity.ts
+++ b/packages/core/src/validity.ts
@@ -159,18 +159,28 @@ export function isCurrentlyValid(temporal: Temporal, nowMs: number): boolean {
 /**
  * Interpret an "evaluate as of" parameter as an instant.
  *
- * Callers that expose a `now` option take a `YYYY-MM-DD` string. A whole day is
- * not an instant, so it has to be resolved to one, and the END of the day is
- * the resolution that preserves existing behaviour: under the old lexical
- * comparison a date-only `valid_until` equal to `now` was NOT expired (the
- * strings compared equal), which is the same answer end-of-day gives. Resolving
- * to midnight instead would expire everything a day early.
+ * Callers that expose a `now` option take a `YYYY-MM-DD` string or an RFC 3339
+ * instant. A whole day is not an instant, so it has to be resolved to one, and
+ * the END of the day is the resolution that preserves existing behaviour:
+ * under the old lexical comparison a date-only `valid_until` equal to `now` was
+ * NOT expired (the strings compared equal), which is the same answer end-of-day
+ * gives. Resolving to midnight instead would expire everything a day early.
+ *
+ * The sibling functions treat an unparseable bound as ABSENT, because stored
+ * engrams have their fields validated by `TemporalSchema` and hiding content
+ * over a data error is the worse outcome. A caller-supplied evaluation instant
+ * is not that case: it is an explicit argument, so an unparseable value throws
+ * a `RangeError` rather than silently answering as of the present moment (#1166).
  *
  * @param now - `YYYY-MM-DD`, or an RFC 3339 instant, or nothing for the
  *   current moment.
+ * @throws {RangeError} When `now` is provided but cannot be parsed as a date or instant.
  */
 export function evaluationInstant(now?: string): number {
   if (!now) return Date.now()
   const ms = closesAt(now)
-  return ms === null ? Date.now() : ms
+  if (ms === null) {
+    throw new RangeError(`Unparseable evaluation instant: "${now}". Expected YYYY-MM-DD or an RFC 3339 timestamp.`)
+  }
+  return ms
 }

--- a/packages/core/test/tensions.test.ts
+++ b/packages/core/test/tensions.test.ts
@@ -401,6 +401,14 @@ describe('getCandidatePairs', () => {
     expect(getCandidatePairs([a, b], { now: '2026-09-07' })).toHaveLength(1)
   })
 
+  it('fails fast when options.now is unparseable (#1166)', () => {
+    // A caller-provided now parameter with a typo must throw rather than
+    // silently answering as of the present moment.
+    const a = makeEngram({ id: 'E1', statement: 'plur search uses BM25.', scope: 'global' })
+    const b = makeEngram({ id: 'E2', statement: 'plur search uses embeddings.', scope: 'global' })
+    expect(() => getCandidatePairs([a, b], { now: 'not-a-date' })).toThrow(RangeError)
+  })
+
   it('skips inactive engrams', () => {
     const a = makeEngram({ id: 'E1', statement: 'plur search uses BM25.', scope: 'global' })
     const b = makeEngram({ id: 'E2', statement: 'plur search uses embeddings.', scope: 'global', status: 'retired' as any })

--- a/packages/core/test/validity-instants.test.ts
+++ b/packages/core/test/validity-instants.test.ts
@@ -21,7 +21,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
-  isCurrentlyValid, isNotYetValid, isExpired, isExpiredBeyondGrace, pinToUtc,
+  isCurrentlyValid, isNotYetValid, isExpired, isExpiredBeyondGrace, pinToUtc, evaluationInstant,
 } from '../src/validity.js'
 import { Plur } from '../src/index.js'
 import { selectAndSpread } from '../src/inject.js'
@@ -220,3 +220,38 @@ describe('list(), recall() and injection agree, at instant granularity (#1150)',
     expect(ids).toContain('ENG-active-instant')
   })
 })
+
+describe('evaluationInstant (#1166)', () => {
+  it('returns current time when now is omitted or empty', () => {
+    const before = Date.now()
+    const instant = evaluationInstant()
+    const after = Date.now()
+    expect(instant).toBeGreaterThanOrEqual(before)
+    expect(instant).toBeLessThanOrEqual(after)
+    expect(evaluationInstant('')).toBeGreaterThanOrEqual(before)
+  })
+
+  it('resolves a date-only parameter to the end of that day UTC', () => {
+    // End-of-day semantics preserve existing behaviour for valid_until comparisons.
+    expect(evaluationInstant('2026-09-07')).toBe(Date.parse('2026-09-07T23:59:59.999Z'))
+  })
+
+  it('resolves an explicit RFC 3339 instant accurately', () => {
+    expect(evaluationInstant('2026-09-07T12:00:00Z')).toBe(Date.parse('2026-09-07T12:00:00.000Z'))
+    expect(evaluationInstant('2026-09-07T14:00:00+02:00')).toBe(Date.parse('2026-09-07T12:00:00.000Z'))
+  })
+
+  it('pins a naive timestamp to UTC', () => {
+    expect(evaluationInstant('2026-09-07T12:00:00')).toBe(Date.parse('2026-09-07T12:00:00.000Z'))
+  })
+
+  it('throws RangeError when now is unparseable (#1166)', () => {
+    // An argument-level typo or malformed date must fail fast rather than
+    // silently answering as of the present moment.
+    expect(() => evaluationInstant('not-a-date')).toThrow(RangeError)
+    expect(() => evaluationInstant('not-a-date')).toThrow(/Unparseable evaluation instant/)
+    expect(() => evaluationInstant('2026-99-99')).toThrow(RangeError)
+    expect(() => evaluationInstant('2026-09-07T99:99:99Z')).toThrow(RangeError)
+  })
+})
+


### PR DESCRIPTION
### Summary
Resolves #1166.

In `packages/core/src/validity.ts`, `evaluationInstant(now)` previously fell back to `Date.now()` when `closesAt(now)` returned `null`:
```ts
const ms = closesAt(now)
return ms === null ? Date.now() : ms
```
As noted in #1166, while stored engram bounds (`isExpired`, `isNotYetValid`) treat unparseable timestamps as absent to avoid hiding valid content over data errors, a caller-provided evaluation instant (`now` in `options.now` across `getCandidatePairsDetailed` / `scanForTensions`) is an explicit argument. Falling back to the current time silently answered queries as of the present moment with no notification that the instant parameter was unparseable.

### Proposed Changes
1. **`packages/core/src/validity.ts`**:
   - Updated docstring to document the `RangeError` contract for caller-supplied evaluation instants.
   - Throws `RangeError('Unparseable evaluation instant: ... Expected YYYY-MM-DD or an RFC 3339 timestamp.')` when `now` is non-empty but cannot be parsed as a date or instant.
2. **`packages/core/test/validity-instants.test.ts`**:
   - Added `evaluationInstant (#1166)` unit test suite asserting:
     - Omitted or empty `now` returns current timestamp.
     - `YYYY-MM-DD` date resolves to end-of-day UTC (`23:59:59.999Z`).
     - RFC 3339 instants resolve accurately with zone offset.
     - Naive timestamps pin to UTC.
     - Unparseable strings throw `RangeError` with descriptive message.
3. **`packages/core/test/tensions.test.ts`**:
   - Added regression test asserting `getCandidatePairs` fails fast with `RangeError` when `options.now` is unparseable.

### Verification
- `npm test -- packages/core/test/validity-instants.test.ts packages/core/test/tensions.test.ts`: **122/122 passed**.
- `packages/core` builds cleanly via `npm run build` (`tsup`).
