### PR TITLE
fix: close audit findings in persistence, privacy, and recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Tags, so packages/migrate/test/method-list.test.ts can read the
           # 0.15.0 source and actually verify its sync -> async claim. Without
@@ -71,13 +71,14 @@ jobs:
           # vacuously — which is how a wrong claim about the past reached the
           # CHANGELOG in the first place.
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+      - run: python3 scripts/check-workflow-pins.py
       - run: pnpm install --frozen-lockfile
       - run: git config --global user.email "ci@plur.ai"
       - run: git config --global user.name "PLUR CI"
@@ -199,7 +200,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Full history: the comparison below needs the PR base commit, which a
           # shallow clone does not have.
@@ -233,13 +234,13 @@ jobs:
             echo "SKIPPING: no change to the embedder, the enrichment fields, or the bar."
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         if: steps.relevant.outputs.run == 'true'
         with:
           # Required: package.json carries no `packageManager` key, so the
           # action cannot infer it. Same pin as the other two jobs.
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         if: steps.relevant.outputs.run == 'true'
         with:
           node-version: 22
@@ -271,7 +272,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Full history so this job builds the same artefacts a release build
           # would see (release.sh runs from a full clone with tags). The
@@ -279,10 +280,10 @@ jobs:
           # apply here — this job never runs vitest; the comment used to be a
           # copy-paste of that one, claiming a reason that was not this job's.
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -26,8 +26,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - run: pip install pytest

--- a/.github/workflows/hermes-compat-monthly.yml
+++ b/.github/workflows/hermes-compat-monthly.yml
@@ -39,9 +39,9 @@ jobs:
         python-version: ['3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -50,7 +50,7 @@ jobs:
       # (test_memory_provider_entrypoint.py) exercises — so the canary needs
       # the CLI on PATH exactly as a user's machine does. Latest published,
       # not a workspace build: this job asks whether the shipped pair works.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - name: Install the plur CLI (latest from npm)
@@ -83,7 +83,7 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/hermes.yml
+++ b/.github/workflows/hermes.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e packages/hermes pytest

--- a/.github/workflows/langchain.yml
+++ b/.github/workflows/langchain.yml
@@ -19,14 +19,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        dependencies: ['minimum', 'latest']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       # Install plur-ai from local source — avoids PyPI dependency before first publish.
       # plur-langchain's pyproject.toml requires plur-ai>=0.10.0; pip finds it here.
       - run: pip install -e packages/python
       - run: pip install -e "packages/langchain[dev]"
+      - if: matrix.dependencies == 'minimum'
+        run: pip install 'langchain-core==0.3.85' 'langsmith==0.8.18'
       - run: pytest packages/langchain -q

--- a/.github/workflows/pr-issue-guard.yml
+++ b/.github/workflows/pr-issue-guard.yml
@@ -32,7 +32,7 @@ jobs:
   issue-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/publish-langchain.yml
+++ b/.github/workflows/publish-langchain.yml
@@ -21,12 +21,12 @@ jobs:
     permissions:
       id-token: write   # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - run: pip install build
       - run: python -m build packages/langchain
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: packages/langchain/dist

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write          # required for GitHub OIDC auth to the registry
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Sync server.json version to the release tag
         run: |
@@ -38,10 +38,13 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          url=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest \
-            | grep -o '"browser_download_url": *"[^"]*linux_amd64.tar.gz"' | head -1 | cut -d'"' -f4)
-          echo "Downloading $url"
-          curl -L "$url" | tar xz mcp-publisher
+          # Immutable release and digest, verified from the upstream release.
+          curl --fail --show-error --silent --location --proto '=https' --max-time 60 \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz \
+            --output mcp-publisher.tar.gz
+          echo 'a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc  mcp-publisher.tar.gz' > mcp-publisher.sha256
+          sha256sum --check --strict mcp-publisher.sha256
+          tar xzf mcp-publisher.tar.gz mcp-publisher
           chmod +x mcp-publisher
 
       - name: Login (GitHub OIDC) and publish

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -21,12 +21,12 @@ jobs:
     permissions:
       id-token: write   # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - run: pip install build
       - run: python -m build packages/python
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: packages/python/dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,15 +17,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -42,11 +42,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/docs/audits/2026-09-08-closed-loop.md
+++ b/docs/audits/2026-09-08-closed-loop.md
@@ -1,0 +1,465 @@
+# Public PLUR closed-loop audit — 2026-09-08/09
+
+## 1. Final verdict
+
+**BLOCKED — MANUAL/EXTERNAL VERIFICATION REQUIRED**
+
+All actionable public-source remediations are implemented and verified. Of 42 findings/questions, 41 are resolved and F14 remains open only for the external remote-write guarantee. All nine BLOCKER findings in public source are resolved. The final fresh public-only review found no new substantive issue. No clean verdict is issued because the supported-server integration requirement remains unverified for the supported server artifact.
+
+Scope: only `plur-ai/plur`, baseline `d005139ee82eb124466472190302a9bc1770693b`, branch `audit/2026-09-08-closed-loop`. This report records verification before branch publication and PR review. No merge or production deployment is included in the audit.
+
+The earlier ledger mixed another repository into this audit. That was a scope error. This corrected ledger retains stable finding and historical cycle IDs, excludes other-repository findings, and describes only the public client side of integration findings. Omitted IDs do not denote missing public findings. A separate private handoff holds the excluded material.
+
+F14 remains an external integration requirement: stable request identity is implemented and verified here, but a server that ignores that identity can duplicate a remotely committed write after its response is lost. Passing against a disposable contract fixture does not establish that a supported server artifact enforces this requirement. No server-source remediation is included in this public verdict.
+
+## 2. Number of audit cycles
+
+18 in-scope audit cycles completed, retaining historical cycle IDs 1–12, 14, 15, 17 and 20–22. The final cycle found no new substantive issue; F14 remains an external dependency requirement. Historical cycles 13, 16, 18 and 19 were wholly outside the corrected scope and are excluded.
+
+## System understanding and identified invariants
+
+The TypeScript core is used by CLI, stdio MCP, Claw/DSH, the browser viewer and Python/Hermes/LangChain adapters. YAML is the default authoritative store; PostgreSQL can serve as primary. SQLite/PGLite and embeddings are derived indexes. Config, history, migration journals, ID reservations, outbox receipts, sessions, provenance, backups and telemetry are separate state with different recovery lifetimes.
+
+Input flows through validation, sensitivity/scope policy, store ownership, persistence and acknowledgement. MCP trusts its stdio host; local filesystem scopes are visibility rules within an OS account, not OS tenant isolation. Remote services authenticate bearer credentials and must enforce their own authorization; the client validates scope/state at the response boundary. Viewer requests use loopback defaults, Host checks, origin checks for desktop actions and escaped HTML. Optional model providers, remote stores, Git sync, archive downloads and telemetry are network boundaries.
+
+Write invariants: refusal preserves existing bytes; corrupt config/state cannot authorize defaults or replacement; lock ownership spans the relevant writes; acknowledgements follow durable state; retries retain identity; cache eviction does not erase authoritative receipts; IDs do not recycle; incomplete migrations reconcile without stale restore; private writes stay local; model output cannot select unoffered or stale targets. Import and source-migration tools must preserve the original input on failure. Startup, dependency loss and shutdown are covered by backend, subprocess, setup, collector and recovery tests.
+
+## 3. Findings by cycle
+
+42 in-scope findings/questions: severity counts appear below. The final status of each is authoritative; historical intermediate failures remain evidence, not passes.
+
+| Historical cycle | In-scope cycle | New findings | New count | Fresh review focus |
+| --- | ---: | --- | ---: | --- |
+| 1 | 1 | F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F13, F14, F15 | 15 | Architecture, trust boundaries, persistence/recovery, privacy and adversarial input |
+| 2 | 2 | F16, F17, F18 | 3 | PostgreSQL ownership, transaction boundaries, history and privileged CI |
+| 3 | 3 | F19, F20 | 2 | Configuration refusal, routing defaults and verification scheduling |
+| 4 | 4 | F21, F22, F23 | 3 | State lifetime, Git commit boundaries and identity allocation |
+| 5 | 5 | F24, F25 | 2 | Parallel CLI configuration paths and disabled setup tests |
+| 6 | 6 | None | 0 | Lost-response integration and the remote retry contract |
+| 7 | 7 | F26 | 1 | Retry equivalence across local mutations and URL spellings |
+| 8 | 8 | F27 | 1 | Content preservation across local and remote write interfaces |
+| 9 | 9 | F28 | 1 | Authority of remote write acknowledgements and cache state |
+| 10 | 10 | F29 | 1 | Explicit private routing and deduplication siblings |
+| 11 | 11 | F30 | 1 | Adversarial model decisions, fresh state and mutation preconditions |
+| 12 | 12 | None | 0 | Remaining wire-field and absent-default serialization variants |
+| 14 | 13 | F32 | 1 | Runtime write shapes, batch preconditions and test isolation |
+| 15 | 14 | F33 | 1 | Within-batch identity admission and retries |
+| 17 | 15 | F35, F36, F37, F38, F40, F41, F44 | 7 | Public dependencies, adapters, telemetry, durability and process scheduling |
+| 20 | 16 | F53, F54 | 2 | Public-only re-scope; import and codemod data-safety review |
+| 21 | 17 | F55 | 1 | Packaged import execution, option ownership and default destination |
+| 22 | 18 | None | 0 | Fresh public-only audit of final source, trust boundaries, persistence and failure paths |
+
+Severity at classification: 9 BLOCKER, 31 IMPORTANT, 1 QUESTION, 1 HARDENING.
+
+### Cycle 1
+
+- **New findings:** F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F13, F14, F15.
+- **Previously known findings still open:** None at entry.
+- **Fresh audit:** Architecture, trust boundaries, persistence/recovery, privacy and adversarial input. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F13, F14, F15; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F13, F14, F15; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F01, F02, F03, F04, F05, F06, F07, F08, F09, F10, F11, F12, F13, F14, F15; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** Background sending initially retried excess work; process teardown signalled too late; archive binary scanning lost its limit flag. All corrected and tested.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 2
+
+- **New findings:** F16, F17, F18.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** PostgreSQL ownership, transaction boundaries, history and privileged CI. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F16, F17, F18; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F16, F17, F18; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F16, F17, F18; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** Post-commit embedding inherited expired ownership and reused clients accumulated listeners. Fixed; caught SQL errors cannot turn ROLLBACK into success.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 3
+
+- **New findings:** F19, F20.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Configuration refusal, routing defaults and verification scheduling. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F19, F20; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F19, F20; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F19, F20; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** A duplicated export in test config was caught and corrected; the failed run was retained.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 4
+
+- **New findings:** F21, F22, F23.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** State lifetime, Git commit boundaries and identity allocation. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F21, F22, F23; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F21, F22, F23; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F21, F22, F23; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** New fixtures had a schema omission and incorrect wire assertion; corrected without relaxing invariants.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 5
+
+- **New findings:** F24, F25.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Parallel CLI configuration paths and disabled setup tests. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F24, F25; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F24, F25; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F24, F25; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** A test-helper flag and noncanonical path expectation were corrected.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 6
+
+- **New findings:** None.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Lost-response integration and the remote retry contract. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F14; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F14; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F14; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 7
+
+- **New findings:** F26.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Retry equivalence across local mutations and URL spellings. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F26; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F26; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F26; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 8
+
+- **New findings:** F27.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Content preservation across local and remote write interfaces. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F27; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F27; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F27; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 9
+
+- **New findings:** F28.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Authority of remote write acknowledgements and cache state. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F28; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F28; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F28; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 10
+
+- **New findings:** F29.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Explicit private routing and deduplication siblings. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F29; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F29; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F29; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 11
+
+- **New findings:** F30.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Adversarial model decisions, fresh state and mutation preconditions. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F30; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F30; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F30; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 12
+
+- **New findings:** None.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Remaining wire-field and absent-default serialization variants. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F27; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F27; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F27; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 14
+
+- **New findings:** F32.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Runtime write shapes, batch preconditions and test isolation. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F32; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F32; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F32; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 15
+
+- **New findings:** F33.
+- **Previously known findings still open:** F14 remote integration guarantee; F15 advisory coverage also remained open through cycle 15. Other findings proceeded through targeted then whole-tree verification.
+- **Fresh audit:** Within-batch identity admission and retries. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F33; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F33; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F33; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14/F15 required further evidence.
+
+
+### Cycle 17
+
+- **New findings:** F35, F36, F37, F38, F40, F41, F44.
+- **Previously known findings still open:** F14 external server compatibility.
+- **Fresh audit:** Public dependencies, adapters, telemetry, durability and process scheduling. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F35, F36, F37, F38, F40, F41, F44; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F35, F36, F37, F38, F40, F41, F44; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F35, F36, F37, F38, F40, F41, F44; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** Process-heavy suites needed the derived serial lane; no timeout or assertion was weakened.
+- **Remaining substantive findings:** F14 external compatibility. All applicable public-source checks have now passed.
+
+
+### Cycle 20
+
+- **New findings:** F53, F54.
+- **Previously known findings still open:** F14 external server compatibility.
+- **Fresh audit:** Public-only re-scope; import and codemod data-safety review. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F53, F54; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F53, F54; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F53, F54; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** Initial import tests used an unsupported constructor option and cleanup method; corrected. Final adversarial review added invalid-UTF-8 preservation to F53.
+- **Remaining substantive findings:** F14 external compatibility. All applicable public-source checks have now passed.
+
+
+### Cycle 21
+
+- **New findings:** F55.
+- **Previously known findings still open:** F14 external server compatibility.
+- **Fresh audit:** Packaged import execution, option ownership and default destination. Current paths, nearby callers, trust/data flows and the preceding diff were reviewed.
+- **Bug classes discovered:** F55; root causes and invariants are in the registers below.
+- **Missing tests discovered:** failure sequences and bypass variants identified for F55; see regression evidence per finding.
+- **Fixes implemented:** public-source fixes and applicable siblings for F55; cycles without new findings attacked existing fixes or investigated the external contract.
+- **Tests added:** named regression suites/cases in the register; no cosmetic coverage target.
+- **Verification executed:** targeted failure reproduction and relevant regression suites; final executed command/results below supersede intermediate checkpoints.
+- **New issues caused by remediation:** None known beyond the variants consolidated into the referenced findings.
+- **Remaining substantive findings:** F14 external compatibility. All applicable public-source checks have now passed.
+
+
+### Cycle 22 — complete final fresh public-only review
+
+- **New findings:** none; zero new BLOCKER, IMPORTANT, actionable security, privacy, data-loss or correctness findings.
+- **Previously known findings still open:** F14 external server idempotency contract. Client changes are verified; compatible server behavior remains an independent requirement.
+- **Fresh audit:** re-read final import/learn and source-rewrite execution paths, inspect the final delta and maintenance siblings, reconsider store ownership, config/routing authority, UI/process boundaries, migration journals, remote acknowledgement/retry, PostgreSQL transactions, adapter transcripts, telemetry and dependency exposure. Explicitly challenged interruption, simultaneous import, stale editor/memory snapshots, malformed bytes, unexpected dependency responses and privileged model targets.
+- **Bug classes discovered:** none new. Every substantive public-source class is closed; the external portion of F14 remains OPEN.
+- **Missing tests discovered:** none new for the identified public-source invariants. The actual supported-server fault/replay qualification remains the material external test gap.
+- **Fixes implemented:** none in this cycle; it reviews the final system, including F53–F55, rather than confirming only the original finding list.
+- **Tests added:** none in this cycle; prior cycle regressions were exercised along with broad verification and actual packaged flows.
+- **Verification executed:** 5,810 full-suite passes/37 evaluated skips; final CLI delta independently rebuilt and tested (12 import cases), type-checked and included in corrected Python and packaged smoke execution. Final input hashes show only the two expected CLI files changed after the broad suite. See exact commands/results below.
+- **New issues caused by remediation:** none known. Verification-script/fixture errors are retained as failed attempts and corrected, not reclassified as passes.
+- **Remaining substantive findings:** F14 only. Stop under the explicit external-verification rule, not a claim of complete integration convergence.
+
+## 4. Complete remediation register
+
+Each row states the original finding/root cause, invariant, root-cause fix and sibling search, regression/bypass evidence, and status. Tests exercise behavior and disposable state. Runtime-dependent guarantees are qualified explicitly.
+
+| ID / severity | Original failure and root cause | Bug class / invariant | Fix and siblings searched/fixed | Regression and adversarial verification | Status |
+| --- | --- | --- | --- | --- | --- |
+| F01 BLOCKER | A transform throws before live persistence; failure recovery copies an old version backup over newer live rows. A second failure point writes migrated corpus before config version. | Recovery must preserve unrelated successful writes and reconcile interrupted multi-file commits. | Removed stale restore in both up/down. Validate config versions/mappings before mutation. Stage bytes with quarantined rows preserved; durable before/after hashes and target-version journal; retry completes config stamp, refuses changed live bytes. Backup uses atomic durable writes. Searched migration registry, config writers, rollback, serializer quarantine and lock order. | `audit-migration-preservation`: stale 1-row backup vs 2 live rows; up/down interruption; replay trap; intervening write refusal; invalid versions. Existing migrations pass. | RESOLVED |
+| F02 IMPORTANT | Nonexclusive predictable temp paths can follow symlinks; bytes initially have broad modes; async replacement changes file mode; directory fsync swallowed real errors. | First byte and acknowledged replacement must preserve confidentiality and report I/O failure. | Shared semantics in sync/async atomic writers: UUID, exclusive 0600 creation, explicit/preserved mode before bytes, fsync+rename, only owned temp cleanup; unsupported directory fsync distinguished from I/O failure. Searched backup/config/store callers. | `audit-atomic-write`: mode observed at first write, destination-mode preservation, planted temp symlink, victim bytes preserved; both writers reject directory EIO but tolerate unsupported EINVAL. | RESOLVED |
+| F03 BLOCKER | A stale-lock reclaimer can move a newly replaced live lock, temporarily permitting a second writer; remote-host age treated as death. | Exactly one cooperating writer enters; age is not proof of owner death. | One shared transition guard for sync/async acquisition and reclamation. Confirm local dead PID; fail closed for live/foreign owners and abandoned guard. Release checks ownership. Searched every filesystem lock implementation. | `audit-lock-recovery`, existing async contention/keys/write-concurrency tests. Guard blocks both APIs, foreign old lock retained; four independent sync/async child processes preserve all 80 increments and never overlap their critical-section sentinel. | RESOLVED |
+| F04 BLOCKER | Backup validates one read but copies another; restore verifies then rereads; state loss overwrites same-day history; superseded filenames collide. | Validation, checksum, acknowledgement and retained history describe immutable exact bytes. | Capture once, validate and write same buffer; retain existing daily snapshot; unique superseded names; atomic snapshot/state/sidecar writes. Searched backup creation, planning, restore, rotation, migration backups. | `audit-backup-snapshot`: swap path between reads, lost state hint, repeated restores at one timestamp; 28 targeted backup tests passed. | RESOLVED |
+| F05 IMPORTANT | Pack download/external tar execution lacks download/decompression/work bounds and archive-entry controls. | Untrusted archives cannot escape extraction or cause unbounded work. | Bounded streaming+timeout; bounded gunzip; pinned tar parser; reject links/special files, traversal, deep/oversized/excess entries before extraction; cleanup on failure. Searched URL/local preview/install paths. | `audit-pack-download`: oversized response, gzip bomb, link archive, signed URL error privacy; existing URL/pack tests. | RESOLVED |
+| F06 BLOCKER | An in-flight outbox success removes a later local edit; failure resurrects canceled metadata. Simultaneous/background flush paths duplicate sends; ID mapping was best-effort and saved after deletion. | Remote responses cannot overwrite newer local state; acknowledged local cleanup must have a durable receipt. | Compare canonical original snapshots under corpus lock; serialize upload workers across instances/processes; one protocol for background/explicit sends; atomic retained receipts before removal; retry consumes matching receipt; invalid receipt file fails closed. Searched learn, learnRouted, flush, rescope, forget, supersession mapping. | `audit-outbox-stale`: success/edit, failure/cancel, simultaneous instances, restart after failed local cleanup sends once. Existing outbox, cooldown and supersession suites. | RESOLVED locally; external retry guarantee tracked separately in F14 |
+| F07 IMPORTANT | Malformed UI URL throws outside async error boundary; optional desktop spawn errors are asynchronous and unhandled. | Untrusted requests/optional launch failures cannot terminate host. | Malformed targets return 400; both desktop launchers handle asynchronous spawn errors. Searched HTTP request and subprocess launch boundaries in CLI/UI. | Malformed HTTP target followed by a successful request; asynchronous ENOENT does not terminate the viewer. | RESOLVED |
+| F08 IMPORTANT | Heartbeat length/type/UTF-8 validation can throw or read unboundedly. Invalid nginx `limit_except` prevents TLS config loading; request log stores caller URLs. | Public ingress parsing is total and bounded; storage failure cannot be acknowledged; declared privacy config is deployable. | Strict length/media-type/type/calendar validation, UTF-8/recursion handling, private fsynced append with 503 on I/O failure; valid Nginx method rejection, URL-free access logs on TLS/redirect/bootstrap, strip Forwarded. Searched backend, both proxy configs, deployment/unit scripts. | 13 new real HTTP/fault cases, existing validation suite; isolated Nginx TLS and HTTP `-t` passed. | RESOLVED in repository; live deployment not certified |
+| F09 IMPORTANT | Provenance file name existence check races across processes; non-atomic writes; same-ms names sort wrongly; reference getter reads arbitrary JSON path. | Every distinct history snapshot survives, newest ordering is consistent, and references stay in store. | Per-engram lock+private atomic files; numerical collision order shared by dedup/list; real-path reference confinement; reject symlink directories before descending. Searched generation/export/history consumers. | `audit-provenance-safety`: 15 simultaneous versions across instances at frozen time, dedup latest, modes, outside JSON and configured symlink. Existing provenance tests. | RESOLVED |
+| F10 IMPORTANT | Timeout cleanup returns when parent dies, leaving descendants that ignore TERM or retain output pipes; a later unbounded communicate can hang. | Timeout is bounded and kills the owned process group before reaping its leader. | Both Python bridges signal TERM/KILL for full group, defer reaping to avoid PID reuse, bound draining. Searched subprocess/Popen/communicate siblings. | Real parent/grandchild tests with parent alive/exited and TERM-ignoring pipe owner; 284 Python tests passed; dedicated real process-tree tests include macOS zombie-group behavior. | RESOLVED |
+| F11 IMPORTANT | Hermes entrypoint registration test invoked the installed CLI with developer configuration. | Tests cannot contact configured real services or use personal stores accidentally. | Temporary PLUR_PATH and a status stub at the registration boundary; broad Python verification explicitly isolates PLUR_PATH and disables auto-discovery. | Entry-point tests pass. Initial run consulted developer configuration and made read requests before isolation; no destructive action was intentional. | RESOLVED |
+| F12 IMPORTANT | Expected-failure test: explicit email attribution makes otherwise safe memory unexportable due JSON punctuation/PII scan. | Chosen exported identity is allowed while every credential-bearing sibling remains scanned. | Mask only entire <=254-character valid email in declared asserted_by for privacy scanning, after its exact bytes pass all sensitive detectors. No whole attribution exemption. Searched export/preview/install/provenance. | Former expected failure now normal test; email export+preview; token-as-email, appended credential and adjacent field checks. | RESOLVED |
+| F13 IMPORTANT | Binary-ish NUL branch truncates input before detectors, hiding the over-limit signal and certifying an unseen tail. | Any unscanned region blocks installation. | Pass original NUL-normalized length to bounded detector; retain secret and truncation findings, preserve bounded injection scan. Search both text/binary/engram branches. | NUL + >1MiB benign prefix + trailing credential must block preview/install. | RESOLVED |
+| F14 IMPORTANT | Remote commit followed by response loss or failed local receipt persistence duplicates retried writes. | A logical retry must retain one durable request identity; acknowledgement must follow the data/receipt commit. | Public client persists intent before POST and retains its operation key through direct fallback, queue flush and explicit move. Client fix is complete; deduplication of a committed request requires a compatible server. | Client loss-of-response/restart/receipt-failure regressions pass. Complete deduplication additionally requires server-side enforcement qualified against the supported artifact; client or contract-fixture tests cannot establish that property. | OPEN — external server compatibility; public client remediation verified |
+| F15 QUESTION | Advisory coverage unavailable because the inventory-upload command was rejected. | Evaluate the public dependency inventory against a pinned advisory snapshot without an inventory upload. | Pinned public advisory snapshot; local matching of public pnpm lock entries and isolated Python dependencies. | 602 npm entries: zero matches/unknowns; 42 Python entries: two assessed optional-API matches, zero unknowns; 12 matcher self-tests. See F35 and verification. | RESOLVED |
+| F16 BLOCKER | Lock session can die while later writes use another pool connection; another writer commits, then stale save deletes its rows. Protected multi-step writes also partially commit. | Ownership loss must terminate the same transaction that owns writes. | One transaction/connection for advisory lock, reads and mutations; inner operations join it; aborted COMMIT rejected; detached contexts fenced; optional work queued after commit. Searched every getPool/acquire/BEGIN/COMMIT/ROLLBACK and core background caller. | `audit-postgres-lock-loss`: dropped owned backend preserves other writer, mid-operation rollback, caught SQL error, post-commit callback ordering, detached stale write refusal. All 125 real PG tests pass. | RESOLVED |
+| F17 HARDENING | Workflow actions use mutable tags; OIDC publisher downloads the current latest binary without checking bytes. | Privileged CI executes reviewed immutable code/artifacts. | Pin all external action refs to resolved full commits; pin MCP publisher v1.8.1 and verified SHA-256; CI guard rejects mutable refs. Searched all 11 workflows, permissions and PR triggers. | Public ref resolution; downloaded artifact SHA-256 matches release digest; guard rejects mutable fixture/accepts SHA+local; YAML and shell validation. Publication itself not executed. | RESOLVED |
+| F18 IMPORTANT | A short/crashed history append leaves a fragment that consumes the next event; fsync errors return true; file defaults expose private event content. | History acknowledgements reflect persistence and later valid events survive partial writes. | Monthly lock, private files, handle all short writes, delimit interrupted tail, reject unsafe month, propagate I/O failure into existing false+warning contract. Searched history readers, restore loss accounting and ID allocation. | `audit-history-preservation`: Unicode in 5-byte writes after broken tail; private mode; failed fsync returns false; unsafe month contained. Existing history suites retained. | RESOLVED |
+| F19 IMPORTANT | Existing corrupt/invalid config becomes defaults, potentially enabling capture or changing persistence/routing; YAML errors can include source secrets. | Unknown configuration cannot grant permission or replace explicit privacy settings. | Only a missing config permits defaults. Other read/parse/top-level failures refuse with source-free errors; public migration readers/writers use the same refusal policy. Searched config reload, backend/consent defaults, migration stamping and CLI writers. | `audit-config-fail-closed`: eight malformed/nonmapping/privacy cases including both migration entry points, unchanged file; compatibility and attribution tests, 55 total pass. | RESOLVED |
+| F20 IMPORTANT | New real CLI subprocess suites bypass manually duplicated serial lists; one timed out under full-suite load despite isolated pass. | Every integration suite remains included once and uses the intended process budget. | Derive subprocess membership from its import boundary and share one list between root/package configs; share PGLite membership too. Searched direct spawn and built-cli-helper siblings. | Core process lane: 155 pass / two existing skips; full client suite: 5,795 pass / 37 evaluated skips. Internal contention, assertions, retry budgets and test timeouts unchanged. | RESOLVED |
+| F21 IMPORTANT | Upload receipts and local-to-server relationships are authoritative, but their path is inside the disposable cache. Cache cleanup removes retry/relationship evidence. | Durable identity evidence outlives cache eviction. | Move to private state/outbox-id-map.json; under the flush lock validate/promote legacy cache before any send; retain legacy bytes, never fall back from corrupt/new state to stale cache. Ignore state/cache in generated Git configuration; retain the sync allowlist. Searched cache cleanup, receipts, relationship remapping and backups. | Five new cases in audit-outbox-stale: deletion/restart retains edge and private mode; corrupt legacy map; failed migration before POST; corrupt new map refuses stale fallback. | RESOLVED |
+| F22 BLOCKER | Git commit includes the complete index, so files staged before sync bypass the input allowlist and can leak secrets/private backup content. | Every committed non-deletion belongs to the allowed store surface. | Check all staged additions/changes with raw NUL-delimited names before and after canonical staging; refuse without discarding caller files/index. Apply at all init/normal/merge commit paths. Searched git add/commit and shared-scope filtering. | Six sync cases: .env, backups, state, pack extras, newline and leading-space filenames; refusal preserves HEAD, bytes and staging. Five reproductions failed before fix; targeted sync suites pass. | RESOLVED |
+| F23 BLOCKER | Per-process allocation cache is stale after another client creates/compacts an ID. Restart after diagnostic history loss also recycles a compacted ID, retargeting relationships/history/receipts to a new record. | A published identity is never released by corpus deletion, process restart or diagnostic-log failure. | Reserve local IDs atomically in private daily state before row publication; PostgreSQL reserves atomically in a persistent database table shared across clients; both learn and routed fallback use canonical allocation. Remove mutable cache; bound numeric sequence; readonly guard rejects the new mutation. Searched all generator/reservation callers and compaction/remote cleanup. | Stale-instance and restart reproductions failed; corruption/write-failure preservation cases; real PostgreSQL independent roots, 20 concurrent reservations and readonly refusal. PG suite: 127 pass. | RESOLVED |
+| F24 IMPORTANT | Parallel configuration paths bypassed safe core persistence: init overwrote remote/unknown keys, line parsing promoted nested text into routing authority, raw scalar interpolation broke token roundtrips, direct writes risked truncation and broad permissions, Cursor merge discarded unknown keys, login parse failure defaulted to empty state. Ignore failure could leave credentials published before protection. | Configuration mutations preserve unrelated values and secrecy; only validated top-level fields authorize routing. | Canonical full-document YAML parsing and locked partial updates for both init commands; malformed routing/login state refuses without source excerpts; shared private atomic writers for login, MCP/harness JSON, settings, telemetry and checkpoint state; explicit modes tighten only. Persist final effective Git ignore rule before token publication; preserve unknown Cursor settings. Searched every CLI file writer, reader and merge boundary. | Project-config nested/block-scalar and partial-update cases; quoted token/verify roundtrip, malformed-file preservation, ignore failure and real Git negation bypass; login corruption; Cursor extra keys; both atomic writers tighten 0644 to 0600 without broadening 0400. | RESOLVED |
+| F25 IMPORTANT | Four remote-setup integration cases were skipped as flaky; newline test accepted either exit status. Harness also leaked response state/timers and compared noncanonical macOS paths. | Important setup success/refusal paths execute with strict behavioral assertions in isolated environments. | Restore all four cases; use true argv arrays for control-character input; reset HTTP state; clear child timer and handle spawn failure; use canonical path expectation and isolated parent fixture. Reviewed all other skipped suites; remote update skips have active replacement coverage in remote-integration/set-pinned-remote. | Restored cases plus strict no-config/no-HTTP newline assertion; complete CLI and full-suite verification below. No new skips or increased timeouts. | RESOLVED |
+| F26 IMPORTANT | Local bookkeeping and equivalent endpoint spellings changed retry identity. | Same destination and transmitted content means the same operation. | Central wire fingerprint, canonical URL comparison, durable key reuse. | Counter, nested key-order, endpoint and absent-licence variants; exact request bytes survive restart and actual response loss. | RESOLVED |
+| F27 IMPORTANT | Supported context was omitted from the public wire body or swallowed by local/delegated/asynchronous deduplication. | Preserve supported supplied meaning through local persistence and serialization; refuse unsupported remote content before sending. | Canonical context comparison across public learn interfaces, source-history aggregation, complete supported wire fields, and explicit refusal of unsupported structured content. Reviewed local, routed, queued and move paths. | Context/dedup/serialization regressions, malformed/unsupported-field cases, exact retry body, no-send and source-preservation tests; local test dependency verifies the public request contract. | RESOLVED |
+| F28 IMPORTANT | Submitted state populated the remote cache despite a different server response. | Validated server state controls cache visibility and routed acknowledgements. | Validate returned state/scope, replace duplicate cache IDs, invalidate incomplete replies, propagate confirmed fields. | Held/foreign/malformed/ID-only acknowledgements, duplicate cache IDs and actual built-client review-state checks. | RESOLVED |
+| F29 BLOCKER | Explicitly private content took the remote branch of the routed writer. | Explicit private writes stay local and never enter the upload queue. | Route through the existing local writer when privacy is explicitly requested; related dedup checks preserve distinct privacy/context. | Before-fix network-call regression failed; after-fix checks no POST, durable local retrieval and no outbox marker. | RESOLVED |
+| F30 BLOCKER | Model-assisted dedup trusted arbitrary targets and stale state, bypassed canonical validation, and discarded differing context. | Model decisions act only on offered, eligible, unchanged candidates after validation. | Shared validation/context predicate; canonical ADD routing and selected-scope mutation guards; candidate binding; fresh scope/content/version/state checks inside mutation locks. | Foreign NOOP/UPDATE/MERGE targets, changed context, concurrent locks, stale pre-lock reads, malformed input before model call, valid update; 13 regression tests. | RESOLVED |
+| F32 IMPORTANT | Runtime callers could persist malformed context/replacement fields that schema readers later quarantine, and a meta batch could persist its valid prefix. | A successful local write remains readable; refusal preserves existing bytes and whole-batch preconditions. | Shared schema-derived context validation without default mutation; validate local replacements and full meta batches; explicit pin/feedback guards. Searched all learn, update, meta, pin and feedback entry points. | Runtime validation and preservation regressions across learn, replacement, meta batch, pin and feedback; full public verification. | RESOLVED |
+| F33 IMPORTANT | The meta-batch duplicate set contained only pre-existing IDs; two new records with one ID were both acknowledged as saved. | The persisted corpus has one accepted record per ID, including within a batch and across concurrent retries. | Reserve accepted IDs immediately in the locked batch set. Searched import, learn, batch and allocation siblings; import already updates its set, learn allocates under ownership. | A failing original reproduction now checks first-content preservation, accurate saved/skipped counts, retry, concurrent callers and reload. | RESOLVED |
+| F35 IMPORTANT | Old dependency bounds and lock entries retained vulnerable serialization and parsers. | Metadata stays data; parser bounds/destinations are preserved; supported versions include security fixes. | Updated public lockfile dependency selections and Python adapter minimums; inspected public manifests, deserialization paths, parser use and action references. | Four before/after serialization failures; adapter minimum/latest compatibility; bounded ID generation and parser regressions. Two unused optional Python APIs remain explicitly assessed, not claimed patched. | RESOLVED |
+| F36 IMPORTANT | Adapters assumed string content and passed multimodal lists/reprs to recall/extraction. | Valid text reaches memory unchanged; non-text blocks do not become memory inputs. | Shared message text conversion for chat history and legacy inputs/outputs. | Three failing-before multimodal recall/learning/legacy cases; positive plain-text and runnable tests retained. | RESOLVED |
+| F37 IMPORTANT | Broad catches hid failed recall and learning; malformed responses escaped validation. | Unavailable memory differs from empty memory; failed persistence is visible without leaking source details. | Shared learning/recall boundary raises exported `PlurMemoryError` with a fixed message; validates recall sections. | Six failing-before read/write/malformed-response tests; recovery and source-detail exclusion. | RESOLVED |
+| F38 IMPORTANT | Transcript and derived last-input state were read/changed separately across slow work; batch updates committed valid prefixes before later failure. | Recall uses one snapshot; failed batches leave transcript unchanged; concurrent completion cannot overwrite newer human state. | Materialize/validate batches, perform fallible learning before a locked transcript commit, snapshot reads and clear under the same lock. Individual durable learn calls remain deduplicated on retry. | Two failing-before batch retry/snapshot races and a concurrent delayed-AI/new-human test; 34 adapter tests pass at minimum/latest. | RESOLVED |
+| F40 IMPORTANT | A partial heartbeat append consumed the next valid record; directory creation was not covered by durable acknowledgement. | Later accepted records survive an interrupted append, and 204 follows durable bytes and directory entries. | POSIX file lock covers tail framing, append and fsync; preserve partial bytes, delimit the next record, report short writes and directory-sync failure. Searched history/provenance/collector append siblings. | Two failing-before HTTP tests; short return, exception after bytes, unterminated valid row, concurrent split writes and directory EIO cases. | RESOLVED |
+| F41 IMPORTANT | Separate counter/queue operations lacked ownership, interruption receipts, stable in-flight state and retry-aware accounting. | Every recorded increment survives; each accepted immutable delivery counts once; corruption never authorizes replacement/deletion. | Shared mutation/drain locks, private canonical persistence, rollover receipts, frozen delivery prefix/identity, acknowledgement subtraction, explicit corruption refusal; collector deduplication, quality flags and UTC activity windows. Searched counter hooks, exit/rollover flushes, collectors and all metric queries. | Four-process 120-increment case; rollover interruption; malformed-state preservation; concurrent drains; upgrade/lost-response/new-arrival retry; stale acknowledgement; real built-client/collector wire test; partial-input, backlog and UTC-boundary tests. | RESOLVED |
+| F44 IMPORTANT | Syncing a leaf directory did not establish durability of newly created ancestors; retries assumed existing directories were already durable. | A durable acknowledgement covers every directory entry on which the file depends, even after interrupted creation. | Shared ancestry traversal for sync/async durable writes; collector syncs ancestry on every append; canonical telemetry directory preparation. Searched atomic writers, append/history, backup, provenance, configuration, reservations and pending queue creation. Existing unsupported-filesystem limits remain explicit. | Two failing-before writer cases inject ancestor EIO on first write and retry, preserve visible bytes and verify bottom-up successful retry; collector interrupted-creation retry also failed before fix; telemetry first-directory failure preserves legacy counters and sends nothing. | RESOLVED |
+| F53 IMPORTANT | Source codemod followed file symlinks, swallowed scan/read errors and truncated files in place. Partial writes could destroy source; incomplete scans could report clean. | Source rewrites preserve original bytes on pre-replacement failure; unknown input is not a clean scan. | Exclusive staged write, original mode, fsync/rename, regular-file/hard-link checks, unchanged byte/inode check and explicit nonzero failure. Six sibling maintenance scripts share the helper. | Ten file-safety tests: symlinks, hard links, unreadable file/directory, partial write, rename failure, changed source, mode/fsync ordering, retry, invalid UTF-8. Six initial regressions failed before fix. | RESOLVED |
+| F54 IMPORTANT | Import first committed an incomplete row, then replaced it using an old snapshot. Interruption lost metadata; a concurrent edit could be overwritten; pre-read ID sets miscounted simultaneous imports. | Imported metadata is present in the initial acknowledged row; importing cannot replace a newer row with an earlier snapshot. | One canonical learn path with metadata initialization/validation before the first write; existing duplicates retain metadata. Creation result is captured under the write lock. Removed importer post-write replacement and stale creation-count set. | Five import preservation cases: initial bytes, concurrent edit, second-write failure/retry, malformed metadata before publication, simultaneous imports and restart. Original incomplete-row and stale-edit failures reproduced. | RESOLVED |
+| F55 IMPORTANT | The import command reused the input --path as the destination store when --store was absent, overriding PLUR_PATH. Tests always supplied --store and hid the documented default failure. | Input files never select persistence destinations; explicit store overrides otherwise use normal configured defaults. | Pass only --store into createPlur destination selection; otherwise let PLUR_PATH/default resolution apply. Reviewed sibling command flag handling. | Packaged command reproduces ENOTDIR before fix; environment-selected destination, explicit override precedence, input-byte preservation and import reload regressions. | RESOLVED |
+
+## 5. Bug-class register
+
+Instance counts are the minimum distinct implementation sites/interfaces identified, not a count of failing inputs. The complete register describes applicable variants and sibling searches.
+
+| Bug class | Instances found | Invariant | Remediation | Tests | Status |
+| --- | ---: | --- | --- | --- | --- |
+| Unsafe migration recovery (F01) | 2 | Recovery must preserve unrelated successful writes and reconcile interrupted multi-file commits. | F01: Removed stale restore in both up/down. Validate config versions/mappings before mutation. Stage bytes with quarantined rows preserved; durable before/after hashes and target-version journal; retry completes config stamp, refuses changed live bytes. Backup uses atomic durable writes. Searched migration registry, config writers, rollback, serializer quarantine and lock order. | `audit-migration-preservation`: stale 1-row backup vs 2 live rows; up/down interruption; replay trap; intervening write refusal; invalid versions. Existing migrations pass. | CLOSED |
+| Unsafe atomic replacement (F02) | 2 | First byte and acknowledged replacement must preserve confidentiality and report I/O failure. | F02: Shared semantics in sync/async atomic writers: UUID, exclusive 0600 creation, explicit/preserved mode before bytes, fsync+rename, only owned temp cleanup; unsupported directory fsync distinguished from I/O failure. Searched backup/config/store callers. | `audit-atomic-write`: mode observed at first write, destination-mode preservation, planted temp symlink, victim bytes preserved; both writers reject directory EIO but tolerate unsupported EINVAL. | CLOSED |
+| Lock reclamation race (F03) | 2 | Exactly one cooperating writer enters; age is not proof of owner death. | F03: One shared transition guard for sync/async acquisition and reclamation. Confirm local dead PID; fail closed for live/foreign owners and abandoned guard. Release checks ownership. Searched every filesystem lock implementation. | `audit-lock-recovery`, existing async contention/keys/write-concurrency tests. Guard blocks both APIs, foreign old lock retained; four independent sync/async child processes preserve all 80 increments and never overlap their critical-section sentinel. | CLOSED |
+| Backup snapshot drift (F04) | 3 | Validation, checksum, acknowledgement and retained history describe immutable exact bytes. | F04: Capture once, validate and write same buffer; retain existing daily snapshot; unique superseded names; atomic snapshot/state/sidecar writes. Searched backup creation, planning, restore, rotation, migration backups. | `audit-backup-snapshot`: swap path between reads, lost state hint, repeated restores at one timestamp; 28 targeted backup tests passed. | CLOSED |
+| Unbounded archive input (F05) | 3 | Untrusted archives cannot escape extraction or cause unbounded work. | F05: Bounded streaming+timeout; bounded gunzip; pinned tar parser; reject links/special files, traversal, deep/oversized/excess entries before extraction; cleanup on failure. Searched URL/local preview/install paths. | `audit-pack-download`: oversized response, gzip bomb, link archive, signed URL error privacy; existing URL/pack tests. | CLOSED |
+| Stale outbox acknowledgements (F06) | 3 | Remote responses cannot overwrite newer local state; acknowledged local cleanup must have a durable receipt. | F06: Compare canonical original snapshots under corpus lock; serialize upload workers across instances/processes; one protocol for background/explicit sends; atomic retained receipts before removal; retry consumes matching receipt; invalid receipt file fails closed. Searched learn, learnRouted, flush, rescope, forget, supersession mapping. | `audit-outbox-stale`: success/edit, failure/cancel, simultaneous instances, restart after failed local cleanup sends once. Existing outbox, cooldown and supersession suites. | CLOSED |
+| Unhandled boundary errors (F07) | 3 | Untrusted requests/optional launch failures cannot terminate host. | F07: Malformed targets return 400; both desktop launchers handle asynchronous spawn errors. Searched HTTP request and subprocess launch boundaries in CLI/UI. | Malformed HTTP target followed by a successful request; asynchronous ENOENT does not terminate the viewer. | CLOSED |
+| Ingress/privacy configuration (F08) | 3 | Public ingress parsing is total and bounded; storage failure cannot be acknowledged; declared privacy config is deployable. | F08: Strict length/media-type/type/calendar validation, UTF-8/recursion handling, private fsynced append with 503 on I/O failure; valid Nginx method rejection, URL-free access logs on TLS/redirect/bootstrap, strip Forwarded. Searched backend, both proxy configs, deployment/unit scripts. | 13 new real HTTP/fault cases, existing validation suite; isolated Nginx TLS and HTTP `-t` passed. | CLOSED |
+| Provenance ordering/confinement (F09) | 1 | Every distinct history snapshot survives, newest ordering is consistent, and references stay in store. | F09: Per-engram lock+private atomic files; numerical collision order shared by dedup/list; real-path reference confinement; reject symlink directories before descending. Searched generation/export/history consumers. | `audit-provenance-safety`: 15 simultaneous versions across instances at frozen time, dedup latest, modes, outside JSON and configured symlink. Existing provenance tests. | CLOSED |
+| Incomplete process teardown (F10) | 2 | Timeout is bounded and kills the owned process group before reaping its leader. | F10: Both Python bridges signal TERM/KILL for full group, defer reaping to avoid PID reuse, bound draining. Searched subprocess/Popen/communicate siblings. | Real parent/grandchild tests with parent alive/exited and TERM-ignoring pipe owner; 284 Python tests passed; dedicated real process-tree tests include macOS zombie-group behavior. | CLOSED |
+| Test environment escape (F11) | 1 | Tests cannot contact configured real services or use personal stores accidentally. | F11: Temporary PLUR_PATH and a status stub at the registration boundary; broad Python verification explicitly isolates PLUR_PATH and disables auto-discovery. | Entry-point tests pass. Initial run consulted developer configuration and made read requests before isolation; no destructive action was intentional. | CLOSED |
+| Attribution scan false positives (F12) | 2 | Chosen exported identity is allowed while every credential-bearing sibling remains scanned. | F12: Mask only entire <=254-character valid email in declared asserted_by for privacy scanning, after its exact bytes pass all sensitive detectors. No whole attribution exemption. Searched export/preview/install/provenance. | Former expected failure now normal test; email export+preview; token-as-email, appended credential and adjacent field checks. | CLOSED |
+| Unscanned-tail bypass (F13) | 1 | Any unscanned region blocks installation. | F13: Pass original NUL-normalized length to bounded detector; retain secret and truncation findings, preserve bounded injection scan. Search both text/binary/engram branches. | NUL + >1MiB benign prefix + trailing credential must block preview/install. | CLOSED |
+| Ambiguous remote acknowledgement (F14) | 3 | A logical retry must retain one durable request identity; acknowledgement must follow the data/receipt commit. | F14: Public client persists intent before POST and retains its operation key through direct fallback, queue flush and explicit move. Client fix is complete; deduplication of a committed request requires a compatible server. | Client loss-of-response/restart/receipt-failure regressions pass. Complete deduplication additionally requires server-side enforcement qualified against the supported artifact; client or contract-fixture tests cannot establish that property. | OPEN — external contract; client fixed |
+| Advisory coverage gap (F15) | 2 | Evaluate the public dependency inventory against a pinned advisory snapshot without an inventory upload. | F15: Pinned public advisory snapshot; local matching of public pnpm lock entries and isolated Python dependencies. | 602 npm entries: zero matches/unknowns; 42 Python entries: two assessed optional-API matches, zero unknowns; 12 matcher self-tests. See F35 and verification. | CLOSED |
+| Database ownership/transaction drift (F16) | 2 | Ownership loss must terminate the same transaction that owns writes. | F16: One transaction/connection for advisory lock, reads and mutations; inner operations join it; aborted COMMIT rejected; detached contexts fenced; optional work queued after commit. Searched every getPool/acquire/BEGIN/COMMIT/ROLLBACK and core background caller. | `audit-postgres-lock-loss`: dropped owned backend preserves other writer, mid-operation rollback, caught SQL error, post-commit callback ordering, detached stale write refusal. All 125 real PG tests pass. | CLOSED |
+| Mutable CI executable inputs (F17) | 7 | Privileged CI executes reviewed immutable code/artifacts. | F17: Pin all external action refs to resolved full commits; pin MCP publisher v1.8.1 and verified SHA-256; CI guard rejects mutable refs. Searched all 11 workflows, permissions and PR triggers. | Public ref resolution; downloaded artifact SHA-256 matches release digest; guard rejects mutable fixture/accepts SHA+local; YAML and shell validation. Publication itself not executed. | CLOSED |
+| Partial history append (F18) | 1 | History acknowledgements reflect persistence and later valid events survive partial writes. | F18: Monthly lock, private files, handle all short writes, delimit interrupted tail, reject unsafe month, propagate I/O failure into existing false+warning contract. Searched history readers, restore loss accounting and ID allocation. | `audit-history-preservation`: Unicode in 5-byte writes after broken tail; private mode; failed fsync returns false; unsafe month contained. Existing history suites retained. | CLOSED |
+| Configuration fail-open (F19) | 4 | Unknown configuration cannot grant permission or replace explicit privacy settings. | F19: Only a missing config permits defaults. Other read/parse/top-level failures refuse with source-free errors; public migration readers/writers use the same refusal policy. Searched config reload, backend/consent defaults, migration stamping and CLI writers. | `audit-config-fail-closed`: eight malformed/nonmapping/privacy cases including both migration entry points, unchanged file; compatibility and attribution tests, 55 total pass. | CLOSED |
+| Test scheduling drift (F20) | 3 | Every integration suite remains included once and uses the intended process budget. | F20: Derive subprocess membership from its import boundary and share one list between root/package configs; share PGLite membership too. Searched direct spawn and built-cli-helper siblings. | Core process lane: 155 pass / two existing skips; full client suite: 5,795 pass / 37 evaluated skips. Internal contention, assertions, retry budgets and test timeouts unchanged. | CLOSED |
+| Authoritative state under cache (F21) | 1 | Durable identity evidence outlives cache eviction. | F21: Move to private state/outbox-id-map.json; under the flush lock validate/promote legacy cache before any send; retain legacy bytes, never fall back from corrupt/new state to stale cache. Ignore state/cache in generated Git configuration; retain the sync allowlist. Searched cache cleanup, receipts, relationship remapping and backups. | Five new cases in audit-outbox-stale: deletion/restart retains edge and private mode; corrupt legacy map; failed migration before POST; corrupt new map refuses stale fallback. | CLOSED |
+| Pre-staged commit bypass (F22) | 3 | Every committed non-deletion belongs to the allowed store surface. | F22: Check all staged additions/changes with raw NUL-delimited names before and after canonical staging; refuse without discarding caller files/index. Apply at all init/normal/merge commit paths. Searched git add/commit and shared-scope filtering. | Six sync cases: .env, backups, state, pack extras, newline and leading-space filenames; refusal preserves HEAD, bytes and staging. Five reproductions failed before fix; targeted sync suites pass. | CLOSED |
+| Non-durable ID allocation (F23) | 2 | A published identity is never released by corpus deletion, process restart or diagnostic-log failure. | F23: Reserve local IDs atomically in private daily state before row publication; PostgreSQL reserves atomically in a persistent database table shared across clients; both learn and routed fallback use canonical allocation. Remove mutable cache; bound numeric sequence; readonly guard rejects the new mutation. Searched all generator/reservation callers and compaction/remote cleanup. | Stale-instance and restart reproductions failed; corruption/write-failure preservation cases; real PostgreSQL independent roots, 20 concurrent reservations and readonly refusal. PG suite: 127 pass. | CLOSED |
+| Divergent configuration paths (F24) | 11 | Configuration mutations preserve unrelated values and secrecy; only validated top-level fields authorize routing. | F24: Canonical full-document YAML parsing and locked partial updates for both init commands; malformed routing/login state refuses without source excerpts; shared private atomic writers for login, MCP/harness JSON, settings, telemetry and checkpoint state; explicit modes tighten only. Persist final effective Git ignore rule before token publication; preserve unknown Cursor settings. Searched every CLI file writer, reader and merge boundary. | Project-config nested/block-scalar and partial-update cases; quoted token/verify roundtrip, malformed-file preservation, ignore failure and real Git negation bypass; login corruption; Cursor extra keys; both atomic writers tighten 0644 to 0600 without broadening 0400. | CLOSED |
+| Disabled/ineffective setup tests (F25) | 5 | Important setup success/refusal paths execute with strict behavioral assertions in isolated environments. | F25: Restore all four cases; use true argv arrays for control-character input; reset HTTP state; clear child timer and handle spawn failure; use canonical path expectation and isolated parent fixture. Reviewed all other skipped suites; remote update skips have active replacement coverage in remote-integration/set-pinned-remote. | Restored cases plus strict no-config/no-HTTP newline assertion; complete CLI and full-suite verification below. No new skips or increased timeouts. | CLOSED |
+| Retry identity normalization (F26) | 4 | Same destination and transmitted content means the same operation. | F26: Central wire fingerprint, canonical URL comparison, durable key reuse. | Counter, nested key-order, endpoint and absent-licence variants; exact request bytes survive restart and actual response loss. | CLOSED |
+| Accepted-content loss (F27) | 5 | Preserve supported supplied meaning through local persistence and serialization; refuse unsupported remote content before sending. | F27: Canonical context comparison across public learn interfaces, source-history aggregation, complete supported wire fields, and explicit refusal of unsupported structured content. Reviewed local, routed, queued and move paths. | Context/dedup/serialization regressions, malformed/unsupported-field cases, exact retry body, no-send and source-preservation tests; local test dependency verifies the public request contract. | CLOSED |
+| Optimistic remote authority (F28) | 3 | Validated server state controls cache visibility and routed acknowledgements. | F28: Validate returned state/scope, replace duplicate cache IDs, invalidate incomplete replies, propagate confirmed fields. | Held/foreign/malformed/ID-only acknowledgements, duplicate cache IDs and actual built-client review-state checks. | CLOSED |
+| Private routing/dedup drift (F29) | 3 | Explicit private writes stay local and never enter the upload queue. | F29: Route through the existing local writer when privacy is explicitly requested; related dedup checks preserve distinct privacy/context. | Before-fix network-call regression failed; after-fix checks no POST, durable local retrieval and no outbox marker. | CLOSED |
+| Untrusted semantic decisions (F30) | 5 | Model decisions act only on offered, eligible, unchanged candidates after validation. | F30: Shared validation/context predicate; canonical ADD routing and selected-scope mutation guards; candidate binding; fresh scope/content/version/state checks inside mutation locks. | Foreign NOOP/UPDATE/MERGE targets, changed context, concurrent locks, stale pre-lock reads, malformed input before model call, valid update; 13 regression tests. | CLOSED |
+| Unchecked runtime write shapes (F32) | 9 | A successful local write remains readable; refusal preserves existing bytes and whole-batch preconditions. | F32: Shared schema-derived context validation without default mutation; validate local replacements and full meta batches; explicit pin/feedback guards. Searched all learn, update, meta, pin and feedback entry points. | Runtime validation and preservation regressions across learn, replacement, meta batch, pin and feedback; full public verification. | CLOSED |
+| Within-batch identity duplication (F33) | 1 | The persisted corpus has one accepted record per ID, including within a batch and across concurrent retries. | F33: Reserve accepted IDs immediately in the locked batch set. Searched import, learn, batch and allocation siblings; import already updates its set, learn allocates under ownership. | A failing original reproduction now checks first-content preservation, accurate saved/skipped counts, retry, concurrent callers and reload. | CLOSED |
+| Vulnerable dependency selection (F35) | 7 | Metadata stays data; parser bounds/destinations are preserved; supported versions include security fixes. | F35: Updated public lockfile dependency selections and Python adapter minimums; inspected public manifests, deserialization paths, parser use and action references. | Four before/after serialization failures; adapter minimum/latest compatibility; bounded ID generation and parser regressions. Two unused optional Python APIs remain explicitly assessed, not claimed patched. | CLOSED |
+| Message representation drift (F36) | 2 | Valid text reaches memory unchanged; non-text blocks do not become memory inputs. | F36: Shared message text conversion for chat history and legacy inputs/outputs. | Three failing-before multimodal recall/learning/legacy cases; positive plain-text and runnable tests retained. | CLOSED |
+| Hidden adapter failure (F37) | 3 | Unavailable memory differs from empty memory; failed persistence is visible without leaking source details. | F37: Shared learning/recall boundary raises exported `PlurMemoryError` with a fixed message; validates recall sections. | Six failing-before read/write/malformed-response tests; recovery and source-detail exclusion. | CLOSED |
+| Partial/concurrent transcripts (F38) | 3 | Recall uses one snapshot; failed batches leave transcript unchanged; concurrent completion cannot overwrite newer human state. | F38: Materialize/validate batches, perform fallible learning before a locked transcript commit, snapshot reads and clear under the same lock. Individual durable learn calls remain deduplicated on retry. | Two failing-before batch retry/snapshot races and a concurrent delayed-AI/new-human test; 34 adapter tests pass at minimum/latest. | CLOSED |
+| Interrupted collector append (F40) | 1 | Later accepted records survive an interrupted append, and 204 follows durable bytes and directory entries. | F40: POSIX file lock covers tail framing, append and fsync; preserve partial bytes, delimit the next record, report short writes and directory-sync failure. Searched history/provenance/collector append siblings. | Two failing-before HTTP tests; short return, exception after bytes, unterminated valid row, concurrent split writes and directory EIO cases. | CLOSED |
+| Telemetry ownership/accounting (F41) | 6 | Every recorded increment survives; each accepted immutable delivery counts once; corruption never authorizes replacement/deletion. | F41: Shared mutation/drain locks, private canonical persistence, rollover receipts, frozen delivery prefix/identity, acknowledgement subtraction, explicit corruption refusal; collector deduplication, quality flags and UTC activity windows. Searched counter hooks, exit/rollover flushes, collectors and all metric queries. | Four-process 120-increment case; rollover interruption; malformed-state preservation; concurrent drains; upgrade/lost-response/new-arrival retry; stale acknowledgement; real built-client/collector wire test; partial-input, backlog and UTC-boundary tests. | CLOSED |
+| Directory ancestry durability (F44) | 4 | A durable acknowledgement covers every directory entry on which the file depends, even after interrupted creation. | F44: Shared ancestry traversal for sync/async durable writes; collector syncs ancestry on every append; canonical telemetry directory preparation. Searched atomic writers, append/history, backup, provenance, configuration, reservations and pending queue creation. Existing unsupported-filesystem limits remain explicit. | Two failing-before writer cases inject ancestor EIO on first write and retry, preserve visible bytes and verify bottom-up successful retry; collector interrupted-creation retry also failed before fix; telemetry first-directory failure preserves legacy counters and sends nothing. | CLOSED |
+| Unsafe source maintenance I/O (F53) | 7 | Source rewrites preserve original bytes on pre-replacement failure; unknown input is not a clean scan. | F53: Exclusive staged write, original mode, fsync/rename, regular-file/hard-link checks, unchanged byte/inode check and explicit nonzero failure. Six sibling maintenance scripts share the helper. | Ten file-safety tests: symlinks, hard links, unreadable file/directory, partial write, rename failure, changed source, mode/fsync ordering, retry, invalid UTF-8. Six initial regressions failed before fix. | CLOSED |
+| Split import publication/stale replacement (F54) | 1 | Imported metadata is present in the initial acknowledged row; importing cannot replace a newer row with an earlier snapshot. | F54: One canonical learn path with metadata initialization/validation before the first write; existing duplicates retain metadata. Creation result is captured under the write lock. Removed importer post-write replacement and stale creation-count set. | Five import preservation cases: initial bytes, concurrent edit, second-write failure/retry, malformed metadata before publication, simultaneous imports and restart. Original incomplete-row and stale-edit failures reproduced. | CLOSED |
+| Input/destination option confusion (F55) | 1 | Input files never select persistence destinations; explicit store overrides otherwise use normal configured defaults. | F55: Pass only --store into createPlur destination selection; otherwise let PLUR_PATH/default resolution apply. Reviewed sibling command flag handling. | Packaged command reproduces ENOTDIR before fix; environment-selected destination, explicit override precedence, input-byte preservation and import reload regressions. | CLOSED |
+
+## 6. Data-loss assessment
+
+Examined creation/update/retirement/import, backup/restore, up/down migration, serialization quarantine, receipt/cache lifetime, concurrent ID allocation, PostgreSQL ownership loss/rollback, short writes, crash points, queue replay, stale responses, telemetry rollover and source codemods. Concrete failures included stale backup overwriting newer rows, lock loss allowing stale corpus replacement, interrupted history/collector append consuming the next record, late remote responses deleting newer edits, recycled IDs retargeting relationships, split import metadata publication, and in-place source truncation.
+
+Preservation tests inject I/O errors, kill database ownership, split appends, lose HTTP responses, interleave writers, interrupt migrations/rollover and restart clients. Fixed paths retain valid bytes/rows, durable identities and pending work or refuse rather than acknowledge uncertainty. F14 is the remaining external ambiguity: a committed remote operation may duplicate if the server does not honor the retained key. Local source data remains available for retry, but the public client cannot guarantee a remote database transaction.
+
+## 7. Security assessment
+
+Public protections now include bounded archive handling, fail-closed scan limits/configuration, private exclusive persistence, whole-index Git checks, confined provenance references, explicit-private routing, validated server acknowledgement authority, model-candidate/current-state checks, bounded ingress, private heartbeat logging and immutable CI action/artifact inputs. No production service or unrelated system was deliberately targeted. Live deployment and server authorization are not certified by this repository audit.
+
+Public dependency matching uses advisory snapshot `581f5c3232c22ad1873da770735ca668d2b17f35`, archive SHA-256 `8135fe6ea6644cd96aa39396ed0d2e4cde99ffcadf9c4cda117a6f7b0467f168`. Local matching found zero affected npm versions in 602 locked entries and two Python matches in 42 entries. The Python matches concern optional image-token URL fetching ([GHSA-2g6r-c272-w58r](https://github.com/advisories/GHSA-2g6r-c272-w58r)) and legacy prompt-file loading ([GHSA-qh6h-p6c9-ff54](https://github.com/advisories/GHSA-qh6h-p6c9-ff54)). The adapter does not call these APIs; multimodal input is reduced to text. This reachability assessment is not a claim those dependency versions contain the upstream patches, and host applications using those optional APIs need their own assessment.
+
+## 8. Missing-test assessment
+
+Added substantive invariant coverage for interruption/recovery, concurrent ownership, data preservation, stale acknowledgements, durable receipts/IDs, malformed input, scope/privacy, model decisions, migration rollback, source rewrite failures, import atomicity, configuration merge/permissions, actual HTTP faults and process-group teardown. Restored four skipped setup scenarios and replaced a permissive negative assertion. Existing live-provider/remote-deployment gates remain skipped without credentials; their skipped status is explicit. No new skip or relaxed assertion/timeout was introduced to make verification pass.
+
+The material remaining integration gap is proving the supported server's durable idempotency contract (F14) using response-loss, restart and concurrent-request cases against the actual distributable. A modified test dependency cannot fill that gap. OS/cloud/provider behavior not available here remains outside executed evidence.
+
+## 9. Verification performed
+
+Commands below were actually executed in the public repository. Sustained verification used process-scoped `caffeinate -i`. PostgreSQL tests used only the disposable local test database via `PLUR_TEST_POSTGRES_URL`; smoke used the same destination through `PLUR_SMOKE_POSTGRES_URL`. Python used an isolated `PLUR_PATH`, `PLUR_AUTO_DISCOVER=0`, package `PYTHONPATH` and `PLUR_CLI="node <repo>/packages/cli/dist/index.js"`.
+
+| Exact command/check | Result | Evidence log |
+| --- | --- | --- |
+| `pnpm build` | PASS | `build-public.log` |
+| `pnpm test --maxWorkers=4` | 5,810 passed, 37 skipped; 411 files passed, 5 skipped; 515.76 seconds | `full-public.log` |
+| `pnpm --filter @plur-ai/cli build` | PASS after F55 | `cli-build-final.log` |
+| `pnpm exec vitest run packages/cli/test/import.test.ts --maxWorkers=1` | 12 passed, including three new F55 cases | `cli-import-final.log` |
+| `pnpm typecheck:tests` | PASS on final source | `test-types-final.log` |
+| `pnpm --filter @plur-ai/core exec tsc --noEmit` | PASS | `core-types.log` |
+| `pnpm --filter @plur-ai/migrate exec tsc --noEmit` | PASS | `migrate-types.log` |
+| `pnpm --filter @plur-ai/cli exec tsc --noEmit` | PASS on final source | `cli-types-final.log` |
+| `/tmp/plur-audit-python-clean/bin/python -m pytest packages/python packages/hermes packages/langchain infra/heartbeat -q --import-mode=importlib` | 312 passed, 7 warnings, 33.31 seconds | `python-public-corrected.log` |
+| `bash scripts/smoke-release.sh` | 19 passed, zero failed, including packaged migration and actual PostgreSQL end-to-end flow | `smoke-public.log` |
+| `python3 scripts/check-workflow-pins.py` | PASS | `workflow-pins.log` |
+| `python3 spec/vectors/build.py --check` | PASS | `vectors-build.log` |
+| `python3 spec/vectors/build_capsules.py --check` | PASS | `vectors-capsules.log` |
+| `python3 spec/vectors/verify.py --index spec/vectors/index.json --capsules spec/vectors/capsules.json` | PASS: 26 fixtures, zero failures, 8 expected notes | `vectors-verify.log` |
+| `git diff --check` | PASS | `diff-check.log` |
+| Python `yaml.safe_load` over all 11 public workflow YAML files | PASS | `static.json` |
+| `node --check` on six modified maintenance scripts and `packages/migrate/src/files.js` | PASS | `static.json` lists exact files |
+| `node packages/migrate/dist/index.js <disposable-source> --write` | PASS: rewrite, mode preservation, retry contract; symlink invocation deliberately exits 1 and preserves target | `packaged-codemod.json` records exact argv |
+| Isolated Python `inventory.py`, `node offline-match.cjs`, isolated Python `offline-pypi.py` | 602 npm entries/1,275 comparisons: zero matches/unknowns; 42 Python entries/94 comparisons: two assessed optional-API matches, zero unknowns; 12 matcher self-tests | Local matching scripts and JSON results |
+
+The broad suite ran before the final one-line CLI destination fix and its three added cases. SHA-256 comparison of 901 non-document inputs confirms that only `packages/cli/src/commands/import.ts` and its test changed afterward. The final CLI build, 12 integration tests, type checks, Python bridge tests and packaged smoke cover that delta. No second broad pass is claimed.
+
+Earlier real-wire evidence remains applicable to unchanged paths: built public client → fault proxy → disposable contract fixture passed exact request identity/content and authoritative review-state checks (`client-integration-security9.log`); built public telemetry → actual Python collector passed lost-response/retry/new-arrival accounting (`telemetry-wire-final2.log`). Contract fixtures do not certify supported-server compatibility. Public nginx HTTP/TLS configuration syntax was checked with isolated Nginx `-t` earlier. A 50-iteration public micro-benchmark completed (`micro-durability.log`); no model-backed dedup benchmark or controlled before/after performance claim is made.
+
+Failure evidence is retained: six initial source-codemod regressions failed; import tests demonstrated incomplete first publication and stale replacement (an invalid test cleanup method was also corrected). A type check caught unsupported constructor options in the new fixture. One Python run failed five tests because the audit runner selected a nonexistent CLI entry point; the corrected command passed all 312 tests. The initial manual CLI probe also used the wrong filename; the corrected probe reproduced the actual ENOTDIR destination bug. No failed attempt is counted as a pass or hidden by skipping a test.
+
+Existing 37 skips are evaluated live-provider/deployment gates and legacy remote-update cases with active replacement coverage. No new skip or relaxed timeout/assertion was introduced. The repository declares no dedicated lint command; no unexecuted linter is claimed.
+
+Exact command arrays/exits, input hashes, source delta, scripts and logs are retained in the local audit evidence bundle. The report contains no other-repository source findings.
+
+## 10. Residual risk and required external action
+
+To close F14, supply a supported server artifact that commits the record and idempotency receipt together and enforces replay authorization/payload consistency. Run the public client against that exact artifact with lost-response, restart and simultaneous retry probes; prove one logical record with preserved content and truthful state. Until then the whole integration cannot receive an unqualified clean verdict.
+
+Physical power-loss, filesystem/controller behavior, hostile same-account filesystem mutation, Windows/NFS semantics, live model providers and hosted CI matrices were not fully exercised. Source codemods require a quiet working tree: their pre-replacement change detection cannot synchronize with an arbitrary editor that ignores ownership conventions. A fsync failure after rename is reported as ambiguous rather than a successful durable acknowledgement. Dependency findings are limited by snapshot and reachability evidence. No guarantee of vulnerability freedom is made.
+
+## Workspace and cleanup
+
+Verification was performed on the isolated audit branch before publication for review. The eight disposable containers selected by label `plur.audit=2026-09-08-resume` were stopped after verification; no Docker volumes were removed and pre-existing containers were not targeted. Exact cleanup targets/results are in private local evidence. The audit did not merge changes or perform a production deployment.

--- a/infra/heartbeat/nginx-heartbeat-http.conf
+++ b/infra/heartbeat/nginx-heartbeat-http.conf
@@ -4,7 +4,7 @@
 # Remove once heartbeat.plur-ai.org HTTPS is live.
 
 limit_req_zone $binary_remote_addr zone=heartbeat_tmp:10m rate=60r/m;
-log_format heartbeat_privacy '$time_iso8601 "$request" $status $body_bytes_sent';
+log_format heartbeat_privacy '$time_iso8601 "$request_method" $status $body_bytes_sent';
 
 server {
     listen 80;
@@ -23,6 +23,7 @@ server {
         proxy_http_version 1.1;
 
         # Strip all IP-identifying headers
+        proxy_set_header   Forwarded "";
         proxy_set_header   X-Real-IP "";
         proxy_set_header   X-Forwarded-For "";
         proxy_set_header   X-Forwarded-Proto "";

--- a/infra/heartbeat/nginx-heartbeat.conf
+++ b/infra/heartbeat/nginx-heartbeat.conf
@@ -5,11 +5,12 @@
 limit_req_zone $binary_remote_addr zone=heartbeat:10m rate=60r/m;
 # log_format must be in http context (not inside server {}); placed here so the
 # include from sites-enabled inherits it at the right scope level.
-log_format heartbeat_privacy '$time_iso8601 "$request" $status $body_bytes_sent';
+log_format heartbeat_privacy '$time_iso8601 "$request_method" $status $body_bytes_sent';
 
 server {
     listen 80;
     server_name heartbeat.plur-ai.org;
+    access_log /var/log/nginx/heartbeat.plur-ai.org.access.log heartbeat_privacy;
     # Let certbot ACME challenge through; redirect everything else
     location /.well-known/acme-challenge/ { root /var/www/certbot; }
     location / { return 301 https://$host$request_uri; }
@@ -31,7 +32,7 @@ server {
     limit_req zone=heartbeat burst=10 nodelay;
 
     location /v1/heartbeat {
-        limit_except POST { return 405; }
+        if ($request_method != POST) { return 405; }
 
         client_max_body_size 1k;
 
@@ -39,6 +40,7 @@ server {
         proxy_http_version 1.1;
 
         # Strip all IP-identifying headers
+        proxy_set_header   Forwarded "";
         proxy_set_header   X-Real-IP "";
         proxy_set_header   X-Forwarded-For "";
         proxy_set_header   X-Forwarded-Proto "";

--- a/infra/heartbeat/query.py
+++ b/infra/heartbeat/query.py
@@ -19,14 +19,28 @@ import sys
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from server import validate, UUID_RE
 
 DATA_DIR = Path(os.environ.get("HEARTBEAT_DATA_DIR", "/var/lib/plur-heartbeat"))
 METRICS_DIR = Path(os.environ.get("METRICS_DIR", "/var/lib/plur-metrics"))
 
 
-def load_records(since: date, until: date) -> list[dict]:
+class LoadedRecords(list):
+    def __init__(self, records, invalid_lines, conflicts):
+        super().__init__(records)
+        self.quality = {
+            "status": "partial" if invalid_lines or conflicts else "complete",
+            "invalid_lines": invalid_lines,
+            "conflicting_deliveries": conflicts,
+        }
+
+
+def load_records(since: date, until: date) -> LoadedRecords:
     """Load all records from JSONL files in date range [since, until]."""
     records = []
+    deliveries = {}
+    conflicts = set()
+    invalid_lines = 0
     current = since
     while current <= until:
         path = DATA_DIR / f"{current.isoformat()}.jsonl"
@@ -36,11 +50,35 @@ def load_records(since: date, until: date) -> list[dict]:
                     line = line.strip()
                     if line:
                         try:
-                            records.append(json.loads(line))
+                            record = json.loads(line)
                         except json.JSONDecodeError:
-                            pass
+                            invalid_lines += 1
+                            continue
+                        if not isinstance(record, dict):
+                            invalid_lines += 1
+                            continue
+                        delivery_id = record.get("_delivery_id")
+                        payload = {key: value for key, value in record.items() if key != "_delivery_id"}
+                        if validate(payload) or (delivery_id is not None and (not isinstance(delivery_id, str) or not UUID_RE.fullmatch(delivery_id))):
+                            invalid_lines += 1
+                            continue
+                        # A queued heartbeat may arrive long after its activity.
+                        # Arrival today must not make old/future activity current.
+                        if not since <= date.fromisoformat(record["date"]) <= until:
+                            continue
+                        if delivery_id:
+                            key = (record.get("install_id"), delivery_id)
+                            if key in deliveries:
+                                if deliveries[key] != record:
+                                    conflicts.add(key)
+                                continue
+                            deliveries[key] = record
+                        records.append(record)
         current += timedelta(days=1)
-    return records
+    return LoadedRecords(
+        [record for record in records if (record.get("install_id"), record.get("_delivery_id")) not in conflicts],
+        invalid_lines, len(conflicts),
+    )
 
 
 def weekly_active_count(days: int = 7) -> dict:
@@ -48,7 +86,7 @@ def weekly_active_count(days: int = 7) -> dict:
     Count distinct install_ids with any activity in the last N days.
     This is the primary H004/H005 metric.
     """
-    until = date.today()
+    until = datetime.now(timezone.utc).date()
     since = until - timedelta(days=days - 1)
     records = load_records(since, until)
 
@@ -60,6 +98,7 @@ def weekly_active_count(days: int = 7) -> dict:
 
     return {
         "window_days": days,
+        "data_quality": records.quality,
         "since": since.isoformat(),
         "until": until.isoformat(),
         "weekly_active_count": len(active_installs),
@@ -70,7 +109,7 @@ def weekly_active_count(days: int = 7) -> dict:
 
 def summary_stats(days: int = 7) -> dict:
     """Full summary: active installs, learn/recall rates, version distribution."""
-    until = date.today()
+    until = datetime.now(timezone.utc).date()
     since = until - timedelta(days=days - 1)
     records = load_records(since, until)
 
@@ -107,6 +146,7 @@ def summary_stats(days: int = 7) -> dict:
 
     return {
         "window_days": days,
+        "data_quality": records.quality,
         "since": since.isoformat(),
         "until": until.isoformat(),
         "total_opted_in_installs": active,
@@ -117,9 +157,9 @@ def summary_stats(days: int = 7) -> dict:
         "strong_signal_pct": round(strong_pct, 1),
         "any_activity_installs": any_activity,
         "any_activity_pct": round(any_pct, 1),
-        "h004_threshold_strong": ">=30% strong signal → PASS" if strong_pct >= 30 else f"{strong_pct:.1f}% < 30% → NOT YET",
-        "h004_threshold_mixed": ">=50% any activity → mixed signal" if any_pct >= 50 else f"{any_pct:.1f}% < 50%",
-        "h004_threshold_invalidation": "<20% any activity → INVALIDATED" if any_pct < 20 and active >= 30 else "not invalidated",
+        "h004_threshold_strong": "UNAVAILABLE: partial input" if records.quality["status"] != "complete" else ">=30% strong signal → PASS" if strong_pct >= 30 else f"{strong_pct:.1f}% < 30% → NOT YET",
+        "h004_threshold_mixed": "UNAVAILABLE: partial input" if records.quality["status"] != "complete" else ">=50% any activity → mixed signal" if any_pct >= 50 else f"{any_pct:.1f}% < 50%",
+        "h004_threshold_invalidation": "UNAVAILABLE: partial input" if records.quality["status"] != "complete" else "<20% any activity → INVALIDATED" if any_pct < 20 and active >= 30 else "not invalidated",
         "sample_floor_met": active >= 30,
         "sample_floor_note": f"{active}/30 required installs — {'FLOOR MET' if active >= 30 else 'below floor, no threshold calls yet'}",
     }
@@ -131,7 +171,7 @@ def mau_stats() -> dict:
     Single pass over 30d of records; computes MAU/WAU/DAU from distinct install_ids.
     Output written to METRICS_DIR/YYYY-MM-DD.json when --write is used.
     """
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     since_30d = today - timedelta(days=29)
     records = load_records(since_30d, today)
 
@@ -158,6 +198,7 @@ def mau_stats() -> dict:
 
     return {
         "date": today.isoformat(),
+        "data_quality": records.quality,
         "mau_30d": len(ids_30d),
         "wau_7d": len(ids_7d),
         "dau_1d": len(ids_1d),
@@ -190,7 +231,7 @@ def main():
         days = args.days
         if args.since:
             since = date.fromisoformat(args.since)
-            days = (date.today() - since).days + 1
+            days = (datetime.now(timezone.utc).date() - since).days + 1
         result = weekly_active_count(days)
         print(json.dumps(result, indent=2))
 

--- a/infra/heartbeat/server.py
+++ b/infra/heartbeat/server.py
@@ -5,10 +5,11 @@ Appends validated payloads to /var/lib/plur-heartbeat/YYYY-MM-DD.jsonl
 No external dependencies beyond stdlib.
 """
 import json
+import fcntl
 import os
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Optional
@@ -31,6 +32,8 @@ KNOWN_FIELDS = frozenset({"install_id", "version", "platform", "date", "learn_co
 
 def validate(payload: dict) -> Optional[str]:
     """Return error string or None if valid."""
+    if not isinstance(payload, dict):
+        return "payload must be a JSON object"
     unknown = set(payload.keys()) - KNOWN_FIELDS
     if unknown:
         return f"unknown fields: {', '.join(sorted(unknown))}"
@@ -38,18 +41,50 @@ def validate(payload: dict) -> Optional[str]:
     missing = required - payload.keys()
     if missing:
         return f"missing fields: {', '.join(sorted(missing))}"
-    if not isinstance(payload["install_id"], str) or not UUID_RE.match(payload["install_id"]):
+    if not isinstance(payload["install_id"], str) or not UUID_RE.fullmatch(payload["install_id"]):
         return "install_id must be UUID v4"
-    if not isinstance(payload["version"], str) or not VERSION_RE.match(payload["version"]):
+    if not isinstance(payload["version"], str) or not VERSION_RE.fullmatch(payload["version"]):
         return "version must match semver"
-    if payload["platform"] not in PLATFORMS:
+    if not isinstance(payload["platform"], str) or payload["platform"] not in PLATFORMS:
         return f"platform must be one of {PLATFORMS}"
-    if not isinstance(payload["date"], str) or not DATE_RE.match(payload["date"]):
+    if not isinstance(payload["date"], str) or not DATE_RE.fullmatch(payload["date"]):
         return "date must be YYYY-MM-DD"
+    try:
+        date.fromisoformat(payload["date"])
+    except ValueError:
+        return "date must be a valid calendar date"
     for field in ("learn_count", "recall_count", "session_count"):
         if not isinstance(payload[field], int) or isinstance(payload[field], bool) or payload[field] < 0:
             return f"{field} must be non-negative integer"
     return None
+
+
+def append_record(out_path: Path, payload: dict) -> None:
+    """Serialize append/recovery across threads and processes, preserving bytes."""
+    out_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    line = (json.dumps(payload, separators=(",", ":")) + "\n").encode()
+    fd = os.open(out_path, os.O_RDWR | os.O_APPEND | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        size = os.fstat(fd).st_size
+        # A previous process can have stopped midway through a record. Keep
+        # those bytes, but never fuse the next accepted record with that tail.
+        if size and os.pread(fd, 1, size - 1) != b"\n":
+            line = b"\n" + line
+        if os.write(fd, line) != len(line):
+            raise OSError("incomplete heartbeat append")
+        os.fsync(fd)
+        # Recheck ancestry on retry too: an interrupted earlier creation may
+        # have left directories present without durable parent entries.
+        directory = out_path.parent.resolve()
+        for directory in [directory, *directory.parents]:
+            directory_fd = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    finally:
+        os.close(fd)  # also releases flock, including on an interrupted append
 
 
 class HeartbeatHandler(BaseHTTPRequestHandler):
@@ -74,19 +109,30 @@ class HeartbeatHandler(BaseHTTPRequestHandler):
             return
 
         ct = self.headers.get("Content-Type", "")
-        if "application/json" not in ct:
+        if ct.split(";", 1)[0].strip().lower() != "application/json":
             self.send_plain(400, "Content-Type must be application/json")
             return
 
-        length = int(self.headers.get("Content-Length", 0))
-        if length > MAX_BODY:
+        lengths = self.headers.get_all("Content-Length", [])
+        if self.headers.get("Transfer-Encoding") or len(lengths) != 1 or not re.fullmatch(r"[0-9]{1,6}", lengths[0]):
+            self.send_plain(400, "invalid Content-Length")
+            return
+        length = int(lengths[0])
+        if length <= 0 or length > MAX_BODY:
             self.send_plain(400, "payload too large")
             return
 
-        raw = self.rfile.read(length)
+        try:
+            raw = self.rfile.read(length)
+        except (TimeoutError, OSError):
+            self.send_plain(408, "incomplete request")
+            return
+        if len(raw) != length:
+            self.send_plain(400, "incomplete request")
+            return
         try:
             payload = json.loads(raw)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError, RecursionError):
             self.send_plain(400, "invalid JSON")
             return
 
@@ -99,13 +145,22 @@ class HeartbeatHandler(BaseHTTPRequestHandler):
             self.send_plain(400, err)
             return
 
+        delivery_ids = self.headers.get_all("Idempotency-Key", [])
+        if len(delivery_ids) > 1 or (delivery_ids and not UUID_RE.fullmatch(delivery_ids[0])):
+            self.send_plain(400, "invalid Idempotency-Key")
+            return
+        if delivery_ids:
+            # A retry keeps this identity. Raw arrivals remain an append-only
+            # record; queries count each logical delivery once.
+            payload = {**payload, "_delivery_id": delivery_ids[0]}
+
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         out_path = DATA_DIR / f"{date_str}.jsonl"
-        DATA_DIR.mkdir(parents=True, exist_ok=True)
-
-        line = json.dumps(payload, separators=(",", ":")) + "\n"
-        with open(out_path, "a") as f:
-            f.write(line)
+        try:
+            append_record(out_path, payload)
+        except OSError:
+            self.send_plain(503, "storage unavailable")
+            return
 
         self.send_response(204)
         self.end_headers()

--- a/infra/heartbeat/test_http.py
+++ b/infra/heartbeat/test_http.py
@@ -168,3 +168,200 @@ def test_access_log_is_suppressed(capsys, ingress):
     captured = capsys.readouterr()
     assert "127.0.0.1" not in captured.err
     assert "127.0.0.1" not in captured.out
+
+
+@pytest.mark.parametrize("payload", [
+    {**VALID, "platform": []}, {**VALID, "platform": {}},
+    {**VALID, "date": "2026-02-31"}, {**VALID, "date": "2026-07-17\n"},
+    {**VALID, "install_id": VALID["install_id"] + "\n"},
+    {**VALID, "version": "1.0.0\n"}, b"\xff", b"[" * 1000,
+])
+def test_adversarial_payload_returns_400_without_writing(ingress, payload):
+    status, _ = request(ingress, body=payload)
+    assert status == 400
+    assert list(ingress[2].glob("*.jsonl")) == []
+
+
+@pytest.mark.parametrize("length", ["-1", "garbage", "1.5", "999999999999999999999"])
+def test_malformed_length_is_bounded(ingress, length):
+    conn = HTTPConnection(ingress[0], ingress[1], timeout=2)
+    try:
+        conn.request("POST", "/v1/heartbeat", headers={"Content-Type": "application/json", "Content-Length": length})
+        assert conn.getresponse().status == 400
+    finally:
+        conn.close()
+
+
+def test_fsync_failure_is_not_acknowledged(ingress, monkeypatch):
+    def fail(_fd):
+        raise OSError("injected disk failure")
+    monkeypatch.setattr(server.os, "fsync", fail)
+    status, _ = request(ingress, body=VALID)
+    assert status == 503
+
+
+@pytest.mark.parametrize("failure", ["short", "error"])
+def test_failed_partial_append_cannot_hide_the_next_accepted_record(ingress, monkeypatch, failure):
+    real_write = server.os.write
+
+    def partial(fd, data):
+        real_write(fd, data[:9])
+        if failure == "short":
+            return 9
+        raise OSError("injected interrupted write")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(server.os, "write", partial)
+        assert request(ingress, body=VALID)[0] == 503
+    accepted = {**VALID, "learn_count": 71}
+    assert request(ingress, body=accepted)[0] == 204
+    lines = next(ingress[2].glob("*.jsonl")).read_text().splitlines()
+    assert json.loads(lines[-1]) == accepted
+
+
+def test_existing_unterminated_record_is_preserved_on_append(ingress):
+    day = server.datetime.now(server.timezone.utc).strftime("%Y-%m-%d")
+    target = ingress[2] / f"{day}.jsonl"
+    target.write_text(json.dumps(VALID))
+    accepted = {**VALID, "learn_count": 72}
+    assert request(ingress, body=accepted)[0] == 204
+    assert [json.loads(line) for line in target.read_text().splitlines()] == [VALID, accepted]
+
+
+def test_concurrent_appends_cannot_interleave_partial_writes(tmp_path, monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+    real_write = server.os.write
+    entered = threading.Event()
+    release = threading.Event()
+
+    def delayed_write(fd, data):
+        split = len(data) // 2
+        real_write(fd, data[:split])
+        entered.set()
+        assert release.wait(3)
+        real_write(fd, data[split:])
+        return len(data)
+
+    target = tmp_path / "concurrent.jsonl"
+    monkeypatch.setattr(server.os, "write", delayed_write)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(server.append_record, target, VALID)
+        assert entered.wait(3)
+        second = executor.submit(server.append_record, target, {**VALID, "learn_count": 73})
+        try:
+            assert not second.done()
+        finally:
+            release.set()
+        first.result(timeout=3)
+        second.result(timeout=3)
+    assert [json.loads(line)["learn_count"] for line in target.read_text().splitlines()] == [5, 73]
+
+
+def test_directory_sync_failure_is_not_acknowledged(ingress, monkeypatch):
+    import stat
+    real_fsync = server.os.fsync
+
+    def fail_directory(fd):
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError("injected directory sync failure")
+        real_fsync(fd)
+
+    monkeypatch.setattr(server.os, "fsync", fail_directory)
+    assert request(ingress, body=VALID)[0] == 503
+
+
+def test_ancestor_sync_failure_is_rechecked_after_interrupted_directory_creation(tmp_path, monkeypatch):
+    target = tmp_path / "new" / "nested" / "records.jsonl"
+    ancestor = tmp_path.stat()
+    real_fsync = server.os.fsync
+
+    def fail_ancestor(fd):
+        current = os.fstat(fd)
+        if (current.st_dev, current.st_ino) == (ancestor.st_dev, ancestor.st_ino):
+            raise OSError("injected ancestor sync failure")
+        real_fsync(fd)
+
+    monkeypatch.setattr(server.os, "fsync", fail_ancestor)
+    for _ in range(2):
+        with pytest.raises(OSError, match="ancestor sync"):
+            server.append_record(target, VALID)
+    monkeypatch.setattr(server.os, "fsync", real_fsync)
+    server.append_record(target, VALID)
+    assert [json.loads(line) for line in target.read_text().splitlines()] == [VALID] * 3
+
+
+def test_retry_delivery_is_counted_once_across_restart_days(ingress, monkeypatch):
+    import query
+    monkeypatch.setattr(query, "DATA_DIR", ingress[2])
+    payload = {**VALID, "date": server.datetime.now(server.timezone.utc).date().isoformat()}
+    headers = {"Content-Type": "application/json", "Idempotency-Key": "a23e4567-e89b-4d3c-a456-426614174000"}
+    assert request(ingress, body=payload, headers=headers)[0] == 204
+    # Simulate response loss followed by retry. Both arrivals remain durable.
+    assert request(ingress, body=payload, headers=headers)[0] == 204
+    written = next(ingress[2].glob("*.jsonl"))
+    rows = written.read_text().splitlines()
+    assert len(rows) == 2
+    # The same receipt may be resent after midnight or process restart.
+    previous = server.datetime.now(server.timezone.utc).date() - query.timedelta(days=1)
+    (ingress[2] / f"{previous.isoformat()}.jsonl").write_text(rows[0] + "\n")
+    today = server.datetime.now(server.timezone.utc).date()
+    result = query.load_records(previous, today)
+    assert len(result) == 1
+    assert result[0]["learn_count"] == VALID["learn_count"]
+
+
+def test_conflicting_delivery_cannot_produce_plausible_metrics(ingress, monkeypatch):
+    import query
+    monkeypatch.setattr(query, "DATA_DIR", ingress[2])
+    payload = {**VALID, "date": server.datetime.now(server.timezone.utc).date().isoformat()}
+    headers = {"Content-Type": "application/json", "Idempotency-Key": "b23e4567-e89b-4d3c-a456-426614174000"}
+    assert request(ingress, body=payload, headers=headers)[0] == 204
+    assert request(ingress, body={**payload, "learn_count": 99}, headers=headers)[0] == 204
+    assert request(ingress, body={**payload, "learn_count": 2})[0] == 204
+    today = server.datetime.now(server.timezone.utc).date()
+    records = query.load_records(today, today)
+    assert [record["learn_count"] for record in records] == [2]
+    assert records.quality == {"status": "partial", "invalid_lines": 0, "conflicting_deliveries": 1}
+    assert query.summary_stats()["data_quality"] == records.quality
+
+
+def test_invalid_delivery_identity_is_refused_before_persistence(ingress):
+    assert request(ingress, body=VALID, headers={"Content-Type": "application/json", "Idempotency-Key": "../invalid"})[0] == 400
+    assert list(ingress[2].glob("*.jsonl")) == []
+
+
+def test_backlog_and_future_activity_do_not_inflate_current_metrics(ingress, monkeypatch):
+    import query
+    monkeypatch.setattr(query, "DATA_DIR", ingress[2])
+    today = server.datetime.now(server.timezone.utc).date()
+    for offset in [-60, 60, 0]:
+        payload = {**VALID, "date": (today + query.timedelta(days=offset)).isoformat()}
+        assert request(ingress, body=payload)[0] == 204
+    records = query.load_records(today - query.timedelta(days=6), today)
+    assert len(records) == 1
+    assert records[0]["date"] == today.isoformat()
+    assert records.quality["status"] == "complete"
+
+
+def test_metrics_windows_use_the_same_utc_day_as_the_collector(tmp_path, monkeypatch):
+    import query
+    from datetime import date, datetime, timezone
+
+    class LocalDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 9, 9)
+
+    class UtcClock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 9, 8, 22, 30, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(query, "date", LocalDate)
+    monkeypatch.setattr(query, "datetime", UtcClock)
+    monkeypatch.setattr(query, "DATA_DIR", tmp_path)
+    (tmp_path / "2026-09-08.jsonl").write_text(json.dumps({**VALID, "date": "2026-09-08"}) + "\n")
+    assert query.weekly_active_count()["until"] == "2026-09-08"
+    assert query.summary_stats()["until"] == "2026-09-08"
+    assert query.mau_stats()["date"] == "2026-09-08"
+    assert query.mau_stats()["dau_1d"] == 1

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "js-yaml": ">=4.3.1 <5",
       "linkify-it": ">=5.0.1",
       "minimatch": ">=10.0.3",
+      "nanoid@3": ">=3.3.18 <4",
       "openclaw": ">=2026.6.5",
       "path-to-regexp": ">=8.4.0",
       "postcss": ">=8.5.18 <9",

--- a/packages/cli/src/antigravity-hooks.ts
+++ b/packages/cli/src/antigravity-hooks.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { atomicWrite } from '@plur-ai/core'
+import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { dirname } from 'path'
 
 /**
@@ -118,5 +119,5 @@ export function readAgyHooksConfig(path: string): AgyHooksConfig {
 
 export function writeAgyHooksConfig(path: string, config: AgyHooksConfig): void {
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify(config, null, 2) + '\n')
+  atomicWrite(path, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 })
 }

--- a/packages/cli/src/codex-hooks.ts
+++ b/packages/cli/src/codex-hooks.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { atomicWrite } from '@plur-ai/core'
+import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { dirname } from 'path'
 
 /**
@@ -192,5 +193,5 @@ export function writeCodexHooksConfig(path: string, config: CodexHooksConfig): v
     description: config.description
       ?? 'Hook configuration (PLUR memory hooks managed by `plur init --codex`)',
   }
-  writeFileSync(path, JSON.stringify(out, null, 2) + '\n')
+  atomicWrite(path, JSON.stringify(out, null, 2) + '\n', { mode: 0o600 })
 }

--- a/packages/cli/src/commands/hook-learn-check.ts
+++ b/packages/cli/src/commands/hook-learn-check.ts
@@ -1,4 +1,5 @@
-import { readSync, readFileSync, writeFileSync, mkdirSync, existsSync, appendFileSync, statSync, renameSync, unlinkSync } from 'fs'
+import { atomicWrite } from '@plur-ai/core'
+import { readSync, readFileSync, mkdirSync, existsSync, appendFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { tmpdir, homedir } from 'os'
 import { type GlobalFlags } from '../plur.js'
@@ -93,20 +94,8 @@ function writeCheckpoint(count: number, cwd: string): void {
     observation_file: `${dateStr}.jsonl`,
   }
 
-  // Atomic write: temp file + rename, so a concurrent reader (hook-session-end,
-  // the deferred wrap-up in hook-inject) never observes a mid-write PARTIAL
-  // file. A plain writeFileSync here made a partial read indistinguishable from
-  // genuine corruption, which hook-session-end then used to justify DESTROYING
-  // a live session's only durable record (#217). renameSync is atomic on POSIX
-  // when src and dst are on the same filesystem (they share this dir).
-  const tmpPath = `${path}.${process.pid}.tmp`
-  writeFileSync(tmpPath, JSON.stringify(checkpoint, null, 2) + '\n')
-  try {
-    renameSync(tmpPath, path)
-  } catch (err) {
-    try { unlinkSync(tmpPath) } catch { /* best-effort temp cleanup */ }
-    throw err
-  }
+  // Checkpoints share the private, durable atomic writer with primary state.
+  atomicWrite(path, JSON.stringify(checkpoint, null, 2) + '\n', { mode: 0o600 })
 }
 
 function readStdinRaw(): string {

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -68,7 +68,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // before exiting, and import — the one command with the largest bulk
   // write — was the one command whose instance the drain could not see.
   // createPlur honours --store by mapping it onto flags.path.
-  const plur = createPlur({ ...flags, path: store || flags.path })
+  const plur = createPlur({ ...flags, path: store })
   const report = await importFrom(plur, { from, path: file, mapping, dryRun, scope })
 
   if (shouldOutputJson(flags)) {

--- a/packages/cli/src/commands/init-remote.ts
+++ b/packages/cli/src/commands/init-remote.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
+import { readProjectConfig, updateProjectConfig, findProjectConfigPath, atomicWrite, withLock } from '@plur-ai/core'
 import { type GlobalFlags } from '../plur.js'
 import { outputText, outputInfo, outputError } from '../output.js'
 
@@ -96,70 +97,6 @@ function parseArgs(args: string[]): ParsedArgs | { error: string } {
 }
 
 /**
- * Strip the existing remote_* keys from .plur.yaml content so we can
- * append a fresh block — keeps non-remote keys (domain, scope) intact.
- *
- * Fixed (cto #1, data #EC03, dijkstra #5):
- *   - Blank lines INSIDE a remote_scopes list no longer terminate the
- *     skip. Only a non-dash, non-blank line breaks out.
- *   - Block-scalar marker (`remote_scopes: |` / `>`) also triggers list
- *     skipping, matching the parser's accepted forms.
- *   - The list-skip activates whenever the value-after-colon is empty
- *     OR is one of the block-scalar markers, regardless of trailing
- *     whitespace.
- */
-function stripRemoteKeys(content: string): string {
-  const lines = content.split('\n')
-  const out: string[] = []
-  let skippingList = false
-  const REMOTE_KEY = /^remote_(url|token|scopes)\s*:(.*)$/
-  for (const line of lines) {
-    const trimmed = line.trim()
-    if (skippingList) {
-      // Inside a previous remote_scopes list — skip dash items AND
-      // intervening blank lines. Only break out when a non-dash
-      // non-blank line appears.
-      if (trimmed === '' || trimmed.startsWith('-')) continue
-      skippingList = false
-    }
-    const m = trimmed.match(REMOTE_KEY)
-    if (m) {
-      const key = m[1]
-      const rest = m[2].trim()
-      // If remote_scopes had an empty or block-scalar value, the next
-      // lines are dash items — keep skipping.
-      if (key === 'scopes' && (rest === '' || rest === '|' || rest === '>')) {
-        skippingList = true
-      }
-      continue
-    }
-    out.push(line)
-  }
-  // Remove trailing blank lines that result from key removal
-  while (out.length > 0 && out[out.length - 1].trim() === '') out.pop()
-  return out.join('\n')
-}
-
-/**
- * Append remote_url, remote_token, and (optional) remote_scopes to the
- * existing .plur.yaml content. Returns the new file body.
- */
-function buildConfigBody(existing: string, url: string, token: string, scopes?: string[]): string {
-  const stripped = stripRemoteKeys(existing)
-  const sep = stripped.length > 0 && !stripped.endsWith('\n') ? '\n\n' : (stripped.length > 0 ? '\n' : '')
-  const block: string[] = []
-  block.push('# --- PLUR Enterprise remote (opt-in for this project) ---')
-  block.push('# remote_token is sensitive — keep .plur.yaml in .gitignore.')
-  block.push(`remote_url: ${url}`)
-  block.push(`remote_token: ${token}`)
-  if (scopes && scopes.length > 0) {
-    block.push('remote_scopes:')
-    for (const s of scopes) block.push(`  - ${s}`)
-  }
-  return stripped + sep + block.join('\n') + '\n'
-}
-
-/**
  * Add `.plur.yaml` to the project's .gitignore if not already present.
  *
  * Bounded by the .git boundary (dijkstra #2, critic #2):
@@ -191,68 +128,19 @@ function ensureGitignore(): { path: string; action: 'added' | 'already' | 'creat
 
   const PATTERN = '.plur.yaml'
 
-  if (!gitignorePath) {
-    // No .gitignore found within the project — create one alongside .plur.yaml.
-    const newPath = join(process.cwd(), '.gitignore')
-    writeFileSync(newPath, `# Added by 'plur init-remote' — .plur.yaml may hold an API token\n${PATTERN}\n`)
-    return { path: newPath, action: 'created' }
-  }
+  const target = gitignorePath ?? join(process.cwd(), '.gitignore')
+  return withLock(target, () => {
+    const exists = existsSync(target)
+    const content = exists ? readFileSync(target, 'utf8') : ''
+    // The final matching rule wins: a later !.plur.yaml must not undo the
+    // protection while an earlier occurrence makes setup report success.
+    const rules = content.split('\n').map(line => line.trim()).filter(line => line && !line.startsWith('#'))
+    if (rules.at(-1) === PATTERN) return { path: target, action: 'already' }
+    const sep = content && !content.endsWith('\n') ? '\n' : ''
+    atomicWrite(target, `${content}${sep}# Added by 'plur init-remote' — .plur.yaml may hold an API token\n${PATTERN}\n`, { mode: 0o644 })
+    return { path: target, action: exists ? 'added' : 'created' }
+  })
 
-  const content = readFileSync(gitignorePath, 'utf8')
-  // Crude but safe — match the literal pattern as a whole word
-  const already = content.split('\n').some(l => l.trim() === PATTERN)
-  if (already) return { path: gitignorePath, action: 'already' }
-
-  const sep = content.endsWith('\n') ? '' : '\n'
-  appendFileSync(gitignorePath, `${sep}# Added by 'plur init-remote' — .plur.yaml may hold an API token\n${PATTERN}\n`)
-  return { path: gitignorePath, action: 'added' }
-}
-
-/**
- * Walk upward from cwd to find the nearest existing .plur.yaml.
- * Mirrors hook-inject.ts findProjectConfigPath but locally scoped here
- * to avoid a cross-command import. Same boundaries: .git, home, root.
- */
-function findExistingConfigPath(): string | null {
-  const home = resolve(homedir())
-  let dir = resolve(process.cwd())
-  const MAX_DEPTH = 12
-  for (let depth = 0; depth < MAX_DEPTH; depth++) {
-    if (dir !== home) {
-      const candidate = join(dir, '.plur.yaml')
-      if (existsSync(candidate)) return candidate
-    }
-    if (existsSync(join(dir, '.git'))) return null
-    if (dir === home || dir === '/' || dir === '.') return null
-    const parent = dirname(dir)
-    if (parent === dir) return null
-    dir = parent
-  }
-  return null
-}
-
-/**
- * Read existing .plur.yaml fields the parser cares about — minimal,
- * matches the line-by-line approach in hook-inject.ts.
- */
-interface ReadConfig {
-  url?: string
-  token?: string
-}
-function readRemoteFromConfig(path: string): ReadConfig {
-  if (!existsSync(path)) return {}
-  const content = readFileSync(path, 'utf8')
-  const out: ReadConfig = {}
-  for (const line of content.split('\n')) {
-    const trimmed = line.trim()
-    if (trimmed.startsWith('#') || !trimmed) continue
-    const m = trimmed.match(/^(remote_url|remote_token)\s*:\s*(.+)$/)
-    if (m) {
-      if (m[1] === 'remote_url') out.url = m[2].trim()
-      if (m[1] === 'remote_token') out.token = m[2].trim()
-    }
-  }
-  return out
 }
 
 /**
@@ -331,17 +219,17 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
   // discovery so `--verify` from a project subdirectory finds the same
   // config the hook would actually use (data #EC06).
   if (opts.verify) {
-    const verifyPath = findExistingConfigPath() ?? configPath
-    const cfg = readRemoteFromConfig(verifyPath)
-    if (!cfg.url || !cfg.token) {
+    const verifyPath = findProjectConfigPath() ?? configPath
+    const cfg = readProjectConfig(process.cwd())
+    if (!cfg.remote_url || !cfg.remote_token) {
       outputError(`No remote config found (walked upward from ${process.cwd()}). Run \`plur init-remote --url <url> --token <key>\` first.`)
       process.exit(1)
     }
     outputInfo(`Using config at ${verifyPath}`, flags)
     try {
-      const me = await verifyConnectivity(cfg.url, cfg.token)
+      const me = await verifyConnectivity(cfg.remote_url, cfg.remote_token)
       // The verify result IS the requested output — never suppressed.
-      outputText(`✓ Connected to ${cfg.url} as ${me.username} (org: ${me.org_id})`)
+      outputText(`✓ Connected to ${cfg.remote_url} as ${me.username} (org: ${me.org_id})`)
       outputText(`  readable scopes: ${me.scopes.length === 0 ? '(none)' : me.scopes.join(', ')}`)
     } catch (err) {
       outputError(`✗ Connection failed: ${(err as Error).message}`)
@@ -388,18 +276,7 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     process.exit(2)
   }
 
-  // Write/update .plur.yaml
-  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf8') : ''
-  const next = buildConfigBody(existing, opts.url, opts.token, opts.scopes)
-  writeFileSync(configPath, next)
-  outputInfo(`✓ Wrote ${configPath}`, flags)
-  if (opts.scopes && opts.scopes.length > 0) {
-    outputInfo(`  scope whitelist: ${opts.scopes.join(', ')}`, flags)
-  } else {
-    outputInfo(`  scope whitelist: (none — hook will query all readable scopes)`, flags)
-  }
-
-  // Ensure .gitignore
+  // Persist ignore protection BEFORE publishing the token-bearing config.
   if (!opts.noGitignore) {
     const gi = ensureGitignore()
     if (gi.action === 'added') outputInfo(`✓ Added .plur.yaml to ${gi.path}`, flags)
@@ -410,6 +287,16 @@ export async function run(args: string[], flags: GlobalFlags): Promise<void> {
     // never suppressed (#730).
     outputText(`⚠ Skipped .gitignore (--no-gitignore). The token in .plur.yaml is sensitive.`)
   }
+
+  // Write/update .plur.yaml
+  updateProjectConfig(configPath, { remote_url: opts.url, remote_token: opts.token, remote_scopes: opts.scopes })
+  outputInfo(`✓ Wrote ${configPath}`, flags)
+  if (opts.scopes && opts.scopes.length > 0) {
+    outputInfo(`  scope whitelist: ${opts.scopes.join(', ')}`, flags)
+  } else {
+    outputInfo(`  scope whitelist: (none — hook will query all readable scopes)`, flags)
+  }
+
 
   outputInfo(`\nDone. The UserPromptSubmit hook will now query ${opts.url} on every prompt`, flags)
   outputInfo(`from this directory tree (bounded by the nearest .git). Personal/non-project`, flags)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,3 +1,4 @@
+import { updateProjectConfig, atomicWrite } from '@plur-ai/core'
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs'
 import { execFileSync } from 'child_process'
 import { join, dirname } from 'path'
@@ -524,12 +525,7 @@ function installProjectConfig(args: string[]): string | null {
   if (!domain && !scope) return null
 
   const configPath = join(process.cwd(), '.plur.yaml')
-  const lines: string[] = ['# PLUR project defaults — read by hooks for automatic scoping']
-  if (domain) lines.push(`domain: ${domain}`)
-  if (scope) lines.push(`scope: ${scope}`)
-  lines.push('')
-
-  writeFileSync(configPath, lines.join('\n'))
+  updateProjectConfig(configPath, { ...(domain ? { domain } : {}), ...(scope ? { scope } : {}) })
   return configPath
 }
 
@@ -1035,7 +1031,7 @@ function installAntigravity(cmd: string): string {
 
 function writeSettings(path: string, settings: Settings): void {
   mkdirSync(join(path, '..'), { recursive: true })
-  writeFileSync(path, JSON.stringify(settings, null, 2) + '\n')
+  atomicWrite(path, JSON.stringify(settings, null, 2) + '\n', { mode: 0o600 })
 }
 
 // ── Telemetry opt-in prompt ─────────────────────────────────────────────────
@@ -1052,7 +1048,7 @@ function telemetryConfigPath(): string {
 function writeTelemetryConfig(enabled: boolean, configPath?: string): void {
   const target = configPath ?? telemetryConfigPath()
   mkdirSync(dirname(target), { recursive: true })
-  writeFileSync(target, JSON.stringify({ enabled }, null, 2) + '\n')
+  atomicWrite(target, JSON.stringify({ enabled }, null, 2) + '\n', { mode: 0o600 })
 }
 
 /**

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,3 +1,4 @@
+import { atomicWrite } from '@plur-ai/core'
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
@@ -110,18 +111,20 @@ export function plurConfigPath(baseDir?: string): string {
 
 export function readPlurConfig(baseDir?: string): PlurConfig {
   const path = plurConfigPath(baseDir)
-  if (!existsSync(path)) return {}
   try {
-    return JSON.parse(readFileSync(path, 'utf8'))
-  } catch {
-    return {}
+    const parsed = JSON.parse(readFileSync(path, 'utf8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('mapping required')
+    return parsed
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Cannot read login configuration; repair it before signing in')
   }
 }
 
 export function writePlurConfig(config: PlurConfig, baseDir?: string): void {
   const path = plurConfigPath(baseDir)
   mkdirSync(join(path, '..'), { recursive: true })
-  writeFileSync(path, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 })
+  atomicWrite(path, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 })
 }
 
 // ── Reload signal ─────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/ui.ts
+++ b/packages/cli/src/commands/ui.ts
@@ -19,7 +19,7 @@ function openBrowser(url: string): void {
   try {
     // Detached and fully ignored: a browser that writes to our stdout would
     // corrupt --json output, and one that outlives us must not hold the pipe.
-    spawn(command, args, { stdio: 'ignore', detached: true }).unref()
+    spawn(command, args, { stdio: 'ignore', detached: true }).on('error', () => { /* optional desktop integration unavailable */ }).unref()
   } catch {
     // A headless box has no browser. The URL is printed either way.
   }

--- a/packages/cli/src/cursor-hooks.ts
+++ b/packages/cli/src/cursor-hooks.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { atomicWrite } from '@plur-ai/core'
+import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { dirname } from 'path'
 
 /**
@@ -97,7 +98,7 @@ export function mergeCursorHooks(config: CursorHooksConfig, additions: Record<st
   for (const [event, entries] of Object.entries(additions)) {
     hooks[event] = [...(hooks[event] ?? []), ...entries]
   }
-  return { version: clean.version ?? 1, hooks }
+  return { ...clean, version: clean.version ?? 1, hooks }
 }
 
 export function readCursorHooksConfig(path: string): CursorHooksConfig {
@@ -115,5 +116,5 @@ export function readCursorHooksConfig(path: string): CursorHooksConfig {
 
 export function writeCursorHooksConfig(path: string, config: CursorHooksConfig): void {
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify(config, null, 2) + '\n')
+  atomicWrite(path, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 })
 }

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { atomicWrite } from '@plur-ai/core'
+import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { CLI_VERSION } from './version.js'
 import { join, dirname } from 'path'
 import { homedir, platform } from 'os'
@@ -297,7 +298,7 @@ export function readConfigForWrite(path: string): ConfigReadResult {
  */
 export function writeConfig(path: string, data: Record<string, unknown>): void {
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify(data, null, 2) + '\n')
+  atomicWrite(path, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 })
 }
 
 /**

--- a/packages/cli/test/cursor-hooks.test.ts
+++ b/packages/cli/test/cursor-hooks.test.ts
@@ -10,6 +10,11 @@ import {
   hasPlurCursorHooks,
 } from '../src/cursor-hooks.js'
 
+it('preserves unrelated top-level settings when merging PLUR hooks', () => {
+  const existing = { version: 1, hooks: {}, custom: { enabled: false, names: ['first', 'second'] } }
+  expect(mergeCursorHooks(existing, buildCursorHooks('plur-hook'))).toMatchObject({ custom: existing.custom })
+})
+
 describe('cursor-hooks', () => {
   let dir: string
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plur-cursor-hooks-')) })

--- a/packages/cli/test/import.test.ts
+++ b/packages/cli/test/import.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 import { createRequire } from 'module'
 import { Plur } from '@plur-ai/core'
 import { builtCliPath } from './helpers/built-cli.js'
@@ -37,6 +37,37 @@ describe('plur import', () => {
       timeout: 20000,
     }).trim()
   }
+
+  it.each(['--path', '--file'])('uses PLUR_PATH for the destination when %s supplies the input', async flag => {
+    const input = join(work, 'source with spaces.json')
+    const bytes = JSON.stringify([{ statement: 'Environment-selected import destination', created_at: '2025-01-02T03:04:05Z' }])
+    writeFileSync(input, bytes)
+    writeFileSync(join(store, 'config.yaml'), 'index: false\n')
+    const report = JSON.parse(execFileSync(process.execPath, [CLI, 'import', '--from', 'generic', flag, input, '--json'], {
+      cwd: work, encoding: 'utf8', timeout: 20000,
+      env: { ...process.env, PLUR_PATH: store, PLUR_AUTO_DISCOVER: '0' },
+    }))
+    expect(report.imported).toBe(1)
+    expect(report.errors).toBe(0)
+    expect(readFileSync(input, 'utf8')).toBe(bytes)
+    const plur = new Plur({ path: store, autoDiscover: false })
+    expect((await plur.list())[0].temporal?.learned_at).toBe('2025-01-02T03:04:05Z')
+  })
+
+  it('keeps an explicit --store override separate from the input and environment default', async () => {
+    const input = join(work, 'source.json')
+    const bytes = JSON.stringify([{ statement: 'Explicit import destination wins' }])
+    writeFileSync(input, bytes)
+    writeFileSync(join(store, 'config.yaml'), 'index: false\n')
+    const report = JSON.parse(execFileSync(process.execPath, [CLI, 'import', '--from', 'generic', '--path', input, '--store', store, '--json'], {
+      cwd: work, encoding: 'utf8', timeout: 20000,
+      env: { ...process.env, PLUR_PATH: join(work, 'unused-store'), PLUR_AUTO_DISCOVER: '0' },
+    }))
+    expect(report.imported).toBe(1)
+    expect(readFileSync(input, 'utf8')).toBe(bytes)
+    const plur = new Plur({ path: store, autoDiscover: false })
+    expect(await plur.list()).toHaveLength(1)
+  })
 
   it('imports a generic JSON file and prints a migration report', async () => {
     const input = join(work, 'memories.json')

--- a/packages/cli/test/init-remote.test.ts
+++ b/packages/cli/test/init-remote.test.ts
@@ -10,12 +10,13 @@
  * we never touch the developer's real .plur.yaml.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync, statSync, realpathSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { spawn } from 'child_process'
+import { spawn, execFileSync } from 'child_process'
 import { createServer, type Server } from 'http'
 import type { AddressInfo } from 'net'
+import { readProjectConfig } from '@plur-ai/core'
 import { builtCliPath } from './helpers/built-cli.js'
 
 const CLI = builtCliPath(join(__dirname, '..'))
@@ -28,17 +29,18 @@ const CLI = builtCliPath(join(__dirname, '..'))
  * spawn + Promise lets the parent keep processing the server event loop
  * while the child runs.
  */
-function runCli(args: string, cwd: string, home: string): Promise<{ stdout: string; status: number }> {
+function runCli(args: string | string[], cwd: string, home: string): Promise<{ stdout: string; status: number }> {
   return new Promise(resolve => {
-    const child = spawn('node', [CLI, ...args.split(' ').filter(s => s.length > 0)], {
+    const child = spawn('node', [CLI, ...(Array.isArray(args) ? args : args.split(' ').filter(s => s.length > 0))], {
       cwd,
-      env: { ...process.env, HOME: home, USERPROFILE: home },
+      env: { ...process.env, HOME: home, USERPROFILE: home, PLUR_PATH: join(home, '.plur'), PLUR_AUTO_DISCOVER: '0' },
     })
     let out = ''
     child.stdout.on('data', c => { out += c.toString() })
     child.stderr.on('data', c => { out += c.toString() })
-    child.on('close', code => resolve({ stdout: out, status: code ?? 0 }))
-    setTimeout(() => { child.kill(); resolve({ stdout: out + '\n[test-timeout]', status: 124 }) }, 8000)
+    const timer = setTimeout(() => { child.kill('SIGKILL') }, 8000)
+    child.on('error', error => { clearTimeout(timer); resolve({ stdout: out + error.message, status: 1 }) })
+    child.on('close', code => { clearTimeout(timer); resolve({ stdout: out, status: code ?? 124 }) })
   })
 }
 
@@ -47,13 +49,16 @@ describe('plur init-remote', () => {
   let cwd: string
   let server: Server
   let serverUrl: string
+  let projectRoot: string
   let lastRequest: { auth?: string; body?: any; path?: string } = {}
   let nextResponse: (req: { path: string }) => { status: number; body: any } =
     () => ({ status: 200, body: { username: 'test-user', org_id: 'test-org', scopes: ['user:test'] } })
 
   beforeEach(async () => {
     home = mkdtempSync(join(tmpdir(), 'plur-init-remote-home-'))
-    cwd  = mkdtempSync(join(tmpdir(), 'plur-init-remote-proj-'))
+    projectRoot = mkdtempSync(join(tmpdir(), 'plur-init-remote-proj-'))
+    cwd = join(projectRoot, 'project'); mkdirSync(cwd)
+    nextResponse = () => ({ status: 200, body: { username: 'test-user', org_id: 'test-org', scopes: ['user:test'] } })
     // Mark cwd as a git project so the .gitignore walk stops there
     mkdirSync(join(cwd, '.git'))
 
@@ -80,14 +85,14 @@ describe('plur init-remote', () => {
 
   afterEach(async () => {
     rmSync(home, { recursive: true, force: true })
-    rmSync(cwd, { recursive: true, force: true })
+    rmSync(projectRoot, { recursive: true, force: true })
     await new Promise<void>(resolve => server.close(() => resolve()))
   })
 
-  it.skip('writes .plur.yaml and updates .gitignore on success [spawn/event-loop flake]', async () => {
+  it('writes .plur.yaml and updates .gitignore on success', async () => {
     const r = await runCli(`init-remote --url ${serverUrl} --token test-token`, cwd, home)
     expect(r.status).toBe(0)
-    expect(r.stdout).toContain(`Wrote ${join(cwd, '.plur.yaml')}`)
+    expect(r.stdout).toContain(`Wrote ${join(realpathSync(cwd), '.plur.yaml')}`)
     expect(r.stdout).toContain('Token sensitivity')   // cloud-sync warning
     const yaml = readFileSync(join(cwd, '.plur.yaml'), 'utf8')
     expect(yaml).toContain(`remote_url: ${serverUrl}`)
@@ -110,12 +115,46 @@ describe('plur init-remote', () => {
   })
 
   it('refuses to write when --token has a newline character', async () => {
-    const r = await runCli(`init-remote --url ${serverUrl} --token "ab\\nc"`, cwd, home)
-    // Newline in shell-quoted string becomes literal \n in the arg
-    // (no actual newline) — instead test by writing directly via env
-    // since shell escaping is annoying. The newline test is enforced in
-    // the validator path; trust the impl for this surface.
-    expect([0, 1]).toContain(r.status)
+    const r = await runCli(['init-remote', '--url', serverUrl, '--token', 'ab\nc'], cwd, home)
+    expect(r.status).toBe(1)
+    expect(existsSync(join(cwd, '.plur.yaml'))).toBe(false)
+    expect(lastRequest.path).toBeUndefined()
+  })
+
+  it('round-trips quoted tokens and preserves nested non-remote keys in private config', async () => {
+    writeFileSync(join(cwd, '.plur.yaml'), 'custom:\n  remote_url: https://preserve.example\n  values: [one, two]\n', { mode: 0o644 })
+    const token = "a'quoted # token: value"
+    const r = await runCli(['init-remote', '--url', serverUrl, '--token', token], cwd, home)
+    expect(r.status).toBe(0)
+    expect(readProjectConfig(cwd).remote_token).toBe(token)
+    expect(readFileSync(join(cwd, '.plur.yaml'), 'utf8')).toContain('https://preserve.example')
+    expect(statSync(join(cwd, '.plur.yaml')).mode & 0o777).toBe(0o600)
+    expect((await runCli('init-remote --verify', cwd, home)).status).toBe(0)
+    expect(lastRequest.auth).toBe(`Bearer ${token}`)
+  })
+
+  it('preserves malformed existing project config and omits its contents from diagnostics', async () => {
+    const bytes = 'custom: [sensitive-example'; writeFileSync(join(cwd, '.plur.yaml'), bytes)
+    const r = await runCli(['init-remote', '--url', serverUrl, '--token', 'new-token'], cwd, home)
+    expect(r.status).not.toBe(0)
+    expect(readFileSync(join(cwd, '.plur.yaml'), 'utf8')).toBe(bytes)
+    expect(r.stdout).not.toContain('sensitive-example')
+  })
+
+  it('does not publish credentials when ignore protection cannot be installed', async () => {
+    mkdirSync(join(cwd, '.gitignore'))
+    const r = await runCli(['init-remote', '--url', serverUrl, '--token', 'new-token'], cwd, home)
+    expect(r.status).not.toBe(0)
+    expect(existsSync(join(cwd, '.plur.yaml'))).toBe(false)
+  })
+
+  it('does not mistake an earlier ignore rule for protection when a later rule negates it', async () => {
+    const env = { ...process.env, GIT_CONFIG_NOSYSTEM: '1', GIT_CONFIG_GLOBAL: '/dev/null' }
+    execFileSync('git', ['init'], { cwd, env, stdio: 'pipe' })
+    writeFileSync(join(cwd, '.gitignore'), '.plur.yaml\n!.plur.yaml\n')
+    const r = await runCli(['init-remote', '--url', serverUrl, '--token', 'new-token'], cwd, home)
+    expect(r.status).toBe(0)
+    expect(execFileSync('git', ['check-ignore', '--', '.plur.yaml'], { cwd, env, encoding: 'utf8' }).trim()).toBe('.plur.yaml')
   })
 
   it('refuses a non-http/https URL scheme', async () => {
@@ -124,7 +163,7 @@ describe('plur init-remote', () => {
     expect(r.stdout).toContain('must be http')
   })
 
-  it.skip('refuses to write a broken config when connectivity fails [flake]', async () => {
+  it('refuses to write a broken config when connectivity fails', async () => {
     nextResponse = () => ({ status: 401, body: { error: 'bad token' } })
     const r = await runCli(`init-remote --url ${serverUrl} --token bad`, cwd, home)
     expect(r.status).toBe(2)
@@ -156,7 +195,7 @@ describe('plur init-remote', () => {
     expect(yaml).not.toContain('group:plur/eng')       // old list dropped
   })
 
-  it.skip('stops the .gitignore walk at .git boundary [flake]', async () => {
+  it('stops the .gitignore walk at .git boundary', async () => {
     // Project at cwd, parent-of-parent has another .gitignore (monorepo root)
     const monorepo = join(cwd, '..')
     const monorepoGitignore = join(monorepo, '.gitignore.tmp-monorepo')
@@ -197,7 +236,7 @@ describe('plur init-remote --verify', () => {
     await new Promise<void>(resolve => server.close(() => resolve()))
   })
 
-  it.skip('reports success when config + connectivity are valid [flake]', async () => {
+  it('reports success when config + connectivity are valid', async () => {
     writeFileSync(join(cwd, '.plur.yaml'),
       `remote_url: ${serverUrl}\nremote_token: valid-token\n`)
     const r = await runCli(`init-remote --verify`, cwd, home)

--- a/packages/cli/test/login.test.ts
+++ b/packages/cli/test/login.test.ts
@@ -82,6 +82,15 @@ describe('login helpers — config read/write', () => {
     expect(cfg).toEqual({})
   })
 
+  it.each(['{broken', '[]', 'null'])('refuses existing invalid login state without exposing it: %s', async bytes => {
+    const { plurConfigPath, readPlurConfig } = await import('../src/commands/login.js')
+    const path = plurConfigPath(tmpHome)
+    mkdirSync(join(path, '..'), { recursive: true })
+    writeFileSync(path, bytes)
+    expect(() => readPlurConfig(tmpHome)).toThrow('Cannot read login configuration')
+    expect(readFileSync(path, 'utf8')).toBe(bytes)
+  })
+
   it('writePlurConfig creates parent directory and writes JSON', async () => {
     const { plurConfigPath, writePlurConfig } = await import('../src/commands/login.js')
     const configPath = plurConfigPath(tmpHome)

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,3 +1,4 @@
+import { readdirSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vitest/config'
 
 // The spawn-heavy suites are EXCLUDED here and run as a separate serial project
@@ -24,21 +25,15 @@ import { defineConfig } from 'vitest/config'
 // means something again. A known-flaky baseline is worse than a slow one:
 // today a real 55-test breakage was nearly attributed to the change under test
 // because the suite's noise floor was not zero.
-export const SPAWN_SUITES = [
-  'test/hook-learn-check.test.ts',
-  'test/hook-session-guard.test.ts',
-  'test/list.test.ts',
-  'test/tensions-lifecycle.test.ts',
-  // Added 2026-08-18: the next members of the same family, observed blowing
-  // their 5s spawn budgets across two release-gate runs and one review run,
-  // each passing in isolation. Same remedy as #793/#889, for the same reason.
-  'test/import.test.ts',
-  'test/readonly-commands.test.ts',
-  'test/recall.test.ts',
-  'test/rescope.test.ts',
-  'test/sync.test.ts',
-  'test/timeline.test.ts',
-]
+// Classify integration suites from their subprocess boundary, so newly added
+// built-CLI tests cannot silently miss the serial project. Mocked subprocess
+// suites may also land here; they still execute, with all assertions intact.
+export const SPAWN_SUITES = readdirSync(new URL('./test/', import.meta.url))
+  .filter(name => name.endsWith('.test.ts'))
+  .filter(name => /from ['"](?:node:)?child_process['"]|from ['"]\.\/helpers\/built-cli(?:\.js)?['"]/.test(
+    readFileSync(new URL(`./test/${name}`, import.meta.url), 'utf8'),
+  ))
+  .map(name => `test/${name}`)
 
 export default defineConfig({
   test: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@electric-sql/pglite": "^0.4.6",
     "js-yaml": "^4.3.1",
+    "tar": "7.5.21",
     "zod": "^3.23.0"
   },
   "optionalDependencies": {

--- a/packages/core/src/backup.ts
+++ b/packages/core/src/backup.ts
@@ -48,7 +48,7 @@
  */
 import * as fs from 'fs'
 import * as path from 'path'
-import { createHash } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import * as yaml from 'js-yaml'
 import { EngramSchemaPassthrough } from './schemas/engram.js'
 import { logger } from './logger.js'
@@ -118,7 +118,7 @@ function readState(root: string): BackupState {
 function writeState(root: string, state: BackupState): void {
   const p = statePath(root)
   fs.mkdirSync(path.dirname(p), { recursive: true })
-  fs.writeFileSync(p, JSON.stringify(state, null, 2) + '\n', 'utf8')
+  atomicWrite(p, JSON.stringify(state, null, 2) + '\n')
 }
 
 export function sha256(content: string | Buffer): string {
@@ -143,8 +143,6 @@ export function sha256(content: string | Buffer): string {
  * (c) is skipped in that case rather than guessed at.
  */
 export function validateStore(filePath: string, lastGoodCount?: number): StoreValidity {
-  const failures: string[] = []
-  const reasons: string[] = []
 
   let raw: Buffer
   try {
@@ -154,6 +152,12 @@ export function validateStore(filePath: string, lastGoodCount?: number): StoreVa
   }
 
   // (e) — size and terminator
+  return validateStoreBytes(raw, lastGoodCount)
+}
+
+function validateStoreBytes(raw: Buffer, lastGoodCount?: number): StoreValidity {
+  const failures: string[] = []
+  const reasons: string[] = []
   if (raw.length === 0) {
     return { ok: false, failures: ['empty'], reasons: ['file is 0 bytes'], count: null }
   }
@@ -256,7 +260,6 @@ export function maybeDailyBackup(root: string, storePath: string, now = new Date
   if (doneThisProcess.has(key)) return { taken: false, skipped: 'already-today' }
   try {
     if (!fs.existsSync(storePath)) {
-      doneThisProcess.add(key)
       return { taken: false, skipped: 'no-store' }
     }
     const state = readState(root)
@@ -279,7 +282,8 @@ export function maybeDailyBackup(root: string, storePath: string, now = new Date
       undefined,
     )
     const baseline = state.last_good_count ?? strongest
-    const validity = validateStore(storePath, baseline)
+    const bytes = fs.readFileSync(storePath)
+    const validity = validateStoreBytes(bytes, baseline)
     if (!validity.ok) {
       // Deliberately NOT marked done: if the user repairs the store later
       // today, the next write should snapshot the repaired copy.
@@ -290,7 +294,6 @@ export function maybeDailyBackup(root: string, storePath: string, now = new Date
       return { taken: false, skipped: 'invalid', validity }
     }
 
-    const bytes = fs.readFileSync(storePath)
     const dest = snapshotPath(root, stamp)
     // Never replace an existing same-day snapshot with a weaker one. The
     // validity gate above compares against the last known-good count; this
@@ -305,6 +308,12 @@ export function maybeDailyBackup(root: string, storePath: string, now = new Date
       )
       doneThisProcess.add(key)
       return { taken: false, skipped: 'invalid', validity }
+    }
+    // A snapshot outlives its state hint. Never overwrite it during a retry.
+    if (sameDay) {
+      const intact = sameDay.sha256 === sha256(fs.readFileSync(sameDay.path))
+      if (!intact) logger.warning(`[plur:backup] keeping unverifiable snapshot ${sameDay.path}; inspect its sidecar before restoring`)
+      return { taken: false, skipped: intact ? 'already-today' : 'invalid' }
     }
     fs.mkdirSync(path.dirname(dest), { recursive: true })
     writeFileDurable(dest, bytes)
@@ -337,33 +346,9 @@ export function maybeDailyBackup(root: string, storePath: string, now = new Date
   }
 }
 
-/** fsync a file written by a non-atomic helper (copyFileSync). Best-effort. */
-function flushFileAt(filePath: string): void {
-  let fd: number | undefined
-  try {
-    fd = fs.openSync(filePath, 'r+')
-    fs.fsyncSync(fd)
-  } catch {
-    /* nothing actionable — the copy itself succeeded */
-  } finally {
-    if (fd !== undefined) {
-      try { fs.closeSync(fd) } catch { /* ignore */ }
-    }
-  }
-}
-
-/**
- * Write and fsync — a backup that is only in the page cache is not a backup,
- * which is the same reasoning as the store's own atomicWrite (audit #794, F4).
- */
+/** Atomic, private, durable publication, including directory metadata. */
 function writeFileDurable(dest: string, bytes: Buffer): void {
-  const fd = fs.openSync(dest, 'w')
-  try {
-    fs.writeFileSync(fd, bytes)
-    fs.fsyncSync(fd)
-  } finally {
-    fs.closeSync(fd)
-  }
+  atomicWrite(dest, bytes)
 }
 
 export interface BackupEntry {
@@ -458,6 +443,10 @@ export interface RestorePlan {
  * lose rather than rolling them back silently.
  */
 export function planRestore(root: string, storePath: string, stamp?: string): RestorePlan {
+  return readRestoreSnapshot(root, storePath, stamp).plan
+}
+
+function readRestoreSnapshot(root: string, storePath: string, stamp?: string): { plan: RestorePlan; bytes: Buffer } {
   const all = listBackups(root)
   if (all.length === 0) throw new Error(`[plur] no backups found in ${path.join(root, BACKUP_DIR)}`)
   const backup = stamp ? all.find(b => b.stamp === stamp) : all[0]
@@ -468,13 +457,13 @@ export function planRestore(root: string, storePath: string, stamp?: string): Re
   const integrityOk = backup.sha256 === undefined ? false : backup.sha256 === actualSha256
   // No lastGoodCount here on purpose: the question is whether the BACKUP is
   // internally sound, not whether it matches today's (possibly ruined) corpus.
-  const validity = validateStore(backup.path)
+  const validity = validateStoreBytes(bytes)
 
-  const backupIds = new Set(idsIn(backup.path))
+  const backupIds = new Set(idsFromBytes(bytes))
   const currentIds = idsIn(storePath)
   const wouldLose = currentIds.filter(id => !backupIds.has(id))
 
-  return {
+  return { bytes, plan: {
     backup,
     validity,
     actualSha256,
@@ -485,12 +474,18 @@ export function planRestore(root: string, storePath: string, stamp?: string): Re
     // this field: it under-reports rather than inventing losses.
     unrecoverable: idsCreatedAfter(root, backup.takenAt ?? `${backup.stamp}T23:59:59.999Z`)
       .filter(id => !backupIds.has(id)),
-  }
+  } }
 }
 
 function idsIn(filePath: string): string[] {
   try {
-    const doc: any = yaml.load(fs.readFileSync(filePath, 'utf8'))
+    return idsFromBytes(fs.readFileSync(filePath))
+  } catch { return [] }
+}
+
+function idsFromBytes(bytes: Buffer): string[] {
+  try {
+    const doc: any = yaml.load(bytes.toString('utf8'))
     if (!doc || !Array.isArray(doc.engrams)) return []
     return doc.engrams.map((e: any) => e?.id).filter((id: unknown): id is string => typeof id === 'string')
   } catch {
@@ -575,9 +570,10 @@ export function restoreBackup(
   // The refusal checks move in with it, so a plan can never be validated
   // against one state and applied to another.
   let plan!: RestorePlan
-  const superseded = `${storePath}.superseded-${Date.now()}`
+  const superseded = `${storePath}.superseded-${Date.now()}-${randomUUID()}`
   withLock(storePath, () => {
-    plan = planRestore(root, storePath, opts.stamp)
+    const snapshot = readRestoreSnapshot(root, storePath, opts.stamp)
+    plan = snapshot.plan
     if (!opts.force) {
       const problems: string[] = []
       if (!plan.validity.ok) problems.push(...plan.validity.reasons)
@@ -598,11 +594,10 @@ export function restoreBackup(
       }
     }
     if (fs.existsSync(storePath)) {
-      fs.copyFileSync(storePath, superseded)
-      flushFileAt(superseded)
+      atomicWrite(superseded, fs.readFileSync(storePath))
     }
     // tmp + fsync + rename, rather than truncating the live file in place.
-    atomicWrite(storePath, fs.readFileSync(plan.backup.path, 'utf8'))
+    atomicWrite(storePath, snapshot.bytes)
   })
 
   if (plan.wouldLose.length > 0) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import yaml from 'js-yaml'
 import { PlurConfigSchema, StoreEntrySchema, type PlurConfig } from './schemas/config.js'
 import { SENSITIVITY_CATEGORIES } from './schemas/scope-metadata.js'
@@ -22,13 +22,17 @@ import { logger } from './logger.js'
  * most the malformed entries, never the whole file.
  */
 export function loadConfig(configPath: string): PlurConfig {
-  if (!existsSync(configPath)) return PlurConfigSchema.parse({})
   let raw: Record<string, unknown>
   try {
-    raw = (yaml.load(readFileSync(configPath, 'utf8')) as Record<string, unknown>) ?? {}
+    raw = yaml.load(readFileSync(configPath, 'utf8')) as Record<string, unknown>
   } catch (err) {
-    logger.warning(`[plur:config] cannot parse YAML at ${configPath}: ${(err as Error).message} — falling back to defaults`)
-    return PlurConfigSchema.parse({})
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return PlurConfigSchema.parse({})
+    // YAML parser errors can include the source line, including tokens. Do
+    // not render them, and never enable default capture/routing after failure.
+    throw new Error(`[plur:config] cannot read or parse configuration at ${configPath}; repair it before continuing`)
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`[plur:config] configuration at ${configPath} must be a mapping`)
   }
   // Validate each store entry independently before the top-level parse so
   // a single bad entry can't take the whole file down.
@@ -40,11 +44,7 @@ export function loadConfig(configPath: string): PlurConfig {
       if (parsed.success) {
         validStores.push(entry)
       } else {
-        const label = (entry as { url?: string; path?: string; scope?: string })?.scope
-          ?? (entry as { url?: string; path?: string })?.url
-          ?? (entry as { path?: string })?.path
-          ?? `index ${i}`
-        logger.warning(`[plur:config] dropping invalid stores[${i}] (${label}) from ${configPath}: ${parsed.error.issues.map(it => it.message).join('; ')}`)
+        logger.warning(`[plur:config] dropping invalid stores[${i}] from ${configPath}: ${parsed.error.issues.map(it => `${it.path.join('.')}: ${it.code}`).join('; ')}`)
       }
     }
     raw.stores = validStores
@@ -53,8 +53,7 @@ export function loadConfig(configPath: string): PlurConfig {
   try {
     parsed = PlurConfigSchema.parse(raw)
   } catch (err) {
-    logger.warning(`[plur:config] top-level config invalid at ${configPath}: ${(err as Error).message} — falling back to defaults`)
-    return PlurConfigSchema.parse({})
+    throw new Error(`[plur:config] invalid configuration at ${configPath}; repair it before continuing`)
   }
   // PR-3 (#353) scope-naming pass. ScopeSensitivitySchema.forbid now preprocesses
   // unknown categories away (non-fatal), but the field-level preprocess can't

--- a/packages/core/src/engrams.ts
+++ b/packages/core/src/engrams.ts
@@ -639,8 +639,8 @@ export function engramIdDatePrefix(now: Date = new Date()): string {
   return `ENG-${now.toISOString().slice(0, 10)}-`
 }
 
-export function generateEngramId(existing: Engram[], alsoAllocated: Iterable<string> = []): string {
-  const day = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+export function generateEngramId(existing: Engram[], alsoAllocated: Iterable<string> = [], now: Date = new Date()): string {
+  const day = now.toISOString().slice(0, 10) // YYYY-MM-DD
   const prefix = `ENG-${day}-`
   // Legacy compact form minted by earlier releases: ENG-YYYYMMDD → ENG-YYYY-MMDD-
   const legacyPrefix = `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`
@@ -672,5 +672,6 @@ export function generateEngramId(existing: Engram[], alsoAllocated: Iterable<str
     const n = suffixOf(id)
     if (n !== null && n > max) max = n
   }
+  if (!Number.isSafeInteger(max + 1)) throw new Error('Engram ID allocation sequence is exhausted')
   return `${prefix}${String(max + 1).padStart(3, '0')}`
 }

--- a/packages/core/src/episodes.ts
+++ b/packages/core/src/episodes.ts
@@ -30,7 +30,7 @@ function generateEpisodeId(): string {
  *
  * `withLock` is the synchronous variant because this function is synchronous
  * and has synchronous callers. That is safe HERE specifically because no async
- * holder ever takes this path's lock, so the busy-wait cannot starve one out
+ * holder ever takes this path's lock, so the synchronous wait cannot block one in the same event loop
  * (the failure mode measured as F10 on the store lock).
  */
 export function captureEpisode(path: string, summary: string, context?: CaptureContext): Episode {

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import { logger } from './logger.js'
+import { withLock, fsyncDir } from './sync.js'
 import { join } from 'path'
 import { createHash } from 'crypto'
 
@@ -57,10 +58,6 @@ export interface HistoryEvent {
  */
 export function appendHistory(root: string, event: HistoryEvent): boolean {
   const historyDir = join(root, 'history')
-  if (!fs.existsSync(historyDir)) {
-    fs.mkdirSync(historyDir, { recursive: true })
-  }
-
   const date = event.timestamp.slice(0, 7) // YYYY-MM
   const filePath = join(historyDir, `${date}.jsonl`)
   const line = JSON.stringify(event) + '\n'
@@ -71,40 +68,46 @@ export function appendHistory(root: string, event: HistoryEvent): boolean {
   // restore cannot recover, so a lost record makes restore UNDER-report the
   // loss, which is the one thing it exists not to do.
   //
-  // Best-effort on the fsync itself: the append already succeeded, and failing
-  // the caller's mutation because a diagnostic log could not be flushed would
-  // trade a small durability gap for a large availability one.
-  // Best-effort on the WHOLE append, not just the fsync.
+  // History remains best-effort for the caller's primary mutation, but its
+  // acknowledgement is honest: any open/write/fsync failure returns false.
+  // The monthly lock also lets a later append delimit an interrupted tail
+  // without racing another writer. Both content and new directory entries are
+  // flushed before returning true.
   //
-  // The reasoning above — that failing a caller's mutation because a
-  // diagnostic log could not be written trades a small durability gap for a
-  // large availability one — was applied only to `fsyncSync`. `openSync` and
-  // `writeSync` were unguarded, so an unwritable history directory (disk full,
-  // permissions, a path that is not a file) propagated out and failed the
-  // learn/forget/feedback that called it. Found by a test that made the month
-  // file unreadable to check id allocation degraded safely: it did not
-  // degrade, it threw EISDIR out of `plur.learn()`.
-  //
-  // Warned rather than silently swallowed: history is load-bearing for `plur
-  // restore` (it NAMES the engrams a restore cannot recover) and, since #816,
-  // for id allocation. A store writing no history is degraded and the operator
-  // needs to know — but the write itself must still land.
+  // History names the engrams a restore cannot recover. A store writing no
+  // history is degraded and the operator needs to know. Durable ID reservations
+  // now live separately, so a diagnostic failure cannot release an identity.
   try {
-    const fd = fs.openSync(filePath, 'a')
-    try {
-      fs.writeSync(fd, line)
-      try { fs.fsyncSync(fd) } catch { /* append landed; durability is best-effort */ }
-    } finally {
-      fs.closeSync(fd)
-    }
-    return true
+    if (!/^\d{4}-(?:0[1-9]|1[0-2])$/.test(date)) throw new Error('Invalid history month')
+    fs.mkdirSync(historyDir, { recursive: true, mode: 0o700 })
+    return withLock(filePath, () => {
+      const fd = fs.openSync(filePath, fs.constants.O_RDWR | fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_NOFOLLOW, 0o600)
+      try {
+        fs.fchmodSync(fd, 0o600)
+        const size = fs.fstatSync(fd).size
+        const last = Buffer.alloc(1)
+        if (size) fs.readSync(fd, last, 0, 1, size - 1)
+        // An earlier disk-full/crash can leave a fragment without a newline.
+        // Delimit it so that it cannot consume the next valid record too.
+        const bytes = Buffer.from((size && last[0] !== 10 ? '\n' : '') + line)
+        let offset = 0
+        while (offset < bytes.length) {
+          const written = fs.writeSync(fd, bytes, offset, bytes.length - offset)
+          if (written === 0) throw new Error('Incomplete history append')
+          offset += written
+        }
+        fs.fsyncSync(fd)
+        fsyncDir(historyDir)
+      } finally { fs.closeSync(fd) }
+      return true
+    })
   } catch (err) {
     if (!warnedHistoryPaths.has(filePath)) {
       warnedHistoryPaths.add(filePath)
       logger.warning(
         `[plur] history could not be written to ${filePath}: ${(err as Error).message}. ` +
         `The operation itself succeeded. While this persists, \`plur restore\` cannot name ` +
-        `unrecoverable engrams and engram-id allocation loses its cross-compaction guarantee (#816).`,
+        `unrecoverable engrams. Durable ID reservations remain independent of this diagnostic log.`,
       )
     }
     return false

--- a/packages/core/src/importers/engine.ts
+++ b/packages/core/src/importers/engine.ts
@@ -56,7 +56,6 @@ export async function runImport(plur: Plur, records: ImportRecord[], opts: RunIm
   // engine misreport their duplicates as fresh imports (re-patching temporal
   // metadata on the existing engram along the way).
   const preExisting = await plur.list({ include_expired: true })
-  const knownIds = new Set(preExisting.map(e => e.id))
   const hashToId = new Map<string, string>()
   for (const e of preExisting) {
     const hash = (e as any).content_hash ?? computeContentHash(e.statement)
@@ -116,20 +115,16 @@ export async function runImport(plur: Plur, records: ImportRecord[], opts: RunIm
       if (record.valid_until) context.valid_until = record.valid_until.slice(0, 10)
       if (record.pinned) context.pinned = true
 
-      const engram = await plur.learn(statement, context)
+      const conflictIds = findConflicts(statement, scope, record.domain, preExisting)
+      const { engram, created } = await plur.learnImported(statement, context, record, conflictIds, now)
 
-      if (knownIds.has(engram.id)) {
+      if (!created) {
         // learn() resolved to an existing engram (hash dedup or cross-scope
         // recurrence) — the dedup gate did its job.
         skipped++
         results.push({ statement, action: 'skipped', id: engram.id })
         continue
       }
-      knownIds.add(engram.id)
-
-      const conflictIds = findConflicts(statement, scope, record.domain, preExisting)
-      const patched = applyImportMetadata(engram, record, conflictIds, now)
-      if (patched) await plur.updateEngram(patched)
 
       imported++
       if (conflictIds.length > 0) conflicts++
@@ -173,11 +168,11 @@ function findConflicts(statement: string, scope: string | undefined, domain: str
 }
 
 /**
- * Post-learn metadata the LearnContext cannot express: source-preserved
+ * Pre-persistence metadata the LearnContext cannot express: source-preserved
  * temporal anchors, confidence, and heuristic conflict links. Returns the
  * patched engram, or null when the record adds nothing.
  */
-function applyImportMetadata(engram: Engram, record: ImportRecord, conflictIds: string[], now: string): Engram | null {
+export function applyImportMetadata(engram: Engram, record: ImportRecord, conflictIds: string[], now: string): Engram | null {
   let changed = false
   const out: Engram = { ...engram }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import { createHash, randomUUID } from 'node:crypto'
 import { tmpdir } from 'os'
 import { join, dirname, basename } from 'path'
 import yaml from 'js-yaml'
@@ -9,6 +10,7 @@ import { PGLiteAdapter } from './storage-pglite.js'
 import { loadConfig } from './config.js'
 import { generateEngramId, engramIdDatePrefix, loadAllPacks, storePrefix, namespaceEngramId, bareEngramId, initFilesystemStore } from './engrams.js'
 import { maybeDailyBackup } from './backup.js'
+import { legacyAllocatedIds, reserveLocalEngramId } from './store/id-allocation.js'
 import { logger } from './logger.js'
 import { searchEngrams, ftsTokenize, extendCorpusStats, searchTextFrom } from './fts.js'
 import { selectAndSpread, scoreEngramsPublic, formatWithLayer, assignLayer, estimateTokens } from './inject.js'
@@ -23,6 +25,8 @@ import { checkRerankerFit, type FitCheckResult } from './rerankers/fit-check.js'
 import { runRerankerSelfEval, loadRerankerEvalCache, saveRerankerEvalResult, isRerankerEvalStale, logRerankerEvalAdvisory, type RerankerEvalResult } from './reranker-eval.js'
 import { _resetCrossEncoderCaches } from './rerankers/transformers-cross-encoder.js'
 import { classifyQuery, routeForIntent, applyIntentRouting, isIntentRoutingDisabled, isEntityDomain, rewriteLexicalQuery, isQueryRewriteDisabled, type QueryIntent, type IntentRoutingProfile } from './intent/index.js'
+import { applyImportMetadata } from './importers/engine.js'
+import type { ImportRecord } from './importers/types.js'
 import { getEmbedder, resolveEmbedderName } from './embedders/index.js'
 import { emitMissSignal } from './telemetry-miss-signal.js'
 import { embedderStatus, resetEmbedder, setEmbeddingsEnabled, type EmbedderStatus } from './embeddings.js'
@@ -31,18 +35,19 @@ import { recallAuto, type AutoSearchResult } from './search-orchestrator.js'
 import { autoSummary } from './summary.js'
 import { installPack, uninstallPack, listPacks, exportPack, scanPrivacy, computePackHash, previewPack, containsEmail } from './packs.js'
 import type { ExportOptions } from './packs.js'
-import { learnContextContent, engramContentFields } from './content-fields.js'
+import { learnContextContent, engramContentFields, LEARN_CONTEXT_FIELD_ROLES } from './content-fields.js'
 export { LEARN_CONTEXT_FIELD_ROLES, LEARN_CONTENT_FIELDS, learnContextContent, engramContentFields } from './content-fields.js'
 // SP5 imports (deferred — vault-export, registry not yet merged)
 // import { exportVault, type VaultExportOptions, type VaultExportResult } from './vault-export.js'
 // import { fetchRegistry, discoverPacks, verifyPackIntegrity, DEFAULT_REGISTRY_URL, type PackRegistry, type RegistryPack } from './registry.js'
-import { atomicWrite, CONFIG_FILE_MODE, sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncStatus, type SyncRemoteType } from './sync.js'
+import { atomicWrite, fsyncDir, CONFIG_FILE_MODE, sync as gitSync, getSyncStatus, withLock, type SyncResult, type SyncStatus, type SyncRemoteType } from './sync.js'
 import { detectSecrets, detectSensitive, sensitivityCategory, SCAN_TRUNCATED } from './secrets.js'
 import type { SecretMatch } from './secrets.js'
 import { SENSITIVITY_CATEGORIES, type ScopeMetadata, type SensitivityCategory } from './schemas/scope-metadata.js'
 import { rankScopes, SCOPE_MATCH_THRESHOLD, type ScopeSignals, type ScopeCandidate } from './scope-routing.js'
-import { mintedIdsWithPrefix, appendHistory, readHistoryForEngram, type HistoryEvent as HistoryEventType, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, isRecentDuplicateInjection, type InjectionEventCounts } from './history.js'
+import { appendHistory, readHistoryForEngram, type HistoryEvent as HistoryEventType, generateEventId, generateInjectionId, computeQueryHash, findLatestInjectionFor, countInjectionEvents, isRecentDuplicateInjection, type InjectionEventCounts } from './history.js'
 import { computeContentHash, isHashable } from './content-hash.js'
+import { validateLearnContext, validateEngramWrite } from './learn-context-validation.js'
 import { isLocalOnlyScope, assertScopeNamesATarget } from './scope-target.js'
 import { orderBySupersedes } from './outbox-order.js'
 import { loadTensions, loadTensionsWithQuarantine, saveTensions, generateTensionId, tensionPairKey, categorizeTension } from './tension-store.js'
@@ -93,7 +98,7 @@ export { computeConfidence, computeMetaConfidence, confidenceBand } from './conf
 export { SessionBreadcrumbs } from './session-state.js'
 export { SessionScopeRegistry } from './session-scopes.js'
 export { AsyncMutex, KeyedAsyncMutex } from './async-mutex.js'
-export { findProjectConfigPath, readProjectConfig, type ProjectConfig } from './project-config.js'
+export { findProjectConfigPath, readProjectConfig, readProjectConfigDocument, updateProjectConfig, type ProjectConfig } from './project-config.js'
 export { generateGuardrails } from './guardrails.js'
 export type { MetaField, StructuralTemplate, EvidenceEntry, MetaConfidence, DomainCoverage, HierarchyPosition, Falsification } from './schemas/meta-engram.js'
 export { MetaFieldSchema, StructuralTemplateSchema, EvidenceEntrySchema, MetaConfidenceSchema, DomainCoverageSchema, HierarchyPositionSchema, FalsificationSchema } from './schemas/meta-engram.js'
@@ -629,7 +634,6 @@ function stableJson(v: unknown): string {
  */
 const REMOTE_GUARD_BUDGET_MS = 45_000
 
-const OUTBOX_ID_MAP_MAX = 5000
 
 const LLM_BREAKER_THRESHOLD = 3
 const LLM_BREAKER_WINDOW_MS = 5 * 60 * 1000
@@ -1645,49 +1649,16 @@ export class Plur {
     }
   }
 
-  /**
-   * Ids this store has minted today that are no longer in the corpus (#816).
-   *
-   * Read from the append-only history log, which — unlike the corpus — never
-   * forgets. See `mintedIdsWithPrefix` for why an incomplete answer is safe.
-   */
-  private _mintedTodayIds(): string[] {
-    const day = new Date().toISOString().slice(0, 10)
-    // Cached per process, per day.
-    //
-    // Without this, every learn() re-read and re-parsed a month of
-    // history.jsonl — on the hottest write path, to answer a question whose
-    // answer this process already knows. The cache is keyed on the DAY so it
-    // self-invalidates across midnight (allocation is per-day, so yesterday's
-    // ids are irrelevant to today's suffix).
-    //
-    // Staleness is safe in the one direction that matters: ids minted by
-    // ANOTHER process after this cache was filled are missing from it, which
-    // degrades to the pre-fix corpus-only behaviour rather than introducing a
-    // new hazard — and the corpus scan, which is always fresh, still sees any
-    // engram that other process actually wrote. Ids minted by THIS process are
-    // added below without a re-read, so a burst of writes in one session stays
-    // monotonic without touching disk again.
-    if (this._mintedCache?.day !== day) {
-      this._mintedCache = {
-        day,
-        ids: new Set(mintedIdsWithPrefix(this.paths.root, day.slice(0, 7), [
-          `ENG-${day}-`,
-          `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`,
-        ])),
-      }
+  /** Called under the primary store lock. The store owns shared allocation;
+   * local stores reserve privately before publishing a row. */
+  private async _allocateEngramId(existing: Engram[]): Promise<string> {
+    if (this._primaryStore.reserveEngramId) {
+      const now = new Date()
+      const minimum = generateEngramId(existing, legacyAllocatedIds(this.paths.root, now), now)
+      return this._primaryStore.reserveEngramId(minimum)
     }
-    return [...this._mintedCache.ids]
+    return reserveLocalEngramId(this.paths.root, existing)
   }
-
-  /** Record an id this process just minted, so the next allocation sees it
-   *  without re-reading history (#816). */
-  private _rememberMintedId(id: string): void {
-    const day = new Date().toISOString().slice(0, 10)
-    if (this._mintedCache?.day === day) this._mintedCache.ids.add(id)
-  }
-
-  private _mintedCache: { day: string; ids: Set<string> } | null = null
 
   private _storeAt(path: string): AsyncPrimaryStore {
     if (path === this.paths.engrams) return this._primaryStore
@@ -1826,12 +1797,35 @@ export class Plur {
    * normalizer no longer produces that for real prose; this is the belt to its
    * braces, and it fails in the safe direction (a missed dedup costs a
    * duplicate row, a false dedup costs the memory). */
-  private _hashDedup(statement: string, engrams: Engram[], scope?: string): Engram | null {
+  /** A repeated sentence cannot absorb a different supplied meaning or policy.
+   * Omitted fields preserve historical dedup semantics; session provenance is
+   * recorded separately in sources[]. Compare the same shape the writer builds.
+   */
+  private _sameLearnContext(engram: Engram, statement: string, context?: LearnContext): boolean {
+    // Explicitly private input requires a local record with no pending export.
+    // A matching sentence in a remote, pack, or outbox cannot satisfy that write.
+    if (context?.visibility === 'private' && ((engram as any)._storeScope || (engram as any)._pack || engram.structured_data?._outbox)) return false
+    const keys = (Object.keys(LEARN_CONTEXT_FIELD_ROLES) as Array<keyof LearnContext>)
+      .filter(key => !['scope', 'session', 'session_episode_id'].includes(key) && context?.[key] !== undefined)
+      .filter(key => key !== 'source' || Boolean((engram as any)._storeScope || (engram as any)._pack || engram.structured_data?._outbox))
+    if (!keys.length) return true
+    const expected = this._buildEngramShape(statement, engram.scope, context, new Date().toISOString())
+    const value = (row: Engram, key: keyof LearnContext): unknown => {
+      if (key === 'valid_from' || key === 'valid_until') return row.temporal?.[key] ?? (row as any)[key]
+      if (key === 'supersedes') return row.relations?.supersedes ?? (row as any).supersedes ?? []
+      if (key === 'license') return row.provenance?.license
+      if (key === 'memory_class') return row.knowledge_type?.memory_class
+      return (row as any)[key]
+    }
+    return keys.every(key => stableJson(value(engram, key)) === stableJson(value(expected, key)))
+  }
+
+  private _hashDedup(statement: string, engrams: Engram[], scope?: string, context?: LearnContext): Engram | null {
     if (!isHashable(statement)) return null
     const hash = computeContentHash(statement)
     for (const e of engrams) {
       if (e.status === 'active' && (e as any).content_hash === hash) {
-        if (scope === undefined || e.scope === scope) return e
+        if ((scope === undefined || e.scope === scope) && this._sameLearnContext(e, statement, context)) return e
       }
     }
     return null
@@ -1958,15 +1952,9 @@ export class Plur {
    */
   setIdentity(identity: string | null): { identity: string; stated: boolean; warning?: string } {
     const value = typeof identity === 'string' ? identity.trim() : ''
-    // An email address is the most natural identity to type and the one that
-    // silently breaks sharing: the export privacy scan flags email addresses,
-    // so every memory attributed this way is dropped from every pack (#999).
-    // Accept it — it is the user's decision — but say so at the moment they
-    // choose it rather than at the first empty export.
+    // Declared email identities are intentionally included in exported packs.
     const warning = value && containsEmail(value)
-      ? `"${value}" is an email address. The pack export privacy scan flags email addresses, so memories `
-        + 'attributed to it are held back from every pack until #999 lands. Prefer a local name '
-        + '(local:yourname) or a DID if you intend to share.'
+      ? 'This email address will be included when attributed memories are exported in packs. Use a public identity if you intend to share.'
       : undefined
     if (warning) logger.warning(`[plur:identity] ${warning}`)
     // Same read-modify-write discipline as every other config mutation here:
@@ -2012,19 +2000,27 @@ export class Plur {
    * Never throws — provenance is a description, and failing to write one must
    * not fail the learn that prompted it.
    */
+  private _afterStoreCommit(callback: () => void): void {
+    if (this._primaryStore.afterCommit) this._primaryStore.afterCommit(callback)
+    else callback()
+  }
+
   private _maybeWriteProvenance(engramId: string): void {
     if (provenanceMode(this.config) !== 'always') return
-    void this.writeProvenance(engramId).catch(err => {
-      logger.warning(`[plur:provenance] could not write a record for ${engramId}: ${(err as Error).message}`)
+    this._afterStoreCommit(() => {
+      void this.writeProvenance(engramId).catch(err => {
+        logger.warning(`[plur:provenance] could not write a record for ${engramId}: ${(err as Error).message}`)
+      })
     })
   }
 
   private _buildSourceEntry(scope: string, context?: LearnContext): {
-    scope: string; session_id: string | null; stored_at: string
+    scope: string; session_id: string | null; stored_at: string; source?: string
   } {
     return {
       scope,
       session_id: context?.session_episode_id ?? null,
+      ...(context?.source !== undefined ? { source: context.source } : {}),
       stored_at: new Date().toISOString(),
     }
   }
@@ -2102,6 +2098,7 @@ export class Plur {
     statement: string,
     engrams: Engram[],
     currentScope: string,
+    context?: LearnContext,
   ): Engram | null {
     // Same guard as `_hashDedup` (#896): an unhashable statement would report
     // every other unhashable statement as the same fact recurring, and this
@@ -2112,7 +2109,7 @@ export class Plur {
     for (const e of engrams) {
       if (e.status === 'active'
           && (e as any).content_hash === hash
-          && e.scope !== currentScope) {
+          && e.scope !== currentScope && this._sameLearnContext(e, statement, context)) {
         return e
       }
     }
@@ -2844,10 +2841,26 @@ export class Plur {
         throw new Error(`Secret detected in statement or context: ${secrets[0].pattern}. Use config.allow_secrets to override.`)
       }
     }
+    validateLearnContext(context)
     return statement
   }
 
   async learn(statement: string, context?: LearnContext): Promise<Engram> {
+    return this._learn(statement, context)
+  }
+
+  /** Import through the canonical learn gates, with metadata present at the
+   * first durable write. Existing duplicates retain their original metadata. */
+  async learnImported(statement: string, context: LearnContext, record: ImportRecord, conflictIds: string[], now: string): Promise<{ engram: Engram; created: boolean }> {
+    let created = false
+    const engram = await this._learn(statement, context, engram => {
+      created = true
+      return applyImportMetadata(engram, record, conflictIds, now) ?? engram
+    })
+    return { engram, created }
+  }
+
+  private async _learn(statement: string, context?: LearnContext, initialize?: (engram: Engram) => Engram): Promise<Engram> {
     this._assertWritable()
     statement = this._validateLearnInput('learn', statement, context)
     const guarded = await this._guardSensitiveScope(statement, context)
@@ -2898,10 +2911,16 @@ export class Plur {
       // Unhashable statements skip the store lookup entirely (#896) — the
       // delegated query has the same collapse the in-memory scan does, and
       // this is the branch a Postgres/PGLite install actually takes.
-      const primaryHashMatch = canDelegate && isHashable(statement)
+      let primaryHashMatch = canDelegate && isHashable(statement)
         ? await ps.findActiveByContentHash!(computeContentHash(statement), scope)
         : null
-      const hashMatch = primaryHashMatch ?? this._hashDedup(statement, allEngrams, scope)
+      if (primaryHashMatch && !this._sameLearnContext(primaryHashMatch, statement, context)) {
+        // Older adapters expose only a sentence-hash lookup. A different
+        // context may have another matching row; search those rows before
+        // creating a new record. The normal same-context path stays targeted.
+        primaryHashMatch = this._hashDedup(statement, await ps.load(), scope, context)
+      }
+      const hashMatch = primaryHashMatch ?? this._hashDedup(statement, allEngrams, scope, context)
       if (hashMatch) {
         // `_recordDuplicate` persists only when the hit is IN the array it is
         // given — a match from a secondary store or a pack is counted in
@@ -2928,7 +2947,7 @@ export class Plur {
       // statement becomes its own engram, and a deployment that wants
       // graduation declines the seam and keeps the corpus scan.
       // See `PrimaryStore.findActiveByContentHash`.
-      const crossMatch = this._crossScopeRecurrenceDetect(statement, allEngrams, scope)
+      const crossMatch = this._crossScopeRecurrenceDetect(statement, allEngrams, scope, context)
       // `engrams` is empty under delegation, so `_recordCrossScopeRecurrence`
       // takes its secondary-store branch — which is where every match it can
       // still see actually lives.
@@ -2936,17 +2955,17 @@ export class Plur {
 
       const id = canDelegate
         ? await ps.nextEngramId!(engramIdDatePrefix())
-        : generateEngramId(allEngrams, this._mintedTodayIds())
-      // Claim it in-process immediately (#816). The history record is written
-      // later and best-effort; without this, two writes in the same tick — or
-      // one whose history append fails — could both take the same suffix.
-      this._rememberMintedId(id)
+        : await this._allocateEngramId(allEngrams)
       const now = new Date().toISOString()
       // One constructor for every write path: `_buildEngramShape` is what the
       // remote route posts, so a field added there is a field added here.
-      const engram: Engram = {
+      let engram: Engram = {
         ...this._buildEngramShape(statement, scope, context, now, validity, id => this._ancestorsOf(engrams, id)),
         id,
+      }
+      if (initialize) {
+        engram = initialize(engram)
+        validateEngramWrite(engram)
       }
 
       // #240: supersedes is a graph edge, not a temporality enum — write the
@@ -3037,70 +3056,13 @@ export class Plur {
         }
         await this._syncIndex()
 
-        // Fire-and-forget: attempt immediate push, clean up on success.
-        //
-        // The push and the local bookkeeping are caught SEPARATELY. Wrapping
-        // both in one try meant a failure while removing the local copy — after
-        // the remote had already accepted the engram — was recorded as a failed
-        // push, so the outbox retried it and the remote ended up with a
-        // duplicate. "The write did not land" and "the write landed but I could
-        // not tidy up" are different facts and must not share a handler.
-        //
-        // The trailing `.catch()` is load-bearing: the error path below itself
-        // awaits a store write, and if THAT throws the IIFE's promise rejects
-        // with nothing attached — an unhandled rejection, which terminates the
-        // process on modern Node. A background task must not be able to take
-        // the host down.
-        void (async () => {
-          let pushed = false
-          try {
-            await remoteDriver.append(engram)
-            pushed = true
-          } catch (err) {
-            // Already saved locally with outbox metadata — will be retried.
-            logger.warning(`[plur:outbox] immediate push failed for ${engram.id}, queued for retry: ${(err as Error).message}`)
-            await this._withStoreLock(this.paths.engrams, async () => {
-              // Targeted read (#827): only this engram's outbox bookkeeping.
-              const fresh = await this._loadTargeted([engram.id])
-              const target = fresh.find(e => e.id === engram.id) as any
-              if (target?.structured_data?._outbox) {
-                target.structured_data._outbox.last_error = (err as Error).message
-                target.structured_data._outbox.attempt_count = 1
-                // Incremental write (#740): only the outbox bookkeeping changed.
-                await this._updateEngrams(fresh, [target as Engram])
-              }
-            })
-            return
-          }
-
-          if (!pushed) return
-          // Remote has it. Remove the local copy — and if this fails, say so
-          // rather than re-queueing something already accepted.
-          try {
-            await this._withStoreLock(this.paths.engrams, async () => {
-              // NOT `_loadTargeted` (#827): this REMOVES a row, and the only
-              // removal primitive `PrimaryStore` has is a whole-corpus save of
-              // the array without it. A one-row targeted read here would be a
-              // full replace by an empty array — the corpus, deleted. It stays
-              // a full load until there is a `remove`/`deleteMany` seam.
-              const fresh = await this._primaryStore.load()
-              const idx = fresh.findIndex(e => e.id === engram.id)
-              if (idx !== -1) {
-                fresh.splice(idx, 1)
-                // Deliberate removal: the remote accepted this engram, so the
-                // local copy is redundant by design (audit #794 shrink guard).
-                await this._writeEngrams(this.paths.engrams, fresh, { allowShrink: true })
-                await this._syncIndex()
-              }
-            })
-          } catch (err) {
-            logger.warning(
-              `[plur:outbox] ${engram.id} was accepted by the remote but its local copy could not be removed: `
-              + `${(err as Error).message}. It will be retried, which may create a duplicate on the remote.`,
-            )
-          }
-        })().catch(err => {
-          logger.warning(`[plur:outbox] background push for ${engram.id} failed unexpectedly: ${(err as Error).message}`)
+        // One durable outbox protocol for background sends and explicit
+        // flushes. The upload lock spans the network operation; the corpus
+        // lock only spans local changes, so learning can continue meanwhile.
+        this._afterStoreCommit(() => {
+          void this._flushOutbox(new Set([engram.id])).catch(err => {
+            logger.warning(`[plur:outbox] background flush failed: ${(err as Error).message}`)
+          })
         })
 
         this._appendHistory({
@@ -3254,7 +3216,7 @@ export class Plur {
     // #347: fail fast on malformed valid_from/valid_until (pure validation),
     // mirroring learn() — before dedup can short-circuit the write.
     resolveValidity(statement, context)
-    const remoteDriver = this._resolveRemoteStoreForScope(scope)
+    const remoteDriver = context?.visibility === 'private' ? null : this._resolveRemoteStoreForScope(scope)
     if (!remoteDriver) {
       // Local route — sync learn() owns dedup, build, write, history. learn()'s
       // own guard sees the already-demoted (local) context and no-ops, so the
@@ -3282,7 +3244,7 @@ export class Plur {
     // representation we hand back to the caller. On failure, save to
     // local outbox for retry (issue #26).
     const allEngrams = await this._loadAllEngrams()
-    const hashMatch = this._hashDedup(statement, allEngrams, scope)
+    const hashMatch = this._hashDedup(statement, allEngrams, scope, context)
     if (hashMatch) {
       // Mutate + persist if local; otherwise return mutated (best-effort)
       return await this._withStoreLock(this.paths.engrams, async () => {
@@ -3291,7 +3253,7 @@ export class Plur {
       })
     }
     // #176: cross-scope recurrence (same semantics as the local learn() path).
-    const crossMatch = this._crossScopeRecurrenceDetect(statement, allEngrams, scope)
+    const crossMatch = this._crossScopeRecurrenceDetect(statement, allEngrams, scope, context)
     if (crossMatch) {
       return await this._withStoreLock(this.paths.engrams, async () => {
         const engrams = await this._primaryStore.load()
@@ -3309,9 +3271,10 @@ export class Plur {
       }
     }
     let serverEngram: Engram
+    const requestId = randomUUID()
     try {
-      const { id: serverId } = await remoteDriver.appendAndGetServerId(localPlaceholder)
-      serverEngram = { ...localPlaceholder, id: serverId }
+      const { id: serverId, engram: confirmed } = await remoteDriver.appendAndGetServerId(localPlaceholder, requestId)
+      serverEngram = { ...localPlaceholder, ...confirmed, id: serverId }
     } catch (err) {
       // Remote failed — save locally with outbox metadata for retry.
       // Audit iter-1 fix (Dijkstra): defensive lookup; the catch is the
@@ -3322,8 +3285,7 @@ export class Plur {
       return await this._withStoreLock(this.paths.engrams, async () => {
         const engrams = await this._primaryStore.load()
         // Replace placeholder ID with a real local ID
-        localPlaceholder.id = generateEngramId([...engrams, ...allEngrams], this._mintedTodayIds())
-        this._rememberMintedId(localPlaceholder.id)
+        localPlaceholder.id = await this._allocateEngramId([...engrams, ...allEngrams])
         if (storeEntry) {
           ;(localPlaceholder as any).structured_data = {
             ...((localPlaceholder as any).structured_data ?? {}),
@@ -3333,6 +3295,7 @@ export class Plur {
               queued_at: now,
               last_attempt: now,
               attempt_count: 1,
+              request_id: requestId,
               last_error: (err as Error).message,
               // #295: flag auth failures distinctly so the queue isn't read as a
               // transient network blip — a 401/403 means the token needs reauth,
@@ -3522,7 +3485,17 @@ export class Plur {
   /** Build deps for learn-async module. */
   private async _learnAsyncDeps() {
     return {
-      hashDedup: async (statement: string, scope?: string) => this._hashDedup(statement, await this._loadAllEngrams(), scope),
+      prepareLearn: async (statement: string, context?: LearnAsyncContext) => {
+        statement = this._validateLearnInput('learn', statement, context)
+        resolveValidity(statement, context)
+        // An unscoped semantic decision may select any offered local candidate.
+        // ADD uses canonical routing; mutations guard the selected row's scope.
+        return { statement, context }
+      },
+      sameLearnContext: (engram: Engram, statement: string, context?: LearnContext) =>
+        this._sameLearnContext(engram, statement, context)
+        && (context?.source === undefined || context.source === engram.source || Boolean(engram.sources?.some(source => source.source === context.source))),
+      hashDedup: async (statement: string, scope?: string, context?: LearnContext) => this._hashDedup(statement, await this._loadAllEngrams(), scope, context),
       // remote:false (#776) — dedup queries are DERIVED FROM STATEMENTS. With
       // the remote leg on, every plur_learn would fire statement-derived POSTs
       // to all hosts, and a namespaced remote row could silently suppress a
@@ -4175,7 +4148,7 @@ export class Plur {
       if (typeof adapter.listEngramsMissingEmbeddings === 'function') {
         const gap = await adapter.listEngramsMissingEmbeddings(1)
         if (gap.length > 0) {
-          this._kickPrimaryAutoEmbed(adapter)
+          this._afterStoreCommit(() => this._kickPrimaryAutoEmbed(adapter))
           return fallback()
         }
       }
@@ -4363,48 +4336,81 @@ export class Plur {
    * measured three consecutive flushes producing the same unfollowable
    * warning.
    *
-   * Derived state, not truth: losing this file costs a supersedes edge on a
-   * pathological ordering, never an engram. Every read and write is
-   * best-effort for that reason.
+   * This is authoritative retry and relationship state. Keep it outside the
+   * disposable cache directory, include it in local operational backups, and
+   * fail closed if it cannot be read or persisted.
    */
   outboxIdMapPath(): string {
-    return join(this.paths.root, 'cache', 'outbox-id-map.json')
+    return join(this.paths.root, 'state', 'outbox-id-map.json')
   }
 
-  /** Read the persisted local→server map. Never throws; `{}` on any problem. */
-  private _readOutboxIdMap(): Record<string, { server_id: string; url: string; at: number }> {
-    try {
-      const raw = JSON.parse(fs.readFileSync(this.outboxIdMapPath(), 'utf8')) as unknown
-      if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-        return raw as Record<string, { server_id: string; url: string; at: number }>
+  /** A persisted operation key lets an explicit remote move survive an
+   * ambiguous response or a failure retiring its local source. */
+  private async _remoteRequestId(identity: string): Promise<string> {
+    const path = join(this.paths.root, 'state', 'remote-write-requests.json')
+    return withAsyncLock(join(this.paths.root, 'remote-write-requests'), async () => {
+      let entries: Record<string, string> = {}
+      try {
+        const raw: unknown = JSON.parse(fs.readFileSync(path, 'utf8'))
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw) || Object.entries(raw).some(([k, v]) =>
+          !/^[a-f0-9]{64}$/.test(k) || typeof v !== 'string' || !/^[A-Za-z0-9_-]{16,128}$/.test(v))) {
+          throw new Error('Invalid remote operation journal')
+        }
+        entries = raw as Record<string, string>
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw new Error('Cannot read durable remote operation journal')
       }
-    } catch { /* absent or corrupt — a cache miss, not an error */ }
-    return {}
+      const key = createHash('sha256').update(identity).digest('hex')
+      if (entries[key]) return entries[key]
+      const requestId = randomUUID()
+      entries[key] = requestId
+      if (fs.mkdirSync(dirname(path), { recursive: true, mode: 0o700 })) fsyncDir(this.paths.root)
+      atomicWrite(path, JSON.stringify(entries), { mode: 0o600 })
+      return requestId
+    })
   }
 
-  /**
-   * Persist local→server mappings recorded during a flush. Never throws.
-   *
-   * Bounded at {@link OUTBOX_ID_MAP_MAX} entries, oldest dropped first: this
-   * grows by one row per remote write forever otherwise, and an unbounded
-   * cache file in the store root is its own defect. Dropping the oldest is
-   * safe because the edges that need it are queued corrections, which are
-   * resolved within a flush or two of the target.
+  /** Read under the outbox-flush lock. Promote a legacy cache before any send;
+   * leave its bytes intact, and never replace newer durable state with it. */
+  private _readOutboxIdMap(): Record<string, { server_id?: string; url: string; at: number; fingerprint?: string; request_id?: string }> {
+    try {
+      let bytes: string
+      let legacy = false
+      try {
+        bytes = fs.readFileSync(this.outboxIdMapPath(), 'utf8')
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+        try {
+          bytes = fs.readFileSync(join(this.paths.root, 'cache', 'outbox-id-map.json'), 'utf8')
+          legacy = true
+        } catch (legacyError) {
+          if ((legacyError as NodeJS.ErrnoException).code === 'ENOENT') return {}
+          throw legacyError
+        }
+      }
+      const raw = JSON.parse(bytes) as unknown
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw) || Object.values(raw).some(v =>
+        !v || typeof v !== 'object' || (typeof v.server_id !== 'string' && !(v.server_id === undefined && typeof v.request_id === 'string' && /^[A-Za-z0-9_-]{16,128}$/.test(v.request_id))) || typeof v.url !== 'string' ||
+        (v.server_id !== undefined && (typeof v.server_id !== 'string' || v.server_id.length === 0 || v.server_id.length > 128 || !/^[\w:./-]+$/.test(v.server_id))) ||
+        (v.request_id !== undefined && (typeof v.request_id !== 'string' || !/^[A-Za-z0-9_-]{16,128}$/.test(v.request_id))) ||
+        typeof v.at !== 'number' || !Number.isFinite(v.at) || (v.fingerprint !== undefined && typeof v.fingerprint !== 'string'))) {
+        throw new Error('Invalid outbox receipt data')
+      }
+      const entries = raw as Record<string, { server_id?: string; url: string; at: number; fingerprint?: string; request_id?: string }>
+      if (legacy) this._writeOutboxIdMap(entries)
+      return entries
+    } catch {
+      throw new Error('Cannot read durable outbox receipts; repair the receipt file before retrying')
+    }
+  }
+
+  /** Durable remote receipts, retained for retry and later relationship repair.
+   * A receipt is authoritative state, so corruption and failed writes must be
+   * visible and old relationships cannot be evicted like a rebuildable cache.
    */
-  private _writeOutboxIdMap(entries: Record<string, { server_id: string; url: string; at: number }>): void {
-    try {
-      const ids = Object.keys(entries)
-      if (ids.length > OUTBOX_ID_MAP_MAX) {
-        const keep = ids
-          .sort((a, b) => (entries[b].at ?? 0) - (entries[a].at ?? 0))
-          .slice(0, OUTBOX_ID_MAP_MAX)
-        const trimmed: typeof entries = {}
-        for (const id of keep) trimmed[id] = entries[id]
-        entries = trimmed
-      }
-      fs.mkdirSync(dirname(this.outboxIdMapPath()), { recursive: true })
-      fs.writeFileSync(this.outboxIdMapPath(), JSON.stringify(entries), 'utf8')
-    } catch { /* derived state — a failed write must never fail a flush */ }
+  private _writeOutboxIdMap(entries: Record<string, { server_id?: string; url: string; at: number; fingerprint?: string; request_id?: string }>): void {
+    if (fs.mkdirSync(dirname(this.outboxIdMapPath()), { recursive: true, mode: 0o700 })) fsyncDir(this.paths.root)
+    atomicWrite(this.outboxIdMapPath(), JSON.stringify(entries), { mode: 0o600 })
   }
 
   /**
@@ -5518,6 +5524,7 @@ export class Plur {
    */
   async feedback(id: string, signal: 'positive' | 'negative' | 'neutral', scope?: string): Promise<void> {
     this._assertWritable()
+    if (!['positive', 'negative', 'neutral'].includes(signal)) throw new TypeError('Invalid feedback signal')
 
     if (scope !== undefined && (typeof scope !== 'string' || scope.trim() === '')) {
       throw new TypeError('plur.feedback: scope must be a non-empty string')
@@ -5822,6 +5829,7 @@ export class Plur {
    */
   async saveMetaEngrams(metas: Engram[]): Promise<{ saved: number; skipped: number }> {
     this._assertWritable()
+    for (const meta of metas) validateEngramWrite(meta)
     return await this._withStoreLock(this.paths.engrams, async () => {
       const engrams = await this._primaryStore.load()
       const existingIds = new Set(engrams.map(e => e.id))
@@ -5868,6 +5876,7 @@ export class Plur {
           }
         }
         engrams.push(meta)
+        existingIds.add(meta.id)
         saved++
       }
       if (saved > 0) {
@@ -5910,6 +5919,9 @@ export class Plur {
       const engrams = await this._loadTargeted([updated.id])
       const idx = engrams.findIndex(e => e.id === updated.id)
       if (idx === -1) return null
+      // Remote records have a different activation shape; only the local
+      // replacement is required to satisfy the local persistence schema.
+      validateEngramWrite(updated)
       // Leak guard (#353): local-resident → demote a sensitive update in place.
       // LOW-2: scan context fields too, not just the statement.
       const demote = this._guardExplicitUpdate(updated.statement, updated.scope, false, this._engramContextFields(updated))
@@ -5988,6 +6000,7 @@ export class Plur {
    */
   async setPinned(id: string, pinned: boolean): Promise<Engram | null> {
     this._assertWritable()
+    if (typeof pinned !== 'boolean') throw new TypeError('pinned must be a boolean')
     // Local primary first.
     const localResult = await this._withStoreLock(this.paths.engrams, async () => {
       // Targeted read (#827): resolving one engram by id.
@@ -6852,10 +6865,12 @@ export class Plur {
       }
       let serverId: string
       try {
-        ;({ id: serverId } = await remoteDriver!.appendAndGetServerId(copy))
+        ;({ id: serverId } = await remoteDriver!.appendAndGetServerId(copy, await this._remoteRequestId(
+          stableJson({ source: id, target, fingerprint: remoteDriver!.appendFingerprint(copy) }),
+        )))
       } catch (err) {
-        // Atomic semantics (#676 constraint 2): the push did not land, so the
-        // source stays exactly as it was. Deliberately NO outbox fallback — an
+        // The remote outcome may be unknown. Preserve the operation key and the
+        // source exactly as it was. An
         // explicit move reports failure instead of becoming a maybe-later.
         const msg = (err as Error).message
         const authHint = /\b40[13]\b/.test(msg)
@@ -7290,7 +7305,7 @@ export class Plur {
     const primary = this._primaryQueryAdapter()
     if (primary && typeof primary.listEngramsMissingEmbeddings === 'function') {
       this._lastIndexError = null // new pass — stale failures cleared on success
-      this._kickPrimaryAutoEmbed(primary)
+      this._afterStoreCommit(() => this._kickPrimaryAutoEmbed(primary))
       return
     }
     if (this.indexedStorage) {
@@ -7602,6 +7617,14 @@ export class Plur {
    * After 7 days: includes warning in expired_warnings.
    */
   async flushOutbox(): Promise<{ flushed: number; failed: number; expired_warnings: string[] }> {
+    return this._flushOutbox()
+  }
+
+  private async _flushOutbox(onlyIds?: Set<string>): Promise<{ flushed: number; failed: number; expired_warnings: string[] }> {
+    return withAsyncLock(join(this.paths.root, 'outbox-flush'), () => this._flushOutboxLocked(onlyIds))
+  }
+
+  private async _flushOutboxLocked(onlyIds?: Set<string>): Promise<{ flushed: number; failed: number; expired_warnings: string[] }> {
     this._assertWritable()
     const engrams = await this._primaryStore.load()
     // #766: skip retired engrams — a retired engram must not be pushed to the
@@ -7612,6 +7635,20 @@ export class Plur {
       (e as any).structured_data?._outbox && e.status !== 'retired'
     )
     if (pending.length === 0) return { flushed: 0, failed: 0, expired_warnings: [] }
+    // Network awaits invalidate every local snapshot, including the rows we
+    // intend to remove. Compare the original version under the write lock.
+    if (onlyIds) {
+      // Background delivery owns the newly queued row and its prerequisites;
+      // unrelated old failures should not be retried on every new learn.
+      for (let changed = true; changed;) {
+        changed = false
+        for (const e of pending) if (onlyIds.has(e.id)) {
+          for (const id of e.relations?.supersedes ?? []) if (!onlyIds.has(id)) { onlyIds.add(id); changed = true }
+        }
+      }
+      for (let i = pending.length - 1; i >= 0; i--) if (!onlyIds.has(pending[i].id)) pending.splice(i, 1)
+    }
+    const pendingSnapshots = new Map(pending.map(e => [e.id, stableJson(e)]))
 
     // #863: push supersedes TARGETS before the engrams that supersede them.
     //
@@ -7645,11 +7682,10 @@ export class Plur {
      * Seeded from the PERSISTED map so an edge whose target left in an earlier
      * flush still resolves; a mapping is only trusted for the host that
      * produced it, since server ids are per-store. Grown as this flush
-     * proceeds, and written back at the end.
+     * proceeds, and durably written before removing each acknowledged row.
      */
     const persistedIdMap = this._readOutboxIdMap()
     const localToServer = new Map<string, string>()
-    let idMapDirty = false
 
     let flushed = 0
     let failed = 0
@@ -7674,7 +7710,7 @@ export class Plur {
     for (const engram of pending) {
       const outbox = (engram as any).structured_data._outbox as {
         target_url: string; target_scope: string; queued_at: string
-        last_attempt: string; attempt_count: number; last_error: string
+        last_attempt: string; attempt_count: number; last_error: string; request_id?: string
       }
 
       // Check TTL warning
@@ -7796,7 +7832,7 @@ export class Plur {
         let refuse: string | null = null
         for (const t of targets) {
           const server = localToServer.get(t)
-            ?? (persistedIdMap[t]?.url === storeEntry.url ? persistedIdMap[t].server_id : undefined)
+            ?? (persistedIdMap[t] && normalizeEndpointUrl(persistedIdMap[t].url) === normalizeEndpointUrl(storeEntry.url!) ? persistedIdMap[t].server_id : undefined)
           if (server) { remapped.push(server); continue }
           const localTarget = engrams.find(e => e.id === t)
           if (localTarget && !pendingIds.has(t)) {
@@ -7805,6 +7841,16 @@ export class Plur {
               + `represented on ${storeEntry.url} and was dropped from the pushed copy. The local record keeps it.`,
             )
             continue
+          }
+          if (!localTarget && !pendingIds.has(t)) {
+            // A canonical remote ID needs no local receipt, but its spelling
+            // is not proof of ownership. Resolve it on this destination and
+            // require the exact target scope before preserving the edge.
+            const remoteTarget = await driver.getById(t)
+            if (remoteTarget?.id === t && remoteTarget.scope === outbox.target_scope) {
+              remapped.push(t)
+              continue
+            }
           }
           refuse = t
           break
@@ -7824,13 +7870,33 @@ export class Plur {
       }
 
       try {
-        const pushed = await driver.appendAndGetServerId(cleanEngram)
+        const legacyFingerprint = createHash('sha256').update(stableJson({
+          ...engram, structured_data: { ...engram.structured_data, _outbox: undefined },
+        })).digest('hex')
+        const fingerprint = driver.appendFingerprint(cleanEngram)
+        const receipt = persistedIdMap[engram.id]
+        const matches = receipt && normalizeEndpointUrl(receipt.url) === normalizeEndpointUrl(storeEntry.url!)
+          && (receipt.fingerprint === fingerprint || receipt.fingerprint === legacyFingerprint)
+        const requestId = matches && receipt.request_id ? receipt.request_id
+          : !receipt && typeof outbox.request_id === 'string' ? outbox.request_id : randomUUID()
+        let pushed: { id: string }
+        if (matches && receipt.server_id) pushed = { id: receipt.server_id }
+        else {
+          // Persist the operation identity BEFORE sending. A crash, lost
+          // response, or failed receipt write must retry the same operation.
+          persistedIdMap[engram.id] = { url: storeEntry.url!, at: Date.now(), fingerprint, request_id: requestId }
+          this._writeOutboxIdMap(persistedIdMap)
+          pushed = await driver.appendAndGetServerId(cleanEngram, requestId)
+        }
         // #863: remember the mapping so a later engram in this same flush can
         // point at the server id rather than the local one.
         if (pushed?.id) {
           localToServer.set(engram.id, pushed.id)
-          persistedIdMap[engram.id] = { server_id: pushed.id, url: storeEntry.url!, at: Date.now() }
-          idMapDirty = true
+          persistedIdMap[engram.id] = { server_id: pushed.id, url: storeEntry.url!, at: Date.now(), fingerprint, request_id: requestId }
+          // Record the acknowledgement BEFORE removing the only local copy.
+          // A retry after local cleanup failure consumes this receipt and does
+          // not upload again. If the receipt cannot be saved, retain the row.
+          this._writeOutboxIdMap(persistedIdMap)
         }
         // #785: a write success clears the host's failure count for BOTH legs.
         recordWriteOutcome(storeEntry.url!, true, Date.now(), this.remoteHealthStatePath())
@@ -7887,10 +7953,18 @@ export class Plur {
         const fresh = await this._storeAt(this.paths.engrams).load()
         const merged = fresh
           // Drop the ones this flush successfully pushed (remote now owns them).
-          .filter(e => !(consideredIds.has(e.id) && !survivorsById.has(e.id)))
+          .filter(e => {
+            if (!consideredIds.has(e.id) || survivorsById.has(e.id)) return true
+            if (stableJson(e) === pendingSnapshots.get(e.id)) return false
+            expired_warnings.push(`${e.id}: changed during upload; newer local state preserved`)
+            return true
+          })
           .map(e => {
             const survivor = survivorsById.get(e.id)
             if (!survivor) return e
+            // In particular, never put _outbox back after a concurrent cancel,
+            // retirement, or rescope. A retry can reconsider the new state.
+            if (stableJson(e) !== pendingSnapshots.get(e.id)) return e
             const sSd = (survivor as any).structured_data as Record<string, unknown> | undefined
             const fSd = { ...((e as any).structured_data as Record<string, unknown> | undefined ?? {}) }
             // `_outbox` and `_demoted` are the flush's own bookkeeping: copy
@@ -7916,11 +7990,6 @@ export class Plur {
       await this._syncIndex()
     }
 
-    // Persist the id map LAST, and only if something was pushed. Writing it
-    // before the store write-back would leave a mapping for an engram whose
-    // local removal had not landed; writing it unconditionally would rewrite
-    // the file on every no-op flush.
-    if (idMapDirty) this._writeOutboxIdMap(persistedIdMap)
 
     return { flushed, failed, expired_warnings }
   }

--- a/packages/core/src/learn-async.ts
+++ b/packages/core/src/learn-async.ts
@@ -26,8 +26,12 @@ import type { LearnContext, LearnAsyncContext, LearnAsyncResult, LearnBatchResul
 export const NEAR_DUPLICATE_OBSERVATION_FLOOR = 0.75
 
 export interface LearnAsyncDeps {
+  /** Canonical product input validation before recall or model invocation. */
+  prepareLearn?: (statement: string, context?: LearnAsyncContext) => Promise<{ statement: string; context?: LearnAsyncContext }>
+  /** Canonical supplied-content invariant shared with ordinary learn. */
+  sameLearnContext?: (engram: Engram, statement: string, context?: LearnContext) => boolean
   /** Content hash dedup against all engrams. Scope-aware: only matches same scope. */
-  hashDedup: (statement: string, scope?: string) => Promise<Engram | null>
+  hashDedup: (statement: string, scope?: string, context?: LearnContext) => Promise<Engram | null>
   /** Hybrid recall for semantic similarity. */
   recallHybrid: (query: string, options?: { limit?: number }) => Promise<Engram[]>
   /** BM25 recall fallback. */
@@ -217,7 +221,17 @@ async function executeDedupDecision(
   context: LearnContext | undefined,
   decision: DedupDecision,
   targetId: string | null,
+  candidate?: Engram,
 ): Promise<LearnAsyncResult> {
+  // The model may select only a candidate actually offered. Recheck the row
+  // against that snapshot; a model response is neither authority nor a lock.
+  const matches = (row: Engram): boolean => Boolean(candidate && row.id === candidate.id
+    && row.scope === candidate.scope && row.status === 'active'
+    && row.statement === candidate.statement && row.commitment === candidate.commitment
+    && (candidate.engram_version === undefined || row.engram_version === candidate.engram_version)
+    && (!context?.scope || row.scope === context.scope)
+    && (!deps.sameLearnContext || deps.sameLearnContext(row, statement, context)))
+  if (decision !== 'ADD' && !candidate) return { engram: await deps.learn(statement, context), decision: 'ADD' }
   // Name the model behind a dedup verdict (#962). A model rewrote the
   // statement, and that rewrite became the memory. Without naming it the
   // decision cannot be reviewed later. Omitted when the caller did not say
@@ -229,7 +243,7 @@ async function executeDedupDecision(
     case 'NOOP': {
       if (targetId) {
         const existing = await deps.getById(targetId)
-        if (existing) return { engram: existing, decision: 'NOOP', existing_id: targetId }
+        if (existing && matches(existing)) return { engram: existing, decision: 'NOOP', existing_id: targetId }
       }
       return { engram: await deps.learn(statement, context), decision: 'ADD' }
     }
@@ -242,7 +256,7 @@ async function executeDedupDecision(
             const engrams = await deps.store.load()
             const idx = engrams.findIndex(e => e.id === targetId)
             // Target gone — fall out of the lock and ADD; see the doc comment.
-            if (idx === -1) return null
+            if (idx === -1 || !matches(engrams[idx]) || engrams[idx].commitment === 'locked') return null
             const updated = { ...engrams[idx] } as any
             updated.statement = statement
             updated.content_hash = computeContentHash(statement)
@@ -281,7 +295,7 @@ async function executeDedupDecision(
             const engrams = await deps.store.load()
             const idx = engrams.findIndex(e => e.id === targetId)
             // Target gone — fall out of the lock and ADD; see the doc comment.
-            if (idx === -1) return null
+            if (idx === -1 || !matches(engrams[idx]) || engrams[idx].commitment === 'locked') return null
             const merged = { ...engrams[idx] } as any
             merged.statement = `${merged.statement} ${statement}`
             merged.content_hash = computeContentHash(merged.statement)
@@ -326,10 +340,16 @@ export async function learnAsync(
   statement: string,
   context?: LearnAsyncContext,
 ): Promise<LearnAsyncResult> {
+  if (deps.prepareLearn) ({ statement, context } = await deps.prepareLearn(statement, context))
   // Step 1: Content hash fast-path (scope-aware — issue #136)
-  const hashMatch = await deps.hashDedup(statement, context?.scope)
+  const hashMatch = await deps.hashDedup(statement, context?.scope, context)
   if (hashMatch) {
-    return { engram: hashMatch, decision: 'NOOP', existing_id: hashMatch.id }
+    // An additional source is new provenance even when the fact is unchanged.
+    // Let the canonical writer retain it under the store lock.
+    const newSource = context?.source !== undefined && context.source !== hashMatch.source
+      && !hashMatch.sources?.some(source => source.source === context.source)
+    const engram = newSource ? await deps.learn(statement, context) : hashMatch
+    return { engram, decision: 'NOOP', existing_id: engram.id }
   }
 
   // Step 2: Check dedup config
@@ -376,6 +396,9 @@ export async function learnAsync(
   if (context?.scope) {
     candidates = candidates.filter(c => c.scope === context.scope)
   }
+  if (deps.sameLearnContext) candidates = candidates.filter(c => deps.sameLearnContext!(c, statement, context))
+  // Keep the pre-decision state even if a dependency returns mutable objects.
+  candidates = structuredClone(candidates)
 
   if (candidates.length === 0) {
     return { engram: await deps.learn(statement, context), decision: 'ADD' }
@@ -511,7 +534,7 @@ export async function learnAsync(
   }
 
   // Step 5: Execute
-  const executed = await executeDedupDecision(deps, statement, context, decision, targetId)
+  const executed = await executeDedupDecision(deps, statement, context, decision, targetId, candidates.find(c => c.id === targetId))
   return { ...executed, dedup: { mode: dedupMode, ...(nearDuplicates ? { near_duplicates: nearDuplicates } : {}) } }
 }
 

--- a/packages/core/src/learn-context-validation.ts
+++ b/packages/core/src/learn-context-validation.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+import { EngramSchema, EngramSchemaPassthrough, KnowledgeTypeSchema, ProvenanceSchema } from './schemas/engram.js'
+import { LEARN_CONTEXT_FIELD_ROLES } from './content-fields.js'
+import type { LearnContext } from './types.js'
+
+// Direct fields reuse their persisted representation. These aliases are the
+// only exceptions; adding a new context field requires an explicit schema.
+const aliases = {
+  memory_class: KnowledgeTypeSchema.shape.memory_class,
+  license: ProvenanceSchema.shape.license,
+  valid_from: z.string(),
+  valid_until: z.string(),
+  supersedes: z.array(z.string()),
+  session: z.string(),
+  session_episode_id: z.string(),
+} satisfies Record<Exclude<keyof LearnContext, keyof typeof EngramSchema.shape>, z.ZodTypeAny>
+
+const shape = Object.fromEntries(Object.keys(LEARN_CONTEXT_FIELD_ROLES).map(key => {
+  const schema = (EngramSchema.shape as Record<string, z.ZodTypeAny>)[key]
+    ?? (aliases as Record<string, z.ZodTypeAny>)[key]
+  if (!schema) throw new Error(`Missing learn-context schema: ${key}`)
+  return [key, schema.optional()]
+}))
+const contextSchema = z.object(shape)
+
+export function validateLearnContext(context: unknown): void {
+  if (context === undefined) return
+  const result = contextSchema.safeParse(context)
+  if (!result.success) {
+    // Field names identify the problem without echoing sensitive input values.
+    throw new TypeError(`Invalid learn context: invalid ${result.error.issues[0]?.path.join('.') || 'object'}`)
+  }
+}
+
+/** Validate replacement records without adding defaults or stripping fields. */
+export function validateEngramWrite(engram: unknown): void {
+  const result = EngramSchemaPassthrough.safeParse(engram)
+  if (!result.success) throw new TypeError(`Invalid engram write: ${result.error.issues[0]?.path.join('.') || 'object'}`)
+}

--- a/packages/core/src/migrations/runner.ts
+++ b/packages/core/src/migrations/runner.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs'
-import * as path from 'path'
+import { createHash, randomUUID } from 'node:crypto'
 import * as yaml from 'js-yaml'
 import { join } from 'path'
 import { loadEngrams, saveEngrams } from '../engrams.js'
-import { atomicWrite, withLock, CONFIG_FILE_MODE } from '../sync.js'
+import { atomicWrite, withLock, fsyncDir, CONFIG_FILE_MODE } from '../sync.js'
 import { logger } from '../logger.js'
 import type { Migration } from './types.js'
 
@@ -29,13 +29,24 @@ export interface MigrationResult {
 
 /** Read schema_version from config.yaml. Defaults to 0 if not present. */
 export function getSchemaVersion(configPath: string): number {
-  if (!fs.existsSync(configPath)) return 0
+  let raw: unknown
   try {
-    const raw = yaml.load(fs.readFileSync(configPath, 'utf8')) as Record<string, unknown> | null
-    if (!raw || typeof raw.schema_version !== 'number') return 0
-    return raw.schema_version
-  } catch {
-    return 0
+    raw = yaml.load(fs.readFileSync(configPath, 'utf8'))
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0
+    throw new Error('Cannot read or parse migration configuration')
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('Cannot read migration schema version: config must be a mapping')
+  }
+  const version = Object.hasOwn(raw, 'schema_version') ? (raw as Record<string, unknown>).schema_version : 0
+  assertVersion(version)
+  return version
+}
+
+function assertVersion(version: unknown): asserts version is number {
+  if (typeof version !== 'number' || !Number.isInteger(version) || version < 0 || version > CURRENT_SCHEMA_VERSION) {
+    throw new Error(`Invalid schema version: expected a non-negative integer from 0 to ${CURRENT_SCHEMA_VERSION}`)
   }
 }
 
@@ -57,13 +68,16 @@ export function getSchemaVersion(configPath: string): number {
  * matching `persistStores`, which rethrows for exactly this reason.
  */
 export function setSchemaVersion(configPath: string, version: number): void {
+  assertVersion(version)
   withLock(configPath, () => {
     let configData: Record<string, unknown> = {}
     try {
       const raw = fs.readFileSync(configPath, 'utf8')
-      if (raw) configData = (yaml.load(raw) as Record<string, unknown>) ?? {}
+      const parsed: unknown = yaml.load(raw)
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('Migration config must be a mapping')
+      configData = parsed as Record<string, unknown>
     } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw new Error('Cannot read or parse migration configuration')
     }
     configData.schema_version = version
     // Atomic + fsynced for the same reason persistStores is: loadConfig turns a
@@ -84,50 +98,60 @@ function createBackup(engramsPath: string, version: number): string | null {
   // rollback target was gone. An existing backup is by definition from an
   // earlier, better state; keep it.
   if (fs.existsSync(backupPath)) return backupPath
-  fs.copyFileSync(engramsPath, backupPath)
-  // A backup that is not on disk is not a backup. copyFileSync leaves the copy
-  // in the page cache, so a power cut during a migration could take the corpus
-  // AND the rollback target with it (audit #794, F4).
-  flushFile(backupPath)
-  // The rename/create is directory metadata: without flushing the directory a
-  // crash can lose the backup's PATHNAME even when its blocks reached disk.
-  flushDir(path.dirname(backupPath))
+  atomicWrite(backupPath, fs.readFileSync(engramsPath))
   return backupPath
 }
 
-/** fsync a directory so a file created in it survives a crash. Best-effort. */
-function flushDir(dir: string): void {
-  let fd: number | undefined
-  try {
-    fd = fs.openSync(dir, 'r')
-    fs.fsyncSync(fd)
-  } catch {
-    /* not supported on this platform/filesystem — the file's own fsync stands */
-  } finally {
-    if (fd !== undefined) {
-      try { fs.closeSync(fd) } catch { /* ignore */ }
-    }
+const digest = (bytes: Buffer) => createHash('sha256').update(bytes).digest('hex')
+function corpusHash(file: string): string | null {
+  try { return digest(fs.readFileSync(file)) } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
   }
 }
 
-/** fsync a path that was just written by a non-atomic helper. Best-effort — see atomicWrite. */
-function flushFile(filePath: string): void {
-  let fd: number | undefined
-  try {
-    fd = fs.openSync(filePath, 'r+')
-    fs.fsyncSync(fd)
-  } catch {
-    /* nothing actionable — the copy itself succeeded */
-  } finally {
-    if (fd !== undefined) {
-      try { fs.closeSync(fd) } catch { /* ignore */ }
-    }
+/** Resolve an interrupted two-file commit without replaying transformations
+ * or restoring stale bytes. Unrelated intervening edits require reconciliation.
+ * Caller holds the corpus lock. */
+function recoverMigration(engramsPath: string, configPath: string): void {
+  const journalPath = `${engramsPath}.migration.json`
+  let text: string
+  try { text = fs.readFileSync(journalPath, 'utf8') } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw err
   }
+  const journal = JSON.parse(text)
+  if (!journal || journal.config !== configPath || typeof journal.after !== 'string' ||
+      !(journal.before === null || typeof journal.before === 'string')) throw new Error('Invalid migration recovery journal')
+  assertVersion(journal.version)
+  const current = corpusHash(engramsPath)
+  if (current === journal.after) setSchemaVersion(configPath, journal.version)
+  else if (current !== journal.before) throw new Error('Interrupted migration followed by other writes; preserve the corpus and reconcile the migration journal manually')
+  fs.unlinkSync(journalPath)
+  fsyncDir(join(engramsPath, '..'))
 }
 
-/** Restore engrams.yaml from backup. */
-function restoreBackup(engramsPath: string, backupPath: string): void {
-  fs.copyFileSync(backupPath, engramsPath)
+/** Stage/validate exact bytes, persist intent, replace corpus, stamp config.
+ * A retry can finish stamping after a crash at any commit boundary. */
+function commitMigration(engramsPath: string, configPath: string, engrams: ReturnType<typeof loadEngrams>, version: number): void {
+  const staged = `${engramsPath}.${randomUUID()}.migration-stage`
+  let bytes: Buffer
+  try {
+    if (fs.existsSync(engramsPath)) {
+      atomicWrite(staged, fs.readFileSync(engramsPath))
+      loadEngrams(staged) // retain quarantined rows through the serializer
+    }
+    saveEngrams(staged, engrams, { allowShrink: true })
+    bytes = fs.readFileSync(staged)
+  } finally {
+    try { fs.unlinkSync(staged) } catch (err) { if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err }
+  }
+  const journalPath = `${engramsPath}.migration.json`
+  atomicWrite(journalPath, JSON.stringify({ config: configPath, before: corpusHash(engramsPath), after: digest(bytes), version }))
+  atomicWrite(engramsPath, bytes)
+  setSchemaVersion(configPath, version)
+  fs.unlinkSync(journalPath)
+  fsyncDir(join(engramsPath, '..'))
 }
 
 /**
@@ -135,7 +159,7 @@ function restoreBackup(engramsPath: string, backupPath: string): void {
  * - Checks schema_version in config
  * - Creates backup before running
  * - Applies each pending migration in order
- * - Rolls back to backup if any migration fails
+ * - Leaves the live corpus untouched if any transformation fails
  * - Updates schema_version after success
  */
 export function runMigrations(
@@ -171,18 +195,15 @@ export function runMigrations(
    * lock for the duration.
    */
   withLock(engramsPath, () => {
+    if (options?.dryRun && fs.existsSync(`${engramsPath}.migration.json`)) throw new Error('Interrupted migration needs recovery before a dry run')
+    if (!options?.dryRun) recoverMigration(engramsPath, configPath)
     currentVersion = getSchemaVersion(configPath)
     const pending = ALL_MIGRATIONS.slice(currentVersion)
     if (pending.length === 0) return
 
-    // The backup is taken inside the lock too. Outside it, a write could land
-    // between `createBackup` and `loadEngrams`, so the file restored on failure
-    // would not be the file that was migrated — a rollback to a state that
-    // never existed.
-    backupPath = options?.dryRun ? null : createBackup(engramsPath, currentVersion)
-
     // Load engrams as raw objects (passthrough mode — we use the passthrough schema)
     let engrams = loadEngrams(engramsPath)
+    backupPath = options?.dryRun ? null : createBackup(engramsPath, currentVersion)
 
     for (const migration of pending) {
       logger.info(`Running migration: ${migration.id} — ${migration.description}`)
@@ -191,12 +212,9 @@ export function runMigrations(
         applied.push(migration.id)
       } catch (err) {
         logger.error(`Migration ${migration.id} failed: ${err}`)
-        // Restore from backup
-        if (backupPath) {
-          restoreBackup(engramsPath, backupPath)
-          logger.info(`Restored engrams.yaml from backup: ${backupPath}`)
-        }
-        throw new Error(`Migration ${migration.id} failed: ${err}. Engrams restored from backup.`)
+        // Only memory changed. A version backup may predate successful writes;
+        // restoring it here would destroy those newer records.
+        throw new Error(`Migration ${migration.id} failed: ${err}. Live engrams unchanged.`)
       }
     }
 
@@ -204,10 +222,7 @@ export function runMigrations(
       // Migrations rewrite the entire corpus by design, and a migration that
       // legitimately drops records would otherwise trip the save-side shrink
       // guard (#801). Declaring it here keeps the guard armed everywhere else.
-      saveEngrams(engramsPath, engrams, { allowShrink: true })
-      // Inside the corpus lock: the corpus and the version it claims to be at
-      // must become visible together, or they can disagree.
-      setSchemaVersion(configPath, currentVersion + applied.length)
+      commitMigration(engramsPath, configPath, engrams, currentVersion + applied.length)
     }
   })
 
@@ -230,6 +245,7 @@ export function rollbackMigrations(
   if (targetVersion < 0) {
     throw new Error('Target version cannot be negative')
   }
+  assertVersion(targetVersion)
 
   const rolledBack: string[] = []
   let currentVersion = 0
@@ -242,14 +258,15 @@ export function rollbackMigrations(
   // concurrent write, since the operator is already recovering from something.
   let backupPath: string | null = null
   withLock(engramsPath, () => {
+    recoverMigration(engramsPath, configPath)
     currentVersion = getSchemaVersion(configPath)
     if (targetVersion >= currentVersion) { noop = true; return }
 
     // Apply down() in reverse order
     const toRollback = ALL_MIGRATIONS.slice(targetVersion, currentVersion).reverse()
 
-    backupPath = createBackup(engramsPath, currentVersion)
     let engrams = loadEngrams(engramsPath)
+    backupPath = createBackup(engramsPath, currentVersion)
 
     for (const migration of toRollback) {
       logger.info(`Rolling back migration: ${migration.id}`)
@@ -258,18 +275,13 @@ export function rollbackMigrations(
         rolledBack.push(migration.id)
       } catch (err) {
         logger.error(`Rollback of ${migration.id} failed: ${err}`)
-        if (backupPath) {
-          restoreBackup(engramsPath, backupPath)
-          logger.info(`Restored engrams.yaml from backup: ${backupPath}`)
-        }
-        throw new Error(`Rollback of ${migration.id} failed: ${err}. Engrams restored from backup.`)
+        throw new Error(`Rollback of ${migration.id} failed: ${err}. Live engrams unchanged.`)
       }
     }
 
     // A down() migration legitimately removes fields and can remove records;
     // the shrink guard must not veto a deliberate rollback.
-    saveEngrams(engramsPath, engrams, { allowShrink: true })
-    setSchemaVersion(configPath, targetVersion)
+    commitMigration(engramsPath, configPath, engrams, targetVersion)
   })
 
   if (noop) {

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as crypto from 'crypto'
 import * as os from 'os'
-import { execFileSync } from 'child_process'
+import { gunzipSync } from 'zlib'
+import * as tar from 'tar'
 import yaml from 'js-yaml'
 import { loadPack, loadEngrams, saveEngrams } from './engrams.js'
 import { atomicWrite, fsyncDir, withLock } from './sync.js'
@@ -46,66 +47,76 @@ export function isPackUrl(source: string): boolean {
  * No auth headers are added: signed-URL delivery means the URL is the
  * credential and no Authorization header is needed.
  */
+export const MAX_PACK_DOWNLOAD_BYTES = 32 * 1024 * 1024
+export const MAX_PACK_ARCHIVE_BYTES = 64 * 1024 * 1024
+export const PACK_DOWNLOAD_TIMEOUT_MS = 30_000
+
 export async function downloadAndExtractPack(url: string): Promise<{ packDir: string; tmpRoot: string }> {
-  // Create a unique temp root for this download
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'plur-pack-dl-'))
-
-  // Download
-  let response: Response
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), PACK_DOWNLOAD_TIMEOUT_MS)
+  // Signed URLs carry credentials in their path/query; errors must not echo them.
   try {
-    response = await fetch(url)
-  } catch (err: unknown) {
-    fs.rmSync(tmpRoot, { recursive: true, force: true })
-    const msg = err instanceof Error ? err.message : String(err)
-    throw new Error(`Failed to fetch pack from ${url}: ${msg}`)
-  }
-
-  if (!response.ok) {
-    fs.rmSync(tmpRoot, { recursive: true, force: true })
-    throw new Error(`Failed to fetch pack from ${url}: HTTP ${response.status} ${response.statusText}`)
-  }
-
-  // Save the response body to a .tar.gz file
-  const archivePath = path.join(tmpRoot, 'pack.tar.gz')
-  const buffer = await response.arrayBuffer()
-  fs.writeFileSync(archivePath, Buffer.from(buffer))
-
-  // Extract the archive
-  const extractDir = path.join(tmpRoot, FLAT_ARCHIVE_DIRNAME)
-  fs.mkdirSync(extractDir)
-  try {
-    execFileSync('tar', ['-xzf', archivePath, '-C', extractDir], { stdio: 'pipe' })
-  } catch (err: unknown) {
-    fs.rmSync(tmpRoot, { recursive: true, force: true })
-    const msg = err instanceof Error ? (err as NodeJS.ErrnoException).message : String(err)
-    throw new Error(`Failed to extract pack archive from ${url}: ${msg}`)
-  }
-
-  // Find the pack directory: either a single top-level subdirectory, or the
-  // extraction root itself (for flat archives).
-  // `lstat`: a tar entry that is a symbolic link to a directory must not be
-  // taken for the pack directory, or the preview would walk wherever it points.
-  const entries = fs.readdirSync(extractDir)
-  const subdirs = entries.filter(e => fs.lstatSync(path.join(extractDir, e)).isDirectory())
-
-  let packDir: string
-  if (subdirs.length === 1) {
-    // Standard layout: archive contains a single top-level directory
-    packDir = path.join(extractDir, subdirs[0])
-  } else {
-    // Flat layout: SKILL.md / engrams.yaml at archive root
-    const hasPackFiles = entries.some(e => e === 'SKILL.md' || e === 'engrams.yaml' || e === 'manifest.yaml')
-    if (hasPackFiles) {
-      packDir = extractDir
-    } else {
-      fs.rmSync(tmpRoot, { recursive: true, force: true })
-      throw new Error(
-        `Pack archive from ${url} has an unexpected layout — expected a single top-level directory or pack files at the root (SKILL.md / engrams.yaml).`,
-      )
+    const response = await fetch(url, { signal: controller.signal })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const declared = Number(response.headers.get('content-length'))
+    if (declared > MAX_PACK_DOWNLOAD_BYTES) {
+      await response.body?.cancel()
+      throw new Error('pack download exceeds size limit')
     }
+    if (!response.body) throw new Error('empty pack response')
+    const reader = response.body.getReader()
+    const chunks: Uint8Array[] = []
+    let total = 0
+    try {
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) break
+        total += value.byteLength
+        if (total > MAX_PACK_DOWNLOAD_BYTES) throw new Error('pack download exceeds size limit')
+        chunks.push(value)
+      }
+    } finally {
+      await reader.cancel().catch(() => {})
+      reader.releaseLock()
+    }
+    // Bound expansion BEFORE extracting even the first archive entry. This
+    // also bounds tar metadata, padding and sparse-file payloads.
+    const archive = gunzipSync(Buffer.concat(chunks), { maxOutputLength: MAX_PACK_ARCHIVE_BYTES })
+    const archivePath = path.join(tmpRoot, 'pack.tar')
+    fs.writeFileSync(archivePath, archive, { mode: 0o600 })
+    let entries = 0
+    tar.list({ file: archivePath, sync: true, strict: true, onReadEntry(entry) {
+      if (++entries > MAX_PACK_ENTRIES) throw new Error('pack archive exceeds entry limit')
+      if (entry.type !== 'File' && entry.type !== 'OldFile' && entry.type !== 'Directory') {
+        throw new Error('pack archive contains a symbolic link, hard link, or special file')
+      }
+      const name = entry.path
+      if (name.startsWith('/') || /^[a-z]:/i.test(name) || name.includes('\\') || name.split('/').includes('..')) {
+        throw new Error('pack archive path escapes extraction directory')
+      }
+      if (name.split('/').length > 64 || entry.size > MAX_PACK_FILE_BYTES) {
+        throw new Error('pack archive entry exceeds size or depth limit')
+      }
+    } })
+    const extractDir = path.join(tmpRoot, FLAT_ARCHIVE_DIRNAME)
+    fs.mkdirSync(extractDir)
+    tar.extract({ file: archivePath, cwd: extractDir, sync: true, strict: true,
+      preservePaths: false, noChmod: true, maxDepth: 64 })
+    const names = fs.readdirSync(extractDir)
+    const subdirs = names.filter(e => fs.lstatSync(path.join(extractDir, e)).isDirectory())
+    const hasPackFiles = names.some(e => ['SKILL.md', 'engrams.yaml', 'manifest.yaml'].includes(e))
+    const packDir = hasPackFiles ? extractDir
+      : subdirs.length === 1 ? path.join(extractDir, subdirs[0]) : undefined
+    if (!packDir) throw new Error('unexpected archive layout — expected a pack directory or pack files at root')
+    return { packDir, tmpRoot }
+  } catch (err) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    const reason = controller.signal.aborted ? 'download timed out' : (err instanceof Error ? err.message : 'invalid archive')
+    throw new Error(`Failed to fetch or extract pack: ${reason}`)
+  } finally {
+    clearTimeout(timeout)
   }
-
-  return { packDir, tmpRoot }
 }
 
 /** Remove the temp directory created by downloadAndExtractPack. Safe to call even if the path no longer exists. */
@@ -479,11 +490,12 @@ function scanPackFiles(packDir: string): PrivacyIssue[] {
     // text file with one NUL byte in front of it cannot carry either past
     // the scan into the store.
     if (text.includes('\u0000')) {
-      const stripped = truncateToScanLimit(text.replace(/\u0000/g, ''))
-      for (const hit of detectSecrets(stripped)) {
+      const stripped = text.replace(/\u0000/g, '')
+      const hardNames = new Set(detectSecrets(truncateToScanLimit(stripped)).map(hit => hit.pattern))
+      for (const hit of detectSensitive(stripped).filter(hit => hit.pattern === 'scan_truncated' || hardNames.has(hit.pattern))) {
         issues.push({ engram_id: label, type: 'secret', detail: `in ${label} — ${hit.pattern}: ${hit.match}` })
       }
-      for (const hit of detectPromptInjection(stripped)) {
+      for (const hit of detectPromptInjection(truncateToScanLimit(stripped))) {
         issues.push({ engram_id: label, type: 'prompt_injection', detail: `in ${label} — ${hit.pattern}: ${hit.match}` })
       }
       continue
@@ -1765,6 +1777,15 @@ function serializeForSecretScan(e: Engram): string {
     // own bookkeeping keys and nothing else. A `_` prefix rule exempted any
     // key a caller cared to name (#1002 review).
     scan[k] = k === 'structured_data' ? (userStructuredData(v) ?? {}) : v
+    // Attribution is intentionally exported identity. Only an entire, bounded
+    // email value can take this path, and its own bytes still pass every
+    // credential/infra detector. Other attribution fields remain scanned.
+    if (k === 'attribution' && v && typeof v === 'object') {
+      const who = (v as { asserted_by?: unknown }).asserted_by
+      if (typeof who === 'string' && who.length <= 254 && who.match(EMAIL_RE)?.[0] === who && detectSensitive(who).length === 0) {
+        scan[k] = { ...v, asserted_by: '[declared identity]' }
+      }
+    }
   }
   return JSON.stringify(scan)
 }

--- a/packages/core/src/project-config.ts
+++ b/packages/core/src/project-config.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, realpathSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
+import yaml from 'js-yaml'
+import { atomicWrite, withLock } from './sync.js'
 
 /**
  * Same #521 canonicalization as the CLI's `isPlurConfigured` guard:
@@ -87,90 +89,53 @@ export function findProjectConfigPath(startDir: string = process.cwd()): string 
   return null
 }
 
-/**
- * Strip balanced single or double quotes around a YAML scalar value.
- * Defensive: a user (or editor auto-format) may quote values.
- */
-function unquoteYamlValue(v: string): string {
-  return v.replace(/^(['"])(.*)\1$/, '$2')
+/** Parse the full document so nested keys cannot become top-level routing
+ * authority. Errors deliberately omit parser excerpts containing tokens. */
+export function readProjectConfigDocument(path: string): Record<string, unknown> {
+  let content: string
+  try { content = readFileSync(path, 'utf8') } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Cannot read project configuration')
+  }
+  try {
+    const document = yaml.load(content)
+    if (!document || typeof document !== 'object' || Array.isArray(document)) throw new Error('mapping required')
+    return document as Record<string, unknown>
+  } catch { throw new Error('Invalid project configuration; expected a YAML mapping') }
 }
 
-/**
- * Read `.plur.yaml` from the nearest enclosing project directory.
- * Returns `{}` if not found or unparseable.
- *
- * The parser is intentionally minimal (line-by-line) rather than pulling
- * js-yaml into the CLI bundle — config files are short, fields are flat,
- * and dependency-free keeps the CLI bundle tiny. Arrays use comma-
- * separated values OR YAML-style `- item` lines.
- *
- * Accepts an optional `startDir` so callers (notably the MCP server,
- * which lives in core and gets the dir from `process.cwd()`) can override
- * the walk root.
- */
+/** Merge under one lock, retaining every unrelated key. Serialize values as
+ * YAML scalars and replace privately/durably; never truncate the live file. */
+export function updateProjectConfig(path: string, patch: Partial<ProjectConfig>): void {
+  withLock(path, () => {
+    const document = readProjectConfigDocument(path)
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined) delete document[key]
+      else document[key] = value
+    }
+    atomicWrite(path, yaml.dump(document, { lineWidth: 120, noRefs: true }), { mode: 0o600 })
+  })
+}
+
+/** Read only top-level routing keys. Preserve legacy comma-separated and block
+ * list scope forms, while refusing malformed existing configuration. */
 export function readProjectConfig(startDir: string = process.cwd()): ProjectConfig {
-  const configPath = findProjectConfigPath(startDir)
-  if (!configPath) return {}
-  try {
-    // Strip UTF-8 BOM — some Windows editors prepend it and the first
-    // key would otherwise be read as `﻿domain` and silently dropped.
-    const content = readFileSync(configPath, 'utf8').replace(/^﻿/, '')
-    const config: ProjectConfig = {}
-    let inListKey: 'remote_scopes' | null = null
-    let listAcc: string[] = []
-    const finishList = () => {
-      if (inListKey === 'remote_scopes') {
-        // Always commit — even an empty list is a valid user intent
-        // (the difference between "no whitelist" and "explicitly empty"
-        // is downstream's problem, not ours).
-        config.remote_scopes = listAcc
-      }
-      inListKey = null
-      listAcc = []
-    }
-
-    for (const rawLine of content.split('\n')) {
-      const line = rawLine.replace(/\r$/, '')
-      const trimmed = line.trim()
-      if (trimmed.startsWith('#') || !trimmed) continue
-
-      // List continuation: ONLY active while we're inside remote_scopes.
-      // A `- foo` value on an unrelated key like remote_token would
-      // otherwise be silently swallowed into listAcc.
-      if (inListKey === 'remote_scopes' && trimmed.startsWith('-')) {
-        listAcc.push(unquoteYamlValue(trimmed.slice(1).trim()))
-        continue
-      }
-      // Any non-dash line ends the previous list
-      if (inListKey) finishList()
-
-      const colonIdx = trimmed.indexOf(':')
-      if (colonIdx < 0) continue
-      const key = trimmed.slice(0, colonIdx).trim()
-      const value = unquoteYamlValue(trimmed.slice(colonIdx + 1).trim())
-
-      switch (key) {
-        case 'domain':       config.domain = value; break
-        case 'scope':        config.scope = value; break
-        case 'remote_url':   config.remote_url = value; break
-        case 'remote_token': config.remote_token = value; break
-        case 'remote_scopes':
-          // Multi-line YAML list form: `remote_scopes:` (empty) OR
-          // `remote_scopes: |` (block scalar marker) — both trigger list
-          // accumulation.
-          if (value === '' || value === '|' || value === '>') {
-            inListKey = 'remote_scopes'
-            listAcc = []
-          } else {
-            // Inline comma-separated form
-            config.remote_scopes = value.split(',').map(s => unquoteYamlValue(s.trim())).filter(Boolean)
-          }
-          break
-      }
-    }
-    finishList()
-    return config
-  } catch {
-    return {}
+  const path = findProjectConfigPath(startDir)
+  if (!path) return {}
+  const document = readProjectConfigDocument(path)
+  const config: ProjectConfig = {}
+  for (const key of ['domain', 'scope', 'remote_url', 'remote_token'] as const) {
+    const value = document[key]
+    if (value === undefined) continue
+    if (typeof value !== 'string') throw new Error(`Invalid project configuration field: ${key}`)
+    config[key] = value
   }
+  const scopes = document.remote_scopes
+  if (scopes !== undefined) {
+    if (scopes === null) config.remote_scopes = []
+    else if (Array.isArray(scopes) && scopes.every(scope => typeof scope === 'string')) config.remote_scopes = scopes
+    else if (typeof scopes === 'string') config.remote_scopes = scopes.split(/[,\n]/).map(scope => scope.trim().replace(/^-\s+/, '')).filter(Boolean)
+    else throw new Error('Invalid project configuration field: remote_scopes')
+  }
+  return config
 }

--- a/packages/core/src/provenance-store.ts
+++ b/packages/core/src/provenance-store.ts
@@ -9,8 +9,10 @@
  * separate step, and the Swarm provenance toolkit already covers it.
  */
 import * as fs from 'node:fs'
-import { join, resolve, sep } from 'node:path'
+import { join, resolve, relative, sep } from 'node:path'
 import { logger } from './logger.js'
+import { atomicWrite } from './sync.js'
+import { withAsyncLock } from './store/async-lock.js'
 
 export interface ProvenanceStore {
   /** Save a record for an engram. Returns a reference that `get` accepts. */
@@ -90,7 +92,16 @@ export class FileProvenanceStore implements ProvenanceStore {
 
   async put(engramId: string, record: unknown): Promise<string> {
     const dir = this.dirFor(engramId)
-    fs.mkdirSync(dir, { recursive: true })
+    let cursor = resolve(this.root)
+    for (const part of relative(cursor, dir).split(sep)) {
+      cursor = join(cursor, part)
+      try { fs.mkdirSync(cursor, { mode: 0o700 }) } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+      }
+      if (!fs.lstatSync(cursor).isDirectory()) throw new Error('Provenance directory must not be a symbolic link')
+    }
+    this.assertContained(dir)
+    return withAsyncLock(join(dir, 'records'), async () => {
     const body = JSON.stringify(record, null, 2) + '\n'
 
     // Records are kept as a timestamped series, because a record made before an
@@ -107,27 +118,47 @@ export class FileProvenanceStore implements ProvenanceStore {
     const stamp = new Date().toISOString().replace(/[:.]/g, '-')
     let path = join(dir, `${stamp}.jsonld`)
     for (let n = 2; fs.existsSync(path); n++) path = join(dir, `${stamp}-${n}.jsonld`)
-    fs.writeFileSync(path, body, 'utf8')
+    atomicWrite(path, body, { mode: 0o600 })
     return path
+    })
+  }
+
+  private assertContained(reference: string): void {
+    const root = fs.realpathSync(this.root)
+    const actual = fs.realpathSync(reference)
+    if (!actual.startsWith(root + sep)) throw new Error('Provenance reference must remain inside the store')
+    const base = fs.realpathSync(this.base)
+    if (actual !== base && !actual.startsWith(base + sep)) throw new Error('Provenance reference must remain inside provenance storage')
+  }
+
+  private orderedIn(dir: string): string[] {
+    this.assertContained(dir)
+    return fs.readdirSync(dir).filter(f => f.endsWith('.jsonld'))
+      .sort((a, b) => {
+        const parts = (name: string) => /^(.*?)(?:-(\d+))?\.jsonld$/.exec(name)!
+        // The timestamp has fixed width (ISO's 24 characters). A same-time
+        // suffix is a numeric sequence; the original unsuffixed file is 1.
+        const stampA = a.slice(0, 24), stampB = b.slice(0, 24)
+        if (stampA !== stampB) return stampB.localeCompare(stampA)
+        const seq = (name: string) => Number(parts(name.slice(24))?.[2] ?? 1)
+        return seq(b) - seq(a)
+      })
+      .map(f => join(dir, f))
   }
 
   /** Newest record already on disk for this engram, by filename. */
   private newestIn(dir: string): string | undefined {
     if (!fs.existsSync(dir)) return undefined
-    // Filenames are ISO timestamps, so a plain sort is chronological — except
-    // for the "-2", "-3" suffixes added on a same-millisecond collision, which
-    // sort correctly among themselves but ahead of the unsuffixed name. Compare
-    // on modification time, which is right in every case.
-    const files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonld'))
-    if (!files.length) return undefined
-    return files
-      .map(f => join(dir, f))
-      .sort((a, b) => fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs)
-      .pop()
+    // Share the same timestamp/sequence ordering as list and dedup, including
+    // more than nine records created in one millisecond.
+    const newest = this.orderedIn(dir)[0]
+    if (newest) this.assertContained(newest)
+    return newest
   }
 
   async get(reference: string): Promise<unknown | undefined> {
     try {
+      this.assertContained(reference)
       return JSON.parse(fs.readFileSync(reference, 'utf8'))
     } catch (err) {
       logger.debug?.(`provenance record unreadable at ${reference}: ${String(err)}`)
@@ -138,12 +169,7 @@ export class FileProvenanceStore implements ProvenanceStore {
   async list(engramId: string): Promise<string[]> {
     const dir = this.dirFor(engramId)
     if (!fs.existsSync(dir)) return []
-    return fs
-      .readdirSync(dir)
-      .filter(f => f.endsWith('.jsonld'))
-      .sort()
-      .reverse()
-      .map(f => join(dir, f))
+    return this.orderedIn(dir)
   }
 }
 

--- a/packages/core/src/remote-recall.ts
+++ b/packages/core/src/remote-recall.ts
@@ -368,7 +368,7 @@ function writeRemoteHealth(path: string, file: RemoteHealthFile): void {
 
 /** Lock options for remote-health.json — the critical section is a
  *  read+merge+rename of a small JSON file (milliseconds), and withLock's
- *  retry delay is a synchronous busy-wait, so keep the worst-case wait small
+ *  retry delay is a synchronous OS wait, so keep the worst-case wait small
  *  (25+50+100 = 175 ms) rather than the 3.1 s engrams.yaml default. */
 const HEALTH_LOCK_OPTS = { maxRetries: 3, baseDelay: 25 }
 

--- a/packages/core/src/schemas/engram.ts
+++ b/packages/core/src/schemas/engram.ts
@@ -55,7 +55,9 @@ export const ProvenanceSchema = z.object({
   chain: z.array(z.string()).default([]),
   signature: z.string().nullable().default(null)
     .describe('RESERVED. Detached signature over the engram. Algorithm and canonicalization not yet specified — see ENGRAM-STANDARD-v1.md §7.'),
-  license: z.string().default('cc-by-sa-4.0'),
+  // Absence is evidence that nobody chose a licence. Effective policy may use
+  // its documented default, but parsing must not turn that into an assertion.
+  license: z.string().optional(),
 }).describe('Origin and signing chain. STABLE for origin/chain/license; signature is RESERVED (see ENGRAM-STANDARD-v1.md §7).')
 
 /**
@@ -482,6 +484,7 @@ export const EngramSchema = z.object({
   sources: z.array(z.object({
     scope: z.string(),
     session_id: z.string().nullable().default(null),
+    source: z.string().optional().describe('Caller-supplied origin of this write; retained across duplicate absorption.'),
     stored_at: z.string().describe('ISO 8601 timestamp of this write.'),
   })).default([]).describe('Provenance of each write attempt; one entry per write.'),
 

--- a/packages/core/src/storage-postgres.ts
+++ b/packages/core/src/storage-postgres.ts
@@ -71,6 +71,7 @@
  * `pg` is an OPTIONAL dependency, imported lazily: a personal install must not
  * pay for a driver it will never open.
  */
+import { AsyncLocalStorage } from 'node:async_hooks'
 import type { Engram } from './schemas/engram.js'
 import { EngramSchemaPassthrough } from './schemas/engram.js'
 import { normalizeEngramInput } from './normalize-engram.js'
@@ -279,6 +280,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
   private readonly efSearch: number
   private readonly maxConnections: number
 
+  private readonly exclusiveSession = new AsyncLocalStorage<{ client: any; active: boolean; failure?: Error; afterCommit: Array<() => void> }>()
   private pool: any = null
   /**
    * In-flight (or completed) pool construction. Memoized so concurrent first
@@ -287,7 +289,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    */
   private poolPromise: Promise<any> | undefined
   /**
-   * Connections used ONLY to hold advisory locks — never for queries.
+   * Connections for exclusive operations: lock, reads and writes share a session.
    *
    * Separate from the main pool so a lock holder can never be waiting on a
    * connection that another lock holder is occupying. See `withExclusiveAccess`.
@@ -370,6 +372,17 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
 
   private async getPool(): Promise<any> {
     if (this.closed) throw new Error('[postgres] adapter is closed')
+    const session = this.exclusiveSession.getStore()
+    if (session) {
+      const query = (...args: any[]) => {
+        if (session.failure) return Promise.reject(session.failure)
+        if (!session.active) return Promise.reject(new Error('[postgres] exclusive operation has ended'))
+        return session.client.query(...args)
+      }
+      // Borrow the lock's connection. Never return it to the pool from an
+      // inner method; the outer protected operation owns its entire lifetime.
+      return { query, connect: async () => ({ query, release: () => {} }) }
+    }
     // Memoize the PROMISE, not the resolved pool.
     //
     // The old shape checked `if (!this.pool)` and then awaited `loadPg()`.
@@ -538,6 +551,12 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
         last_accessed TEXT,
         data JSONB NOT NULL,
         source TEXT NOT NULL DEFAULT 'primary'
+      )
+    `)
+    await this.ddl(client, `
+      CREATE TABLE IF NOT EXISTS "${this.schema}".id_allocations (
+        date_prefix TEXT PRIMARY KEY,
+        last_sequence BIGINT NOT NULL CHECK (last_sequence > 0)
       )
     `)
     await this.ddl(client, `CREATE INDEX IF NOT EXISTS idx_engrams_status ON "${this.schema}".engrams(status)`)
@@ -896,7 +915,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     const pool = await this.getPool()
     const client = await this.acquire(pool)
     try {
-      await client.query('BEGIN')
+      if (!this.exclusiveSession.getStore()) await client.query('BEGIN')
       for (let i = 0; i < engrams.length; i += SAVE_CHUNK_SIZE) {
         const chunk = engrams.slice(i, i + SAVE_CHUNK_SIZE)
         await client.query(
@@ -919,11 +938,11 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
           [JSON.stringify(chunk.map(toRow))],
         )
       }
-      await client.query('COMMIT')
+      if (!this.exclusiveSession.getStore()) await client.query('COMMIT')
       // No cache to drop — `loadCached()` delegates to `load()` on this adapter
       // precisely because another process may have written since.
     } catch (err) {
-      await client.query('ROLLBACK').catch(() => { /* connection already broken */ })
+      if (!this.exclusiveSession.getStore()) await client.query('ROLLBACK').catch(() => { /* connection already broken */ })
       throw err
     } finally {
       client.release()
@@ -957,7 +976,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     const pool = await this.getPool()
     const client = await this.acquire(pool)
     try {
-      await client.query('BEGIN')
+      if (!this.exclusiveSession.getStore()) await client.query('BEGIN')
       for (let i = 0; i < engrams.length; i += SAVE_CHUNK_SIZE) {
         const chunk = engrams.slice(i, i + SAVE_CHUNK_SIZE)
         await client.query(
@@ -990,9 +1009,9 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
       } else {
         await client.query(`DELETE FROM "${this.schema}".engrams`)
       }
-      await client.query('COMMIT')
+      if (!this.exclusiveSession.getStore()) await client.query('COMMIT')
     } catch (err) {
-      await client.query('ROLLBACK').catch(() => { /* connection already broken */ })
+      if (!this.exclusiveSession.getStore()) await client.query('ROLLBACK').catch(() => { /* connection already broken */ })
       throw err
     } finally {
       client.release()
@@ -1039,61 +1058,75 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
    */
 
   /**
-   * Serialize a read-modify-write across every process sharing this schema,
-   * using a Postgres advisory lock.
-   *
-   * `pg_advisory_lock` is session-scoped, so the lock and its release must
-   * happen on the SAME connection — hence a dedicated client checked out for
-   * the duration rather than `pool.query`, which may hand back a different
-   * connection each call.
-   *
-   * The key is derived from the schema name, so two adapters pointed at the
-   * same schema contend and two pointed at different schemas do not. `hashtext`
-   * is Postgres's own hash, computed server-side, so every client agrees on it
-   * without the driver having to reproduce the hash function.
-   *
-   * Costs, both real and accepted here:
-   *   - one pooled connection is held for the whole critical section, so a pool
-   *     of N supports N-1 concurrent non-write operations. `maxConnections`
-   *     defaults to 10.
-   *   - writers serialize globally per schema. That is the point; the
-   *     alternative on a whole-corpus `save()` is losing data.
-   *
-   * The real fix for the throughput cost is incremental writes — an
-   * `append`/`update` seam on `PrimaryStore` so a write does not rewrite the
-   * corpus at all. That is a larger change; this makes the current write path
-   * CORRECT, which it was not.
+   * Protected operations use one transaction and one connection for locking,
+   * reads and writes. Losing that connection aborts the transaction and its
+   * ownership together. A separate pool avoids starving ordinary readers;
+   * incremental mutations join the outer transaction instead of committing it.
    */
+  /** Background work must start after commit, outside the connection's
+   * ownership context. Rolled-back operations never launch these callbacks. */
+  afterCommit(callback: () => void): void {
+    const session = this.exclusiveSession.getStore()
+    if (session?.active) session.afterCommit.push(callback)
+    else this.exclusiveSession.exit(callback)
+  }
+
+  async reserveEngramId(minimumId: string): Promise<string> {
+    const match = /^(ENG-\d{4}-\d{2}-\d{2}-)(\d{3,})$/.exec(minimumId)
+    if (!match || !Number.isSafeInteger(Number(match[2]))) throw new Error('Invalid minimum ID allocation')
+    const pool = await this.getPool()
+    const result = await pool.query(`
+      INSERT INTO "${this.schema}".id_allocations AS allocations (date_prefix, last_sequence)
+      VALUES ($1, $2::bigint)
+      ON CONFLICT (date_prefix) DO UPDATE
+        SET last_sequence = GREATEST(allocations.last_sequence + 1, EXCLUDED.last_sequence)
+      RETURNING last_sequence
+    `, [match[1], match[2]])
+    const sequence = Number(result.rows[0].last_sequence)
+    if (!Number.isSafeInteger(sequence)) throw new Error('Engram ID allocation sequence is exhausted')
+    return `${match[1]}${String(sequence).padStart(3, '0')}`
+  }
+
   async withExclusiveAccess<T>(fn: () => Promise<T>): Promise<T> {
-    // The lock connection comes from a SEPARATE pool.
-    //
-    // It used to come from the main pool, which deadlocks: the lock is held for
-    // the whole critical section, and `fn()` — a `save()` or a `load()` — needs
-    // its own connection from that same pool. With `maxConnections` writers in
-    // flight, every connection is held by a lock holder waiting for a
-    // connection that can never be freed. Reproduced with pool=2 and three
-    // writers: permanent hang, no error, no timeout.
-    //
-    // A second pool removes the circular wait by construction. Reserving
-    // headroom inside one pool would not: nothing enforces the reservation.
-    // The cost is up to `maxConnections` additional server connections, which
-    // is the honest price of holding a session lock across arbitrary work.
+    const existing = this.exclusiveSession.getStore()
+    if (existing) {
+      if (existing.failure) throw existing.failure
+      if (!existing.active) throw new Error('[postgres] exclusive operation has ended')
+      return fn()
+    }
+    // The separate pool avoids capacity deadlocks with ordinary readers.
+    // ALL work in this operation uses this connection. If it dies, its lock
+    // and transaction die together; no stale writer can switch connections.
     const pool = await this.getLockPool()
     const client = await this.acquire(pool)
+    const session: { client: any; active: boolean; failure?: Error; afterCommit: Array<() => void> } = { client, active: true, afterCommit: [] }
+    let discard: Error | undefined
+    const onError = (error: Error) => { session.failure = error; discard = error }
+    client.on('error', onError)
     try {
-      await client.query(`SELECT pg_advisory_lock(hashtext($1))`, [`plur:${this.schema}`])
-      try {
-        return await fn()
-      } finally {
-        // Release on the same session, even if `fn` threw. If THIS throws the
-        // connection is broken; releasing it below discards it from the pool,
-        // and Postgres drops session advisory locks when the session ends, so
-        // the lock cannot leak.
-        await client.query(`SELECT pg_advisory_unlock(hashtext($1))`, [`plur:${this.schema}`])
-          .catch(() => { /* session is going away; the lock dies with it */ })
+      await client.query('BEGIN')
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`plur:${this.schema}`])
+      const result = await this.exclusiveSession.run(session, fn)
+      if (session.failure) throw session.failure
+      // Disallow detached work before committing/releasing the connection.
+      session.active = false
+      const committed = await client.query('COMMIT')
+      if (committed.command !== 'COMMIT') throw new Error('[postgres] transaction was aborted; protected writes were rolled back')
+      for (const callback of session.afterCommit) {
+        const report = (error: unknown) => logger.warning(`[postgres] post-commit background work failed: ${String(error)}`)
+        try { Promise.resolve(this.exclusiveSession.exit(callback)).catch(report) } catch (error) { report(error) }
       }
+      return result
+    } catch (error) {
+      session.active = false
+      await client.query('ROLLBACK').catch((rollbackError: Error) => { discard = rollbackError })
+      throw error
     } finally {
-      client.release()
+      session.active = false
+      // Keep the error listener through release: a disconnected socket can
+      // report another event while pg destroys it. Never reuse a broken client.
+      client.release(discard)
+      if (!discard) client.removeListener('error', onError)
     }
   }
 
@@ -1527,7 +1560,7 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
     // #751: every checkout goes through acquire() so close() can destroy it.
     const client = await this.acquire(pool)
     try {
-      await client.query('BEGIN')
+      if (!this.exclusiveSession.getStore()) await client.query('BEGIN')
       if (this.hnswActive) {
         await client.query(`SET LOCAL hnsw.ef_search = ${this.efSearchForLimit(limit)}`)
       }
@@ -1540,10 +1573,10 @@ export class PostgresAdapter implements StorageAdapter, AsyncPrimaryStore {
          LIMIT $${limitIdx}`,
         [...params, literal, limit],
       )
-      await client.query('COMMIT')
+      if (!this.exclusiveSession.getStore()) await client.query('COMMIT')
       return res.rows.map((r: any) => ({ engram: parseRow(r), score: Number(r.score) }))
     } catch (err) {
-      await client.query('ROLLBACK').catch(() => { /* connection already broken */ })
+      if (!this.exclusiveSession.getStore()) await client.query('ROLLBACK').catch(() => { /* connection already broken */ })
       throw err
     } finally {
       client.release()

--- a/packages/core/src/store/async-fs.ts
+++ b/packages/core/src/store/async-fs.ts
@@ -3,11 +3,15 @@
  * Async equivalent of atomicWrite() from sync.ts.
  */
 import { existsSync } from 'fs'
-import { open, rename, mkdir, unlink } from 'fs/promises'
+import { open, rename, mkdir, unlink, stat } from 'fs/promises'
 import { dirname } from 'path'
+import { randomUUID } from 'crypto'
+import { directoryAncestry } from './durability.js'
 
 /** Options for {@link asyncAtomicWrite}. */
 export interface AsyncAtomicWriteOptions {
+  /** Mode for a new file; can tighten existing permissions, never loosen them. */
+  mode?: number
   /**
    * fsync the file and its parent directory before resolving. Default `true`.
    *
@@ -15,9 +19,6 @@ export interface AsyncAtomicWriteOptions {
    */
   durable?: boolean
 }
-
-/** Counter making each tmp name unique within a process (pid makes it unique across them). */
-let tmpCounter = 0
 
 /**
  * Atomic write: write to a temp file, flush it, then rename over the target.
@@ -36,10 +37,19 @@ export async function asyncAtomicWrite(
   const durable = opts.durable !== false
   const dir = dirname(filePath)
   if (!existsSync(dir)) await mkdir(dir, { recursive: true })
-  const tmp = `${filePath}.${process.pid}.${tmpCounter++}.tmp`
+  const tmp = `${filePath}.${randomUUID()}.tmp`
+  let mode = opts.mode ?? 0o600
   try {
-    const handle = await open(tmp, 'w')
+    mode = ((await stat(filePath)).mode & 0o777) & (opts.mode ?? 0o777)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+  }
+  let created = false
+  try {
+    const handle = await open(tmp, 'wx', 0o600)
+    created = true
     try {
+      await handle.chmod(mode)
       await handle.writeFile(content)
       if (durable) await handle.sync()
     } finally {
@@ -50,7 +60,7 @@ export async function asyncAtomicWrite(
   } catch (err) {
     // Never leave the tmp behind on a failed write — with a unique name
     // nothing else would ever clean it up.
-    try { await unlink(tmp) } catch { /* already gone, or never created */ }
+    if (created) try { await unlink(tmp) } catch { /* already gone */ }
     throw err
   }
 }
@@ -58,17 +68,23 @@ export async function asyncAtomicWrite(
 /**
  * fsync a directory so a rename into it is durable.
  *
- * Best-effort: directory handles cannot be synced on Windows and some
- * filesystems reject it. A failure means the rename may not survive power loss;
- * it does not mean the write failed, so it must not throw.
+ * Unsupported directory sync is tolerated on those platforms. Actual I/O
+ * failures propagate: replacement may already be visible, but durability was
+ * not acknowledged. Callers must resolve an ambiguous write before retrying.
  */
 async function fsyncDir(dir: string): Promise<void> {
+  for (const directory of directoryAncestry(dir)) await fsyncDirectoryEntry(directory)
+}
+
+async function fsyncDirectoryEntry(dir: string): Promise<void> {
   let handle
   try {
     handle = await open(dir, 'r')
     await handle.sync()
-  } catch {
-    /* platform does not support it — the file's own fsync still happened */
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (!['EINVAL', 'ENOTSUP', 'EOPNOTSUPP'].includes(code ?? '') &&
+        !(process.platform === 'win32' && ['EPERM', 'EACCES', 'EISDIR'].includes(code ?? ''))) throw err
   } finally {
     if (handle) {
       try { await handle.close() } catch { /* ignore */ }

--- a/packages/core/src/store/async-lock.ts
+++ b/packages/core/src/store/async-lock.ts
@@ -19,7 +19,7 @@
  * process and could simply have taken turns.
  *
  * The backoff is an async sleep, never a busy-wait: the synchronous
- * `withLock()` in `sync.ts` spins on `Date.now()`, which blocks the event loop
+ * `withLock()` in `sync.ts` uses an OS wait, which blocks the event loop
  * for the whole delay. In a deployment serving concurrent sessions that stalls
  * every other in-flight request, not just the contending one.
  *
@@ -27,9 +27,8 @@
  * mutex would wait on a lock its own caller is holding. Nesting on a
  * *different* path works but is a lock-ordering hazard; don't.
  */
-import { writeFile, unlink, stat, readFile, rename, open } from 'fs/promises'
-import { constants } from 'fs'
-import { hostname } from 'os'
+import { makeToken, tryFileLock, releaseFileLock } from './file-lock.js'
+export { makeToken, holderIsAlive } from './file-lock.js'
 import * as path from 'path'
 import { KeyedAsyncMutex } from '../async-mutex.js'
 
@@ -99,8 +98,8 @@ export const DEFAULT_STALE_THRESHOLD = 60_000
  * hold, not merely the typical one.
  *
  * The cost is bounded, and paid only by a waiter behind a LIVE holder — a dead
- * one is stolen from immediately by the liveness check, and a wedged one is
- * stolen after `DEFAULT_STALE_THRESHOLD`. Anything that raises git's per-command
+ * one is stolen from immediately by the liveness check, and a live or foreign-host owner is
+ * never reclaimed merely because time passed. Anything that raises git's per-command
  * timeout must raise this too, or reopen the same hole.
  */
 export const DEFAULT_ACQUIRE_TIMEOUT = 180_000
@@ -123,54 +122,6 @@ export function activeLockCount(): number {
 /** Sleep for the given number of milliseconds. */
 function sleep(ms: number): Promise<void> {
   return new Promise(res => setTimeout(res, ms))
-}
-
-/** Monotonic counter making each token unique within a process. */
-let tokenCounter = 0
-
-/**
- * Contents written into the lock file: who holds it, and which acquisition.
- *
- * The nonce is what makes release safe. Before this, release was an
- * unconditional `unlink`, so once a waiter stole a lock the ORIGINAL holder's
- * `finally` deleted the *thief's* lock on its way out — and a third process
- * walked straight in while the thief was still writing (audit #794, F9;
- * measured by probe p05b). A holder now removes the lock only if the file still
- * carries its own token.
- *
- * The hostname is what makes the liveness check safe: a pid is only meaningful
- * on the machine that owns it, and `~/.plur` on a synced or networked volume can
- * hold a lock written by a different host.
- */
-export function makeToken(): string {
-  return `${hostname()}:${process.pid}:${Date.now()}:${tokenCounter++}`
-}
-
-/**
- * Is the process that wrote this token still alive?
- *
- * `undefined` means "cannot tell" — a token from another host, or an
- * unparseable one — and callers must treat that as "assume alive". Guessing
- * "dead" would steal a lock from a live writer, which is the corpus-corruption
- * outcome the whole mechanism exists to prevent.
- */
-export function holderIsAlive(token: string): boolean | undefined {
-  const parts = token.split(':')
-  if (parts.length < 2) return undefined
-  const [host, pidRaw] = parts
-  if (host !== hostname()) return undefined
-  const pid = Number(pidRaw)
-  if (!Number.isInteger(pid) || pid <= 0) return undefined
-  try {
-    // Signal 0 performs the permission and existence checks without delivering
-    // a signal: it throws ESRCH when no such process exists.
-    process.kill(pid, 0)
-    return true
-  } catch (err: any) {
-    // EPERM means it exists but belongs to another user — alive, not ours.
-    if (err?.code === 'EPERM') return true
-    return false
-  }
 }
 
 /** Take the cross-process lock file, run `fn`, release. */
@@ -223,57 +174,11 @@ async function withFileLock<T>(
         )
       }
     }
-    try {
-      await writeFile(lockPath, token, { flag: constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL })
-      acquired = true
-      break
-    } catch (err: any) {
-      if (err.code !== 'EEXIST') throw err
-
-      // Is the incumbent abandoned? Two independent reasons to say yes.
-      let abandoned = false
-      let holder = ''
-      try {
-        const [s, contents] = await Promise.all([
-          stat(lockPath),
-          readFile(lockPath, 'utf8').catch(() => ''),
-        ])
-        holder = contents.trim()
-        const alive = holderIsAlive(holder)
-        // (1) The holder's process is gone. Definitive, and immediate — this is
-        //     what keeps crash recovery fast despite the long stale threshold.
-        if (alive === false) abandoned = true
-        // (2) We cannot probe this holder — another host, or a pid we cannot
-        //     reason about — so age is the only signal left.
-        //
-        //     Age is deliberately NOT consulted when liveness came back TRUE.
-        //     An `else if` here would steal from a writer we have just
-        //     confirmed is running, purely for being slow, and a 50k-engram
-        //     save legitimately holds the lock for seconds. Stealing from a
-        //     live writer corrupts the corpus; waiting on a wedged one is a
-        //     visible error after `acquireTimeout` that names the lock file.
-        //     A loud stall beats silent corruption.
-        else if (alive === undefined && Date.now() - s.mtimeMs > staleThreshold) abandoned = true
-      } catch {
-        // Vanished between the EEXIST and the check — the holder released.
-        // Retry immediately; there is nothing to steal.
-        continue
-      }
-
-      if (abandoned) {
-        // Remove only the file we just inspected. If the holder released and a
-        // third party re-locked in between, this deletes the newcomer's lock —
-        // so re-read and compare before unlinking.
-        await stealLock(lockPath, holder)
-        continue
-      }
-
-      // The incumbent is alive and recently active, so waiting is the only
-      // correct move — stealing from a live writer corrupts the store. The
-      // deadline check at the top of the next iteration decides when to stop.
-      lastHolder = holder
-      await sleep(Math.min(baseDelay * Math.pow(2, attempt), 5000))
-    }
+    const result = tryFileLock(lockPath, token, staleThreshold)
+    if (result.acquired) { acquired = true; break }
+    lastHolder = result.holder
+    if (result.retryNow) continue
+    await sleep(Math.min(baseDelay * Math.pow(2, attempt), 5000, Math.max(0, acquireTimeout - (Date.now() - start))))
   }
 
   try {
@@ -283,67 +188,7 @@ async function withFileLock<T>(
     // holder's file; the token comparison stops US deleting a THIEF's file
     // after our lock was stolen, which is what turned one stale-lock steal into
     // a cascade (F9).
-    if (acquired) await releaseIfOurs(lockPath, token)
-  }
-}
-
-/**
- * Remove a lock believed abandoned — by CLAIMING it first (audit 2026-08-03,
- * finding 1).
- *
- * The previous shape was read-compare-unlink, which closed the case where the
- * holder released and a third party acquired between the inspection and the
- * steal (F9), but left a narrower window open: between the compare and the
- * `unlink` itself. Two contenders that both judge the same lock stale can both
- * pass the compare; the first unlinks and acquires, the second then unlinks the
- * pathname — now the FIRST one's live lock — and acquires too. Both run the
- * critical section, and on a whole-corpus writer that is a lost update.
- *
- * `rename` is the atomic primitive that fixes it. Only one process can
- * successfully rename a given path; the loser gets ENOENT. So a contender can
- * only ever delete a file it has already moved out of the way, and can never
- * delete a lock another process created at `lockPath` — because the file it
- * deletes is not at `lockPath` any more.
- *
- * Losing the claim is not a failure: the caller loops, finds either a fresh
- * lock or none, and takes the normal `O_EXCL` path. Mutual exclusion is still
- * decided by that create, not by this function.
- */
-async function stealLock(lockPath: string, expected: string): Promise<void> {
-  const claim = `${lockPath}.steal.${makeToken().replace(/[^\w.-]/g, '_')}`
-  try {
-    await rename(lockPath, claim)
-  } catch {
-    return // another contender claimed it, or the holder released — re-evaluate
-  }
-  try {
-    const current = (await readFile(claim, 'utf8')).trim()
-    if (current === expected) {
-      await unlink(claim) // confirmed the one we judged stale
-      return
-    }
-    // Not the lock we judged stale — a live holder's. Put it back, but never on
-    // top of a lock someone has since acquired: `wx` fails rather than clobber.
-    try {
-      const fd = await open(lockPath, 'wx')
-      try { await fd.writeFile(current) } finally { await fd.close() }
-    } catch { /* someone acquired meanwhile — theirs wins, drop ours */ }
-    await unlink(claim).catch(() => {})
-  } catch {
-    // Never leave the claim file behind: it is uniquely named, so nothing else
-    // would ever clean it up.
-    await unlink(claim).catch(() => {})
-  }
-}
-
-/** Release the lock iff the file still carries our token. */
-async function releaseIfOurs(lockPath: string, token: string): Promise<void> {
-  try {
-    const current = (await readFile(lockPath, 'utf8')).trim()
-    if (current !== token) return
-    await unlink(lockPath)
-  } catch {
-    /* already gone */
+    if (acquired) releaseFileLock(lockPath, token)
   }
 }
 

--- a/packages/core/src/store/durability.ts
+++ b/packages/core/src/store/durability.ts
@@ -1,0 +1,14 @@
+import { dirname, resolve } from 'node:path'
+
+/** A synced leaf can still disappear if a newly created ancestor is lost.
+ * Walk on every acknowledgement: an earlier failed write may have left the
+ * directories present without ever making their parent entries durable. */
+export function* directoryAncestry(directory: string): Generator<string> {
+  let current = resolve(directory)
+  for (;;) {
+    yield current
+    const parent = dirname(current)
+    if (parent === current) return
+    current = parent
+  }
+}

--- a/packages/core/src/store/file-lock.ts
+++ b/packages/core/src/store/file-lock.ts
@@ -1,0 +1,80 @@
+/** Shared filesystem lock transitions. Both sync and async callers use this
+ * short synchronous operation; waiting and protected work remain caller-owned.
+ *
+ * Creating, inspecting and reclaiming the data lock all require the guard.
+ * Moving a supposedly stale lock before checking its token is unsafe: another
+ * contender may already have replaced it with a live lock. The guard removes
+ * that pathname race instead of trying to restore a live lock after moving it.
+ * A crashed guard fails closed and requires manual removal after stopping its
+ * owner. Reclaiming the guard would need another guard and the same proof.
+ */
+import { closeSync, openSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs'
+import { hostname } from 'os'
+
+let tokenCounter = 0
+export function makeToken(): string {
+  return `${hostname()}:${process.pid}:${Date.now()}:${tokenCounter++}`
+}
+
+export function holderIsAlive(token: string): boolean | undefined {
+  const [host, rawPid] = token.split(':')
+  if (host !== hostname()) return undefined
+  const pid = Number(rawPid)
+  if (!Number.isInteger(pid) || pid <= 0) return undefined
+  try { process.kill(pid, 0); return true } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false
+    return undefined // permission/OS failures are not evidence of death
+  }
+}
+
+export type LockAttempt = { acquired: true } | { acquired: false; holder: string; retryNow?: boolean }
+
+export function tryFileLock(lockPath: string, token: string, staleThreshold: number): LockAttempt {
+  const guard = `${lockPath}.guard`
+  let fd: number
+  try {
+    fd = openSync(guard, 'wx', 0o600)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+    return { acquired: false, holder: `transition guard ${guard}; if abandoned, stop its owner before removing it` }
+  }
+  try {
+    writeFileSync(fd, token)
+    try {
+      writeFileSync(lockPath, token, { flag: 'wx', mode: 0o600 })
+      return { acquired: true }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+    }
+    let holder: string
+    let mtime: number
+    try {
+      holder = readFileSync(lockPath, 'utf8').trim()
+      mtime = statSync(lockPath).mtimeMs
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+      return { acquired: false, holder: '', retryNow: true }
+    }
+    const alive = holderIsAlive(holder)
+    // Timestamp expiry is only a compatibility path for legacy malformed
+    // tokens. A token with a host/PID must be proved dead on that host.
+    const legacy = !holder.includes(':')
+    if (alive === false || (legacy && Date.now() - mtime > staleThreshold)) {
+      unlinkSync(lockPath)
+      return { acquired: false, holder, retryNow: true }
+    }
+    return { acquired: false, holder }
+  } finally {
+    try { closeSync(fd) } finally { unlinkSync(guard) }
+  }
+}
+
+export function releaseFileLock(lockPath: string, token: string): void {
+  try {
+    // A valid live token cannot be reclaimed, so no cooperating writer can
+    // replace this pathname between the comparison and our unlink.
+    if (readFileSync(lockPath, 'utf8').trim() === token) unlinkSync(lockPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+  }
+}

--- a/packages/core/src/store/id-allocation.ts
+++ b/packages/core/src/store/id-allocation.ts
@@ -1,0 +1,48 @@
+/** Allocation is durable state, independent of corpus retention and diagnostic
+ * history. Reserve before publishing a row; a failed write may leave a gap,
+ * but compaction, restart and another process can never recycle that identity. */
+import { mkdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { generateEngramId } from '../engrams.js'
+import { mintedIdsWithPrefix } from '../history.js'
+import type { Engram } from '../schemas/engram.js'
+import { atomicWrite, fsyncDir, withLock } from '../sync.js'
+
+export function legacyAllocatedIds(root: string, now: Date): string[] {
+  const day = now.toISOString().slice(0, 10)
+  return mintedIdsWithPrefix(root, day.slice(0, 7), [
+    `ENG-${day}-`, `ENG-${day.slice(0, 4)}-${day.slice(5, 7)}${day.slice(8, 10)}-`,
+  ])
+}
+
+export function reserveLocalEngramId(root: string, existing: Engram[]): string {
+  const now = new Date()
+  const day = now.toISOString().slice(0, 10)
+  const directory = join(root, 'state', 'id-allocations')
+  const created = mkdirSync(directory, { recursive: true, mode: 0o700 })
+  if (created) {
+    // A durable leaf file also needs the new state/directory entries to exist
+    // after a power failure. The Plur storage root is already established.
+    fsyncDir(join(root, 'state'))
+    fsyncDir(root)
+  }
+  const path = join(directory, `${day}.json`)
+  return withLock(path, () => {
+    let allocated: string[]
+    try {
+      const raw = JSON.parse(readFileSync(path, 'utf8'))
+      if (!raw || typeof raw.id !== 'string' || !new RegExp(`^ENG-${day}-[0-9]{3,}$`).test(raw.id)) {
+        throw new Error('Invalid allocation state')
+      }
+      allocated = [raw.id]
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw new Error('Cannot read durable ID allocation state; repair it before writing')
+      // Upgrade seed only. After the first reservation, history is diagnostic
+      // and may disappear without releasing any post-upgrade identities.
+      allocated = legacyAllocatedIds(root, now)
+    }
+    const id = generateEngramId(existing, allocated, now)
+    atomicWrite(path, JSON.stringify({ id }), { mode: 0o600 })
+    return id
+  })
+}

--- a/packages/core/src/store/primary-store.ts
+++ b/packages/core/src/store/primary-store.ts
@@ -87,6 +87,10 @@ export interface SaveOptions {
  * that satisfies neither is outside what the engine can defend.
  */
 export interface PrimaryStore {
+  /** Queue background work until the current transaction commits. Stores
+   * without transactions may omit this capability. */
+  afterCommit?(callback: () => void): void
+
   /** Backing medium — for diagnostics and `status()` reporting. */
   readonly kind: PrimaryStoreKind
 
@@ -321,6 +325,11 @@ export interface PrimaryStore {
    * @see findActiveByContentHash — the other half of the `learn()` seam.
    */
   nextEngramId?(datePrefix: string): Promise<string>
+
+  /** Reserve a monotonically increasing ID at least as high as minimumId.
+   * Must survive corpus deletion and be atomic across all store clients.
+   * Independent of the optional scope-query delegation seam above. */
+  reserveEngramId?(minimumId: string): Promise<string>
 
   /**
    * Cheap, approximate size of the store — for choosing a backend, never for

--- a/packages/core/src/store/readonly-store-guard.ts
+++ b/packages/core/src/store/readonly-store-guard.ts
@@ -94,6 +94,7 @@ export class ReadonlyStoreGuard implements PrimaryStore {
    * from a read-only guard would burn ids on a path that can never write one.
    */
   readonly nextEngramId?: (datePrefix: string) => Promise<string>
+  readonly reserveEngramId?: (minimumId: string) => Promise<string>
 
   /**
    * Query-adapter surface (#830). All READS, all delegating unchanged.
@@ -142,6 +143,7 @@ export class ReadonlyStoreGuard implements PrimaryStore {
       this.findActiveByContentHash = (hash, scope) => _inner.findActiveByContentHash!(hash, scope)
     }
     if (_inner.nextEngramId) this.nextEngramId = () => Promise.reject(new ReadonlyStoreError())
+    if (_inner.reserveEngramId) this.reserveEngramId = () => Promise.reject(new ReadonlyStoreError())
 
     // Query-adapter surface (#830) — reads, forwarded verbatim like loadByIds.
     const inner = _inner as unknown as {

--- a/packages/core/src/store/remote-store.ts
+++ b/packages/core/src/store/remote-store.ts
@@ -1,8 +1,10 @@
+import { createHash, randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import type { Engram } from '../schemas/engram.js'
 import { logger } from '../logger.js'
 import { normalizeEngramInput } from '../normalize-engram.js'
 import { ScopeMetadataSchema, type ScopeMetadata } from '../schemas/scope-metadata.js'
+import { userStructuredData } from '../content-fields.js'
 
 /**
  * Lenient validation for semi-trusted remote rows (security audit 2026-06-10,
@@ -98,6 +100,8 @@ const LOAD_FETCH_TIMEOUT_MS = 30_000
  * the normalized form — the user's spelling is preserved on disk.
  */
 export function normalizeEndpointUrl(url: string): string {
+  // Match URL normalization performed by fetch (host case, default ports, dot segments).
+  try { url = new URL(url).href } catch { /* validation remains at the caller boundary */ }
   return url.replace(/\/sse\/?$/, '').replace(/\/$/, '')
 }
 
@@ -626,13 +630,31 @@ export class RemoteStore {
    * placeholder will fail — the engram only exists on the server with
    * the server's ID.
    */
-  async appendAndGetServerId(engram: Engram): Promise<{ id: string }> {
+  appendFingerprint(engram: Engram): string {
+    return createHash('sha256').update(JSON.stringify([this.apiBase, JSON.parse(RemoteStore.appendBody(engram))], (_key, value) =>
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? Object.fromEntries(Object.keys(value).sort().map(key => [key, value[key]])) : value)).digest('hex')
+  }
+
+  private static appendBody(engram: Engram): string {
     // #768: transmit the full engram, not just the core four — pinned,
     // rationale, tags, commitment, validity windows and supersedes were
     // silently dropped, so team-scope pins never round-tripped. Optional
     // fields are included only when set, so older servers that ignore
     // unknown keys see no behavioral change.
     const e = engram as any
+    // These content forms have no remote representation yet. Refuse before
+    // sending, so a move keeps its original and a queued write remains visible.
+    // Silently dropping a qualifier is not a successful remote write.
+    for (const key of ['entities', 'episodic', 'exchange', 'insight', 'polarity']) {
+      const value = e[key]
+      if (value != null && (!Array.isArray(value) || value.length > 0)) {
+        throw new Error(`Remote write does not support content field: ${key}`)
+      }
+    }
+    if (userStructuredData(e.structured_data) !== undefined) {
+      throw new Error('Remote write does not support user structured_data')
+    }
     // Canonical engrams carry the validity window nested under `temporal`
     // (temporal.valid_from / temporal.valid_until, #347) and supersession
     // under `relations.supersedes` (#240) — the wire contract
@@ -644,7 +666,7 @@ export class RemoteStore {
     const supersedes  = Array.isArray(e.relations?.supersedes) && e.relations.supersedes.length > 0
       ? e.relations.supersedes
       : e.supersedes
-    const body = JSON.stringify({
+    return JSON.stringify({
       statement: e.statement,
       scope:     engram.scope,
       domain:    e.domain,
@@ -694,10 +716,19 @@ export class RemoteStore {
       // `provenance` is already above.
       ...(e.attribution != null             ? { attribution: e.attribution }   : {}),
       ...(e.claim_class != null             ? { claim_class: e.claim_class }   : {}),
+      ...(e.summary !== undefined           ? { summary: e.summary }           : {}),
+      ...(e.contraindications !== undefined ? { contraindications: e.contraindications } : {}),
+      ...(e.knowledge_type !== undefined    ? { knowledge_type: e.knowledge_type } : {}),
+      ...(e.visibility !== undefined        ? { visibility: e.visibility }     : {}),
+      ...(e.created_at !== undefined        ? { created_at: e.created_at }     : {}),
     })
+  }
+
+  async appendAndGetServerId(engram: Engram, requestId: string = randomUUID()): Promise<{ id: string; engram?: Engram }> {
+    const body = RemoteStore.appendBody(engram)
     const r = await this.fetchBounded(`${this.apiBase}/engrams`, {
       method: 'POST',
-      headers: this.headers({ 'Content-Type': 'application/json' }),
+      headers: this.headers({ 'Content-Type': 'application/json', 'Idempotency-Key': requestId }),
       body,
     }, RemoteStore.readBounded)
     if (!r.ok) throw new Error(`Remote store append failed: ${r.status} ${r.text}`)
@@ -711,20 +742,27 @@ export class RemoteStore {
       const shown = typeof id === 'string' ? `"${id.slice(0, 64).replace(/[^\w:./-]/g, '?')}"` : typeof id
       throw new Error(`Remote store append: server returned an invalid id (${shown})`)
     }
-    // Optimistic cache insert (issue #89): the POST succeeded so the server
-    // has the engram. Insert with the server-assigned id so the very next
-    // recall sees it without waiting for a background refresh. If the server
-    // transformed other fields, the next refresh corrects them.
-    const stored = { ...(engram as any), id } as Engram
-    if (this.cache) {
-      this.cache.engrams.push(stored)
-    } else {
-      // Cold cache (no prior load()): one engram is not "all engrams in
-      // this scope". Mark stale (ts: 0) so the next load() refetches
-      // from the server instead of treating the partial view as fresh.
-      this.cache = { ts: 0, engrams: [stored] }
+    // A write acknowledgement can carry server decisions (review hold,
+    // canonical content, or a retired replay). Never publish the submitted
+    // state into the read cache. Legacy ID-only replies invalidate the cache.
+    const echo = r.json as Record<string, unknown>
+    const candidate = echo.data && typeof echo.data === 'object'
+      ? { ...(echo.data as Record<string, unknown>), id: echo.id, scope: echo.scope, status: echo.status }
+      : echo
+    const hasState = Object.keys(candidate).some(key => key !== 'id')
+    let stored: Engram | undefined
+    if (hasState) {
+      if (!RemoteRowSchema.safeParse(candidate).success || candidate.scope !== this.scope) {
+        this.cache = null
+        throw new Error('Remote store append: invalid or out-of-scope acknowledgement')
+      }
+      stored = this.reshape({ id, scope: candidate.scope, status: candidate.status, data: candidate }) ?? undefined
     }
-    return { id }
+    if (!stored) this.cache = null
+    else if (this.cache) {
+      this.cache.engrams = [...this.cache.engrams.filter(row => row.id !== id), stored]
+    } else this.cache = { ts: 0, engrams: [stored] }
+    return { id, ...(stored ? { engram: stored } : {}) }
   }
 
   /**

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -1,9 +1,12 @@
 import { execFileSync } from 'child_process'
-import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync, statSync, readdirSync, openSync, closeSync, fsyncSync, chmodSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync, statSync, readdirSync, openSync, closeSync, fsyncSync, fchmodSync } from 'fs'
+import { randomUUID } from 'crypto'
 import { join, dirname, relative } from 'path'
 import * as yaml from 'js-yaml'
 import { isSharedScope } from './scope-util.js'
-import { DEFAULT_STALE_THRESHOLD, holderIsAlive, makeToken } from './store/async-lock.js'
+import { DEFAULT_STALE_THRESHOLD } from './store/async-lock.js'
+import { makeToken, tryFileLock, releaseFileLock } from './store/file-lock.js'
+import { directoryAncestry } from './store/durability.js'
 
 export interface SyncStatus {
   initialized: boolean
@@ -54,6 +57,10 @@ embeddings/
 *.sqlite
 store.pglite/
 exchange/
+cache/
+
+# PLUR — durable machine-local receipts (include in operational backups)
+state/
 
 # PLUR — local backups (#799). Machine-local by design: a snapshot is a
 # whole-corpus copy INCLUDING scope:local engrams, so pushing one would leak
@@ -168,6 +175,10 @@ function stageStoreFiles(root: string): number {
   for (const secret of SECRET_PATHS) {
     gitSafe(['rm', '--cached', '--ignore-unmatch', '--quiet', '--', secret], root)
   }
+  // git commit includes the caller's existing index, not only paths we add.
+  // Refuse foreign staged content without unstaging or deleting the user's
+  // work. Deletions may proceed so previously tracked private data can be removed.
+  assertOnlyStoreContentStaged(root)
   // Root store files (allowlist), EXCEPT `packs` which is staged by its own
   // file-level allowlist below — never as a whole force-added directory (#428).
   const present = SYNC_PATHS.filter((p) => p !== 'packs' && existsSync(join(root, p)))
@@ -177,8 +188,20 @@ function stageStoreFiles(root: string): number {
     // no secret file (root or nested in a pack) can ever ride along.
     git(['add', '-A', '-f', '--', ...pathspecs], root)
   }
+  assertOnlyStoreContentStaged(root)
   const staged = gitSafe(['diff', '--cached', '--name-only'], root)
   return staged ? staged.split('\n').filter(Boolean).length : 0
+}
+
+function assertOnlyStoreContentStaged(root: string): void {
+  const paths = execFileSync('git', ['diff', '--cached', '--diff-filter=ACMRTUXB', '--name-only', '-z'], { cwd: root, encoding: 'utf8', timeout: 30_000 })
+    .split('\0').filter(Boolean)
+  const allowedRoot = new Set<string>(SYNC_PATHS.filter(p => p !== 'packs'))
+  const allowedPack = new Set<string>(PACK_ALLOW_NAMES)
+  if (paths.some(path => !allowedRoot.has(path) &&
+    !(path.startsWith('packs/') && allowedPack.has(path.split('/').pop() ?? '')))) {
+    throw new Error('Refusing to sync: non-store files are staged. Unstage them or commit them separately after review; files and staged work have been preserved.')
+  }
 }
 
 /**
@@ -727,53 +750,12 @@ export interface LockOptions {
  * legitimate hold.
  *
  * The retry budget is deliberately NOT raised, because this implementation
- * busy-waits on `Date.now()` — it blocks the event loop for the whole delay
+ * waits synchronously — it blocks the event loop for the whole delay
  * (F10). Waiting longer here would make a long-lived MCP server less responsive,
  * not more correct. Callers that need to wait out a slow holder belong on
  * `withAsyncLock`; this variant exists for the remaining synchronous callers
  * (tensions, config, episode capture), whose holds are short.
  */
-/**
- * Remove a lock believed abandoned — by CLAIMING it first (audit 2026-08-03,
- * finding 1). Synchronous twin of `stealLock` in `store/async-lock.ts`; see the
- * reasoning there.
- *
- * Read-compare-unlink left a window between the compare and the `unlink`: two
- * contenders judging the same lock stale can both pass the compare, the first
- * unlinks and acquires, and the second then unlinks the pathname — the first
- * one's LIVE lock — and acquires too. Both run the critical section.
- *
- * `rename` is atomic and single-winner, so a contender can only ever delete a
- * file it has already moved aside, never a lock another process created at
- * `lockPath`. Losing the claim is normal: the caller loops and takes the usual
- * O_EXCL path, which is what actually decides who holds the lock.
- */
-function stealLockSync(lockPath: string, expected: string, token: string): void {
-  const claim = `${lockPath}.steal.${token.replace(/[^\w.-]/g, '_')}`
-  try {
-    renameSync(lockPath, claim)
-  } catch {
-    return // another contender claimed it, or the holder released — re-evaluate
-  }
-  try {
-    const current = readFileSync(claim, 'utf8').trim()
-    if (current === expected) {
-      unlinkSync(claim) // confirmed the one we judged stale
-      return
-    }
-    // A live holder's lock, not the stale one. Put it back — but never over a
-    // lock someone has since acquired, so create exclusively and accept EEXIST.
-    try {
-      const fd = openSync(lockPath, 'wx')
-      try { writeFileSync(fd, current) } finally { closeSync(fd) }
-    } catch { /* someone acquired meanwhile — theirs wins */ }
-    try { unlinkSync(claim) } catch { /* already gone */ }
-  } catch {
-    // The claim file is uniquely named; nothing else would ever clean it up.
-    try { unlinkSync(claim) } catch { /* already gone */ }
-  }
-}
-
 export function withLock<T>(
   filePath: string,
   fn: () => T,
@@ -799,61 +781,33 @@ export function withLock<T>(
   // attempt the final one.
   let acquired = false
 
+  let lastHolder = ''
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      writeFileSync(lockPath, token, { flag: 'wx' })
-      acquired = true
-      break
-    } catch (err: any) {
-      if (err.code !== 'EEXIST') throw err
-      try {
-        const stat = statSync(lockPath)
-        // Liveness is what pays for the raised stale threshold, and it has to
-        // be here as well as on the async lock. Raising the threshold to 60s
-        // without it would take crash recovery on THESE paths (episodes,
-        // tensions, config) from 10s to 60s.
-        const holder = readFileSync(lockPath, 'utf8').trim()
-        const alive = holderIsAlive(holder)
-        // Age is consulted ONLY when liveness is unknown — another host, or the
-        // bare pid an older client wrote. A confirmed-live holder is never
-        // stolen from for being slow: that corrupts the artifact it is midway
-        // through writing, whereas waiting on a wedged holder surfaces as a
-        // loud failure the operator can act on.
-        const steal = alive === false
-          || (alive === undefined && Date.now() - stat.mtimeMs > staleThreshold)
-        if (steal) {
-          stealLockSync(lockPath, holder, token)
-          continue
-        }
-      } catch {
-        continue
-      }
-      if (attempt === maxRetries) {
-        throw new Error(`Failed to acquire lock on ${filePath} after ${maxRetries} retries`)
-      }
-      const delay = baseDelay * Math.pow(2, attempt)
-      const end = Date.now() + delay
-      while (Date.now() < end) { /* busy wait — sync context */ }
-    }
+    const result = tryFileLock(lockPath, token, staleThreshold)
+    if (result.acquired) { acquired = true; break }
+    lastHolder = result.holder
+    if (result.retryNow) continue
+    if (attempt === maxRetries) break
+    // Yield the CPU to the process holding the lock. Spinning here makes
+    // simultaneous writers starve the owner while spending their own budget.
+    const delay = Math.min(baseDelay * Math.pow(2, attempt), 5000)
+    if (Number.isFinite(delay) && delay > 0) Atomics.wait(syncLockWaiter, 0, 0, delay)
   }
 
   if (!acquired) {
     throw new Error(
-      `Failed to acquire lock on ${filePath} after ${maxRetries} retries (contended throughout)`,
+      `Failed to acquire lock on ${filePath} after ${maxRetries} retries (held by ${lastHolder})`,
     )
   }
 
   try {
     return fn()
   } finally {
-    // Only ours to remove. Without the token comparison, a holder whose lock
-    // was stolen deletes the THIEF's lock on its way out and a third writer
-    // walks in mid-write — the cascade fixed on the async lock (audit #794 F9).
-    try {
-      if (readFileSync(lockPath, 'utf8').trim() === token) unlinkSync(lockPath)
-    } catch { /* already gone */ }
+    releaseFileLock(lockPath, token)
   }
 }
+
+const syncLockWaiter = new Int32Array(new SharedArrayBuffer(4))
 
 /**
  * Mode for files that carry credentials — `config.yaml` holds remote bearer
@@ -864,14 +818,9 @@ export const CONFIG_FILE_MODE = 0o600
 /** Options for {@link atomicWrite}. */
 export interface AtomicWriteOptions {
   /**
-   * Mode for a file this write CREATES. Ignored when the destination already
-   * exists — an existing file's mode is preserved instead, which is the more
-   * important half (audit 2026-08-03, finding 7).
-   *
-   * Pass `0o600` for anything credential-bearing. Without it a new
-   * `config.yaml` — bearer tokens, Postgres DSNs — is born world-readable under
-   * the default umask, and the preservation path then faithfully keeps it that
-   * way forever.
+   * New files default to private `0o600`; explicit modes support public
+   * artifacts. Existing permissions are preserved when omitted. An explicit
+   * mode can tighten existing permissions but can never broaden them.
    */
   mode?: number
   /**
@@ -883,9 +832,6 @@ export interface AtomicWriteOptions {
    */
   durable?: boolean
 }
-
-/** Counter making each tmp name unique within a process (pid makes it unique across them). */
-let tmpCounter = 0
 
 /**
  * Atomic write: write to a temp file, flush it, then rename over the target.
@@ -915,53 +861,48 @@ let tmpCounter = 0
  * already been renamed away. Unique names make concurrent writers independent;
  * the last rename wins cleanly instead of publishing a half-written blend.
  */
-export function atomicWrite(filePath: string, content: string, opts: AtomicWriteOptions = {}): void {
+export function atomicWrite(filePath: string, content: string | Buffer, opts: AtomicWriteOptions = {}): void {
   const durable = opts.durable !== false
   const dir = dirname(filePath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-  const tmp = `${filePath}.${process.pid}.${tmpCounter++}.tmp`
+  const tmp = `${filePath}.${randomUUID()}.tmp`
   // Preserve the destination's permissions (audit 2026-08-03, finding 7).
   //
   // A replace-by-rename creates a NEW inode, so the result carries the tmp
-  // file's mode — `0666 & ~umask`, i.e. 0644 under the common umask 022 — not
-  // the mode the file had. `config.yaml` holds remote bearer tokens and
+  // file's mode, not the mode the file had. `config.yaml` holds remote bearer tokens and
   // Postgres DSNs and is expected to be 0600; every config writer now routes
   // through here, so store registration, scope persistence and migrations were
   // each quietly widening it to world-readable on POSIX.
   //
   // Read the mode BEFORE writing, and apply it to the tmp file BEFORE the
   // rename, so the file is never briefly visible at the wrong mode at its final
-  // path. A missing destination means there is nothing to preserve — a first
-  // write keeps the platform default, which is what created it today.
-  let destMode: number | undefined = opts.mode
+  // path. A missing destination uses the explicit mode or private default.
+  let destMode = opts.mode ?? 0o600
   try {
-    // An EXISTING file's own mode wins over opts.mode: the operator may have
-    // tightened it further, and a write must never loosen what it found.
-    if (existsSync(filePath)) destMode = statSync(filePath).mode & 0o7777
-  } catch { /* unreadable stat — fall through and keep opts.mode/default */ }
+    // An explicit mode can tighten an existing file but never loosen it.
+    destMode = (statSync(filePath).mode & 0o777) & (opts.mode ?? 0o777)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+  }
+  let created = false
   try {
-    if (durable) {
-      const fd = openSync(tmp, 'w')
-      try {
-        writeFileSync(fd, content)
-        fsyncSync(fd)
-      } finally {
-        closeSync(fd)
-      }
-    } else {
-      writeFileSync(tmp, content)
-    }
-    if (destMode !== undefined) {
-      // Best-effort: a filesystem without POSIX modes (some Windows/network
-      // mounts) must not fail an otherwise good write over cosmetics.
-      try { chmodSync(tmp, destMode) } catch { /* not a mode-bearing filesystem */ }
+    // Exclusive creation rejects symlinks/collisions. Start private, then set
+    // the final mode before writing any sensitive bytes (including temp files).
+    const fd = openSync(tmp, 'wx', 0o600)
+    created = true
+    try {
+      fchmodSync(fd, destMode)
+      writeFileSync(fd, content)
+      if (durable) fsyncSync(fd)
+    } finally {
+      closeSync(fd)
     }
     renameSync(tmp, filePath)
     if (durable) fsyncDir(dir)
   } catch (err) {
     // Never leave the tmp behind on a failed write — it would accumulate, and
     // with a unique name nothing would ever clean it up.
-    try { unlinkSync(tmp) } catch { /* already gone, or never created */ }
+    if (created) try { unlinkSync(tmp) } catch { /* already gone */ }
     throw err
   }
 }
@@ -969,18 +910,23 @@ export function atomicWrite(filePath: string, content: string, opts: AtomicWrite
 /**
  * fsync a directory so a rename into it is durable.
  *
- * Best-effort by design: directory fds cannot be opened for sync on Windows,
- * and some filesystems reject the fsync outright. A failure here means the
- * rename may not survive power loss — it does NOT mean the write failed, and
- * throwing would turn a working write into a spurious error.
+ * Tolerates only unsupported directory sync. A real I/O failure means the
+ * replacement may be visible without durable metadata, so it must not be
+ * acknowledged as durable. File contents are not rolled back after rename.
  */
 export function fsyncDir(dir: string): void {
+  for (const directory of directoryAncestry(dir)) fsyncDirectoryEntry(directory)
+}
+
+function fsyncDirectoryEntry(dir: string): void {
   let fd: number | undefined
   try {
     fd = openSync(dir, 'r')
     fsyncSync(fd)
-  } catch {
-    /* platform does not support it — the file's own fsync still happened */
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (!['EINVAL', 'ENOTSUP', 'EOPNOTSUPP'].includes(code ?? '') &&
+        !(process.platform === 'win32' && ['EPERM', 'EACCES', 'EISDIR'].includes(code ?? ''))) throw err
   } finally {
     if (fd !== undefined) {
       try { closeSync(fd) } catch { /* ignore */ }

--- a/packages/core/src/telemetry-counters.ts
+++ b/packages/core/src/telemetry-counters.ts
@@ -25,15 +25,14 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  renameSync,
   unlinkSync,
-  writeFileSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 
 import { isTelemetryEnabled } from './telemetry.js'
+import { atomicWrite, withLock, fsyncDir } from './sync.js'
 
 export type CounterEvent = 'learn' | 'recall' | 'session'
 
@@ -76,40 +75,54 @@ function gateOpts(opts: CountersOpts): { env?: NodeJS.ProcessEnv; configPath?: s
 
 function ensureParentDir(path: string): void {
   const dir = dirname(path)
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 })
-  }
-}
-
-// Unique per call, not just per process (#188): pid-only tmp names collide
-// when two writes to the same path interleave in async contexts — the second
-// write clobbers the first tmp file before its rename.
-function tmpPath(path: string): string {
-  return `${path}.tmp.${process.pid}.${randomUUID()}`
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+  // Also retry an earlier failed directory sync: existence is not durability.
+  fsyncDir(dir)
 }
 
 function atomicWriteJson(path: string, data: unknown): void {
-  ensureParentDir(path)
-  const tmp = tmpPath(path)
-  writeFileSync(tmp, JSON.stringify(data), { encoding: 'utf8', mode: 0o600 })
-  renameSync(tmp, path)
+  const dir = dirname(path)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+  // The canonical writer syncs the complete ancestry after replacement.
+  atomicWrite(path, JSON.stringify(data), { mode: 0o600 })
 }
 
-function atomicWriteString(path: string, data: string): void {
+export function telemetryQueuePath(opts: CountersOpts): string {
+  return join(opts.pendingDir ?? defaultPendingDir(), '.queue')
+}
+
+export function prepareTelemetryQueue(opts: CountersOpts): string {
+  const path = telemetryQueuePath(opts)
   ensureParentDir(path)
-  const tmp = tmpPath(path)
-  writeFileSync(tmp, data, { encoding: 'utf8', mode: 0o600 })
-  renameSync(tmp, path)
+  return path
+}
+
+function withTelemetryLock<T>(opts: CountersOpts, fn: () => T): T {
+  const path = telemetryQueuePath(opts)
+  const dir = dirname(path)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+  return withLock(path, fn)
+}
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+function validDate(date: unknown): date is string {
+  return typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date) && !date.startsWith('0000')
+    && Number.isFinite(Date.parse(date)) && new Date(date).toISOString().slice(0, 10) === date
 }
 
 export function readOrCreateInstallId(path: string): string {
-  if (existsSync(path)) {
-    const raw = readFileSync(path, 'utf8').trim()
-    if (raw.length > 0) return raw
-  }
-  const id = randomUUID()
-  atomicWriteString(path, id)
-  return id
+  ensureParentDir(path)
+  return withLock(path, () => {
+    let raw: string
+    try { raw = readFileSync(path, 'utf8').trim() } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      const id = randomUUID()
+      atomicWrite(path, id, { mode: 0o600 })
+      return id
+    }
+    if (!UUID.test(raw)) throw new Error('Invalid telemetry install identity; existing data preserved')
+    return raw
+  })
 }
 
 type StoredCounters = {
@@ -117,26 +130,44 @@ type StoredCounters = {
   learn: number
   recall: number
   session: number
+  _rolloverId?: string
+  _applied?: string[]
+  _deliveryId?: string
+  _wireIdentity?: DeliveryIdentity
+  _deliveryCounters?: Pick<StoredCounters, 'date' | 'learn' | 'recall' | 'session'>
 }
 
+type DeliveryIdentity = { installId: string; version: string; platform: NodeJS.Platform }
+
 function readStoredCounters(path: string): StoredCounters | null {
-  if (!existsSync(path)) return null
-  try {
-    const parsed = JSON.parse(readFileSync(path, 'utf8'))
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      typeof parsed.date === 'string' &&
-      typeof parsed.learn === 'number' &&
-      typeof parsed.recall === 'number' &&
-      typeof parsed.session === 'number'
-    ) {
-      return parsed as StoredCounters
-    }
-    return null
-  } catch {
-    return null
+  let raw: string
+  try { raw = readFileSync(path, 'utf8') } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw new Error('Cannot read telemetry counters; existing data preserved')
   }
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || !validDate(parsed.date)
+      || !['learn', 'recall', 'session'].every(key => Number.isSafeInteger(parsed[key]) && parsed[key] >= 0)
+      || ['_rolloverId', '_deliveryId'].some(key => parsed[key] !== undefined && (typeof parsed[key] !== 'string' || !UUID.test(parsed[key])))
+      || (parsed._applied !== undefined && (!Array.isArray(parsed._applied) || !parsed._applied.every((v: unknown) => typeof v === 'string' && UUID.test(v))))
+      || (parsed._deliveryCounters !== undefined && (!parsed._deliveryCounters
+        || parsed._deliveryCounters.date !== parsed.date
+        || !['_deliveryId', '_wireIdentity'].every(key => parsed[key] !== undefined)
+        || !['learn', 'recall', 'session'].every(key => Number.isSafeInteger(parsed._deliveryCounters[key])
+          && parsed._deliveryCounters[key] >= 0 && parsed._deliveryCounters[key] <= parsed[key])))
+      || (parsed._wireIdentity !== undefined && (!parsed._wireIdentity || !UUID.test(parsed._wireIdentity.installId)
+        || typeof parsed._wireIdentity.version !== 'string' || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(parsed._wireIdentity.version)
+        || !['linux', 'darwin', 'win32'].includes(parsed._wireIdentity.platform)))) throw new Error('invalid')
+    return parsed as StoredCounters
+  } catch {
+    throw new Error('Invalid telemetry counters; existing data preserved')
+  }
+}
+
+function countsOnly(stored: StoredCounters): StoredCounters {
+  const { date, learn, recall, session } = stored
+  return { date, learn, recall, session }
 }
 
 function freshCounters(date: string): StoredCounters {
@@ -151,25 +182,36 @@ function viewAsToday(stored: StoredCounters | null, today: string): StoredCounte
   return stored
 }
 
-function moveToPending(stored: StoredCounters, pendingDir: string): void {
+function moveToPending(stored: StoredCounters, pendingDir: string, countersPath: string): void {
+  // Persist a stable transfer identity BEFORE touching the destination. A
+  // retry after either replacement reuses it instead of summing twice.
+  if (!stored._rolloverId) {
+    stored = { ...stored, _rolloverId: randomUUID() }
+    atomicWriteJson(countersPath, stored)
+  }
   const path = join(pendingDir, `${stored.date}.json`)
-  // If a pending file already exists for this date (e.g. multiple processes
-  // each detected the same rollover), merge counts so we don't double-count
-  // OR drop the smaller snapshot.
   const existing = readStoredCounters(path)
-  const merged: StoredCounters =
-    existing && existing.date === stored.date
-      ? {
-          date: stored.date,
-          learn: existing.learn + stored.learn,
-          recall: existing.recall + stored.recall,
-          session: Math.max(existing.session, stored.session),
-        }
-      : stored
+  if (existing && existing.date !== stored.date) throw new Error('Telemetry pending date mismatch')
+  if (existing?._applied?.includes(stored._rolloverId!)) return
+  const merged: StoredCounters = {
+    ...existing,
+    date: stored.date,
+    learn: (existing?.learn ?? 0) + stored.learn,
+    recall: (existing?.recall ?? 0) + stored.recall,
+    session: Math.max(existing?.session ?? 0, stored.session),
+    _applied: [...(existing?._applied ?? []), stored._rolloverId!],
+    _deliveryId: existing?._deliveryId ?? randomUUID(),
+  }
+  if (![merged.learn, merged.recall, merged.session].every(Number.isSafeInteger)) throw new Error('Telemetry counter limit exceeded')
   atomicWriteJson(path, merged)
 }
 
 export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): boolean {
+  if (!isTelemetryEnabled(gateOpts(opts))) return false
+  return withTelemetryLock(opts, () => recordEventLocked(event, opts))
+}
+
+function recordEventLocked(event: CounterEvent, opts: CountersOpts = {}): boolean {
   if (!isTelemetryEnabled(gateOpts(opts))) return false
 
   const countersPath = opts.countersPath ?? defaultCountersPath()
@@ -183,17 +225,18 @@ export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): boole
   const stored = readStoredCounters(countersPath)
   let current: StoredCounters
   let rolledOver = false
-  if (stored && stored.date !== today) {
+  if (stored && (stored.date !== today || stored._rolloverId)) {
     // Rollover: preserve yesterday's snapshot in pending-dir BEFORE overwriting
     // counters.json with today's fresh state. This is the load-bearing fix for
     // #128 — without it, a long-lived process emitting an event after midnight
     // would silently discard yesterday's counts.
-    moveToPending(stored, pendingDir)
+    moveToPending(stored, pendingDir, countersPath)
     current = freshCounters(today)
     rolledOver = true
   } else {
     current = stored ?? freshCounters(today)
   }
+  if (current._rolloverId) throw new Error('Telemetry rollover is incomplete; retry using the later date before recording')
   const sessionAlreadyCounted = current.session > 0
 
   if (event === 'learn') current.learn += 1
@@ -204,6 +247,7 @@ export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): boole
     current.session += 1
   }
 
+  if (![current.learn, current.recall, current.session].every(Number.isSafeInteger)) throw new Error('Telemetry counter limit exceeded')
   atomicWriteJson(countersPath, current)
   return rolledOver
 }
@@ -213,29 +257,64 @@ export function recordEvent(event: CounterEvent, opts: CountersOpts = {}): boole
 
 export function listPendingDates(opts: CountersOpts = {}): string[] {
   const pendingDir = opts.pendingDir ?? defaultPendingDir()
-  if (!existsSync(pendingDir)) return []
   try {
-    return readdirSync(pendingDir)
-      .filter((f) => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
-      .map((f) => f.slice(0, -5))
-      .sort()
-  } catch {
-    return []
+    return readdirSync(pendingDir).filter(f => /^\d{4}-\d{2}-\d{2}\.json$/.test(f)).map(f => f.slice(0, -5)).sort()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw new Error('Cannot list pending telemetry; existing data preserved')
   }
+}
+
+function pendingPath(date: string, opts: CountersOpts): string {
+  if (!validDate(date)) throw new Error('Invalid pending telemetry date')
+  return join(opts.pendingDir ?? defaultPendingDir(), `${date}.json`)
 }
 
 export function readPendingCounters(date: string, opts: CountersOpts = {}): StoredCounters | null {
-  const pendingDir = opts.pendingDir ?? defaultPendingDir()
-  return readStoredCounters(join(pendingDir, `${date}.json`))
+  const stored = readStoredCounters(pendingPath(date, opts))
+  if (stored && stored.date !== date) throw new Error('Telemetry pending date mismatch')
+  return stored && countsOnly(stored)
 }
 
-export function deletePending(date: string, opts: CountersOpts = {}): void {
-  const pendingDir = opts.pendingDir ?? defaultPendingDir()
-  try {
-    unlinkSync(join(pendingDir, `${date}.json`))
-  } catch {
-    /* ignore — already gone */
-  }
+export type PendingDelivery = { counters: StoredCounters; id: string; identity: DeliveryIdentity }
+export function readPendingDelivery(date: string, opts: CountersOpts, identity: DeliveryIdentity): PendingDelivery | null {
+  return withTelemetryLock(opts, () => {
+    const path = pendingPath(date, opts)
+    const stored = readStoredCounters(path)
+    if (!stored) return null
+    if (stored.date !== date) throw new Error('Telemetry pending date mismatch')
+    if (!stored._deliveryId || !stored._wireIdentity || !stored._deliveryCounters) {
+      stored._deliveryId ??= randomUUID()
+      stored._wireIdentity ??= identity
+      // Freeze the exact acknowledged prefix before sending. New counts can
+      // arrive while a response is lost, or before local acknowledgement.
+      stored._deliveryCounters ??= countsOnly(stored)
+      atomicWriteJson(path, stored)
+    }
+    return { counters: countsOnly(stored._deliveryCounters), id: stored._deliveryId, identity: stored._wireIdentity }
+  })
+}
+
+export function deletePending(date: string, opts: CountersOpts, sent: PendingDelivery): void {
+  withTelemetryLock(opts, () => {
+    const path = pendingPath(date, opts)
+    const current = readStoredCounters(path)
+    if (!current) return
+    if (current._deliveryId !== sent.id) throw new Error('Pending telemetry identity changed; data preserved')
+    if ((['learn', 'recall', 'session'] as const).every(key => current[key] === sent.counters[key])) {
+      unlinkSync(path)
+      fsyncDir(dirname(path))
+      return
+    }
+    // New rollover counts arrived during the request. Remove only the
+    // acknowledged prefix and give the retained remainder a new identity.
+    const next = { ...current, _deliveryId: randomUUID(), _deliveryCounters: undefined, _wireIdentity: undefined }
+    for (const key of ['learn', 'recall', 'session'] as const) {
+      if (next[key] < sent.counters[key]) throw new Error('Pending telemetry changed incompatibly; data preserved')
+      next[key] -= sent.counters[key]
+    }
+    atomicWriteJson(path, next)
+  })
 }
 
 // Migration helper: if counters.json holds a stale date (e.g. upgrade from a
@@ -243,18 +322,28 @@ export function deletePending(date: string, opts: CountersOpts = {}): void {
 // Returns true when migration ran.
 export function migrateStaleCounters(opts: CountersOpts = {}): boolean {
   if (!isTelemetryEnabled(gateOpts(opts))) return false
+  return withTelemetryLock(opts, () => migrateStaleCountersLocked(opts))
+}
+
+function migrateStaleCountersLocked(opts: CountersOpts): boolean {
+  if (!isTelemetryEnabled(gateOpts(opts))) return false
   const countersPath = opts.countersPath ?? defaultCountersPath()
   const pendingDir = opts.pendingDir ?? defaultPendingDir()
   const now = (opts.now ?? (() => new Date()))()
   const today = utcDate(now)
   const stored = readStoredCounters(countersPath)
-  if (!stored || stored.date >= today) return false
-  moveToPending(stored, pendingDir)
+  if (!stored || (stored.date >= today && !stored._rolloverId)) return false
+  moveToPending(stored, pendingDir, countersPath)
   atomicWriteJson(countersPath, freshCounters(today))
   return true
 }
 
 export function getCounters(opts: CountersOpts = {}): CounterSnapshot | null {
+  if (!isTelemetryEnabled(gateOpts(opts))) return null
+  return withTelemetryLock(opts, () => getCountersLocked(opts))
+}
+
+function getCountersLocked(opts: CountersOpts): CounterSnapshot | null {
   if (!isTelemetryEnabled(gateOpts(opts))) return null
 
   const countersPath = opts.countersPath ?? defaultCountersPath()
@@ -275,6 +364,11 @@ export function getCounters(opts: CountersOpts = {}): CounterSnapshot | null {
 }
 
 export function resetCounters(opts: CountersOpts = {}): CounterSnapshot | null {
+  if (!isTelemetryEnabled(gateOpts(opts))) return null
+  return withTelemetryLock(opts, () => resetCountersLocked(opts))
+}
+
+function resetCountersLocked(opts: CountersOpts): CounterSnapshot | null {
   if (!isTelemetryEnabled(gateOpts(opts))) return null
 
   const countersPath = opts.countersPath ?? defaultCountersPath()

--- a/packages/core/src/telemetry-flush.ts
+++ b/packages/core/src/telemetry-flush.ts
@@ -28,10 +28,12 @@ import {
   getCounters,
   listPendingDates,
   migrateStaleCounters,
-  readPendingCounters,
+  readPendingDelivery,
+  prepareTelemetryQueue,
   type CounterSnapshot,
   type CountersOpts,
 } from './telemetry-counters.js'
+import { withAsyncLock } from './store/async-lock.js'
 
 export type HeartbeatPayload = {
   install_id: string
@@ -48,6 +50,7 @@ export type FlushOpts = CountersOpts & {
   endpoint?: string
   timeoutMs?: number
   packageVersion?: string
+  deliveryId?: string
 }
 
 const DEFAULT_ENDPOINT = 'https://plur.ai/v1/heartbeat'
@@ -108,7 +111,7 @@ export async function sendHeartbeat(
   try {
     const res = await fetchImpl(endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...(opts.deliveryId ? { 'Idempotency-Key': opts.deliveryId } : {}) },
       body: JSON.stringify(payload),
       signal: controller.signal,
     })
@@ -130,6 +133,14 @@ export async function flushIfNeeded(opts: FlushOpts = {}): Promise<void> {
   // pending-dir check below handles the empty case.
   if (countersPath && !existsSync(countersPath) && listPendingDates(opts).length === 0) return
 
+  const queuePath = prepareTelemetryQueue(opts)
+  // Separate from the short synchronous mutation lock: never block a counter
+  // event behind network I/O in the same event loop.
+  await withAsyncLock(`${queuePath}.flush`, () => flushPending(opts))
+}
+
+async function flushPending(opts: FlushOpts): Promise<void> {
+
   // Migrate any stale counters.json (e.g. upgrade from pre-#128, or beforeExit
   // firing after midnight on a process that never re-recorded). Adds an entry
   // to pending-dir; the drain loop below ships it.
@@ -141,22 +152,23 @@ export async function flushIfNeeded(opts: FlushOpts = {}): Promise<void> {
   if (!baseSnapshot) return
 
   for (const date of listPendingDates(opts)) {
-    const pending = readPendingCounters(date, opts)
-    if (!pending) {
-      // Malformed or already-removed; drop the file so we don't loop on it.
-      deletePending(date, opts)
-      continue
-    }
-    const snapshot: CounterSnapshot = {
+    const delivery = readPendingDelivery(date, opts, {
       installId: baseSnapshot.installId,
+      version: opts.packageVersion ?? readPackageVersion(),
+      platform: process.platform,
+    })
+    if (!delivery) continue
+    const pending = delivery.counters
+    const snapshot: CounterSnapshot = {
+      installId: delivery.identity.installId,
       date: pending.date,
       learn: pending.learn,
       recall: pending.recall,
       session: pending.session,
     }
-    const payload = buildHeartbeatPayload(snapshot, opts)
-    const ok = await sendHeartbeat(payload, opts)
-    if (ok) deletePending(date, opts)
+    const payload = { ...buildHeartbeatPayload(snapshot, { packageVersion: delivery.identity.version }), platform: delivery.identity.platform }
+    const ok = await sendHeartbeat(payload, { ...opts, deliveryId: delivery.id })
+    if (ok) deletePending(date, opts, delivery)
     // On failure, file stays on disk and is retried on next flush.
   }
 }

--- a/packages/core/test/audit-atomic-write.test.ts
+++ b/packages/core/test/audit-atomic-write.test.ts
@@ -1,0 +1,114 @@
+/** Invariant: private replacement bytes are never exposed at broader modes,
+ * and a colliding temporary pathname cannot redirect or truncate a write. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as real from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { atomicWrite } from '../src/sync.js'
+import { asyncAtomicWrite } from '../src/store/async-fs.js'
+
+const probes = vi.hoisted(() => ({ modes: [] as number[], victim: '', collide: false, fsyncError: '', fsyncPath: '', synced: [] as string[], descriptors: new Map<number, string>() }))
+vi.mock('fs', async importOriginal => {
+  const fs = await importOriginal<typeof import('node:fs')>()
+  return { ...fs,
+    fsyncSync: (fd: number) => {
+      const path = probes.descriptors.get(fd)!
+      if (fs.fstatSync(fd).isDirectory()) probes.synced.push(path)
+      if (probes.fsyncError && fs.fstatSync(fd).isDirectory() && (!probes.fsyncPath || path === probes.fsyncPath)) throw Object.assign(new Error('directory sync failed'), { code: probes.fsyncError })
+      return fs.fsyncSync(fd)
+    },
+    openSync: (p: string, flags: string | number, mode?: number) => {
+      if (probes.collide && String(p).endsWith('.tmp')) fs.symlinkSync(probes.victim, p)
+      const fd = fs.openSync(p, flags, mode)
+      probes.descriptors.set(fd, String(p))
+      return fd
+    },
+    writeFileSync: (p: string | number, data: string, ...args: any[]) => {
+      if (typeof p === 'number') probes.modes.push(fs.fstatSync(p).mode & 0o777)
+      return (fs.writeFileSync as any)(p, data, ...args)
+    },
+  }
+})
+vi.mock('fs/promises', async importOriginal => {
+  const fs = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...fs, open: async (p: string, flags: string | number, mode?: number) => {
+    if (probes.collide && String(p).endsWith('.tmp')) await fs.symlink(probes.victim, p)
+    const handle = await fs.open(p, flags, mode)
+    const sync = handle.sync.bind(handle)
+    handle.sync = async () => {
+      if ((await handle.stat()).isDirectory()) probes.synced.push(String(p))
+      if (probes.fsyncError && (await handle.stat()).isDirectory() && (!probes.fsyncPath || String(p) === probes.fsyncPath)) throw Object.assign(new Error('directory sync failed'), { code: probes.fsyncError })
+      return sync()
+    }
+    const write = handle.writeFile.bind(handle)
+    handle.writeFile = async (...args: Parameters<typeof write>) => {
+      probes.modes.push((await handle.stat()).mode & 0o777)
+      return write(...args)
+    }
+    return handle
+  } }
+})
+
+let root: string
+beforeEach(() => {
+  root = real.mkdtempSync(join(tmpdir(), 'plur-atomic-audit-'))
+  probes.modes = []; probes.collide = false; probes.fsyncError = ''
+  probes.fsyncPath = ''; probes.synced = []; probes.descriptors.clear()
+  probes.victim = join(root, 'unrelated')
+  real.writeFileSync(probes.victim, 'must survive')
+})
+afterEach(() => { real.rmSync(root, { recursive: true, force: true }) })
+
+describe.each([
+  ['sync', async (p: string, mode?: number) => atomicWrite(p, 'private bytes', { mode })],
+  ['async', async (p: string, mode?: number) => asyncAtomicWrite(p, 'private bytes', { mode })],
+] as const)('%s atomic replacement', (_name, write) => {
+  it('checks new directory ancestry and repeats that check after an interrupted first write', async () => {
+    const dir = join(root, 'new', 'nested')
+    const dest = join(dir, 'private.yaml')
+    probes.fsyncError = 'EIO'; probes.fsyncPath = root
+    await expect(write(dest)).rejects.toThrow('directory sync failed')
+    await expect(write(dest)).rejects.toThrow('directory sync failed')
+    expect(real.readFileSync(dest, 'utf8')).toBe('private bytes')
+    probes.fsyncError = ''; probes.synced = []
+    await write(dest)
+    const canonical = (path: string) => real.realpathSync(path)
+    expect(probes.synced.map(canonical).slice(0, 3)).toEqual([dir, join(root, 'new'), root].map(canonical))
+  })
+  it('tightens a previously public credential file without broadening stricter permissions', async () => {
+    const dest = join(root, 'config.yaml')
+    real.writeFileSync(dest, 'old', { mode: 0o644 })
+    await write(dest, 0o600)
+    expect(real.statSync(dest).mode & 0o777).toBe(0o600)
+    real.chmodSync(dest, 0o400)
+    await write(dest, 0o600)
+    expect(real.statSync(dest).mode & 0o777).toBe(0o400)
+  })
+  it('reports directory I/O failure after rename instead of acknowledging durability', async () => {
+    const dest = join(root, 'private.yaml')
+    probes.fsyncError = 'EIO'
+    await expect(write(dest)).rejects.toThrow('directory sync failed')
+    expect(real.readFileSync(dest, 'utf8')).toBe('private bytes')
+  })
+  it('tolerates only an unsupported directory sync operation', async () => {
+    probes.fsyncError = 'EINVAL'
+    await expect(write(join(root, 'private.yaml'))).resolves.toBeUndefined()
+  })
+  it('preserves private permissions before writing bytes and after rename', async () => {
+    const dest = join(root, 'private.yaml')
+    real.writeFileSync(dest, 'old', { mode: 0o600 })
+    await write(dest)
+    expect(probes.modes).toEqual([0o600])
+    expect(real.statSync(dest).mode & 0o777).toBe(0o600)
+    expect(real.readFileSync(dest, 'utf8')).toBe('private bytes')
+  })
+
+  it('refuses a preexisting symlink without touching either file', async () => {
+    const dest = join(root, 'private.yaml')
+    real.writeFileSync(dest, 'old', { mode: 0o600 })
+    probes.collide = true
+    await expect(write(dest)).rejects.toThrow()
+    expect(real.readFileSync(probes.victim, 'utf8')).toBe('must survive')
+    expect(real.readFileSync(dest, 'utf8')).toBe('old')
+  })
+})

--- a/packages/core/test/audit-backup-snapshot.test.ts
+++ b/packages/core/test/audit-backup-snapshot.test.ts
@@ -1,0 +1,72 @@
+/** Invariant: validation, checksum, and restore refer to identical bytes;
+ * repeat attempts never overwrite an existing recovery snapshot. */
+import { beforeEach, afterEach, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import yaml from 'js-yaml'
+import { _resetBackupProcessState, maybeDailyBackup, restoreBackup, listBackups } from '../src/backup.js'
+import { EngramSchemaPassthrough } from '../src/schemas/engram.js'
+
+const probe = vi.hoisted(() => ({ target: '', reads: 0, swap: '' }))
+vi.mock('fs', async importOriginal => {
+  const real = await importOriginal<typeof import('node:fs')>()
+  return { ...real, readFileSync: (...args: any[]) => {
+    const result = (real.readFileSync as any)(...args)
+    if (args[0] === probe.target && ++probe.reads === 1) real.writeFileSync(probe.target, probe.swap)
+    return result
+  } }
+})
+let root: string
+let store: string
+function content(n: number) {
+  return yaml.dump({ engrams: Array.from({ length: n }, (_, i) => EngramSchemaPassthrough.parse({
+    id: `ENG-2026-09-08-${i}`, scope: 'local', type: 'behavioral', status: 'active', statement: `Keep fact ${i}`,
+  })) })
+}
+beforeEach(() => {
+  root = fs.mkdtempSync(join(tmpdir(), 'plur-backup-snapshot-')); store = join(root, 'engrams.yaml')
+  probe.target = ''; probe.reads = 0; probe.swap = ''; _resetBackupProcessState()
+})
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }) })
+
+it('snapshots exactly the validated bytes if the path changes after the read', () => {
+  const good = content(2)
+  fs.writeFileSync(store, good)
+  probe.target = store; probe.swap = 'corrupt: ['
+  const result = maybeDailyBackup(root, store)
+  expect(result.taken).toBe(true)
+  expect(fs.readFileSync(result.path!, 'utf8')).toBe(good)
+})
+
+it('restores exactly the checksum-verified bytes despite a replaced backup path', () => {
+  const good = content(2)
+  fs.writeFileSync(store, good); maybeDailyBackup(root, store)
+  const backup = listBackups(root)[0]
+  fs.writeFileSync(store, content(1))
+  probe.target = backup.path; probe.swap = content(3)
+  restoreBackup(root, store)
+  expect(fs.readFileSync(store, 'utf8')).toBe(good)
+})
+
+it('never overwrites a same-day recovery snapshot when state metadata is lost', () => {
+  const good = content(2)
+  fs.writeFileSync(store, good); maybeDailyBackup(root, store)
+  const backup = listBackups(root)[0]
+  fs.unlinkSync(join(root, 'backups', '.state.json'))
+  fs.writeFileSync(store, content(3)); _resetBackupProcessState()
+  maybeDailyBackup(root, store)
+  expect(fs.readFileSync(backup.path, 'utf8')).toBe(good)
+})
+
+it('preserves separate pre-restore copies when restores share a timestamp', () => {
+  fs.writeFileSync(store, content(1)); maybeDailyBackup(root, store)
+  vi.spyOn(Date, 'now').mockReturnValue(1234567890)
+  try {
+    fs.writeFileSync(store, content(2)); const first = restoreBackup(root, store)
+    fs.writeFileSync(store, content(3)); const second = restoreBackup(root, store)
+    expect(first.supersededPath).not.toBe(second.supersededPath)
+    expect(fs.readFileSync(first.supersededPath, 'utf8')).toBe(content(2))
+    expect(fs.readFileSync(second.supersededPath, 'utf8')).toBe(content(3))
+  } finally { vi.restoreAllMocks() }
+})

--- a/packages/core/test/audit-config-fail-closed.test.ts
+++ b/packages/core/test/audit-config-fail-closed.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { loadConfig } from '../src/config.js'
+import { Plur } from '../src/index.js'
+
+const roots: string[] = []
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }) })
+it.each(['', 'null', '[]', 'auto_learn: false\nembeddings: [', 'auto_capture: false\ninjection_budget: invalid'])('does not replace an existing invalid config with permissive defaults: %j', source => {
+  const root = mkdtempSync(join(tmpdir(), 'plur-config-audit-')); roots.push(root)
+  const file = join(root, 'config.yaml'); writeFileSync(file, source)
+  expect(() => loadConfig(file)).toThrow(/config/)
+  expect(() => new Plur({ path: root, autoDiscover: false })).toThrow(/config/)
+  expect(readFileSync(file, 'utf8')).toBe(source)
+})
+
+it('does not include a secret-containing YAML source line in its error', () => {
+  const root = mkdtempSync(join(tmpdir(), 'plur-config-audit-')); roots.push(root)
+  const file = join(root, 'config.yaml'); writeFileSync(file, 'token: [audit-secret-value')
+  try { loadConfig(file); throw new Error('must reject') } catch (error) {
+    expect(String(error)).not.toContain('audit-secret-value')
+    expect(String(error)).toContain('cannot read or parse')
+  }
+})
+
+it.each(['read', 'stamp'] as const)('migration config %s refuses malformed YAML without exposing or changing its contents', async operation => {
+  const { getSchemaVersion, setSchemaVersion } = await import('../src/migrations/runner.js')
+  const root = mkdtempSync(join(tmpdir(), 'plur-migration-config-audit-')); roots.push(root)
+  const file = join(root, 'config.yaml')
+  const source = 'token: [audit-secret-value\n'
+  writeFileSync(file, source)
+  let failure: unknown
+  try { operation === 'read' ? getSchemaVersion(file) : setSchemaVersion(file, 1) } catch (error) { failure = error }
+  expect(failure).toBeInstanceOf(Error)
+  expect(String(failure)).not.toContain('audit-secret-value')
+  expect(readFileSync(file, 'utf8')).toBe(source)
+})

--- a/packages/core/test/audit-dependency-boundaries.test.ts
+++ b/packages/core/test/audit-dependency-boundaries.test.ts
@@ -1,0 +1,20 @@
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+describe('build dependency resource bounds', () => {
+  it('terminates when generating a zero-length custom ID', () => {
+    const require = createRequire(import.meta.url);
+    const viteRequire = createRequire(require.resolve('vite/package.json'));
+    const postcssRequire = createRequire(viteRequire.resolve('postcss/package.json'));
+    const nanoid = postcssRequire.resolve('nanoid');
+    // Run in a child so a reintroduced infinite loop cannot hang the suite.
+    const result = spawnSync(process.execPath, ['-e',
+      'const {customAlphabet}=require(process.argv[1]); process.stdout.write(JSON.stringify(customAlphabet("ab",0)()));',
+      nanoid,
+    ], { encoding: 'utf8', timeout: 2000 });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('""');
+  });
+});

--- a/packages/core/test/audit-history-preservation.test.ts
+++ b/packages/core/test/audit-history-preservation.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { appendHistory, readHistory, type HistoryEvent } from '../src/history.js'
+
+const fault = vi.hoisted(() => ({ sync: false, short: false }))
+vi.mock('fs', async original => {
+  const real = await original<typeof import('node:fs')>()
+  return { ...real,
+    fsyncSync: (fd: number) => { if (fault.sync) throw new Error('injected history sync failure'); return real.fsyncSync(fd) },
+    writeSync: (fd: number, buffer: Buffer, offset: number, length: number) => real.writeSync(fd, buffer, offset, fault.short ? Math.min(5, length) : length),
+  }
+})
+let root: string
+const event: HistoryEvent = { timestamp: '2026-09-08T00:00:00Z', event: 'engram_created', engram_id: 'ENG-AUDIT-1', data: { statement: 'Private history 🗃️' } }
+beforeEach(() => { root = fs.mkdtempSync(join(tmpdir(), 'plur-history-audit-')); fault.sync = false; fault.short = false })
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }))
+
+it('retains a valid Unicode event across short writes and an earlier interrupted append', () => {
+  fs.mkdirSync(join(root, 'history'))
+  const file = join(root, 'history', '2026-09.jsonl')
+  fs.writeFileSync(file, '{"incomplete":')
+  fault.short = true
+  expect(appendHistory(root, event)).toBe(true)
+  expect(readHistory(root, '2026-09')).toEqual([event])
+  expect(fs.statSync(file).mode & 0o777).toBe(0o600)
+})
+
+it('reports failed persistence instead of returning a successful history acknowledgement', () => {
+  fault.sync = true
+  expect(appendHistory(root, event)).toBe(false)
+})
+
+it('contains malformed timestamp paths without creating a file outside history', () => {
+  expect(appendHistory(root, { ...event, timestamp: '../escape' })).toBe(false)
+  expect(fs.existsSync(join(root, 'escape.jsonl'))).toBe(false)
+})

--- a/packages/core/test/audit-import-preservation.test.ts
+++ b/packages/core/test/audit-import-preservation.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Plur } from '../src/index.js'
+import { runImport } from '../src/importers/engine.js'
+
+let root: string
+let plur: Plur
+const record = { statement: 'Preserve imported source details', created_at: '2025-01-02T03:04:05Z', confidence: 0.8 }
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), 'plur-import-preserve-'))
+  writeFileSync(join(root, 'config.yaml'), 'index: false\n')
+  plur = new Plur({ path: root, autoDiscover: false })
+  await plur.ready()
+})
+afterEach(() => { vi.restoreAllMocks(); rmSync(root, { recursive: true, force: true }) })
+
+it('publishes source metadata in the initial durable record', async () => {
+  const append = (plur as any)._appendEngram.bind(plur)
+  const published: any[] = []
+  vi.spyOn(plur as any, '_appendEngram').mockImplementation(async (...args: any[]) => {
+    published.push(structuredClone(args[1]))
+    return append(...args)
+  })
+  const report = await runImport(plur, [record], { from: 'generic' })
+  expect(report.imported).toBe(1)
+  expect(published).toHaveLength(1)
+  expect(published[0].temporal.learned_at).toBe(record.created_at)
+  expect(published[0].episodic.confidence).toBe(8)
+})
+
+it('never overwrites a concurrent edit with the importer snapshot', async () => {
+  const original = (plur as any)._learn.bind(plur)
+  vi.spyOn(plur as any, '_learn').mockImplementation(async (...args: any[]) => {
+    const created = await original(...args)
+    await plur.updateEngram({ ...created, pinned: true })
+    return created
+  })
+  const report = await runImport(plur, [record], { from: 'generic' })
+  const [stored] = await plur.list()
+  expect(report.errors).toBe(0)
+  expect(stored.pinned).toBe(true)
+  expect(stored.temporal?.learned_at).toBe(record.created_at)
+  expect(stored.episodic?.confidence).toBe(8)
+})
+
+it('does not need a second write to complete metadata, and retry preserves it', async () => {
+  const update = vi.spyOn(plur as any, '_updateEngrams').mockRejectedValue(new Error('second write unavailable'))
+  const report = await runImport(plur, [record], { from: 'generic' })
+  expect(report.imported).toBe(1)
+  expect(report.errors).toBe(0)
+  const [stored] = await plur.list()
+  expect(stored.temporal?.learned_at).toBe(record.created_at)
+  expect(stored.episodic?.confidence).toBe(8)
+  update.mockRestore()
+  const retry = await runImport(plur, [{ ...record, created_at: '2026-01-01T00:00:00Z' }], { from: 'generic' })
+  expect(retry.skipped).toBe(1)
+  expect((await plur.list())[0].temporal?.learned_at).toBe(record.created_at)
+})
+
+it('refuses invalid import metadata before publishing a partial row', async () => {
+  const report = await runImport(plur, [{ ...record, confidence: NaN }], { from: 'generic' })
+  expect(report.errors).toBe(1)
+  expect(await plur.list()).toEqual([])
+  const retry = await runImport(plur, [record], { from: 'generic' })
+  expect(retry.imported).toBe(1)
+  expect((await plur.list())[0].episodic?.confidence).toBe(8)
+})
+
+it('reports one creation across concurrent imports and preserves metadata after restart', async () => {
+  const other = new Plur({ path: root, autoDiscover: false }); await other.ready()
+  const reports = await Promise.all([runImport(plur, [record], { from: 'generic' }), runImport(other, [record], { from: 'generic' })])
+  expect(reports.reduce((n, r) => n + r.imported, 0)).toBe(1)
+  expect(reports.reduce((n, r) => n + r.skipped, 0)).toBe(1)
+  expect(reports.reduce((n, r) => n + r.errors, 0)).toBe(0)
+  const restarted = new Plur({ path: root, autoDiscover: false }); await restarted.ready()
+  const rows = await restarted.list()
+  expect(rows).toHaveLength(1)
+  expect(rows[0].temporal?.learned_at).toBe(record.created_at)
+  expect(rows[0].episodic?.confidence).toBe(8)
+})

--- a/packages/core/test/audit-learn-context.test.ts
+++ b/packages/core/test/audit-learn-context.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Plur, computeContentHash } from '../src/index.js'
+let root: string
+let plur: Plur
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), 'plur-context-preservation-'))
+  writeFileSync(join(root, 'config.yaml'), 'index: false\ndedup:\n  mode: off\n')
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+})
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); rmSync(root, { recursive: true, force: true }) })
+it.each(['learn', 'learnRouted', 'learnAsync'] as const)('%s preserves distinct measurement contexts and deduplicates exact repeats', async method => {
+  const write = async (hardware: string) => {
+    const result = await plur[method]('Latency was measured as 18 milliseconds', { scope: 'local', measured_under: { hardware, dataset: 'synthetic' } })
+    return method === 'learnAsync' ? (result as any).engram : result
+  }
+  const first = await write('cpu'); const second = await write('gpu'); const repeat = await write('gpu')
+  expect(second.id).not.toBe(first.id)
+  expect(repeat.id).toBe(second.id)
+  const fresh = new Plur({ path: root, autoDiscover: false }); await fresh.ready()
+  expect((await fresh.getById(first.id))?.measured_under?.hardware).toBe('cpu')
+  expect((await fresh.getById(second.id))?.measured_under?.hardware).toBe('gpu')
+})
+it('does not broaden a differently conditioned assertion across scopes', async () => {
+  const first = await plur.learn('A benchmark has a measured outcome', { scope: 'project:one', measured_under: { hardware: 'cpu' } })
+  const second = await plur.learn('A benchmark has a measured outcome', { scope: 'project:two', measured_under: { hardware: 'gpu' } })
+  expect(second.id).not.toBe(first.id)
+  expect(second.scope).toBe('project:two')
+  expect((await plur.getById(first.id))?.scope).toBe('project:one')
+})
+it('preserves changed licence and provenance content instead of absorbing it', async () => {
+  const first = await plur.learn('A reusable attributed assertion', { license: 'MIT', source: 'source-one', scope: 'local' })
+  const second = await plur.learn('A reusable attributed assertion', { license: 'Apache-2.0', source: 'source-two', scope: 'local' })
+  expect(second.id).not.toBe(first.id)
+  expect(second.provenance?.license).toBe('Apache-2.0')
+  expect(second.source).toBe('source-two')
+})
+
+it('does not invent an explicit licence when source provenance is reloaded', async () => {
+  const row = await plur.learn('An observation with a source but no chosen licence', { scope: 'local', source: 'source-note' })
+  expect(row.provenance?.license).toBeUndefined()
+  const fresh = new Plur({ path: root, autoDiscover: false }); await fresh.ready()
+  expect((await fresh.getById(row.id))?.provenance?.license).toBeUndefined()
+})
+
+it('preserves the local original when its custom content has no remote representation', async () => {
+  writeFileSync(join(root, 'config.yaml'), JSON.stringify({ index: false, stores: [{ url: 'https://audit.invalid', scope: 'group:audit/team', token: 'fixture', readonly: false }] }))
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  const row = await plur.learn('A qualified observation', { scope: 'local' })
+  await plur.updateEngram({ ...row, structured_data: { qualification: 'Only after manual confirmation' } })
+  const fetcher = vi.fn(async () => new Response(JSON.stringify({ rows: [], total_count: 0 })))
+  vi.stubGlobal('fetch', fetcher)
+  const result = await plur.rescope(row.id, 'group:audit/team')
+  expect(result.success).toBe(false)
+  expect(result.results[0].status).toBe('error')
+  const preserved = await plur.getById(row.id)
+  expect(preserved?.status).toBe('active')
+  expect(preserved?.scope).toBe('local')
+  expect(preserved?.structured_data).toEqual({ qualification: 'Only after manual confirmation' })
+  expect(fetcher.mock.calls.some(call => (call as any)[1]?.method === 'POST')).toBe(false)
+})
+it('keeps an explicitly private routed write on disk without contacting the remote', async () => {
+  writeFileSync(join(root, 'config.yaml'), JSON.stringify({ index: false, stores: [{ url: 'https://audit.invalid', scope: 'group:audit/team', token: 'fixture', readonly: false }] }))
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  const fetcher = vi.fn(async (_url: string, init?: RequestInit) => init?.method === 'POST'
+    ? new Response(JSON.stringify({ id: 'ENG-SERVER-PRIVATE', scope: 'group:audit/team', status: 'active', statement: 'Personal observation' }))
+    : new Response(JSON.stringify({ rows: [], total_count: 0 })))
+  vi.stubGlobal('fetch', fetcher)
+  const result = await plur.learnRouted('Personal observation', { scope: 'group:audit/team', visibility: 'private' })
+  expect(fetcher.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(0)
+  expect(await plur.getById(result.id)).not.toBeNull()
+  expect(result.structured_data?._outbox).toBeUndefined()
+})
+
+it('transmits changed context to a remote and returns the server review decision', async () => {
+  writeFileSync(join(root, 'config.yaml'), JSON.stringify({ index: false, stores: [{ url: 'https://audit.invalid', scope: 'group:audit/team', token: 'fixture', readonly: false }] }))
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  const rows: any[] = []
+  vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+    if (init?.method === 'POST') {
+      const sent = JSON.parse(init.body as string)
+      const row = { ...sent, id: `ENG-SERVER-${rows.length + 1}`, status: 'active', commitment: 'draft', review_state: 'policy', review_required: true }
+      rows.push(row)
+      return new Response(JSON.stringify(row), { status: 201 })
+    }
+    return new Response(JSON.stringify({ rows: rows.map(row => ({ id: row.id, scope: row.scope, status: row.status, data: row })), total_count: rows.length }))
+  }))
+  const first = await plur.learnRouted('Remote measured assertion', { scope: 'group:audit/team', measured_under: { hardware: 'cpu' } })
+  const second = await plur.learnRouted('Remote measured assertion', { scope: 'group:audit/team', measured_under: { hardware: 'gpu' } })
+  expect(second.id).not.toBe(first.id)
+  expect(rows.map(row => row.measured_under.hardware)).toEqual(['cpu', 'gpu'])
+  expect(first.commitment).toBe('draft')
+  expect((first as any).review_required).toBe(true)
+})
+
+it.each(['learn', 'learnRouted', 'learnAsync'] as const)('%s preserves additional source references when a local duplicate is absorbed', async method => {
+  const write = async (source: string) => {
+    const result = await plur[method]('One fact from several sources', { scope: 'local', source })
+    return method === 'learnAsync' ? (result as any).engram : result
+  }
+  const first = await write('source-one')
+  const second = await write('source-two')
+  expect(second.id).toBe(first.id)
+  const fresh = new Plur({ path: root, autoDiscover: false }); await fresh.ready()
+  expect((await fresh.getById(first.id))?.sources.map(source => source.source)).toEqual(['source-one', 'source-two'])
+})
+it('keeps distinct sources in separate pending remote writes', async () => {
+  writeFileSync(join(root, 'config.yaml'), JSON.stringify({ index: false, stores: [{ url: 'https://audit.invalid', scope: 'group:audit/team', token: 'fixture', readonly: false }] }))
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  // Hold the background uploader; this test examines what is durable before delivery.
+  vi.spyOn(plur as any, '_flushOutbox').mockResolvedValue({ flushed: 0, failed: 0, expired_warnings: [] })
+  const first = await plur.learn('An assertion queued for sharing', { scope: 'group:audit/team', source: 'source-one' })
+  const second = await plur.learn('An assertion queued for sharing', { scope: 'group:audit/team', source: 'source-two' })
+  expect(second.id).not.toBe(first.id)
+  expect(first.structured_data?._outbox).toBeDefined()
+  expect(second.structured_data?._outbox).toBeDefined()
+  expect((await plur.getById(first.id))?.source).toBe('source-one')
+  expect((await plur.getById(second.id))?.source).toBe('source-two')
+})
+
+it.each(['learn', 'learnRouted', 'learnAsync'] as const)('%s cannot absorb an explicitly private write into a queued upload', async method => {
+  writeFileSync(join(root, 'config.yaml'), JSON.stringify({ index: false, stores: [{ url: 'https://audit.invalid', scope: 'group:audit/team', token: 'fixture', readonly: false }] }))
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  vi.spyOn(plur as any, '_flushOutbox').mockResolvedValue({ flushed: 0, failed: 0, expired_warnings: [] })
+  const shared = await plur.learn('An assertion with separate private evidence', { scope: 'group:audit/team' })
+  const result = await plur[method]('An assertion with separate private evidence', { scope: 'group:audit/team', visibility: 'private' })
+  const personal = method === 'learnAsync' ? (result as any).engram : result
+  expect(personal.id).not.toBe(shared.id)
+  expect(personal.structured_data?._outbox).toBeUndefined()
+  const fresh = new Plur({ path: root, autoDiscover: false }); await fresh.ready()
+  const queued = await fresh.getById(shared.id)
+  expect(queued?.structured_data?._outbox).toBeDefined()
+  expect(queued?.write_count).toBe(shared.write_count)
+  expect((await fresh.getById(personal.id))?.visibility).toBe('private')
+})
+
+it.each(['learn', 'learnRouted', 'learnAsync'] as const)('%s creates a local private copy when the remote already holds the statement', async method => {
+  const scope = 'group:audit/team'
+  const statement = 'A private observation also recorded elsewhere'
+  writeFileSync(join(root, 'config.yaml'), JSON.stringify({ index: false, dedup: { mode: 'off' }, stores: [{ url: 'https://audit.invalid', scope, token: 'fixture', readonly: false }] }))
+  const row = { id: 'ENG-REMOTE-PRIVATE', scope, status: 'active', statement, visibility: 'private', content_hash: computeContentHash(statement) }
+  const fetcher = vi.fn(async () => new Response(JSON.stringify({ rows: [{ ...row, data: row }], total_count: 1 })))
+  vi.stubGlobal('fetch', fetcher)
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  const result = await plur[method](statement, { scope, visibility: 'private' })
+  const personal = method === 'learnAsync' ? (result as any).engram : result
+  expect(personal.id).not.toContain('REMOTE')
+  expect(personal.structured_data?._outbox).toBeUndefined()
+  const rows = await (plur as any)._primaryStore.load()
+  expect(rows.find((e: any) => e.id === personal.id)?.statement).toBe(statement)
+})

--- a/packages/core/test/audit-learn-validation.test.ts
+++ b/packages/core/test/audit-learn-validation.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur } from '../src/index.js'
+
+let root: string
+let plur: Plur
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), 'plur-context-validation-'))
+  writeFileSync(join(root, 'config.yaml'), 'index: false\ndedup:\n  mode: off\n')
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  await plur.learn('Preserve the existing valid record', { scope: 'local' })
+})
+afterEach(() => { vi.unstubAllGlobals(); rmSync(root, { recursive: true, force: true }) })
+
+it.each(['learn', 'learnRouted', 'learnAsync'] as const)('%s refuses malformed context before persisting or using a model', async method => {
+  const before = readFileSync(join(root, 'engrams.yaml'), 'utf8')
+  const llm = vi.fn(async () => 'DECISION: ADD')
+  for (const context of [{ tags: [7] }, { source: 7 }, { rationale: 7 }, { commitment: 'invalid' }, { pinned: 'yes' }, { knowledge_anchors: [{ path: 'a', relevance: 'invalid' }] }, { attribution: { runtime: { name: 7 } } }, { dual_coding: {} }, { memory_class: 'invalid' }, { visibility: 'invalid' }]) {
+    await expect(plur[method]('A proposed observation', { scope: 'local', ...context, llm } as any)).rejects.toThrow(/context/)
+    expect(readFileSync(join(root, 'engrams.yaml'), 'utf8')).toBe(before)
+  }
+  expect(llm).not.toHaveBeenCalled()
+})
+
+it('batch validation reports the malformed item and preserves valid siblings', async () => {
+  const result = await plur.learnBatch([
+    { statement: 'A malformed item', context: { tags: [7] } as any },
+    { statement: 'A valid surviving item', context: { scope: 'local', source: 'fixture' } },
+  ])
+  expect(result.failures).toHaveLength(1)
+  expect(result.failures[0].index).toBe(0)
+  const fresh = new Plur({ path: root, autoDiscover: false }); await fresh.ready()
+  expect((await fresh.list()).map(row => row.statement)).toEqual(expect.arrayContaining(['Preserve the existing valid record', 'A valid surviving item']))
+  expect((await fresh.list()).some(row => row.statement === 'A malformed item')).toBe(false)
+})
+
+it.each(['updateEngram', 'updateEngramAsync'] as const)('%s refuses to overwrite a valid record with malformed content', async method => {
+  const row = (await plur.list())[0]
+  const before = readFileSync(join(root, 'engrams.yaml'), 'utf8')
+  await expect(plur[method]({ ...row, tags: [7] } as any)).rejects.toThrow(/Invalid engram/)
+  expect(readFileSync(join(root, 'engrams.yaml'), 'utf8')).toBe(before)
+})
+
+it('refuses a malformed meta batch without persisting its valid prefix', async () => {
+  const row = (await plur.list())[0]
+  const before = readFileSync(join(root, 'engrams.yaml'), 'utf8')
+  await expect(plur.saveMetaEngrams([{ ...row, id: 'META-VALID-001' }, { ...row, id: 'META-INVALID-001', tags: [7] } as any])).rejects.toThrow(/Invalid engram/)
+  expect(readFileSync(join(root, 'engrams.yaml'), 'utf8')).toBe(before)
+})
+
+it.each(['setPinned', 'setPinnedAsync'] as const)('%s refuses malformed booleans without clearing a pin', async method => {
+  const row = (await plur.list())[0]
+  await plur.setPinned(row.id, true)
+  const before = readFileSync(join(root, 'engrams.yaml'), 'utf8')
+  await expect(plur[method](row.id, 'yes' as any)).rejects.toThrow(/boolean/)
+  expect(readFileSync(join(root, 'engrams.yaml'), 'utf8')).toBe(before)
+})
+
+it('refuses an unknown feedback signal without changing activation', async () => {
+  const row = (await plur.list())[0]
+  const before = readFileSync(join(root, 'engrams.yaml'), 'utf8')
+  await expect(plur.feedback(row.id, 'unknown' as any)).rejects.toThrow(/signal/)
+  expect(readFileSync(join(root, 'engrams.yaml'), 'utf8')).toBe(before)
+})

--- a/packages/core/test/audit-lock-recovery.test.ts
+++ b/packages/core/test/audit-lock-recovery.test.ts
@@ -1,0 +1,72 @@
+/** Invariant: acquisition cannot pass a recovery operation, and age alone
+ * cannot prove that a writer on another machine has stopped. */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'node:fs'
+import { tmpdir, hostname } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { withLock } from '../src/sync.js'
+import { withAsyncLock, DEFAULT_STALE_THRESHOLD } from '../src/store/async-lock.js'
+
+let root: string
+let target: string
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'plur-lock-recovery-')); target = join(root, 'store') })
+afterEach(() => rmSync(root, { recursive: true, force: true }))
+describe.each([
+  ['sync', async (fn: () => void) => withLock(target, fn, { maxRetries: 0 })],
+  ['async', async (fn: () => void) => withAsyncLock(target, async () => fn(), { maxRetries: 0 })],
+] as const)('%s recovery', (_name, lock) => {
+  it('cannot acquire while a recovery guard owns the pathname transition', async () => {
+    writeFileSync(`${target}.lock.guard`, `${hostname()}:${process.pid}:0:0`)
+    let entered = false
+    await expect(lock(() => { entered = true })).rejects.toThrow(/lock/)
+    expect(entered).toBe(false)
+  })
+  it('cannot steal an old lock belonging to a different host', async () => {
+    const token = `other-${hostname()}:123:0:0`
+    writeFileSync(`${target}.lock`, token)
+    const old = new Date(Date.now() - DEFAULT_STALE_THRESHOLD * 3)
+    utimesSync(`${target}.lock`, old, old)
+    let entered = false
+    await expect(lock(() => { entered = true })).rejects.toThrow(/lock/)
+    expect(entered).toBe(false)
+    expect(readFileSync(`${target}.lock`, 'utf8')).toBe(token)
+  })
+})
+
+
+it('serializes independent sync and async processes while reclaiming a dead owner', async () => {
+  const require = createRequire(import.meta.url)
+  const cli = require.resolve('tsx/cli')
+  const syncModule = fileURLToPath(new URL('../src/sync.ts', import.meta.url))
+  const asyncModule = fileURLToPath(new URL('../src/store/async-lock.ts', import.meta.url))
+  const script = join(root, 'contender.mts')
+  writeFileSync(script, `
+    import { withLock } from ${JSON.stringify(syncModule)};
+    import { withAsyncLock } from ${JSON.stringify(asyncModule)};
+    import { readFileSync, writeFileSync, openSync, closeSync, unlinkSync } from 'node:fs';
+    const [kind, target] = process.argv.slice(2);
+    const sentinel = target + '.critical';
+    function enter() {
+      const fd = openSync(sentinel, 'wx');
+      const n = Number(readFileSync(target, 'utf8'));
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2);
+      writeFileSync(target, String(n + 1));
+      closeSync(fd); unlinkSync(sentinel);
+    }
+    for (let i = 0; i < 20; i++) {
+      if (kind === 'sync') withLock(target, enter);
+      else await withAsyncLock(target, async () => enter());
+    }
+  `)
+  writeFileSync(target, '0')
+  // Derive a confirmed exited local PID, rather than guessing a dead number.
+  const run = promisify(execFile)
+  const exited = await run(process.execPath, ['-e', 'process.stdout.write(String(process.pid))'])
+  writeFileSync(`${target}.lock`, `${hostname()}:${exited.stdout}:0:0`)
+  await Promise.all(['sync', 'async', 'sync', 'async'].map(kind => run(process.execPath, [cli, script, kind, target], { timeout: 30000 })))
+  expect(readFileSync(target, 'utf8')).toBe('80')
+}, 35000)

--- a/packages/core/test/audit-meta-batch.test.ts
+++ b/packages/core/test/audit-meta-batch.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur } from '../src/index.js'
+
+const roots: string[] = []
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }) })
+
+it('reserves each meta ID within its batch and across retries and concurrent callers', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'plur-meta-identity-')); roots.push(root)
+  writeFileSync(join(root, 'config.yaml'), 'index: false\ndedup:\n  mode: off\n')
+  const plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+  const seed = await plur.learn('Preserve this unrelated record', { scope: 'local' })
+  const first = { ...seed, id: 'META-AUDIT-001', statement: 'First accepted metadata' }
+  const conflict = { ...first, statement: 'Conflicting metadata must not replace the first' }
+  const second = { ...seed, id: 'META-AUDIT-002', statement: 'A distinct metadata record' }
+  expect(await plur.saveMetaEngrams([first, conflict, second])).toEqual({ saved: 2, skipped: 1 })
+  expect(await plur.saveMetaEngrams([conflict, first])).toEqual({ saved: 0, skipped: 2 })
+  const other = new Plur({ path: root, autoDiscover: false }); await other.ready()
+  const third = { ...seed, id: 'META-AUDIT-003', statement: 'Concurrent metadata record' }
+  const results = await Promise.all([plur.saveMetaEngrams([third, third]), other.saveMetaEngrams([third])])
+  expect(results.reduce((n, r) => n + r.saved, 0)).toBe(1)
+  expect(results.reduce((n, r) => n + r.skipped, 0)).toBe(2)
+  const fresh = new Plur({ path: root, autoDiscover: false }); await fresh.ready()
+  const rows = await fresh.list()
+  expect(rows).toHaveLength(4)
+  expect(new Set(rows.map(row => row.id)).size).toBe(4)
+  expect((await fresh.getById(first.id))?.statement).toBe(first.statement)
+  expect((await fresh.getById(seed.id))?.statement).toBe(seed.statement)
+})

--- a/packages/core/test/audit-migration-preservation.test.ts
+++ b/packages/core/test/audit-migration-preservation.test.ts
@@ -1,0 +1,96 @@
+/** Invariant: a failed in-memory migration never changes the live corpus,
+ * even when an older backup exists and successful writes followed that backup. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { ALL_MIGRATIONS, getSchemaVersion, runMigrations, rollbackMigrations, setSchemaVersion } from '../src/migrations/runner.js'
+import { saveEngrams } from '../src/engrams.js'
+import { EngramSchemaPassthrough } from '../src/schemas/engram.js'
+
+let root: string
+let store: string
+let config: string
+const fault = vi.hoisted(() => ({ path: '' }))
+vi.mock('../src/sync.js', async importOriginal => {
+  const original = await importOriginal<typeof import('../src/sync.js')>()
+  return { ...original, atomicWrite: (...args: Parameters<typeof original.atomicWrite>) => {
+    if (args[0] === fault.path) throw new Error('injected commit interruption')
+    return original.atomicWrite(...args)
+  } }
+})
+beforeEach(() => {
+  root = fs.mkdtempSync(join(tmpdir(), 'plur-migration-preserve-'))
+  store = join(root, 'engrams.yaml')
+  config = join(root, 'config.yaml')
+  fault.path = ''
+})
+
+it.each(['up', 'down'] as const)('recovers %s after corpus replacement but before the version stamp', direction => {
+  saveEngrams(store, [row(1), row(2)])
+  setSchemaVersion(config, direction === 'up' ? 0 : ALL_MIGRATIONS.length)
+  const run = () => direction === 'up' ? runMigrations(store, config) : rollbackMigrations(store, config, 0)
+  fault.path = config
+  expect(run).toThrow('injected commit interruption')
+  const committed = fs.readFileSync(store, 'utf8')
+  expect(fs.existsSync(`${store}.migration.json`)).toBe(true)
+  fault.path = ''
+  for (const migration of ALL_MIGRATIONS) vi.spyOn(migration, direction).mockImplementation(() => { throw new Error('must not replay') })
+  run()
+  expect(fs.readFileSync(store, 'utf8')).toBe(committed)
+  expect(getSchemaVersion(config)).toBe(direction === 'up' ? ALL_MIGRATIONS.length : 0)
+  expect(fs.existsSync(`${store}.migration.json`)).toBe(false)
+})
+
+it('does not overwrite intervening writes while recovering an interrupted migration', () => {
+  saveEngrams(store, [row(1)])
+  setSchemaVersion(config, 0)
+  fault.path = config
+  expect(() => runMigrations(store, config)).toThrow('injected commit interruption')
+  fault.path = ''
+  saveEngrams(store, [row(1), row(2)])
+  const newer = fs.readFileSync(store, 'utf8')
+  expect(() => runMigrations(store, config)).toThrow(/reconcile/)
+  expect(fs.readFileSync(store, 'utf8')).toBe(newer)
+})
+afterEach(() => { vi.restoreAllMocks(); fs.rmSync(root, { recursive: true, force: true }) })
+
+function row(n: number) {
+  return EngramSchemaPassthrough.parse({ id: `ENG-2026-09-08-${n}`, statement: `Keep record ${n}`, type: 'behavioral', scope: 'local', status: 'active', version: 2 })
+}
+
+describe('failed transformation preserves current data', () => {
+  it.each(['up', 'down'] as const)('%s failure cannot restore a stale backup', direction => {
+    const version = direction === 'up' ? 0 : ALL_MIGRATIONS.length
+    saveEngrams(store, [row(1)])
+    fs.copyFileSync(store, `${store}.bak.${version}`)
+    const oldBackup = fs.readFileSync(`${store}.bak.${version}`, 'utf8')
+    saveEngrams(store, [row(1), row(2)])
+    setSchemaVersion(config, version)
+    const before = fs.readFileSync(store, 'utf8')
+    const migration = direction === 'up' ? ALL_MIGRATIONS[0] : ALL_MIGRATIONS.at(-1)!
+    vi.spyOn(migration, direction).mockImplementation(() => { throw new Error('injected transformation failure') })
+    expect(() => direction === 'up' ? runMigrations(store, config) : rollbackMigrations(store, config, 0))
+      .toThrow('injected transformation failure')
+    expect(fs.readFileSync(store, 'utf8')).toBe(before)
+    expect(getSchemaVersion(config)).toBe(version)
+    expect(fs.readFileSync(`${store}.bak.${version}`, 'utf8')).toBe(oldBackup)
+  })
+
+  it.each([-1, 1.5, NaN, Infinity, ALL_MIGRATIONS.length + 1])('rejects invalid recorded version %s before mutation', version => {
+    saveEngrams(store, [row(1)])
+    fs.writeFileSync(config, `schema_version: ${String(version)}\n`)
+    const before = fs.readFileSync(store, 'utf8')
+    expect(() => runMigrations(store, config)).toThrow(/version/i)
+    expect(fs.readFileSync(store, 'utf8')).toBe(before)
+    expect(fs.readdirSync(root).filter(f => f.includes('.bak.'))).toEqual([])
+  })
+
+  it.each([0.5, NaN, Infinity])('rejects invalid rollback target %s before mutation', version => {
+    saveEngrams(store, [row(1)])
+    setSchemaVersion(config, ALL_MIGRATIONS.length)
+    const before = fs.readFileSync(store, 'utf8')
+    expect(() => rollbackMigrations(store, config, version)).toThrow(/version/i)
+    expect(fs.readFileSync(store, 'utf8')).toBe(before)
+  })
+})

--- a/packages/core/test/audit-outbox-stale.test.ts
+++ b/packages/core/test/audit-outbox-stale.test.ts
@@ -1,0 +1,268 @@
+/** Invariant: a network response cannot delete or resurrect newer local state. */
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import yaml from 'js-yaml'
+import { Plur } from '../src/index.js'
+import { saveEngrams, loadEngrams } from '../src/engrams.js'
+import { withAsyncLock } from '../src/store/async-lock.js'
+import { EngramSchemaPassthrough } from '../src/schemas/engram.js'
+
+let root: string
+let store: string
+let plur: Plur
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), 'plur-outbox-stale-')); store = join(root, 'engrams.yaml')
+  writeFileSync(join(root, 'config.yaml'), yaml.dump({ index: false, stores: [{
+    url: 'https://audit.example', token: 'test-only', scope: 'group:example/team', readonly: false,
+  }] }))
+  saveEngrams(store, [EngramSchemaPassthrough.parse({
+    id: 'ENG-2026-09-08-001', type: 'behavioral', scope: 'group:example/team', status: 'active',
+    visibility: 'public', statement: 'Original queued fact', structured_data: { _outbox: {
+      target_scope: 'group:example/team', target_url: 'https://audit.example', queued_at: new Date().toISOString(),
+      last_attempt: '', last_error: '', attempt_count: 0,
+    } },
+  })])
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+})
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); rmSync(root, { recursive: true, force: true }) })
+
+it.each(['lost response', 'failed receipt'])('retries the same durable request after %s and restart', async failure => {
+  const accepted = new Map<string, string>()
+  const keys: string[] = []
+  const originalWrite = (plur as any)._writeOutboxIdMap.bind(plur)
+  let receiptWrites = 0
+  vi.spyOn(plur as any, '_writeOutboxIdMap').mockImplementation(entries => {
+    if (++receiptWrites === 2 && failure === 'failed receipt') throw new Error('receipt disk failure')
+    originalWrite(entries)
+  })
+  const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+    const key = new Headers(init?.headers).get('Idempotency-Key')!
+    expect(key).toMatch(/^[a-zA-Z0-9_-]{16,128}$/)
+    const journal = JSON.parse(readFileSync(plur.outboxIdMapPath(), 'utf8'))
+    expect(journal['ENG-2026-09-08-001'].request_id).toBe(key)
+    keys.push(key)
+    if (!accepted.has(key)) accepted.set(key, `ENG-SERVER-${accepted.size + 1}`)
+    if (keys.length === 1 && failure === 'lost response') throw new Error('response lost after commit')
+    return new Response(JSON.stringify({ id: accepted.get(key) }), { status: 201 })
+  })
+  vi.stubGlobal('fetch', fetcher)
+  expect((await plur.flushOutbox()).failed).toBe(1)
+  expect(loadEngrams(store)).toHaveLength(1)
+  const restarted = new Plur({ path: root, autoDiscover: false }); await restarted.ready()
+  expect((await restarted.flushOutbox()).flushed).toBe(1)
+  expect(keys).toHaveLength(2)
+  expect(new Set(keys).size).toBe(1)
+  expect(accepted.size).toBe(1)
+  expect(loadEngrams(store)).toEqual([])
+})
+
+it('refuses to send if operation identity cannot be durably recorded', async () => {
+  vi.spyOn(plur as any, '_writeOutboxIdMap').mockImplementation(() => { throw new Error('intent disk failure') })
+  const fetcher = vi.fn(); vi.stubGlobal('fetch', fetcher)
+  expect((await plur.flushOutbox()).failed).toBe(1)
+  expect(fetcher).not.toHaveBeenCalled()
+  expect(loadEngrams(store)).toHaveLength(1)
+})
+
+it.each(['local counter', 'endpoint alias', 'default port', 'object key order'])('keeps write identity across a change to %s', async variant => {
+  const keys: string[] = []
+  vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+    if (init?.method !== 'POST') return new Response(JSON.stringify({ rows: [] }), { status: 200 })
+    keys.push(new Headers(init.headers).get('Idempotency-Key')!)
+    if (keys.length === 1) throw new Error('response lost after commit')
+    return new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 })
+  }))
+  if (variant === 'object key order') {
+    const rows = loadEngrams(store); rows[0].measured_under = { model: 'small', hardware: 'cpu' }; saveEngrams(store, rows)
+  }
+  expect((await plur.flushOutbox()).failed).toBe(1)
+  if (variant === 'local counter') {
+    const rows = loadEngrams(store)
+    rows[0].activation.frequency += 1
+    saveEngrams(store, rows)
+  } else if (variant === 'object key order') {
+    const rows = loadEngrams(store); rows[0].measured_under = { hardware: 'cpu', model: 'small' }; saveEngrams(store, rows)
+  } else {
+    writeFileSync(join(root, 'config.yaml'), yaml.dump({ index: false, stores: [{ url: variant === 'default port' ? 'https://AUDIT.example:443/sse/' : 'https://audit.example/sse', token: 'test-only', scope: 'group:example/team', readonly: false }] }))
+  }
+  const restarted = new Plur({ path: root, autoDiscover: false }); await restarted.ready()
+  expect((await restarted.flushOutbox()).flushed).toBe(1)
+  expect(keys).toHaveLength(2)
+  expect(keys[1]).toBe(keys[0])
+})
+
+it.each([undefined, 'a-source'])('keeps the exact request identity and body when a direct write with source %s falls back to the outbox', async source => {
+  saveEngrams(store, [], { allowShrink: true })
+  const keys: string[] = []
+  const bodies: unknown[] = []
+  vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+    if (init?.method !== 'POST') return new Response(JSON.stringify({ rows: [] }), { status: 200 })
+    keys.push(new Headers(init.headers).get('Idempotency-Key')!)
+    bodies.push(JSON.parse(init.body as string))
+    if (keys.length === 1) throw new Error('response lost after commit')
+    return new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 })
+  }))
+  const queued = await plur.learnRouted('A direct routed operation', { scope: 'group:example/team', source,
+    measured_under: { hardware: 'cpu' }, knowledge_anchors: [{ path: 'bench.json' }],
+    attribution: { asserted_by: 'agent:audit' }, dual_coding: { example: 'A measured workload' },
+  })
+  expect(queued.structured_data?._outbox).toBeDefined()
+  const restarted = new Plur({ path: root, autoDiscover: false }); await restarted.ready()
+  expect((await restarted.flushOutbox()).flushed).toBe(1)
+  expect(keys).toHaveLength(2)
+  expect(keys[0]).toBe(keys[1])
+  expect(bodies[1]).toEqual(bodies[0])
+})
+
+it('reuses a remote move identity after response loss and process restart', async () => {
+  const rows = loadEngrams(store)
+  rows[0].scope = 'local'; delete rows[0].structured_data!._outbox
+  saveEngrams(store, rows)
+  const keys: string[] = []
+  vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+    if (init?.method !== 'POST') return new Response(JSON.stringify({ rows: [] }), { status: 200 })
+    keys.push(new Headers(init.headers).get('Idempotency-Key')!)
+    if (keys.length === 1) throw new Error('response lost after commit')
+    return new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 })
+  }))
+  expect((await plur.rescope([rows[0].id], 'group:example/team')).success).toBe(false)
+  expect(loadEngrams(store)[0].status).toBe('active')
+  const restarted = new Plur({ path: root, autoDiscover: false }); await restarted.ready()
+  expect((await restarted.rescope([rows[0].id], 'group:example/team')).success).toBe(true)
+  expect(keys).toHaveLength(2)
+  expect(keys[0]).toBe(keys[1])
+  expect(loadEngrams(store)[0].status).toBe('retired')
+})
+
+it.each(['success', 'failure'] as const)('preserves an edit made during %s', async outcome => {
+  let started!: () => void
+  const entered = new Promise<void>(r => { started = r })
+  let finish!: () => void
+  const held = new Promise<void>(r => { finish = r })
+  vi.stubGlobal('fetch', vi.fn(async () => {
+    started(); await held
+    if (outcome === 'failure') throw new Error('test network failure')
+    return new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 })
+  }))
+  const flush = plur.flushOutbox(); await entered
+  await withAsyncLock(store, async () => {
+    const rows = loadEngrams(store)
+    rows[0].statement = 'Newer fact that must survive'
+    if (outcome === 'failure') {
+      rows[0].status = 'retired'
+      delete rows[0].structured_data!._outbox
+    }
+    saveEngrams(store, rows)
+  })
+  finish(); await flush
+  const rows = loadEngrams(store)
+  expect(rows).toHaveLength(1)
+  expect(rows[0].statement).toBe('Newer fact that must survive')
+  if (outcome === 'failure') expect(rows[0].structured_data?._outbox).toBeUndefined()
+})
+
+it('serializes flushes from separate instances sharing a store', async () => {
+  const other = new Plur({ path: root, autoDiscover: false }); await other.ready()
+  const fetcher = vi.fn(async () => {
+    await new Promise(r => setTimeout(r, 20))
+    return new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 })
+  })
+  vi.stubGlobal('fetch', fetcher)
+  const results = await Promise.all([plur.flushOutbox(), other.flushOutbox()])
+  expect(results.reduce((n, r) => n + r.flushed, 0)).toBe(1)
+  expect(fetcher).toHaveBeenCalledTimes(1)
+  expect(loadEngrams(store)).toEqual([])
+})
+
+it('reuses a durable receipt when cleanup failed after remote acknowledgement', async () => {
+  const fetcher = vi.fn(async () => new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 }))
+  vi.stubGlobal('fetch', fetcher)
+  vi.spyOn(plur as any, '_writeEngrams').mockRejectedValueOnce(new Error('injected local cleanup failure'))
+  await expect(plur.flushOutbox()).rejects.toThrow('injected local cleanup failure')
+  expect(loadEngrams(store)).toHaveLength(1)
+  const restarted = new Plur({ path: root, autoDiscover: false }); await restarted.ready()
+  expect((await restarted.flushOutbox()).flushed).toBe(1)
+  expect(fetcher).toHaveBeenCalledTimes(1)
+  expect(loadEngrams(store)).toEqual([])
+})
+
+it('migrates legacy receipts before sending and preserves relationships after cache deletion', async () => {
+  const oldId = 'ENG-LOCAL-OLD'
+  const receipts = { [oldId]: { server_id: 'ENG-SERVER-OLD', url: 'https://audit.example', at: Date.now() } }
+  mkdirSync(join(root, 'cache'), { recursive: true })
+  writeFileSync(join(root, 'cache', 'outbox-id-map.json'), JSON.stringify(receipts))
+  const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+    expect(JSON.parse(readFileSync(join(root, 'state', 'outbox-id-map.json'), 'utf8'))[oldId]).toEqual(receipts[oldId])
+    if (init?.method !== 'POST') throw new Error('Must resolve legacy local ID from receipt')
+    return new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 })
+  })
+  vi.stubGlobal('fetch', fetcher)
+  expect((await plur.flushOutbox()).flushed).toBe(1)
+  rmSync(join(root, 'cache'), { recursive: true, force: true })
+  const row = EngramSchemaPassthrough.parse({
+    id: 'ENG-2026-09-08-002', type: 'behavioral', scope: 'group:example/team', status: 'active', visibility: 'public',
+    statement: 'A later correction', relations: { supersedes: [oldId] },
+    structured_data: { _outbox: { target_scope: 'group:example/team', target_url: 'https://audit.example', queued_at: new Date().toISOString(), last_attempt: '', last_error: '', attempt_count: 0 } },
+  })
+  saveEngrams(store, [row])
+  const restarted = new Plur({ path: root, autoDiscover: false }); await restarted.ready()
+  expect((await restarted.flushOutbox()).flushed).toBe(1)
+  expect(fetcher).toHaveBeenCalledTimes(2)
+  expect(JSON.parse(fetcher.mock.calls[1][1]!.body as string).supersedes).toEqual(['ENG-SERVER-OLD'])
+  expect(statSync(restarted.outboxIdMapPath()).mode & 0o777).toBe(0o600)
+})
+
+it.each(['{broken', '[]'])('refuses corrupt legacy receipt state before sending: %s', bytes => {
+  mkdirSync(join(root, 'cache'), { recursive: true })
+  writeFileSync(join(root, 'cache', 'outbox-id-map.json'), bytes)
+  const fetcher = vi.fn(); vi.stubGlobal('fetch', fetcher)
+  return expect(plur.flushOutbox()).rejects.toThrow('durable outbox receipts').then(() => {
+    expect(fetcher).not.toHaveBeenCalled()
+    expect(loadEngrams(store)).toHaveLength(1)
+    expect(readFileSync(join(root, 'cache', 'outbox-id-map.json'), 'utf8')).toBe(bytes)
+  })
+})
+
+it('refuses a failed legacy promotion before sending and preserves both queued and legacy bytes', async () => {
+  mkdirSync(join(root, 'cache'), { recursive: true })
+  const legacy = join(root, 'cache', 'outbox-id-map.json')
+  writeFileSync(legacy, '{}')
+  vi.spyOn(plur as any, '_writeOutboxIdMap').mockImplementationOnce(() => { throw new Error('injected promotion failure') })
+  const fetcher = vi.fn(); vi.stubGlobal('fetch', fetcher)
+  await expect(plur.flushOutbox()).rejects.toThrow('durable outbox receipts')
+  expect(fetcher).not.toHaveBeenCalled()
+  expect(readFileSync(legacy, 'utf8')).toBe('{}')
+  expect(loadEngrams(store)).toHaveLength(1)
+})
+
+it('never falls back from corrupt authoritative receipts to a stale valid legacy cache', async () => {
+  mkdirSync(join(root, 'cache'), { recursive: true })
+  mkdirSync(join(root, 'state'), { recursive: true })
+  writeFileSync(join(root, 'cache', 'outbox-id-map.json'), '{}')
+  writeFileSync(plur.outboxIdMapPath(), '{broken')
+  const fetcher = vi.fn(); vi.stubGlobal('fetch', fetcher)
+  await expect(plur.flushOutbox()).rejects.toThrow('durable outbox receipts')
+  expect(fetcher).not.toHaveBeenCalled()
+  expect(loadEngrams(store)).toHaveLength(1)
+})
+
+it.each(['group:example/team', 'group:other/team', 'missing'])('validates canonical supersession targets in destination scope: %s', remoteScope => {
+  return (async () => {
+    const rows = loadEngrams(store)
+    rows[0].relations = { ...rows[0].relations, supersedes: ['ENG-SERVER-OLD'] } as any
+    saveEngrams(store, rows)
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') return new Response(JSON.stringify({ id: 'ENG-SERVER-001' }), { status: 201 })
+      if (remoteScope === 'missing') return new Response('{}', { status: 404 })
+      return new Response(JSON.stringify({ id: 'ENG-SERVER-OLD', scope: remoteScope, status: 'active', data: { statement: 'Existing remote fact' } }))
+    })
+    vi.stubGlobal('fetch', fetcher)
+    const result = await plur.flushOutbox()
+    const posts = fetcher.mock.calls.filter(([, init]) => init?.method === 'POST')
+    expect(posts).toHaveLength(remoteScope === 'group:example/team' ? 1 : 0)
+    expect(result.flushed).toBe(remoteScope === 'group:example/team' ? 1 : 0)
+    if (remoteScope !== 'group:example/team') expect(loadEngrams(store)).toHaveLength(1)
+  })()
+})

--- a/packages/core/test/audit-pack-download.test.ts
+++ b/packages/core/test/audit-pack-download.test.ts
@@ -1,0 +1,46 @@
+/** Invariant: untrusted archives have bounded network, expansion, file and
+ * entry work, are validated before extraction, and failures clean up. */
+import { afterEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, symlinkSync, readFileSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as tar from 'tar'
+import { gzipSync } from 'node:zlib'
+import { downloadAndExtractPack, MAX_PACK_ARCHIVE_BYTES, MAX_PACK_DOWNLOAD_BYTES } from '../src/packs.js'
+
+afterEach(() => vi.unstubAllGlobals())
+it('rejects excessive declared body size before consuming it', async () => {
+  const cancel = vi.fn()
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(new ReadableStream({ cancel }), {
+    headers: { 'content-length': String(MAX_PACK_DOWNLOAD_BYTES + 1) },
+  })))
+  await expect(downloadAndExtractPack('https://audit.example/signed-secret')).rejects.toThrow(/size limit/)
+  expect(cancel).toHaveBeenCalled()
+})
+it('bounds decompression even when the compressed download is tiny', async () => {
+  const before = readdirSync(tmpdir()).filter(f => f.startsWith('plur-pack-dl-'))
+  const bomb = gzipSync(Buffer.alloc(MAX_PACK_ARCHIVE_BYTES + 1))
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(bomb)))
+  await expect(downloadAndExtractPack('https://audit.example/signed-secret')).rejects.toThrow()
+  expect(readdirSync(tmpdir()).filter(f => f.startsWith('plur-pack-dl-'))).toEqual(before)
+})
+it('rejects link entries before unpacking any file', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'plur-pack-link-'))
+  try {
+    writeFileSync(join(root, 'outside'), 'unchanged')
+    symlinkSync('outside', join(root, 'linked'))
+    const file = join(root, 'test.tar.gz')
+    tar.create({ file, cwd: root, gzip: true, sync: true }, ['linked'])
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(readFileSync(file))))
+    await expect(downloadAndExtractPack('https://audit.example/signed-secret')).rejects.toThrow(/link/)
+    expect(readFileSync(join(root, 'outside'), 'utf8')).toBe('unchanged')
+  } finally { rmSync(root, { recursive: true, force: true }) }
+})
+it('never echoes a signed URL on an HTTP error', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })))
+  await expect(downloadAndExtractPack('https://audit.example/secret?token=private')).rejects.toThrow('HTTP 404')
+  try { await downloadAndExtractPack('https://audit.example/secret?token=private') } catch (err) {
+    expect(String(err)).not.toContain('private')
+    expect(String(err)).not.toContain('/secret')
+  }
+})

--- a/packages/core/test/audit-postgres-lock-loss.test.ts
+++ b/packages/core/test/audit-postgres-lock-loss.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { PostgresAdapter } from '../src/storage-postgres.js'
+import { EngramSchemaPassthrough } from '../src/schemas/engram.js'
+import { Plur } from '../src/index.js'
+import { ReadonlyStoreGuard } from '../src/store/readonly-store-guard.js'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const url = process.env.PLUR_TEST_POSTGRES_URL
+const adapters: PostgresAdapter[] = []
+const roots: string[] = []
+let seq = 0
+function pair() {
+  const schema = `audit_lock_loss_${process.pid}_${seq++}`
+  const make = () => new PostgresAdapter({ connectionString: url!, schema, vectorIndex: 'exact' })
+  const a = make(), b = make(); adapters.push(a, b); return { a, b }
+}
+const row = (id: number) => EngramSchemaPassthrough.parse({ id: `ENG-AUDIT-${id}`, statement: `Preserve ${id}`, type: 'behavioral', scope: 'global', status: 'active' })
+afterEach(async () => {
+  for (const a of adapters.splice(0)) { await a.dropSchema(); await a.close() }
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe.skipIf(!url)('Postgres ownership and transaction interruption', () => {
+  it('does not recycle compacted IDs across clients with independent local state', async () => {
+    const { a, b } = pair()
+    const make = (store: PostgresAdapter) => {
+      const path = mkdtempSync(join(tmpdir(), 'plur-pg-ids-')); roots.push(path)
+      return new Plur({ path, store, autoDiscover: false })
+    }
+    const first = make(a), other = make(b)
+    const removed = await first.learn('A PostgreSQL identity that must survive compaction', { scope: 'global' })
+    await first.forget(removed.id, 'remove test row', { scope: 'primary', force: true })
+    await first.compact()
+    const next = await other.learn('A separate identity after removing the entire corpus', { scope: 'global' })
+    expect(next.id).not.toBe(removed.id)
+  }, 30000)
+
+  it('reserves IDs atomically across sessions and refuses reservation through a readonly guard', async () => {
+    const { a, b } = pair()
+    const minimum = 'ENG-2026-09-08-001'
+    const ids = await Promise.all(Array.from({ length: 20 }, (_, i) => (i % 2 ? a : b).reserveEngramId(minimum)))
+    expect(new Set(ids).size).toBe(20)
+    await a.save([])
+    expect(ids).not.toContain(await b.reserveEngramId(minimum))
+    await expect(new ReadonlyStoreGuard(a).reserveEngramId!(minimum)).rejects.toThrow(/read.only/i)
+  }, 30000)
+
+  it('cannot overwrite another writer after losing the advisory-lock session', async () => {
+    const { a, b } = pair(); await a.save([row(1)]); await b.load()
+    let entered!: () => void, resume!: () => void
+    const ready = new Promise<void>(r => { entered = r })
+    const held = new Promise<void>(r => { resume = r })
+    const first = a.withExclusiveAccess(async () => {
+      const stale = await a.load(); entered(); await held
+      await a.save(stale)
+    }).then(() => null, error => error)
+    await ready
+    const ownedClient = [...(a as any).liveClients][0]
+    const disconnected = new Promise<void>(r => ownedClient.once('error', () => r()))
+    const admin = await (b as any).getPool()
+    await admin.query('SELECT pg_terminate_backend($1)', [ownedClient.processID])
+    await disconnected
+    await b.withExclusiveAccess(async () => { await b.append(row(2)) })
+    resume()
+    const result = await first
+    expect((await b.load()).map(e => e.id)).toEqual(['ENG-AUDIT-1', 'ENG-AUDIT-2'])
+    expect(result).toBeInstanceOf(Error)
+  }, 30000)
+
+  it('rolls back earlier writes when a protected operation fails midway', async () => {
+    const { a } = pair(); await a.save([row(1)])
+    await expect(a.withExclusiveAccess(async () => {
+      await a.append(row(2))
+      throw new Error('injected failure after append')
+    })).rejects.toThrow('injected failure after append')
+    expect((await a.load()).map(e => e.id)).toEqual(['ENG-AUDIT-1'])
+  }, 30000)
+
+  it('does not acknowledge a transaction PostgreSQL rolled back after a caught query error', async () => {
+    const { a } = pair(); await a.save([row(1)])
+    await expect(a.withExclusiveAccess(async () => {
+      await a.append(row(2))
+      const connection = await (a as any).getPool()
+      await connection.query('SELECT 1 / 0').catch(() => {})
+    })).rejects.toThrow(/rolled back/)
+    expect((await a.load()).map(e => e.id)).toEqual(['ENG-AUDIT-1'])
+  }, 30000)
+
+  it('launches background work only after successful commit', async () => {
+    const { a, b } = pair(); await a.save([row(1)])
+    let count = 0
+    await expect(a.withExclusiveAccess(async () => {
+      a.afterCommit(() => { count++ })
+      await a.append(row(2))
+      throw new Error('rollback')
+    })).rejects.toThrow('rollback')
+    expect(count).toBe(0)
+    let observed!: Promise<string[]>
+    await a.withExclusiveAccess(async () => {
+      await a.append(row(2))
+      a.afterCommit(() => { observed = b.load().then(rows => rows.map(e => e.id)) })
+    })
+    expect(await observed).toEqual(['ENG-AUDIT-1', 'ENG-AUDIT-2'])
+  }, 30000)
+
+  it('refuses detached writes carrying an expired ownership context', async () => {
+    const { a } = pair(); await a.save([row(1)])
+    let resume!: () => void, detached!: Promise<unknown>
+    const held = new Promise<void>(r => { resume = r })
+    await a.withExclusiveAccess(async () => {
+      detached = held.then(() => a.append(row(2))).then(() => null, error => error)
+    })
+    resume()
+    expect(await detached).toBeInstanceOf(Error)
+    expect((await a.load()).map(e => e.id)).toEqual(['ENG-AUDIT-1'])
+  }, 30000)
+})

--- a/packages/core/test/audit-provenance-safety.test.ts
+++ b/packages/core/test/audit-provenance-safety.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { FileProvenanceStore } from '../src/provenance-store.js'
+
+const roots: string[] = []
+function temp() { const root = mkdtempSync(join(tmpdir(), 'plur-provenance-audit-')); roots.push(root); return root }
+afterEach(() => { vi.useRealTimers(); for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }) })
+
+it('preserves and orders same-millisecond versions across store instances', async () => {
+  vi.useFakeTimers({ toFake: ['Date'] }); vi.setSystemTime(new Date('2026-09-08T00:00:00Z'))
+  const root = temp()
+  const stores = [new FileProvenanceStore(root), new FileProvenanceStore(root)]
+  const refs = await Promise.all(Array.from({ length: 15 }, (_, n) => stores[n % 2].put('ENG-1', { n })))
+  expect(new Set(refs).size).toBe(15)
+  const ordered = await stores[0].list('ENG-1')
+  expect(await Promise.all(ordered.map(ref => stores[0].get(ref)))).toEqual(Array.from({ length: 15 }, (_, n) => ({ n: 14 - n })))
+  for (const ref of refs) expect(statSync(ref).mode & 0o777).toBe(0o600)
+  expect(await stores[0].put('ENG-1', { n: 14 })).toBe(ordered[0])
+})
+
+it('does not read a foreign JSON file or write through a configured symlink', async () => {
+  const root = temp(), outside = temp()
+  const foreign = join(outside, 'private.jsonld'); writeFileSync(foreign, '{"private":true}')
+  const store = new FileProvenanceStore(root)
+  expect(await store.get(foreign)).toBeUndefined()
+  symlinkSync(outside, join(root, 'provenance'))
+  await expect(store.put('ENG-1', { n: 1 })).rejects.toThrow(/symbolic link/)
+})

--- a/packages/core/test/audit-remote-authority.test.ts
+++ b/packages/core/test/audit-remote-authority.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RemoteStore } from '../src/store/remote-store.js'
+
+const scope = 'group:audit/review'
+const input = { id: 'ENG-LOCAL-001', statement: 'Requires human review', scope, status: 'active', type: 'behavioral', commitment: 'decided' } as any
+const row = { ...input, id: 'ENG-SERVER-001', commitment: 'draft', review_state: 'policy', review_required: true }
+const json = (body: unknown) => new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+afterEach(() => vi.unstubAllGlobals())
+
+describe('remote acknowledgements are authoritative', () => {
+  it.each(['entities', 'episodic', 'exchange', 'insight', 'polarity', 'structured_data'])('refuses unsupported %s content before sending', async key => {
+    const fetcher = vi.fn(); vi.stubGlobal('fetch', fetcher)
+    const store = new RemoteStore('https://audit.invalid', 'fixture', scope)
+    await expect(store.appendAndGetServerId({ ...input, [key]: key === 'structured_data' ? { custom_note: 'Preserve this qualification' } : { note: 'Preserve this qualification' } })).rejects.toThrow(/does not support/)
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+  it('caches and returns the held state, and replaces repeated IDs', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => init?.method === 'POST' ? json(row) : json({ rows: [], total_count: 0 })))
+    const store = new RemoteStore('https://audit.invalid', 'fixture', scope)
+    await store.load()
+    const result = await store.appendAndGetServerId(input)
+    await store.appendAndGetServerId(input)
+    const cached = await store.load()
+    expect(cached).toHaveLength(1)
+    expect(cached[0].commitment).toBe('draft')
+    expect((cached[0] as any).review_state).toBe('policy')
+    expect((result as any).engram.commitment).toBe('draft')
+  })
+  it.each([
+    ['ID-only', { id: row.id }],
+    ['foreign scope', { ...row, scope: 'group:other/private' }],
+    ['malformed state', { ...row, commitment: { invalid: true } }],
+  ])('invalidates the cache after a %s acknowledgement', async (_name, response) => {
+    const fetcher = vi.fn(async (_url: string, init?: RequestInit) => init?.method === 'POST' ? json(response) : json({ rows: [], total_count: 0 }))
+    vi.stubGlobal('fetch', fetcher)
+    const store = new RemoteStore('https://audit.invalid', 'fixture', scope)
+    await store.load()
+    if (_name !== 'ID-only') {
+      await expect(store.appendAndGetServerId(input)).rejects.toThrow('acknowledgement')
+      expect(await store.load()).toEqual([])
+      return
+    }
+    const result = await store.appendAndGetServerId(input)
+    expect(result.id).toBe(row.id) // preserve the confirmed receipt; never retry just because the echo is incomplete
+    expect((result as any).engram).toBeUndefined()
+    expect(await store.load()).toEqual([])
+    expect(fetcher.mock.calls.filter(([, init]) => init?.method !== 'POST')).toHaveLength(2)
+  })
+})

--- a/packages/core/test/audit-semantic-write.test.ts
+++ b/packages/core/test/audit-semantic-write.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Plur } from '../src/index.js'
+
+let root: string
+let plur: Plur
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), 'plur-semantic-audit-'))
+  writeFileSync(join(root, 'config.yaml'), 'index: false\ndedup:\n  mode: llm\n')
+  plur = new Plur({ path: root, autoDiscover: false }); await plur.ready()
+})
+afterEach(() => { vi.restoreAllMocks(); rmSync(root, { recursive: true, force: true }) })
+
+it.each(['NOOP', 'UPDATE', 'MERGE'])('refuses a model-selected foreign target for %s', async decision => {
+  const victim = await plur.learn('An unrelated protected observation', { scope: 'project:other' })
+  const candidate = await plur.learn('A similar current observation', { scope: 'project:current' })
+  vi.spyOn(plur, 'recallHybrid').mockResolvedValue([candidate])
+  const result = await plur.learnAsync('A fresh current observation', { scope: 'project:current', llm: async () => `DECISION: ${decision}\nTARGET: ${victim.id}` })
+  expect(result.decision).toBe('ADD')
+  expect(result.engram.scope).toBe('project:current')
+  expect((await plur.getById(victim.id))?.statement).toBe(victim.statement)
+})
+
+it.each(['NOOP', 'UPDATE', 'MERGE'])('preserves distinct supplied context despite a model %s', async decision => {
+  const candidate = await plur.learn('The measured latency was eighteen milliseconds', { scope: 'local', measured_under: { hardware: 'cpu' } })
+  vi.spyOn(plur, 'recallHybrid').mockResolvedValue([candidate])
+  const result = await plur.learnAsync('Latency measured eighteen milliseconds', { scope: 'local', measured_under: { hardware: 'gpu' }, llm: async () => `DECISION: ${decision}\nTARGET: ${candidate.id}` })
+  expect(result.decision).toBe('ADD')
+  expect(result.engram.measured_under?.hardware).toBe('gpu')
+  expect((await plur.getById(candidate.id))?.measured_under?.hardware).toBe('cpu')
+})
+
+it.each(['NOOP', 'UPDATE', 'MERGE'])('rechecks changed target state after model %s', async decision => {
+  const candidate = await plur.learn('An observation awaiting confirmation', { scope: 'local' })
+  vi.spyOn(plur, 'recallHybrid').mockResolvedValue([candidate])
+  const result = await plur.learnAsync('A later observation', { scope: 'local', llm: async () => {
+    await plur.updateEngram({ ...candidate, statement: 'A concurrent confirmed observation', commitment: 'locked' })
+    return `DECISION: ${decision}\nTARGET: ${candidate.id}`
+  } })
+  expect(result.decision).toBe('ADD')
+  expect((await plur.getById(candidate.id))?.statement).toBe('A concurrent confirmed observation')
+})
+
+it('validates input before calling a model or entering a semantic write path', async () => {
+  const candidate = await plur.learn('An existing observation', { scope: 'local' })
+  vi.spyOn(plur, 'recallHybrid').mockResolvedValue([candidate])
+  const llm = vi.fn(async () => `DECISION: UPDATE\nTARGET: ${candidate.id}`)
+  await expect(plur.learnAsync('A malformed observation', { scope: 'local', type: 'invalid' as any, llm })).rejects.toThrow(/invalid type/)
+  expect(llm).not.toHaveBeenCalled()
+  expect((await plur.getById(candidate.id))?.statement).toBe(candidate.statement)
+})
+
+it.each(['UPDATE', 'MERGE'])('rechecks the %s target inside the write lock', async decision => {
+  const candidate = await plur.learn('An initially mutable observation', { scope: 'local' })
+  vi.spyOn(plur, 'recallHybrid').mockResolvedValue([candidate])
+  const result = await plur.learnAsync('A concurrent proposed observation', { scope: 'local', llm: async () => {
+    // Return a stale pre-lock read after a concurrent writer commits a lock.
+    vi.spyOn(plur, 'getById').mockImplementationOnce(async () => {
+      await plur.updateEngram({ ...candidate, commitment: 'locked' })
+      return candidate
+    })
+    return `DECISION: ${decision}\nTARGET: ${candidate.id}`
+  } })
+  expect(result.decision).toBe('ADD')
+  expect((await plur.getById(candidate.id))?.statement).toBe(candidate.statement)
+  expect((await plur.getById(candidate.id))?.commitment).toBe('locked')
+})
+
+it('allows a valid model update within unchanged scope and supplied context', async () => {
+  const candidate = await plur.learn('An initial observation', { scope: 'local', measured_under: { hardware: 'cpu' } })
+  vi.spyOn(plur, 'recallHybrid').mockResolvedValue([candidate])
+  const result = await plur.learnAsync('An expanded observation', { scope: 'local', measured_under: { hardware: 'cpu' }, llm: async () => `DECISION: UPDATE\nTARGET: ${candidate.id}` })
+  expect(result.decision).toBe('UPDATE')
+  expect(result.engram.id).toBe(candidate.id)
+  expect((await plur.getById(candidate.id))?.statement).toBe('An expanded observation')
+})

--- a/packages/core/test/audit-telemetry-preservation.test.ts
+++ b/packages/core/test/audit-telemetry-preservation.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { recordEvent, getCounters, readPendingCounters, migrateStaleCounters, type CountersOpts } from '../src/telemetry-counters.js'
+import { flushIfNeeded, type FlushOpts } from '../src/telemetry-flush.js'
+
+const fault = vi.hoisted(() => ({ path: '', directory: '' }))
+vi.mock('../src/sync.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/sync.js')>()
+  return { ...actual, fsyncDir: (path: string) => {
+    if (path === fault.directory) throw new Error('injected directory sync failure')
+    return actual.fsyncDir(path)
+  }, atomicWrite: (...args: Parameters<typeof actual.atomicWrite>) => {
+    if (args[0] === fault.path && JSON.parse(String(args[1])).date === '2026-09-09') throw new Error('injected reset interruption')
+    return actual.atomicWrite(...args)
+  } }
+})
+
+let root: string
+let opts: CountersOpts
+const before = () => new Date('2026-09-08T12:00:00Z')
+const after = () => new Date('2026-09-09T12:00:00Z')
+beforeEach(() => {
+  root = fs.mkdtempSync(join(tmpdir(), 'plur-telemetry-preserve-'))
+  opts = { env: { PLUR_TELEMETRY: 'on' }, countersPath: join(root, 'counters.json'), installIdPath: join(root, 'install-id'), pendingDir: join(root, 'pending'), now: before }
+  fault.path = ''
+  fault.directory = ''
+})
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }))
+
+it('preserves legacy counters when making the first pending directory durable fails', async () => {
+  const original = JSON.stringify({ date: '2026-09-08', learn: 3, recall: 2, session: 1 })
+  fs.writeFileSync(opts.countersPath!, original)
+  fault.directory = opts.pendingDir!
+  const fetch = vi.fn()
+  await expect(flushIfNeeded({ ...opts, now: after, fetch })).rejects.toThrow('injected directory sync failure')
+  await expect(flushIfNeeded({ ...opts, now: after, fetch })).rejects.toThrow('injected directory sync failure')
+  expect(fs.readFileSync(opts.countersPath!, 'utf8')).toBe(original)
+  expect(fetch).not.toHaveBeenCalled()
+})
+
+it('retries interrupted rollover without counting the same snapshot twice', () => {
+  recordEvent('learn', opts)
+  fault.path = opts.countersPath!
+  expect(() => recordEvent('recall', { ...opts, now: after })).toThrow('injected reset interruption')
+  expect(readPendingCounters('2026-09-08', opts)?.learn).toBe(1)
+  fault.path = ''
+  recordEvent('recall', { ...opts, now: after })
+  expect(readPendingCounters('2026-09-08', opts)?.learn).toBe(1)
+  expect(getCounters({ ...opts, now: after })?.recall).toBe(1)
+})
+
+it('preserves malformed pending bytes and sends nothing', async () => {
+  recordEvent('learn', opts)
+  recordEvent('recall', { ...opts, now: after })
+  const path = join(opts.pendingDir!, '2026-09-08.json')
+  fs.writeFileSync(path, '{ valuable interrupted data')
+  const fetch = vi.fn()
+  await expect(flushIfNeeded({ ...opts, now: after, fetch })).rejects.toThrow(/existing data preserved/)
+  expect(fs.readFileSync(path, 'utf8')).toBe('{ valuable interrupted data')
+  expect(fetch).not.toHaveBeenCalled()
+})
+
+it('serializes concurrent drains and keeps one delivery identity and body across an upgrade retry', async () => {
+  recordEvent('learn', opts)
+  recordEvent('recall', { ...opts, now: after })
+  const calls: RequestInit[] = []
+  const failed = (async (_url, init) => { calls.push(init!); return { ok: false } as Response }) as typeof fetch
+  await flushIfNeeded({ ...opts, now: after, packageVersion: '0.19.4', fetch: failed })
+  const succeeded = (async (_url, init) => { calls.push(init!); await new Promise(r => setTimeout(r, 20)); return { ok: true } as Response }) as typeof fetch
+  await Promise.all([1, 2].map(() => flushIfNeeded({ ...opts, now: after, packageVersion: '0.20.0', fetch: succeeded })))
+  expect(calls).toHaveLength(2)
+  expect(calls[1].body).toBe(calls[0].body)
+  expect(calls[1].headers).toEqual(calls[0].headers)
+  expect((calls[0].headers as Record<string, string>)['Idempotency-Key']).toMatch(/^[0-9a-f-]{36}$/)
+})
+
+it('an earlier acknowledgement subtracts only its counts from a newer queued snapshot', async () => {
+  recordEvent('learn', opts)
+  recordEvent('recall', { ...opts, now: after })
+  const fetch = (async () => {
+    recordEvent('learn', opts)
+    recordEvent('learn', opts)
+    migrateStaleCounters({ ...opts, now: after })
+    return { ok: true } as Response
+  }) as typeof globalThis.fetch
+  await flushIfNeeded({ ...opts, now: after, fetch })
+  expect(readPendingCounters('2026-09-08', opts)).toEqual({ date: '2026-09-08', learn: 2, recall: 0, session: 0 })
+})
+
+it('new counts cannot change an accepted delivery after its response is lost', async () => {
+  recordEvent('learn', opts)
+  recordEvent('recall', { ...opts, now: after })
+  const calls: RequestInit[] = []
+  const accepted = new Map<string, string>()
+  let first = true
+  const fetch = (async (_url, init) => {
+    calls.push(init!)
+    const id = (init!.headers as Record<string, string>)['Idempotency-Key']
+    const body = String(init!.body)
+    if (accepted.has(id)) expect(body).toBe(accepted.get(id))
+    accepted.set(id, body)
+    if (first) {
+      first = false
+      // Clock correction and another rollover occur while the first delivery
+      // is in flight. The collector commits it, but the response is lost.
+      recordEvent('learn', opts)
+      recordEvent('learn', opts)
+      migrateStaleCounters({ ...opts, now: after })
+      throw new Error('lost response after acceptance')
+    }
+    return { ok: true } as Response
+  }) as typeof globalThis.fetch
+  const flushOpts: FlushOpts = { ...opts, now: after, packageVersion: '0.19.4', fetch }
+  await flushIfNeeded(flushOpts)
+  await flushIfNeeded({ ...flushOpts, packageVersion: '0.20.0' })
+  expect(calls[1].body).toBe(calls[0].body)
+  expect(calls[1].headers).toEqual(calls[0].headers)
+  await flushIfNeeded(flushOpts)
+  const deliveries = [...accepted.values()].map(body => JSON.parse(body))
+  expect(deliveries.reduce((sum, delivery) => sum + delivery.learn_count, 0)).toBe(3)
+  expect(deliveries.reduce((sum, delivery) => sum + delivery.recall_count, 0)).toBe(1)
+  expect(readPendingCounters('2026-09-08', opts)).toBeNull()
+})
+
+it.each(['../../outside', '2026-02-31'])('refuses unsafe or invalid pending date %s', date => {
+  expect(() => readPendingCounters(date, opts)).toThrow(/date/)
+})
+
+it('preserves every increment and one installation identity across four processes', async () => {
+  const require = createRequire(import.meta.url)
+  const moduleUrl = new URL('../src/telemetry-counters.ts', import.meta.url).href
+  const { now: _now, ...serializable } = opts
+  const script = `import { recordEvent } from ${JSON.stringify(moduleUrl)}; const opts = ${JSON.stringify(serializable)}; opts.now = () => new Date('2026-09-08T12:00:00Z'); for(let i=0;i<30;i++) recordEvent('learn',opts);`
+  await Promise.all(Array.from({ length: 4 }, () => new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', require.resolve('tsx'), '--input-type=module', '-e', script], { stdio: ['ignore', 'ignore', 'pipe'] })
+    let error = ''
+    child.stderr.on('data', chunk => { error += chunk })
+    child.on('error', reject)
+    child.on('close', code => code === 0 ? resolve() : reject(new Error(error)))
+  })))
+  expect(getCounters(opts)?.learn).toBe(120)
+  expect(getCounters(opts)?.session).toBe(1)
+})

--- a/packages/core/test/engram-id-reuse.test.ts
+++ b/packages/core/test/engram-id-reuse.test.ts
@@ -19,14 +19,15 @@
  * so an incomplete log degrades to the old behaviour and can never manufacture
  * a collision the old behaviour would have avoided.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, mkdirSync } from 'fs'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Plur } from '../src/index.js'
 import { generateEngramId } from '../src/engrams.js'
 import { mintedIdsWithPrefix, readHistoryForEngram } from '../src/history.js'
 import type { Engram } from '../src/schemas/engram.js'
+import * as syncFiles from '../src/sync.js'
 
 describe('engram ids are never reused after compaction (#816)', () => {
   let dir: string
@@ -108,6 +109,50 @@ describe('engram ids are never reused after compaction (#816)', () => {
       plur.learn('the other of two simultaneous facts', { scope: 'global', type: 'behavioral' }),
     ])
     expect(x.id).not.toBe(y.id)
+  })
+
+  it('does not reuse an ID created and compacted by another instance after its cache was filled', async () => {
+    const first = await plur.learn('Initial allocator cache seed', { scope: 'global' })
+    const other = new Plur({ path: dir, autoDiscover: false }); await other.ready()
+    const removed = await other.learn('Independent temporary record', { scope: 'global' })
+    await other.forget(removed.id, 'remove after independent allocation', { scope: 'primary', force: true })
+    await other.compact()
+    const next = await plur.learn('Distinct later record from stale allocator', { scope: 'global' })
+    expect(new Set([first.id, removed.id, next.id]).size).toBe(3)
+  })
+
+  it('preserves allocations through restart after history loss and compaction', async () => {
+    const removed = await plur.learn('An identity that must not be recycled', { scope: 'global' })
+    await plur.forget(removed.id, 'removed', { scope: 'primary', force: true })
+    await plur.compact()
+    rmSync(join(dir, 'history'), { recursive: true, force: true })
+    const restarted = new Plur({ path: dir, autoDiscover: false }); await restarted.ready()
+    const next = await restarted.learn('A new identity after diagnostic history loss', { scope: 'global' })
+    expect(next.id).not.toBe(removed.id)
+  })
+
+  it('fails closed on corrupt durable allocation state without changing the corpus', async () => {
+    const first = await plur.learn('A record before allocation state corruption', { scope: 'global' })
+    const allocations = join(dir, 'state', 'id-allocations')
+    mkdirSync(allocations, { recursive: true })
+    writeFileSync(join(allocations, `${new Date().toISOString().slice(0, 10)}.json`), '{broken')
+    const before = await plur.getById(first.id)
+    await expect(plur.learn('Must not be saved without an allocation', { scope: 'global' })).rejects.toThrow('allocation')
+    expect(await plur.getById(first.id)).toEqual(before)
+  })
+
+  it('does not publish a record when its reservation cannot be persisted', async () => {
+    await plur.ready()
+    const before = await plur.list()
+    const original = syncFiles.atomicWrite
+    const fault = vi.spyOn(syncFiles, 'atomicWrite').mockImplementation((path, data, options) => {
+      if (path.includes('id-allocations')) throw new Error('injected allocation disk failure')
+      return original(path, data, options)
+    })
+    try {
+      await expect(plur.learn('A record whose allocation cannot persist', { scope: 'global' })).rejects.toThrow('allocation disk failure')
+      expect(await plur.list()).toEqual(before)
+    } finally { fault.mockRestore() }
   })
 
   describe('the allocator itself', () => {

--- a/packages/core/test/leak-surface.test.ts
+++ b/packages/core/test/leak-surface.test.ts
@@ -63,7 +63,8 @@ function canaryContext(mark: string): { context: LearnContext; canaries: Record<
   const canaries: Record<string, string> = {}
   let context: LearnContext = {}
   for (const field of LEARN_CONTENT_FIELDS) {
-    const v = `${mark}-${field}-7f3a`
+    // The canary must itself be valid for a content-bearing enum.
+    const v = field === 'claim_class' ? 'observed' : `${mark}-${field}-7f3a`
     canaries[field] = v
     context = { ...context, ...contextWith(field, v) }
   }

--- a/packages/core/test/pack-file-scan.test.ts
+++ b/packages/core/test/pack-file-scan.test.ts
@@ -141,19 +141,9 @@ describe('attribution is an identity, not a leaked credential', () => {
     expect(result.engram_count).toBe(1)
   })
 
-  it.fails('exports a memory attributed by an email address', () => {
-    // KNOWN BUG, deliberately recorded as failing rather than deleted (#999).
-    //
-    // An email in `asserted_by` trips the privacy scan twice — as a web address
-    // carrying a password, and as personal information — so the engram is
-    // dropped from every pack. Two reviewers called this the reason not to
-    // ship: naming a colleague is the most natural provenance act the tool
-    // offers, and it makes the memory unshareable.
-    //
-    // I fixed it once by exempting the whole attribution block from the scan,
-    // and a reviewer walked a GitHub token through the hole within the hour.
-    // That was worse: a usability bug is loud, a silent credential channel is
-    // not. Reverted, and the narrow fix is designed in #999.
+  it('exports a memory attributed by an email address', () => {
+    // A declared email identity is shareable; credentials anywhere in the
+    // attribution block are still forbidden (including in the email value).
     const result = exportPack([engram({ attribution: { asserted_by: 'alice@acme.example' } })], dir,
       { name: 'p', version: '1.0.0', license: 'cc-by-4.0' })
     expect(result.engram_count).toBe(1)
@@ -174,6 +164,19 @@ describe('attribution is an identity, not a leaked credential', () => {
       rationale: 'we found AKIAIOSFODNN7EXAMPLE in the old config',
     })], dir, { name: 'p', version: '1.0.0', license: 'cc-by-4.0' })
     expect(result.engram_count).toBe(0)
+  })
+
+  it.each(['AKIAIOSFODNN7EXAMPLE@acme.example', 'alice@acme.example AWS=AKIAIOSFODNN7EXAMPLE'])('does not disguise credentials as declared email identity: %s', who => {
+    expect(exportPack([engram({ attribution: { asserted_by: who } })], dir,
+      { name: 'p', version: '1.0.0', license: 'cc-by-4.0' }).engram_count).toBe(0)
+  })
+
+  it('exports and previews a declared email while keeping adjacent fields scanned', async () => {
+    exportPack([engram({ attribution: { asserted_by: 'alice@acme.example' } })], dir,
+      { name: 'p', version: '1.0.0', license: 'cc-by-4.0' })
+    expect((await previewPack(dir)).security.clean).toBe(true)
+    expect(exportPack([{ ...engram({}), attribution: { asserted_by: 'alice@acme.example', extra: 'AKIAIOSFODNN7EXAMPLE' } } as any], dir,
+      { name: 'p', version: '1.0.0', license: 'cc-by-4.0' }).engram_count).toBe(0)
   })
 })
 
@@ -302,6 +305,14 @@ describe('files the scan cannot read block the install rather than slipping past
     const { security } = await previewPack(dir)
     expect(security.clean).toBe(false)
     expect(security.issues.some(i => i.engram_id === 'long.md' && /scan_truncated/.test(i.detail))).toBe(true)
+  })
+
+  it('adding a NUL byte cannot hide an oversized unscanned tail', async () => {
+    writeFileSync(join(dir, 'binary.md'), '\0' + 'x'.repeat(1024 * 1024 + 10) + `\n${AWS}\n`)
+    const { security } = await previewPack(dir)
+    expect(security.clean).toBe(false)
+    expect(security.issues.some(i => i.engram_id === 'binary.md' && /scan_truncated/.test(i.detail))).toBe(true)
+    await expect(installPack(packs, dir)).rejects.toThrow()
   })
 
   it.skipIf(process.platform === 'win32')('flags a special file, and install refuses it', async () => {

--- a/packages/core/test/project-config.test.ts
+++ b/packages/core/test/project-config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, realpathSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { tmpdir, homedir } from 'os'
-import { findProjectConfigPath, readProjectConfig } from '../src/project-config.js'
+import { findProjectConfigPath, readProjectConfig, updateProjectConfig, readProjectConfigDocument } from '../src/project-config.js'
 
 /**
  * Tests for project-config — covers the .plur.yaml reader that was extracted
@@ -196,11 +196,30 @@ describe('project-config (#177)', () => {
       expect(cfg.remote_token).toBe('t')  // post-list parser correctly returns to scalar mode
     })
 
-    it('returns {} on malformed YAML (graceful)', () => {
+    it('refuses malformed YAML instead of treating unknown routing as defaults', () => {
       // Use a file we can't read by removing read perms or pointing at a dir
       writeFileSync(join(root, '.plur.yaml'), '\x00\x01\x02 binary garbage')
-      // Should not throw; returns {} or whatever was parseable
-      expect(() => readProjectConfig(root)).not.toThrow()
+      expect(() => readProjectConfig(root)).toThrow('Invalid project configuration')
+    })
+
+    it('does not promote nested or block-scalar keys into remote routing authority', () => {
+      writeFileSync(join(root, '.plur.yaml'), 'other:\n  remote_url: https://unrelated.example\n  remote_token: other-key\nnote: |\n  scope: global\n')
+      expect(readProjectConfig(root)).toEqual({})
+    })
+
+    it('preserves remote consent, unrelated nested keys and exact scalar values across partial updates', () => {
+      const path = join(root, '.plur.yaml')
+      writeFileSync(path, 'custom:\n  value: 7\nremote_url: https://example.test\nremote_token: original\n')
+      updateProjectConfig(path, { scope: 'project:test', domain: 'a: value # with punctuation' })
+      const config = readProjectConfig(root)
+      expect(config.remote_token).toBe('original')
+      expect(config.domain).toBe('a: value # with punctuation')
+      expect(readProjectConfigDocument(path).custom).toEqual({ value: 7 })
+    })
+
+    it('continues accepting legacy block-list scope syntax', () => {
+      writeFileSync(join(root, '.plur.yaml'), 'remote_scopes: |\n  - group:one\n  - group:two\n')
+      expect(readProjectConfig(root).remote_scopes).toEqual(['group:one', 'group:two'])
     })
 
     it('ignores unrelated YAML keys silently', () => {

--- a/packages/core/test/remote-integration.test.ts
+++ b/packages/core/test/remote-integration.test.ts
@@ -595,6 +595,7 @@ describe('Plur integration with stub server', () => {
     // through appendAndGetServerId. The wire body must carry the fields FLAT
     // (enterprise#627 contract); reading them at the engram top level would
     // silently drop them (the original #768 review finding).
+    server.seedEngram({ id: 'ENG-2026-0101-001', scope: 'group:test', status: 'active', data: { statement: 'The existing remote rule' } })
     const plur = new Plur({ path: primaryDir })
     await plur.learn('team rule with expiry — wire shape test', {
       scope: 'group:test',

--- a/packages/core/test/remote-store-cache.test.ts
+++ b/packages/core/test/remote-store-cache.test.ts
@@ -34,7 +34,7 @@ describe('RemoteStore — optimistic cache insert (issue #89)', () => {
       if (method === 'POST') {
         return {
           ok: true, status: 201,
-          json: async () => ({ id: 'ENG-SERVER-001' }),
+          json: async () => ({ id: 'ENG-SERVER-001', scope: 'user:plur:tester', status: 'active', statement: 'optimistic insert test', type: 'behavioral' }),
           text: async () => '',
         } as Response
       }

--- a/packages/core/test/remote-write-contract.test.ts
+++ b/packages/core/test/remote-write-contract.test.ts
@@ -39,7 +39,7 @@ const TRANSMITTED = new Set([
   'measured_under', 'knowledge_anchors', 'dual_coding',
   // #1172. `license` is absent on purpose: it travels inside
   // `provenance.license`, so it is covered by `provenance` above.
-  'attribution', 'claim_class',
+  'attribution', 'claim_class', 'summary', 'contraindications', 'knowledge_type', 'visibility', 'created_at',
 ])
 
 /** Sent as flattened top-level keys, not as the nested object. */
@@ -73,61 +73,37 @@ const LOCAL = new Map([
   ['pack', 'local pack membership'],
   ['abstract', 'local abstraction bookkeeping'],
   ['derived_from', 'local derivation bookkeeping'],
+  ['sources', 'local write/session history; source and provenance carry portable attribution'],
+  ['locked_at', 'the server owns the time of its state transition'],
+  ['updated_at', 'the destination owns its mutation timestamp'],
 ])
 
-/**
- * Not modelled by the wire contract, and not yet argued either way — tracked,
- * not decided.
- *
- * Being in this set is NOT a claim that losing the field is correct. Two of
- * them are rendered straight to the model: `summary` is the entire payload of a
- * layer-1 entry, and `contraindications` is the "does NOT apply when" clause a
- * constraint is qualified by. Losing those on a shared store is the same class
- * of defect as #1151, reached through a different field.
- *
- * They are separated from LOCAL so the distinction stays visible: LOCAL says
- * "we decided", this says "we have not".
- */
-const NOT_MODELLED = new Set([
-  'visibility', 'contraindications', 'knowledge_type', 'entities', 'episodic',
-  'exchange', 'structured_data', 'insight', 'polarity', 'locked_at', 'sources',
-  'summary',
-  // Added by #1138 and caught here on the merge, which is the guard working:
-  // two new schema fields could not reach `main` without someone stating what
-  // a remote write should do with them.
-  //
-  // Provenance timestamps have a real claim to being TRANSMITTED — `created_at`
-  // is an immutable first-mint record, and #1151 is precisely about provenance
-  // being dropped on a shared write. But deciding that here would mean adding
-  // them to `appendAndGetServerId` in a PR about injection ordering, which is
-  // the bundling that hid #1138's own blocking defect. Recorded as undecided,
-  // which is what this set means, and routed to #1153 with the other twelve.
-  'created_at', 'updated_at',
-])
+/** Unsupported content is refused before a send, never silently dropped. */
+const REFUSED = new Set(['entities', 'episodic', 'exchange', 'structured_data', 'insight', 'polarity'])
 
 describe('the remote write contract covers every schema field (#1151)', () => {
   const fields = Object.keys(EngramSchema.shape)
 
   it('classifies every field of EngramSchema', () => {
     const unclassified = fields.filter(f =>
-      !TRANSMITTED.has(f) && !FLATTENED.has(f) && !LOCAL.has(f) && !NOT_MODELLED.has(f))
+      !TRANSMITTED.has(f) && !FLATTENED.has(f) && !LOCAL.has(f) && !REFUSED.has(f))
 
     expect(unclassified,
       'a field was added to EngramSchema without deciding whether a remote write should carry it. '
-      + 'Add it to TRANSMITTED (and to appendAndGetServerId\'s body), or to LOCAL / NOT_MODELLED with a reason. '
+      + 'Add it to TRANSMITTED (and to appendAndGetServerId\'s body), or to LOCAL / REFUSED with a reason. '
       + 'This is the check that #768 and #1151 both needed and neither had.',
     ).toEqual([])
   })
 
   it('classifies each field exactly once', () => {
     const dupes = fields.filter(f =>
-      [TRANSMITTED.has(f), FLATTENED.has(f), LOCAL.has(f), NOT_MODELLED.has(f)].filter(Boolean).length > 1)
+      [TRANSMITTED.has(f), FLATTENED.has(f), LOCAL.has(f), REFUSED.has(f)].filter(Boolean).length > 1)
     expect(dupes).toEqual([])
   })
 
   it('names no field that the schema does not have', () => {
     const known = new Set(fields)
-    const stale = [...TRANSMITTED, ...FLATTENED.keys(), ...LOCAL.keys(), ...NOT_MODELLED]
+    const stale = [...TRANSMITTED, ...FLATTENED.keys(), ...LOCAL.keys(), ...REFUSED]
       .filter(f => !known.has(f))
     expect(stale, 'a classified field is gone from the schema — drop it from this list').toEqual([])
   })
@@ -213,6 +189,8 @@ describe('every TRANSMITTED field actually reaches the wire (#1158)', () => {
         runtime: { name: 'plur-core', version: '0.19.4' },
       },
       claim_class: 'observed',
+      created_at: '2026-09-08T00:00:00Z', summary: 'A measured baseline', contraindications: ['Does not apply on a different dataset'],
+      knowledge_type: { memory_class: 'semantic', cognitive_level: 'understand' }, visibility: 'public',
     })
 
     await driver.appendAndGetServerId(full as never)

--- a/packages/core/test/scope-discovery.test.ts
+++ b/packages/core/test/scope-discovery.test.ts
@@ -475,6 +475,7 @@ describe('endpoint URL identity normalization (scope-audit 2026-07-24)', () => {
     expect(normalizeEndpointUrl('https://x.com/')).toBe('https://x.com')
     expect(normalizeEndpointUrl('https://x.com/sse')).toBe('https://x.com')
     expect(normalizeEndpointUrl('https://x.com/sse/')).toBe('https://x.com')
+    expect(normalizeEndpointUrl('https://X.com:443/sse/')).toBe('https://x.com')
     // A genuine path prefix is NOT a spelling variant — must stay distinct.
     expect(normalizeEndpointUrl('https://x.com/api')).toBe('https://x.com/api')
     expect(normalizeEndpointUrl('https://x.com/ssex')).toBe('https://x.com/ssex')

--- a/packages/core/test/supersedes-flush-remap.test.ts
+++ b/packages/core/test/supersedes-flush-remap.test.ts
@@ -23,6 +23,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import yaml from 'js-yaml'
 import { Plur } from '../src/index.js'
+import { recordWriteOutcome } from '../src/remote-recall.js'
 
 const REMOTE = 'https://plur.example.com/sse'
 const SCOPE = 'group:acme/team'
@@ -191,6 +192,9 @@ describe('supersedes ordering for chains and across flushes (#863 follow-up)', (
 
   const down = () => { globalThis.fetch = vi.fn(async () => { throw new Error('fetch failed') }) as never }
   const up = () => {
+    // Background sends now feed the same breaker as explicit flushes. This
+    // fixture transitions the host to reachable before testing edge remapping.
+    recordWriteOutcome(REMOTE, true, Date.now(), join(dir, 'cache', 'remote-health.json'))
     const res = (status: number, body: unknown): Response => ({
       ok: true, status,
       json: async (): Promise<unknown> => body,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -89,6 +89,20 @@ describe('sync', () => {
     const TOKEN = 'eyJSECRETtokenABC123'
     const configWithToken = `stores:\n  - url: https://plur.datafund.io\n    token: ${TOKEN}\n    scope: group:plur/plur-ai/engineering\n`
 
+    it.each(['.env', 'backups/private.yaml', 'state/outbox-id-map.json', 'packs/example/private.json', 'odd\nname.txt', ' engrams.yaml'])(
+      'refuses already staged non-store content without discarding it: %s', file => {
+        sync(dir)
+        const before = git('rev-parse HEAD', dir)
+        mkdirSync(join(dir, file, '..'), { recursive: true })
+        writeFileSync(join(dir, file), 'private-content')
+        execSync('git add -f -- "$PLUR_AUDIT_STAGED_FILE"', { cwd: dir, env: { ...process.env, PLUR_AUDIT_STAGED_FILE: file } })
+        expect(() => sync(dir)).toThrow('non-store files are staged')
+        expect(git('rev-parse HEAD', dir)).toBe(before)
+        expect(readFileSync(join(dir, file), 'utf8')).toBe('private-content')
+        expect(execSync('git diff --cached --name-only -z', { cwd: dir, encoding: 'utf8' }).split('\0')).toContain(file)
+      },
+    )
+
     it('never commits config.yaml even when it holds a Bearer token', () => {
       writeFileSync(join(dir, 'config.yaml'), configWithToken)
       sync(dir)

--- a/packages/core/test/telemetry-atomic-write.test.ts
+++ b/packages/core/test/telemetry-atomic-write.test.ts
@@ -6,20 +6,32 @@
 // Lives in its own file because it partially mocks node:fs to observe tmp
 // paths; the main telemetry-counters suite uses the real filesystem.
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mkdtempSync } from 'node:fs'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 const writtenPaths: string[] = []
 const renames: Array<{ from: string; to: string }> = []
+const descriptors = new Map<number, string>()
+const opens: Array<{ path: string; flags: unknown; mode: unknown }> = []
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>()
   return {
     ...actual,
+    openSync: (path: any, flags: any, mode: any) => {
+      const fd = actual.openSync(path, flags, mode)
+      descriptors.set(fd, String(path))
+      opens.push({ path: String(path), flags, mode })
+      return fd
+    },
+    closeSync: (fd: number) => {
+      descriptors.delete(fd)
+      return actual.closeSync(fd)
+    },
     writeFileSync: (path: any, data: any, opts: any) => {
-      writtenPaths.push(String(path))
+      writtenPaths.push(typeof path === 'number' ? descriptors.get(path)! : String(path))
       return actual.writeFileSync(path, data, opts)
     },
     renameSync: (from: any, to: any) => {
@@ -38,6 +50,8 @@ describe('atomic write tmp naming (#188)', () => {
   beforeEach(() => {
     writtenPaths.length = 0
     renames.length = 0
+    opens.length = 0
+    descriptors.clear()
     dir = mkdtempSync(join(tmpdir(), 'plur-atomic-'))
     opts = {
       env: { PLUR_TELEMETRY: 'on' },
@@ -48,34 +62,41 @@ describe('atomic write tmp naming (#188)', () => {
       now: () => new Date('2026-05-02T18:00:00Z'),
     }
   })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
 
   it('never reuses a tmp path across writes to the same file', () => {
     recordEvent('learn', opts)
     recordEvent('recall', opts)
     resetCounters(opts)
 
-    const tmpPaths = writtenPaths.filter((p) => p.includes('.tmp.'))
+    const tmpPaths = writtenPaths.filter((p) => p.endsWith('.tmp'))
     // 3 counters.json writes + 1 install-id write
     expect(tmpPaths.length).toBeGreaterThanOrEqual(4)
     expect(new Set(tmpPaths).size).toBe(tmpPaths.length)
   })
 
-  it('keeps the `<path>.tmp.` prefix convention for tmp files', () => {
+  it('creates each temporary file exclusively and privately beside its destination', () => {
     recordEvent('learn', opts)
 
-    const counterTmps = writtenPaths.filter((p) => p.startsWith(`${join(dir, 'counters.json')}.tmp.`))
+    const counterTmps = opens.filter(({ path }) => path.startsWith(`${join(dir, 'counters.json')}.`) && path.endsWith('.tmp'))
     expect(counterTmps.length).toBe(1)
-    const installTmps = writtenPaths.filter((p) => p.startsWith(`${join(dir, 'install-id')}.tmp.`))
+    const installTmps = opens.filter(({ path }) => path.startsWith(`${join(dir, 'install-id')}.`) && path.endsWith('.tmp'))
     expect(installTmps.length).toBe(1)
+    for (const entry of [...counterTmps, ...installTmps]) {
+      expect(entry.flags).toBe('wx')
+      expect(entry.mode).toBe(0o600)
+    }
   })
 
   it('renames each tmp file onto its final path', () => {
     recordEvent('learn', opts)
     recordEvent('recall', opts)
 
-    for (const { from, to } of renames) {
+    const replacements = renames.filter(({ from }) => from.endsWith('.tmp'))
+    expect(replacements).toHaveLength(3)
+    for (const { from, to } of replacements) {
       expect(writtenPaths).toContain(from)
-      expect(from.startsWith(`${to}.tmp.`)).toBe(true)
+      expect(from.startsWith(`${to}.`)).toBe(true)
     }
   })
 })

--- a/packages/core/test/telemetry-counters.test.ts
+++ b/packages/core/test/telemetry-counters.test.ts
@@ -153,13 +153,11 @@ describe('telemetry counters (#51 slice D-2a)', () => {
     })
   })
 
-  it('env-on malformed counters file: parse-fails treated as missing, fresh write', () => {
+  it('env-on malformed counters file: refuses and preserves the existing bytes', () => {
     writeFileSync(countersPath, '{ this is not json')
     const fixedNow = () => new Date('2026-05-02T18:00:00Z')
-    recordEvent('learn', onOpts({ now: fixedNow }))
-
-    const counters = JSON.parse(readFileSync(countersPath, 'utf8'))
-    expect(counters).toEqual({ date: '2026-05-02', learn: 1, recall: 0, session: 1 })
+    expect(() => recordEvent('learn', onOpts({ now: fixedNow }))).toThrow(/existing data preserved/)
+    expect(readFileSync(countersPath, 'utf8')).toBe('{ this is not json')
   })
 
   it('env-on install-id stable across recordEvent calls', () => {

--- a/packages/core/test/write-path-seams.test.ts
+++ b/packages/core/test/write-path-seams.test.ts
@@ -188,6 +188,17 @@ describe('#828 learn() write-path seams', () => {
     expect(store.nextIdCalls).toBe(2)
   })
 
+  it('searches sibling contexts when the legacy hash seam returns a different one', async () => {
+    const store = new CountingStore()
+    const plur = new Plur({ path: tempDir(), store, autoDiscover: false }); await plur.ready()
+    const write = (hardware: string) => plur.learn('A measured assertion', { scope: 'global', measured_under: { hardware } })
+    const first = await write('cpu'); const second = await write('gpu'); const third = await write('gpu')
+    expect(first.id).not.toBe(second.id)
+    expect(third.id).toBe(second.id)
+    expect(store.peek()).toHaveLength(2)
+    expect(store.peek().find(e => e.id === first.id)?.measured_under?.hardware).toBe('cpu')
+  })
+
   it('deduplicates through the store and persists the write_count increment', async () => {
     const store = new CountingStore()
     const plur = new Plur({ path: tempDir(), store, autoDiscover: false })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,4 +1,16 @@
 import { defineConfig } from 'vitest/config'
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// A worker that launches more processes is not one unit of CPU/I/O load.
+// Run these after the ordinary projects; concurrency inside each test remains
+// unchanged (including the four independent counter/lock writers).
+const testDirectory = new URL('./test/', import.meta.url)
+export const CORE_PROCESS_SUITES = readdirSync(testDirectory)
+  .filter(name => name.endsWith('.test.ts') && /(?:from\s*|import\(\s*|require\(\s*)['"](?:node:)?child_process['"]/.test(
+    readFileSync(fileURLToPath(new URL(name, testDirectory)), 'utf8'),
+  ))
+  .map(name => `test/${name}`)
 
 // The PGLite suites are EXCLUDED here and run as a separate serial project
 // (see the root vitest.config.ts). They are not excluded from the test run —
@@ -34,6 +46,7 @@ export const PGLITE_SUITES = [
   // to a real database and boots PGLite alongside it for the cross-adapter
   // parity check. Skips entirely unless PLUR_TEST_POSTGRES_URL is set.
   'test/postgres-*.test.ts',
+  'test/audit-postgres-*.test.ts',
 ]
 
 // testTimeout raised from the 5s default: the BGE embedder (@huggingface/
@@ -47,7 +60,7 @@ export default defineConfig({
     globals: true,
     testTimeout: 30000,
     hookTimeout: 30000,
-    exclude: ['**/node_modules/**', '**/dist/**', ...PGLITE_SUITES],
+    exclude: ['**/node_modules/**', '**/dist/**', ...PGLITE_SUITES, ...CORE_PROCESS_SUITES],
     // The #1069 host breaker is process-global by design; without a per-test
     // reset it leaks "host down" verdicts across test files (see the helper).
     setupFiles: ['test/helpers/reset-remote-breaker-setup.ts'],

--- a/packages/dsh/test/conformance.test.ts
+++ b/packages/dsh/test/conformance.test.ts
@@ -89,14 +89,14 @@ describe('the real Plur satisfies PlurClient', () => {
     expect(typeof (injection as { count?: unknown }).count).toBe('number')
   })
 
-  it('feedback takes the signal WORD — a number is silently ignored, not rejected', async () => {
+  it('feedback accepts the signal word and rejects a numeric signal without mutation', async () => {
     const stored = await plur.learn!('Conformance: feedback takes a word.', { scope: SCOPE }) as { id: string }
     await expect(plur.feedback!(stored.id, 'positive', SCOPE)).resolves.not.toThrow()
-    // The regression this suite exists for: an earlier contract passed 1 / -1.
-    // Core does NOT reject that — it no-ops. So the bug would have shipped as a
-    // feature that quietly never trained anything, which is why a type-level
-    // contract alone was not enough and this suite exists.
-    await expect(plur.feedback!(stored.id, 1 as never, SCOPE)).resolves.not.toThrow()
+    // The earlier numeric contract silently failed to train. Runtime validation
+    // now refuses it, and the accepted positive feedback must remain intact.
+    const before = await plur.list!()
+    await expect(plur.feedback!(stored.id, 1 as never, SCOPE)).rejects.toThrow(/signal/)
+    expect(await plur.list!()).toEqual(before)
   })
 
   it('capture accepts a positional summary plus a context object', async () => {

--- a/packages/hermes/plur_hermes/bridge.py
+++ b/packages/hermes/plur_hermes/bridge.py
@@ -198,20 +198,36 @@ def _kill_process_group(proc: subprocess.Popen) -> None:
     """SIGTERM then SIGKILL the child's process group. Falls back to killing
     just the child if the group is already gone (or on platforms without
     killpg), so this can never raise out of a timeout handler."""
-    try:
-        pgid = os.getpgid(proc.pid)
-    except (ProcessLookupError, OSError):
+    if os.name != "posix":
+        proc.kill()
         return
-    for sig in (signal.SIGTERM, signal.SIGKILL):
+    # start_new_session=True fixes the group ID at creation. The parent can
+    # already be reaped while a grandchild still owns our stdout pipe.
+    pgid = proc.pid
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    # Do not reap the group leader until after signalling the group: reaping
+    # frees its PID for reuse and can make the next signal target another job.
+    time.sleep(0.5)
+    # Parent exit is not proof that the group exited. Descendants can ignore
+    # TERM; always finish group teardown even when wait() returned immediately.
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except PermissionError:
+        # macOS returns EPERM for a group containing only an unreaped zombie.
+        # Reap our exited leader, then prove the group is gone. A live group
+        # or a real permission failure still propagates; never claim cleanup.
+        if proc.poll() is None:
+            raise
         try:
-            os.killpg(pgid, sig)
-        except (ProcessLookupError, OSError):
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
             return
-        try:
-            proc.wait(timeout=2)
-            return  # died on SIGTERM; no need to escalate
-        except subprocess.TimeoutExpired:
-            continue
+        raise
 
 
 class PlurBridge:

--- a/packages/hermes/test/test_bridge_process_group.py
+++ b/packages/hermes/test/test_bridge_process_group.py
@@ -94,3 +94,31 @@ def test_timeout_reaps_grandchild(tmp_path):
         )
     finally:
         _force_kill(gc_pid)  # never leak a real 600s sleeper
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group semantics")
+@pytest.mark.parametrize("parent_exits", [False, True])
+def test_timeout_kills_term_ignoring_pipe_owner(tmp_path, parent_exits):
+    import subprocess
+    script = tmp_path / "parent.py"
+    pidfile = tmp_path / "gc.pid"
+    child_code = "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+    script.write_text(
+        "import subprocess,sys,time\n"
+        + f"p = subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+        + "open(sys.argv[1], 'w').write(str(p.pid))\n"
+        + ("time.sleep(0.2)\n" if parent_exits else "time.sleep(60)\n")
+    )
+    started = time.monotonic()
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            from plur_hermes.bridge import PlurBridge
+            PlurBridge()._invoke_cli([sys.executable, str(script), str(pidfile)], "status", timeout=1)
+        assert time.monotonic() - started < 4
+        gc_pid = int(pidfile.read_text())
+        for _ in range(50):
+            if _is_reaped(gc_pid): break
+            time.sleep(0.02)
+        assert _is_reaped(gc_pid)
+    finally:
+        if pidfile.exists(): _force_kill(int(pidfile.read_text()))

--- a/packages/hermes/test/test_memory_provider_entrypoint.py
+++ b/packages/hermes/test/test_memory_provider_entrypoint.py
@@ -47,8 +47,14 @@ def test_target_exposes_register():
     )
 
 
-def test_register_registers_a_provider():
+def test_register_registers_a_provider(monkeypatch, tmp_path):
     """Mimics Hermes' _ProviderCollector: register_memory_provider() just assigns."""
+    from plur_hermes.bridge import PlurBridge
+    # Discovery must not execute an installed CLI against the developer's
+    # personal store or contact configured remote services. CLI roundtrips
+    # have separate tests; this one exercises real entry-point registration.
+    monkeypatch.setenv("PLUR_PATH", str(tmp_path))
+    monkeypatch.setattr(PlurBridge, "status", lambda self: {"engram_count": 0})
     class Collector:
         def __init__(self):
             self.provider = None

--- a/packages/langchain/.gitignore
+++ b/packages/langchain/.gitignore
@@ -1,0 +1,4 @@
+build/
+dist/
+*.egg-info/
+__pycache__/

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -39,13 +39,23 @@ from plur_langchain import PlurMemory
 chain = ConversationChain(llm=llm, memory=PlurMemory())
 ```
 
-> **Note:** `PlurMemory` uses `BaseMemory`, which was removed in `langchain-core>=0.3`. Use `PlurChatMessageHistory` for modern LangChain.
+> Requires Python 3.10+ and patched LangChain Core 0.3 (`>=0.3.85,<0.4`).
+> `PlurMemory` retains the legacy `BaseMemory` interface, deprecated in Core 0.3
+> and removed in 1.0. Use `PlurChatMessageHistory` for LCEL. The older Core 0.2
+> dependency is no longer supported because it lacks serialization security fixes.
 
 ## How it works
 
 PLUR stores learned facts (engrams) locally in `~/.plur/`. On every chain invocation, relevant engrams are retrieved via semantic search and injected as context. Self-correction patterns in AI responses are captured and persisted — so the chain learns from its own mistakes.
 
-Your data never leaves your machine.
+Storage and retrieval default to local operation. Configured PLUR remotes,
+model providers, or LangChain tracing can send data to their configured services.
+
+Text blocks in multimodal messages participate in recall and learning; image
+URLs and other non-text blocks are not sent to the memory bridge. Failed reads,
+malformed recall responses and failed learning raise `PlurMemoryError` with a
+source-free message. Callers can handle that failure explicitly; an unavailable
+store is not reported as empty memory or a successful write.
 
 ## Links
 

--- a/packages/langchain/plur_langchain/__init__.py
+++ b/packages/langchain/plur_langchain/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from .chat_history import PlurChatMessageHistory
 from .memory import PlurMemory
+from ._utils import PlurMemoryError
 
 __version__ = "0.10.0"
-__all__ = ["PlurMemory", "PlurChatMessageHistory", "__version__"]
+__all__ = ["PlurMemory", "PlurChatMessageHistory", "PlurMemoryError", "__version__"]

--- a/packages/langchain/plur_langchain/_utils.py
+++ b/packages/langchain/plur_langchain/_utils.py
@@ -2,8 +2,34 @@
 from __future__ import annotations
 
 import os
+from typing import Any
+
+from langchain_core.messages import BaseMessage, HumanMessage
 
 from plur_ai import Plur  # type: ignore[import]
+
+from .learner import extract_learning_patterns
+
+
+class PlurMemoryError(RuntimeError):
+    """A memory operation failed; its result must not be treated as successful."""
+
+
+def message_text(value: Any) -> str:
+    """Extract text from supported message forms without copying image metadata."""
+    if isinstance(value, BaseMessage):
+        return value.text()
+    if isinstance(value, list):
+        return HumanMessage(content=value).text()
+    return "" if value is None else str(value)
+
+
+def learn_from_text(bridge: Plur, text: str, *, source: str, rationale: str) -> None:
+    for statement in extract_learning_patterns(text):
+        try:
+            bridge.learn(statement, source=source, rationale=rationale)
+        except Exception:
+            raise PlurMemoryError("PLUR memory learning failed; persistence was not confirmed") from None
 
 
 def make_bridge(plur_path: str | None = None) -> Plur:
@@ -16,14 +42,11 @@ def inject_to_text(bridge: Plur, task: str, budget: int = 1500) -> str:
     """Inject relevant engrams and return a formatted context string."""
     try:
         result = bridge.inject(task, budget=budget)
+        if not isinstance(result, dict):
+            raise ValueError("Invalid recall response")
+        sections = [result.get(key, "") for key in ("directives", "constraints", "consider")]
+        if any(s is not None and not isinstance(s, str) for s in sections):
+            raise ValueError("Invalid recall section")
     except Exception:
-        return ""
-    sections = [
-        s for s in (
-            result.get("directives", ""),
-            result.get("constraints", ""),
-            result.get("consider", ""),
-        )
-        if s and s.strip()
-    ]
-    return "\n".join(sections)
+        raise PlurMemoryError("PLUR memory recall failed; context is unavailable") from None
+    return "\n".join(s for s in sections if s and s.strip())

--- a/packages/langchain/plur_langchain/chat_history.py
+++ b/packages/langchain/plur_langchain/chat_history.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 from typing import Any, List, Sequence
+from threading import RLock
 
 from langchain_core.chat_history import BaseChatMessageHistory  # type: ignore[import]
 from langchain_core.messages import AIMessage, BaseMessage, SystemMessage  # type: ignore[import]
 
-from ._utils import inject_to_text, make_bridge
-from .learner import extract_learning_patterns
+from ._utils import inject_to_text, learn_from_text, make_bridge, message_text
 
 
 class PlurChatMessageHistory(BaseChatMessageHistory):
@@ -41,43 +41,54 @@ class PlurChatMessageHistory(BaseChatMessageHistory):
         self.inject_budget = inject_budget
         self.auto_learn = auto_learn
         self._bridge = make_bridge(plur_path)
+        self._lock = RLock()
         self._messages: list[BaseMessage] = []
         self._last_human_input: str = ""
 
     @property
     def messages(self) -> list[BaseMessage]:
-        if not self._last_human_input:
-            return list(self._messages)
-        context = inject_to_text(self._bridge, self._last_human_input, budget=self.inject_budget)
+        with self._lock:
+            last_input = self._last_human_input
+            snapshot = list(self._messages)
+        if not last_input:
+            return snapshot
+        context = inject_to_text(self._bridge, last_input, budget=self.inject_budget)
         if not context:
-            return list(self._messages)
+            return snapshot
         system_msg = SystemMessage(content=f"[Relevant memory]\n{context}")
-        return [system_msg] + list(self._messages)
+        return [system_msg] + snapshot
 
     def add_message(self, message: BaseMessage) -> None:
-        from langchain_core.messages import HumanMessage  # type: ignore[import]
-        if isinstance(message, HumanMessage):
-            self._last_human_input = message.content or ""
-        elif isinstance(message, AIMessage) and self.auto_learn:
-            self._learn_from_ai(str(message.content or ""))
-        self._messages.append(message)
+        self.add_messages([message])
 
     def add_messages(self, messages: Sequence[BaseMessage]) -> None:
-        for message in messages:
-            self.add_message(message)
+        from langchain_core.messages import HumanMessage  # type: ignore[import]
+        batch = list(messages)
+        last_input = None
+        learning_texts = []
+        for message in batch:
+            if not isinstance(message, BaseMessage):
+                raise TypeError("Chat history requires BaseMessage instances")
+            if isinstance(message, HumanMessage):
+                last_input = message_text(message)
+            elif isinstance(message, AIMessage) and self.auto_learn:
+                learning_texts.append(message_text(message))
+        # Complete fallible work before committing transcript state. Successful
+        # learn calls are individually durable; PLUR deduplicates them on retry.
+        for text in learning_texts:
+            self._learn_from_ai(text)
+        with self._lock:
+            self._messages.extend(batch)
+            if last_input is not None:
+                self._last_human_input = last_input
 
     def _learn_from_ai(self, text: str) -> None:
-        learnings = extract_learning_patterns(text)
-        for statement in learnings:
-            try:
-                self._bridge.learn(
-                    statement,
-                    source="langchain:PlurChatMessageHistory",
-                    rationale="Auto-extracted from LangChain AI message",
-                )
-            except Exception:
-                pass
+        learn_from_text(
+            self._bridge, text, source="langchain:PlurChatMessageHistory",
+            rationale="Auto-extracted from LangChain AI message",
+        )
 
     def clear(self) -> None:
-        self._messages.clear()
-        self._last_human_input = ""
+        with self._lock:
+            self._messages.clear()
+            self._last_human_input = ""

--- a/packages/langchain/plur_langchain/memory.py
+++ b/packages/langchain/plur_langchain/memory.py
@@ -5,8 +5,7 @@ from typing import Any, Optional
 
 from langchain_core.memory import BaseMemory  # type: ignore[import]
 
-from ._utils import inject_to_text, make_bridge
-from .learner import extract_learning_patterns
+from ._utils import inject_to_text, learn_from_text, make_bridge, message_text
 
 
 class PlurMemory(BaseMemory):
@@ -43,8 +42,8 @@ class PlurMemory(BaseMemory):
         return [self.memory_key]
 
     def load_memory_variables(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        task = inputs.get(self.input_key, "") or " ".join(str(v) for v in inputs.values())
-        context = inject_to_text(self._bridge, str(task), budget=self.inject_budget)
+        task = message_text(inputs.get(self.input_key, "")) or " ".join(message_text(v) for v in inputs.values())
+        context = inject_to_text(self._bridge, task, budget=self.inject_budget)
         if not context:
             return {self.memory_key: ""}
         return {self.memory_key: f"[Relevant memory]\n{context}"}
@@ -52,19 +51,13 @@ class PlurMemory(BaseMemory):
     def save_context(self, inputs: dict[str, Any], outputs: dict[str, Any]) -> None:
         if not self.auto_learn:
             return
-        response = outputs.get(self.output_key, "") or " ".join(str(v) for v in outputs.values())
+        response = message_text(outputs.get(self.output_key, "")) or " ".join(message_text(v) for v in outputs.values())
         if not response:
             return
-        learnings = extract_learning_patterns(str(response))
-        for statement in learnings:
-            try:
-                self._bridge.learn(
-                    statement,
-                    source="langchain:PlurMemory",
-                    rationale="Auto-extracted from LangChain chain output",
-                )
-            except Exception:
-                pass
+        learn_from_text(
+            self._bridge, response, source="langchain:PlurMemory",
+            rationale="Auto-extracted from LangChain chain output",
+        )
 
     def clear(self) -> None:
         pass

--- a/packages/langchain/pyproject.toml
+++ b/packages/langchain/pyproject.toml
@@ -7,7 +7,7 @@ name = "plur-langchain"
 version = "0.10.0"
 description = "LangChain memory adapter for PLUR — BaseMemory + BaseChatMessageHistory"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [{ name = "PLUR" }]
 keywords = ["memory", "agent-memory", "llm", "langchain", "local-first", "mcp", "ai-agents"]
@@ -16,12 +16,13 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "langchain-core>=0.2,<0.3",
+  "langchain-core>=0.3.85,<0.4",
+  "langsmith>=0.8.18,<1",
   "plur-ai>=0.10.0",
 ]
 

--- a/packages/langchain/tests/test_message_boundaries.py
+++ b/packages/langchain/tests/test_message_boundaries.py
@@ -1,0 +1,157 @@
+"""Valid multimodal input and visible, source-free dependency failures."""
+from unittest.mock import MagicMock, patch
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from plur_langchain import PlurChatMessageHistory, PlurMemory
+
+
+def history_with(bridge):
+    with patch("plur_langchain.chat_history.make_bridge", return_value=bridge):
+        return PlurChatMessageHistory()
+
+
+def memory_with(bridge):
+    with patch("plur_langchain.memory.make_bridge", return_value=bridge):
+        return PlurMemory()
+
+
+def blocks(text):
+    return [{"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "https://example.invalid/private-image"}}]
+
+
+def test_multimodal_human_input_recalls_using_only_text():
+    bridge = MagicMock()
+    bridge.inject.return_value = {"directives": "Remember deploy checks"}
+    history = history_with(bridge)
+    message = HumanMessage(content=blocks("deploy the service"))
+    history.add_message(message)
+    assert "Remember deploy checks" in history.messages[0].content
+    bridge.inject.assert_called_once_with("deploy the service", budget=1500)
+    assert history.messages[-1] is message
+
+
+def test_multimodal_ai_correction_is_learned_without_nontext_blocks():
+    bridge = MagicMock()
+    history = history_with(bridge)
+    text = "I was wrong about the deployment target."
+    history.add_message(AIMessage(content=blocks(text)))
+    bridge.learn.assert_called_once_with(
+        text, source="langchain:PlurChatMessageHistory",
+        rationale="Auto-extracted from LangChain AI message",
+    )
+
+
+def test_legacy_adapter_accepts_message_objects_and_content_blocks():
+    bridge = MagicMock()
+    bridge.inject.return_value = {"directives": "Keep deployment checks"}
+    memory = memory_with(bridge)
+    memory.load_memory_variables({"input": HumanMessage(content=blocks("deploy"))})
+    bridge.inject.assert_called_once_with("deploy", budget=1500)
+    text = "I was wrong about the deployment target."
+    memory.save_context({}, {"response": blocks(text)})
+    assert bridge.learn.call_args.args[0] == text
+
+
+def test_failed_recall_raises_without_leaking_error_details_and_recovers():
+    bridge = MagicMock()
+    bridge.inject.side_effect = [RuntimeError("synthetic-private-detail"), {"directives": "Recovered"}]
+    memory = memory_with(bridge)
+    with pytest.raises(RuntimeError, match="PLUR memory recall failed") as failure:
+        memory.load_memory_variables({"input": "deploy"})
+    assert "synthetic-private-detail" not in str(failure.value)
+    assert "Recovered" in memory.load_memory_variables({"input": "deploy"})["history"]
+
+
+@pytest.mark.parametrize("factory", [history_with, memory_with])
+def test_failed_learning_raises_without_claiming_persistence(factory):
+    bridge = MagicMock()
+    bridge.learn.side_effect = RuntimeError("synthetic-private-detail")
+    adapter = factory(bridge)
+    text = "I was wrong about the deployment target."
+    with pytest.raises(RuntimeError, match="PLUR memory learning failed") as failure:
+        if isinstance(adapter, PlurMemory):
+            adapter.save_context({}, {"response": text})
+        else:
+            adapter.add_message(AIMessage(content=text))
+    assert "synthetic-private-detail" not in str(failure.value)
+
+
+@pytest.mark.parametrize("response", [None, [], {"directives": ["invalid"]}])
+def test_malformed_recall_responses_are_visible_failures(response):
+    bridge = MagicMock()
+    bridge.inject.return_value = response
+    with pytest.raises(RuntimeError, match="PLUR memory recall failed"):
+        memory_with(bridge).load_memory_variables({"input": "deploy"})
+
+
+def test_failed_batch_preserves_history_and_retry_does_not_duplicate_prefix():
+    bridge = MagicMock()
+    history = history_with(bridge)
+    prior = HumanMessage(content="previous task")
+    history.add_message(prior)
+    batch = [HumanMessage(content="new task"),
+             AIMessage(content="I was wrong about the deployment target.")]
+    bridge.learn.side_effect = RuntimeError("storage unavailable")
+    with pytest.raises(RuntimeError):
+        history.add_messages(batch)
+    assert history._messages == [prior]
+    assert history._last_human_input == "previous task"
+    bridge.learn.side_effect = None
+    history.add_messages(batch)
+    assert history._messages == [prior, *batch]
+    assert history._last_human_input == "new task"
+
+
+def test_concurrent_recall_uses_a_coherent_history_snapshot():
+    bridge = MagicMock()
+    history = history_with(bridge)
+    prior = HumanMessage(content="previous task")
+    history.add_message(prior)
+    started, release = Event(), Event()
+
+    def recall(task, **kwargs):
+        assert task == "previous task"
+        started.set()
+        assert release.wait(5)
+        return {"directives": "Context for previous task"}
+
+    bridge.inject.side_effect = recall
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        result = pool.submit(lambda: history.messages)
+        try:
+            assert started.wait(5)
+            history.add_message(HumanMessage(content="concurrent new task"))
+        finally:
+            release.set()
+        snapshot = result.result(timeout=5)
+    assert [m.content for m in snapshot] == ["[Relevant memory]\nContext for previous task", "previous task"]
+    assert history._last_human_input == "concurrent new task"
+
+
+def test_pending_ai_learning_does_not_overwrite_a_new_human_turn():
+    bridge = MagicMock()
+    history = history_with(bridge)
+    started, release = Event(), Event()
+
+    def learn(*args, **kwargs):
+        started.set()
+        assert release.wait(5)
+
+    bridge.learn.side_effect = learn
+    ai = AIMessage(content="I was wrong about the deployment target.")
+    human = HumanMessage(content="concurrent new task")
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        result = pool.submit(history.add_message, ai)
+        try:
+            assert started.wait(5)
+            history.add_message(human)
+        finally:
+            release.set()
+        result.result(timeout=5)
+    assert history._messages == [human, ai]
+    assert history._last_human_input == "concurrent new task"

--- a/packages/langchain/tests/test_security_compatibility.py
+++ b/packages/langchain/tests/test_security_compatibility.py
@@ -1,0 +1,51 @@
+"""Security and API contracts for the supported LangChain dependency line."""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.load import dumps, loads
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables import RunnableLambda
+from langchain_core.runnables.history import RunnableWithMessageHistory
+
+from plur_langchain import PlurChatMessageHistory, PlurMemory
+
+
+@pytest.mark.parametrize("field", ["additional_kwargs", "response_metadata"])
+@pytest.mark.parametrize("kind", ["secret", "constructor"])
+def test_message_serialization_preserves_untrusted_markers_as_data(monkeypatch, field, kind):
+    monkeypatch.setenv("PLUR_TEST_SERIALIZATION_CANARY", "synthetic-canary-value")
+    marker = {"lc": 1, "type": "secret", "id": ["PLUR_TEST_SERIALIZATION_CANARY"]}
+    constructor = {"lc": 1, "type": "constructor",
+                   "id": ["untrusted", "NeverConstruct"], "kwargs": {}}
+    payload = {"nested": [marker if kind == "secret" else constructor]}
+    message = AIMessage(content="ordinary response", **{field: payload})
+    # Trusting our own serialization must not turn message metadata into code
+    # or secret lookups, even when a caller explicitly enables env secrets.
+    restored = loads(dumps(message), secrets_from_env=True)
+    assert isinstance(restored, AIMessage)
+    assert getattr(restored, field) == payload
+    assert "synthetic-canary-value" not in json.dumps(getattr(restored, field))
+
+
+def test_runnable_history_preserves_messages_and_legacy_adapter_contract():
+    bridge = MagicMock()
+    bridge.inject.return_value = {"directives": "", "constraints": "", "consider": ""}
+    with patch("plur_langchain.chat_history.make_bridge", return_value=bridge):
+        history = PlurChatMessageHistory(session_id="test-session", auto_learn=False)
+    chain = RunnableWithMessageHistory(
+        RunnableLambda(lambda inputs: AIMessage(content="reply to " + inputs["input"])),
+        lambda session_id: history,
+        input_messages_key="input", history_messages_key="chat_history",
+    )
+    config = {"configurable": {"session_id": "test-session"}}
+    assert chain.invoke({"input": "first"}, config=config).content == "reply to first"
+    assert chain.invoke({"input": "second"}, config=config).content == "reply to second"
+    assert [m.content for m in history.messages] == [
+        "first", "reply to first", "second", "reply to second",
+    ]
+    assert isinstance(history.messages[0], HumanMessage)
+    with patch("plur_langchain.memory.make_bridge", return_value=bridge):
+        memory = PlurMemory(memory_key="context")
+    assert memory.memory_variables == ["context"]
+    assert memory.load_memory_variables({"input": "first"}) == {"context": ""}

--- a/packages/migrate/src/files.d.ts
+++ b/packages/migrate/src/files.d.ts
@@ -1,0 +1,1 @@
+export declare function replaceSource(file: string, original: string, next: string): void

--- a/packages/migrate/src/files.js
+++ b/packages/migrate/src/files.js
@@ -1,0 +1,44 @@
+import * as fs from 'node:fs'
+import { dirname } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+/** Standalone codemod persistence: do not pull the memory engine into this CLI. */
+/** @param {string} file @param {string} original @param {string} next */
+export function replaceSource(file, original, next) {
+  const before = fs.lstatSync(file)
+  if (!before.isFile() || before.nlink !== 1) throw new Error('Source must be an unlinked regular file')
+  const temporary = `${file}.${randomUUID()}.tmp`
+  let owned = false
+  try {
+    const fd = fs.openSync(temporary, 'wx', 0o600)
+    owned = true
+    try {
+      fs.fchmodSync(fd, before.mode & 0o777)
+      fs.writeFileSync(fd, next, 'utf8')
+      fs.fsyncSync(fd)
+    } finally { fs.closeSync(fd) }
+    // Catch editor changes and replaced links while staging. Editors do not
+    // participate in our locks, so callers should run --write on a quiet tree.
+    const current = fs.lstatSync(file)
+    if (!current.isFile() || current.nlink !== 1 || current.dev !== before.dev || current.ino !== before.ino ||
+        current.mode !== before.mode || !fs.readFileSync(file).equals(Buffer.from(original, 'utf8'))) {
+      throw new Error('Source changed during rewrite')
+    }
+    fs.renameSync(temporary, file)
+    let directory
+    try {
+      directory = fs.openSync(dirname(file), 'r')
+      fs.fsyncSync(directory)
+    } catch (error) {
+      const code = /** @type {{ code?: string }} */ (error).code ?? ''
+      if (!['EINVAL', 'ENOTSUP', 'EOPNOTSUPP'].includes(code) &&
+          !(process.platform === 'win32' && ['EPERM', 'EACCES', 'EISDIR'].includes(code))) throw error
+    } finally { if (directory !== undefined) fs.closeSync(directory) }
+  } finally {
+    if (owned) {
+      try { fs.unlinkSync(temporary) } catch (error) {
+        if (/** @type {{ code?: string }} */ (error).code !== 'ENOENT') throw error
+      }
+    }
+  }
+}

--- a/packages/migrate/src/index.ts
+++ b/packages/migrate/src/index.ts
@@ -6,9 +6,10 @@
  * codemods that did this migration inside PLUR itself were wrong in ways no
  * test caught before they were right. See `scan.ts` for the specific hazards.
  */
-import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs'
+import { readFileSync, readdirSync, lstatSync } from 'node:fs'
 import { join, relative, extname } from 'node:path'
 import { scanSource, applyFixes, NEWLY_ASYNC, type Finding } from './scan.js'
+import { replaceSource } from './files.js'
 
 const HELP = `plur-migrate — find PLUR calls left un-awaited by the 0.16 async migration
 
@@ -30,6 +31,9 @@ OPTIONS
   --write        apply fixes (default: report only)
   --ext .ts,.js  file extensions to scan (default: .ts,.tsx,.js,.mjs,.cjs)
   --help         this
+
+Run --write on a quiet working tree. Symlinks and hard-linked source files
+are refused; an incomplete scan or failed replacement exits non-zero.
 `
 
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git', 'coverage', '.next'])
@@ -44,14 +48,14 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git', 'coverage', 
 const PREFILTER = new RegExp(String.raw`\.\s*(?:${NEWLY_ASYNC.join('|')})\s*\(`)
 
 function walk(dir: string, exts: Set<string>, out: string[] = []): string[] {
-  let entries
-  try { entries = readdirSync(dir, { withFileTypes: true }) } catch { return out }
+  const entries = readdirSync(dir, { withFileTypes: true })
   for (const e of entries) {
     const p = join(dir, e.name)
     if (e.isDirectory()) {
       if (SKIP_DIRS.has(e.name)) continue
       walk(p, exts, out)
     } else if (exts.has(extname(e.name))) {
+      if (!e.isFile()) throw new Error('Source is not a regular file')
       out.push(p)
     }
   }
@@ -74,7 +78,9 @@ export function run(argv: string[]): number {
 
   let files: string[]
   try {
-    files = statSync(root).isDirectory() ? walk(root, exts) : [root]
+    const entry = lstatSync(root)
+    if (!entry.isDirectory() && !entry.isFile()) throw new Error('Source is not a regular file')
+    files = entry.isDirectory() ? walk(root, exts) : [root]
   } catch {
     process.stderr.write(`plur-migrate: cannot read ${root}\n`)
     return 1
@@ -82,9 +88,17 @@ export function run(argv: string[]): number {
 
   const all: Finding[] = []
   let changed = 0
+  let failed = false
   for (const f of files) {
     let src: string
-    try { src = readFileSync(f, 'utf8') } catch { continue }
+    try {
+      if (!lstatSync(f).isFile()) throw new Error('Source is not a regular file')
+      src = readFileSync(f, 'utf8')
+    } catch {
+      process.stderr.write(`plur-migrate: cannot read source ${f}\n`)
+      failed = true
+      continue
+    }
     // Cheap pre-filter, DERIVED from the method table rather than hand-written.
     //
     // It used to list ten names while `NEWLY_ASYNC` held twenty-eight, so a file
@@ -102,12 +116,21 @@ export function run(argv: string[]): number {
     if (write) {
       const { src: next, applied } = applyFixes(src, findings)
       if (applied > 0) {
-        writeFileSync(f, next)
-        changed++
+        try {
+          replaceSource(f, src, next)
+          changed++
+        } catch {
+          process.stderr.write(`plur-migrate: rewrite failed for ${f}; inspect source before retrying\n`)
+          failed = true
+        }
       }
     }
   }
 
+  if (failed) {
+    process.stderr.write('plur-migrate: incomplete scan or rewrite; no clean result.\n')
+    return 1
+  }
   if (all.length === 0) {
     process.stdout.write('plur-migrate: no un-awaited PLUR calls found.\n')
     return 0

--- a/packages/migrate/test/file-safety.test.ts
+++ b/packages/migrate/test/file-safety.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { run } from '../src/index.js'
+
+vi.mock('node:fs', async importOriginal => ({ ...await importOriginal<typeof fs>() }))
+
+let root: string
+const source = 'async function f() { plur.recall("memory"); }\n'
+beforeEach(() => {
+  root = fs.mkdtempSync(join(tmpdir(), 'plur-codemod-safety-'))
+  vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+  vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+})
+afterEach(() => { vi.restoreAllMocks(); fs.rmSync(root, { recursive: true, force: true }) })
+
+it('does not follow source-file symlinks during a directory rewrite', () => {
+  const project = join(root, 'project'); fs.mkdirSync(project)
+  const outside = join(root, 'outside.ts'); fs.writeFileSync(outside, source)
+  fs.symlinkSync(outside, join(project, 'linked.ts'))
+  expect(run([project, '--write'])).toBe(1)
+  expect(fs.readFileSync(outside, 'utf8')).toBe(source)
+  expect(fs.lstatSync(join(project, 'linked.ts')).isSymbolicLink()).toBe(true)
+})
+
+it('refuses an explicitly supplied symlink without modifying its target', () => {
+  const original = join(root, 'original.ts'); const link = join(root, 'linked.ts')
+  fs.writeFileSync(original, source); fs.symlinkSync(original, link)
+  expect(run([link, '--write'])).toBe(1)
+  expect(fs.readFileSync(original, 'utf8')).toBe(source)
+})
+
+it('reports an incomplete scan when a source file cannot be read', () => {
+  const file = join(root, 'source.ts'); fs.writeFileSync(file, source)
+  const original = fs.readFileSync
+  vi.spyOn(fs, 'readFileSync').mockImplementation(((path: any, ...args: any[]) => {
+    if (path === file) throw Object.assign(new Error('unreadable'), { code: 'EACCES' })
+    return (original as any)(path, ...args)
+  }) as any)
+  expect(run([root])).toBe(1)
+  expect(process.stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('no un-awaited'))
+})
+
+it('preserves original bytes and permissions when replacement fails', () => {
+  const file = join(root, 'source.ts'); fs.writeFileSync(file, source, { mode: 0o640 })
+  vi.spyOn(fs, 'renameSync').mockImplementation(() => { throw Object.assign(new Error('I/O error'), { code: 'EIO' }) })
+  expect(run([file, '--write'])).toBe(1)
+  expect(fs.readFileSync(file, 'utf8')).toBe(source)
+  expect(fs.statSync(file).mode & 0o777).toBe(0o640)
+  expect(fs.readdirSync(root)).toEqual(['source.ts'])
+})
+
+it('flushes staged bytes before replacing and preserves executable mode', () => {
+  const file = join(root, 'source.ts'); fs.writeFileSync(file, source, { mode: 0o750 })
+  const sync = vi.spyOn(fs, 'fsyncSync'); const rename = vi.spyOn(fs, 'renameSync')
+  expect(run([file, '--write'])).toBe(0)
+  expect(fs.readFileSync(file, 'utf8')).toContain('await plur.recall')
+  expect(fs.statSync(file).mode & 0o777).toBe(0o750)
+  expect(sync.mock.invocationCallOrder[0]).toBeLessThan(rename.mock.invocationCallOrder[0])
+  expect(fs.readdirSync(root)).toEqual(['source.ts'])
+  expect(run([file, '--write'])).toBe(0)
+})
+
+it('refuses to overwrite a file changed while its replacement was staged', () => {
+  const file = join(root, 'source.ts'); fs.writeFileSync(file, source)
+  const changed = '// concurrent edit\n' + source
+  const original = fs.fsyncSync; let injected = false
+  vi.spyOn(fs, 'fsyncSync').mockImplementation(fd => {
+    if (!injected) { injected = true; fs.writeFileSync(file, changed) }
+    return original(fd)
+  })
+  expect(run([file, '--write'])).toBe(1)
+  expect(fs.readFileSync(file, 'utf8')).toBe(changed)
+  expect(fs.readdirSync(root)).toEqual(['source.ts'])
+})
+
+it('refuses hard links without changing either source name', () => {
+  const file = join(root, 'source.ts'); const alias = join(root, 'alias.ts')
+  fs.writeFileSync(file, source); fs.linkSync(file, alias)
+  expect(run([file, '--write'])).toBe(1)
+  expect(fs.readFileSync(file, 'utf8')).toBe(source)
+  expect(fs.readFileSync(alias, 'utf8')).toBe(source)
+})
+
+it('preserves source bytes when staging fails after a partial write', () => {
+  const file = join(root, 'source.ts'); fs.writeFileSync(file, source)
+  const original = fs.writeFileSync
+  vi.spyOn(fs, 'writeFileSync').mockImplementation(((path: any, data: any, ...args: any[]) => {
+    if (typeof path === 'number') { original(path, 'partial'); throw new Error('disk full') }
+    return (original as any)(path, data, ...args)
+  }) as any)
+  expect(run([file, '--write'])).toBe(1)
+  expect(fs.readFileSync(file, 'utf8')).toBe(source)
+  expect(fs.readdirSync(root)).toEqual(['source.ts'])
+})
+
+it('does not report a failed directory scan as clean', () => {
+  vi.spyOn(fs, 'readdirSync').mockImplementation(() => { throw new Error('unreadable') })
+  expect(run([root])).toBe(1)
+  expect(process.stdout.write).not.toHaveBeenCalled()
+})
+
+it('refuses to rewrite non-UTF-8 source instead of replacing undecodable bytes', () => {
+  const file = join(root, 'source.ts')
+  const bytes = Buffer.concat([Buffer.from('// '), Buffer.from([0xff]), Buffer.from('\n' + source)])
+  fs.writeFileSync(file, bytes)
+  expect(run([file, '--write'])).toBe(1)
+  expect(fs.readFileSync(file)).toEqual(bytes)
+})

--- a/packages/migrate/test/method-list.test.ts
+++ b/packages/migrate/test/method-list.test.ts
@@ -48,6 +48,8 @@ const ALWAYS_ASYNC = new Set([
   'checkRemoteHealth', 'discoverRemoteScopes', 'registerDiscoveredScopes',
   'registerScope', 'offerableScopes', 'warmRemoteCaches', 'waitForIndex',
   'reportFailure', 'ready',
+  // New async import entry point; it never had synchronous callers.
+  'learnImported',
   // Born async (#676) — never had a sync form, so there is no pre-0.16
   // call site for the migrate tool to rewrite.
   'rescope',

--- a/packages/python/plur_ai/bridge.py
+++ b/packages/python/plur_ai/bridge.py
@@ -19,6 +19,7 @@ import shlex
 import shutil
 import signal
 import subprocess
+import time
 from typing import Any, Sequence
 
 # @plur-ai/cli pin for the npx fallback. Keep >= the published CLI that carries
@@ -86,23 +87,33 @@ def _kill_process_group(proc: "subprocess.Popen[str]") -> None:
     if os.name != "posix":
         proc.kill()
         return
-    try:
-        pgid = os.getpgid(proc.pid)
-    except ProcessLookupError:
-        return
+    # start_new_session=True fixes the group ID at creation. The parent can
+    # already be reaped while a grandchild still owns our stdout pipe.
+    pgid = proc.pid
     try:
         os.killpg(pgid, signal.SIGTERM)
     except ProcessLookupError:
         return
-    try:
-        proc.wait(timeout=0.5)  # brief grace for SIGTERM before escalating
-        return
-    except subprocess.TimeoutExpired:
-        pass
+    # Do not reap the group leader until after signalling the group: reaping
+    # frees its PID for reuse and can make the next signal target another job.
+    time.sleep(0.5)
+    # Parent exit is not proof that the group exited. Descendants can ignore
+    # TERM; always finish group teardown even when wait() returned immediately.
     try:
         os.killpg(pgid, signal.SIGKILL)
     except ProcessLookupError:
         pass
+    except PermissionError:
+        # macOS returns EPERM for a group containing only an unreaped zombie.
+        # Reap our exited leader, then prove the group is gone. A live group
+        # or a real permission failure still propagates; never claim cleanup.
+        if proc.poll() is None:
+            raise
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        raise
 
 
 def _run_in_process_group(
@@ -134,7 +145,10 @@ def _run_in_process_group(
             stdout, stderr = proc.communicate(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
-            stdout, stderr = proc.communicate()
+            proc.wait(timeout=5)
+            if proc.stdout: proc.stdout.close()
+            if proc.stderr: proc.stderr.close()
+            stdout, stderr = "", ""
         raise subprocess.TimeoutExpired(cmd, timeout, output=stdout, stderr=stderr)
     return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
 

--- a/packages/python/tests/test_bridge_process_group.py
+++ b/packages/python/tests/test_bridge_process_group.py
@@ -98,3 +98,31 @@ def test_timeout_reaps_grandchild(tmp_path, monkeypatch):
         )
     finally:
         _force_kill(gc_pid)  # never leak a real 600s sleeper
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group semantics")
+@pytest.mark.parametrize("parent_exits", [False, True])
+def test_timeout_kills_term_ignoring_pipe_owner(tmp_path, parent_exits):
+    import subprocess
+    script = tmp_path / "parent.py"
+    pidfile = tmp_path / "gc.pid"
+    child_code = "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+    script.write_text(
+        "import subprocess,sys,time\n"
+        + f"p = subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+        + "open(sys.argv[1], 'w').write(str(p.pid))\n"
+        + ("time.sleep(0.2)\n" if parent_exits else "time.sleep(60)\n")
+    )
+    started = time.monotonic()
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            from plur_ai.bridge import _run_in_process_group
+            _run_in_process_group([sys.executable, str(script), str(pidfile)], env=dict(os.environ), timeout=1)
+        assert time.monotonic() - started < 4
+        gc_pid = int(pidfile.read_text())
+        for _ in range(50):
+            if _is_reaped(gc_pid): break
+            time.sleep(0.02)
+        assert _is_reaped(gc_pid)
+    finally:
+        if pidfile.exists(): _force_kill(int(pidfile.read_text()))

--- a/packages/ui/src/server.ts
+++ b/packages/ui/src/server.ts
@@ -81,7 +81,7 @@ function revealFolder(path: string): void {
     : 'xdg-open'
   try {
     // The path is the store root the host resolved, never request input.
-    spawn(command, [path], { stdio: 'ignore', detached: true }).unref()
+    spawn(command, [path], { stdio: 'ignore', detached: true }).on('error', () => { /* optional desktop integration unavailable */ }).unref()
   } catch {
     // No file manager. The path is on screen either way.
   }
@@ -314,7 +314,14 @@ export function createUiServer(opts: UiServerOptions): Server {
         'referrer-policy': 'no-referrer',
       }
 
-      const url = new URL(req.url ?? '/', 'http://localhost')
+      let url: URL
+      try {
+        url = new URL(req.url ?? '/', 'http://localhost')
+      } catch {
+        res.writeHead(400, headers)
+        res.end(errorPage('Invalid request URL.'))
+        return
+      }
 
       // Rebinding check: catches a DNS-rebound request whose `Host` header
       // carries the attacker's domain. ALWAYS applied — a widened bind adds

--- a/packages/ui/test/audit-desktop-error.test.ts
+++ b/packages/ui/test/audit-desktop-error.test.ts
@@ -1,0 +1,24 @@
+import { expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { createUiServer } from '../src/server.js'
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => {
+    const child = new EventEmitter() as EventEmitter & { unref(): void }
+    child.unref = () => {}
+    queueMicrotask(() => child.emit('error', Object.assign(new Error('desktop executable absent'), { code: 'ENOENT' })))
+    return child
+  }),
+}))
+
+it('survives an asynchronous failure from the optional desktop launcher', async () => {
+  const server = createUiServer({ load: async () => [], where: '', openPath: '/tmp/audit-disposable' })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('no local address')
+  const base = `http://127.0.0.1:${address.port}`
+  try {
+    expect((await fetch(`${base}/open-store`, { method: 'POST', headers: { origin: base }, redirect: 'manual' })).status).toBe(303)
+    expect((await fetch(base)).status).toBe(200)
+  } finally { await new Promise<void>(resolve => server.close(() => resolve())) }
+})

--- a/packages/ui/test/server.test.ts
+++ b/packages/ui/test/server.test.ts
@@ -68,6 +68,15 @@ describe('startViewer', () => {
 })
 
 describe('the shared server', () => {
+  it('rejects a malformed request target and continues serving', async () => {
+    const viewer = await startViewer({ load: async () => ROWS, where: '' })
+    try {
+      const port = Number(new URL(viewer.url).port)
+      const response = await rawGet(port, '//[invalid', { host: `127.0.0.1:${port}` })
+      expect(response.status).toBe(400)
+      expect((await fetch(viewer.url)).status).toBe(200)
+    } finally { await viewer.close() }
+  })
   it('is the same implementation the CLI serves', async () => {
     // Regression guard for the split: if this drifts from the CLI's route
     // table, one of the two hosts is serving a different viewer.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   js-yaml: '>=4.3.1 <5'
   linkify-it: '>=5.0.1'
   minimatch: '>=10.0.3'
+  nanoid@3: '>=3.3.18 <4'
   openclaw: '>=2026.6.5'
   path-to-regexp: '>=8.4.0'
   postcss: '>=8.5.18 <9'
@@ -97,6 +98,9 @@ importers:
       js-yaml:
         specifier: '>=4.3.1 <5'
         version: 4.3.1
+      tar:
+        specifier: '>=7.5.21'
+        version: 7.5.22
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -2032,8 +2036,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4762,7 +4766,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -5030,7 +5034,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/scripts/add-awaits.mjs
+++ b/scripts/add-awaits.mjs
@@ -28,6 +28,7 @@
  *   node scripts/add-awaits.mjs --methods a,b,c <glob-root> [--dry]
  */
 import * as fs from 'fs'
+import { replaceSource } from '../packages/migrate/src/files.js'
 import * as path from 'path'
 
 const args = process.argv.slice(2)
@@ -153,7 +154,7 @@ for (const root of roots) {
       }
       if (done) break
     }
-    if (src !== before0) { files++; if (!DRY) fs.writeFileSync(file, src) }
+    if (src !== before0) { files++; if (!DRY) replaceSource(file, before0, src) }
   }
 }
 console.log(`${DRY ? '[dry] ' : ''}rewrote ${sites} call site(s) across ${files} file(s)`)

--- a/scripts/async-codemod.mjs
+++ b/scripts/async-codemod.mjs
@@ -34,6 +34,7 @@
  *   node scripts/async-codemod.mjs <file> [--seed name,name] [--dry]
  */
 import * as fs from 'fs'
+import { replaceSource } from '../packages/migrate/src/files.js'
 
 const [, , file, ...rest] = process.argv
 if (!file) { console.error('usage: async-codemod.mjs <file> [--seed a,b] [--dry]'); process.exit(1) }
@@ -41,6 +42,7 @@ const DRY = rest.includes('--dry')
 const seedArg = rest.includes('--seed') ? rest[rest.indexOf('--seed') + 1] : ''
 
 let src = fs.readFileSync(file, 'utf8')
+const original = src
 
 /** Class members are declared at exactly two spaces of indent in this codebase. */
 const MEMBER = /^ {2}(?:(private|public|protected|readonly)\s+)*(?:(async)\s+)?(?:(get|set)\s+)?([A-Za-z_$][\w$]*)\s*(?:<[^>]*>)?\s*\(/
@@ -150,6 +152,6 @@ src = src.replace(/await (this\.[\w$]+\([^()]*\))\s*\./g, '(await $1).')
 src = src.replace(/await (this\._primaryStore\.\w+\([^()]*\))\s*\./g, '(await $1).')
 
 if (DRY) { console.log(`[dry] rounds=${round} asyncSet=${asyncSet.size}`); process.exit(0) }
-fs.writeFileSync(file, src)
+replaceSource(file, original, src)
 console.log(`rounds=${round}  async methods now: ${asyncSet.size}`)
 console.log([...asyncSet].sort().join(', '))

--- a/scripts/async-mocks.mjs
+++ b/scripts/async-mocks.mjs
@@ -23,6 +23,7 @@
  * Usage: node scripts/async-mocks.mjs --members a,b,c <root...> [--dry]
  */
 import * as fs from 'fs'
+import { replaceSource } from '../packages/migrate/src/files.js'
 import * as path from 'path'
 
 const args = process.argv.slice(2)
@@ -63,7 +64,7 @@ for (const root of roots) {
       hits++
       return `${indent}async ${name}${rest}`
     })
-    if (out !== src) { files++; if (!DRY) fs.writeFileSync(f, out) }
+    if (out !== src) { files++; if (!DRY) replaceSource(f, src, out) }
   }
 }
 console.log(`${DRY ? '[dry] ' : ''}made ${hits} member(s) async across ${files} file(s)`)

--- a/scripts/await-local-helpers.mjs
+++ b/scripts/await-local-helpers.mjs
@@ -17,6 +17,7 @@
  * Usage: node scripts/await-local-helpers.mjs <root...> [--dry]
  */
 import * as fs from 'fs'
+import { replaceSource } from '../packages/migrate/src/files.js'
 import * as path from 'path'
 
 const args = process.argv.slice(2)
@@ -85,7 +86,7 @@ for (const root of roots) {
       }
       if (done) break
     }
-    if (src !== before) { files++; if (!DRY) fs.writeFileSync(f, src) }
+    if (src !== before) { files++; if (!DRY) replaceSource(f, before, src) }
   }
 }
 console.log(`${DRY ? '[dry] ' : ''}awaited ${sites} local-helper call(s) across ${files} file(s)`)

--- a/scripts/check-workflow-pins.py
+++ b/scripts/check-workflow-pins.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Fail CI when an external action is executable through a mutable reference."""
+import re
+from pathlib import Path
+
+
+def violations(root: Path):
+    for workflow in sorted((root / '.github/workflows').glob('*.y*ml')):
+        for number, line in enumerate(workflow.read_text().splitlines(), 1):
+            match = re.match(r'\s*(?:-\s*)?uses:\s*([^\s#]+)', line)
+            if not match:
+                continue
+            reference = match[1]
+            if reference.startswith('./'):
+                continue
+            if not re.fullmatch(r'[\w.-]+/[\w./-]+@[0-9a-f]{40}', reference):
+                yield f'{workflow.relative_to(root)}:{number}: external action must use a full commit SHA: {reference}'
+
+
+if __name__ == '__main__':
+    errors = list(violations(Path(__file__).resolve().parents[1]))
+    if errors:
+        raise SystemExit('\n'.join(errors))
+    print('All external workflow actions use immutable commit IDs.')

--- a/scripts/fix-await-scopes.mjs
+++ b/scripts/fix-await-scopes.mjs
@@ -20,6 +20,7 @@
  * Usage: node scripts/fix-await-scopes.mjs <tsc-command...>
  */
 import * as fs from 'fs'
+import { replaceSource } from '../packages/migrate/src/files.js'
 import { execSync } from 'child_process'
 
 const cmd = process.argv.slice(2).join(' ')
@@ -143,13 +144,14 @@ for (;;) {
 
   let fixed = 0
   for (const [file, lineSet] of byFile) {
-    const lines = fs.readFileSync(file, 'utf8').split('\n')
+    const original = fs.readFileSync(file, 'utf8')
+    const lines = original.split('\n')
     // Bottom-up so earlier edits cannot shift later line numbers.
     for (const ln of [...lineSet].sort((a, b) => b - a)) {
       const fn = enclosing(lines, ln)
       if (fn >= 0 && markAsync(lines, fn)) fixed++
     }
-    fs.writeFileSync(file, lines.join('\n'))
+    replaceSource(file, original, lines.join('\n'))
   }
   console.log(`round ${round}: ${errs.length} TS1308 -> marked ${fixed} function(s) async`)
   if (fixed === 0) { console.error('made no progress; remaining sites need a human'); process.exit(1) }

--- a/scripts/fix-throw-assertions.mjs
+++ b/scripts/fix-throw-assertions.mjs
@@ -24,6 +24,7 @@
  * Usage: node scripts/fix-throw-assertions.mjs --methods a,b,c <root...> [--dry]
  */
 import * as fs from 'fs'
+import { replaceSource } from '../packages/migrate/src/files.js'
 import * as path from 'path'
 
 const args = process.argv.slice(2)
@@ -93,7 +94,7 @@ for (const root of roots) {
       }
     }
     src = src.replace(/expectSKIP\(/g, 'expect(')
-    if (src !== before) { files++; if (!DRY) fs.writeFileSync(f, src) }
+    if (src !== before) { files++; if (!DRY) replaceSource(f, before, src) }
   }
 }
 console.log(`${DRY ? '[dry] ' : ''}converted ${pos} toThrow + ${neg} not.toThrow across ${files} file(s)`)

--- a/spec/ENGRAM-STANDARD-v1.md
+++ b/spec/ENGRAM-STANDARD-v1.md
@@ -511,7 +511,7 @@ engram: the spec has two mechanisms and no rule for choosing between them*.
 | `provenance.origin` | string (R within object) | | Where this engram came from. |
 | `provenance.chain` | string[] | default `[]` | Derivation/transfer chain. |
 | `provenance.signature` | string \| null | default `null` | **RESERVED.** Detached signature over the engram. Algorithm and canonicalization are NOT specified in v1 (§7). Producers MUST write `null`; consumers MUST round-trip whatever value is present without ascribing trust to it. |
-| `provenance.license` | string | default `cc-by-sa-4.0` | License of this engram's content. |
+| `provenance.license` | string | optional | Explicitly chosen license. When absent, effective policy defaults to `cc-by-sa-4.0` without recording a choice. |
 
 **Who is answerable, and what kind of claim it is — PROPOSED (#961, #963)**
 

--- a/spec/engram.schema.json
+++ b/spec/engram.schema.json
@@ -361,8 +361,7 @@
           "description": "RESERVED. Detached signature over the engram. Algorithm and canonicalization not yet specified — see ENGRAM-STANDARD-v1.md §7."
         },
         "license": {
-          "type": "string",
-          "default": "cc-by-sa-4.0"
+          "type": "string"
         }
       },
       "required": [
@@ -763,6 +762,10 @@
               "null"
             ],
             "default": null
+          },
+          "source": {
+            "type": "string",
+            "description": "Caller-supplied origin of this write; retained across duplicate absorption."
           },
           "stored_at": {
             "type": "string",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from 'vitest/config'
+import { SPAWN_SUITES } from './packages/cli/vitest.config.js'
+import { PGLITE_SUITES, CORE_PROCESS_SUITES } from './packages/core/vitest.config.js'
 
 // Replaces vitest.workspace.ts (audit fix, 2026-07-09): that file was being
 // silently ignored by this vitest version (4.1.1) — confirmed empirically by
@@ -34,6 +36,19 @@ export default defineConfig({
       'packages/migrate',
       {
         test: {
+          name: 'core-process',
+          root: 'packages/core',
+          globals: true,
+          include: CORE_PROCESS_SUITES,
+          fileParallelism: false,
+          sequence: { groupOrder: 1 },
+          setupFiles: ['test/helpers/reset-remote-breaker-setup.ts'],
+          testTimeout: 30000,
+          hookTimeout: 30000,
+        },
+      },
+      {
+        test: {
           // Same shape as core-pglite, same reason: contention, not defects.
           // These four spawn real CLI processes and wait on their exit against
           // fixed 5s/30s budgets. In the fully-parallel pool the spawns starve
@@ -49,19 +64,7 @@ export default defineConfig({
           name: 'cli-spawn',
           root: 'packages/cli',
           globals: true,
-          // Keep in sync with SPAWN_SUITES in packages/cli/vitest.config.ts.
-          include: [
-            'test/hook-learn-check.test.ts',
-            'test/hook-session-guard.test.ts',
-            'test/list.test.ts',
-            'test/tensions-lifecycle.test.ts',
-            'test/import.test.ts',
-            'test/readonly-commands.test.ts',
-            'test/recall.test.ts',
-            'test/rescope.test.ts',
-            'test/sync.test.ts',
-            'test/timeline.test.ts',
-          ],
+          include: SPAWN_SUITES,
           // The whole point: one file at a time, so no two batches of CLI
           // processes are spawning concurrently.
           fileParallelism: false,
@@ -77,14 +80,7 @@ export default defineConfig({
           name: 'core-pglite',
           root: 'packages/core',
           globals: true,
-          // Keep in sync with PGLITE_SUITES in packages/core/vitest.config.ts.
-          include: [
-            'test/pglite-*.test.ts',
-            'test/sync-index-error.test.ts',
-            'test/postgres-*.test.ts',
-            'test/embedding-staleness-812.test.ts',
-            'test/packs-url.test.ts',
-          ],
+          include: PGLITE_SUITES,
           // The whole point: one file at a time, so no two WASM Postgres
           // instances are booting concurrently.
           fileParallelism: false,


### PR DESCRIPTION
Interrupted writes, stale responses, malformed configuration, and inconsistent adapter behavior could lose valid data, weaken private routing, or hide failed operations. This PR remediates those bug classes across the public PLUR repository and adds regression coverage for their failure and recovery paths.

## Changes

- Preserve data through migration/restore interruption, atomic replacement, lock reclamation, PostgreSQL ownership loss, ID allocation, import, and source codemods.
- Keep outbox intent and receipts durable, retain retry identity, reject stale acknowledgements, and use validated remote state for cache visibility.
- Keep explicitly private writes local; bind model-assisted mutations to eligible, unchanged candidates; enforce runtime write validation and bounded archive scanning.
- Preserve configuration and credentials through canonical parsing and atomic updates; validate the complete Git commit index before sync.
- Make Python process cleanup bounded, expose adapter failures, preserve multimodal text and coherent transcript batches, and make telemetry append/retry accounting durable.
- Update dependency selections, pin privileged workflow inputs, restore setup coverage, and maintain process-test scheduling without relaxing assertions or timeouts.

The [audit ledger](https://github.com/plur-ai/plur/blob/audit/2026-09-08-closed-loop/docs/audits/2026-09-08-closed-loop.md) contains 18 in-scope cycles, all 42 findings/questions, root causes, sibling searches, fixes, regression evidence, and residual risks. It records 41 resolved findings and one external integration requirement.

## Regression verification

- `pnpm build` — passed.
- `pnpm test --maxWorkers=4` — **5,810 passed, 37 evaluated skips**; 411 files passed, five skipped.
- Final CLI change: rebuilt `@plur-ai/cli`; `pnpm exec vitest run packages/cli/test/import.test.ts --maxWorkers=1` — **12 passed**, including three new destination/override cases.
- `pnpm typecheck:tests` and `tsc --noEmit` for core, CLI, and migrate — passed.
- Isolated Python suites for Python/Hermes/LangChain/heartbeat — **312 passed**, with seven warnings.
- `bash scripts/smoke-release.sh` — **19 passed**, including packaged commands, migration output, and real PostgreSQL primary-store behavior.
- Workflow pin guard, 11 workflow YAML parses, modified-script syntax checks, spec vectors, and staged diff checks — passed.
- Local advisory matching: 602 npm entries with zero matches/unknowns; two Python optional-API matches were evaluated as outside the adapter's execution paths, not claimed patched.

The full suite preceded the final one-line CLI import destination fix and three added CLI cases. Hash comparison of 901 non-document inputs confirmed that only that command and its test changed afterward; the subsequent CLI build/tests, type checks, Python bridges, and packaged smoke cover that delta. No tests were newly skipped and no assertions or timeouts were weakened to obtain a pass.

## Review and compatibility notes

- F14 remains **OPEN for external verification**: complete remote retry deduplication requires a supported server that atomically commits the write and its idempotency receipt and validates replay authorization/payload consistency. The public client now durably retains request identity; passing client/contract-fixture tests cannot certify a server artifact. This PR does not claim complete integration convergence.
- Malformed existing configuration now refuses instead of enabling defaults; unsupported remote content refuses before sending; adapter persistence failures are explicit; source codemods refuse links and unsafe replacement. These are intentional changes to failure behavior.
- Physical power-loss behavior, unsupported filesystems/platforms, live model providers, and the hosted CI matrix are outside the completed local verification. CI on this PR supplies additional evidence; local results do not stand in for it.

Only public-repository changes are included. No merge or deployment is performed by this PR.
